### PR TITLE
[glue] Serve peers from published snapshot captures

### DIFF
--- a/examples/reshare/src/validator.rs
+++ b/examples/reshare/src/validator.rs
@@ -31,7 +31,7 @@ use commonware_glue::{
     },
     stateful::{
         Config as StatefulConfig, Stateful, SyncPlan,
-        db::{DatabaseSet, p2p as qmdb_resolver},
+        db::{DatabaseSet, p2p as qmdb_resolver, snapshot::Publisher},
     },
 };
 use commonware_macros::boxed;
@@ -230,12 +230,13 @@ pub async fn run(context: tokio::Context, args: Validator) {
     )
     .await;
 
+    let publication_context = context.child("publication");
+    let (snapshot_publisher, snapshot_reader) = Publisher::new(&publication_context);
     let (qmdb_actor, qmdb_sync_resolver) = qmdb_resolver::Actor::new(
         context.child("qmdb_resolver"),
         qmdb_resolver::Config {
             peer_provider: oracle.clone(),
             blocker: oracle.clone(),
-            database: None,
             mailbox_size: MAILBOX_SIZE,
             me: Some(local.clone()),
             initial: Duration::from_secs(1),
@@ -245,6 +246,7 @@ pub async fn run(context: tokio::Context, args: Validator) {
             priority_requests: false,
             priority_responses: false,
         },
+        snapshot_reader,
     );
     let qmdb_handle = qmdb_actor.start(qmdb_network);
 
@@ -307,6 +309,7 @@ pub async fn run(context: tokio::Context, args: Validator) {
             mailbox_size: MAILBOX_SIZE,
             plan,
             resolvers: qmdb_sync_resolver,
+            snapshot_publisher,
             sync_config: types::sync_config(),
             prune_config: None,
         },

--- a/glue/src/dkg/tests/reshare/harness.rs
+++ b/glue/src/dkg/tests/reshare/harness.rs
@@ -1018,12 +1018,14 @@ impl EngineDefinition for ReshareEngine {
             init_concurrency: (),
         };
 
+        let publication_context = context.child("publication");
+        let (snapshot_publisher, snapshot_reader) =
+            crate::stateful::db::snapshot::Publisher::new(&publication_context);
         let (qmdb_resolver_actor, qmdb_sync_resolver) = qmdb_resolver::Actor::new(
             context.child("qmdb_resolver"),
             qmdb_resolver::Config {
                 peer_provider: oracle.manager(),
                 blocker: oracle.control(public_key.clone()),
-                database: None,
                 mailbox_size: NZUsize!(100),
                 me: Some(public_key.clone()),
                 initial: Duration::from_secs(1),
@@ -1033,6 +1035,7 @@ impl EngineDefinition for ReshareEngine {
                 priority_requests: false,
                 priority_responses: false,
             },
+            snapshot_reader,
         );
         let qmdb_handle = qmdb_resolver_actor.start(qmdb_network);
 
@@ -1115,6 +1118,7 @@ impl EngineDefinition for ReshareEngine {
                 mailbox_size: NZUsize!(100),
                 plan,
                 resolvers: qmdb_sync_resolver,
+                snapshot_publisher,
                 sync_config: SyncEngineConfig {
                     fetch_batch_size: NZU64!(16),
                     apply_batch_size: NZU64!(64),

--- a/glue/src/stateful/actor/core/mod.rs
+++ b/glue/src/stateful/actor/core/mod.rs
@@ -12,7 +12,7 @@ use crate::stateful::{
         processor::{PendingSyncTargets, Processor, Pruning},
         syncer::{self, SyncPlan, SyncResult},
     },
-    db::{AttachableResolverSet, DatabaseSet, StateSyncSet, SyncEngineConfig},
+    db::{DatabaseSet, SnapshotsOf, StateSyncSet, SyncEngineConfig, snapshot::Publisher},
 };
 use commonware_actor::mailbox::{self as actor_mailbox};
 use commonware_consensus::{
@@ -104,8 +104,11 @@ where
     /// metadata handle and the startup decision shared with marshal.
     pub plan: SyncPlan<E, S, V>,
 
-    /// Resolver(s) for state sync fetches and post-bootstrap serving.
+    /// Resolver(s) for state sync fetches.
     pub resolvers: R,
+
+    /// Publishes the latest durable capture of snapshots.
+    pub snapshot_publisher: Publisher<SnapshotsOf<A::Databases, E>>,
 
     /// Sync engine tuning knobs.
     pub sync_config: SyncEngineConfig,
@@ -149,8 +152,11 @@ where
     /// Startup plan carrying the metadata handle and floor decision.
     plan: SyncPlan<E, S, V>,
 
-    /// Resolver(s) for state sync fetches and post-bootstrap serving.
+    /// Resolver(s) for state sync fetches.
     resolvers: R,
+
+    /// Publishes the latest durable capture of snapshots.
+    snapshot_publisher: Publisher<SnapshotsOf<A::Databases, E>>,
 
     /// Sync engine tuning knobs.
     sync_config: SyncEngineConfig,
@@ -166,7 +172,7 @@ where
     A::Databases: StateSyncSet<E, R, BlockDigest<A, E>>,
     S: Scheme,
     V: Variant<ApplicationBlock = A::Block>,
-    R: AttachableResolverSet<A::Databases>,
+    R: Send + Sync + 'static,
     MarshalMailbox<S, V>: BlockProvider<Block = A::Block>,
 {
     /// Construct a [`Stateful`] actor and its [`Mailbox`].
@@ -193,6 +199,7 @@ where
                 db_config: config.db_config,
                 plan: config.plan,
                 resolvers: config.resolvers,
+                snapshot_publisher: config.snapshot_publisher,
                 sync_config: config.sync_config,
                 pruning,
             },
@@ -229,7 +236,7 @@ where
             context: self.context.child("syncer"),
             db_config: self.db_config,
             sync_config: self.sync_config,
-            resolvers: self.resolvers.clone(),
+            resolvers: self.resolvers,
             finalization,
             marshal: (marshal.clone(), floor),
             sync_complete,
@@ -245,7 +252,7 @@ where
             deferred_verifications: Vec::new(),
             database_subscribers: Vec::new(),
             artifact: None,
-            resolvers: self.resolvers,
+            snapshot_publisher: self.snapshot_publisher,
             sync_completed,
             pending_finalizations: Default::default(),
             pruning: self.pruning,
@@ -268,21 +275,21 @@ where
         )
         .await;
 
-        // Attach the resolvers to the initialized databases before starting the processor,
-        // so that this instance can serve peers database operations and proofs. The
-        // resolver handles can be dropped after this: serving runs on the resolver
-        // actors' own contexts.
-        self.resolvers.attach_databases(databases.clone()).await;
-
         let metrics = StatefulMetrics::new(self.context.as_present());
         let _ = metrics.sync_done.try_set(1);
         let processor = Processor::new(self.application, databases, anchor, metrics, self.pruning);
+
+        // The recovered state alone must publish before the loop starts, so
+        // serving begins before the next finalization.
+        let mut snapshot_publisher = self.snapshot_publisher;
+        processor.publish_snapshot(&mut snapshot_publisher).await;
         Processing {
             context: self.context,
             mailbox: self.mailbox,
             provider: self.provider,
             marshal,
             processor,
+            snapshot_publisher,
             deferred_verifications: Vec::new(),
             skip_finalized_until,
         }
@@ -296,7 +303,7 @@ mod tests {
     use super::{Config, Stateful};
     use crate::stateful::{
         actor::syncer::SyncPlan,
-        db::{AttachableResolver, Shared, StateSyncDb, SyncEngineConfig},
+        db::{StateSyncDb, SyncEngineConfig, snapshot::Publisher},
         tests::{
             fixtures,
             mocks::{TestApp, TestBlock, TestDb},
@@ -315,17 +322,13 @@ mod tests {
     #[derive(Clone)]
     struct NoopResolver;
 
-    impl AttachableResolver<TestDb> for NoopResolver {
-        async fn attach_database(&self, _db: Shared<TestDb>) {}
-    }
-
-    impl StateSyncDb<deterministic::Context, NoopResolver> for TestDb {
+    impl<S: Send> StateSyncDb<deterministic::Context, S> for TestDb {
         type SyncError = Infallible;
 
         async fn sync_db(
             _context: deterministic::Context,
             _config: Self::Config,
-            _resolver: NoopResolver,
+            _source: S,
             _target: Self::SyncTarget,
             _tip_updates: mpsc::Receiver<Self::SyncTarget>,
             _finish: Option<mpsc::Receiver<()>>,
@@ -334,6 +337,57 @@ mod tests {
         ) -> Result<Self, Self::SyncError> {
             Ok(Self::default())
         }
+    }
+
+    #[test]
+    fn startup_serves_recovered_state_as_the_first_capture() {
+        deterministic::Runner::timed(Duration::from_secs(5)).start(|context| async move {
+            let mut signing_context = context.child("signing");
+            let fixture = scheme_mocks::fixture(&mut signing_context, b"startup-serve", 1);
+            let marshal = fixtures::marshal_fixture(
+                context.child("marshal_fixture"),
+                "startup-serve",
+                fixture.schemes[0].clone(),
+                None,
+                NZUsize!(1),
+                true,
+            )
+            .await;
+
+            let plan = SyncPlan::init(&context, "startup-serve-stateful".to_string()).await;
+            let publication_context = context.child("publication");
+            let (snapshot_publisher, snapshot_reader) = Publisher::new(&publication_context);
+            let (stateful, _mailbox) = Stateful::init(
+                context.child("stateful"),
+                Config {
+                    application: TestApp,
+                    db_config: (),
+                    provider: (),
+                    marshal: (marshal.mailbox, marshal.floor),
+                    mailbox_size: NZUsize!(8),
+                    plan,
+                    resolvers: NoopResolver,
+                    snapshot_publisher,
+                    sync_config: SyncEngineConfig {
+                        fetch_batch_size: NZU64!(1),
+                        apply_batch_size: NZU64!(1),
+                        max_outstanding_requests: 1,
+                        update_channel_size: NZUsize!(1),
+                        max_retained_roots: 1,
+                    },
+                    prune_config: None,
+                },
+            );
+            let handle = stateful.start();
+
+            // No block is ever reported: the recovered state alone must publish as
+            // the first capture and begin serving.
+            while snapshot_reader.latest() != Some(0) {
+                context.sleep(Duration::from_millis(1)).await;
+            }
+
+            handle.abort();
+        });
     }
 
     #[test]
@@ -353,6 +407,7 @@ mod tests {
             .await;
 
             let plan = SyncPlan::init(&context, "pending-floor-stateful".to_string()).await;
+            let publication_context = context.child("publication");
             let (stateful, mut mailbox) = Stateful::init(
                 context.child("stateful"),
                 Config {
@@ -363,6 +418,7 @@ mod tests {
                     mailbox_size: NZUsize!(8),
                     plan: plan.with_floor(finalization),
                     resolvers: NoopResolver,
+                    snapshot_publisher: Publisher::new(&publication_context).0,
                     sync_config: SyncEngineConfig {
                         fetch_batch_size: NZU64!(1),
                         apply_batch_size: NZU64!(1),

--- a/glue/src/stateful/actor/core/mod.rs
+++ b/glue/src/stateful/actor/core/mod.rs
@@ -262,7 +262,7 @@ where
     }
 
     /// Starts the application by initializing the database set at marshal's current floor.
-    async fn start_from_marshal(self) {
+    async fn start_from_marshal(mut self) {
         let (marshal, _) = self.marshal;
         let syncer::StartupResult {
             sync: SyncResult { databases, anchor },
@@ -279,17 +279,18 @@ where
         let _ = metrics.sync_done.try_set(1);
         let processor = Processor::new(self.application, databases, anchor, metrics, self.pruning);
 
-        // The recovered state alone must publish before the loop starts, so
-        // serving begins before the next finalization.
-        let mut snapshot_publisher = self.snapshot_publisher;
-        processor.publish_snapshot(&mut snapshot_publisher).await;
+        // Publish now so serving does not wait for the first post-restart
+        // finalization.
+        processor
+            .publish_snapshot(&mut self.snapshot_publisher)
+            .await;
         Processing {
             context: self.context,
             mailbox: self.mailbox,
             provider: self.provider,
             marshal,
             processor,
-            snapshot_publisher,
+            snapshot_publisher: self.snapshot_publisher,
             deferred_verifications: Vec::new(),
             skip_finalized_until,
         }

--- a/glue/src/stateful/actor/core/processing.rs
+++ b/glue/src/stateful/actor/core/processing.rs
@@ -7,6 +7,7 @@ use crate::stateful::{
         },
         processor::{Applied, Processor},
     },
+    db::{SnapshotsOf, snapshot::Publisher},
 };
 use commonware_actor::mailbox as actor_mailbox;
 use commonware_consensus::{
@@ -26,23 +27,16 @@ use futures::{
     future::{Either, ready},
 };
 use rand_core::Rng;
-use std::{collections::BTreeSet, sync::mpsc::TryRecvError};
+use std::sync::mpsc::TryRecvError;
 use tracing::{Instrument as _, debug, info_span};
 
-/// A single unit of work for the processing loop: either a mailbox message to
-/// handle or a deferred prune to run while the mailbox is idle.
+/// A single unit of work for the processing loop: a mailbox message to handle,
+/// or deferred maintenance (a prune, or a fresh post-prune capture) run while
+/// the mailbox is idle.
 enum Step<M, P> {
     Message(M),
     Prune(P),
-}
-
-/// Records a tracked flush completion and returns whether it is durable.
-fn complete(pending: &mut BTreeSet<Height>, (height, durable): (Height, bool)) -> bool {
-    assert!(
-        pending.remove(&height),
-        "completed flush must have a pending height",
-    );
-    durable
+    Refresh,
 }
 
 fn requeue_verifications<E, A>(
@@ -95,6 +89,9 @@ where
     /// The processing state of the actor.
     pub(super) processor: Processor<E, A>,
 
+    /// Publishes the latest durable capture of snapshots for serving.
+    pub(super) snapshot_publisher: Publisher<SnapshotsOf<A::Databases, E>>,
+
     /// Verification requests deferred until processing starts.
     pub(super) deferred_verifications: Vec<VerificationRequest<E, A>>,
 
@@ -122,18 +119,18 @@ where
         // Deferred finalize flushes, each releasing its block's marshal
         // acknowledgement once the flush completes (see `Barrier`).
         let mut syncs = Pool::<(Height, bool)>::default();
-        let mut pending_syncs = BTreeSet::new();
         select_loop! {
             self.context,
             on_start => {
                 // Observe every already-completed flush (releasing its marshal
-                // acknowledgement) before taking the next unit of work, so
-                // acknowledgements keep flowing even while the mailbox is
-                // never idle.
-                while let Some(completion) = syncs.next_completed().now_or_never() {
-                    if !complete(&mut pending_syncs, completion) {
+                // acknowledgement and publishing its capture) before taking the
+                // next unit of work, so acknowledgements keep flowing even while
+                // the mailbox is never idle.
+                while let Some((height, durable)) = syncs.next_completed().now_or_never() {
+                    if !durable {
                         return;
                     }
+                    self.snapshot_publisher.complete(height);
                 }
 
                 // Publish completed verdicts before admitting another message.
@@ -147,21 +144,25 @@ where
                     None => self.mailbox.try_recv(),
                 };
 
-                // Pruning is non-critical work. We only run it when the mailbox is idle, and
-                // it is never raced against the mailbox due to its internal lock acquisition.
-                // If a message is ready, it is always processed immediately.
+                // Pruning and fresh captures are non-critical work, run only when the
+                // mailbox is idle and never raced against it. If a message is ready,
+                // it is always processed immediately.
                 let next = match message {
                     Ok(message) => Either::Left(ready(Some(Step::Message(message)))),
                     Err(TryRecvError::Empty) => {
                         match pending_prune.take() {
                             // No message, but a prune is queued: run it.
                             Some(prune) => Either::Left(ready(Some(Step::Prune(prune)))),
+                            // The served snapshot is stale and every flush drained.
+                            None if self.snapshot_publisher.needs_refresh() => {
+                                Either::Left(ready(Some(Step::Refresh)))
+                            }
                             // No message and nothing to prune: wait on the mailbox, driving flush
                             // completions while idle.
                             None => {
                                 let mailbox = &mut self.mailbox;
                                 let syncs = &mut syncs;
-                                let pending_syncs = &mut pending_syncs;
+                                let snapshot_publisher = &mut self.snapshot_publisher;
                                 let verifications = &mut verifications;
                                 Either::Right(async move {
                                     loop {
@@ -169,9 +170,13 @@ where
                                             message = mailbox.recv() => {
                                                 break message.map(Step::Message);
                                             },
-                                            completion = syncs.next_completed() => {
-                                                if !complete(pending_syncs, completion) {
+                                            (height, durable) = syncs.next_completed() => {
+                                                if !durable {
                                                     return None;
+                                                }
+                                                snapshot_publisher.complete(height);
+                                                if snapshot_publisher.needs_refresh() {
+                                                    break Some(Step::Refresh);
                                                 }
                                             },
                                             _ = verifications.next_completed() => {
@@ -307,7 +312,12 @@ where
                             let applied = verifications
                                 .drive(self.processor.finalize(&self.context, block.as_ref()))
                                 .await;
-                            let Some(Applied { barrier, prune }) = applied else {
+                            let Some(Applied {
+                                snapshots,
+                                barrier,
+                                prune,
+                            }) = applied
+                            else {
                                 // Duplicate report: marshal redelivers a processed
                                 // height only after a restart, where startup aligned
                                 // the databases to durable state.
@@ -319,18 +329,16 @@ where
                                 "applied finalized database batch"
                             );
 
-                            // Acknowledge marshal only once the batch's flush
-                            // completes, so marshal's processed floor never runs
-                            // ahead of flushed database state (the startup rewind
+                            // The snapshot publishes and marshal is acknowledged
+                            // only once the batch's flush completes, so neither
+                            // served state nor marshal's processed floor gets
+                            // ahead of what is on disk (the startup rewind
                             // contract), without blocking the loop on the flush.
                             // Marshal's ack window bounds the flush backlog. A
                             // false `Barrier::durable` leaves the block
                             // unacknowledged, and marshal redelivers it on restart.
                             let height = block.height();
-                            assert!(
-                                pending_syncs.insert(height),
-                                "finalize flush height must be unique",
-                            );
+                            self.snapshot_publisher.stage(height, snapshots);
                             syncs.push(async move {
                                 let durable = barrier.durable().await;
                                 if durable {
@@ -357,15 +365,13 @@ where
                     // The prune target must be durable, but later blocks remain available in
                     // marshal for replay and do not delay maintenance. Verification may complete
                     // during this wait. Later mailbox work remains ordered behind the prune.
-                    while pending_syncs
-                        .first()
-                        .is_some_and(|height| *height <= prune.barrier_height)
-                    {
+                    while self.snapshot_publisher.blocks_prune(prune.barrier_height) {
                         select! {
-                            completion = syncs.next_completed() => {
-                                if !complete(&mut pending_syncs, completion) {
+                            (height, durable) = syncs.next_completed() => {
+                                if !durable {
                                     return;
                                 }
+                                self.snapshot_publisher.complete(height);
                             },
                             _ = verifications.next_completed() => {},
                         }
@@ -378,7 +384,26 @@ where
                     prune
                         .run(self.processor.databases(), &self.marshal)
                         .await;
+                    // The published snapshot predates this prune and keeps the pruned
+                    // storage alive, as do snapshots staged before it.
+                    self.snapshot_publisher.mark_stale();
+                    if self.snapshot_publisher.needs_refresh() {
+                        self.processor
+                            .publish_snapshot(&mut self.snapshot_publisher)
+                            .await;
+                    }
                     requeue_verifications(retry_mailbox.as_ref(), retry);
+                }
+                Step::Refresh => {
+                    // The served snapshot went stale at the last prune and no
+                    // later flush replaced it. Every flush has drained, so the
+                    // applied state is durable and can publish directly.
+                    verifications
+                        .drive(
+                            self.processor
+                                .publish_snapshot(&mut self.snapshot_publisher),
+                        )
+                        .await;
                 }
             },
         }
@@ -409,7 +434,10 @@ mod tests {
             metrics::Metrics as StatefulMetrics,
             processor::{Processor, Pruning},
         },
-        db::{DatabaseSet, Shared},
+        db::{
+            DatabaseSet, Shared,
+            snapshot::{self, Publisher},
+        },
         tests::{
             fixtures,
             mocks::{
@@ -430,8 +458,8 @@ mod tests {
     };
     use commonware_macros::select;
     use commonware_runtime::{
-        Clock as _, ContextCell, Error as RuntimeError, Handle, Name, Runner as _, Spawner as _,
-        Supervisor as _, deterministic,
+        Clock as _, ContextCell, Error as RuntimeError, Handle, Metrics as _, Name, Runner as _,
+        Spawner as _, Supervisor as _, deterministic,
     };
     use commonware_utils::{
         NZUsize,
@@ -623,6 +651,7 @@ mod tests {
         app: GatedApp,
     ) -> (
         Mailbox<deterministic::Context, GatedApp>,
+        snapshot::Reader<u64>,
         Box<dyn std::any::Any>,
         Handle<()>,
     ) {
@@ -646,17 +675,19 @@ mod tests {
             None,
         );
         let (sender, receiver) = actor_mailbox::new(context.child("mailbox"), NZUsize!(8));
+        let (publisher, reader) = Publisher::new(context);
         let processing = Processing {
             context: ContextCell::new(context.child("processing")),
             mailbox: receiver,
             provider: (),
             marshal: marshal.mailbox,
             processor,
+            snapshot_publisher: publisher,
             deferred_verifications: Vec::new(),
             skip_finalized_until: None,
         };
         let actor = context.child("loop").spawn(move |_| processing.start());
-        (Mailbox::new(sender), marshal.guards, actor)
+        (Mailbox::new(sender), reader, marshal.guards, actor)
     }
 
     /// Spawn a [`Processing`] loop over a gated [`TestDb`], returning its
@@ -669,6 +700,7 @@ mod tests {
     ) -> (
         Mailbox<deterministic::Context, GatedApp>,
         FlushControl,
+        snapshot::Reader<u64>,
         Box<dyn std::any::Any>,
         Handle<()>,
     ) {
@@ -683,6 +715,7 @@ mod tests {
     ) -> (
         Mailbox<deterministic::Context, GatedApp>,
         FlushControl,
+        snapshot::Reader<u64>,
         Box<dyn std::any::Any>,
         Handle<()>,
     ) {
@@ -716,17 +749,31 @@ mod tests {
             pruning,
         );
         let (sender, receiver) = actor_mailbox::new(context.child("mailbox"), NZUsize!(8));
+        let (mut publisher, reader) = Publisher::new(context);
+        processor.publish_snapshot(&mut publisher).await;
         let processing = Processing {
             context: ContextCell::new(context.child("processing")),
             mailbox: receiver,
             provider: (),
             marshal: marshal.mailbox,
             processor,
+            snapshot_publisher: publisher,
             deferred_verifications: Vec::new(),
             skip_finalized_until: None,
         };
         let actor = context.child("loop").spawn(move |_| processing.start());
-        (Mailbox::new(sender), control, marshal.guards, actor)
+        (Mailbox::new(sender), control, reader, marshal.guards, actor)
+    }
+
+    /// The value of the `publications` counter.
+    fn publications(context: &deterministic::Context) -> u64 {
+        context
+            .encode()
+            .lines()
+            .find_map(|line| line.strip_prefix("publications_total "))
+            .expect("counter must be registered")
+            .parse()
+            .expect("counter must be an integer")
     }
 
     #[test]
@@ -740,7 +787,7 @@ mod tests {
                 verify_valid: true,
                 observed_contexts: Arc::default(),
             };
-            let (mut mailbox, _marshal, actor) =
+            let (mut mailbox, _reader, _marshal, actor) =
                 spawn_gated_application(&context, "concurrent-verify", app).await;
 
             let genesis = TestBlock::new(0, 0);
@@ -806,7 +853,7 @@ mod tests {
                 verify_valid: true,
                 observed_contexts: observed_contexts.clone(),
             };
-            let (mut mailbox, _marshal, actor) =
+            let (mut mailbox, _reader, _marshal, actor) =
                 spawn_gated_application(&context, "verify-attributes", app).await;
 
             let genesis = TestBlock::new(0, 0);
@@ -853,7 +900,7 @@ mod tests {
                 verify_valid: true,
                 observed_contexts: Arc::default(),
             };
-            let (mut mailbox, _marshal, actor) =
+            let (mut mailbox, _reader, _marshal, actor) =
                 spawn_gated_application(&context, "caller-cancellation", app).await;
 
             let genesis = TestBlock::new(0, 0);
@@ -887,7 +934,7 @@ mod tests {
                 verify_valid: true,
                 observed_contexts: Arc::default(),
             };
-            let (mut mailbox, _marshal, actor) =
+            let (mut mailbox, _reader, _marshal, actor) =
                 spawn_gated_application(&context, "incomplete-verify", app).await;
 
             let genesis = TestBlock::new(0, 0);
@@ -948,7 +995,7 @@ mod tests {
                 verify_valid: false,
                 observed_contexts: Arc::default(),
             };
-            let (mut mailbox, _marshal, actor) =
+            let (mut mailbox, _reader, _marshal, actor) =
                 spawn_gated_application(&context, "rejected-verify", app).await;
 
             let genesis = TestBlock::new(0, 0);
@@ -968,7 +1015,7 @@ mod tests {
     #[test]
     fn conflicting_processed_block_is_rejected() {
         deterministic::Runner::timed(Duration::from_secs(5)).start(|context| async move {
-            let (mut mailbox, control, _marshal, actor) =
+            let (mut mailbox, control, _reader, _marshal, actor) =
                 spawn_processing(&context, "conflicting-processed", None).await;
             let genesis = TestBlock::new(0, 0);
             let canonical = TestBlock::child(&genesis, 1);
@@ -1013,7 +1060,7 @@ mod tests {
                 verify_valid: true,
                 observed_contexts: Arc::default(),
             };
-            let (mut mailbox, _marshal, actor) =
+            let (mut mailbox, _reader, _marshal, actor) =
                 spawn_gated_application(&context, "propose-verify", app).await;
 
             let genesis = TestBlock::new(0, 0);
@@ -1073,7 +1120,7 @@ mod tests {
                 verify_valid: true,
                 observed_contexts: Arc::default(),
             };
-            let (mut mailbox, _marshal, actor) =
+            let (mut mailbox, _reader, _marshal, actor) =
                 spawn_gated_application(&context, "propose-new-verify", app).await;
 
             let genesis = TestBlock::new(0, 0);
@@ -1127,7 +1174,7 @@ mod tests {
                 verify_valid: true,
                 observed_contexts: Arc::default(),
             };
-            let (mut mailbox, _marshal, actor) =
+            let (mut mailbox, _reader, _marshal, actor) =
                 spawn_gated_application(&context, "proposal-finalization", app).await;
 
             let genesis = TestBlock::new(0, 0);
@@ -1215,7 +1262,7 @@ mod tests {
                 verify_valid: true,
                 observed_contexts: Arc::default(),
             };
-            let (mut mailbox, _marshal, actor) =
+            let (mut mailbox, _reader, _marshal, actor) =
                 spawn_gated_application(&context, "finalize-compatible", app).await;
 
             let genesis = TestBlock::new(0, 0);
@@ -1272,7 +1319,7 @@ mod tests {
                 verify_valid: true,
                 observed_contexts: Arc::default(),
             };
-            let (mut mailbox, _marshal, actor) =
+            let (mut mailbox, _reader, _marshal, actor) =
                 spawn_gated_application(&context, "finalize-incompatible", app).await;
 
             let genesis = TestBlock::new(0, 0);
@@ -1349,7 +1396,7 @@ mod tests {
                 verify_valid: true,
                 observed_contexts: Arc::default(),
             };
-            let (mut mailbox, _marshal, actor) =
+            let (mut mailbox, _reader, _marshal, actor) =
                 spawn_gated_application(&context, "finalize-deep-incompatible", app).await;
 
             let genesis = TestBlock::new(0, 0);
@@ -1460,6 +1507,7 @@ mod tests {
                 provider: (),
                 marshal: marshal.mailbox,
                 processor,
+                snapshot_publisher: Publisher::new(&context).0,
                 deferred_verifications: Vec::new(),
                 skip_finalized_until: Some(finalized.height()),
             };
@@ -1577,6 +1625,7 @@ mod tests {
                 provider: (),
                 marshal: marshal.mailbox,
                 processor,
+                snapshot_publisher: Publisher::new(&context).0,
                 deferred_verifications: vec![request],
                 skip_finalized_until: Some(Height::new(0)),
             };
@@ -1643,6 +1692,7 @@ mod tests {
                 provider: (),
                 marshal: marshal.mailbox,
                 processor,
+                snapshot_publisher: Publisher::new(&context).0,
                 deferred_verifications: Vec::new(),
                 skip_finalized_until: None,
             };
@@ -1741,6 +1791,7 @@ mod tests {
                 provider: (),
                 marshal: marshal.mailbox,
                 processor,
+                snapshot_publisher: Publisher::new(&context).0,
                 deferred_verifications: Vec::new(),
                 skip_finalized_until: None,
             };
@@ -1834,6 +1885,7 @@ mod tests {
                 provider: (),
                 marshal: marshal.mailbox,
                 processor,
+                snapshot_publisher: Publisher::new(&context).0,
                 deferred_verifications: Vec::new(),
                 skip_finalized_until: None,
             };
@@ -1940,6 +1992,7 @@ mod tests {
                 provider: (),
                 marshal: marshal.mailbox,
                 processor,
+                snapshot_publisher: Publisher::new(&context).0,
                 deferred_verifications: Vec::new(),
                 skip_finalized_until: None,
             };
@@ -2064,6 +2117,7 @@ mod tests {
                 provider: (),
                 marshal: marshal.mailbox.clone(),
                 processor,
+                snapshot_publisher: Publisher::new(&context).0,
                 deferred_verifications: Vec::new(),
                 skip_finalized_until: None,
             };
@@ -2179,6 +2233,7 @@ mod tests {
                 provider: (),
                 marshal: marshal.mailbox,
                 processor,
+                snapshot_publisher: Publisher::new(&context).0,
                 deferred_verifications: Vec::new(),
                 skip_finalized_until: None,
             };
@@ -2270,7 +2325,7 @@ mod tests {
         deterministic::Runner::timed(Duration::from_secs(10)).start(|context| async move {
             // Marshal only receives prune requests here. Its actor never runs.
             let (verify_gate, verify_started, verify_release) = application_gate();
-            let (mut mailbox, control, _marshal, _actor) = spawn_processing_with_gates(
+            let (mut mailbox, control, _reader, _marshal, _actor) = spawn_processing_with_gates(
                 &context,
                 "gated-prune",
                 Some(PruneConfig {
@@ -2359,7 +2414,7 @@ mod tests {
     #[test]
     fn aborted_target_flush_prevents_prune() {
         deterministic::Runner::timed(Duration::from_secs(10)).start(|context| async move {
-            let (mut mailbox, control, _marshal, actor) = spawn_processing(
+            let (mut mailbox, control, _reader, _marshal, actor) = spawn_processing(
                 &context,
                 "gated-aborted-prune",
                 Some(PruneConfig {
@@ -2407,7 +2462,7 @@ mod tests {
     #[test]
     fn idle_acks_follow_flush_outcome() {
         deterministic::Runner::timed(Duration::from_secs(10)).start(|context| async move {
-            let (mut mailbox, control, _marshal, actor) =
+            let (mut mailbox, control, _reader, _marshal, actor) =
                 spawn_processing(&context, "gated-idle", None).await;
 
             // Park the loop idle with block 1's flush pending.
@@ -2453,7 +2508,7 @@ mod tests {
     #[test]
     fn ready_aborted_flush_stops_processing() {
         deterministic::Runner::timed(Duration::from_secs(10)).start(|context| async move {
-            let (mut mailbox, control, _marshal, actor) =
+            let (mut mailbox, control, _reader, _marshal, actor) =
                 spawn_processing(&context, "gated-ready-abort", None).await;
 
             let (acknowledgement, waiter1) = Exact::handle();
@@ -2489,7 +2544,7 @@ mod tests {
     #[test]
     fn shutdown_cancels_pending_flush_ack() {
         deterministic::Runner::timed(Duration::from_secs(10)).start(|context| async move {
-            let (mut mailbox, control, _marshal, actor) =
+            let (mut mailbox, control, _reader, _marshal, actor) =
                 spawn_processing(&context, "gated-shutdown", None).await;
 
             let (acknowledgement, waiter) = Exact::handle();
@@ -2516,7 +2571,7 @@ mod tests {
     #[should_panic(expected = "database finalize flush failed (type")]
     fn flush_failure_panics_processing() {
         deterministic::Runner::timed(Duration::from_secs(10)).start(|context| async move {
-            let (mut mailbox, control, _marshal, _actor) =
+            let (mut mailbox, control, _reader, _marshal, _actor) =
                 spawn_processing(&context, "gated-failure", None).await;
 
             let (acknowledgement, _waiter) = Exact::handle();
@@ -2554,5 +2609,179 @@ mod tests {
 
         assert!(!skip_finalized_block(&mut skip_until, Height::new(4)));
         assert_eq!(skip_until, None);
+    }
+
+    /// A later flush completing first releases its acknowledgement, but nothing
+    /// serves until every earlier flush lands. The frontier then publishes the
+    /// newest capture, superseding the earlier one.
+    #[test]
+    fn out_of_order_flush_publishes_at_the_frontier() {
+        deterministic::Runner::timed(Duration::from_secs(10)).start(|context| async move {
+            let (mut mailbox, control, source, _marshal, _actor) =
+                spawn_processing(&context, "gated-out-of-order", None).await;
+
+            let (acknowledgement, mut waiter1) = Exact::handle();
+            let _ = mailbox.report(Update::Block(
+                Arc::new(TestBlock::new(1, 1)),
+                acknowledgement,
+            ));
+            let (acknowledgement, waiter2) = Exact::handle();
+            let _ = mailbox.report(Update::Block(
+                Arc::new(TestBlock::new(2, 2)),
+                acknowledgement,
+            ));
+            while control.flushes.lock().len() < 2 {
+                context.sleep(Duration::from_millis(10)).await;
+            }
+
+            // Block 2's flush lands first: its acknowledgement releases, but
+            // serving stays behind block 1's pending flush.
+            let release = control.flushes.lock().remove(1);
+            let _ = release.send(Ok(()));
+            waiter2.await.expect("block 2 acknowledgement");
+            assert_eq!(
+                source.latest(),
+                Some(0),
+                "nothing may serve past a pending earlier flush",
+            );
+            assert!(poll!(&mut waiter1).is_pending());
+
+            // Block 1 lands: the frontier jumps to block 2's capture.
+            let release = control.flushes.lock().remove(0);
+            let _ = release.send(Ok(()));
+            waiter1.await.expect("block 1 acknowledgement");
+            while source.latest() != Some(2) {
+                context.sleep(Duration::from_millis(10)).await;
+            }
+        });
+    }
+
+    /// A prune with no later finalization must publish a fresh capture, so serving
+    /// stops pinning the pruned state.
+    #[test]
+    fn prune_without_later_block_publishes_a_fresh_capture() {
+        deterministic::Runner::timed(Duration::from_secs(10)).start(|context| async move {
+            let (mut mailbox, control, source, _marshal, _actor) = spawn_processing(
+                &context,
+                "gated-prune-capture",
+                Some(PruneConfig {
+                    maintenance_interval: NZUsize!(1),
+                    retained_marshal_blocks: 0,
+                    retained_qmdb_blocks: 0,
+                }),
+            )
+            .await;
+
+            // Blocks 1 and 2 fill the retention window, scheduling a prune at block 1.
+            // Both captures predate the prune.
+            let (acknowledgement, waiter1) = Exact::handle();
+            let _ = mailbox.report(Update::Block(
+                Arc::new(TestBlock::new(1, 1)),
+                acknowledgement,
+            ));
+            let (acknowledgement, waiter2) = Exact::handle();
+            let _ = mailbox.report(Update::Block(
+                Arc::new(TestBlock::new(2, 2)),
+                acknowledgement,
+            ));
+            while control.flushes.lock().len() < 2 {
+                context.sleep(Duration::from_millis(10)).await;
+            }
+            let release = control.flushes.lock().remove(0);
+            let _ = release.send(Ok(()));
+            waiter1.await.expect("block 1 acknowledgement");
+            while control.pruned.lock().is_empty() {
+                context.sleep(Duration::from_millis(10)).await;
+            }
+            assert_eq!(control.pruned.lock().clone(), vec![1]);
+
+            // Block 2's snapshot was captured before the prune, so its publish must
+            // not replace the stale snapshot: with no later block, the loop itself captures
+            // and publishes again once every flush drains. The fresh capture
+            // carries the same content as block 2's publish, so count
+            // publications instead: startup, block 1, block 2, then the capture.
+            let release = control.flushes.lock().remove(0);
+            let _ = release.send(Ok(()));
+            waiter2.await.expect("block 2 acknowledgement");
+            while publications(&context) < 4 {
+                context.sleep(Duration::from_millis(10)).await;
+            }
+            assert_eq!(
+                source.latest(),
+                Some(2),
+                "the fresh capture must serve block 2's state"
+            );
+        });
+    }
+
+    /// When a block finalized after the prune publishes, its snapshot replaces
+    /// the stale one. The loop must not also capture a fresh snapshot.
+    #[test]
+    fn post_prune_publish_replaces_the_stale_snapshot() {
+        deterministic::Runner::timed(Duration::from_secs(10)).start(|context| async move {
+            let (mut mailbox, control, source, _marshal, _actor) = spawn_processing(
+                &context,
+                "gated-prune-clear",
+                Some(PruneConfig {
+                    maintenance_interval: NZUsize!(2),
+                    retained_marshal_blocks: 0,
+                    retained_qmdb_blocks: 0,
+                }),
+            )
+            .await;
+
+            // Blocks 1 and 2 fill the retention window, scheduling a prune at block 1.
+            let (acknowledgement, waiter1) = Exact::handle();
+            let _ = mailbox.report(Update::Block(
+                Arc::new(TestBlock::new(1, 1)),
+                acknowledgement,
+            ));
+            let (acknowledgement, waiter2) = Exact::handle();
+            let _ = mailbox.report(Update::Block(
+                Arc::new(TestBlock::new(2, 2)),
+                acknowledgement,
+            ));
+            while control.flushes.lock().len() < 2 {
+                context.sleep(Duration::from_millis(10)).await;
+            }
+
+            // Releasing block 1 lets the prune run while block 2's pre-prune flush
+            // is still pending, marking publication stale.
+            let release = control.flushes.lock().remove(0);
+            let _ = release.send(Ok(()));
+            waiter1.await.expect("block 1 acknowledgement");
+            while control.pruned.lock().is_empty() {
+                context.sleep(Duration::from_millis(10)).await;
+            }
+            assert_eq!(control.pruned.lock().clone(), vec![1]);
+
+            // Block 3 is finalized after the prune, so its capture is post-prune.
+            let (acknowledgement, waiter3) = Exact::handle();
+            let _ = mailbox.report(Update::Block(
+                Arc::new(TestBlock::new(3, 3)),
+                acknowledgement,
+            ));
+            while control.flushes.lock().len() < 2 {
+                context.sleep(Duration::from_millis(10)).await;
+            }
+
+            // Block 2's pre-prune publish must not replace the stale snapshot. Block 3's
+            // post-prune publish must, so no extra capture ever publishes.
+            let release = control.flushes.lock().remove(0);
+            let _ = release.send(Ok(()));
+            waiter2.await.expect("block 2 acknowledgement");
+            let release = control.flushes.lock().remove(0);
+            let _ = release.send(Ok(()));
+            waiter3.await.expect("block 3 acknowledgement");
+            while source.latest() < Some(3) {
+                context.sleep(Duration::from_millis(10)).await;
+            }
+            context.sleep(Duration::from_millis(50)).await;
+            assert_eq!(
+                source.latest(),
+                Some(3),
+                "block 3's own publish must replace the stale snapshot without a separate capture",
+            );
+        });
     }
 }

--- a/glue/src/stateful/actor/core/syncing.rs
+++ b/glue/src/stateful/actor/core/syncing.rs
@@ -8,7 +8,7 @@ use crate::stateful::{
         processor::{Applied, PendingSyncTargets, Processor, Pruning},
         syncer::{self, StateSyncMetadata, SyncResult},
     },
-    db::{Anchor, AttachableResolverSet},
+    db::{Anchor, SnapshotsOf, snapshot::Publisher},
 };
 use commonware_actor::mailbox as actor_mailbox;
 use commonware_consensus::{
@@ -48,13 +48,12 @@ pub(super) struct PendingFinalization<B> {
 }
 
 /// Serves application requests while coordinating state sync and its handoff.
-pub(super) struct Syncing<E, A, S, V, R>
+pub(super) struct Syncing<E, A, S, V>
 where
     E: Rng + Spawner + Context,
     A: Application<E>,
     S: Scheme,
     V: Variant<ApplicationBlock = A::Block>,
-    R: AttachableResolverSet<A::Databases>,
 {
     /// Runtime context.
     pub(super) context: ContextCell<E>,
@@ -86,9 +85,8 @@ where
     /// The cached [`SyncResult`], populated when sync completes.
     pub(super) artifact: Option<SyncResult<E, A>>,
 
-    /// The state sync resolvers used for state sync fetching and post-bootstrap
-    /// serving.
-    pub(super) resolvers: R,
+    /// Publishes the latest durable capture of snapshots.
+    pub(super) snapshot_publisher: Publisher<SnapshotsOf<A::Databases, E>>,
 
     /// Signals that the syncer has produced a usable artifact.
     pub(super) sync_completed: oneshot::Receiver<SyncResult<E, A>>,
@@ -103,13 +101,12 @@ where
     pub(super) metrics: StatefulMetrics,
 }
 
-impl<E, A, S, V, R> Syncing<E, A, S, V, R>
+impl<E, A, S, V> Syncing<E, A, S, V>
 where
     E: Rng + Spawner + Context,
     A: Application<E>,
     S: Scheme,
     V: Variant<ApplicationBlock = A::Block>,
-    R: AttachableResolverSet<A::Databases>,
     MarshalMailbox<S, V>: BlockProvider<Block = A::Block>,
 {
     pub async fn start(mut self) {
@@ -326,6 +323,12 @@ where
             self.pruning,
         );
 
+        // Serving must not wait for the next finalization, so the synced state
+        // alone publishes as the first capture.
+        processor
+            .publish_snapshot(&mut self.snapshot_publisher)
+            .await;
+
         let mut pending_prune = None;
 
         for handoff in handoffs {
@@ -338,7 +341,11 @@ where
                     acknowledgement.acknowledge();
                 }
                 FinalizedHandoff::Apply(block, acknowledgement) => {
-                    let Applied { barrier, prune } = processor
+                    let Applied {
+                        snapshots,
+                        barrier,
+                        prune,
+                    } = processor
                         .finalize(self.context.as_present(), block.as_ref())
                         .await
                         .expect("sync handoff block cannot be a duplicate");
@@ -349,6 +356,8 @@ where
                     if !barrier.durable().await {
                         return;
                     }
+                    self.snapshot_publisher
+                        .publish_now(block.height(), snapshots);
                     acknowledgement.acknowledge();
                     pending_prune = prune.or(pending_prune);
                     completed_height = block.height();
@@ -365,16 +374,14 @@ where
         self.sync_metadata = self.sync_metadata.set_complete(completed_height).await;
         if let Some(prune) = pending_prune {
             prune.run(processor.databases(), &self.marshal).await;
+            // The published snapshot was captured before this prune. Republish so
+            // serving stops pinning the pruned state. Every handoff barrier was
+            // awaited above, so the capture is already durable.
+            processor
+                .publish_snapshot(&mut self.snapshot_publisher)
+                .await;
         }
 
-        // Attach the resolvers to the initialized databases before starting the processor,
-        // so that this instance can serve peers database operations and proofs.
-        self.resolvers
-            .attach_databases(processor.databases().clone())
-            .await;
-
-        // `subscribe_databases` promises a database set that is already attached to the
-        // serving actor, so keep subscribers waiting until the resolver handoff is complete.
         for subscriber in self.database_subscribers.drain(..) {
             subscriber.send_lossy(processor.databases().clone());
         }
@@ -385,6 +392,7 @@ where
             provider: self.provider,
             marshal: self.marshal,
             processor,
+            snapshot_publisher: self.snapshot_publisher,
             deferred_verifications: self.deferred_verifications,
             skip_finalized_until: Some(completed_height),
         }
@@ -405,7 +413,7 @@ mod tests {
             processor::Pruning,
             syncer::{self, StateSyncMetadata, SyncResult},
         },
-        db::{Anchor, AttachableResolver, Shared},
+        db::{Anchor, Shared, snapshot::Publisher},
         tests::{
             fixtures::{self, MarshalFixture},
             mocks::{
@@ -439,18 +447,11 @@ mod tests {
         }
     }
 
-    #[derive(Clone)]
-    struct NoopResolver;
-
-    impl<DB: Send + Sync + 'static> AttachableResolver<DB> for NoopResolver {
-        async fn attach_database(&self, _db: Shared<DB>) {}
-    }
-
     struct TestHarness<E>
     where
         E: rand_core::Rng + commonware_runtime::Spawner + commonware_storage::Context,
     {
-        syncing: Syncing<E, TestApp, TestScheme, TestVariant, NoopResolver>,
+        syncing: Syncing<E, TestApp, TestScheme, TestVariant>,
     }
 
     impl TestHarness<deterministic::Context> {
@@ -565,7 +566,7 @@ mod tests {
                     deferred_verifications: Vec::new(),
                     database_subscribers: Vec::new(),
                     artifact: None,
-                    resolvers: NoopResolver,
+                    snapshot_publisher: Publisher::new(&syncing_context).0,
                     sync_completed,
                     pending_finalizations: VecDeque::new(),
                     pruning: None,
@@ -622,7 +623,7 @@ mod tests {
                         databases: test_databases(),
                         anchor,
                     }),
-                    resolvers: NoopResolver,
+                    snapshot_publisher: Publisher::new(&syncing_context).0,
                     sync_completed,
                     pending_finalizations: VecDeque::new(),
                     pruning: None,

--- a/glue/src/stateful/actor/core/syncing.rs
+++ b/glue/src/stateful/actor/core/syncing.rs
@@ -323,8 +323,8 @@ where
             self.pruning,
         );
 
-        // Serving must not wait for the next finalization, so the synced state
-        // alone publishes as the first capture.
+        // Publish now so serving does not wait for the first post-sync
+        // finalization.
         processor
             .publish_snapshot(&mut self.snapshot_publisher)
             .await;
@@ -374,9 +374,8 @@ where
         self.sync_metadata = self.sync_metadata.set_complete(completed_height).await;
         if let Some(prune) = pending_prune {
             prune.run(processor.databases(), &self.marshal).await;
-            // The published snapshot was captured before this prune. Republish so
-            // serving stops pinning the pruned state. Every handoff barrier was
-            // awaited above, so the capture is already durable.
+            // Republish so serving stops pinning the pruned state. Every handoff
+            // barrier was awaited above, so the fresh capture is already durable.
             processor
                 .publish_snapshot(&mut self.snapshot_publisher)
                 .await;

--- a/glue/src/stateful/actor/processor/mod.rs
+++ b/glue/src/stateful/actor/processor/mod.rs
@@ -25,7 +25,7 @@
 use crate::stateful::{
     Application, Input, Proposed, PruneConfig,
     actor::{core::Verification, metrics::Metrics as StatefulMetrics},
-    db::{Anchor, Barrier, DatabaseSet},
+    db::{Anchor, Barrier, DatabaseSet, SnapshotsOf, snapshot::Publisher},
 };
 use commonware_consensus::{
     Block, CertifiableBlock, Heightable, Roundable,
@@ -478,8 +478,11 @@ impl Cancellation for Verification {
 }
 
 /// State applied for a newly finalized block.
-pub(super) struct Applied<T> {
-    /// Deferred flush for the applied batch (see [`Barrier`]).
+pub(super) struct Applied<T, S> {
+    /// A snapshot of the database set, captured at the apply boundary.
+    pub(super) snapshots: S,
+
+    /// Proves the snapshot durable. Resolves once every database flush completes.
     pub(super) barrier: Barrier,
 
     /// Prune made due by this finalization.
@@ -685,6 +688,23 @@ where
         &self.execution.databases
     }
 
+    /// Capture a snapshot of the database set's applied state and publish it
+    /// at the processed height.
+    ///
+    /// A future factory: the future captures a clone of the set rather than
+    /// `&self`, so it stays `Send` without requiring `Application: Sync`.
+    pub(super) fn publish_snapshot<'p>(
+        &self,
+        publisher: &'p mut Publisher<SnapshotsOf<A::Databases, E>>,
+    ) -> impl Future<Output = ()> + Send + 'p {
+        let databases = self.execution.databases.clone();
+        let height = self.execution.last_processed().height;
+        async move {
+            let snapshots = databases.snapshot().await;
+            publisher.publish_now(height, snapshots);
+        }
+    }
+
     #[cfg(test)]
     fn last_processed(&self) -> Anchor<PendingDigest<A, E>> {
         self.execution.last_processed()
@@ -856,7 +876,7 @@ where
         &mut self,
         context: &E,
         block: &A::Block,
-    ) -> Option<Applied<PendingSyncTargets<A, E>>> {
+    ) -> Option<Applied<PendingSyncTargets<A, E>, SnapshotsOf<A::Databases, E>>> {
         let finalized = Anchor::from(block);
         let (height, digest) = (finalized.height, finalized.digest);
         let last_processed = self.execution.last_processed();
@@ -930,7 +950,7 @@ where
         if let Some(owner) = reconstruction {
             owner.finish(Ok(()));
         }
-        let barrier = self.execution.databases.finalize(batch).await;
+        let (snapshots, barrier) = self.execution.databases.finalize(batch).await;
         self.notify_finalized(context, block).await;
         let prune = self
             .pruning
@@ -939,7 +959,11 @@ where
         self.execution.finish_finalization(finalized);
         timer.observe(context);
 
-        Some(Applied { barrier, prune })
+        Some(Applied {
+            snapshots,
+            barrier,
+            prune,
+        })
     }
 
     /// Notify the application that marshal delivered a finalized block already
@@ -2110,7 +2134,11 @@ mod tests {
                 <DbSet<deterministic::Context> as DatabaseSet<deterministic::Context>>::SyncTargets,
             >,
         > {
-            let Applied { barrier, prune } = self
+            let Applied {
+                snapshots: _,
+                barrier,
+                prune,
+            } = self
                 .processor
                 .finalize(self.context_cell.as_present(), &block)
                 .await

--- a/glue/src/stateful/actor/processor/mod.rs
+++ b/glue/src/stateful/actor/processor/mod.rs
@@ -690,13 +690,11 @@ where
 
     /// Capture a snapshot of the database set's applied state and publish it
     /// at the processed height.
-    ///
-    /// A future factory: the future captures a clone of the set rather than
-    /// `&self`, so it stays `Send` without requiring `Application: Sync`.
     pub(super) fn publish_snapshot<'p>(
         &self,
         publisher: &'p mut Publisher<SnapshotsOf<A::Databases, E>>,
     ) -> impl Future<Output = ()> + Send + 'p {
+        // Clones the set so the future is `Send` without `A: Sync`.
         let databases = self.execution.databases.clone();
         let height = self.execution.last_processed().height;
         async move {

--- a/glue/src/stateful/actor/syncer/actor.rs
+++ b/glue/src/stateful/actor/syncer/actor.rs
@@ -267,6 +267,7 @@ mod tests {
         type Unmerkleized = TestUnmerkleized;
         type Merkleized = TestMerkleized;
         type Readers = ();
+        type Snapshots = ();
         type Config = u64;
         type SyncTargets = u64;
 
@@ -292,7 +293,11 @@ mod tests {
 
         fn readers(&self) -> Self::Readers {}
 
-        async fn finalize(&self, _batches: Self::Merkleized) -> Barrier {
+        async fn finalize(&self, _batches: Self::Merkleized) -> (Self::Snapshots, Barrier) {
+            unreachable!("WedgeSet only serves the syncer harness")
+        }
+
+        async fn snapshot(&self) -> Self::Snapshots {
             unreachable!("WedgeSet only serves the syncer harness")
         }
 

--- a/glue/src/stateful/db/any.rs
+++ b/glue/src/stateful/db/any.rs
@@ -7,8 +7,8 @@
 //! traits can be implemented without a DB parameter.
 
 use crate::stateful::db::{
-    BatchContext, ManagedDb, Merkleized as MerkleizedTrait, Shared, StateSyncDb, SyncEngineConfig,
-    Unmerkleized as UnmerkleizedTrait, sync_standard_db,
+    BatchContext, LogSnapshot, ManagedDb, Merkleized as MerkleizedTrait, Shared, StateSyncDb,
+    SyncEngineConfig, Unmerkleized as UnmerkleizedTrait, sync_standard_db,
 };
 use commonware_codec::{Codec, Read as CodecRead};
 use commonware_cryptography::Hasher;
@@ -523,6 +523,8 @@ where
     type Error = Error<F>;
     type Config = FixedConfig<T, S>;
     type SyncTarget = AnySyncTarget<F, H::Digest>;
+    type Snapshot =
+        LogSnapshot<F, E, FixedJournal<E, Operation<F, unordered::Update<K, FixedEncoding<V>>>>, H>;
 
     async fn init(context: E, config: Self::Config) -> Result<Self, Error<F>> {
         <Self>::init(context, config).await
@@ -550,9 +552,19 @@ where
             && *target.range.end() == batch.bounds().tip.size
     }
 
-    async fn finalize(self, batch: Self::Merkleized) -> Result<(Self, Handle<()>), Error<F>> {
+    async fn finalize(
+        self,
+        batch: Self::Merkleized,
+    ) -> Result<(Self, Self::Snapshot, Handle<()>), Error<F>> {
         let (db, _) = self.apply_batch(batch.inner).await?;
-        db.start_sync().await
+        let (db, handle) = db.start_sync().await?;
+        let (db, snapshot) = db.snapshot().await?;
+        Ok((db, Arc::new(snapshot), handle))
+    }
+
+    async fn snapshot(self) -> Result<(Self, Self::Snapshot), Error<F>> {
+        let (db, snapshot) = self.snapshot().await?;
+        Ok((db, Arc::new(snapshot)))
     }
 
     async fn prune(self, target: &Self::SyncTarget) -> Result<Self, Error<F>> {
@@ -627,6 +639,12 @@ where
         S,
     >;
     type SyncTarget = AnySyncTarget<F, H::Digest>;
+    type Snapshot = LogSnapshot<
+        F,
+        E,
+        VariableJournal<E, Operation<F, unordered::Update<K, VariableEncoding<V>>>>,
+        H,
+    >;
 
     async fn init(context: E, config: Self::Config) -> Result<Self, Error<F>> {
         <Self>::init(context, config).await
@@ -654,9 +672,19 @@ where
             && *target.range.end() == batch.bounds().tip.size
     }
 
-    async fn finalize(self, batch: Self::Merkleized) -> Result<(Self, Handle<()>), Error<F>> {
+    async fn finalize(
+        self,
+        batch: Self::Merkleized,
+    ) -> Result<(Self, Self::Snapshot, Handle<()>), Error<F>> {
         let (db, _) = self.apply_batch(batch.inner).await?;
-        db.start_sync().await
+        let (db, handle) = db.start_sync().await?;
+        let (db, snapshot) = db.snapshot().await?;
+        Ok((db, Arc::new(snapshot), handle))
+    }
+
+    async fn snapshot(self) -> Result<(Self, Self::Snapshot), Error<F>> {
+        let (db, snapshot) = self.snapshot().await?;
+        Ok((db, Arc::new(snapshot)))
     }
 
     async fn prune(self, target: &Self::SyncTarget) -> Result<Self, Error<F>> {
@@ -847,9 +875,10 @@ mod tests {
                 .unwrap();
 
             let (slot, database) = db.write().await;
-            let (database, sync) = <UnorderedFixedDb as ManagedDb<_>>::finalize(database, winner)
-                .await
-                .unwrap();
+            let (database, _snapshot, sync) =
+                <UnorderedFixedDb as ManagedDb<_>>::finalize(database, winner)
+                    .await
+                    .unwrap();
             slot.put(database);
             sync.await.expect("finalize flush failed");
 
@@ -886,7 +915,7 @@ mod tests {
                 .unwrap();
             {
                 let (slot, database) = db.write().await;
-                let (database, sync) =
+                let (database, _snapshot, sync) =
                     <UnorderedFixedDb as ManagedDb<_>>::finalize(database, merkleized)
                         .await
                         .unwrap();
@@ -983,9 +1012,10 @@ mod tests {
                 .unwrap();
 
             let (slot, database) = db.write().await;
-            let (database, sync) = <DelayedFixedDb as ManagedDb<_>>::finalize(database, merkleized)
-                .await
-                .unwrap();
+            let (database, _snapshot, sync) =
+                <DelayedFixedDb as ManagedDb<_>>::finalize(database, merkleized)
+                    .await
+                    .unwrap();
             slot.put(database);
 
             // The flush is parked, yet the batch is already readable.

--- a/glue/src/stateful/db/current.rs
+++ b/glue/src/stateful/db/current.rs
@@ -7,8 +7,8 @@
 //! traits can be implemented without a DB parameter.
 
 use crate::stateful::db::{
-    BatchContext, ManagedDb, Merkleized as MerkleizedTrait, Shared, StateSyncDb, SyncEngineConfig,
-    Unmerkleized as UnmerkleizedTrait, sync_standard_db,
+    BatchContext, LogSnapshot, ManagedDb, Merkleized as MerkleizedTrait, Shared, StateSyncDb,
+    SyncEngineConfig, Unmerkleized as UnmerkleizedTrait, sync_standard_db,
 };
 use commonware_codec::{Codec, Read as CodecRead};
 use commonware_cryptography::Hasher;
@@ -521,6 +521,8 @@ where
     type Error = Error<F>;
     type Config = FixedConfig<T, S>;
     type SyncTarget = CurrentSyncTarget<F, H::Digest>;
+    type Snapshot =
+        LogSnapshot<F, E, FixedJournal<E, Operation<F, unordered::Update<K, FixedEncoding<V>>>>, H>;
 
     async fn init(context: E, config: Self::Config) -> Result<Self, Error<F>> {
         <Self>::init(context, config).await
@@ -548,9 +550,19 @@ where
             && *target.range.end() == batch.bounds().tip.size
     }
 
-    async fn finalize(self, batch: Self::Merkleized) -> Result<(Self, Handle<()>), Error<F>> {
+    async fn finalize(
+        self,
+        batch: Self::Merkleized,
+    ) -> Result<(Self, Self::Snapshot, Handle<()>), Error<F>> {
         let (db, _) = self.apply_batch(batch.inner).await?;
-        db.start_sync().await
+        let (db, handle) = db.start_sync().await?;
+        let (db, snapshot) = db.snapshot().await?;
+        Ok((db, Arc::new(snapshot), handle))
+    }
+
+    async fn snapshot(self) -> Result<(Self, Self::Snapshot), Error<F>> {
+        let (db, snapshot) = self.snapshot().await?;
+        Ok((db, Arc::new(snapshot)))
     }
 
     async fn prune(self, target: &Self::SyncTarget) -> Result<Self, Error<F>> {
@@ -622,6 +634,8 @@ where
     type Error = Error<F>;
     type Config = FixedConfig<T, S>;
     type SyncTarget = CurrentSyncTarget<F, H::Digest>;
+    type Snapshot =
+        LogSnapshot<F, E, FixedJournal<E, Operation<F, ordered::Update<K, FixedEncoding<V>>>>, H>;
 
     async fn init(context: E, config: Self::Config) -> Result<Self, Error<F>> {
         <Self>::init(context, config).await
@@ -649,9 +663,19 @@ where
             && *target.range.end() == batch.bounds().tip.size
     }
 
-    async fn finalize(self, batch: Self::Merkleized) -> Result<(Self, Handle<()>), Error<F>> {
+    async fn finalize(
+        self,
+        batch: Self::Merkleized,
+    ) -> Result<(Self, Self::Snapshot, Handle<()>), Error<F>> {
         let (db, _) = self.apply_batch(batch.inner).await?;
-        db.start_sync().await
+        let (db, handle) = db.start_sync().await?;
+        let (db, snapshot) = db.snapshot().await?;
+        Ok((db, Arc::new(snapshot), handle))
+    }
+
+    async fn snapshot(self) -> Result<(Self, Self::Snapshot), Error<F>> {
+        let (db, snapshot) = self.snapshot().await?;
+        Ok((db, Arc::new(snapshot)))
     }
 
     async fn prune(self, target: &Self::SyncTarget) -> Result<Self, Error<F>> {
@@ -801,6 +825,12 @@ where
         S,
     >;
     type SyncTarget = CurrentSyncTarget<F, H::Digest>;
+    type Snapshot = LogSnapshot<
+        F,
+        E,
+        VariableJournal<E, Operation<F, unordered::Update<K, VariableEncoding<V>>>>,
+        H,
+    >;
 
     async fn init(context: E, config: Self::Config) -> Result<Self, Error<F>> {
         open::variable(context, config).await
@@ -828,9 +858,19 @@ where
             && *target.range.end() == batch.bounds().tip.size
     }
 
-    async fn finalize(self, batch: Self::Merkleized) -> Result<(Self, Handle<()>), Error<F>> {
+    async fn finalize(
+        self,
+        batch: Self::Merkleized,
+    ) -> Result<(Self, Self::Snapshot, Handle<()>), Error<F>> {
         let (db, _) = self.apply_batch(batch.inner).await?;
-        db.start_sync().await
+        let (db, handle) = db.start_sync().await?;
+        let (db, snapshot) = db.snapshot().await?;
+        Ok((db, Arc::new(snapshot), handle))
+    }
+
+    async fn snapshot(self) -> Result<(Self, Self::Snapshot), Error<F>> {
+        let (db, snapshot) = self.snapshot().await?;
+        Ok((db, Arc::new(snapshot)))
     }
 
     async fn prune(self, target: &Self::SyncTarget) -> Result<Self, Error<F>> {
@@ -907,6 +947,12 @@ where
         S,
     >;
     type SyncTarget = CurrentSyncTarget<F, H::Digest>;
+    type Snapshot = LogSnapshot<
+        F,
+        E,
+        VariableJournal<E, Operation<F, ordered::Update<K, VariableEncoding<V>>>>,
+        H,
+    >;
 
     async fn init(context: E, config: Self::Config) -> Result<Self, Error<F>> {
         open::ordered_variable(context, config).await
@@ -934,9 +980,19 @@ where
             && *target.range.end() == batch.bounds().tip.size
     }
 
-    async fn finalize(self, batch: Self::Merkleized) -> Result<(Self, Handle<()>), Error<F>> {
+    async fn finalize(
+        self,
+        batch: Self::Merkleized,
+    ) -> Result<(Self, Self::Snapshot, Handle<()>), Error<F>> {
         let (db, _) = self.apply_batch(batch.inner).await?;
-        db.start_sync().await
+        let (db, handle) = db.start_sync().await?;
+        let (db, snapshot) = db.snapshot().await?;
+        Ok((db, Arc::new(snapshot), handle))
+    }
+
+    async fn snapshot(self) -> Result<(Self, Self::Snapshot), Error<F>> {
+        let (db, snapshot) = self.snapshot().await?;
+        Ok((db, Arc::new(snapshot)))
     }
 
     async fn prune(self, target: &Self::SyncTarget) -> Result<Self, Error<F>> {
@@ -1185,7 +1241,7 @@ mod tests {
     /// ([`ManagedDb::finalize`] embeds the database in its state machine).
     #[boxed]
     async fn finalize<D: ManagedDb<deterministic::Context>>(db: D, batch: D::Merkleized) -> D {
-        let (db, sync) = D::finalize(db, batch).await.unwrap();
+        let (db, _snapshot, sync) = D::finalize(db, batch).await.unwrap();
         sync.await.expect("finalize flush failed");
         db
     }

--- a/glue/src/stateful/db/immutable/compact.rs
+++ b/glue/src/stateful/db/immutable/compact.rs
@@ -18,6 +18,7 @@ use commonware_storage::{
     qmdb::{
         Error,
         any::value::{FixedEncoding, FixedValue, ValueEncoding, VariableEncoding, VariableValue},
+        compact,
         immutable::{
             CompactDb, CompactMerkleizedBatch, CompactUnmerkleizedBatch, Operation, fixed,
             initial_root, variable,
@@ -227,6 +228,7 @@ where
     type Error = Error<F>;
     type Config = fixed::CompactConfig<S>;
     type SyncTarget = sync::CompactTarget<F, H::Digest>;
+    type Snapshot = compact::Snapshot<F, Operation<F, K, FixedEncoding<V>>, H::Digest>;
 
     async fn init(context: E, config: Self::Config) -> Result<Self, Error<F>> {
         <Self>::init(context, config).await
@@ -253,9 +255,19 @@ where
         batch.root() == target.root && target.size == batch.bounds().tip.size
     }
 
-    async fn finalize(self, batch: Self::Merkleized) -> Result<(Self, Handle<()>), Error<F>> {
+    async fn finalize(
+        self,
+        batch: Self::Merkleized,
+    ) -> Result<(Self, Self::Snapshot, Handle<()>), Error<F>> {
         let (db, _) = self.apply_batch(batch.inner)?;
-        db.start_sync().await
+        let (db, handle) = db.start_sync().await?;
+        let snapshot = Self::snapshot(&db);
+        Ok((db, snapshot, handle))
+    }
+
+    async fn snapshot(self) -> Result<(Self, Self::Snapshot), Error<F>> {
+        let snapshot = Self::snapshot(&self);
+        Ok((self, snapshot))
     }
 
     async fn prune(self, target: &Self::SyncTarget) -> Result<Self, Error<F>> {
@@ -294,6 +306,7 @@ where
     type Error = Error<F>;
     type Config = variable::CompactConfig<C, S>;
     type SyncTarget = sync::CompactTarget<F, H::Digest>;
+    type Snapshot = compact::Snapshot<F, Operation<F, K, VariableEncoding<V>>, H::Digest>;
 
     async fn init(context: E, config: Self::Config) -> Result<Self, Error<F>> {
         <Self>::init(context, config).await
@@ -320,9 +333,19 @@ where
         batch.root() == target.root && target.size == batch.bounds().tip.size
     }
 
-    async fn finalize(self, batch: Self::Merkleized) -> Result<(Self, Handle<()>), Error<F>> {
+    async fn finalize(
+        self,
+        batch: Self::Merkleized,
+    ) -> Result<(Self, Self::Snapshot, Handle<()>), Error<F>> {
         let (db, _) = self.apply_batch(batch.inner)?;
-        db.start_sync().await
+        let (db, handle) = db.start_sync().await?;
+        let snapshot = Self::snapshot(&db);
+        Ok((db, snapshot, handle))
+    }
+
+    async fn snapshot(self) -> Result<(Self, Self::Snapshot), Error<F>> {
+        let snapshot = Self::snapshot(&self);
+        Ok((self, snapshot))
     }
 
     async fn prune(self, target: &Self::SyncTarget) -> Result<Self, Error<F>> {
@@ -575,9 +598,10 @@ mod tests {
 
             {
                 let (slot, database) = db.write().await;
-                let (database, sync) = <FixedDb as ManagedDb<_>>::finalize(database, merkleized)
-                    .await
-                    .unwrap();
+                let (database, _snapshot, sync) =
+                    <FixedDb as ManagedDb<_>>::finalize(database, merkleized)
+                        .await
+                        .unwrap();
                 slot.put(database);
                 sync.await.expect("finalize flush failed");
             }

--- a/glue/src/stateful/db/immutable/compact.rs
+++ b/glue/src/stateful/db/immutable/compact.rs
@@ -45,7 +45,7 @@ where
     batch: CompactUnmerkleizedBatch<F, H, K, V, S>,
     db: Shared<CompactDb<F, E, K, V, H, C, S>>,
     metadata: Option<V::Value>,
-    inactivity_floor: Option<Location<F>>,
+    inactivity_floor: Location<F>,
 }
 
 impl<F, E, K, V, H, S, C> Deref for ImmutableUnjournaledUnmerkleized<F, E, K, V, H, S, C>
@@ -87,7 +87,7 @@ where
 
     /// Set the inactivity floor included in the next merkleization.
     pub const fn with_inactivity_floor(mut self, floor: Location<F>) -> Self {
-        self.inactivity_floor = Some(floor);
+        self.inactivity_floor = floor;
         self
     }
 
@@ -174,11 +174,7 @@ where
         let db = self.db.read().await;
         let merkleized = self
             .batch
-            .merkleize(
-                &db,
-                self.metadata,
-                self.inactivity_floor.unwrap_or_default(),
-            )
+            .merkleize(&db, self.metadata, self.inactivity_floor)
             .await;
         Ok(ImmutableUnjournaledMerkleized {
             inner: merkleized,
@@ -211,7 +207,7 @@ where
             batch: self.inner.new_batch::<H>(),
             db: self.db.clone(),
             metadata: None,
-            inactivity_floor: None,
+            inactivity_floor: self.inner.bounds().inactivity_floor,
         }
     }
 }
@@ -249,7 +245,7 @@ where
             batch: database.new_batch(),
             db: shared,
             metadata: None,
-            inactivity_floor: None,
+            inactivity_floor: database.inactivity_floor_loc(),
         }
     }
 
@@ -316,7 +312,7 @@ where
             batch: database.new_batch(),
             db: shared,
             metadata: None,
-            inactivity_floor: None,
+            inactivity_floor: database.inactivity_floor_loc(),
         }
     }
 

--- a/glue/src/stateful/db/immutable/standard.rs
+++ b/glue/src/stateful/db/immutable/standard.rs
@@ -6,8 +6,8 @@
 //! so the batch API can read through to applied state.
 
 use crate::stateful::db::{
-    BatchContext, ManagedDb, Merkleized as MerkleizedTrait, Shared, StateSyncDb, SyncEngineConfig,
-    Unmerkleized as UnmerkleizedTrait, sync_standard_db,
+    BatchContext, LogSnapshot, ManagedDb, Merkleized as MerkleizedTrait, Shared, StateSyncDb,
+    SyncEngineConfig, Unmerkleized as UnmerkleizedTrait, sync_standard_db,
 };
 use commonware_codec::{Codec, EncodeShared, Read as CodecRead};
 use commonware_cryptography::Hasher;
@@ -297,6 +297,7 @@ where
     type Error = Error<F>;
     type Config = fixed::Config<T, S>;
     type SyncTarget = AnySyncTarget<F, H::Digest>;
+    type Snapshot = LogSnapshot<F, E, FixedJournal<E, fixed::Operation<F, K, V>>, H>;
 
     async fn init(context: E, config: Self::Config) -> Result<Self, Error<F>> {
         <Self>::init(context, config).await
@@ -325,9 +326,19 @@ where
             && *target.range.end() == batch.bounds().tip.size
     }
 
-    async fn finalize(self, batch: Self::Merkleized) -> Result<(Self, Handle<()>), Error<F>> {
+    async fn finalize(
+        self,
+        batch: Self::Merkleized,
+    ) -> Result<(Self, Self::Snapshot, Handle<()>), Error<F>> {
         let (db, _) = self.apply_batch(batch.inner).await?;
-        db.start_sync().await
+        let (db, handle) = db.start_sync().await?;
+        let (db, snapshot) = db.snapshot().await?;
+        Ok((db, Arc::new(snapshot), handle))
+    }
+
+    async fn snapshot(self) -> Result<(Self, Self::Snapshot), Error<F>> {
+        let (db, snapshot) = self.snapshot().await?;
+        Ok((db, Arc::new(snapshot)))
     }
 
     async fn prune(self, target: &Self::SyncTarget) -> Result<Self, Error<F>> {
@@ -389,6 +400,7 @@ where
     type Error = Error<F>;
     type Config = variable::Config<T, <variable::Operation<F, K, V> as CodecRead>::Cfg, S>;
     type SyncTarget = AnySyncTarget<F, H::Digest>;
+    type Snapshot = LogSnapshot<F, E, VariableJournal<E, variable::Operation<F, K, V>>, H>;
 
     async fn init(context: E, config: Self::Config) -> Result<Self, Error<F>> {
         <Self>::init(context, config).await
@@ -417,9 +429,19 @@ where
             && *target.range.end() == batch.bounds().tip.size
     }
 
-    async fn finalize(self, batch: Self::Merkleized) -> Result<(Self, Handle<()>), Error<F>> {
+    async fn finalize(
+        self,
+        batch: Self::Merkleized,
+    ) -> Result<(Self, Self::Snapshot, Handle<()>), Error<F>> {
         let (db, _) = self.apply_batch(batch.inner).await?;
-        db.start_sync().await
+        let (db, handle) = db.start_sync().await?;
+        let (db, snapshot) = db.snapshot().await?;
+        Ok((db, Arc::new(snapshot), handle))
+    }
+
+    async fn snapshot(self) -> Result<(Self, Self::Snapshot), Error<F>> {
+        let (db, snapshot) = self.snapshot().await?;
+        Ok((db, Arc::new(snapshot)))
     }
 
     async fn prune(self, target: &Self::SyncTarget) -> Result<Self, Error<F>> {

--- a/glue/src/stateful/db/immutable/standard.rs
+++ b/glue/src/stateful/db/immutable/standard.rs
@@ -55,7 +55,7 @@ where
     batch: UnmerkleizedBatch<F, H, K, V, S>,
     db: ImmutableDbHandle<F, E, K, V, C, H, T, S>,
     metadata: Option<V::Value>,
-    inactivity_floor: Option<Location<F>>,
+    inactivity_floor: Location<F>,
 }
 
 impl<F, E, K, V, C, H, T, S> Deref for ImmutableUnmerkleized<F, E, K, V, C, H, T, S>
@@ -97,10 +97,8 @@ where
     }
 
     /// Set the inactivity floor to include within the next [`merkleize`](UnmerkleizedTrait::merkleize) call.
-    ///
-    /// If unset, [`merkleize`](UnmerkleizedTrait::merkleize) will use the [`Default`] of [`Location`].
     pub const fn with_inactivity_floor(mut self, floor: Location<F>) -> Self {
-        self.inactivity_floor = Some(floor);
+        self.inactivity_floor = floor;
         self
     }
 
@@ -228,11 +226,7 @@ where
         let db = self.db.read().await;
         let merkleized = self
             .batch
-            .merkleize(
-                &db,
-                self.metadata,
-                self.inactivity_floor.unwrap_or_default(),
-            )
+            .merkleize(&db, self.metadata, self.inactivity_floor)
             .await;
         Ok(ImmutableMerkleized {
             inner: merkleized,
@@ -265,7 +259,7 @@ where
             batch: self.inner.new_batch::<H>(),
             db: self.db.clone(),
             metadata: None,
-            inactivity_floor: None,
+            inactivity_floor: self.inner.bounds().inactivity_floor,
         }
     }
 }
@@ -321,7 +315,7 @@ where
             batch: database.new_batch(),
             db: shared,
             metadata: None,
-            inactivity_floor: None,
+            inactivity_floor: database.inactivity_floor_loc(),
         }
     }
 
@@ -413,7 +407,7 @@ where
             batch: database.new_batch(),
             db: shared,
             metadata: None,
-            inactivity_floor: None,
+            inactivity_floor: database.inactivity_floor_loc(),
         }
     }
 

--- a/glue/src/stateful/db/keyless/compact.rs
+++ b/glue/src/stateful/db/keyless/compact.rs
@@ -43,7 +43,7 @@ where
     batch: CompactUnmerkleizedBatch<F, H, V, S>,
     db: Shared<CompactDb<F, E, V, H, C, S>>,
     metadata: Option<V::Value>,
-    inactivity_floor: Option<Location<F>>,
+    inactivity_floor: Location<F>,
 }
 
 impl<F, E, V, H, S, C> Deref for KeylessUnjournaledUnmerkleized<F, E, V, H, S, C>
@@ -83,7 +83,7 @@ where
 
     /// Set the inactivity floor included in the next merkleization.
     pub const fn with_inactivity_floor(mut self, floor: Location<F>) -> Self {
-        self.inactivity_floor = Some(floor);
+        self.inactivity_floor = floor;
         self
     }
 
@@ -165,11 +165,7 @@ where
         let db = self.db.read().await;
         let merkleized = self
             .batch
-            .merkleize(
-                &db,
-                self.metadata,
-                self.inactivity_floor.unwrap_or_default(),
-            )
+            .merkleize(&db, self.metadata, self.inactivity_floor)
             .await;
         Ok(KeylessUnjournaledMerkleized {
             inner: merkleized,
@@ -201,7 +197,7 @@ where
             batch: self.inner.new_batch::<H>(),
             db: self.db.clone(),
             metadata: None,
-            inactivity_floor: None,
+            inactivity_floor: self.inner.bounds().inactivity_floor,
         }
     }
 }
@@ -238,7 +234,7 @@ where
             batch: database.new_batch(),
             db: shared,
             metadata: None,
-            inactivity_floor: None,
+            inactivity_floor: database.inactivity_floor_loc(),
         }
     }
 
@@ -304,7 +300,7 @@ where
             batch: database.new_batch(),
             db: shared,
             metadata: None,
-            inactivity_floor: None,
+            inactivity_floor: database.inactivity_floor_loc(),
         }
     }
 

--- a/glue/src/stateful/db/keyless/compact.rs
+++ b/glue/src/stateful/db/keyless/compact.rs
@@ -18,6 +18,7 @@ use commonware_storage::{
     qmdb::{
         Error,
         any::value::{FixedEncoding, FixedValue, ValueEncoding, VariableEncoding, VariableValue},
+        compact,
         keyless::{
             CompactDb, CompactMerkleizedBatch, CompactUnmerkleizedBatch, Operation, fixed,
             initial_root, variable,
@@ -216,6 +217,7 @@ where
     type Error = Error<F>;
     type Config = fixed::CompactConfig<S>;
     type SyncTarget = sync::CompactTarget<F, H::Digest>;
+    type Snapshot = compact::Snapshot<F, Operation<F, FixedEncoding<V>>, H::Digest>;
 
     async fn init(context: E, config: Self::Config) -> Result<Self, Error<F>> {
         <Self>::init(context, config).await
@@ -242,9 +244,19 @@ where
         batch.root() == target.root && target.size == batch.bounds().tip.size
     }
 
-    async fn finalize(self, batch: Self::Merkleized) -> Result<(Self, Handle<()>), Error<F>> {
+    async fn finalize(
+        self,
+        batch: Self::Merkleized,
+    ) -> Result<(Self, Self::Snapshot, Handle<()>), Error<F>> {
         let (db, _) = self.apply_batch(batch.inner)?;
-        db.start_sync().await
+        let (db, handle) = db.start_sync().await?;
+        let snapshot = Self::snapshot(&db);
+        Ok((db, snapshot, handle))
+    }
+
+    async fn snapshot(self) -> Result<(Self, Self::Snapshot), Error<F>> {
+        let snapshot = Self::snapshot(&self);
+        Ok((self, snapshot))
     }
 
     async fn prune(self, target: &Self::SyncTarget) -> Result<Self, Error<F>> {
@@ -282,6 +294,7 @@ where
     type Error = Error<F>;
     type Config = variable::CompactConfig<C, S>;
     type SyncTarget = sync::CompactTarget<F, H::Digest>;
+    type Snapshot = compact::Snapshot<F, Operation<F, VariableEncoding<V>>, H::Digest>;
 
     async fn init(context: E, config: Self::Config) -> Result<Self, Error<F>> {
         <Self>::init(context, config).await
@@ -308,9 +321,19 @@ where
         batch.root() == target.root && target.size == batch.bounds().tip.size
     }
 
-    async fn finalize(self, batch: Self::Merkleized) -> Result<(Self, Handle<()>), Error<F>> {
+    async fn finalize(
+        self,
+        batch: Self::Merkleized,
+    ) -> Result<(Self, Self::Snapshot, Handle<()>), Error<F>> {
         let (db, _) = self.apply_batch(batch.inner)?;
-        db.start_sync().await
+        let (db, handle) = db.start_sync().await?;
+        let snapshot = Self::snapshot(&db);
+        Ok((db, snapshot, handle))
+    }
+
+    async fn snapshot(self) -> Result<(Self, Self::Snapshot), Error<F>> {
+        let snapshot = Self::snapshot(&self);
+        Ok((self, snapshot))
     }
 
     async fn prune(self, target: &Self::SyncTarget) -> Result<Self, Error<F>> {
@@ -566,9 +589,10 @@ mod tests {
 
             {
                 let (slot, database) = db.write().await;
-                let (database, sync) = <FixedDb as ManagedDb<_>>::finalize(database, merkleized)
-                    .await
-                    .unwrap();
+                let (database, _snapshot, sync) =
+                    <FixedDb as ManagedDb<_>>::finalize(database, merkleized)
+                        .await
+                        .unwrap();
                 slot.put(database);
                 sync.await.expect("finalize flush failed");
             }

--- a/glue/src/stateful/db/keyless/standard.rs
+++ b/glue/src/stateful/db/keyless/standard.rs
@@ -7,8 +7,8 @@
 //! can read through to applied state.
 
 use crate::stateful::db::{
-    BatchContext, ManagedDb, Merkleized as MerkleizedTrait, Shared, StateSyncDb, SyncEngineConfig,
-    Unmerkleized as UnmerkleizedTrait, sync_standard_db,
+    BatchContext, LogSnapshot, ManagedDb, Merkleized as MerkleizedTrait, Shared, StateSyncDb,
+    SyncEngineConfig, Unmerkleized as UnmerkleizedTrait, sync_standard_db,
 };
 use commonware_codec::{EncodeShared, Read as CodecRead};
 use commonware_cryptography::Hasher;
@@ -265,6 +265,7 @@ where
     type Error = Error<F>;
     type Config = fixed::Config<S>;
     type SyncTarget = AnySyncTarget<F, H::Digest>;
+    type Snapshot = LogSnapshot<F, E, FixedJournal<E, fixed::Operation<F, V>>, H>;
 
     async fn init(context: E, config: Self::Config) -> Result<Self, Error<F>> {
         <Self>::init(context, config).await
@@ -293,9 +294,19 @@ where
             && *target.range.end() == batch.bounds().tip.size
     }
 
-    async fn finalize(self, batch: Self::Merkleized) -> Result<(Self, Handle<()>), Error<F>> {
+    async fn finalize(
+        self,
+        batch: Self::Merkleized,
+    ) -> Result<(Self, Self::Snapshot, Handle<()>), Error<F>> {
         let (db, _) = self.apply_batch(batch.inner).await?;
-        db.start_sync().await
+        let (db, handle) = db.start_sync().await?;
+        let (db, snapshot) = db.snapshot().await?;
+        Ok((db, Arc::new(snapshot), handle))
+    }
+
+    async fn snapshot(self) -> Result<(Self, Self::Snapshot), Error<F>> {
+        let (db, snapshot) = self.snapshot().await?;
+        Ok((db, Arc::new(snapshot)))
     }
 
     async fn prune(self, target: &Self::SyncTarget) -> Result<Self, Error<F>> {
@@ -350,6 +361,7 @@ where
     type Error = Error<F>;
     type Config = variable::Config<<variable::Operation<F, V> as CodecRead>::Cfg, S>;
     type SyncTarget = AnySyncTarget<F, H::Digest>;
+    type Snapshot = LogSnapshot<F, E, VariableJournal<E, variable::Operation<F, V>>, H>;
 
     async fn init(context: E, config: Self::Config) -> Result<Self, Error<F>> {
         <Self>::init(context, config).await
@@ -378,9 +390,19 @@ where
             && *target.range.end() == batch.bounds().tip.size
     }
 
-    async fn finalize(self, batch: Self::Merkleized) -> Result<(Self, Handle<()>), Error<F>> {
+    async fn finalize(
+        self,
+        batch: Self::Merkleized,
+    ) -> Result<(Self, Self::Snapshot, Handle<()>), Error<F>> {
         let (db, _) = self.apply_batch(batch.inner).await?;
-        db.start_sync().await
+        let (db, handle) = db.start_sync().await?;
+        let (db, snapshot) = db.snapshot().await?;
+        Ok((db, Arc::new(snapshot), handle))
+    }
+
+    async fn snapshot(self) -> Result<(Self, Self::Snapshot), Error<F>> {
+        let (db, snapshot) = self.snapshot().await?;
+        Ok((db, Arc::new(snapshot)))
     }
 
     async fn prune(self, target: &Self::SyncTarget) -> Result<Self, Error<F>> {
@@ -555,9 +577,10 @@ mod tests {
 
             {
                 let (slot, database) = db.write().await;
-                let (database, sync) = <FixedDb as ManagedDb<_>>::finalize(database, merkleized)
-                    .await
-                    .unwrap();
+                let (database, _snapshot, sync) =
+                    <FixedDb as ManagedDb<_>>::finalize(database, merkleized)
+                        .await
+                        .unwrap();
                 slot.put(database);
                 sync.await.expect("finalize flush failed");
             }
@@ -647,9 +670,10 @@ mod tests {
                 .unwrap();
             {
                 let (slot, database) = db.write().await;
-                let (database, sync) = <FixedDb as ManagedDb<_>>::finalize(database, merkleized)
-                    .await
-                    .unwrap();
+                let (database, _snapshot, sync) =
+                    <FixedDb as ManagedDb<_>>::finalize(database, merkleized)
+                        .await
+                        .unwrap();
                 slot.put(database);
                 sync.await.expect("finalize flush failed");
             }
@@ -663,9 +687,10 @@ mod tests {
             let fork = MerkleizedTrait::new_batch(&merkleized);
             {
                 let (slot, database) = db.write().await;
-                let (database, sync) = <FixedDb as ManagedDb<_>>::finalize(database, merkleized)
-                    .await
-                    .unwrap();
+                let (database, _snapshot, sync) =
+                    <FixedDb as ManagedDb<_>>::finalize(database, merkleized)
+                        .await
+                        .unwrap();
                 slot.put(database);
                 sync.await.expect("finalize flush failed");
             }
@@ -679,9 +704,10 @@ mod tests {
                 .unwrap();
             {
                 let (slot, database) = db.write().await;
-                let (database, sync) = <FixedDb as ManagedDb<_>>::finalize(database, merkleized)
-                    .await
-                    .unwrap();
+                let (database, _snapshot, sync) =
+                    <FixedDb as ManagedDb<_>>::finalize(database, merkleized)
+                        .await
+                        .unwrap();
                 slot.put(database);
                 sync.await.expect("finalize flush failed");
             }

--- a/glue/src/stateful/db/keyless/standard.rs
+++ b/glue/src/stateful/db/keyless/standard.rs
@@ -49,7 +49,7 @@ where
     batch: UnmerkleizedBatch<F, H, V, S>,
     db: Shared<Keyless<F, E, V, C, H, S>>,
     metadata: Option<V::Value>,
-    inactivity_floor: Option<Location<F>>,
+    inactivity_floor: Location<F>,
 }
 
 impl<F, E, V, C, H, S> Deref for KeylessUnmerkleized<F, E, V, C, H, S>
@@ -87,10 +87,8 @@ where
     }
 
     /// Set the inactivity floor to include within the next [`merkleize`](UnmerkleizedTrait::merkleize) call.
-    ///
-    /// If unset, [`merkleize`](UnmerkleizedTrait::merkleize) will use the [`Default`] of [`Location`].
     pub const fn with_inactivity_floor(mut self, floor: Location<F>) -> Self {
-        self.inactivity_floor = Some(floor);
+        self.inactivity_floor = floor;
         self
     }
 
@@ -216,11 +214,7 @@ where
         let db = self.db.read().await;
         let merkleized = self
             .batch
-            .merkleize(
-                &db,
-                self.metadata,
-                self.inactivity_floor.unwrap_or_default(),
-            )
+            .merkleize(&db, self.metadata, self.inactivity_floor)
             .await;
         Ok(KeylessMerkleized {
             inner: merkleized,
@@ -251,7 +245,7 @@ where
             batch: self.inner.new_batch::<H>(),
             db: self.db.clone(),
             metadata: None,
-            inactivity_floor: None,
+            inactivity_floor: self.inner.bounds().inactivity_floor,
         }
     }
 }
@@ -289,7 +283,7 @@ where
             batch: database.new_batch(),
             db: shared,
             metadata: None,
-            inactivity_floor: None,
+            inactivity_floor: database.inactivity_floor_loc(),
         }
     }
 
@@ -374,7 +368,7 @@ where
             batch: database.new_batch(),
             db: shared,
             metadata: None,
-            inactivity_floor: None,
+            inactivity_floor: database.inactivity_floor_loc(),
         }
     }
 
@@ -631,6 +625,68 @@ mod tests {
                 &merkleized,
                 &wrong_end,
             ));
+        });
+    }
+
+    /// A batch that does not set the floor must carry the parent's floor forward,
+    /// not regress it to zero.
+    #[test]
+    fn unset_floor_carries_forward_across_commits() {
+        deterministic::Runner::default().start(|context| async move {
+            let config = fixed_config("stateful-keyless-floor-carry", &context);
+            let db = FixedDb::init(context.child("db"), config).await.unwrap();
+            let db = Shared::new("test", db);
+
+            let batch = db
+                .new_batch_for_test::<_>()
+                .await
+                .append(U64::new(7))
+                .with_inactivity_floor(mmr::Location::new(1));
+            let merkleized = crate::stateful::db::Unmerkleized::merkleize(batch)
+                .await
+                .unwrap();
+            {
+                let (slot, database) = db.write().await;
+                let (database, sync) = <FixedDb as ManagedDb<_>>::finalize(database, merkleized)
+                    .await
+                    .unwrap();
+                slot.put(database);
+                sync.await.expect("finalize flush failed");
+            }
+
+            // A fresh batch without an explicit floor must commit at the raised
+            // floor instead of regressing it to zero.
+            let batch = db.new_batch_for_test::<_>().await.append(U64::new(8));
+            let merkleized = crate::stateful::db::Unmerkleized::merkleize(batch)
+                .await
+                .unwrap();
+            let fork = MerkleizedTrait::new_batch(&merkleized);
+            {
+                let (slot, database) = db.write().await;
+                let (database, sync) = <FixedDb as ManagedDb<_>>::finalize(database, merkleized)
+                    .await
+                    .unwrap();
+                slot.put(database);
+                sync.await.expect("finalize flush failed");
+            }
+            let target = <FixedDb as ManagedDb<_>>::sync_target(&*db.read().await);
+            assert_eq!(target.range.start(), mmr::Location::new(1));
+
+            // The same holds for a batch forked from a merkleized parent.
+            let fork = fork.append(U64::new(9));
+            let merkleized = crate::stateful::db::Unmerkleized::merkleize(fork)
+                .await
+                .unwrap();
+            {
+                let (slot, database) = db.write().await;
+                let (database, sync) = <FixedDb as ManagedDb<_>>::finalize(database, merkleized)
+                    .await
+                    .unwrap();
+                slot.put(database);
+                sync.await.expect("finalize flush failed");
+            }
+            let target = <FixedDb as ManagedDb<_>>::sync_target(&*db.read().await);
+            assert_eq!(target.range.start(), mmr::Location::new(1));
         });
     }
 }

--- a/glue/src/stateful/db/mod.rs
+++ b/glue/src/stateful/db/mod.rs
@@ -82,7 +82,10 @@ use commonware_consensus::{
 use commonware_cryptography::Digest;
 use commonware_macros::select;
 use commonware_runtime::{Error as RuntimeError, Handle, Metrics, Spawner, reschedule};
-use commonware_storage::qmdb::sync::{self, FeedbackTx, Request, Response, Source};
+use commonware_storage::{
+    journal::{authenticated, contiguous::Snapshottable},
+    qmdb::sync::{self, FeedbackTx, Request, Response, Source},
+};
 use commonware_utils::{
     channel::{fallible::AsyncFallibleExt, mpsc, oneshot, ring},
     sync::{AsyncRwLockReadGuard, AsyncRwLockWriteGuard, TracedAsyncRwLock},
@@ -363,6 +366,9 @@ pub trait ManagedDb<E>: Send + Sync + Sized {
     /// Typically a database-specific state commitment plus the operation range needed to reach it.
     type SyncTarget: Clone + PartialEq + Send + Sync;
 
+    /// Owned immutable snapshot of applied state.
+    type Snapshot: Clone + Send + Sync + 'static;
+
     /// Construct a new database from its configuration.
     fn init(
         context: E,
@@ -385,18 +391,26 @@ pub trait ManagedDb<E>: Send + Sync + Sized {
     /// Return true if a merkleized batch matches a sync target.
     fn matches_sync_target(batch: &Self::Merkleized, target: &Self::SyncTarget) -> bool;
 
-    /// Apply a merkleized batch's changeset to the underlying database and
-    /// begin persisting it.
+    /// Apply a merkleized batch's changeset to the underlying database, capture a snapshot
+    /// of the applied state, and begin persisting it.
     ///
-    /// In QMDB, this encapsulates calling `merkleized.finalize()` to produce
-    /// a `Changeset`, then `db.apply_batch(changeset)` and `db.start_sync()`.
-    /// The returned database reflects the batch immediately. The returned
-    /// handle resolves once the batch is durable, and failures of the deferred
-    /// flush surface only there, so the caller must observe every handle.
+    /// The returned database reflects the batch immediately, while the flush may still
+    /// be running. The returned handle resolves once the batch is durable. Flush
+    /// failures surface only through the handle, so callers must await every handle and
+    /// must not serve the snapshot before its handle resolves successfully. When the
+    /// handle resolves with an error, the snapshot may prove earlier state than the
+    /// returned database, and neither may be used further. Databases
+    /// without deferred persistence flush before returning and yield a ready handle.
     fn finalize(
         self,
         batch: Self::Merkleized,
-    ) -> impl Future<Output = Result<(Self, Handle<()>), Self::Error>> + Send;
+    ) -> impl Future<Output = Result<(Self, Self::Snapshot, Handle<()>), Self::Error>> + Send;
+
+    /// Capture a snapshot of the current applied state.
+    ///
+    /// The snapshot reflects every batch applied before this call and nothing
+    /// applied after it, including state that may not yet be durably persisted.
+    fn snapshot(self) -> impl Future<Output = Result<(Self, Self::Snapshot), Self::Error>> + Send;
 
     /// Prune the database to a previously finalized sync target.
     ///
@@ -522,6 +536,9 @@ pub trait DatabaseSet<E>: Clone + Send + Sync + 'static {
     /// rewind database batches.
     type Readers: Send;
 
+    /// One [`ManagedDb::Snapshot`] per database, shaped like [`Self::Unmerkleized`].
+    type Snapshots: Send + Sync + 'static;
+
     /// Configuration needed to construct every database in the set.
     ///
     /// - Single database sets use that database's [`ManagedDb::Config`].
@@ -558,15 +575,27 @@ pub trait DatabaseSet<E>: Clone + Send + Sync + 'static {
     /// Return read-only handles for every database in the set.
     fn readers(&self) -> Self::Readers;
 
-    /// Apply each merkleized batch's changeset and begin persisting it.
+    /// Apply each merkleized batch's changeset to its underlying database, capture each
+    /// database's snapshot, and begin persisting them.
     ///
-    /// Returns once every database reflects its batch. The returned
-    /// [`Barrier`] resolves once every deferred flush completes and must be
-    /// observed.
+    /// Returns once every database reflects its batch. The captured set snapshot must
+    /// not be served before the returned [`Barrier`] proves it durable, and every
+    /// barrier must be awaited (see [`Barrier`]).
     ///
     /// Cancelling the future mid-flight loses the databases whose mutations
     /// were in progress (see [Shared]); every later access panics.
-    fn finalize(&self, batches: Self::Merkleized) -> impl Future<Output = Barrier> + Send;
+    fn finalize(
+        &self,
+        batches: Self::Merkleized,
+    ) -> impl Future<Output = (Self::Snapshots, Barrier)> + Send;
+
+    /// Capture a snapshot of every database's current applied state.
+    ///
+    /// A snapshot can include state that is not yet durably persisted.
+    ///
+    /// Cancelling the future mid-flight loses the databases whose mutations
+    /// were in progress (see [Shared]); every later access panics.
+    fn snapshot(&self) -> impl Future<Output = Self::Snapshots> + Send;
 
     /// Prune each database to the provided per-database targets.
     ///
@@ -589,6 +618,17 @@ pub trait DatabaseSet<E>: Clone + Send + Sync + 'static {
     /// were in progress (see [Shared]); every later access panics.
     fn rewind_to_targets(&self, targets: Self::SyncTargets) -> impl Future<Output = ()> + Send;
 }
+
+/// The snapshot a log-backed QMDB database produces, shared for serving.
+///
+/// `C` is the database's operations log. Every full QMDB variant returns this
+/// shape from [`ManagedDb::snapshot`]; naming it here keeps the projection out
+/// of each variant's associated-type definition.
+pub type LogSnapshot<F, E, C, H> =
+    Arc<authenticated::Snapshot<F, E, <C as Snapshottable>::Reader, H>>;
+
+/// Syntactic sugar for the type of published snapshot used by a given [DatabaseSet] D.
+pub type SnapshotsOf<D, E> = <D as DatabaseSet<E>>::Snapshots;
 
 /// Parameters for a one-time state-sync pass.
 #[derive(Clone, Copy, Debug)]
@@ -729,6 +769,7 @@ impl<E: Send + Sync, T: ManagedDb<E> + 'static> DatabaseSet<E> for Shared<T> {
     type Unmerkleized = T::Unmerkleized;
     type Merkleized = T::Merkleized;
     type Readers = Reader<T>;
+    type Snapshots = T::Snapshot;
     type Config = T::Config;
     type SyncTargets = T::SyncTarget;
 
@@ -760,11 +801,18 @@ impl<E: Send + Sync, T: ManagedDb<E> + 'static> DatabaseSet<E> for Shared<T> {
         Reader(self.clone())
     }
 
-    async fn finalize(&self, batches: Self::Merkleized) -> Barrier {
-        let handle = finalize_shared_or_panic::<E, T>(self, batches, None).await;
-        Barrier {
-            syncs: vec![(core::any::type_name::<T>(), None, handle)],
-        }
+    async fn finalize(&self, batches: Self::Merkleized) -> (Self::Snapshots, Barrier) {
+        let (snapshot, handle) = finalize_shared_or_panic::<E, T>(self, batches, None).await;
+        (
+            snapshot,
+            Barrier {
+                syncs: vec![(core::any::type_name::<T>(), None, handle)],
+            },
+        )
+    }
+
+    async fn snapshot(&self) -> Self::Snapshots {
+        snapshot_shared_or_panic::<E, T>(self, None).await
     }
 
     async fn prune(&self, target: &Self::SyncTargets) {
@@ -952,6 +1000,7 @@ macro_rules! impl_database_set {
             type Unmerkleized = ($($T::Unmerkleized,)+);
             type Merkleized = ($($T::Merkleized,)+);
             type Readers = ($(Reader<$T>,)+);
+            type Snapshots = ($($T::Snapshot,)+);
             type Config = ($($T::Config,)+);
             type SyncTargets = ($($T::SyncTarget,)+);
 
@@ -1000,21 +1049,30 @@ macro_rules! impl_database_set {
             async fn finalize(
                 &self,
                 batches: Self::Merkleized,
-            ) -> Barrier {
+            ) -> (Self::Snapshots, Barrier) {
                 // Each member completes its own write-lock lifecycle. Holding
                 // a partial tuple of writers can deadlock cross-database reads.
-                let handles = join!($(finalize_shared_or_panic::<E, $T>(
+                let results = join!($(finalize_shared_or_panic::<E, $T>(
                     &self.$idx,
                     batches.$idx,
                     Some($idx),
                 ),)+);
-                Barrier {
+                let snapshots = ($(results.$idx.0,)+);
+                let barrier = Barrier {
                     syncs: vec![$((
                         core::any::type_name::<$T>(),
                         Some($idx),
-                        handles.$idx,
+                        results.$idx.1,
                     ),)+],
-                }
+                };
+                (snapshots, barrier)
+            }
+
+            async fn snapshot(&self) -> Self::Snapshots {
+                join!($(snapshot_shared_or_panic::<E, $T>(
+                    &self.$idx,
+                    Some($idx),
+                ),)+)
             }
 
             async fn prune(
@@ -1786,7 +1844,7 @@ async fn finalize_or_panic<E, T: ManagedDb<E>>(
     database: T,
     batch: T::Merkleized,
     index: Option<usize>,
-) -> (T, Handle<()>) {
+) -> (T, T::Snapshot, Handle<()>) {
     // Mutable finalize failures are fatal by design because the batch may already have been
     // applied to other databases in the same set, leaving partially applied state.
     match database.finalize(batch).await {
@@ -1805,11 +1863,33 @@ async fn finalize_shared_or_panic<E, T: ManagedDb<E>>(
     shared: &Shared<T>,
     batch: T::Merkleized,
     index: Option<usize>,
-) -> Handle<()> {
+) -> (T::Snapshot, Handle<()>) {
     let (slot, database) = shared.write().await;
-    let (database, handle) = finalize_or_panic(database, batch, index).await;
+    let (database, snapshot, handle) = finalize_or_panic(database, batch, index).await;
     slot.put(database);
-    handle
+    (snapshot, handle)
+}
+
+#[tracing::instrument(name = "stateful.db.snapshot_or_panic", level = "info", skip_all, fields(index = index))]
+async fn snapshot_shared_or_panic<E, T: ManagedDb<E>>(
+    shared: &Shared<T>,
+    index: Option<usize>,
+) -> T::Snapshot {
+    let (slot, database) = shared.write().await;
+    // Capture failures are fatal by design: a set that cannot snapshot its applied
+    // state cannot publish, and other members may already have captured.
+    let (database, snapshot) = match database.snapshot().await {
+        Ok(result) => result,
+        Err(err) => {
+            let index = index.map_or(String::new(), |i| format!("index {i}, "));
+            panic!(
+                "database snapshot capture failed ({index}type {}): {err:?}",
+                core::any::type_name::<T>(),
+            );
+        }
+    };
+    slot.put(database);
+    snapshot
 }
 
 async fn prune_shared_or_panic<E, T: ManagedDb<E>>(
@@ -1874,87 +1954,12 @@ async fn prune_or_panic<E, T: ManagedDb<E>>(
     }
 }
 
-/// A resolver that can attach a database at runtime.
-///
-/// Implementations receive a database handle after startup so they can
-/// serve incoming sync requests once the database is initialized.
-pub trait AttachableResolver<DB>: Clone + Send + Sync + 'static {
-    /// Attach a database for serving incoming requests.
-    fn attach_database(&self, db: Shared<DB>) -> impl Future<Output = ()> + Send;
-}
-
-/// Attach a database set to a resolver set with matching shape.
-pub trait AttachableResolverSet<DBs>: Clone + Send + Sync + 'static {
-    /// Attach all databases to their corresponding resolvers.
-    fn attach_databases(&self, databases: DBs) -> impl Future<Output = ()> + Send;
-}
-
-impl<R, DB> AttachableResolverSet<Shared<DB>> for R
-where
-    R: AttachableResolver<DB>,
-    DB: Send + Sync + 'static,
-{
-    async fn attach_databases(&self, db: Shared<DB>) {
-        self.attach_database(db).await;
-    }
-}
-
-macro_rules! impl_attachable_resolver_set {
-    ($($R:ident : $DB:ident : $idx:tt),+) => {
-        impl<$($R, $DB),+> AttachableResolverSet<($(Shared<$DB>,)+)> for ($($R,)+)
-        where
-            $(
-                $R: AttachableResolver<$DB>,
-                $DB: Send + Sync + 'static,
-            )+
-        {
-            async fn attach_databases(&self, databases: ($(Shared<$DB>,)+)) {
-                futures::join!($(
-                    self.$idx.attach_database(databases.$idx),
-                )+);
-            }
-        }
-    };
-}
-
-impl_attachable_resolver_set!(R1: DB1: 0, R2: DB2: 1);
-impl_attachable_resolver_set!(R1: DB1: 0, R2: DB2: 1, R3: DB3: 2);
-impl_attachable_resolver_set!(R1: DB1: 0, R2: DB2: 1, R3: DB3: 2, R4: DB4: 3);
-impl_attachable_resolver_set!(R1: DB1: 0, R2: DB2: 1, R3: DB3: 2, R4: DB4: 3, R5: DB5: 4);
-impl_attachable_resolver_set!(
-    R1: DB1: 0,
-    R2: DB2: 1,
-    R3: DB3: 2,
-    R4: DB4: 3,
-    R5: DB5: 4,
-    R6: DB6: 5
-);
-impl_attachable_resolver_set!(
-    R1: DB1: 0,
-    R2: DB2: 1,
-    R3: DB3: 2,
-    R4: DB4: 3,
-    R5: DB5: 4,
-    R6: DB6: 5,
-    R7: DB7: 6
-);
-impl_attachable_resolver_set!(
-    R1: DB1: 0,
-    R2: DB2: 1,
-    R3: DB3: 2,
-    R4: DB4: 3,
-    R5: DB5: 4,
-    R6: DB6: 5,
-    R7: DB7: 6,
-    R8: DB8: 7
-);
-
 #[cfg(test)]
 mod tests {
     use super::{
-        Anchor, AttachableResolver, AttachableResolverSet, Barrier, BatchContext,
-        CoordinatorAction, CoordinatorState, DatabaseSet, MAX_CHANNEL_DRAIN_PER_TICK, ManagedDb,
-        Shared, StateSyncDb, StateSyncSet, SyncEngineConfig, TipUpdate, drain_single_tip_updates,
+        Anchor, Barrier, BatchContext, CoordinatorAction, CoordinatorState, DatabaseSet,
+        MAX_CHANNEL_DRAIN_PER_TICK, ManagedDb, Shared, StateSyncDb, StateSyncSet, SyncEngineConfig,
+        TipUpdate, drain_single_tip_updates,
     };
     use crate::stateful::tests::mocks::{TestMerkleized, TestUnmerkleized, anchor as mock_anchor};
     use commonware_cryptography::sha256;
@@ -2313,7 +2318,7 @@ mod tests {
                 .await
                 .expect("empty batch must merkleize");
             let (slot, database) = db.write().await;
-            let (database, sync) = T::finalize(database, batch).await.unwrap();
+            let (database, _snapshot, sync) = T::finalize(database, batch).await.unwrap();
             slot.put(database);
             sync.await.expect("empty batch finalize flush failed");
         }
@@ -2381,8 +2386,8 @@ mod tests {
             async fn finalize(
                 self,
                 _batch: Self::Merkleized,
-            ) -> Result<(Self, Handle<()>), Self::Error> {
-                Ok((self, Handle::ready(Ok(()))))
+            ) -> Result<(Self, Self::Snapshot, Handle<()>), Self::Error> {
+                Ok((self, (), Handle::ready(Ok(()))))
             }
         };
     }
@@ -2405,6 +2410,11 @@ mod tests {
         type Error = Infallible;
         type Config = ();
         type SyncTarget = ();
+        type Snapshot = ();
+
+        async fn snapshot(self) -> Result<(Self, Self::Snapshot), Self::Error> {
+            Ok((self, ()))
+        }
 
         fn initial_sync_target() -> Self::SyncTarget {}
 
@@ -2435,6 +2445,11 @@ mod tests {
         type Error = Infallible;
         type Config = ();
         type SyncTarget = u64;
+        type Snapshot = ();
+
+        async fn snapshot(self) -> Result<(Self, Self::Snapshot), Self::Error> {
+            Ok((self, ()))
+        }
 
         fn initial_sync_target() -> Self::SyncTarget {
             unreachable!("CountingRewindDb is constructed directly in tests")
@@ -2471,6 +2486,11 @@ mod tests {
         type Error = Infallible;
         type Config = Arc<AtomicUsize>;
         type SyncTarget = ();
+        type Snapshot = ();
+
+        async fn snapshot(self) -> Result<(Self, Self::Snapshot), Self::Error> {
+            Ok((self, ()))
+        }
 
         fn initial_sync_target() -> Self::SyncTarget {}
 
@@ -2576,6 +2596,11 @@ mod tests {
         type Error = TestFinalizeError;
         type Config = ();
         type SyncTarget = ();
+        type Snapshot = ();
+
+        async fn snapshot(self) -> Result<(Self, Self::Snapshot), Self::Error> {
+            Ok((self, ()))
+        }
 
         fn initial_sync_target() -> Self::SyncTarget {}
 
@@ -2594,7 +2619,7 @@ mod tests {
         async fn finalize(
             self,
             _batch: Self::Merkleized,
-        ) -> Result<(Self, Handle<()>), Self::Error> {
+        ) -> Result<(Self, Self::Snapshot, Handle<()>), Self::Error> {
             Err(TestFinalizeError)
         }
 
@@ -2663,6 +2688,11 @@ mod tests {
         type Error = Infallible;
         type Config = ();
         type SyncTarget = ();
+        type Snapshot = ();
+
+        async fn snapshot(self) -> Result<(Self, Self::Snapshot), Self::Error> {
+            Ok((self, ()))
+        }
 
         fn initial_sync_target() -> Self::SyncTarget {}
 
@@ -2681,14 +2711,14 @@ mod tests {
         async fn finalize(
             mut self,
             _batch: Self::Merkleized,
-        ) -> Result<(Self, Handle<()>), Self::Error> {
+        ) -> Result<(Self, Self::Snapshot, Handle<()>), Self::Error> {
             if let Some(started) = self.started.take() {
                 let _ = started.send(());
             }
             if let Some(release) = self.release.take() {
                 let _ = release.await;
             }
-            Ok((self, Handle::ready(Ok(()))))
+            Ok((self, (), Handle::ready(Ok(()))))
         }
 
         fn sync_target(&self) -> Self::SyncTarget {}
@@ -2704,6 +2734,11 @@ mod tests {
         type Error = Infallible;
         type Config = ();
         type SyncTarget = u64;
+        type Snapshot = ();
+
+        async fn snapshot(self) -> Result<(Self, Self::Snapshot), Self::Error> {
+            Ok((self, ()))
+        }
 
         fn initial_sync_target() -> Self::SyncTarget {
             unreachable!("SlowSyncDb is only constructed through state sync in tests")
@@ -2738,6 +2773,11 @@ mod tests {
         type Error = Infallible;
         type Config = ();
         type SyncTarget = u64;
+        type Snapshot = ();
+
+        async fn snapshot(self) -> Result<(Self, Self::Snapshot), Self::Error> {
+            Ok((self, ()))
+        }
 
         fn initial_sync_target() -> Self::SyncTarget {
             unreachable!(
@@ -2776,6 +2816,11 @@ mod tests {
         type Error = Infallible;
         type Config = ();
         type SyncTarget = u64;
+        type Snapshot = ();
+
+        async fn snapshot(self) -> Result<(Self, Self::Snapshot), Self::Error> {
+            Ok((self, ()))
+        }
 
         fn initial_sync_target() -> Self::SyncTarget {
             unreachable!("FastSyncDb is only constructed through state sync in tests")
@@ -2810,6 +2855,11 @@ mod tests {
         type Error = Infallible;
         type Config = ();
         type SyncTarget = u64;
+        type Snapshot = ();
+
+        async fn snapshot(self) -> Result<(Self, Self::Snapshot), Self::Error> {
+            Ok((self, ()))
+        }
 
         fn initial_sync_target() -> Self::SyncTarget {
             unreachable!("FailingStateSyncDb is only constructed through state sync in tests")
@@ -2844,6 +2894,11 @@ mod tests {
         type Error = Infallible;
         type Config = ();
         type SyncTarget = u64;
+        type Snapshot = ();
+
+        async fn snapshot(self) -> Result<(Self, Self::Snapshot), Self::Error> {
+            Ok((self, ()))
+        }
 
         fn initial_sync_target() -> Self::SyncTarget {
             unreachable!("MismatchedTargetSyncDb is only constructed through state sync in tests")
@@ -2878,6 +2933,11 @@ mod tests {
         type Error = Infallible;
         type Config = ();
         type SyncTarget = u64;
+        type Snapshot = ();
+
+        async fn snapshot(self) -> Result<(Self, Self::Snapshot), Self::Error> {
+            Ok((self, ()))
+        }
 
         fn initial_sync_target() -> Self::SyncTarget {
             unreachable!("ImmediateStateSyncDb is only constructed through state sync in tests")
@@ -2912,6 +2972,11 @@ mod tests {
         type Error = Infallible;
         type Config = ();
         type SyncTarget = u64;
+        type Snapshot = ();
+
+        async fn snapshot(self) -> Result<(Self, Self::Snapshot), Self::Error> {
+            Ok((self, ()))
+        }
 
         fn initial_sync_target() -> Self::SyncTarget {
             unreachable!("FinishClosedSyncDb is only constructed through state sync in tests")
@@ -2946,6 +3011,11 @@ mod tests {
         type Error = Infallible;
         type Config = ();
         type SyncTarget = u64;
+        type Snapshot = ();
+
+        async fn snapshot(self) -> Result<(Self, Self::Snapshot), Self::Error> {
+            Ok((self, ()))
+        }
 
         fn initial_sync_target() -> Self::SyncTarget {
             unreachable!("ObservedSlowSyncDb is only constructed through state sync in tests")
@@ -2980,6 +3050,11 @@ mod tests {
         type Error = Infallible;
         type Config = ();
         type SyncTarget = u64;
+        type Snapshot = ();
+
+        async fn snapshot(self) -> Result<(Self, Self::Snapshot), Self::Error> {
+            Ok((self, ()))
+        }
 
         fn initial_sync_target() -> Self::SyncTarget {
             unreachable!("ObservedFastSyncDb is only constructed through state sync in tests")
@@ -3014,6 +3089,11 @@ mod tests {
         type Error = Infallible;
         type Config = ();
         type SyncTarget = u64;
+        type Snapshot = ();
+
+        async fn snapshot(self) -> Result<(Self, Self::Snapshot), Self::Error> {
+            Ok((self, ()))
+        }
 
         fn initial_sync_target() -> Self::SyncTarget {
             unreachable!(
@@ -3161,6 +3241,11 @@ mod tests {
         type Error = Infallible;
         type Config = ();
         type SyncTarget = u64;
+        type Snapshot = ();
+
+        async fn snapshot(self) -> Result<(Self, Self::Snapshot), Self::Error> {
+            Ok((self, ()))
+        }
 
         fn initial_sync_target() -> Self::SyncTarget {
             unreachable!("StaleReachedSyncDb is only constructed through state sync in tests")
@@ -3684,7 +3769,7 @@ mod tests {
             );
 
             drop(reader1);
-            assert!(finalize.await.durable().await);
+            assert!(finalize.await.1.durable().await);
         });
     }
 
@@ -3720,7 +3805,7 @@ mod tests {
 
             let _ = release1_tx.send(());
             let _ = release2_tx.send(());
-            assert!(finalize.await.durable().await);
+            assert!(finalize.await.1.durable().await);
         });
     }
 
@@ -4652,81 +4737,6 @@ mod tests {
                 0,
                 "the unchanged-target database should not receive duplicate target updates",
             );
-        });
-    }
-
-    #[derive(Default)]
-    struct AttachDb1;
-
-    #[derive(Default)]
-    struct AttachDb2;
-
-    #[derive(Clone)]
-    struct RecordingResolver {
-        id: &'static str,
-        log: Arc<commonware_utils::sync::Mutex<Vec<&'static str>>>,
-    }
-
-    impl RecordingResolver {
-        fn new(
-            id: &'static str,
-            log: Arc<commonware_utils::sync::Mutex<Vec<&'static str>>>,
-        ) -> Self {
-            Self { id, log }
-        }
-    }
-
-    impl<DB: Send + Sync + 'static> AttachableResolver<DB> for RecordingResolver {
-        async fn attach_database(&self, _db: Shared<DB>) {
-            self.log.lock().push(self.id);
-        }
-    }
-
-    #[test]
-    fn single_db_attach_calls_single_resolver() {
-        deterministic::Runner::default().start(|_| async move {
-            let log = Arc::new(commonware_utils::sync::Mutex::new(Vec::new()));
-            let resolver = RecordingResolver::new("db1", log.clone());
-            let db = Shared::new("test", AttachDb1);
-
-            resolver.attach_databases(db).await;
-            assert_eq!(&*log.lock(), &["db1"]);
-        });
-    }
-
-    #[test]
-    fn tuple_attach_is_index_stable() {
-        deterministic::Runner::default().start(|_| async move {
-            let log = Arc::new(commonware_utils::sync::Mutex::new(Vec::new()));
-            let resolvers = (
-                RecordingResolver::new("resolver_0", log.clone()),
-                RecordingResolver::new("resolver_1", log.clone()),
-            );
-            let databases = (
-                Shared::new("test", AttachDb1),
-                Shared::new("test", AttachDb2),
-            );
-
-            resolvers.attach_databases(databases).await;
-            assert_eq!(&*log.lock(), &["resolver_0", "resolver_1"]);
-        });
-    }
-
-    #[test]
-    fn heterogeneous_tuple_attach_compiles() {
-        deterministic::Runner::default().start(|_| async move {
-            let log = Arc::new(commonware_utils::sync::Mutex::new(Vec::new()));
-            let resolvers = (
-                RecordingResolver::new("db1", log.clone()),
-                RecordingResolver::new("db2", log.clone()),
-            );
-            let databases = (
-                Shared::new("test", AttachDb1),
-                Shared::new("test", AttachDb2),
-            );
-
-            resolvers.attach_databases(databases).await;
-            assert_eq!(&*log.lock(), &["db1", "db2"]);
         });
     }
 }

--- a/glue/src/stateful/db/p2p/actor.rs
+++ b/glue/src/stateful/db/p2p/actor.rs
@@ -1,7 +1,7 @@
 //! Resolver service actor for QMDB sync over P2P.
 
 use super::{Mailbox, handler, mailbox, metrics::Metrics as ResolverMetrics};
-use crate::stateful::db::Shared;
+use crate::stateful::db::snapshot::Reader;
 use commonware_actor::mailbox as actor_mailbox;
 use commonware_codec::{Codec, Decode, Encode};
 use commonware_cryptography::PublicKey;
@@ -24,17 +24,16 @@ use std::{
     num::{NonZeroU64, NonZeroUsize},
     time::Duration,
 };
-use tracing::{debug, info};
+use tracing::debug;
 
-type Op<DB> = <Shared<DB> as Source>::Op;
-type DatabaseRoot<DB> = <Shared<DB> as Source>::Digest;
-type SyncMailbox<F, DB> = Mailbox<DB, F, Op<DB>, DatabaseRoot<DB>>;
-type SyncMessage<F, DB> = mailbox::Message<DB, F, Op<DB>, DatabaseRoot<DB>>;
-type PendingSubs<F, DB> =
-    BTreeMap<Request<F>, Vec<mailbox::ResponseTx<F, Op<DB>, DatabaseRoot<DB>>>>;
+type Op<M> = <M as Source>::Op;
+type SnapshotRoot<M> = <M as Source>::Digest;
+type SyncMailbox<F, M> = Mailbox<F, Op<M>, SnapshotRoot<M>>;
+type SyncMessage<F, M> = mailbox::Message<F, Op<M>, SnapshotRoot<M>>;
+type PendingSubs<F, M> = BTreeMap<Request<F>, Vec<mailbox::ResponseTx<F, Op<M>, SnapshotRoot<M>>>>;
 
 /// Configuration for [`Actor`].
-pub struct Config<P, D, B, DB>
+pub struct Config<P, D, B>
 where
     P: PublicKey,
     D: Provider<PublicKey = P>,
@@ -45,9 +44,6 @@ where
 
     /// Blocker used when peers send invalid data.
     pub blocker: B,
-
-    /// Local database used to serve incoming requests when available.
-    pub database: Option<Shared<DB>>,
 
     /// Maximum size of resolver mailbox backlogs.
     pub mailbox_size: NonZeroUsize,
@@ -74,14 +70,6 @@ where
     pub priority_responses: bool,
 }
 
-/// Runtime serving state for the resolver actor.
-enum State<DB> {
-    /// Database is not attached yet.
-    NoDb,
-    /// Database is attached and can serve incoming requests.
-    HasDb(Shared<DB>),
-}
-
 /// An action dispatched by incoming mailbox messages.
 enum MailboxAction<F: Family> {
     None,
@@ -90,43 +78,43 @@ enum MailboxAction<F: Family> {
 }
 
 /// Runs a QMDB sync resolver service over `commonware_resolver::p2p::Engine`.
-pub struct Actor<E, P, D, B, F, DB>
+pub struct Actor<E, P, D, B, F, S, M>
 where
     E: BufferPooler + Clock + Spawner + Rng + Metrics,
     P: PublicKey,
     D: Provider<PublicKey = P>,
     B: Blocker<PublicKey = P>,
     F: Family,
-    DB: Send + Sync + 'static,
-    Shared<DB>: Source<Family = F>,
-    Op<DB>: Codec<Cfg = ()> + Send + Clone + 'static,
+    S: Send + Sync + 'static,
+    M: Source<Family = F> + Clone + Send + Sync + 'static,
+    Op<M>: Codec<Cfg = ()> + Send + Clone + 'static,
 {
     context: ContextCell<E>,
-    config: Config<P, D, B, DB>,
-    mailbox_rx: actor_mailbox::Receiver<SyncMessage<F, DB>>,
-    state: State<DB>,
+    config: Config<P, D, B>,
+    mailbox_rx: actor_mailbox::Receiver<SyncMessage<F, M>>,
+    snapshot_reader: Reader<S, M>,
     metrics: ResolverMetrics,
-    pending: PendingSubs<F, DB>,
+    pending: PendingSubs<F, M>,
 }
 
-impl<E, P, D, B, F, DB> Actor<E, P, D, B, F, DB>
+impl<E, P, D, B, F, S, M> Actor<E, P, D, B, F, S, M>
 where
     E: BufferPooler + Clock + Spawner + Rng + Metrics,
     P: PublicKey,
     D: Provider<PublicKey = P>,
     B: Blocker<PublicKey = P>,
     F: Family,
-    DB: Send + Sync + 'static,
-    Shared<DB>: Source<Family = F>,
-    Op<DB>: Codec<Cfg = ()> + Send + Clone + 'static,
+    S: Send + Sync + 'static,
+    M: Source<Family = F> + Clone + Send + Sync + 'static,
+    Op<M>: Codec<Cfg = ()> + Send + Clone + 'static,
 {
-    /// Create a new resolver actor and mailbox.
-    pub fn new(context: E, mut cfg: Config<P, D, B, DB>) -> (Self, SyncMailbox<F, DB>) {
+    /// Create a new resolver actor and mailbox, serving from `reader`.
+    pub fn new(
+        context: E,
+        cfg: Config<P, D, B>,
+        snapshot_reader: Reader<S, M>,
+    ) -> (Self, SyncMailbox<F, M>) {
         let metrics = ResolverMetrics::new(&context);
-        let state = cfg.database.take().map_or(State::NoDb, |db| {
-            let _ = metrics.has_database.try_set(1i64);
-            State::HasDb(db)
-        });
         let (mailbox_tx, mailbox_rx) =
             actor_mailbox::new(context.child("mailbox"), cfg.mailbox_size);
         let mailbox = Mailbox::new(mailbox_tx);
@@ -134,7 +122,7 @@ where
             context: ContextCell::new(context),
             config: cfg,
             mailbox_rx,
-            state,
+            snapshot_reader,
             metrics,
             pending: BTreeMap::new(),
         };
@@ -224,15 +212,8 @@ where
     }
 
     /// Process a mailbox message. Returns a request to fetch if a new key was registered.
-    fn handle_mailbox_message(&mut self, message: SyncMessage<F, DB>) -> MailboxAction<F> {
+    fn handle_mailbox_message(&mut self, message: SyncMessage<F, M>) -> MailboxAction<F> {
         match message {
-            mailbox::Message::AttachDatabase(db) => {
-                let replacing_existing = matches!(self.state, State::HasDb(_));
-                info!(replacing_existing, "attached resolver database");
-                self.state = State::HasDb(db);
-                let _ = self.metrics.has_database.try_set(1i64);
-                MailboxAction::None
-            }
             mailbox::Message::GetOperations { request, response } => {
                 if let Some(subscribers) = self.pending.get_mut(&request) {
                     subscribers.retain(|subscriber| !subscriber.is_closed());
@@ -288,7 +269,7 @@ where
         let _ = self.metrics.pending_requests.try_set(self.pending.len());
 
         let cfg = (key.max_ops().get() as usize, ());
-        let response = match Response::<F, Op<DB>, DatabaseRoot<DB>>::decode_cfg(value, &cfg) {
+        let response = match Response::<F, Op<M>, SnapshotRoot<M>>::decode_cfg(value, &cfg) {
             Ok(response)
                 if matches!(
                     (&key, &response),
@@ -341,23 +322,23 @@ where
         feedback_tx.send_lossy(peer_valid);
     }
 
-    /// Serve a peer's request by querying the local database.
+    /// Serve a peer's request from the latest published snapshot.
     async fn handle_produce(
         &mut self,
         key: Request<F>,
         response_tx: oneshot::Sender<bytes::Bytes>,
     ) {
-        let State::HasDb(database) = &self.state else {
-            self.metrics.serve_requests.inc(status::Status::Dropped);
-            return;
-        };
         if let Request::Operations { max_ops, .. } = key
             && max_ops > self.config.max_serve_ops
         {
             self.metrics.serve_requests.inc(status::Status::Dropped);
             return;
         }
-        let result = database.serve(key).await;
+        let Some(source) = self.snapshot_reader.latest() else {
+            self.metrics.serve_requests.inc(status::Status::Dropped);
+            return;
+        };
+        let result = source.serve(key).await;
 
         let Ok((response, _feedback_tx)) = result else {
             self.metrics.serve_requests.inc(status::Status::Failure);
@@ -372,7 +353,9 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::stateful::db::snapshot::Publisher;
     use bytes::Bytes;
+    use commonware_consensus::types::Height;
     use commonware_cryptography::{Sha256, ed25519, sha256};
     use commonware_p2p::{Provider, TrackedPeers};
     use commonware_parallel::Sequential;
@@ -386,7 +369,7 @@ mod tests {
         translator::TwoCap,
     };
     use commonware_utils::{NZU16, NZU64, NZUsize, channel::oneshot};
-    use std::time::Duration;
+    use std::{sync::Arc, time::Duration};
 
     #[derive(Clone, Debug)]
     struct DummyProvider;
@@ -424,7 +407,7 @@ mod tests {
         TwoCap,
         Sequential,
     >;
-    type TestOp = <Shared<TestDb> as Source>::Op;
+    type TestOp = <TestDb as Source>::Op;
 
     type TestActor = Actor<
         deterministic::Context,
@@ -432,16 +415,19 @@ mod tests {
         DummyProvider,
         DummyBlocker,
         mmr::Family,
-        TestDb,
+        Arc<TestDb>,
+        Arc<TestDb>,
     >;
 
-    fn test_config(
-        database: Option<Shared<TestDb>>,
-    ) -> Config<ed25519::PublicKey, DummyProvider, DummyBlocker, TestDb> {
+    /// A reader over a closed cell. Deliver-path tests never produce.
+    fn closed_reader(context: &deterministic::Context) -> Reader<Arc<TestDb>> {
+        Publisher::<Arc<TestDb>>::new(context).1
+    }
+
+    fn test_config() -> Config<ed25519::PublicKey, DummyProvider, DummyBlocker> {
         Config {
             peer_provider: DummyProvider,
             blocker: DummyBlocker,
-            database,
             mailbox_size: NZUsize!(16),
             me: None,
             initial: Duration::from_millis(10),
@@ -495,11 +481,17 @@ mod tests {
         }
     }
 
-    async fn init_db(context: deterministic::Context, suffix: &str) -> Shared<TestDb> {
+    async fn init_reader(
+        context: deterministic::Context,
+        suffix: &str,
+    ) -> (Publisher<Arc<TestDb>>, Reader<Arc<TestDb>>, Location) {
         let db = TestDb::init(context.child("db"), db_config(suffix, &context))
             .await
             .expect("db init should succeed");
-        Shared::new("test", db)
+        let size = db.bounds().end;
+        let (mut publisher, reader) = Publisher::new(&context);
+        publisher.publish_now(Height::new(0), Arc::new(db));
+        (publisher, reader, size)
     }
 
     fn encoded_fetch_payload() -> Bytes {
@@ -515,9 +507,11 @@ mod tests {
     }
 
     #[test]
-    fn produce_denied_before_attach() {
+    fn produce_denied_when_source_is_empty() {
         deterministic::Runner::default().start(|context| async move {
-            let (mut actor, _mailbox) = TestActor::new(context.child("actor"), test_config(None));
+            let (_publisher, reader) = Publisher::<Arc<TestDb>>::new(&context);
+            let (mut actor, _mailbox) =
+                TestActor::new(context.child("actor"), test_config(), reader);
 
             let (response_tx, response_rx) = oneshot::channel();
             actor
@@ -528,21 +522,19 @@ mod tests {
     }
 
     #[test]
-    fn same_request_served_after_attach() {
+    fn produce_serves_from_the_source() {
         deterministic::Runner::default().start(|context| async move {
-            let (mut actor, _mailbox) = TestActor::new(context.child("actor"), test_config(None));
-            let db = init_db(context.child("resolver_db"), "resolver-after-attach").await;
-            let size = db.read().await.bounds().end;
-            actor.handle_mailbox_message(mailbox::Message::AttachDatabase(db));
+            let (_publisher, reader, size) =
+                init_reader(context.child("resolver_db"), "resolver-serves").await;
+            let (mut actor, _mailbox) =
+                TestActor::new(context.child("actor"), test_config(), reader);
 
             let (response_tx, response_rx) = oneshot::channel();
             actor
                 .handle_produce(test_request_at(size), response_tx)
                 .await;
 
-            let payload = response_rx
-                .await
-                .expect("response should be available after attach");
+            let payload = response_rx.await.expect("response should be available");
             assert!(!payload.is_empty());
         });
     }
@@ -550,10 +542,10 @@ mod tests {
     #[test]
     fn produce_rejects_request_above_max_serve_ops() {
         deterministic::Runner::default().start(|context| async move {
-            let (mut actor, _mailbox) = TestActor::new(context.child("actor"), test_config(None));
-            let db = init_db(context.child("resolver_db"), "resolver-unbounded-max-ops").await;
-            let size = db.read().await.bounds().end;
-            actor.handle_mailbox_message(mailbox::Message::AttachDatabase(db));
+            let (_publisher, reader, size) =
+                init_reader(context.child("resolver_db"), "resolver-unbounded-max-ops").await;
+            let (mut actor, _mailbox) =
+                TestActor::new(context.child("actor"), test_config(), reader);
 
             let request = Request::Operations {
                 size,
@@ -570,7 +562,8 @@ mod tests {
     #[test]
     fn deliver_with_dropped_response_receiver_is_treated_as_valid() {
         deterministic::Runner::default().start(|context| async move {
-            let (mut actor, _mailbox) = TestActor::new(context, test_config(None));
+            let reader = closed_reader(&context);
+            let (mut actor, _mailbox) = TestActor::new(context, test_config(), reader);
             let request = test_request_at(Location::new(1));
 
             let (subscriber_tx, subscriber_rx) = test_subscriber();
@@ -589,7 +582,8 @@ mod tests {
     #[test]
     fn deliver_with_rejected_subscriber_blocks_peer() {
         deterministic::Runner::default().start(|context| async move {
-            let (mut actor, _mailbox) = TestActor::new(context, test_config(None));
+            let reader = closed_reader(&context);
+            let (mut actor, _mailbox) = TestActor::new(context, test_config(), reader);
             let request = test_request_at(Location::new(1));
 
             let (sub1_tx, sub1_rx) = test_subscriber();
@@ -622,7 +616,8 @@ mod tests {
     #[test]
     fn deliver_ignores_dropped_subscriber_approval() {
         deterministic::Runner::default().start(|context| async move {
-            let (mut actor, _mailbox) = TestActor::new(context, test_config(None));
+            let reader = closed_reader(&context);
+            let (mut actor, _mailbox) = TestActor::new(context, test_config(), reader);
             let request = test_request_at(Location::new(1));
 
             let (sub1_tx, sub1_rx) = test_subscriber();
@@ -652,7 +647,8 @@ mod tests {
     #[test]
     fn failed_then_deliver_clears_pending_and_allows_retry() {
         deterministic::Runner::default().start(|context| async move {
-            let (mut actor, _mailbox) = TestActor::new(context, test_config(None));
+            let reader = closed_reader(&context);
+            let (mut actor, _mailbox) = TestActor::new(context, test_config(), reader);
             let request = test_request_at(Location::new(1));
 
             let (subscriber_tx, _subscriber_rx) = test_subscriber();
@@ -671,7 +667,8 @@ mod tests {
     #[test]
     fn get_operations_refetches_when_pending_subscribers_are_closed() {
         deterministic::Runner::default().start(|context| async move {
-            let (mut actor, _mailbox) = TestActor::new(context, test_config(None));
+            let reader = closed_reader(&context);
+            let (mut actor, _mailbox) = TestActor::new(context, test_config(), reader);
             let request = test_request_at(Location::new(1));
 
             let (stale_tx, stale_rx) = test_subscriber();
@@ -694,7 +691,8 @@ mod tests {
     #[test]
     fn deliver_rejects_answer_shaped_unlike_its_question() {
         deterministic::Runner::default().start(|context| async move {
-            let (mut actor, _mailbox) = TestActor::new(context, test_config(None));
+            let reader = closed_reader(&context);
+            let (mut actor, _mailbox) = TestActor::new(context, test_config(), reader);
             let request = Request::Boundary {
                 size: Location::new(1),
                 start: Location::new(0),
@@ -717,7 +715,8 @@ mod tests {
     #[test]
     fn cancel_operations_cancels_pruned_request() {
         deterministic::Runner::default().start(|context| async move {
-            let (mut actor, _mailbox) = TestActor::new(context, test_config(None));
+            let reader = closed_reader(&context);
+            let (mut actor, _mailbox) = TestActor::new(context, test_config(), reader);
             let request = test_request_at(Location::new(1));
 
             let action =

--- a/glue/src/stateful/db/p2p/handler.rs
+++ b/glue/src/stateful/db/p2p/handler.rs
@@ -21,7 +21,7 @@ pub(super) enum EngineMessage<F: Family> {
         response: oneshot::Sender<bool>,
     },
     /// A peer requested data for `key`.
-    /// The actor queries the local database and sends the encoded
+    /// The actor serves the latest published snapshot and sends the encoded
     /// [`Response`](commonware_storage::qmdb::sync::Response) back through `response`.
     Produce {
         key: Request<F>,
@@ -84,7 +84,7 @@ impl<F: Family> Policy for EngineMessage<F> {
 ///
 /// Every callback from the resolver engine is converted into an
 /// [`EngineMessage`] and sent to the actor. This keeps all mutable
-/// state (pending subscribers, database handle) on the actor task,
+/// state (pending subscribers, the serving source) on the actor task,
 /// while the engine runs independently.
 #[derive(Clone)]
 pub(super) struct Handler<F: Family> {

--- a/glue/src/stateful/db/p2p/mailbox.rs
+++ b/glue/src/stateful/db/p2p/mailbox.rs
@@ -1,6 +1,6 @@
 //! Mailbox and wire types for the QMDB sync resolver service.
 
-use crate::stateful::db::{AttachableResolver, Shared, p2p::cancel};
+use crate::stateful::db::p2p::cancel;
 use commonware_actor::mailbox::{Overflow, Policy, Sender};
 use commonware_codec::Read;
 use commonware_cryptography::Digest;
@@ -9,7 +9,7 @@ use commonware_storage::{
     qmdb::sync::{FeedbackTx, Request, Response, Source},
 };
 use commonware_utils::channel::oneshot;
-use std::{collections::VecDeque, future::Future};
+use std::collections::VecDeque;
 
 /// The resolver actor dropped the response before completion.
 #[derive(Debug, thiserror::Error)]
@@ -21,9 +21,7 @@ pub struct ResponseDropped;
 pub(super) type ResponseTx<F, Op, D> = oneshot::Sender<(Response<F, Op, D>, FeedbackTx)>;
 
 /// Messages sent from the [`Mailbox`] to the resolver [`Actor`](super::Actor).
-pub(super) enum Message<DB, F: Family, Op, D: Digest> {
-    /// Provide a database handle so the actor can serve incoming requests.
-    AttachDatabase(Shared<DB>),
+pub(super) enum Message<F: Family, Op, D: Digest> {
     /// Fetch operations from a remote peer via the P2P resolver engine.
     GetOperations {
         request: Request<F>,
@@ -33,81 +31,62 @@ pub(super) enum Message<DB, F: Family, Op, D: Digest> {
     CancelOperations { request: Request<F> },
 }
 
-impl<DB, F: Family, Op, D: Digest> Message<DB, F, Op, D> {
+impl<F: Family, Op, D: Digest> Message<F, Op, D> {
     fn response_closed(&self) -> bool {
         match self {
-            Self::AttachDatabase(_) | Self::CancelOperations { .. } => false,
+            Self::CancelOperations { .. } => false,
             Self::GetOperations { response, .. } => response.is_closed(),
         }
     }
 }
 
-pub(super) struct Pending<DB, F: Family, Op, D: Digest> {
-    database: Option<Shared<DB>>,
-    messages: VecDeque<Message<DB, F, Op, D>>,
-}
+pub(super) struct Pending<F: Family, Op, D: Digest>(VecDeque<Message<F, Op, D>>);
 
-impl<DB, F: Family, Op, D: Digest> Default for Pending<DB, F, Op, D> {
+impl<F: Family, Op, D: Digest> Default for Pending<F, Op, D> {
     fn default() -> Self {
-        Self {
-            database: None,
-            messages: VecDeque::new(),
-        }
+        Self(VecDeque::new())
     }
 }
 
-impl<DB, F: Family, Op, D: Digest> Overflow<Message<DB, F, Op, D>> for Pending<DB, F, Op, D> {
+impl<F: Family, Op, D: Digest> Overflow<Message<F, Op, D>> for Pending<F, Op, D> {
     fn is_empty(&self) -> bool {
-        self.database.is_none() && self.messages.is_empty()
+        self.0.is_empty()
     }
 
     fn drain<P>(&mut self, mut push: P)
     where
-        P: FnMut(Message<DB, F, Op, D>) -> Option<Message<DB, F, Op, D>>,
+        P: FnMut(Message<F, Op, D>) -> Option<Message<F, Op, D>>,
     {
-        if let Some(database) = self.database.take()
-            && let Some(Message::AttachDatabase(database)) = push(Message::AttachDatabase(database))
-        {
-            self.database = Some(database);
-            return;
-        }
-
-        while let Some(message) = self.messages.pop_front() {
+        while let Some(message) = self.0.pop_front() {
             if message.response_closed() {
                 continue;
             }
 
             if let Some(message) = push(message) {
-                self.messages.push_front(message);
+                self.0.push_front(message);
                 break;
             }
         }
     }
 }
 
-impl<DB, F: Family, Op, D: Digest> Policy for Message<DB, F, Op, D> {
-    type Overflow = Pending<DB, F, Op, D>;
+impl<F: Family, Op, D: Digest> Policy for Message<F, Op, D> {
+    type Overflow = Pending<F, Op, D>;
 
     fn handle(overflow: &mut Self::Overflow, message: Self) {
         if message.response_closed() {
             return;
         }
-
-        match message {
-            Self::AttachDatabase(database) => {
-                overflow.database = Some(database);
-            }
-            message => overflow.messages.push_back(message),
-        }
+        overflow.0.push_back(message);
     }
 }
 
 /// Client-facing resolver mailbox used by the QMDB sync engine.
-pub struct Mailbox<DB, F: Family, Op, D: Digest> {
-    sender: Sender<Message<DB, F, Op, D>>,
+pub struct Mailbox<F: Family, Op, D: Digest> {
+    sender: Sender<Message<F, Op, D>>,
 }
 
-impl<DB, F: Family, Op, D: Digest> Clone for Mailbox<DB, F, Op, D> {
+impl<F: Family, Op, D: Digest> Clone for Mailbox<F, Op, D> {
     fn clone(&self) -> Self {
         Self {
             sender: self.sender.clone(),
@@ -115,24 +94,17 @@ impl<DB, F: Family, Op, D: Digest> Clone for Mailbox<DB, F, Op, D> {
     }
 }
 
-impl<DB, F: Family, Op, D: Digest> Mailbox<DB, F, Op, D> {
-    pub(super) const fn new(sender: Sender<Message<DB, F, Op, D>>) -> Self {
+impl<F: Family, Op, D: Digest> Mailbox<F, Op, D> {
+    pub(super) const fn new(sender: Sender<Message<F, Op, D>>) -> Self {
         Self { sender }
     }
 }
 
-impl<DB: Send + Sync, F: Family, Op: Send, D: Digest> Mailbox<DB, F, Op, D> {
-    pub fn attach_database(&self, db: Shared<DB>) {
-        let _ = self.sender.enqueue(Message::AttachDatabase(db));
-    }
-}
-
-impl<DB, F, Op, D> Source for Mailbox<DB, F, Op, D>
+impl<F, Op, D> Source for Mailbox<F, Op, D>
 where
     F: Family,
     Op: Read<Cfg = ()> + Send + Sync + Clone + 'static,
     D: Digest,
-    DB: Send + Sync + 'static,
 {
     type Family = F;
     type Digest = D;
@@ -157,19 +129,6 @@ where
     }
 }
 
-impl<DB, F, Op, D> AttachableResolver<DB> for Mailbox<DB, F, Op, D>
-where
-    F: Family,
-    Op: Read<Cfg = ()> + Send + Sync + Clone + 'static,
-    D: Digest,
-    DB: Send + Sync + 'static,
-{
-    fn attach_database(&self, db: Shared<DB>) -> impl Future<Output = ()> + Send {
-        Self::attach_database(self, db);
-        std::future::ready(())
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -184,7 +143,7 @@ mod tests {
     fn dropping_get_operations_sends_cancel_message() {
         deterministic::Runner::default().start(|context| async move {
             let (sender, mut receiver) = commonware_actor::mailbox::new(context, NZUsize!(4));
-            let mailbox = Mailbox::<(), mmr::Family, u64, sha256::Digest>::new(sender);
+            let mailbox = Mailbox::<mmr::Family, u64, sha256::Digest>::new(sender);
             let size = mmr::Location::new(10);
             let start_loc = mmr::Location::new(3);
             let max_ops = NZU64!(2);
@@ -207,7 +166,6 @@ mod tests {
                     assert_eq!(request.max_ops(), max_ops);
                     assert!(matches!(request, Request::Operations { .. }));
                 }
-                Message::AttachDatabase(_) => panic!("unexpected attach message"),
                 Message::CancelOperations { .. } => panic!("cancel should come after request"),
             }
 
@@ -218,7 +176,6 @@ mod tests {
                     assert_eq!(request.max_ops(), max_ops);
                     assert!(matches!(request, Request::Operations { .. }));
                 }
-                Message::AttachDatabase(_) => panic!("unexpected attach message"),
                 Message::GetOperations { .. } => panic!("unexpected duplicate request"),
             }
         });
@@ -229,7 +186,7 @@ mod tests {
     fn completed_get_operations_sends_no_cancel() {
         deterministic::Runner::default().start(|context| async move {
             let (sender, mut receiver) = commonware_actor::mailbox::new(context, NZUsize!(4));
-            let mailbox = Mailbox::<(), mmr::Family, u64, sha256::Digest>::new(sender);
+            let mailbox = Mailbox::<mmr::Family, u64, sha256::Digest>::new(sender);
             let get = mailbox.serve(Request::Operations {
                 size: mmr::Location::new(10),
                 start: mmr::Location::new(3),

--- a/glue/src/stateful/db/p2p/metrics.rs
+++ b/glue/src/stateful/db/p2p/metrics.rs
@@ -21,11 +21,8 @@ pub(super) struct Metrics {
     /// Deliveries from peers by outcome.
     pub deliveries: status::Counter,
 
-    /// Incoming serve requests by outcome.
+    /// Completed serve requests by outcome.
     pub serve_requests: status::Counter,
-
-    /// Whether a database is currently attached (1) or not (0).
-    pub has_database: Registered<Gauge>,
 }
 
 impl Metrics {
@@ -47,20 +44,14 @@ impl Metrics {
             Counter::default(),
         );
         let deliveries = context.family("deliveries", "Deliveries from peers by outcome");
-        let serve_requests = context.family("serve_requests", "Incoming serve requests by outcome");
-        let has_database = context.register(
-            "has_database",
-            "Whether a database is currently attached",
-            Gauge::default(),
-        );
-
+        let serve_requests =
+            context.family("serve_requests", "Completed serve requests by outcome");
         Self {
             pending_requests,
             fetch_requests,
             cancel_requests,
             deliveries,
             serve_requests,
-            has_database,
         }
     }
 }

--- a/glue/src/stateful/db/p2p/mod.rs
+++ b/glue/src/stateful/db/p2p/mod.rs
@@ -9,7 +9,7 @@
 //!   engine so that duplicate requests share a single network round-trip.
 //! - [`Actor`]: service loop that bridges the [`Mailbox`] with the P2P
 //!   engine, dispatches fetches, fans out deliveries to waiting callers,
-//!   and serves produce requests from the local database.
+//!   and serves produce requests from the latest published snapshot.
 
 mod actor;
 pub use actor::{Actor, Config};

--- a/glue/src/stateful/tests/common.rs
+++ b/glue/src/stateful/tests/common.rs
@@ -9,9 +9,7 @@ use commonware_runtime::{Quota, buffer::paged::CacheRef};
 use commonware_storage::{archive::prunable, translator::TwoCap};
 use commonware_utils::{NZU16, NZU64, NZUsize};
 use std::{
-    future::Future,
     num::{NonZeroU16, NonZeroU32, NonZeroU64, NonZeroUsize},
-    pin::Pin,
     sync::Arc,
 };
 
@@ -20,8 +18,7 @@ use std::{
 ///
 /// Used by pruning properties to observe that QMDB actually discarded
 /// historical operations through the live actor.
-pub(crate) type OldestRetained =
-    Arc<dyn Fn() -> Pin<Box<dyn Future<Output = u64> + Send>> + Send + Sync>;
+pub(crate) type OldestRetained = Arc<dyn Fn() -> u64 + Send + Sync>;
 
 pub(super) const EPOCH_LENGTH: NonZeroU64 = NZU64!(u64::MAX);
 pub(super) const NAMESPACE: &[u8] = b"stateful_e2e_test";
@@ -106,8 +103,8 @@ where
         self.state_sync_entries
     }
 
-    pub(crate) async fn oldest_retained(&self) -> u64 {
-        (self.oldest_retained)().await
+    pub(crate) fn oldest_retained(&self) -> u64 {
+        (self.oldest_retained)()
     }
 }
 

--- a/glue/src/stateful/tests/mocks.rs
+++ b/glue/src/stateful/tests/mocks.rs
@@ -90,6 +90,7 @@ impl FlushControl {
 pub(crate) struct TestDb {
     finalize: Mutex<Option<Handle<()>>>,
     control: Option<FlushControl>,
+    finalized: u64,
 }
 
 impl TestDb {
@@ -97,6 +98,7 @@ impl TestDb {
         Self {
             finalize: Mutex::new(Some(handle)),
             control: None,
+            finalized: 0,
         }
     }
 
@@ -105,6 +107,7 @@ impl TestDb {
         Self {
             finalize: Mutex::new(None),
             control: Some(control),
+            finalized: 0,
         }
     }
 }
@@ -115,6 +118,12 @@ impl<E: Send> ManagedDb<E> for TestDb {
     type Error = Infallible;
     type Config = ();
     type SyncTarget = u64;
+    type Snapshot = u64;
+
+    async fn snapshot(self) -> Result<(Self, Self::Snapshot), Self::Error> {
+        let snapshot = self.finalized;
+        Ok((self, snapshot))
+    }
 
     fn initial_sync_target() -> Self::SyncTarget {
         unreachable!("TestDb is constructed directly in tests")
@@ -132,18 +141,23 @@ impl<E: Send> ManagedDb<E> for TestDb {
         true
     }
 
-    async fn finalize(self, _batch: Self::Merkleized) -> Result<(Self, Handle<()>), Self::Error> {
+    async fn finalize(
+        mut self,
+        _batch: Self::Merkleized,
+    ) -> Result<(Self, Self::Snapshot, Handle<()>), Self::Error> {
+        self.finalized += 1;
+        let snapshot = self.finalized;
         if let Some(control) = &self.control {
             let (release, released) = oneshot::channel();
             control.flushes.lock().push(release);
-            return Ok((self, Handle::from_receiver(released)));
+            return Ok((self, snapshot, Handle::from_receiver(released)));
         }
         let handle = self
             .finalize
             .lock()
             .take()
             .unwrap_or_else(|| Handle::ready(Ok(())));
-        Ok((self, handle))
+        Ok((self, snapshot, handle))
     }
 
     async fn prune(self, target: &Self::SyncTarget) -> Result<Self, Self::Error> {

--- a/glue/src/stateful/tests/mod.rs
+++ b/glue/src/stateful/tests/mod.rs
@@ -3,10 +3,10 @@
 use self::{
     common::{EPOCH_LENGTH, IO_BUFFER_SIZE, PAGE_CACHE_SIZE, PAGE_SIZE, archive_config},
     multi_db_app::{
-        App as MultiApp, Block as MultiBlock, MultiDatabaseSet, MultiDbEngine, QmdbB,
+        App as MultiApp, Block as MultiBlock, MultiDatabaseSet, MultiDbEngine,
         qmdb_config as multi_qmdb_config,
     },
-    single_db_app::{App, Block, Qmdb, SingleDatabaseSet, SingleDbEngine, qmdb_config},
+    single_db_app::{App, Block, SingleDatabaseSet, SingleDbEngine, qmdb_config},
 };
 use crate::{
     simulate::{
@@ -20,7 +20,7 @@ use crate::{
     stateful::{
         Application, Config as StatefulConfig, Input, Proposed, PruneConfig,
         Stateful as StatefulActor, SyncPlan,
-        db::{AttachableResolver, DatabaseSet, Merkleized as _, Shared, SyncEngineConfig},
+        db::{DatabaseSet, Merkleized as _, SyncEngineConfig, snapshot::Publisher},
     },
 };
 use commonware_actor::Feedback;
@@ -857,10 +857,6 @@ impl QmdbSource for NoopQmdbResolver {
     }
 }
 
-impl AttachableResolver<Qmdb<deterministic::Context>> for NoopQmdbResolver {
-    async fn attach_database(&self, _db: Shared<Qmdb<deterministic::Context>>) {}
-}
-
 #[derive(Clone)]
 struct NoopCompactQmdbResolver;
 
@@ -879,10 +875,6 @@ impl QmdbSource for NoopCompactQmdbResolver {
     + 'a {
         std::future::pending()
     }
-}
-
-impl AttachableResolver<QmdbB<deterministic::Context>> for NoopCompactQmdbResolver {
-    async fn attach_database(&self, _db: Shared<QmdbB<deterministic::Context>>) {}
 }
 
 #[derive(Clone)]
@@ -1196,6 +1188,8 @@ fn out_of_order_certifications_complete_on_qmdb() {
         );
 
         let plan = SyncPlan::init(&context, "certify-qmdb-stateful".to_string()).await;
+        let publication_context = context.child("publication");
+        let (snapshot_publisher, _snapshot_reader) = Publisher::new(&publication_context);
         let (stateful, stateful_mailbox) = StatefulActor::init(
             context.child("stateful"),
             StatefulConfig {
@@ -1214,6 +1208,7 @@ fn out_of_order_certifications_complete_on_qmdb() {
                     max_retained_roots: 1,
                 },
                 prune_config: None,
+                snapshot_publisher,
             },
         );
         let stateful_actor = stateful.start();
@@ -1326,6 +1321,8 @@ fn overlapping_finalizations_complete_on_multi_qmdb() {
             finalize_gate: finalize_gate.clone(),
         };
         let plan = SyncPlan::init(&context, "certify-multi-qmdb-stateful".to_string()).await;
+        let publication_context = context.child("publication");
+        let (snapshot_publisher, _snapshot_reader) = Publisher::new(&publication_context);
         let (stateful, stateful_mailbox) = StatefulActor::init(
             context.child("stateful"),
             StatefulConfig {
@@ -1344,6 +1341,7 @@ fn overlapping_finalizations_complete_on_multi_qmdb() {
                     max_retained_roots: 1,
                 },
                 prune_config: None,
+                snapshot_publisher,
             },
         );
         let stateful_actor = stateful.start();
@@ -1580,6 +1578,8 @@ fn pruning_quiesces_and_retries_verification_on_real_qmdbs() {
             finalize_gate: finalize_gate.clone(),
         };
         let plan = SyncPlan::init(&context, "prune-overlap-multi-qmdb-stateful".to_string()).await;
+        let publication_context = context.child("publication");
+        let (snapshot_publisher, _snapshot_reader) = Publisher::new(&publication_context);
         let (stateful, stateful_mailbox) = StatefulActor::init(
             context.child("stateful"),
             StatefulConfig {
@@ -1604,6 +1604,7 @@ fn pruning_quiesces_and_retries_verification_on_real_qmdbs() {
                     retained_marshal_blocks: 2,
                     retained_qmdb_blocks: 0,
                 }),
+                snapshot_publisher,
             },
         );
         let stateful_actor = stateful.start();

--- a/glue/src/stateful/tests/multi_db_app.rs
+++ b/glue/src/stateful/tests/multi_db_app.rs
@@ -8,7 +8,7 @@ use crate::{
         Application, Config as StatefulConfig, Input, Proposed, PruneConfig,
         Stateful as StatefulActor, SyncPlan,
         db::{
-            DatabaseSet, Merkleized as _, Shared, SyncEngineConfig, Unmerkleized as _,
+            DatabaseSet, Merkleized as _, Shared, SnapshotsOf, SyncEngineConfig, Unmerkleized as _,
             p2p as qmdb_resolver,
         },
         probe::{Config as ProbeConfig, Probe},
@@ -47,7 +47,9 @@ use commonware_runtime::{
 use commonware_storage::{
     Context as StorageContext,
     archive::prunable,
-    journal::contiguous::{fixed::Config as FixedLogConfig, variable::Config as VariableLogConfig},
+    journal::contiguous::{
+        Contiguous as _, fixed::Config as FixedLogConfig, variable::Config as VariableLogConfig,
+    },
     mmr::{self, Location, full::Config as MmrJournalConfig},
     qmdb::{
         any::{FixedConfig, unordered::fixed},
@@ -78,6 +80,9 @@ type DbB<E> = Shared<QmdbB<E>>;
 
 /// A full and a compact QMDB as a tuple.
 pub(crate) type MultiDatabaseSet<E> = (DbA<E>, DbB<E>);
+
+/// Readers over the set's published snapshots.
+type MultiSnapshot<E> = SnapshotsOf<MultiDatabaseSet<E>, E>;
 
 /// Builds the full and compact QMDB configurations used by multi-database tests.
 pub(super) fn qmdb_config(
@@ -585,43 +590,47 @@ impl EngineDefinition for MultiDbEngine {
             .await;
         let sync_floor = plan.floor().cloned();
 
-        // QMDB state-sync resolvers (one per database).
-        let (qmdb_resolver_actor_a, qmdb_sync_resolver_a) =
-            qmdb_resolver::Actor::<_, ed25519::PublicKey, _, _, mmr::Family, QmdbA<_>>::new(
-                context.child("qmdb_resolver_a"),
-                qmdb_resolver::Config {
-                    peer_provider: oracle.manager(),
-                    blocker: oracle.control(public_key.clone()),
-                    database: None,
-                    mailbox_size: NZUsize!(100),
-                    me: Some(public_key.clone()),
-                    initial: Duration::from_secs(1),
-                    timeout: Duration::from_secs(2),
-                    fetch_retry_timeout: Duration::from_millis(100),
-                    max_serve_ops: NZU64!(16),
-                    priority_requests: false,
-                    priority_responses: false,
-                },
-            );
+        // Snapshot publication channel and the QMDB state-sync resolvers (one per
+        // database), each serving from its own reader.
+        let publication_context = context.child("publication");
+        let (snapshot_publisher, snapshot_reader) =
+            crate::stateful::db::snapshot::Publisher::<MultiSnapshot<_>>::new(&publication_context);
+        let snapshot_reader_a = snapshot_reader.view(|snapshots| &snapshots.0);
+        let snapshot_reader_b = snapshot_reader.view(|snapshots| &snapshots.1);
+        let (qmdb_resolver_actor_a, qmdb_sync_resolver_a) = qmdb_resolver::Actor::new(
+            context.child("qmdb_resolver_a"),
+            qmdb_resolver::Config {
+                peer_provider: oracle.manager(),
+                blocker: oracle.control(public_key.clone()),
+                mailbox_size: NZUsize!(100),
+                me: Some(public_key.clone()),
+                initial: Duration::from_secs(1),
+                timeout: Duration::from_secs(2),
+                fetch_retry_timeout: Duration::from_millis(100),
+                max_serve_ops: NZU64!(16),
+                priority_requests: false,
+                priority_responses: false,
+            },
+            snapshot_reader_a.clone(),
+        );
         qmdb_resolver_actor_a.start(qmdb_a_resolver_network);
 
-        let (qmdb_resolver_actor_b, qmdb_sync_resolver_b) =
-            qmdb_resolver::Actor::<_, ed25519::PublicKey, _, _, mmr::Family, QmdbB<_>>::new(
-                context.child("qmdb_resolver_b"),
-                qmdb_resolver::Config {
-                    peer_provider: oracle.manager(),
-                    blocker: oracle.control(public_key.clone()),
-                    database: None,
-                    mailbox_size: NZUsize!(100),
-                    me: Some(public_key.clone()),
-                    initial: Duration::from_secs(1),
-                    timeout: Duration::from_secs(2),
-                    fetch_retry_timeout: Duration::from_millis(100),
-                    max_serve_ops: NZU64!(16),
-                    priority_requests: false,
-                    priority_responses: false,
-                },
-            );
+        let (qmdb_resolver_actor_b, qmdb_sync_resolver_b) = qmdb_resolver::Actor::new(
+            context.child("qmdb_resolver_b"),
+            qmdb_resolver::Config {
+                peer_provider: oracle.manager(),
+                blocker: oracle.control(public_key.clone()),
+                mailbox_size: NZUsize!(100),
+                me: Some(public_key.clone()),
+                initial: Duration::from_secs(1),
+                timeout: Duration::from_secs(2),
+                fetch_retry_timeout: Duration::from_millis(100),
+                max_serve_ops: NZU64!(16),
+                priority_requests: false,
+                priority_responses: false,
+            },
+            snapshot_reader_b,
+        );
         qmdb_resolver_actor_b.start(qmdb_b_resolver_network);
 
         // Stateful actor
@@ -636,6 +645,7 @@ impl EngineDefinition for MultiDbEngine {
                 mailbox_size: NZUsize!(100),
                 plan,
                 resolvers: (qmdb_sync_resolver_a, qmdb_sync_resolver_b),
+                snapshot_publisher,
                 sync_config: self.sync_config,
                 prune_config: Some(PruneConfig {
                     maintenance_interval: NZUsize!(5),
@@ -647,14 +657,11 @@ impl EngineDefinition for MultiDbEngine {
 
         // Observe the oldest operation the full QMDB still retains, to assert pruning ran.
         // The compact db keeps no operation history to observe.
-        let prune_observer = stateful_mailbox.clone();
         let oldest_retained: OldestRetained = Arc::new(move || {
-            let mailbox = prune_observer.clone();
-            Box::pin(async move {
-                let (a, _b) = mailbox.subscribe_databases().await;
-
-                *a.read().await.bounds().start
-            })
+            let snapshot = snapshot_reader_a
+                .latest()
+                .expect("a published capture must exist");
+            snapshot.bounds().start
         });
 
         // Deferred wrapper

--- a/glue/src/stateful/tests/properties.rs
+++ b/glue/src/stateful/tests/properties.rs
@@ -151,7 +151,7 @@ where
     ) -> Pin<Box<dyn Future<Output = Result<(), String>> + Send + 'a>> {
         Box::pin(async move {
             for (index, state) in states.iter().enumerate() {
-                let oldest_retained = state.oldest_retained().await;
+                let oldest_retained = state.oldest_retained();
                 if oldest_retained < self.min_oldest_retained {
                     return Err(format!(
                         "validator {index} retains operations from location {oldest_retained}; \

--- a/glue/src/stateful/tests/single_db_app.rs
+++ b/glue/src/stateful/tests/single_db_app.rs
@@ -46,7 +46,7 @@ use commonware_runtime::{
 use commonware_storage::{
     Context as StorageContext,
     archive::prunable,
-    journal::contiguous::fixed::Config as FixedLogConfig,
+    journal::contiguous::{Contiguous as _, fixed::Config as FixedLogConfig},
     mmr::{self, Location, full::Config as MmrJournalConfig},
     qmdb::{
         any::{FixedConfig, unordered::fixed},
@@ -486,24 +486,26 @@ impl EngineDefinition for SingleDbEngine {
             .await;
         let sync_floor = plan.floor().cloned();
 
-        // QMDB state-sync resolver.
-        let (qmdb_resolver_actor, qmdb_sync_resolver) =
-            qmdb_resolver::Actor::<_, ed25519::PublicKey, _, _, mmr::Family, Qmdb<_>>::new(
-                context.child("qmdb_resolver"),
-                qmdb_resolver::Config {
-                    peer_provider: oracle.manager(),
-                    blocker: oracle.control(public_key.clone()),
-                    database: None,
-                    mailbox_size: NZUsize!(100),
-                    me: Some(public_key.clone()),
-                    initial: Duration::from_secs(1),
-                    timeout: Duration::from_secs(2),
-                    fetch_retry_timeout: Duration::from_millis(100),
-                    max_serve_ops: NZU64!(16),
-                    priority_requests: false,
-                    priority_responses: false,
-                },
-            );
+        // Snapshot publication channel and the QMDB state-sync resolver serving from it.
+        let publication_context = context.child("publication");
+        let (snapshot_publisher, snapshot_reader) =
+            crate::stateful::db::snapshot::Publisher::new(&publication_context);
+        let (qmdb_resolver_actor, qmdb_sync_resolver) = qmdb_resolver::Actor::new(
+            context.child("qmdb_resolver"),
+            qmdb_resolver::Config {
+                peer_provider: oracle.manager(),
+                blocker: oracle.control(public_key.clone()),
+                mailbox_size: NZUsize!(100),
+                me: Some(public_key.clone()),
+                initial: Duration::from_secs(1),
+                timeout: Duration::from_secs(2),
+                fetch_retry_timeout: Duration::from_millis(100),
+                max_serve_ops: NZU64!(16),
+                priority_requests: false,
+                priority_responses: false,
+            },
+            snapshot_reader.clone(),
+        );
         let _qmdb_resolver_handle = qmdb_resolver_actor.start(qmdb_resolver_network);
 
         // Stateful actor
@@ -518,6 +520,7 @@ impl EngineDefinition for SingleDbEngine {
                 mailbox_size: NZUsize!(100),
                 plan,
                 resolvers: qmdb_sync_resolver,
+                snapshot_publisher,
                 sync_config: self.sync_config,
                 prune_config: Some(PruneConfig {
                     maintenance_interval: NZUsize!(5),
@@ -528,15 +531,11 @@ impl EngineDefinition for SingleDbEngine {
         );
 
         // Observe the oldest operation QMDB still retains, to assert pruning ran.
-        let prune_observer = stateful_mailbox.clone();
         let oldest_retained: OldestRetained = Arc::new(move || {
-            let mailbox = prune_observer.clone();
-            Box::pin(async move {
-                let databases = mailbox.subscribe_databases().await;
-                let guard = databases.read().await;
-                let bounds = guard.bounds();
-                *bounds.start
-            })
+            let snapshot = snapshot_reader
+                .latest()
+                .expect("a published capture must exist");
+            snapshot.bounds().start
         });
 
         // Deferred wrapper


### PR DESCRIPTION
## Summary

Peer serving previously read through `Shared<DB>`, the same lock mutations run under. That cost us twice: a slow serve could delay finalization, and a serve could observe applied state that was not yet on disk. Serving wants the opposite of what a live database gives: shared reads of state that is guaranteed durable.

So serving now gets its own data: immutable snapshots, published only once they are durable. A mutation never waits on a serve, and a peer is never shown state a crash would take back. `Shared`'s ownership model, `DatabaseSet: Clone`, and the verification machinery are untouched, and mutation still runs under the existing write slots. The ownership rework comes in #4417.

Also a bug fix the new paths exposed: a batch that never set an inactivity floor merkleized with the `Default` floor of zero, so once anything raised the database's floor, the next batch that left it unset failed with `FloorRegressed`. Only tests set the floor explicitly, which kept this latent. New batches now inherit the floor of whatever they fork from: the database's current floor, or the parent batch's.

## Design

**Capture.** The right moment to capture is `finalize`: the batch has just applied and the write slot is already held, so the snapshot adds no locking. `finalize` now returns the database, its snapshot, and the flush handle. A standalone `snapshot()` covers the moments outside an apply: startup, the state-sync handoff, and the post-prune refresh. `DatabaseSet` mirrors both.

**Publication.** A snapshot reflects everything applied before it, including state whose flush is still running, so capture and serving must be separated by durability. The `Publisher` is that gap. It replaces the loop's pending-flush bookkeeping one for one: snapshots are staged at finalize, flush completions are recorded where the loop previously ticked a `BTreeSet` of pending heights, and pruning gates on the same question it asked before. A snapshot publishes once its own flush and every earlier one has finished, and when one completion unblocks several, only the newest publishes. Readers never move backward and never see unflushed state. Marshal acknowledgement rides the same completions, unchanged.

**Startup and state sync.** A node should serve as soon as it holds anything durable, not after its next finalization. Recovered state publishes before the processing loop starts, synced state publishes at the handoff, and each handoff block publishes after its inline durability wait.

**Pruning.** A prune waits for every flush at or below its target, as before. The served snapshot was captured before the prune, so it pins the pruned storage. The prune marks it stale, and the space frees when a snapshot captured after the prune replaces it: either the next block's own publish, or, when nothing is staged, a fresh snapshot taken once the mailbox is idle (`Step::Refresh`).

**Serving.** The p2p resolver takes a snapshot reader at construction and answers every request from the latest published snapshot. A request that finds nothing published declines cleanly. That leaves the attach-database machinery (`AttachableResolver`, `AttachableResolverSet`, the `AttachDatabase` message, the `has_database` metric) with no job, so it is deleted. Resolvers keep their state-sync fetch role unchanged.

## API changes

All ALPHA, so breaking is fine.

- `ManagedDb` gains `type Snapshot` and `snapshot()`; `finalize` returns `(Self, Snapshot, Handle<()>)`. `DatabaseSet` mirrors both: `type Snapshots`, `snapshot()`, and `finalize` returning `(Snapshots, Barrier)`. `LogSnapshot` names the `Arc`-shared snapshot every log-backed QMDB variant produces.
- `Stateful`'s `Config` takes the `Publisher`; the resolver takes a `Reader` at construction. Publication metrics register under the context passed to `Publisher::new`.
- The `R` bound on `Stateful` relaxes from `AttachableResolverSet` to plain `Send + Sync + 'static`: resolvers are now only sync-fetch sources to the actor.

