### PR TITLE
[runtime] Add crash-faithful storage and runtime shutdown

### DIFF
--- a/broadcast/fuzz/fuzz_targets/broadcast_engine_operations.rs
+++ b/broadcast/fuzz/fuzz_targets/broadcast_engine_operations.rs
@@ -13,7 +13,9 @@ use commonware_cryptography::{
 };
 use commonware_p2p::{Recipients, simulated::Network};
 use commonware_runtime::{Buf, BufMut, Clock, Quota, Runner, Supervisor as _, deterministic};
-use commonware_utils::{NZUsize, TestRng, channel::oneshot, futures::Pool, vec::Bounded};
+use commonware_utils::{
+    NZUsize, Probability, TestRng, channel::oneshot, futures::Pool, vec::Bounded,
+};
 use futures::FutureExt as _;
 use libfuzzer_sys::fuzz_target;
 use rand::seq::SliceRandom;
@@ -150,7 +152,7 @@ impl<'a> Arbitrary<'a> for BroadcastAction {
 #[derive(Debug)]
 pub struct FuzzInput {
     peer_seeds: Vec<u64>,
-    network_success_rate: f64,
+    network_success_rate: Probability,
     network_latency_ms: u64,
     network_jitter_ms: u64,
     cache_size: usize,
@@ -161,7 +163,7 @@ impl<'a> arbitrary::Arbitrary<'a> for FuzzInput {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         let num_peers = u.int_in_range(1..=5)?;
         let peer_seeds = (0..num_peers).collect::<Vec<_>>(); // avoid duplicate seeds
-        let network_success_rate = u.int_in_range(30..=100)? as f64 / 100.0;
+        let network_success_rate = Probability!(u.int_in_range(30..=100)?, 100);
         let network_latency_ms = u.int_in_range(1..=100)?;
         let network_jitter_ms = u.int_in_range(0..=50)?;
         let cache_size = u.int_in_range(5..=10)?;

--- a/broadcast/src/buffered/mod.rs
+++ b/broadcast/src/buffered/mod.rs
@@ -56,7 +56,7 @@ mod tests {
         Clock, Error, IoBuf, Metrics as _, Quota, Runner, Supervisor as _, deterministic,
         telemetry::metrics::count_running_tasks,
     };
-    use commonware_utils::NZUsize;
+    use commonware_utils::{NZUsize, Probability};
     use std::{
         collections::{BTreeMap, VecDeque},
         num::NonZeroU32,
@@ -91,7 +91,7 @@ mod tests {
     async fn initialize_simulation(
         context: deterministic::Context,
         num_peers: usize,
-        success_rate: f64,
+        success_rate: Probability,
     ) -> (
         Vec<PublicKey>,
         Registrations,
@@ -379,7 +379,7 @@ mod tests {
         let runner = deterministic::Runner::timed(Duration::from_secs(5));
         runner.start(|context| async move {
             let (peers, mut registrations, oracle) =
-                initialize_simulation(context.child("network"), 4, 1.0).await;
+                initialize_simulation(context.child("network"), 4, Probability!(1.0)).await;
             let mailboxes =
                 spawn_peer_engines(context.child("peers"), &oracle, &mut registrations).await;
 
@@ -436,7 +436,7 @@ mod tests {
         runner.start(|context| async move {
             // Initialize simulation with 1 peer
             let (peers, mut registrations, oracle) =
-                initialize_simulation(context.child("network"), 1, 1.0).await;
+                initialize_simulation(context.child("network"), 1, Probability!(1.0)).await;
             let mailboxes =
                 spawn_peer_engines(context.child("peers"), &oracle, &mut registrations).await;
 
@@ -490,7 +490,7 @@ mod tests {
         let runner = deterministic::Runner::timed(Duration::from_secs(5));
         runner.start(|context| async move {
             let (peers, mut registrations, oracle) =
-                initialize_simulation(context.child("network"), 1, 1.0).await;
+                initialize_simulation(context.child("network"), 1, Probability!(1.0)).await;
             let mailboxes =
                 spawn_peer_engines(context.child("peers"), &oracle, &mut registrations).await;
             let mailbox = mailboxes.get(&peers[0]).unwrap();
@@ -513,7 +513,7 @@ mod tests {
         let runner = deterministic::Runner::timed(Duration::from_secs(30));
         runner.start(|context| async move {
             let (peers, mut registrations, oracle) =
-                initialize_simulation(context.child("network"), 10, 0.1).await;
+                initialize_simulation(context.child("network"), 10, Probability!(0.1)).await;
             let mailboxes =
                 spawn_peer_engines(context.child("peers"), &oracle, &mut registrations).await;
 
@@ -559,7 +559,7 @@ mod tests {
         let runner = deterministic::Runner::timed(Duration::from_secs(5));
         runner.start(|context| async move {
             let (peers, mut registrations, oracle) =
-                initialize_simulation(context.child("network"), 2, 1.0).await;
+                initialize_simulation(context.child("network"), 2, Probability!(1.0)).await;
             let mailboxes =
                 spawn_peer_engines(context.child("peers"), &oracle, &mut registrations).await;
 
@@ -592,7 +592,7 @@ mod tests {
         let runner = deterministic::Runner::timed(Duration::from_secs(5));
         runner.start(|context| async move {
             let (peers, mut registrations, oracle) =
-                initialize_simulation(context.child("network"), 2, 1.0).await;
+                initialize_simulation(context.child("network"), 2, Probability!(1.0)).await;
             let mailboxes =
                 spawn_peer_engines(context.child("peers"), &oracle, &mut registrations).await;
 
@@ -630,7 +630,7 @@ mod tests {
         let runner = deterministic::Runner::timed(Duration::from_secs(5));
         runner.start(|context| async move {
             let (peers, mut registrations, oracle) =
-                initialize_simulation(context.child("network"), 2, 1.0).await;
+                initialize_simulation(context.child("network"), 2, Probability!(1.0)).await;
             let mailboxes =
                 spawn_peer_engines(context.child("peers"), &oracle, &mut registrations).await;
 
@@ -674,7 +674,7 @@ mod tests {
         runner.start(|context| async move {
             // Initialize simulation with 3 peers
             let (peers, mut registrations, oracle) =
-                initialize_simulation(context.child("network"), 3, 1.0).await;
+                initialize_simulation(context.child("network"), 3, Probability!(1.0)).await;
             let mailboxes =
                 spawn_peer_engines(context.child("peers"), &oracle, &mut registrations).await;
 
@@ -735,7 +735,7 @@ mod tests {
         let runner = deterministic::Runner::timed(Duration::from_secs(5));
         runner.start(|context| async move {
             let (peers, mut registrations, oracle) =
-                initialize_simulation(context.child("network"), 4, 1.0).await;
+                initialize_simulation(context.child("network"), 4, Probability!(1.0)).await;
 
             let sender_pk = peers[0].clone();
             let target_peer = peers[1].clone();
@@ -780,7 +780,7 @@ mod tests {
         runner.start(|context| async move {
             // three peers so we can observe from a third
             let (peers, mut registrations, oracle) =
-                initialize_simulation(context.child("network"), 3, 1.0).await;
+                initialize_simulation(context.child("network"), 3, Probability!(1.0)).await;
             let mailboxes =
                 spawn_peer_engines(context.child("peers"), &oracle, &mut registrations).await;
 
@@ -831,7 +831,7 @@ mod tests {
             let runner = deterministic::Runner::new(config);
             runner.start(|context| async move {
                 let (peers, mut registrations, oracle) =
-                    initialize_simulation(context.child("network"), 1, 1.0).await;
+                    initialize_simulation(context.child("network"), 1, Probability!(1.0)).await;
                 let mailboxes =
                     spawn_peer_engines(context.child("peers"), &oracle, &mut registrations).await;
 
@@ -869,7 +869,7 @@ mod tests {
         let runner = deterministic::Runner::timed(Duration::from_secs(10));
         runner.start(|context| async move {
             let (peers, mut registrations, oracle) =
-                initialize_simulation(context.child("network"), 3, 1.0).await;
+                initialize_simulation(context.child("network"), 3, Probability!(1.0)).await;
 
             let attacker = peers[0].clone();
             let honest = peers[1].clone();
@@ -912,7 +912,7 @@ mod tests {
         let runner = deterministic::Runner::timed(Duration::from_secs(10));
         runner.start(|context| async move {
             let (peers, mut registrations, oracle) =
-                initialize_simulation(context.child("network"), 1, 1.0).await;
+                initialize_simulation(context.child("network"), 1, Probability!(1.0)).await;
             let peer = peers[0].clone();
             let (sender, receiver) = registrations.remove(&peer).unwrap();
 
@@ -1027,7 +1027,7 @@ mod tests {
         let runner = deterministic::Runner::timed(Duration::from_secs(5));
         runner.start(|context| async move {
             let (peers, mut registrations, oracle) =
-                initialize_simulation(context.child("network"), 2, 1.0).await;
+                initialize_simulation(context.child("network"), 2, Probability!(1.0)).await;
             let (mut mailboxes, handles) = spawn_peer_engines_with_handles(
                 context.child("peers"),
                 &oracle,
@@ -1082,7 +1082,7 @@ mod tests {
         let runner = deterministic::Runner::new(cfg);
         runner.start(|context| async move {
             let (peers, mut registrations, oracle) =
-                initialize_simulation(context.child("network"), 2, 1.0).await;
+                initialize_simulation(context.child("network"), 2, Probability!(1.0)).await;
 
             let (mailboxes, handles) = spawn_peer_engines_with_handles(
                 context.child("peers"),
@@ -1146,7 +1146,7 @@ mod tests {
         let runner = deterministic::Runner::timed(Duration::from_secs(5));
         runner.start(|context| async move {
             let (peers, mut registrations, oracle) =
-                initialize_simulation(context.child("network"), 3, 1.0).await;
+                initialize_simulation(context.child("network"), 3, Probability!(1.0)).await;
 
             let peer_a = peers[0].clone();
             let peer_b = peers[1].clone();
@@ -1249,7 +1249,7 @@ mod tests {
             let link = Link {
                 latency: NETWORK_SPEED,
                 jitter: Duration::ZERO,
-                success_rate: 1.0,
+                success_rate: Probability!(1.0),
             };
             for p1 in peers.iter() {
                 for p2 in peers.iter() {
@@ -1378,7 +1378,7 @@ mod tests {
             let link = Link {
                 latency: NETWORK_SPEED,
                 jitter: Duration::ZERO,
-                success_rate: 1.0,
+                success_rate: Probability!(1.0),
             };
             for p1 in &peers {
                 for p2 in &peers {
@@ -1450,7 +1450,7 @@ mod tests {
         runner.start(|context| async move {
             // Add a sole peer (self) to the network
             let (peers, mut registrations, oracle) =
-                initialize_simulation(context.child("network"), 1, 1.0).await;
+                initialize_simulation(context.child("network"), 1, Probability!(1.0)).await;
             let peer = peers[0].clone();
             let network = registrations.remove(&peer).unwrap();
             let config = Config {
@@ -1517,7 +1517,7 @@ mod tests {
             let link = Link {
                 latency: NETWORK_SPEED,
                 jitter: Duration::ZERO,
-                success_rate: 1.0,
+                success_rate: Probability!(1.0),
             };
             for p1 in &peers {
                 for p2 in &peers {
@@ -1591,7 +1591,7 @@ mod tests {
         let runner = deterministic::Runner::timed(Duration::from_secs(5));
         runner.start(|context| async move {
             let (peers, mut registrations, oracle) =
-                initialize_simulation(context.child("network"), 3, 1.0).await;
+                initialize_simulation(context.child("network"), 3, Probability!(1.0)).await;
 
             let peer_a = peers[0].clone();
             let peer_b = peers[1].clone();

--- a/collector/src/p2p/mod.rs
+++ b/collector/src/p2p/mod.rs
@@ -66,7 +66,7 @@ mod tests {
         Clock, Quota, Runner, Supervisor as _, deterministic,
         telemetry::metrics::count_running_tasks,
     };
-    use commonware_utils::{NZU32, NZUsize, ordered::Set};
+    use commonware_utils::{NZU32, NZUsize, Probability, ordered::Set};
     use std::{num::NonZeroUsize, time::Duration};
 
     /// Default rate limit quota for tests (high enough to not interfere with normal operation)
@@ -76,12 +76,12 @@ mod tests {
     const LINK: Link = Link {
         latency: Duration::from_millis(10),
         jitter: Duration::from_millis(1),
-        success_rate: 1.0,
+        success_rate: Probability!(1.0),
     };
     const LINK_SLOW: Link = Link {
         latency: Duration::from_secs(1),
         jitter: Duration::from_millis(1),
-        success_rate: 1.0,
+        success_rate: Probability!(1.0),
     };
 
     async fn setup_network_and_peers(

--- a/consensus/fuzz/src/lib.rs
+++ b/consensus/fuzz/src/lib.rs
@@ -36,7 +36,7 @@ use commonware_parallel::Sequential;
 use commonware_runtime::{
     Clock, IoBuf, Runner, Spawner, Supervisor as _, buffer::paged::CacheRef, deterministic,
 };
-use commonware_utils::{FuzzRng, NZU16, NZU32, NZUsize, channel::mpsc::Receiver};
+use commonware_utils::{FuzzRng, NZU16, NZU32, NZUsize, Probability, channel::mpsc::Receiver};
 use futures::future::join_all;
 pub use simplex::{
     SimplexBls12381MinPk, SimplexBls12381MinSig, SimplexBls12381MultisigMinPk,
@@ -100,7 +100,7 @@ async fn setup_degraded_network<E: Clock>(
     let degraded = Link {
         latency: Duration::from_millis(50),
         jitter: Duration::from_millis(50),
-        success_rate: 0.6,
+        success_rate: Probability!(0.6),
     };
     for (peer_idx, peer) in participants.iter().enumerate() {
         if peer_idx == victim_idx {
@@ -269,7 +269,7 @@ async fn setup_network<P: simplex::Simplex>(
     let link = Link {
         latency: Duration::from_millis(10),
         jitter: Duration::from_millis(1),
-        success_rate: 1.0,
+        success_rate: Probability!(1.0),
     };
     link_peers(
         &mut oracle,
@@ -542,7 +542,7 @@ fn run_with_twin_mutator<P: simplex::Simplex>(input: FuzzInput) {
             Action::Update(Link {
                 latency: Duration::from_millis(500),
                 jitter: Duration::from_millis(500),
-                success_rate: 1.0,
+                success_rate: Probability!(1.0),
             }),
             input.partition.filter(),
         )

--- a/consensus/src/aggregation/mod.rs
+++ b/consensus/src/aggregation/mod.rs
@@ -120,7 +120,7 @@ mod tests {
         deterministic::{self, Context},
     };
     use commonware_utils::{
-        NZU16, NZUsize, NonZeroDuration, TestRng,
+        NZU16, NZUsize, NonZeroDuration, Probability, TestRng,
         channel::{fallible::OneshotExt, oneshot},
         test_rng,
     };
@@ -177,7 +177,7 @@ mod tests {
     const RELIABLE_LINK: Link = Link {
         latency: Duration::from_millis(10),
         jitter: Duration::from_millis(1),
-        success_rate: 1.0,
+        success_rate: Probability!(1.0),
     };
 
     /// Register all participants with the network oracle.
@@ -812,7 +812,7 @@ mod tests {
             let degraded_link = Link {
                 latency: Duration::from_millis(200),
                 jitter: Duration::from_millis(150),
-                success_rate: 0.5,
+                success_rate: Probability!(0.5),
             };
 
             let (mut oracle, mut registrations) =
@@ -1119,7 +1119,7 @@ mod tests {
             let delayed_link = Link {
                 latency: Duration::from_millis(80),
                 jitter: Duration::from_millis(10),
-                success_rate: 0.98,
+                success_rate: Probability!(0.98),
             };
 
             // Initialize the simulated network

--- a/consensus/src/marshal/coding/shards/engine.rs
+++ b/consensus/src/marshal/coding/shards/engine.rs
@@ -1899,7 +1899,8 @@ mod tests {
     use commonware_parallel::Sequential;
     use commonware_runtime::{Quota, Runner, Supervisor as _, deterministic};
     use commonware_utils::{
-        N3f1, NZUsize, Participant, channel::oneshot::error::TryRecvError, ordered::Set,
+        N3f1, NZUsize, Participant, Probability, channel::oneshot::error::TryRecvError,
+        ordered::Set,
     };
     use std::{
         future::Future,
@@ -1940,7 +1941,7 @@ mod tests {
     const DEFAULT_LINK: Link = Link {
         latency: Duration::from_millis(50),
         jitter: Duration::ZERO,
-        success_rate: 1.0,
+        success_rate: Probability!(1.0),
     };
 
     /// Rate limit quota for tests (effectively unlimited).

--- a/consensus/src/marshal/mocks/harness.rs
+++ b/consensus/src/marshal/mocks/harness.rs
@@ -49,7 +49,7 @@ use commonware_storage::{
     archive::{immutable, prunable},
     translator::EightCap,
 };
-use commonware_utils::{NZU16, NZU64, NZUsize, TestRng, test_rng, vec::NonEmptyVec};
+use commonware_utils::{NZU16, NZU64, NZUsize, Probability, TestRng, test_rng, vec::NonEmptyVec};
 use futures::StreamExt;
 use rand::{
     RngExt as _,
@@ -88,12 +88,12 @@ pub const BLOCKS_PER_EPOCH: NonZeroU64 = NZU64!(20);
 pub const LINK: Link = Link {
     latency: Duration::from_millis(100),
     jitter: Duration::from_millis(1),
-    success_rate: 1.0,
+    success_rate: Probability!(1.0),
 };
 pub const UNRELIABLE_LINK: Link = Link {
     latency: Duration::from_millis(200),
     jitter: Duration::from_millis(50),
-    success_rate: 0.7,
+    success_rate: Probability!(0.7),
 };
 pub const TEST_QUOTA: Quota = Quota::per_second(NonZeroU32::MAX);
 

--- a/consensus/src/marshal/standard/mod.rs
+++ b/consensus/src/marshal/standard/mod.rs
@@ -101,7 +101,7 @@ mod tests {
         translator::{EightCap, TwoCap},
     };
     use commonware_utils::{
-        Acknowledgement as _, NZU16, NZU64, NZUsize,
+        Acknowledgement as _, NZU16, NZU64, NZUsize, Probability,
         acknowledgement::Exact,
         channel::{fallible::OneshotExt, mpsc, oneshot, oneshot::error::TryRecvError},
         ordered::{Quorum as _, Set},
@@ -3546,7 +3546,7 @@ mod tests {
 
             // Sync failures are fatal to the local storage state. They must not be
             // converted into a `false` certification/verification verdict.
-            context.storage_fault_config().write().sync_rate = Some(1.0);
+            context.storage_fault_config().write().sync_rate = Some(Probability!(1.0));
 
             let genesis = make_raw_block(Sha256::hash(&[b""]), Height::zero(), 0);
             let round = Round::new(Epoch::zero(), View::new(1));
@@ -3600,7 +3600,7 @@ mod tests {
             assert_eq!(application.acknowledged().await, Height::zero());
             context.sleep(Duration::from_millis(10)).await;
 
-            context.storage_fault_config().write().sync_rate = Some(1.0);
+            context.storage_fault_config().write().sync_rate = Some(Probability!(1.0));
 
             let genesis = make_raw_block(Sha256::hash(&[b""]), Height::zero(), 0);
             let round = Round::new(Epoch::zero(), View::new(1));
@@ -3653,7 +3653,7 @@ mod tests {
             assert_eq!(application.acknowledged().await, Height::zero());
             context.sleep(Duration::from_millis(10)).await;
 
-            context.storage_fault_config().write().sync_rate = Some(1.0);
+            context.storage_fault_config().write().sync_rate = Some(Probability!(1.0));
 
             let genesis = make_raw_block(Sha256::hash(&[b""]), Height::zero(), 0);
             let round = Round::new(Epoch::zero(), View::new(1));

--- a/consensus/src/ordered_broadcast/mod.rs
+++ b/consensus/src/ordered_broadcast/mod.rs
@@ -98,7 +98,7 @@ mod tests {
         deterministic::{self, Context},
     };
     use commonware_utils::{
-        NZU16, NZU64, NZUsize,
+        NZU16, NZU64, NZUsize, Probability,
         channel::{fallible::OneshotExt, oneshot},
     };
     use futures::future::join_all;
@@ -203,7 +203,7 @@ mod tests {
     const RELIABLE_LINK: Link = Link {
         latency: Duration::from_millis(10),
         jitter: Duration::from_millis(1),
-        success_rate: 1.0,
+        success_rate: Probability!(1.0),
     };
 
     async fn initialize_simulation<S: certificate::Scheme>(
@@ -576,7 +576,7 @@ mod tests {
             let delayed_link = Link {
                 latency: Duration::from_millis(50),
                 jitter: Duration::from_millis(40),
-                success_rate: 0.5,
+                success_rate: Probability!(0.5),
             };
             link_participants(
                 &mut oracle,
@@ -1026,7 +1026,7 @@ mod tests {
             let delayed_link = Link {
                 latency: Duration::from_millis(80),
                 jitter: Duration::from_millis(10),
-                success_rate: 0.98,
+                success_rate: Probability!(0.98),
             };
 
             let (mut oracle, mut registrations) =

--- a/consensus/src/simplex/actors/batcher/mod.rs
+++ b/consensus/src/simplex/actors/batcher/mod.rs
@@ -88,7 +88,7 @@ mod tests {
         telemetry::traces::{TracedExt as _, collector::TraceStorage},
         tokio,
     };
-    use commonware_utils::{NZUsize, TestRng, ordered::Set, sync::Mutex, test_rng};
+    use commonware_utils::{NZUsize, Probability, TestRng, ordered::Set, sync::Mutex, test_rng};
     use std::{marker::PhantomData, num::NonZeroU32, sync::Arc, time::Duration};
     use tracing::{Level, Span};
 
@@ -173,7 +173,7 @@ mod tests {
                 Link {
                     latency,
                     jitter: Duration::from_millis(0),
-                    success_rate: 1.0,
+                    success_rate: Probability!(1.0),
                 },
             )
             .await
@@ -1765,7 +1765,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: 1.0,
+                success_rate: Probability!(1.0),
             };
             oracle
                 .add_link(injector_pk.clone(), me.clone(), link)
@@ -1917,7 +1917,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: 1.0,
+                success_rate: Probability!(1.0),
             };
             let mut finalize_senders = Vec::new();
             for (i, participant) in participants
@@ -2518,7 +2518,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: 1.0,
+                success_rate: Probability!(1.0),
             };
             let mut participant_senders = Vec::new();
             for (i, pk) in participants.iter().enumerate() {
@@ -2722,7 +2722,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: 1.0,
+                success_rate: Probability!(1.0),
             };
             let mut participant_senders = Vec::new();
             for (i, pk) in participants.iter().enumerate() {
@@ -2889,7 +2889,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: 1.0,
+                success_rate: Probability!(1.0),
             };
             let mut participant_senders = Vec::new();
             for (i, pk) in participants.iter().enumerate() {
@@ -3117,7 +3117,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: 1.0,
+                success_rate: Probability!(1.0),
             };
             let mut participant_senders = Vec::new();
             for (i, pk) in participants.iter().enumerate() {
@@ -3330,7 +3330,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: 1.0,
+                success_rate: Probability!(1.0),
             };
             let injector_pk = PrivateKey::from_seed(3_000_000).public_key();
             let (mut injector_sender, _injector_receiver) = oracle
@@ -3496,7 +3496,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: 1.0,
+                success_rate: Probability!(1.0),
             };
             let mut participant_senders = Vec::new();
             for (i, pk) in participants.iter().enumerate() {
@@ -3705,7 +3705,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: 1.0,
+                success_rate: Probability!(1.0),
             };
             let mut participant_senders = Vec::new();
             for (i, pk) in participants.iter().enumerate() {
@@ -3899,7 +3899,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: 1.0,
+                success_rate: Probability!(1.0),
             };
             let mut participant_senders = Vec::new();
             for (i, pk) in participants.iter().enumerate() {
@@ -4086,7 +4086,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: 1.0,
+                success_rate: Probability!(1.0),
             };
             let mut participant_senders = Vec::new();
             for (i, pk) in participants.iter().enumerate() {
@@ -4283,7 +4283,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: 1.0,
+                success_rate: Probability!(1.0),
             };
             let leader_pk = participants[1].clone();
             let (mut leader_sender, _leader_receiver) = oracle
@@ -4405,7 +4405,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: 1.0,
+                success_rate: Probability!(1.0),
             };
             let leader_pk = participants[1].clone();
             let (mut leader_sender, _leader_receiver) = oracle
@@ -4636,7 +4636,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: 1.0,
+                success_rate: Probability!(1.0),
             };
             let mut peer_senders = Vec::new();
             for (i, pk) in participants.iter().enumerate().skip(1) {
@@ -5008,7 +5008,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: 1.0,
+                success_rate: Probability!(1.0),
             };
             let leader_pk = participants[1].clone();
             let (mut leader_sender, _leader_receiver) = oracle
@@ -5153,7 +5153,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: 1.0,
+                success_rate: Probability!(1.0),
             };
             let leader = Participant::new(1);
             let leader_pk = participants[usize::from(leader)].clone();
@@ -5318,7 +5318,7 @@ mod tests {
                     Link {
                         latency: Duration::from_millis(0),
                         jitter: Duration::from_millis(0),
-                        success_rate: 1.0,
+                        success_rate: Probability!(1.0),
                     },
                 )
                 .await
@@ -5435,7 +5435,7 @@ mod tests {
                     Link {
                         latency: Duration::from_millis(0),
                         jitter: Duration::from_millis(0),
-                        success_rate: 1.0,
+                        success_rate: Probability!(1.0),
                     },
                 )
                 .await
@@ -5808,7 +5808,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: 1.0,
+                success_rate: Probability!(1.0),
             };
             let mut participant_senders = Vec::new();
             for (i, pk) in participants.iter().enumerate() {
@@ -5989,7 +5989,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: 1.0,
+                success_rate: Probability!(1.0),
             };
             let (mut peer_sender, _receiver) = oracle
                 .control(participants[1].clone())
@@ -6128,7 +6128,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: 1.0,
+                success_rate: Probability!(1.0),
             };
             let (mut peer_sender, _receiver) = oracle
                 .control(participants[1].clone())
@@ -6436,7 +6436,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: 1.0,
+                success_rate: Probability!(1.0),
             };
             let mut participant_senders = Vec::new();
             for (i, pk) in participants.iter().enumerate() {
@@ -6658,7 +6658,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: 1.0,
+                success_rate: Probability!(1.0),
             };
             oracle
                 .add_link(sender_pk.clone(), me.clone(), link)
@@ -6851,7 +6851,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: 1.0,
+                success_rate: Probability!(1.0),
             };
             oracle
                 .add_link(sender_pk.clone(), me.clone(), link)

--- a/consensus/src/simplex/actors/resolver/actor.rs
+++ b/consensus/src/simplex/actors/resolver/actor.rs
@@ -649,7 +649,9 @@ mod tests {
     use commonware_p2p::simulated::{Config as NetworkConfig, Link, Network};
     use commonware_parallel::Sequential;
     use commonware_runtime::{Quota, Runner, Supervisor, deterministic};
-    use commonware_utils::{NZU32, NZUsize, channel::oneshot, non_empty_vec, sync::Mutex};
+    use commonware_utils::{
+        NZU32, NZUsize, Probability, channel::oneshot, non_empty_vec, sync::Mutex,
+    };
     use std::{collections::BTreeSet, sync::Arc};
 
     const NAMESPACE: &[u8] = b"resolver-actor";
@@ -831,7 +833,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: 1.0,
+                success_rate: Probability!(1.0),
             };
             oracle
                 .add_link(
@@ -1016,7 +1018,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: 1.0,
+                success_rate: Probability!(1.0),
             };
             oracle
                 .add_link(

--- a/consensus/src/simplex/actors/voter/mod.rs
+++ b/consensus/src/simplex/actors/voter/mod.rs
@@ -95,7 +95,7 @@ mod tests {
         telemetry::traces::collector::{RecordedEvents, TraceStorage},
     };
     use commonware_storage::journal::segmented::variable::{Config as JConfig, Journal};
-    use commonware_utils::{NZU16, NZU32, NZUsize, sync::Mutex};
+    use commonware_utils::{NZU16, NZU32, NZUsize, Probability, sync::Mutex};
     use futures::FutureExt;
     use rand_core::CryptoRng;
     use std::{
@@ -2572,7 +2572,7 @@ mod tests {
                     Link {
                         latency: Duration::ZERO,
                         jitter: Duration::ZERO,
-                        success_rate: 1.0,
+                        success_rate: Probability!(1.0),
                     },
                 )
                 .await
@@ -4949,7 +4949,7 @@ mod tests {
                     Link {
                         latency: Duration::from_millis(0),
                         jitter: Duration::from_millis(0),
-                        success_rate: 1.0,
+                        success_rate: Probability!(1.0),
                     },
                 )
                 .await
@@ -9725,7 +9725,7 @@ mod tests {
                     Link {
                         latency: Duration::ZERO,
                         jitter: Duration::ZERO,
-                        success_rate: 1.0,
+                        success_rate: Probability!(1.0),
                     },
                 )
                 .await

--- a/consensus/src/simplex/mod.rs
+++ b/consensus/src/simplex/mod.rs
@@ -697,7 +697,8 @@ mod tests {
         buffer::paged::CacheRef, deterministic, telemetry::metrics::count_running_tasks,
     };
     use commonware_utils::{
-        Faults, N3f1, NZU16, NZU32, NZUsize, TestRng, ordered::Set, sync::Mutex, test_rng,
+        Faults, N3f1, NZU16, NZU32, NZUsize, Probability, TestRng, ordered::Set, sync::Mutex,
+        test_rng,
     };
     use engine::Engine;
     use futures::future::join_all;
@@ -1083,7 +1084,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(200),
                 jitter: Duration::from_millis(1),
-                success_rate: 1.0,
+                success_rate: Probability!(1.0),
             };
             link_validators(&mut oracle, &participants, Action::Link(link), None).await;
 
@@ -1336,7 +1337,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: 1.0,
+                success_rate: Probability!(1.0),
             };
             link_validators(&mut oracle, active, Action::Link(link.clone()), None).await;
 
@@ -1604,7 +1605,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: 1.0,
+                success_rate: Probability!(1.0),
             };
             link_validators(&mut oracle, &participants, Action::Link(link), None).await;
 
@@ -1844,7 +1845,7 @@ mod tests {
                 Link {
                     latency: link_latency,
                     jitter: Duration::from_millis(0),
-                    success_rate: 1.0,
+                    success_rate: Probability!(1.0),
                 },
                 TermLength::new(NZU32!(128)),
                 ViewDelta::new(128),
@@ -1895,7 +1896,7 @@ mod tests {
                 Link {
                     latency: Duration::from_millis(1_000),
                     jitter: Duration::from_millis(1),
-                    success_rate: 1.0,
+                    success_rate: Probability!(1.0),
                 },
                 TermLength::new(NZU32!(1000)),
                 ViewDelta::new(100),
@@ -2031,7 +2032,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: 1.0,
+                success_rate: Probability!(1.0),
             };
             link_validators(&mut oracle, &all_validators, Action::Link(link), None).await;
 
@@ -2201,7 +2202,7 @@ mod tests {
                 let link = Link {
                     latency: Duration::from_millis(50),
                     jitter: Duration::from_millis(50),
-                    success_rate: 1.0,
+                    success_rate: Probability!(1.0),
                 };
                 link_validators(&mut oracle, &participants, Action::Link(link), None).await;
 
@@ -2396,7 +2397,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: 1.0,
+                success_rate: Probability!(1.0),
             };
             link_validators(
                 &mut oracle,
@@ -2496,7 +2497,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_secs(3),
                 jitter: Duration::from_millis(0),
-                success_rate: 1.0,
+                success_rate: Probability!(1.0),
             };
             link_validators(
                 &mut oracle,
@@ -2535,7 +2536,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(3),
-                success_rate: 1.0,
+                success_rate: Probability!(1.0),
             };
             link_validators(
                 &mut oracle,
@@ -2669,7 +2670,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: 1.0,
+                success_rate: Probability!(1.0),
             };
             link_validators(
                 &mut oracle,
@@ -2906,7 +2907,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: 1.0,
+                success_rate: Probability!(1.0),
             };
             link_validators(&mut oracle, &participants, Action::Link(link), None).await;
 
@@ -3078,7 +3079,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_secs(3),
                 jitter: Duration::from_millis(0),
-                success_rate: 1.0,
+                success_rate: Probability!(1.0),
             };
             link_validators(&mut oracle, &participants, Action::Link(link), None).await;
 
@@ -3186,7 +3187,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: 1.0,
+                success_rate: Probability!(1.0),
             };
             link_validators(&mut oracle, &participants, Action::Link(link), None).await;
 
@@ -3380,7 +3381,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: 1.0,
+                success_rate: Probability!(1.0),
             };
             link_validators(
                 &mut oracle,
@@ -3516,7 +3517,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: 1.0,
+                success_rate: Probability!(1.0),
             };
             link_validators(&mut oracle, &participants, Action::Link(link.clone()), None).await;
 
@@ -3723,7 +3724,7 @@ mod tests {
             let degraded_link = Link {
                 latency: Duration::from_millis(200),
                 jitter: Duration::from_millis(150),
-                success_rate: 0.5,
+                success_rate: Probability!(0.5),
             };
             link_validators(
                 &mut oracle,
@@ -3926,7 +3927,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: 1.0,
+                success_rate: Probability!(1.0),
             };
             link_validators(&mut oracle, &participants, Action::Link(link), None).await;
 
@@ -4106,7 +4107,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: 1.0,
+                success_rate: Probability!(1.0),
             };
             link_validators(&mut oracle, &participants, Action::Link(link), None).await;
 
@@ -4261,7 +4262,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(100),
                 jitter: Duration::from_millis(1),
-                success_rate: 1.0,
+                success_rate: Probability!(1.0),
             };
             fn link_graph(_: usize, i: usize, j: usize) -> bool {
                 if i == 0 || j == 0 {
@@ -4421,7 +4422,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(0),
                 jitter: Duration::from_millis(0),
-                success_rate: 1.0,
+                success_rate: Probability!(1.0),
             };
             oracle
                 .add_link(injector_pk.clone(), me.clone(), link)
@@ -4562,7 +4563,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: 1.0,
+                success_rate: Probability!(1.0),
             };
             link_validators(&mut oracle, &participants, Action::Link(link), None).await;
 
@@ -4720,7 +4721,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: 1.0,
+                success_rate: Probability!(1.0),
             };
             link_validators(&mut oracle, &participants, Action::Link(link), None).await;
 
@@ -4989,7 +4990,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: 1.0,
+                success_rate: Probability!(1.0),
             };
             link_validators(&mut oracle, &participants, Action::Link(link), None).await;
 
@@ -5137,7 +5138,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: 1.0,
+                success_rate: Probability!(1.0),
             };
             link_validators(&mut oracle, &participants, Action::Link(link), None).await;
 
@@ -5298,7 +5299,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: 1.0,
+                success_rate: Probability!(1.0),
             };
             link_validators(&mut oracle, &participants, Action::Link(link), None).await;
 
@@ -5437,7 +5438,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(80),
                 jitter: Duration::from_millis(10),
-                success_rate: 0.98,
+                success_rate: Probability!(0.98),
             };
             link_validators(&mut oracle, &participants, Action::Link(link), None).await;
 
@@ -5571,7 +5572,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: 1.0,
+                success_rate: Probability!(1.0),
             };
             link_validators(&mut oracle, &participants, Action::Link(link), None).await;
 
@@ -5727,7 +5728,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: 1.0,
+                success_rate: Probability!(1.0),
             };
             link_validators(&mut oracle, &participants, Action::Link(link), None).await;
 
@@ -6001,7 +6002,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(0),
-                success_rate: 1.0,
+                success_rate: Probability!(1.0),
             };
             for p in participants.iter() {
                 oracle
@@ -6331,7 +6332,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(0),
-                success_rate: 1.0,
+                success_rate: Probability!(1.0),
             };
             for p in participants.iter() {
                 oracle
@@ -6616,7 +6617,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(0),
-                success_rate: 1.0,
+                success_rate: Probability!(1.0),
             };
             for p in participants.iter() {
                 oracle
@@ -6905,7 +6906,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(0),
-                success_rate: 1.0,
+                success_rate: Probability!(1.0),
             };
             for p in participants.iter() {
                 oracle
@@ -7141,7 +7142,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(5),
-                success_rate: 1.0,
+                success_rate: Probability!(1.0),
             };
             link_validators(&mut oracle, &participants, Action::Link(link), None).await;
 
@@ -7293,7 +7294,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: 1.0,
+                success_rate: Probability!(1.0),
             };
             link_validators(&mut oracle, &participants, Action::Link(link), None).await;
 
@@ -8106,7 +8107,7 @@ mod tests {
     const TWINS_LINK: Link = Link {
         latency: Duration::from_millis(500),
         jitter: Duration::from_millis(500),
-        success_rate: 1.0,
+        success_rate: Probability!(1.0),
     };
 
     /// Runs `campaign` with `elector` over a fast link and the slow [TWINS_LINK].
@@ -8115,7 +8116,7 @@ mod tests {
             Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(10),
-                success_rate: 1.0,
+                success_rate: Probability!(1.0),
             },
             TWINS_LINK,
         ] {

--- a/examples/estimator/src/main.rs
+++ b/examples/estimator/src/main.rs
@@ -13,7 +13,7 @@ use commonware_runtime::{
     deterministic,
 };
 use commonware_utils::{
-    NZUsize,
+    NZUsize, Probability,
     channel::{mpsc, oneshot},
 };
 use estimator::{
@@ -35,8 +35,8 @@ const DEFAULT_QUOTA: Quota = Quota::per_second(NonZeroU32::MAX);
 /// The channel to use for all messages
 const DEFAULT_CHANNEL: u64 = 0;
 
-/// The success rate over all links (1.0 = 100%)
-const DEFAULT_SUCCESS_RATE: f64 = 1.0;
+/// The success probability over all links (100%).
+const DEFAULT_SUCCESS_RATE: Probability = Probability!(1.0);
 
 /// Returns a network configuration that accepts every supported application payload size.
 const fn network_config(max_peers_per_set: usize) -> Config {

--- a/examples/flood/src/bin/flood.rs
+++ b/examples/flood/src/bin/flood.rs
@@ -16,7 +16,7 @@ use commonware_runtime::{
     telemetry::metrics::{HistogramExt as _, MetricsExt as _},
     tokio,
 };
-use commonware_utils::{TryCollect, ordered::Set, union};
+use commonware_utils::{Probability, TryCollect, ordered::Set, union};
 use rand::{Rng, SeedableRng, rngs::SmallRng};
 use std::{
     collections::HashMap,
@@ -82,7 +82,7 @@ fn main() {
             Some(tokio::tracing::Config {
                 endpoint: format!("http://{}:4318/v1/traces", hosts.monitoring.private),
                 name: public_key.to_string(),
-                rate: 1.0,
+                rate: Probability!(1.0),
             })
         } else {
             None

--- a/glue/src/dkg/orchestrator/mod.rs
+++ b/glue/src/dkg/orchestrator/mod.rs
@@ -107,8 +107,8 @@ mod tests {
     };
     use commonware_storage::archive::immutable;
     use commonware_utils::{
-        Acknowledgement, N3f1, NZU16, NZU32, NZU64, NZUsize, TestRng, acknowledgement::Exact,
-        ordered::Set, sequence::Unit,
+        Acknowledgement, N3f1, NZU16, NZU32, NZU64, NZUsize, Probability, TestRng,
+        acknowledgement::Exact, ordered::Set, sequence::Unit,
     };
     use std::{
         net::{IpAddr, Ipv4Addr, SocketAddr},
@@ -124,7 +124,7 @@ mod tests {
     const LINK: Link = Link {
         latency: Duration::from_millis(1),
         jitter: Duration::ZERO,
-        success_rate: 1.0,
+        success_rate: Probability!(1.0),
     };
     type TestStateSync = StateSync<mocks::TestScheme, mocks::TestDigest, mocks::TestBlsVariant>;
 

--- a/glue/src/dkg/probe/mod.rs
+++ b/glue/src/dkg/probe/mod.rs
@@ -267,8 +267,8 @@ mod tests {
     };
     use commonware_storage::archive::immutable;
     use commonware_utils::{
-        N3f1, NZDuration, NZU16, NZU32, NZU64, NZUsize, TestRng, channel::oneshot, ordered::Set,
-        sequence::Unit,
+        N3f1, NZDuration, NZU16, NZU32, NZU64, NZUsize, Probability, TestRng, channel::oneshot,
+        ordered::Set, sequence::Unit,
     };
     use std::{num::NonZeroU64, time::Duration};
 
@@ -279,7 +279,7 @@ mod tests {
     const LINK: Link = Link {
         latency: Duration::from_millis(1),
         jitter: Duration::ZERO,
-        success_rate: 1.0,
+        success_rate: Probability!(1.0),
     };
 
     struct Harness {

--- a/glue/src/dkg/tests/dkg/harness.rs
+++ b/glue/src/dkg/tests/dkg/harness.rs
@@ -39,8 +39,8 @@ use commonware_runtime::{
     telemetry::metrics::count_running_tasks,
 };
 use commonware_utils::{
-    NZU32, NZU64, NZUsize, Participant, channel::oneshot, ordered::Set, sequence::Unit,
-    sync::Mutex, test_rng,
+    NZU32, NZU64, NZUsize, Participant, Probability, channel::oneshot, ordered::Set,
+    sequence::Unit, sync::Mutex, test_rng,
 };
 use futures::future::pending;
 use std::{
@@ -342,7 +342,7 @@ pub(super) fn good_link() -> Link {
     Link {
         latency: Duration::from_millis(20),
         jitter: Duration::from_millis(5),
-        success_rate: 1.0,
+        success_rate: Probability!(1.0),
     }
 }
 

--- a/glue/src/dkg/tests/dkg/mod.rs
+++ b/glue/src/dkg/tests/dkg/mod.rs
@@ -4,6 +4,7 @@ mod properties;
 use crate::simulate::action::{Action, Crash, Schedule};
 use commonware_macros::{test_group, test_traced};
 use commonware_p2p::simulated::Link;
+use commonware_utils::Probability;
 use harness::{
     DkgEngine, good_link, run_activation_failure_completes_empty, run_closed_network_receiver,
     run_plan, run_restart_completion_state_is_fresh,
@@ -29,7 +30,7 @@ fn dkg_e2e_lossy_network() {
         Link {
             latency: Duration::from_millis(60),
             jitter: Duration::from_millis(20),
-            success_rate: 0.75,
+            success_rate: Probability!(0.75),
         },
         vec![],
         ExpectedOutcome::Success,

--- a/glue/src/dkg/tests/reshare/mod.rs
+++ b/glue/src/dkg/tests/reshare/mod.rs
@@ -3,6 +3,7 @@ use commonware_consensus::types::{Epoch, Epocher, FixedEpocher, Height};
 use commonware_cryptography::{bls12381::primitives::sharing::Mode, ed25519};
 use commonware_macros::{test_group, test_traced};
 use commonware_p2p::simulated::Link;
+use commonware_utils::Probability;
 use rstest::rstest;
 use std::time::Duration;
 
@@ -482,7 +483,7 @@ fn reshare_e2e_state_sync_restart_before_epoch_boundary(#[case] network: Network
     .link(Link {
         latency: Duration::from_millis(4),
         jitter: Duration::from_millis(1),
-        success_rate: 1.0,
+        success_rate: Probability!(1.0),
     })
     .crash(Crash::ProcessedHeight {
         participant: delayed.clone(),
@@ -647,7 +648,7 @@ fn reshare_e2e_lossy_network(#[case] network: Network) {
     .link(Link {
         latency: Duration::from_millis(100),
         jitter: Duration::from_millis(50),
-        success_rate: 0.7,
+        success_rate: Probability!(0.7),
     })
     .timeout(Duration::from_secs(720))
     .run()

--- a/glue/src/simulate/plan.rs
+++ b/glue/src/simulate/plan.rs
@@ -16,7 +16,7 @@ use commonware_p2p::{
     simulated::{self, Link, Network},
 };
 use commonware_runtime::{Clock, Runner as _, Spawner, Supervisor as _, deterministic};
-use commonware_utils::{NZUsize, TryCollect, channel::mpsc, ordered::Set};
+use commonware_utils::{NZUsize, Probability, TryCollect, channel::mpsc, ordered::Set};
 use rand::seq::IndexedRandom;
 use std::{
     collections::HashSet,
@@ -147,7 +147,7 @@ impl<D: EngineDefinition> PlanBuilder<D> {
             link: Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(5),
-                success_rate: 1.0,
+                success_rate: Probability!(1.0),
             },
             max_message_size: 1024 * 1024,
             engine,
@@ -979,7 +979,8 @@ mod tests {
             &self,
             ctx: super::super::engine::InitContext<'_, Self::PublicKey>,
         ) -> impl Future<Output = (Self::Engine, Self::State)> + Send {
-            let saw_fault = ctx.context.storage_fault_config().read().open_rate == Some(1.0);
+            let saw_fault =
+                ctx.context.storage_fault_config().read().open_rate == Some(Probability!(1.0));
             async move {
                 (
                     FaultObservingNode {
@@ -1086,7 +1087,7 @@ mod tests {
         let link = Link {
             latency: Duration::from_millis(10),
             jitter: Duration::from_millis(0),
-            success_rate: 1.0,
+            success_rate: Probability!(1.0),
         };
         let result = PlanBuilder::new(FinalizingEngine::new(1, Duration::from_millis(100), 1))
             .required_finalizations(1)
@@ -1113,7 +1114,7 @@ mod tests {
         let link = Link {
             latency: Duration::from_millis(10),
             jitter: Duration::from_millis(0),
-            success_rate: 1.0,
+            success_rate: Probability!(1.0),
         };
         let engine = FinalizingEngine::new(2, Duration::from_millis(100), 2);
         let delayed = engine.participants[0].clone();
@@ -1199,7 +1200,7 @@ mod tests {
     #[test]
     fn storage_fault_is_visible_during_engine_init() {
         PlanBuilder::new(FaultObservingEngine::new(1))
-            .with_storage_fault(deterministic::FaultConfig::default().open(1.0))
+            .with_storage_fault(deterministic::FaultConfig::default().open(Probability!(1.0)))
             .timeout(Duration::from_secs(1))
             .required_finalizations(1)
             .property(AllStatesSawFault)

--- a/glue/src/stateful/probe/mod.rs
+++ b/glue/src/stateful/probe/mod.rs
@@ -169,7 +169,7 @@ mod test {
     };
     use commonware_storage::archive::immutable;
     use commonware_utils::{
-        Acknowledgement, NZDuration, NZU16, NZU64, NZUsize, NonZeroDuration, TestRng,
+        Acknowledgement, NZDuration, NZU16, NZU64, NZUsize, NonZeroDuration, Probability, TestRng,
         channel::oneshot, sync::Mutex, test_rng,
     };
     use std::{
@@ -185,7 +185,7 @@ mod test {
     const LINK: Link = Link {
         latency: Duration::from_millis(10),
         jitter: Duration::from_millis(1),
-        success_rate: 1.0,
+        success_rate: Probability!(1.0),
     };
     const PROBE_CHANNEL: u64 = 0;
     const BACKFILL_CHANNEL: u64 = 1;

--- a/glue/src/stateful/tests/mod.rs
+++ b/glue/src/stateful/tests/mod.rs
@@ -55,7 +55,7 @@ use commonware_storage::{
     },
 };
 use commonware_utils::{
-    Acknowledgement as _, NZU64, NZUsize, acknowledgement::Exact, channel::oneshot,
+    Acknowledgement as _, NZU64, NZUsize, Probability, acknowledgement::Exact, channel::oneshot,
     non_empty_range, sync::Mutex,
 };
 use properties::{
@@ -156,7 +156,7 @@ fn state_sync_lossy_network() {
     let link = Link {
         latency: Duration::from_millis(200),
         jitter: Duration::from_millis(150),
-        success_rate: 0.7,
+        success_rate: Probability!(0.7),
     };
     run_state_sync_lossy(
         SingleDbEngine::new(NUM_VALIDATORS).with_state_sync(),
@@ -171,7 +171,7 @@ fn lossy_network() {
     let link = Link {
         latency: Duration::from_millis(200),
         jitter: Duration::from_millis(150),
-        success_rate: 0.7,
+        success_rate: Probability!(0.7),
     };
     run_lossy(SingleDbEngine::new(NUM_VALIDATORS), link.clone());
     run_lossy(MultiDbEngine::new(NUM_VALIDATORS), link);
@@ -290,7 +290,7 @@ where
 }
 
 fn storage_fault_config() -> deterministic::FaultConfig {
-    deterministic::FaultConfig::default().sync(0.01)
+    deterministic::FaultConfig::default().sync(Probability!(0.01))
 }
 
 fn default_storage_fault_schedule<P>(restart_order: impl IntoIterator<Item = P>) -> Schedule<P>
@@ -493,7 +493,7 @@ where
     let dead_link = Link {
         latency: Duration::from_secs(1),
         jitter: Duration::ZERO,
-        success_rate: 0.0,
+        success_rate: Probability!(0.0),
     };
 
     let mut schedule = Schedule::new();
@@ -598,7 +598,7 @@ where
         .link(Link {
             latency: Duration::from_millis(100),
             jitter: Duration::from_millis(5),
-            success_rate: 1.0,
+            success_rate: Probability!(1.0),
         })
         .crash(Crash::Random {
             // A full-cluster crash discards all in-flight votes, and a
@@ -796,12 +796,12 @@ where
     let good_link = Link {
         latency: Duration::from_millis(10),
         jitter: Duration::from_millis(5),
-        success_rate: 1.0,
+        success_rate: Probability!(1.0),
     };
     let dead_link = Link {
         latency: Duration::from_secs(1),
         jitter: Duration::ZERO,
-        success_rate: 0.0,
+        success_rate: Probability!(0.0),
     };
 
     // Build a schedule that kills all links to/from the isolated node at

--- a/p2p/TESTING.md
+++ b/p2p/TESTING.md
@@ -28,7 +28,7 @@ let (certificate_sender, certificate_receiver) = oracle
 oracle.add_link(pk1, pk2, Link {
     latency: Duration::from_millis(10),
     jitter: Duration::from_millis(3),
-    success_rate: 0.95,
+    success_rate: commonware_utils::Probability!(0.95),
 }).await.unwrap();
 ```
 

--- a/p2p/fuzz/Cargo.toml
+++ b/p2p/fuzz/Cargo.toml
@@ -15,7 +15,7 @@ commonware-cryptography.workspace = true
 commonware-macros.workspace = true
 commonware-p2p.workspace = true
 commonware-runtime.workspace = true
-commonware-utils.workspace = true
+commonware-utils = { workspace = true, features = ["arbitrary"] }
 futures.workspace = true
 libfuzzer-sys.workspace = true
 rand.workspace = true

--- a/p2p/fuzz/fuzz_targets/simulated.rs
+++ b/p2p/fuzz/fuzz_targets/simulated.rs
@@ -7,7 +7,7 @@ use commonware_p2p::{
     Channel, Receiver as ReceiverTrait, Recipients, Sender as SenderTrait, simulated,
 };
 use commonware_runtime::{Clock, IoBuf, Quota, Runner, Supervisor as _, deterministic};
-use commonware_utils::NZUsize;
+use commonware_utils::{NZUsize, Probability};
 use libfuzzer_sys::fuzz_target;
 use rand::RngExt as _;
 use std::{
@@ -58,7 +58,7 @@ enum Operation {
         latency_ms: u16,
         /// Latency jitter in milliseconds.
         jitter: u16,
-        /// Success rate (0-255 maps to 0.0-1.0).
+        /// Success rate as a numerator over 255.
         success_rate: u8,
     },
     /// Remove a network link between two peers.
@@ -279,12 +279,11 @@ fn fuzz(input: FuzzInput) {
                     let from_idx = (from_idx as usize) % peer_pks.len();
                     let to_idx = (to_idx as usize) % peer_pks.len();
 
-                    // Create link with specified characteristics
-                    // success_rate is normalized from u8 (0-255) to f64 (0.0-1.0)
+                    // Create link with specified characteristics.
                     let link = simulated::Link {
                         latency: Duration::from_millis(latency_ms as u64),
                         jitter: Duration::from_millis(jitter as u64),
-                        success_rate: (success_rate as f64) / 255.0,
+                        success_rate: Probability!(u64::from(success_rate), u64::from(u8::MAX)),
                     };
                     let _ = oracle
                         .add_link(peer_pks[from_idx].clone(), peer_pks[to_idx].clone(), link)

--- a/p2p/fuzz/fuzz_targets/simulated.rs
+++ b/p2p/fuzz/fuzz_targets/simulated.rs
@@ -58,8 +58,8 @@ enum Operation {
         latency_ms: u16,
         /// Latency jitter in milliseconds.
         jitter: u16,
-        /// Success rate as a numerator over 255.
-        success_rate: u8,
+        /// Probability that a message is delivered successfully.
+        success_rate: Probability,
     },
     /// Remove a network link between two peers.
     RemoveLink {
@@ -283,7 +283,7 @@ fn fuzz(input: FuzzInput) {
                     let link = simulated::Link {
                         latency: Duration::from_millis(latency_ms as u64),
                         jitter: Duration::from_millis(jitter as u64),
-                        success_rate: Probability!(u64::from(success_rate), u64::from(u8::MAX)),
+                        success_rate,
                     };
                     let _ = oracle
                         .add_link(peer_pks[from_idx].clone(), peer_pks[to_idx].clone(), link)

--- a/p2p/src/simulated/ingress.rs
+++ b/p2p/src/simulated/ingress.rs
@@ -6,6 +6,7 @@ use commonware_actor::Feedback;
 use commonware_cryptography::PublicKey;
 use commonware_runtime::{Clock, IoBuf, Quota};
 use commonware_utils::{
+    Probability,
     channel::{fallible::FallibleExt, mpsc, oneshot, ring},
     ordered::Map,
 };
@@ -52,7 +53,7 @@ pub enum Message<P: PublicKey, E: Clock> {
         sender: P,
         receiver: P,
         sampler: Normal<f64>,
-        success_rate: f64,
+        success_rate: Probability,
         result: oneshot::Sender<Result<(), Error>>,
     },
     RemoveLink {
@@ -138,8 +139,8 @@ pub struct Link {
     /// Standard deviation of the latency for the delivery of a message.
     pub jitter: Duration,
 
-    /// Probability of a message being delivered successfully (in range \[0,1\]).
-    pub success_rate: f64,
+    /// Probability of a message being delivered successfully.
+    pub success_rate: Probability,
 }
 
 /// Interface for modifying the simulated network.
@@ -230,9 +231,6 @@ impl<P: PublicKey, E: Clock> Oracle<P, E> {
         // Sanity checks
         if sender == receiver {
             return Err(Error::LinkingSelf);
-        }
-        if config.success_rate < 0.0 || config.success_rate > 1.0 {
-            return Err(Error::InvalidSuccessRate(config.success_rate));
         }
 
         // Convert Duration to milliseconds as f64 for the Normal distribution

--- a/p2p/src/simulated/mod.rs
+++ b/p2p/src/simulated/mod.rs
@@ -62,7 +62,7 @@
 //! use commonware_p2p::simulated::{Config, Link, Network};
 //! use commonware_cryptography::{ed25519, PrivateKey, Signer as _, PublicKey as _, };
 //! use commonware_runtime::{deterministic, Metrics, Quota, Runner, Spawner, Supervisor};
-//! use commonware_utils::{NZU32, NZUsize};
+//! use commonware_utils::{NZU32, NZUsize, Probability};
 //! use std::time::Duration;
 //!
 //! // Generate peers
@@ -111,7 +111,7 @@
 //!         Link {
 //!             latency: Duration::from_millis(5),
 //!             jitter: Duration::from_millis(2),
-//!             success_rate: 0.75,
+//!             success_rate: Probability!(0.75),
 //!         },
 //!     ).await.unwrap();
 //!
@@ -128,7 +128,7 @@
 //!         Link {
 //!             latency: Duration::from_millis(100),
 //!             jitter: Duration::from_millis(25),
-//!             success_rate: 0.8,
+//!             success_rate: Probability!(0.8),
 //!         },
 //!     ).await.unwrap();
 //!
@@ -158,8 +158,6 @@ pub enum Error {
     LinkExists,
     #[error("link missing")]
     LinkMissing,
-    #[error("invalid success rate (must be in [0, 1]): {0}")]
-    InvalidSuccessRate(f64),
     #[error("send_frame failed")]
     SendFrameFailed,
     #[error("recv_frame failed")]
@@ -197,7 +195,7 @@ mod tests {
         telemetry::metrics::count_running_tasks,
     };
     use commonware_utils::{
-        NZU32, NZUsize,
+        NZU32, NZUsize, Probability,
         channel::mpsc,
         hostname, ordered,
         ordered::{Map, Set},
@@ -291,7 +289,7 @@ mod tests {
                             Link {
                                 latency: Duration::from_millis(5),
                                 jitter: Duration::from_millis(2),
-                                success_rate: 0.75,
+                                success_rate: Probability!(0.75),
                             },
                         )
                         .await;
@@ -426,7 +424,7 @@ mod tests {
                     Link {
                         latency: Duration::from_millis(5),
                         jitter: Duration::from_millis(2),
-                        success_rate: 0.75,
+                        success_rate: Probability!(0.75),
                     },
                 )
                 .await;
@@ -464,7 +462,7 @@ mod tests {
                     Link {
                         latency: Duration::from_millis(10),
                         jitter: Duration::from_millis(1),
-                        success_rate: 1.0,
+                        success_rate: Probability!(1.0),
                     },
                 )
                 .await
@@ -476,7 +474,7 @@ mod tests {
                     Link {
                         latency: Duration::from_millis(10),
                         jitter: Duration::from_millis(1),
-                        success_rate: 1.0,
+                        success_rate: Probability!(1.0),
                     },
                 )
                 .await
@@ -540,56 +538,6 @@ mod tests {
     }
 
     #[test]
-    fn test_invalid_success_rate() {
-        let executor = deterministic::Runner::default();
-        executor.start(|context| async move {
-            // Create simulated network
-            let (network, oracle) = Network::new(
-                context.child("network"),
-                Config {
-                    max_size: 1024 * 1024,
-                    max_peers_per_set: NZUsize!(1),
-                    disconnect_on_block: true,
-                    tracked_peer_sets: NZUsize!(1),
-                },
-            );
-
-            // Start network
-            network.start();
-
-            // Register agents
-            let pk1 = PrivateKey::from_seed(0).public_key();
-            let pk2 = PrivateKey::from_seed(1).public_key();
-            oracle
-                .control(pk1.clone())
-                .register(0, TEST_QUOTA)
-                .await
-                .unwrap();
-            oracle
-                .control(pk2.clone())
-                .register(0, TEST_QUOTA)
-                .await
-                .unwrap();
-
-            // Attempt to link with invalid success rate
-            let result = oracle
-                .add_link(
-                    pk1,
-                    pk2,
-                    Link {
-                        latency: Duration::from_millis(5),
-                        jitter: Duration::from_millis(2),
-                        success_rate: 1.5,
-                    },
-                )
-                .await;
-
-            // Confirm error is correct
-            assert!(matches!(result, Err(Error::InvalidSuccessRate(_))));
-        });
-    }
-
-    #[test]
     fn test_add_link_before_channel_registration() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
@@ -619,7 +567,7 @@ mod tests {
                     Link {
                         latency: Duration::ZERO,
                         jitter: Duration::ZERO,
-                        success_rate: 1.0,
+                        success_rate: Probability!(1.0),
                     },
                 )
                 .await
@@ -699,7 +647,7 @@ mod tests {
                     Link {
                         latency: Duration::from_millis(5),
                         jitter: Duration::from_millis(2),
-                        success_rate: 1.0,
+                        success_rate: Probability!(1.0),
                     },
                 )
                 .await
@@ -711,7 +659,7 @@ mod tests {
                     Link {
                         latency: Duration::from_millis(5),
                         jitter: Duration::from_millis(2),
-                        success_rate: 1.0,
+                        success_rate: Probability!(1.0),
                     },
                 )
                 .await
@@ -774,7 +722,7 @@ mod tests {
                     Link {
                         latency: Duration::from_millis(5),
                         jitter: Duration::ZERO,
-                        success_rate: 1.0,
+                        success_rate: Probability!(1.0),
                     },
                 )
                 .await
@@ -835,7 +783,7 @@ mod tests {
                     Link {
                         latency: Duration::from_millis(5),
                         jitter: Duration::from_millis(2),
-                        success_rate: 1.0,
+                        success_rate: Probability!(1.0),
                     },
                 )
                 .await
@@ -847,7 +795,7 @@ mod tests {
                     Link {
                         latency: Duration::from_millis(5),
                         jitter: Duration::from_millis(2),
-                        success_rate: 1.0,
+                        success_rate: Probability!(1.0),
                     },
                 )
                 .await
@@ -927,7 +875,7 @@ mod tests {
                     Link {
                         latency: Duration::from_millis(5),
                         jitter: Duration::from_millis(2),
-                        success_rate: 1.0,
+                        success_rate: Probability!(1.0),
                     },
                 )
                 .await
@@ -939,7 +887,7 @@ mod tests {
                     Link {
                         latency: Duration::from_millis(5),
                         jitter: Duration::from_millis(2),
-                        success_rate: 1.0,
+                        success_rate: Probability!(1.0),
                     },
                 )
                 .await
@@ -1030,7 +978,7 @@ mod tests {
                     // No latency so it doesn't interfere with bandwidth delay calculation
                     latency: Duration::ZERO,
                     jitter: Duration::ZERO,
-                    success_rate: 1.0,
+                    success_rate: Probability!(1.0),
                 },
             )
             .await
@@ -1213,7 +1161,7 @@ mod tests {
                         Link {
                             latency: Duration::ZERO,
                             jitter: Duration::ZERO,
-                            success_rate: 1.0,
+                            success_rate: Probability!(1.0),
                         },
                     )
                     .await
@@ -1225,7 +1173,7 @@ mod tests {
                         Link {
                             latency: Duration::ZERO,
                             jitter: Duration::ZERO,
-                            success_rate: 1.0,
+                            success_rate: Probability!(1.0),
                         },
                     )
                     .await
@@ -1346,7 +1294,7 @@ mod tests {
                     Link {
                         latency: Duration::from_millis(50),
                         jitter: Duration::from_millis(40),
-                        success_rate: 1.0,
+                        success_rate: Probability!(1.0),
                     },
                 )
                 .await
@@ -1413,7 +1361,7 @@ mod tests {
                     Link {
                         latency: Duration::from_millis(5_000),
                         jitter: Duration::ZERO,
-                        success_rate: 1.0,
+                        success_rate: Probability!(1.0),
                     },
                 )
                 .await
@@ -1434,7 +1382,7 @@ mod tests {
                     Link {
                         latency: Duration::from_millis(1),
                         jitter: Duration::ZERO,
-                        success_rate: 1.0,
+                        success_rate: Probability!(1.0),
                     },
                 )
                 .await
@@ -1537,7 +1485,7 @@ mod tests {
                         Link {
                             latency: Duration::ZERO,
                             jitter: Duration::ZERO,
-                            success_rate: 1.0,
+                            success_rate: Probability!(1.0),
                         },
                     )
                     .await
@@ -1627,7 +1575,7 @@ mod tests {
                         Link {
                             latency: Duration::ZERO,
                             jitter: Duration::ZERO,
-                            success_rate: 1.0,
+                            success_rate: Probability!(1.0),
                         },
                     )
                     .await
@@ -1724,7 +1672,7 @@ mod tests {
                         Link {
                             latency: Duration::ZERO,
                             jitter: Duration::ZERO,
-                            success_rate: 1.0,
+                            success_rate: Probability!(1.0),
                         },
                     )
                     .await
@@ -1821,7 +1769,7 @@ mod tests {
                         Link {
                             latency: Duration::from_millis(1),
                             jitter: Duration::ZERO,
-                            success_rate: 1.0,
+                            success_rate: Probability!(1.0),
                         },
                     )
                     .await
@@ -1967,7 +1915,7 @@ mod tests {
                         Link {
                             latency: Duration::from_millis(1),
                             jitter: Duration::ZERO,
-                            success_rate: 1.0,
+                            success_rate: Probability!(1.0),
                         },
                     )
                     .await
@@ -2065,7 +2013,7 @@ mod tests {
                     Link {
                         latency: Duration::from_secs(1), // 1 second latency
                         jitter: Duration::ZERO,
-                        success_rate: 1.0,
+                        success_rate: Probability!(1.0),
                     },
                 )
                 .await
@@ -2156,7 +2104,7 @@ mod tests {
                     Link {
                         latency: Duration::from_millis(1), // Small latency
                         jitter: Duration::ZERO,
-                        success_rate: 1.0,
+                        success_rate: Probability!(1.0),
                     },
                 )
                 .await
@@ -2247,7 +2195,7 @@ mod tests {
                     Link {
                         latency: Duration::ZERO,
                         jitter: Duration::ZERO,
-                        success_rate: 1.0,
+                        success_rate: Probability!(1.0),
                     },
                 )
                 .await
@@ -2326,7 +2274,7 @@ mod tests {
                     Link {
                         latency: Duration::ZERO,
                         jitter: Duration::ZERO,
-                        success_rate: 1.0,
+                        success_rate: Probability!(1.0),
                     },
                 )
                 .await
@@ -2731,7 +2679,7 @@ mod tests {
                                 Link {
                                     latency: Duration::from_millis(1),
                                     jitter: Duration::ZERO,
-                                    success_rate: 1.0,
+                                    success_rate: Probability!(1.0),
                                 },
                             )
                             .await
@@ -2872,7 +2820,7 @@ mod tests {
                     Link {
                         latency: Duration::from_millis(1),
                         jitter: Duration::ZERO,
-                        success_rate: 1.0,
+                        success_rate: Probability!(1.0),
                     },
                 )
                 .await
@@ -3213,7 +3161,7 @@ mod tests {
             let link = ingress::Link {
                 latency: Duration::from_millis(0),
                 jitter: Duration::from_millis(0),
-                success_rate: 1.0,
+                success_rate: Probability!(1.0),
             };
             oracle
                 .add_link(pk1.clone(), pk2.clone(), link.clone())
@@ -3281,7 +3229,7 @@ mod tests {
             let link = ingress::Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(0),
-                success_rate: 1.0,
+                success_rate: Probability!(1.0),
             };
             oracle
                 .add_link(pk1.clone(), pk2.clone(), link.clone())
@@ -3347,7 +3295,7 @@ mod tests {
             let link = ingress::Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(0),
-                success_rate: 1.0,
+                success_rate: Probability!(1.0),
             };
             oracle
                 .add_link(pk1.clone(), pk2.clone(), link.clone())

--- a/p2p/src/simulated/network.rs
+++ b/p2p/src/simulated/network.rs
@@ -26,13 +26,13 @@ use commonware_runtime::{
 };
 use commonware_stream::utils::codec::{recv_frame, send_frame};
 use commonware_utils::{
-    NZUsize, TryCollect,
+    NZUsize, Probability, TryCollect,
     channel::{fallible::FallibleExt, mpsc, oneshot, ring},
     ordered::Set,
 };
 use either::Either;
 use futures::{Sink, future};
-use rand::{Rng, RngExt as _};
+use rand::Rng;
 use rand_distr::{Distribution, Normal};
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap, VecDeque},
@@ -813,7 +813,7 @@ impl<E: RNetwork + Spawner + Rng + Clock + Metrics, P: PublicKey> Network<E, P> 
             let latency = Duration::from_millis(link.sampler.sample(self.context.as_mut()) as u64);
 
             // Determine if the message should be delivered
-            let should_deliver = self.context.random_bool(link.success_rate);
+            let should_deliver = link.success_rate.sample(self.context.as_mut());
 
             // Enqueue message for delivery
             let completions = self.transmitter.enqueue(
@@ -1428,7 +1428,7 @@ impl<P: PublicKey> Peer<P> {
 // Messages can be sent over the link with a given latency, jitter, and success rate.
 struct Link {
     sampler: Normal<f64>,
-    success_rate: f64,
+    success_rate: Probability,
     // Messages with their receive time for ordered delivery
     inbox: mpsc::UnboundedSender<(Channel, IoBuf, SystemTime)>,
 }
@@ -1442,7 +1442,7 @@ impl Link {
         receiver: P,
         socket: SocketAddr,
         sampler: Normal<f64>,
-        success_rate: f64,
+        success_rate: Probability,
         max_frame_size: u32,
         received_messages: CounterFamily<metrics::Message>,
     ) -> Self {
@@ -1569,7 +1569,7 @@ mod tests {
             let link = ingress::Link {
                 latency: Duration::from_millis(2),
                 jitter: Duration::from_millis(1),
-                success_rate: 0.9,
+                success_rate: Probability!(0.9),
             };
             oracle
                 .add_link(pk1.clone(), pk2.clone(), link.clone())
@@ -1646,7 +1646,7 @@ mod tests {
                     ingress::Link {
                         latency: Duration::ZERO,
                         jitter: Duration::ZERO,
-                        success_rate: 1.0,
+                        success_rate: Probability!(1.0),
                     },
                 )
                 .await
@@ -1918,7 +1918,7 @@ mod tests {
             let link = ingress::Link {
                 latency: Duration::from_millis(0),
                 jitter: Duration::from_millis(0),
-                success_rate: 1.0,
+                success_rate: Probability!(1.0),
             };
             oracle
                 .add_link(peer_a.clone(), twin.clone(), link.clone())
@@ -2005,7 +2005,7 @@ mod tests {
             let link = ingress::Link {
                 latency: Duration::from_millis(0),
                 jitter: Duration::from_millis(0),
-                success_rate: 1.0,
+                success_rate: Probability!(1.0),
             };
             oracle
                 .add_link(peer_c.clone(), twin.clone(), link.clone())
@@ -2075,7 +2075,7 @@ mod tests {
             let link = ingress::Link {
                 latency: Duration::from_millis(0),
                 jitter: Duration::from_millis(0),
-                success_rate: 1.0,
+                success_rate: Probability!(1.0),
             };
             oracle
                 .add_link(peer_c.clone(), twin.clone(), link.clone())
@@ -2306,7 +2306,7 @@ mod tests {
                     ingress::Link {
                         latency: Duration::from_millis(0),
                         jitter: Duration::from_millis(0),
-                        success_rate: 1.0,
+                        success_rate: Probability!(1.0),
                     },
                 )
                 .await
@@ -2392,7 +2392,7 @@ mod tests {
             let link = ingress::Link {
                 latency: Duration::from_millis(0),
                 jitter: Duration::from_millis(0),
-                success_rate: 1.0,
+                success_rate: Probability!(1.0),
             };
             oracle
                 .add_link(sender_pk.clone(), recipient_a.clone(), link.clone())
@@ -2480,7 +2480,7 @@ mod tests {
             let link = ingress::Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::ZERO,
-                success_rate: 1.0,
+                success_rate: Probability!(1.0),
             };
             for (a, b) in [(&pk1, &pk2), (&pk1, &pk3), (&pk2, &pk3)] {
                 oracle
@@ -2631,7 +2631,7 @@ mod tests {
             let link = ingress::Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::ZERO,
-                success_rate: 1.0,
+                success_rate: Probability!(1.0),
             };
             oracle
                 .add_link(primary_1.clone(), secondary_0.clone(), link.clone())

--- a/p2p/src/utils/codec.rs
+++ b/p2p/src/utils/codec.rs
@@ -301,7 +301,7 @@ mod tests {
     use commonware_macros::test_traced;
     use commonware_parallel::{Manual, Sequential, Strategy};
     use commonware_runtime::{Clock as _, IoBuf, Quota, Runner, Supervisor as _, deterministic};
-    use commonware_utils::{NZUsize, channel::mpsc, ordered::Set};
+    use commonware_utils::{NZUsize, Probability, channel::mpsc, ordered::Set};
     use std::{
         io,
         num::{NonZeroU32, NonZeroUsize},
@@ -315,7 +315,7 @@ mod tests {
     const LINK: Link = Link {
         latency: Duration::from_millis(0),
         jitter: Duration::from_millis(0),
-        success_rate: 1.0,
+        success_rate: Probability!(1.0),
     };
 
     const TEST_QUOTA: Quota = Quota::per_second(NonZeroU32::MAX);

--- a/p2p/src/utils/mux.rs
+++ b/p2p/src/utils/mux.rs
@@ -505,7 +505,7 @@ mod tests {
     };
     use commonware_macros::{select, test_traced};
     use commonware_runtime::{IoBuf, Quota, Runner, Supervisor as _, deterministic};
-    use commonware_utils::{NZUsize, ordered::Set};
+    use commonware_utils::{NZUsize, Probability, ordered::Set};
     use std::{
         num::NonZeroU32,
         time::{Duration, SystemTime},
@@ -514,7 +514,7 @@ mod tests {
     const LINK: Link = Link {
         latency: Duration::from_millis(0),
         jitter: Duration::from_millis(0),
-        success_rate: 1.0,
+        success_rate: Probability!(1.0),
     };
     const CAPACITY: usize = 5usize;
 

--- a/resolver/src/p2p/mod.rs
+++ b/resolver/src/p2p/mod.rs
@@ -127,7 +127,7 @@ mod tests {
         telemetry::metrics::count_running_tasks,
     };
     use commonware_utils::{
-        NZU32, NZUsize,
+        NZU32, NZUsize, Probability,
         channel::{
             fallible::{FallibleExt, OneshotExt},
             mpsc, oneshot,
@@ -151,12 +151,12 @@ mod tests {
     const LINK: Link = Link {
         latency: Duration::from_millis(10),
         jitter: Duration::from_millis(1),
-        success_rate: 1.0,
+        success_rate: Probability!(1.0),
     };
     const LINK_UNRELIABLE: Link = Link {
         latency: Duration::from_millis(10),
         jitter: Duration::from_millis(1),
-        success_rate: 0.5,
+        success_rate: Probability!(0.5),
     };
 
     fn status_metric_total(metrics: &str, name: &str, status: &str) -> u64 {

--- a/runtime/src/deterministic.rs
+++ b/runtime/src/deterministic.rs
@@ -42,7 +42,7 @@
 //! });
 //! ```
 
-pub use crate::storage::faulty::Config as FaultConfig;
+pub use crate::storage::faulty::{Config as FaultConfig, PartialWriteMode};
 #[cfg(feature = "external")]
 use crate::{Blocker, Pacer};
 use crate::{
@@ -54,8 +54,10 @@ use crate::{
     },
     prefixed_name,
     storage::{
-        audited::Storage as AuditedStorage, faulty::Storage as FaultyStorage,
-        memory::Storage as MemStorage, metered::Storage as MeteredStorage,
+        audited::Storage as AuditedStorage,
+        faulty::Storage as FaultyStorage,
+        memory::{Snapshot as MemStorageSnapshot, Storage as MemStorage},
+        metered::Storage as MeteredStorage,
     },
     telemetry::metrics::{
         Counter, CounterFamily, GaugeFamily, Metric, Register, Registered, Registry, add_attribute,
@@ -499,7 +501,8 @@ pub struct Checkpoint {
     auditor: Arc<Auditor>,
     rng: Arc<Mutex<BoxDynRng>>,
     time: Mutex<SystemTime>,
-    storage: Arc<Storage>,
+    storage: MemStorageSnapshot,
+    storage_fault_cfg: FaultConfig,
     dns: Mutex<HashMap<String, Vec<IpAddr>>>,
     catch_panics: bool,
     network_buffer_pool_cfg: BufferPoolConfig,
@@ -707,6 +710,15 @@ impl Runner {
         // root future is still Pending and holds captured variables with Context references.
         drop(root);
 
+        // No task can issue or make a write durable after this crash boundary.
+        storage
+            .inner()
+            .inner()
+            .crash()
+            .expect("retaining successful unsynced writes at crash should succeed");
+        let storage_fault_cfg = storage.inner().inner().config().read().clone();
+        let storage = storage.inner().inner().inner().take_snapshot();
+
         // Assert the context doesn't escape the start() function (behavior
         // is undefined in this case)
         assert!(
@@ -731,6 +743,7 @@ impl Runner {
             rng: executor.rng,
             time: executor.time,
             storage,
+            storage_fault_cfg,
             dns: executor.dns,
             catch_panics: executor.panicker.catch(),
             network_buffer_pool_cfg,
@@ -907,6 +920,22 @@ impl Tasks {
 type Network = MeteredNetwork<AuditedNetwork<DeterministicNetwork>>;
 type Storage = MeteredStorage<AuditedStorage<FaultyStorage<MemStorage>>>;
 
+fn build_storage(
+    inner: MemStorage,
+    rng: Arc<Mutex<BoxDynRng>>,
+    faults: FaultConfig,
+    auditor: Arc<Auditor>,
+    registry: &mut impl Register,
+) -> Storage {
+    MeteredStorage::new(
+        AuditedStorage::new(
+            FaultyStorage::new(inner, rng, Arc::new(RwLock::new(faults))),
+            auditor,
+        ),
+        registry,
+    )
+}
+
 /// Implementation of [crate::Spawner], [crate::Clock],
 /// [crate::Network], and [crate::Storage] for the `deterministic`
 /// runtime.
@@ -949,17 +978,11 @@ impl Context {
             &mut runtime_registry.sub_registry("storage_buffer_pool"),
         );
 
-        // Create storage fault config (default to disabled if None)
-        let storage_fault_config = Arc::new(RwLock::new(cfg.storage_fault_cfg));
-        let storage = MeteredStorage::new(
-            AuditedStorage::new(
-                FaultyStorage::new(
-                    MemStorage::new(storage_buffer_pool.clone()),
-                    rng.clone(),
-                    storage_fault_config,
-                ),
-                auditor.clone(),
-            ),
+        let storage = build_storage(
+            MemStorage::new(storage_buffer_pool.clone()),
+            rng.clone(),
+            cfg.storage_fault_cfg,
+            auditor.clone(),
             &mut runtime_registry,
         );
 
@@ -1002,10 +1025,11 @@ impl Context {
         )
     }
 
-    /// Recover the inner state (deadline, metrics, auditor, rng, synced storage, etc.) from the
-    /// current runtime and use it to initialize a new instance of the runtime. A recovered runtime
-    /// does not inherit the current runtime's pending tasks, unsynced storage, network connections, nor
-    /// its shutdown signaler.
+    /// Recover the inner state (deadline, metrics, auditor, rng, storage, etc.) from the current
+    /// runtime and use it to initialize a new instance of the runtime. Storage recovery includes
+    /// durable state and any unsynchronized mutations retained by the configured crash policy. A
+    /// recovered runtime does not inherit pending tasks, network connections, or its shutdown
+    /// signaler.
     ///
     /// This is useful for performing a deterministic simulation that spans multiple runtime instantiations,
     /// like simulating unclean shutdown (which involves repeatedly halting the runtime at unexpected intervals).
@@ -1032,6 +1056,13 @@ impl Context {
         let storage_buffer_pool = BufferPool::new(
             checkpoint.storage_buffer_pool_cfg.clone(),
             &mut runtime_registry.sub_registry("storage_buffer_pool"),
+        );
+        let storage = build_storage(
+            MemStorage::from_snapshot(checkpoint.storage, storage_buffer_pool.clone()),
+            checkpoint.rng.clone(),
+            checkpoint.storage_fault_cfg,
+            checkpoint.auditor.clone(),
+            &mut runtime_registry,
         );
 
         // Initialize panicker
@@ -1060,7 +1091,7 @@ impl Context {
                 attributes: Vec::new(),
                 executor: Arc::downgrade(&executor),
                 network: Arc::new(network),
-                storage: checkpoint.storage,
+                storage: Arc::new(storage),
                 network_buffer_pool,
                 storage_buffer_pool,
                 tree: Tree::root(),
@@ -1884,6 +1915,88 @@ mod tests {
     }
 
     #[test]
+    fn test_recover_snapshots_fault_configuration() {
+        let (stale_config, checkpoint) =
+            deterministic::Runner::default().start_and_recover(|context| async move {
+                let config = context.storage_fault_config();
+                *config.write() = FaultConfig::default().open(1.0);
+                config
+            });
+        *stale_config.write() = FaultConfig::default();
+
+        deterministic::Runner::from(checkpoint).start(|context| async move {
+            assert!(context.open("fault_config", b"blob").await.is_err());
+        });
+    }
+
+    #[test]
+    fn test_recover_retained_successful_resize() {
+        let cfg = deterministic::Config::default()
+            .with_storage_fault_config(FaultConfig::default().resize(0.0, 1.0));
+        let (_, checkpoint) =
+            deterministic::Runner::new(cfg).start_and_recover(|context| async move {
+                let (blob, _) = context.open("crash_resize", b"blob").await.unwrap();
+                blob.write_at(0, b"abcdefgh", WriteOptions::SYNC)
+                    .await
+                    .unwrap();
+                blob.resize(3).await.unwrap();
+            });
+
+        deterministic::Runner::from(checkpoint).start(|context| async move {
+            let (blob, len) = context.open("crash_resize", b"blob").await.unwrap();
+            assert_eq!(len, 3);
+            assert_eq!(blob.read_at(0, 3).await.unwrap().coalesce(), b"abc");
+        });
+    }
+
+    #[test]
+    fn test_recover_random_crash_writes_is_seeded_and_epoch_scoped() {
+        const STABLE_LEN: usize = 32;
+        const PENDING_LEN: usize = 256;
+
+        fn run(seed: u64) -> (Vec<u8>, Digest) {
+            let cfg = deterministic::Config::default()
+                .with_seed(seed)
+                .with_storage_fault_config(
+                    FaultConfig::default().write(0.0, (PartialWriteMode::Subset, 0.5)),
+                );
+            let (_, checkpoint) =
+                deterministic::Runner::new(cfg).start_and_recover(|context| async move {
+                    let (blob, _) = context.open("crash_epoch", b"blob").await.unwrap();
+                    blob.write_at(0, vec![0xA5; STABLE_LEN], WriteOptions::default())
+                        .await
+                        .unwrap();
+                    blob.sync().await.unwrap();
+                    blob.write_at(
+                        STABLE_LEN as u64,
+                        vec![0x5A; PENDING_LEN],
+                        WriteOptions::default(),
+                    )
+                    .await
+                    .unwrap();
+                });
+
+            deterministic::Runner::from(checkpoint).start(|context| async move {
+                let (blob, len) = context.open("crash_epoch", b"blob").await.unwrap();
+                let mut bytes = vec![0; STABLE_LEN + PENDING_LEN];
+                let len = usize::try_from(len).unwrap();
+                let durable = blob.read_at(0, len).await.unwrap().coalesce();
+                bytes[..durable.len()].copy_from_slice(durable.as_ref());
+                (bytes, context.storage_audit())
+            })
+        }
+
+        let first = run(12345);
+        let second = run(12345);
+        let different = run(54321);
+        assert_eq!(first, second);
+        assert_ne!(first.0, different.0);
+        assert!(first.0[..STABLE_LEN].iter().all(|&byte| byte == 0xA5));
+        assert!(first.0[STABLE_LEN..].contains(&0));
+        assert!(first.0[STABLE_LEN..].contains(&0x5A));
+    }
+
+    #[test]
     fn test_recover_dns_mappings_persist() {
         // Initialize the first runtime
         let executor = deterministic::Runner::default();
@@ -2338,7 +2451,7 @@ mod tests {
                 .with_seed(seed)
                 .with_storage_fault_config(FaultConfig {
                     open_rate: Some(0.5),
-                    write_rate: Some(0.3),
+                    write_rate: Some((0.3, (PartialWriteMode::Prefix, 0.0))),
                     sync_rate: Some(0.2),
                     ..Default::default()
                 });

--- a/runtime/src/deterministic.rs
+++ b/runtime/src/deterministic.rs
@@ -1960,7 +1960,7 @@ mod tests {
                 .with_seed(seed)
                 .with_storage_fault_config(FaultConfig::default().write(WriteConfig {
                     failure_rate: 0.0,
-                    retention_frequency: 0.5,
+                    retention_rate: 0.5,
                     mode: PartialWriteMode::Subset,
                 }));
             let (_, checkpoint) =
@@ -2456,7 +2456,7 @@ mod tests {
                     open_rate: Some(0.5),
                     write_rate: Some(WriteConfig {
                         failure_rate: 0.3,
-                        retention_frequency: 0.0,
+                        retention_rate: 0.0,
                         mode: PartialWriteMode::Prefix,
                     }),
                     sync_rate: Some(0.2),

--- a/runtime/src/deterministic.rs
+++ b/runtime/src/deterministic.rs
@@ -1644,13 +1644,13 @@ mod tests {
     use crate::FutureExt;
     use crate::{
         Blob, Metrics as _, Resolver, Runner as _, Spawner as _, Storage, Strategizer,
-        Supervisor as _, WriteOptions, deterministic, reschedule, storage::faulty::ScriptedRng,
+        Supervisor as _, WriteOptions, deterministic, reschedule,
     };
     use commonware_macros::test_traced;
     use commonware_parallel::Strategy;
     #[cfg(feature = "external")]
     use commonware_utils::channel::mpsc;
-    use commonware_utils::{NZUsize, Probability, channel::oneshot};
+    use commonware_utils::{NZUsize, Probability, ScriptedRng, channel::oneshot};
     #[cfg(feature = "external")]
     use futures::StreamExt;
     #[cfg(not(feature = "external"))]
@@ -1933,7 +1933,7 @@ mod tests {
 
     #[test]
     fn test_recover_retained_successful_resize() {
-        let retained_resize = [ScriptedRng::EVENT_DOES_NOT_OCCUR, ScriptedRng::EVENT_OCCURS];
+        let retained_resize = [u64::MAX, 0];
         let cfg = deterministic::Config::default()
             .with_rng(Box::new(ScriptedRng::new(retained_resize)))
             .with_storage_fault_config(FaultConfig::default().resize(ResizeConfig {

--- a/runtime/src/deterministic.rs
+++ b/runtime/src/deterministic.rs
@@ -42,7 +42,7 @@
 //! });
 //! ```
 
-pub use crate::storage::faulty::{Config as FaultConfig, PartialWriteMode};
+pub use crate::storage::faulty::{Config as FaultConfig, PartialWriteMode, WriteConfig};
 #[cfg(feature = "external")]
 use crate::{Blocker, Pacer};
 use crate::{
@@ -1932,7 +1932,8 @@ mod tests {
     #[test]
     fn test_recover_retained_successful_resize() {
         let cfg = deterministic::Config::default()
-            .with_storage_fault_config(FaultConfig::default().resize(0.0, 1.0));
+            .with_seed(83)
+            .with_storage_fault_config(FaultConfig::default().resize(0.5));
         let (_, checkpoint) =
             deterministic::Runner::new(cfg).start_and_recover(|context| async move {
                 let (blob, _) = context.open("crash_resize", b"blob").await.unwrap();
@@ -1957,9 +1958,10 @@ mod tests {
         fn run(seed: u64) -> (Vec<u8>, Digest) {
             let cfg = deterministic::Config::default()
                 .with_seed(seed)
-                .with_storage_fault_config(
-                    FaultConfig::default().write(0.0, (PartialWriteMode::Subset, 0.5)),
-                );
+                .with_storage_fault_config(FaultConfig::default().write(WriteConfig {
+                    failure_rate: 0.0,
+                    mode: PartialWriteMode::Subset(0.5),
+                }));
             let (_, checkpoint) =
                 deterministic::Runner::new(cfg).start_and_recover(|context| async move {
                     let (blob, _) = context.open("crash_epoch", b"blob").await.unwrap();
@@ -2451,7 +2453,10 @@ mod tests {
                 .with_seed(seed)
                 .with_storage_fault_config(FaultConfig {
                     open_rate: Some(0.5),
-                    write_rate: Some((0.3, (PartialWriteMode::Prefix, 0.0))),
+                    write_rate: Some(WriteConfig {
+                        failure_rate: 0.3,
+                        mode: PartialWriteMode::Subset(0.0),
+                    }),
                     sync_rate: Some(0.2),
                     ..Default::default()
                 });

--- a/runtime/src/deterministic.rs
+++ b/runtime/src/deterministic.rs
@@ -42,7 +42,9 @@
 //! });
 //! ```
 
-pub use crate::storage::faulty::{Config as FaultConfig, PartialWriteMode, WriteConfig};
+pub use crate::storage::faulty::{
+    Config as FaultConfig, PartialWriteMode, ResizeConfig, WriteConfig,
+};
 #[cfg(feature = "external")]
 use crate::{Blocker, Pacer};
 use crate::{
@@ -1648,7 +1650,7 @@ mod tests {
     use commonware_parallel::Strategy;
     #[cfg(feature = "external")]
     use commonware_utils::channel::mpsc;
-    use commonware_utils::{NZUsize, channel::oneshot};
+    use commonware_utils::{NZUsize, Probability, channel::oneshot};
     #[cfg(feature = "external")]
     use futures::StreamExt;
     #[cfg(not(feature = "external"))]
@@ -1919,7 +1921,7 @@ mod tests {
         let (stale_config, checkpoint) =
             deterministic::Runner::default().start_and_recover(|context| async move {
                 let config = context.storage_fault_config();
-                *config.write() = FaultConfig::default().open(1.0);
+                *config.write() = FaultConfig::default().open(Probability!(1.0));
                 config
             });
         *stale_config.write() = FaultConfig::default();
@@ -1933,7 +1935,10 @@ mod tests {
     fn test_recover_retained_successful_resize() {
         let cfg = deterministic::Config::default()
             .with_seed(83)
-            .with_storage_fault_config(FaultConfig::default().resize(0.5));
+            .with_storage_fault_config(FaultConfig::default().resize(ResizeConfig {
+                failure_rate: Probability!(0.5),
+                partial_rate: Probability!(0.0),
+            }));
         let (_, checkpoint) =
             deterministic::Runner::new(cfg).start_and_recover(|context| async move {
                 let (blob, _) = context.open("crash_resize", b"blob").await.unwrap();
@@ -1959,8 +1964,8 @@ mod tests {
             let cfg = deterministic::Config::default()
                 .with_seed(seed)
                 .with_storage_fault_config(FaultConfig::default().write(WriteConfig {
-                    failure_rate: 0.0,
-                    retention_rate: 0.5,
+                    failure_rate: Probability!(0.0),
+                    retention_rate: Probability!(0.5),
                     mode: PartialWriteMode::Subset,
                 }));
             let (_, checkpoint) =
@@ -2336,7 +2341,7 @@ mod tests {
     fn test_storage_fault_injection_and_recovery() {
         // Phase 1: Run with 100% sync failure rate
         let cfg = deterministic::Config::default().with_storage_fault_config(FaultConfig {
-            sync_rate: Some(1.0),
+            sync_rate: Some(Probability!(1.0)),
             ..Default::default()
         });
 
@@ -2389,7 +2394,7 @@ mod tests {
 
             // Enable sync faults dynamically
             let storage_fault_cfg = ctx.storage_fault_config();
-            storage_fault_cfg.write().sync_rate = Some(1.0);
+            storage_fault_cfg.write().sync_rate = Some(Probability!(1.0));
 
             // Now sync should fail
             blob.write_at(0, b"updated".to_vec(), WriteOptions::default())
@@ -2399,7 +2404,7 @@ mod tests {
             assert!(result.is_err(), "sync should fail with faults enabled");
 
             // Disable faults
-            storage_fault_cfg.write().sync_rate = Some(0.0);
+            storage_fault_cfg.write().sync_rate = Some(Probability!(0.0));
 
             // Sync should succeed again
             blob.sync()
@@ -2415,7 +2420,7 @@ mod tests {
             let cfg = deterministic::Config::default()
                 .with_seed(seed)
                 .with_storage_fault_config(FaultConfig {
-                    open_rate: Some(0.5),
+                    open_rate: Some(Probability!(0.5)),
                     ..Default::default()
                 });
 
@@ -2453,13 +2458,13 @@ mod tests {
             let cfg = deterministic::Config::default()
                 .with_seed(seed)
                 .with_storage_fault_config(FaultConfig {
-                    open_rate: Some(0.5),
+                    open_rate: Some(Probability!(0.5)),
                     write_rate: Some(WriteConfig {
-                        failure_rate: 0.3,
-                        retention_rate: 0.0,
+                        failure_rate: Probability!(0.3),
+                        retention_rate: Probability!(0.0),
                         mode: PartialWriteMode::Prefix,
                     }),
-                    sync_rate: Some(0.2),
+                    sync_rate: Some(Probability!(0.2)),
                     ..Default::default()
                 });
 

--- a/runtime/src/deterministic.rs
+++ b/runtime/src/deterministic.rs
@@ -1644,7 +1644,7 @@ mod tests {
     use crate::FutureExt;
     use crate::{
         Blob, Metrics as _, Resolver, Runner as _, Spawner as _, Storage, Strategizer,
-        Supervisor as _, WriteOptions, deterministic, reschedule,
+        Supervisor as _, WriteOptions, deterministic, reschedule, storage::faulty::ScriptedRng,
     };
     use commonware_macros::test_traced;
     use commonware_parallel::Strategy;
@@ -1933,36 +1933,9 @@ mod tests {
 
     #[test]
     fn test_recover_retained_successful_resize() {
-        #[derive(Default)]
-        struct RetainedResizeRng {
-            next: usize,
-        }
-
-        impl TryRng for RetainedResizeRng {
-            type Error = Infallible;
-
-            fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
-                panic!("retained resize should only sample u64 probabilities");
-            }
-
-            fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
-                let sample = [u64::MAX, 0]
-                    .get(self.next)
-                    .copied()
-                    .expect("retained resize should consume exactly two samples");
-                self.next += 1;
-                Ok(sample)
-            }
-
-            fn try_fill_bytes(&mut self, _dst: &mut [u8]) -> Result<(), Self::Error> {
-                panic!("retained resize should only sample u64 probabilities");
-            }
-        }
-
-        impl TryCryptoRng for RetainedResizeRng {}
-
+        let retained_resize = [ScriptedRng::EVENT_DOES_NOT_OCCUR, ScriptedRng::EVENT_OCCURS];
         let cfg = deterministic::Config::default()
-            .with_rng(Box::new(RetainedResizeRng::default()))
+            .with_rng(Box::new(ScriptedRng::new(retained_resize)))
             .with_storage_fault_config(FaultConfig::default().resize(ResizeConfig {
                 failure_rate: Probability!(0.5),
                 partial_rate: Probability!(0.0),

--- a/runtime/src/deterministic.rs
+++ b/runtime/src/deterministic.rs
@@ -1933,8 +1933,36 @@ mod tests {
 
     #[test]
     fn test_recover_retained_successful_resize() {
+        #[derive(Default)]
+        struct RetainedResizeRng {
+            next: usize,
+        }
+
+        impl TryRng for RetainedResizeRng {
+            type Error = Infallible;
+
+            fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
+                panic!("retained resize should only sample u64 probabilities");
+            }
+
+            fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
+                let sample = [u64::MAX, 0]
+                    .get(self.next)
+                    .copied()
+                    .expect("retained resize should consume exactly two samples");
+                self.next += 1;
+                Ok(sample)
+            }
+
+            fn try_fill_bytes(&mut self, _dst: &mut [u8]) -> Result<(), Self::Error> {
+                panic!("retained resize should only sample u64 probabilities");
+            }
+        }
+
+        impl TryCryptoRng for RetainedResizeRng {}
+
         let cfg = deterministic::Config::default()
-            .with_seed(83)
+            .with_rng(Box::new(RetainedResizeRng::default()))
             .with_storage_fault_config(FaultConfig::default().resize(ResizeConfig {
                 failure_rate: Probability!(0.5),
                 partial_rate: Probability!(0.0),

--- a/runtime/src/deterministic.rs
+++ b/runtime/src/deterministic.rs
@@ -1960,7 +1960,8 @@ mod tests {
                 .with_seed(seed)
                 .with_storage_fault_config(FaultConfig::default().write(WriteConfig {
                     failure_rate: 0.0,
-                    mode: PartialWriteMode::Subset(0.5),
+                    retention_frequency: 0.5,
+                    mode: PartialWriteMode::Subset,
                 }));
             let (_, checkpoint) =
                 deterministic::Runner::new(cfg).start_and_recover(|context| async move {
@@ -2455,7 +2456,8 @@ mod tests {
                     open_rate: Some(0.5),
                     write_rate: Some(WriteConfig {
                         failure_rate: 0.3,
-                        mode: PartialWriteMode::Subset(0.0),
+                        retention_frequency: 0.0,
+                        mode: PartialWriteMode::Prefix,
                     }),
                     sync_rate: Some(0.2),
                     ..Default::default()

--- a/runtime/src/storage/audited.rs
+++ b/runtime/src/storage/audited.rs
@@ -92,6 +92,7 @@ impl<B: crate::Blob> crate::Blob for Blob<B> {
             hasher.update(&self.name);
             hasher.update(offset.to_be_bytes());
             hasher.update(len.to_be_bytes());
+            hasher.update([options.0]);
         });
         self.inner.read_at(offset, len, options).await
     }
@@ -109,6 +110,7 @@ impl<B: crate::Blob> crate::Blob for Blob<B> {
             hasher.update(&self.name);
             hasher.update(offset.to_be_bytes());
             hasher.update(len.to_be_bytes());
+            hasher.update([options.0]);
         });
         self.inner.read_at_buf(offset, len, bufs, options).await
     }
@@ -125,6 +127,7 @@ impl<B: crate::Blob> crate::Blob for Blob<B> {
             hasher.update(&self.name);
             hasher.update(offset.to_be_bytes());
             hasher.update_bufs(&bufs);
+            hasher.update([options.0]);
         });
         self.inner.write_at(offset, bufs, options).await
     }
@@ -199,50 +202,49 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_write_options_do_not_change_audit_event() {
-        let auditor1 = Arc::new(Auditor::default());
-        let storage1 = AuditedStorage::new(MemStorage::new(test_pool()), auditor1.clone());
-        let auditor2 = Arc::new(Auditor::default());
-        let storage2 = AuditedStorage::new(MemStorage::new(test_pool()), auditor2.clone());
+    async fn test_write_options_change_audit_event() {
+        let mut states = Vec::new();
+        for options in [
+            WriteOptions::default(),
+            WriteOptions::SYNC,
+            WriteOptions::DONT_CACHE,
+            WriteOptions::SYNC | WriteOptions::DONT_CACHE,
+        ] {
+            let auditor = Arc::new(Auditor::default());
+            let storage = AuditedStorage::new(MemStorage::new(test_pool()), auditor.clone());
+            let (blob, _) = storage.open("partition", b"blob").await.unwrap();
+            blob.write_at(0, b"data", options).await.unwrap();
+            states.push(auditor.state());
+        }
 
-        let (blob1, _) = storage1.open("partition", b"blob").await.unwrap();
-        let (blob2, _) = storage2.open("partition", b"blob").await.unwrap();
-        blob1
-            .write_at(0, b"data", WriteOptions::default())
-            .await
-            .unwrap();
-        blob2
-            .write_at(0, b"data", WriteOptions::SYNC | WriteOptions::DONT_CACHE)
-            .await
-            .unwrap();
-
-        assert_eq!(auditor1.state(), auditor2.state());
+        states.sort_unstable();
+        states.dedup();
+        assert_eq!(states.len(), 4);
     }
 
     #[tokio::test]
-    async fn test_read_options_do_not_change_audit_event() {
-        let auditor1 = Arc::new(Auditor::default());
-        let auditor2 = Arc::new(Auditor::default());
-        let storage1 = AuditedStorage::new(MemStorage::new(test_pool()), auditor1.clone());
-        let storage2 = AuditedStorage::new(MemStorage::new(test_pool()), auditor2.clone());
+    async fn test_read_options_change_audit_event() {
+        for use_provided_buffer in [false, true] {
+            let mut states = Vec::new();
+            for options in [ReadOptions::default(), ReadOptions::DONT_CACHE] {
+                let auditor = Arc::new(Auditor::default());
+                let storage = AuditedStorage::new(MemStorage::new(test_pool()), auditor.clone());
+                let (blob, _) = storage.open("partition", b"blob").await.unwrap();
+                blob.write_at(0, b"data", WriteOptions::default())
+                    .await
+                    .unwrap();
 
-        let (blob1, _) = storage1.open("partition", b"blob").await.unwrap();
-        let (blob2, _) = storage2.open("partition", b"blob").await.unwrap();
-        blob1
-            .write_at(0, b"data", WriteOptions::default())
-            .await
-            .unwrap();
-        blob2
-            .write_at(0, b"data", WriteOptions::default())
-            .await
-            .unwrap();
-        assert_eq!(auditor1.state(), auditor2.state());
-
-        // Cache policy is a backend hint and must not enter the deterministic audit event.
-        blob1.read_at(0, 4, ReadOptions::default()).await.unwrap();
-        blob2.read_at(0, 4, ReadOptions::DONT_CACHE).await.unwrap();
-
-        assert_eq!(auditor1.state(), auditor2.state());
+                if use_provided_buffer {
+                    blob.read_at_buf(0, 4, IoBufMut::with_capacity(4), options)
+                        .await
+                        .unwrap();
+                } else {
+                    blob.read_at(0, 4, options).await.unwrap();
+                }
+                states.push(auditor.state());
+            }
+            assert_ne!(states[0], states[1]);
+        }
     }
 
     #[tokio::test]

--- a/runtime/src/storage/faulty.rs
+++ b/runtime/src/storage/faulty.rs
@@ -36,10 +36,8 @@ pub enum PartialWriteMode {
     Subset,
 }
 
-/// Fault configuration for `write_at` operations.
-///
-/// The retention mode applies to failed writes and successful writes that remain unsynchronized
-/// when a crash is simulated.
+/// Fault configuration for `write_at` operations and byte retention from failed writes or
+/// successful unsynchronized writes when a crash is simulated.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WriteConfig {
     /// Probability that `write_at` returns an injected failure.
@@ -64,14 +62,14 @@ pub struct Config {
     /// Failure rate for `read_at` operations.
     pub read_rate: Option<f64>,
 
-    /// Fault configuration for `write_at` operations.
+    /// Failure and byte-retention configuration for `write_at` operations.
     pub write_rate: Option<WriteConfig>,
 
     /// Failure rate for `sync` operations.
     pub sync_rate: Option<f64>,
 
-    /// Failure rate for `resize` operations, also used independently as the probability that a
-    /// successful unsynchronized resize survives a simulated crash.
+    /// Failure rate for `resize` operations and probability that a successful unsynchronized
+    /// resize survives a simulated crash.
     pub resize_rate: Option<f64>,
 
     /// Probability that a resize failure is partial (resized to an intermediate

--- a/runtime/src/storage/faulty.rs
+++ b/runtime/src/storage/faulty.rs
@@ -17,48 +17,6 @@ use std::{
     },
 };
 
-/// A bounded RNG for tests that require explicit probability outcomes.
-#[cfg(test)]
-pub(crate) struct ScriptedRng {
-    samples: std::vec::IntoIter<u64>,
-}
-
-#[cfg(test)]
-impl ScriptedRng {
-    pub(crate) const EVENT_OCCURS: u64 = 0;
-    pub(crate) const EVENT_DOES_NOT_OCCUR: u64 = u64::MAX;
-
-    pub(crate) fn new(samples: impl IntoIterator<Item = u64>) -> Self {
-        Self {
-            samples: samples.into_iter().collect::<Vec<_>>().into_iter(),
-        }
-    }
-}
-
-#[cfg(test)]
-impl rand::TryRng for ScriptedRng {
-    type Error = std::convert::Infallible;
-
-    fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
-        panic!("fault script should only sample u64 probabilities");
-    }
-
-    fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
-        Ok(self
-            .samples
-            .next()
-            .expect("fault script consumed more samples than expected"))
-    }
-
-    fn try_fill_bytes(&mut self, _dst: &mut [u8]) -> Result<(), Self::Error> {
-        panic!("fault script should only sample u64 probabilities");
-    }
-}
-
-// ScriptedRng is test-only; this marker satisfies the deterministic runtime's RNG bound.
-#[cfg(test)]
-impl rand::TryCryptoRng for ScriptedRng {}
-
 /// Operation types for fault injection.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Op {
@@ -892,6 +850,7 @@ mod tests {
         storage::{memory::Storage as MemStorage, tests::run_storage_tests},
         telemetry::metrics::Registry,
     };
+    use commonware_utils::ScriptedRng;
     use futures::task::noop_waker;
     use rand::{SeedableRng, rngs::StdRng};
     use std::{
@@ -1427,8 +1386,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_crash_replays_writes_and_resizes_in_issue_order() {
-        let retained_resizes =
-            [ScriptedRng::EVENT_DOES_NOT_OCCUR, ScriptedRng::EVENT_OCCURS].repeat(3);
+        let retained_resizes = [u64::MAX, 0].repeat(3);
         let h = Harness::with_rng(
             Box::new(ScriptedRng::new(retained_resizes)),
             Config::default()
@@ -1473,13 +1431,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_partial_sync_write_replays_after_retained_resize() {
-        let retained_resize = [ScriptedRng::EVENT_DOES_NOT_OCCUR, ScriptedRng::EVENT_OCCURS];
-        let retained_write_bytes = [
-            ScriptedRng::EVENT_OCCURS,
-            ScriptedRng::EVENT_DOES_NOT_OCCUR,
-            ScriptedRng::EVENT_OCCURS,
-            ScriptedRng::EVENT_DOES_NOT_OCCUR,
-        ];
+        let retained_resize = [u64::MAX, 0];
+        let retained_write_bytes = [0, u64::MAX, 0, u64::MAX];
         let h = Harness::with_rng(
             Box::new(ScriptedRng::new(
                 retained_resize.into_iter().chain(retained_write_bytes),

--- a/runtime/src/storage/faulty.rs
+++ b/runtime/src/storage/faulty.rs
@@ -301,7 +301,7 @@ impl Oracle {
     /// Check if an event should occur based on a probability rate.
     fn roll(&self, rate: Option<f64>) -> bool {
         let rate = rate.unwrap_or(0.0);
-        if rate <= 0.0 {
+        if rate <= 0.0 || rate.is_nan() {
             return false;
         }
         if rate >= 1.0 {
@@ -1592,6 +1592,16 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn test_nan_fault_rate_does_not_consume_randomness() {
+        let expected = Harness::with_seed(0, Config::default());
+        let expected = expected.storage.ctx.rng.lock().random::<u64>();
+
+        let h = Harness::with_seed(0, Config::default());
+        assert!(!h.storage.ctx.roll(Some(f64::NAN)));
+        assert_eq!(h.storage.ctx.rng.lock().random::<u64>(), expected);
     }
 
     #[test]

--- a/runtime/src/storage/faulty.rs
+++ b/runtime/src/storage/faulty.rs
@@ -26,19 +26,33 @@ enum Op {
     Scan,
 }
 
-/// Selects how retained bytes are arranged when a write is partially preserved.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+/// Selects which submitted bytes are retained from a write.
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum PartialWriteMode {
-    /// Retain bytes from the beginning of the write until the first omitted byte.
+    /// Retain a uniformly selected prefix, including the empty and full prefixes.
     Prefix,
 
-    /// Independently retain submitted byte positions.
-    Subset,
+    /// Independently retain each submitted byte at the supplied retention frequency.
+    Subset(f64),
+}
+
+/// Fault configuration for `write_at` operations.
+///
+/// The retention mode applies to failed writes and successful writes that remain unsynchronized
+/// when a crash is simulated.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct WriteConfig {
+    /// Probability that `write_at` returns an injected failure.
+    pub failure_rate: f64,
+
+    /// Arrangement of bytes retained by the simulated storage device.
+    pub mode: PartialWriteMode,
 }
 
 /// Configuration for deterministic storage fault injection.
 ///
-/// Each rate is a probability from 0.0 (never fail) to 1.0 (always fail).
+/// Each rate is interpreted as a probability. Values that are `NaN` or at or below 0.0 never
+/// trigger, while values at or above 1.0 always trigger.
 #[derive(Clone, Debug, Default)]
 pub struct Config {
     /// Failure rate for `open_versioned` operations.
@@ -47,20 +61,15 @@ pub struct Config {
     /// Failure rate for `read_at` operations.
     pub read_rate: Option<f64>,
 
-    /// Failure rate and byte-retention policy for `write_at` operations.
-    ///
-    /// The outer tuple contains the failure rate and retention policy. The retention policy applies
-    /// to failed writes and successful unsynchronized writes at a simulated crash. Retention
-    /// frequencies that are `NaN` or at or below 0.0 retain no bytes, while frequencies at or above
-    /// 1.0 retain every byte.
-    pub write_rate: Option<(f64, (PartialWriteMode, f64))>,
+    /// Fault configuration for `write_at` operations.
+    pub write_rate: Option<WriteConfig>,
 
     /// Failure rate for `sync` operations.
     pub sync_rate: Option<f64>,
 
-    /// Failure rate for `resize` operations and probability that a successful unsynchronized
-    /// resize survives a simulated crash.
-    pub resize_rate: Option<(f64, f64)>,
+    /// Failure rate for `resize` operations, also used independently as the probability that a
+    /// successful unsynchronized resize survives a simulated crash.
+    pub resize_rate: Option<f64>,
 
     /// Probability that a resize failure is partial (resized to an intermediate
     /// size before failure) rather than a complete failure (size unchanged).
@@ -81,9 +90,9 @@ impl Config {
         match op {
             Op::Open => self.open_rate,
             Op::Read => self.read_rate,
-            Op::Write => self.write_rate.map(|(failure_rate, _)| failure_rate),
+            Op::Write => self.write_rate.map(|config| config.failure_rate),
             Op::Sync => self.sync_rate,
-            Op::Resize => self.resize_rate.map(|(failure_rate, _)| failure_rate),
+            Op::Resize => self.resize_rate,
             Op::Remove => self.remove_rate,
             Op::Scan => self.scan_rate,
         }
@@ -102,9 +111,9 @@ impl Config {
         self
     }
 
-    /// Set the write failure rate and byte-retention policy.
-    pub const fn write(mut self, failure_rate: f64, retention: (PartialWriteMode, f64)) -> Self {
-        self.write_rate = Some((failure_rate, retention));
+    /// Set the write fault configuration.
+    pub const fn write(mut self, config: WriteConfig) -> Self {
+        self.write_rate = Some(config);
         self
     }
 
@@ -114,9 +123,9 @@ impl Config {
         self
     }
 
-    /// Set the resize failure and crash-retention rates.
-    pub const fn resize(mut self, failure_rate: f64, retention_rate: f64) -> Self {
-        self.resize_rate = Some((failure_rate, retention_rate));
+    /// Set the resize failure and crash-retention rate.
+    pub const fn resize(mut self, rate: f64) -> Self {
+        self.resize_rate = Some(rate);
         self
     }
 
@@ -146,7 +155,12 @@ struct Oracle {
     config: Arc<RwLock<Config>>,
 }
 
+/// An issued mutation or durability cut whose crash outcome remains unresolved.
+///
+/// Entries remain in issue order so crash replay and sync completion preserve mutation order.
 enum PendingMutation<B> {
+    /// A write fragment whose `selection_offset` maps it into one issued write's shared byte
+    /// selection.
     Write {
         generation: Arc<FileGeneration>,
         blob: B,
@@ -155,14 +169,14 @@ enum PendingMutation<B> {
         retention: Arc<PendingWriteRetention>,
         selection_offset: usize,
     },
+    /// A successful resize already selected to survive a simulated crash.
     Resize {
         generation: Arc<FileGeneration>,
         blob: B,
         len: u64,
     },
-    Sync {
-        sync: Arc<PendingSync>,
-    },
+    /// A full-sync cut whose completion determines whether earlier mutations remain pending.
+    Sync { sync: Arc<PendingSync> },
 }
 
 /// One initiated full sync owns its durability cut and is observed by both its caller and crash
@@ -181,13 +195,13 @@ impl PendingSync {
 /// Retention choices belong to the issued write and are shared by fragments created by later
 /// durability barriers.
 struct PendingWriteRetention {
-    policy: (PartialWriteMode, f64),
+    policy: PartialWriteMode,
     len: usize,
     selected: OnceLock<Vec<bool>>,
 }
 
 impl PendingWriteRetention {
-    const fn new(policy: (PartialWriteMode, f64), len: usize) -> Self {
+    const fn new(policy: PartialWriteMode, len: usize) -> Self {
         Self {
             policy,
             len,
@@ -261,13 +275,16 @@ impl Oracle {
 
     /// Check if a write fault should be injected.
     /// Reads config once to avoid nested lock acquisition.
-    fn check_write_fault(&self) -> (bool, Option<(PartialWriteMode, f64)>) {
+    fn check_write_fault(&self) -> (bool, Option<PartialWriteMode>) {
         let config = self.config.read();
         let fail = self.roll(Some(config.rate_for(Op::Write)));
         let retention = config
             .write_rate
-            .map(|(_, retention)| retention)
-            .filter(|(_, frequency)| *frequency > 0.0);
+            .map(|config| config.mode)
+            .filter(|mode| match mode {
+                PartialWriteMode::Prefix => true,
+                PartialWriteMode::Subset(retention_frequency) => *retention_frequency > 0.0,
+            });
         (fail, retention)
     }
 
@@ -275,9 +292,9 @@ impl Oracle {
     /// Reads config once to avoid nested lock acquisition.
     fn check_resize_fault(&self) -> (bool, Option<f64>, bool) {
         let config = self.config.read();
-        let fail = self.roll(Some(config.rate_for(Op::Resize)));
-        let retention_rate = config.resize_rate.map(|(_, retention_rate)| retention_rate);
-        let retain = !fail && self.roll(retention_rate);
+        let failure_rate = config.rate_for(Op::Resize);
+        let fail = self.roll(Some(failure_rate));
+        let retain = !fail && self.roll(Some(failure_rate));
         (fail, config.partial_resize_rate, retain)
     }
 
@@ -306,21 +323,27 @@ impl Oracle {
     }
 
     /// Select retained byte positions according to a snapshotted write policy.
-    fn retained_bytes(&self, len: usize, (mode, frequency): (PartialWriteMode, f64)) -> Vec<bool> {
-        debug_assert!(frequency > 0.0);
-        if frequency >= 1.0 {
-            return vec![true; len];
-        }
-
-        let mut rng = self.rng.lock();
+    fn retained_bytes(&self, len: usize, mode: PartialWriteMode) -> Vec<bool> {
         match mode {
             PartialWriteMode::Prefix => {
-                let retained = (0..len).take_while(|_| rng.random_bool(frequency)).count();
                 let mut positions = vec![false; len];
+                let retained = self.rng.lock().random_range(0..=len);
                 positions[..retained].fill(true);
                 positions
             }
-            PartialWriteMode::Subset => (0..len).map(|_| rng.random_bool(frequency)).collect(),
+            PartialWriteMode::Subset(retention_frequency) => {
+                if retention_frequency <= 0.0 || retention_frequency.is_nan() {
+                    return vec![false; len];
+                }
+                if retention_frequency >= 1.0 {
+                    return vec![true; len];
+                }
+
+                let mut rng = self.rng.lock();
+                (0..len)
+                    .map(|_| rng.random_bool(retention_frequency))
+                    .collect()
+            }
         }
     }
 
@@ -540,7 +563,7 @@ impl<B: crate::Blob> Blob<B> {
         }
     }
 
-    fn record_pending(&self, offset: u64, bufs: IoBufs, retention: (PartialWriteMode, f64)) {
+    fn record_pending(&self, offset: u64, bufs: IoBufs, retention: PartialWriteMode) {
         if bufs.is_empty() {
             return;
         }
@@ -649,7 +672,7 @@ impl<B: crate::Blob> Blob<B> {
         }
         if follows_resize {
             let retention = Arc::new(PendingWriteRetention::new(
-                (PartialWriteMode::Prefix, 1.0),
+                PartialWriteMode::Subset(1.0),
                 durable.remaining(),
             ));
             retained.push(PendingMutation::Write {
@@ -939,7 +962,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_start_sync_returns_before_backing_completion() {
-        let h = Harness::new(Config::default().write(0.0, (PartialWriteMode::Prefix, 1.0)));
+        let h = Harness::new(Config::default().write(WriteConfig {
+            failure_rate: 0.0,
+            mode: PartialWriteMode::Subset(1.0),
+        }));
         let (inner, _) = h.inner.open("partition", b"start-sync").await.unwrap();
         inner
             .write_at(0, b"data", WriteOptions::SYNC)
@@ -975,7 +1001,10 @@ mod tests {
     }
 
     async fn run_overlapping_barrier(start: bool) {
-        let h = Harness::new(Config::default().write(0.0, (PartialWriteMode::Prefix, 1.0)));
+        let h = Harness::new(Config::default().write(WriteConfig {
+            failure_rate: 0.0,
+            mode: PartialWriteMode::Subset(1.0),
+        }));
         let (inner, _) = h.inner.open("partition", b"overlap").await.unwrap();
         inner
             .write_at(0, b"base", WriteOptions::SYNC)
@@ -1035,7 +1064,7 @@ mod tests {
                     retention,
                     ..
                 } => {
-                    assert_eq!(retention.policy, (PartialWriteMode::Prefix, 1.0));
+                    assert_eq!(retention.policy, PartialWriteMode::Subset(1.0));
                     blob.inner
                         .retain_crash_write(offset, bufs, || true)
                         .unwrap();
@@ -1051,7 +1080,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_completed_backing_write_cannot_record_after_later_full_sync() {
-        let h = Harness::new(Config::default().write(0.0, (PartialWriteMode::Prefix, 1.0)));
+        let h = Harness::new(Config::default().write(WriteConfig {
+            failure_rate: 0.0,
+            mode: PartialWriteMode::Subset(1.0),
+        }));
         let (inner, _) = h.inner.open("partition", b"late-record").await.unwrap();
         inner
             .write_at(0, b"base!", WriteOptions::SYNC)
@@ -1105,7 +1137,7 @@ mod tests {
             else {
                 panic!("write test recorded a resize");
             };
-            assert_eq!(retention.policy, (PartialWriteMode::Prefix, 1.0));
+            assert_eq!(retention.policy, PartialWriteMode::Subset(1.0));
             blob.inner
                 .retain_crash_write(offset, bufs, || true)
                 .unwrap();
@@ -1120,7 +1152,10 @@ mod tests {
 
         let h = Harness::with_seed(
             seed,
-            Config::default().write(0.0, (PartialWriteMode::Subset, 0.5)),
+            Config::default().write(WriteConfig {
+                failure_rate: 0.0,
+                mode: PartialWriteMode::Subset(0.5),
+            }),
         );
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
         blob.write_at(0, original.to_vec(), WriteOptions::default())
@@ -1130,7 +1165,10 @@ mod tests {
 
         {
             let mut config = h.config.write();
-            config.write_rate = Some((1.0, (PartialWriteMode::Subset, 0.5)));
+            config.write_rate = Some(WriteConfig {
+                failure_rate: 1.0,
+                mode: PartialWriteMode::Subset(0.5),
+            });
         }
 
         let result = blob
@@ -1152,7 +1190,10 @@ mod tests {
     async fn run_random_crash(seed: u64, len: usize) -> Vec<u8> {
         let h = Harness::with_seed(
             seed,
-            Config::default().write(0.0, (PartialWriteMode::Subset, 0.5)),
+            Config::default().write(WriteConfig {
+                failure_rate: 0.0,
+                mode: PartialWriteMode::Subset(0.5),
+            }),
         );
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
         blob.write_at(0, vec![0; len], WriteOptions::SYNC)
@@ -1178,7 +1219,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_reopened_sync_clears_prior_handle_crash_writes() {
-        let h = Harness::new(Config::default().write(0.0, (PartialWriteMode::Prefix, 1.0)));
+        let h = Harness::new(Config::default().write(WriteConfig {
+            failure_rate: 0.0,
+            mode: PartialWriteMode::Subset(1.0),
+        }));
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
         blob.write_at(0, b"stale", WriteOptions::default())
             .await
@@ -1203,7 +1247,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_dropped_completed_start_sync_clears_the_crash_epoch() {
-        let h = Harness::new(Config::default().write(0.0, (PartialWriteMode::Prefix, 1.0)));
+        let h = Harness::new(Config::default().write(WriteConfig {
+            failure_rate: 0.0,
+            mode: PartialWriteMode::Subset(1.0),
+        }));
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
         blob.write_at(0, b"stale", WriteOptions::default())
             .await
@@ -1216,7 +1263,10 @@ mod tests {
         let completion = blob.start_sync().await;
         drop(completion);
 
-        h.config.write().write_rate = Some((0.0, (PartialWriteMode::Prefix, 1.0)));
+        h.config.write().write_rate = Some(WriteConfig {
+            failure_rate: 0.0,
+            mode: PartialWriteMode::Subset(1.0),
+        });
         blob.write_at(5, b"later", WriteOptions::default())
             .await
             .unwrap();
@@ -1232,7 +1282,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_sync_write_does_not_barrier_disjoint_pending_write() {
-        let h = Harness::new(Config::default().write(0.0, (PartialWriteMode::Prefix, 1.0)));
+        let h = Harness::new(Config::default().write(WriteConfig {
+            failure_rate: 0.0,
+            mode: PartialWriteMode::Subset(1.0),
+        }));
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
         blob.write_at(0, b"........", WriteOptions::SYNC)
             .await
@@ -1251,7 +1304,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_sync_write_retires_only_overlapping_pending_bytes() {
-        let h = Harness::new(Config::default().write(0.0, (PartialWriteMode::Prefix, 1.0)));
+        let h = Harness::new(Config::default().write(WriteConfig {
+            failure_rate: 0.0,
+            mode: PartialWriteMode::Subset(1.0),
+        }));
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
         let (other, _) = h.storage.open("partition", b"other").await.unwrap();
         for candidate in [&blob, &other] {
@@ -1283,7 +1339,10 @@ mod tests {
         for seed in 0..64 {
             let h = Harness::with_seed(
                 seed,
-                Config::default().write(0.0, (PartialWriteMode::Prefix, 0.5)),
+                Config::default().write(WriteConfig {
+                    failure_rate: 0.0,
+                    mode: PartialWriteMode::Prefix,
+                }),
             );
             let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
             blob.write_at(0, b"........", WriteOptions::SYNC)
@@ -1307,10 +1366,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_crash_replays_writes_and_resizes_in_issue_order() {
-        let h = Harness::new(
+        let h = Harness::with_seed(
+            83,
             Config::default()
-                .write(0.0, (PartialWriteMode::Prefix, 1.0))
-                .resize(0.0, 1.0),
+                .write(WriteConfig {
+                    failure_rate: 0.0,
+                    mode: PartialWriteMode::Subset(1.0),
+                })
+                .resize(0.5),
         );
         let (write_then_resize, _) = h.storage.open("partition", b"first").await.unwrap();
         write_then_resize
@@ -1343,7 +1406,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_partial_sync_write_replays_after_retained_resize() {
-        let h = Harness::new(Config::default().resize(0.0, 1.0));
+        let h = Harness::with_seed(83, Config::default().resize(0.5));
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
         blob.write_at(0, b"abcdefghij", WriteOptions::SYNC)
             .await
@@ -1351,7 +1414,10 @@ mod tests {
         blob.resize(3).await.unwrap();
         {
             let mut config = h.config.write();
-            config.write_rate = Some((1.0, (PartialWriteMode::Subset, 0.5)));
+            config.write_rate = Some(WriteConfig {
+                failure_rate: 1.0,
+                mode: PartialWriteMode::Subset(0.5),
+            });
         }
 
         assert!(blob.write_at(6, b"WXYZ", WriteOptions::SYNC).await.is_err());
@@ -1385,7 +1451,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_preissued_sync_write_survives_failed_partial_resize() {
-        let h = Harness::new(Config::default().resize(1.0, 0.0).partial_resize(1.0));
+        let h = Harness::new(Config::default().resize(1.0).partial_resize(1.0));
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
         blob.write_at(0, b"abcdefghij", WriteOptions::SYNC)
             .await
@@ -1425,8 +1491,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_partial_sync_write_retires_each_persisted_range() {
-        for partial_write_mode in [PartialWriteMode::Prefix, PartialWriteMode::Subset] {
-            let h = Harness::new(Config::default().write(0.0, (PartialWriteMode::Prefix, 1.0)));
+        for partial_write_mode in [PartialWriteMode::Prefix, PartialWriteMode::Subset(0.5)] {
+            let h = Harness::new(Config::default().write(WriteConfig {
+                failure_rate: 0.0,
+                mode: PartialWriteMode::Subset(1.0),
+            }));
             let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
             blob.write_at(0, b"........", WriteOptions::SYNC)
                 .await
@@ -1436,7 +1505,10 @@ mod tests {
                 .unwrap();
             {
                 let mut config = h.config.write();
-                config.write_rate = Some((1.0, (partial_write_mode, 0.5)));
+                config.write_rate = Some(WriteConfig {
+                    failure_rate: 1.0,
+                    mode: partial_write_mode,
+                });
             }
 
             assert!(blob.write_at(2, b"wxyz", WriteOptions::SYNC).await.is_err());
@@ -1481,40 +1553,57 @@ mod tests {
     }
 
     #[test]
-    fn test_write_retention_frequency_upper_bound() {
+    fn test_subset_retention_frequency_matches_fault_rate_bounds() {
         let h = Harness::new(Config::default());
-        for mode in [PartialWriteMode::Prefix, PartialWriteMode::Subset] {
-            for frequency in [1.0, 2.0, f64::INFINITY] {
-                assert_eq!(
-                    h.storage.ctx.retained_bytes(4, (mode, frequency)),
-                    [true; 4]
-                );
-            }
+        for (retention_frequency, expected) in [
+            (f64::NEG_INFINITY, false),
+            (-1.0, false),
+            (0.0, false),
+            (f64::NAN, false),
+            (1.0, true),
+            (2.0, true),
+            (f64::INFINITY, true),
+        ] {
+            assert_eq!(h.storage.ctx.roll(Some(retention_frequency)), expected);
+            assert_eq!(
+                h.storage
+                    .ctx
+                    .retained_bytes(4, PartialWriteMode::Subset(retention_frequency),),
+                [expected; 4]
+            );
         }
     }
 
     #[test]
-    fn test_prefix_retention_stops_after_the_first_omission() {
-        for seed in 0..64 {
+    fn test_prefix_retention_selects_inclusive_prefix() {
+        let mut saw_empty = false;
+        let mut saw_full = false;
+        for seed in 0..512 {
             let h = Harness::with_seed(seed, Config::default());
-            let retained = h
-                .storage
-                .ctx
-                .retained_bytes(64, (PartialWriteMode::Prefix, 0.5));
-            let mut omitted = false;
-            for keep in retained {
-                if omitted {
-                    assert!(!keep);
-                } else if !keep {
-                    omitted = true;
-                }
-            }
+            let retained = h.storage.ctx.retained_bytes(64, PartialWriteMode::Prefix);
+            let prefix_len = retained.iter().take_while(|&&keep| keep).count();
+            assert!(retained[prefix_len..].iter().all(|&keep| !keep));
+            saw_empty |= prefix_len == 0;
+            saw_full |= prefix_len == retained.len();
         }
+        assert!(saw_empty, "expected an empty prefix");
+        assert!(saw_full, "expected a full prefix");
+
+        let h = Harness::new(Config::default());
+        assert!(
+            h.storage
+                .ctx
+                .retained_bytes(0, PartialWriteMode::Prefix)
+                .is_empty()
+        );
     }
 
     #[tokio::test]
     async fn test_write_rejects_offset_overflow_before_retention() {
-        let h = Harness::new(Config::default().write(1.0, (PartialWriteMode::Subset, 0.5)));
+        let h = Harness::new(Config::default().write(WriteConfig {
+            failure_rate: 1.0,
+            mode: PartialWriteMode::Subset(0.5),
+        }));
         let (blob, _) = h.storage.open("partition", b"blob").await.unwrap();
         assert!(matches!(
             blob.write_at(u64::MAX, vec![1, 2], WriteOptions::default())
@@ -1527,7 +1616,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_failed_write_can_retain_every_byte() {
-        let h = Harness::new(Config::default().write(1.0, (PartialWriteMode::Prefix, 1.0)));
+        let h = Harness::new(Config::default().write(WriteConfig {
+            failure_rate: 1.0,
+            mode: PartialWriteMode::Subset(1.0),
+        }));
         let (blob, _) = h.storage.open("partition", b"blob").await.unwrap();
 
         assert!(matches!(
@@ -1555,7 +1647,10 @@ mod tests {
     async fn test_faulty_storage_start_sync_always_fails() {
         let h = Harness::new(
             Config::default()
-                .write(0.0, (PartialWriteMode::Prefix, 1.0))
+                .write(WriteConfig {
+                    failure_rate: 0.0,
+                    mode: PartialWriteMode::Subset(1.0),
+                })
                 .sync(1.0),
         );
 
@@ -1571,7 +1666,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_faulty_storage_write_always_fails() {
-        let h = Harness::new(Config::default().write(1.0, (PartialWriteMode::Prefix, 0.0)));
+        let h = Harness::new(Config::default().write(WriteConfig {
+            failure_rate: 1.0,
+            mode: PartialWriteMode::Subset(0.0),
+        }));
 
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
 
@@ -1584,7 +1682,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_faulty_storage_write_at_sync_write_always_fails() {
-        let h = Harness::new(Config::default().write(1.0, (PartialWriteMode::Prefix, 0.0)));
+        let h = Harness::new(Config::default().write(WriteConfig {
+            failure_rate: 1.0,
+            mode: PartialWriteMode::Subset(0.0),
+        }));
 
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
 
@@ -1628,7 +1729,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_empty_unsynced_write_does_not_create_crash_debt() {
-        let h = Harness::new(Config::default().write(0.0, (PartialWriteMode::Prefix, 1.0)));
+        let h = Harness::new(Config::default().write(WriteConfig {
+            failure_rate: 0.0,
+            mode: PartialWriteMode::Subset(1.0),
+        }));
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
         blob.write_at(0, Vec::<u8>::new(), WriteOptions::default())
             .await
@@ -1734,8 +1838,11 @@ mod tests {
     async fn test_faulty_storage_rate_for() {
         let config = Config::default()
             .open(0.1)
-            .write(0.3, (PartialWriteMode::Subset, 0.4))
-            .resize(0.7, 0.8)
+            .write(WriteConfig {
+                failure_rate: 0.3,
+                mode: PartialWriteMode::Subset(0.4),
+            })
+            .resize(0.7)
             .sync(0.9);
 
         assert!((config.rate_for(Op::Open) - 0.1).abs() < f64::EPSILON);
@@ -1760,7 +1867,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_write_retention_is_snapshotted_and_replayed_in_order() {
-        let h = Harness::new(Config::default().write(0.0, (PartialWriteMode::Prefix, 1.0)));
+        let h = Harness::new(Config::default().write(WriteConfig {
+            failure_rate: 0.0,
+            mode: PartialWriteMode::Subset(1.0),
+        }));
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
         blob.write_at(0, b"........", WriteOptions::SYNC)
             .await
@@ -1773,7 +1883,10 @@ mod tests {
         blob.write_at(2, b"CD", WriteOptions::default())
             .await
             .unwrap();
-        h.config.write().write_rate = Some((0.0, (PartialWriteMode::Prefix, 1.0)));
+        h.config.write().write_rate = Some(WriteConfig {
+            failure_rate: 0.0,
+            mode: PartialWriteMode::Subset(1.0),
+        });
         blob.write_at(1, b"XY", WriteOptions::default())
             .await
             .unwrap();
@@ -1813,13 +1926,16 @@ mod tests {
 
     #[tokio::test]
     async fn failed_partial_write_does_not_barrier_prior_crash_writes() {
-        for partial_write_mode in [PartialWriteMode::Prefix, PartialWriteMode::Subset] {
+        for partial_write_mode in [PartialWriteMode::Prefix, PartialWriteMode::Subset(0.5)] {
             let mut saw_old = false;
             let mut saw_new = false;
             for seed in 0..64 {
                 let h = Harness::with_seed(
                     seed,
-                    Config::default().write(0.0, (PartialWriteMode::Subset, 0.5)),
+                    Config::default().write(WriteConfig {
+                        failure_rate: 0.0,
+                        mode: PartialWriteMode::Subset(0.5),
+                    }),
                 );
                 let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
                 blob.write_at(0, b"......", WriteOptions::SYNC)
@@ -1830,7 +1946,10 @@ mod tests {
                     .unwrap();
                 {
                     let mut config = h.config.write();
-                    config.write_rate = Some((1.0, (partial_write_mode, 0.5)));
+                    config.write_rate = Some(WriteConfig {
+                        failure_rate: 1.0,
+                        mode: partial_write_mode,
+                    });
                 }
 
                 assert!(
@@ -1856,7 +1975,10 @@ mod tests {
         for seed in 0..64 {
             let h = Harness::with_seed(
                 seed,
-                Config::default().write(0.0, (PartialWriteMode::Subset, 0.5)),
+                Config::default().write(WriteConfig {
+                    failure_rate: 0.0,
+                    mode: PartialWriteMode::Subset(0.5),
+                }),
             );
             let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
             blob.write_at(0, b"......", WriteOptions::SYNC)
@@ -1867,7 +1989,7 @@ mod tests {
                 .unwrap();
             {
                 let mut config = h.config.write();
-                config.resize_rate = Some((1.0, 0.0));
+                config.resize_rate = Some(1.0);
                 config.partial_resize_rate = Some(1.0);
             }
 
@@ -1885,7 +2007,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_crash_journal_clears_only_after_completed_durability() {
-        let h = Harness::new(Config::default().write(0.0, (PartialWriteMode::Prefix, 1.0)));
+        let h = Harness::new(Config::default().write(WriteConfig {
+            failure_rate: 0.0,
+            mode: PartialWriteMode::Subset(1.0),
+        }));
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
 
         blob.write_at(0, b"a", WriteOptions::default())
@@ -1933,7 +2058,10 @@ mod tests {
     async fn test_sync_failure_journals_the_successful_inner_write() {
         let h = Harness::new(
             Config::default()
-                .write(0.0, (PartialWriteMode::Prefix, 1.0))
+                .write(WriteConfig {
+                    failure_rate: 0.0,
+                    mode: PartialWriteMode::Subset(1.0),
+                })
                 .sync(1.0),
         );
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
@@ -1951,7 +2079,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_faulty_storage_zero_write_retention_preserves_nothing() {
-        let h = Harness::new(Config::default().write(1.0, (PartialWriteMode::Prefix, 0.0)));
+        let h = Harness::new(Config::default().write(WriteConfig {
+            failure_rate: 1.0,
+            mode: PartialWriteMode::Subset(0.0),
+        }));
 
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
         let data = b"hello world".to_vec();
@@ -1997,36 +2128,41 @@ mod tests {
 
     #[tokio::test]
     async fn test_faulty_storage_write_retention_frequency_edges() {
-        for mode in [PartialWriteMode::Prefix, PartialWriteMode::Subset] {
-            for (frequency, expected) in [
-                (0.0, b"old".as_slice()),
-                (f64::NAN, b"old".as_slice()),
-                (1.0, b"new".as_slice()),
-            ] {
-                let failed = Harness::new(Config::default().write(1.0, (mode, frequency)));
-                let (blob, _) = failed.storage.open("partition", b"failed").await.unwrap();
-                blob.write_at(0, b"new", WriteOptions::SYNC)
-                    .await
-                    .unwrap_err();
-                let (durable, len) = failed.inner.open("partition", b"failed").await.unwrap();
-                if frequency >= 1.0 {
-                    assert_eq!(len, 3);
-                    assert_eq!(durable.read_at(0, 3).await.unwrap().coalesce(), expected);
-                } else {
-                    assert_eq!(len, 0);
-                }
-
-                let crashed = Harness::new(Config::default().write(0.0, (mode, frequency)));
-                let (blob, _) = crashed.storage.open("partition", b"crashed").await.unwrap();
-                blob.write_at(0, b"old", WriteOptions::SYNC).await.unwrap();
-                blob.write_at(0, b"new", WriteOptions::default())
-                    .await
-                    .unwrap();
-                crashed.storage.crash().unwrap();
-                let (durable, len) = crashed.inner.open("partition", b"crashed").await.unwrap();
+        for (retention_frequency, expected) in [
+            (0.0, b"old".as_slice()),
+            (f64::NAN, b"old".as_slice()),
+            (1.0, b"new".as_slice()),
+        ] {
+            let mode = PartialWriteMode::Subset(retention_frequency);
+            let failed = Harness::new(Config::default().write(WriteConfig {
+                failure_rate: 1.0,
+                mode,
+            }));
+            let (blob, _) = failed.storage.open("partition", b"failed").await.unwrap();
+            blob.write_at(0, b"new", WriteOptions::SYNC)
+                .await
+                .unwrap_err();
+            let (durable, len) = failed.inner.open("partition", b"failed").await.unwrap();
+            if retention_frequency >= 1.0 {
                 assert_eq!(len, 3);
                 assert_eq!(durable.read_at(0, 3).await.unwrap().coalesce(), expected);
+            } else {
+                assert_eq!(len, 0);
             }
+
+            let crashed = Harness::new(Config::default().write(WriteConfig {
+                failure_rate: 0.0,
+                mode,
+            }));
+            let (blob, _) = crashed.storage.open("partition", b"crashed").await.unwrap();
+            blob.write_at(0, b"old", WriteOptions::SYNC).await.unwrap();
+            blob.write_at(0, b"new", WriteOptions::default())
+                .await
+                .unwrap();
+            crashed.storage.crash().unwrap();
+            let (durable, len) = crashed.inner.open("partition", b"crashed").await.unwrap();
+            assert_eq!(len, 3);
+            assert_eq!(durable.read_at(0, 3).await.unwrap().coalesce(), expected);
         }
     }
 
@@ -2045,7 +2181,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_faulty_storage_partial_resize_grow() {
-        let h = Harness::new(Config::default().resize(1.0, 0.0).partial_resize(1.0));
+        let h = Harness::new(Config::default().resize(1.0).partial_resize(1.0));
 
         let (blob, initial_size) = h.storage.open("partition", b"test").await.unwrap();
         assert_eq!(initial_size, 0);
@@ -2073,7 +2209,7 @@ mod tests {
 
         {
             let mut cfg = h.config.write();
-            cfg.resize_rate = Some((1.0, 0.0));
+            cfg.resize_rate = Some(1.0);
             cfg.partial_resize_rate = Some(1.0);
         }
 
@@ -2092,7 +2228,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_faulty_storage_partial_resize_disabled() {
-        let h = Harness::new(Config::default().resize(1.0, 0.0).partial_resize(0.0));
+        let h = Harness::new(Config::default().resize(1.0).partial_resize(0.0));
 
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
         let result = blob.resize(100).await;
@@ -2105,7 +2241,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_faulty_storage_partial_resize_same_size() {
-        let h = Harness::new(Config::default().resize(1.0, 0.0).partial_resize(1.0));
+        let h = Harness::new(Config::default().resize(1.0).partial_resize(1.0));
 
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
         let result = blob.resize(0).await;
@@ -2133,7 +2269,7 @@ mod tests {
 
         {
             let mut cfg = h.config.write();
-            cfg.resize_rate = Some((1.0, 0.0));
+            cfg.resize_rate = Some(1.0);
             cfg.partial_resize_rate = Some(1.0);
         }
 
@@ -2152,7 +2288,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_faulty_storage_partial_resize_one_byte_difference() {
-        let h = Harness::new(Config::default().resize(1.0, 0.0).partial_resize(1.0));
+        let h = Harness::new(Config::default().resize(1.0).partial_resize(1.0));
 
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
         let result = blob.resize(1).await;

--- a/runtime/src/storage/faulty.rs
+++ b/runtime/src/storage/faulty.rs
@@ -44,7 +44,7 @@ pub struct WriteConfig {
     pub failure_rate: f64,
 
     /// Probability used by the selected mode when retaining submitted bytes.
-    pub retention_frequency: f64,
+    pub retention_rate: f64,
 
     /// Arrangement of bytes retained by the simulated storage device.
     pub mode: PartialWriteMode,
@@ -157,8 +157,6 @@ struct Oracle {
 }
 
 /// An issued mutation or durability cut whose crash outcome remains unresolved.
-///
-/// Entries remain in issue order so crash replay and sync completion preserve mutation order.
 enum PendingMutation<B> {
     /// A write fragment whose `selection_offset` maps it into one issued write's shared byte
     /// selection.
@@ -220,8 +218,13 @@ impl<B> PendingMutation<B> {
     }
 }
 
+/// Unresolved entries in issue order within each file generation.
 type PendingMutations<B> = Arc<Mutex<Vec<PendingMutation<B>>>>;
+
+/// Identifies a file by partition and name.
 type FileKey = (String, Vec<u8>);
+
+/// Identifies one live file generation and serializes its mutations across handles.
 struct FileGeneration {
     mutation: AsyncMutex<()>,
 }
@@ -234,8 +237,7 @@ impl FileGeneration {
     }
 }
 
-// Every handle for one live file generation shares its durability cut and pending-mutation epoch.
-// Replacements receive a new generation object.
+/// Tracks the generation shared by existing handles and unresolved mutations for each file.
 type FileGenerations = Arc<Mutex<BTreeMap<FileKey, Weak<FileGeneration>>>>;
 
 fn clear_pending<B>(pending: &PendingMutations<B>, generation: &Arc<FileGeneration>) {
@@ -281,8 +283,8 @@ impl Oracle {
         let fail = self.roll(Some(config.rate_for(Op::Write)));
         let retention = config
             .write_rate
-            .map(|config| (config.mode, config.retention_frequency))
-            .filter(|(_, retention_frequency)| *retention_frequency > 0.0);
+            .map(|config| (config.mode, config.retention_rate))
+            .filter(|(_, retention_rate)| *retention_rate > 0.0);
         (fail, retention)
     }
 
@@ -324,12 +326,12 @@ impl Oracle {
     fn retained_bytes(
         &self,
         len: usize,
-        (mode, retention_frequency): (PartialWriteMode, f64),
+        (mode, retention_rate): (PartialWriteMode, f64),
     ) -> Vec<bool> {
-        if retention_frequency <= 0.0 || retention_frequency.is_nan() {
+        if retention_rate <= 0.0 || retention_rate.is_nan() {
             return vec![false; len];
         }
-        if retention_frequency >= 1.0 {
+        if retention_rate >= 1.0 {
             return vec![true; len];
         }
 
@@ -338,14 +340,12 @@ impl Oracle {
             PartialWriteMode::Prefix => {
                 let mut positions = vec![false; len];
                 let retained = (0..len)
-                    .take_while(|_| rng.random_bool(retention_frequency))
+                    .take_while(|_| rng.random_bool(retention_rate))
                     .count();
                 positions[..retained].fill(true);
                 positions
             }
-            PartialWriteMode::Subset => (0..len)
-                .map(|_| rng.random_bool(retention_frequency))
-                .collect(),
+            PartialWriteMode::Subset => (0..len).map(|_| rng.random_bool(retention_rate)).collect(),
         }
     }
 
@@ -392,6 +392,7 @@ impl<S: crate::Storage> Storage<S> {
         self.ctx.config.clone()
     }
 
+    /// Associates an open blob with the current generation for its file.
     fn wrap_blob(&self, partition: &str, name: &[u8], inner: S::Blob, size: u64) -> Blob<S::Blob> {
         let key = (partition.to_string(), name.to_vec());
         let generation = {
@@ -414,6 +415,7 @@ impl<S: crate::Storage> Storage<S> {
         )
     }
 
+    /// Retires generations and pending mutations for one file or an entire partition.
     fn retire_names(&self, partition: &str, name: Option<&[u8]>) {
         let retired = {
             let mut generations = self.generations.lock();
@@ -966,7 +968,7 @@ mod tests {
     async fn test_start_sync_returns_before_backing_completion() {
         let h = Harness::new(Config::default().write(WriteConfig {
             failure_rate: 0.0,
-            retention_frequency: 1.0,
+            retention_rate: 1.0,
             mode: PartialWriteMode::Prefix,
         }));
         let (inner, _) = h.inner.open("partition", b"start-sync").await.unwrap();
@@ -1006,7 +1008,7 @@ mod tests {
     async fn run_overlapping_barrier(start: bool) {
         let h = Harness::new(Config::default().write(WriteConfig {
             failure_rate: 0.0,
-            retention_frequency: 1.0,
+            retention_rate: 1.0,
             mode: PartialWriteMode::Prefix,
         }));
         let (inner, _) = h.inner.open("partition", b"overlap").await.unwrap();
@@ -1086,7 +1088,7 @@ mod tests {
     async fn test_completed_backing_write_cannot_record_after_later_full_sync() {
         let h = Harness::new(Config::default().write(WriteConfig {
             failure_rate: 0.0,
-            retention_frequency: 1.0,
+            retention_rate: 1.0,
             mode: PartialWriteMode::Prefix,
         }));
         let (inner, _) = h.inner.open("partition", b"late-record").await.unwrap();
@@ -1159,7 +1161,7 @@ mod tests {
             seed,
             Config::default().write(WriteConfig {
                 failure_rate: 0.0,
-                retention_frequency: 0.5,
+                retention_rate: 0.5,
                 mode: PartialWriteMode::Subset,
             }),
         );
@@ -1173,7 +1175,7 @@ mod tests {
             let mut config = h.config.write();
             config.write_rate = Some(WriteConfig {
                 failure_rate: 1.0,
-                retention_frequency: 0.5,
+                retention_rate: 0.5,
                 mode: PartialWriteMode::Subset,
             });
         }
@@ -1199,7 +1201,7 @@ mod tests {
             seed,
             Config::default().write(WriteConfig {
                 failure_rate: 0.0,
-                retention_frequency: 0.5,
+                retention_rate: 0.5,
                 mode: PartialWriteMode::Subset,
             }),
         );
@@ -1229,7 +1231,7 @@ mod tests {
     async fn test_reopened_sync_clears_prior_handle_crash_writes() {
         let h = Harness::new(Config::default().write(WriteConfig {
             failure_rate: 0.0,
-            retention_frequency: 1.0,
+            retention_rate: 1.0,
             mode: PartialWriteMode::Prefix,
         }));
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
@@ -1258,7 +1260,7 @@ mod tests {
     async fn test_dropped_completed_start_sync_clears_the_crash_epoch() {
         let h = Harness::new(Config::default().write(WriteConfig {
             failure_rate: 0.0,
-            retention_frequency: 1.0,
+            retention_rate: 1.0,
             mode: PartialWriteMode::Prefix,
         }));
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
@@ -1275,7 +1277,7 @@ mod tests {
 
         h.config.write().write_rate = Some(WriteConfig {
             failure_rate: 0.0,
-            retention_frequency: 1.0,
+            retention_rate: 1.0,
             mode: PartialWriteMode::Prefix,
         });
         blob.write_at(5, b"later", WriteOptions::default())
@@ -1295,7 +1297,7 @@ mod tests {
     async fn test_sync_write_does_not_barrier_disjoint_pending_write() {
         let h = Harness::new(Config::default().write(WriteConfig {
             failure_rate: 0.0,
-            retention_frequency: 1.0,
+            retention_rate: 1.0,
             mode: PartialWriteMode::Prefix,
         }));
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
@@ -1318,7 +1320,7 @@ mod tests {
     async fn test_sync_write_retires_only_overlapping_pending_bytes() {
         let h = Harness::new(Config::default().write(WriteConfig {
             failure_rate: 0.0,
-            retention_frequency: 1.0,
+            retention_rate: 1.0,
             mode: PartialWriteMode::Prefix,
         }));
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
@@ -1354,7 +1356,7 @@ mod tests {
                 seed,
                 Config::default().write(WriteConfig {
                     failure_rate: 0.0,
-                    retention_frequency: 0.5,
+                    retention_rate: 0.5,
                     mode: PartialWriteMode::Prefix,
                 }),
             );
@@ -1385,7 +1387,7 @@ mod tests {
             Config::default()
                 .write(WriteConfig {
                     failure_rate: 0.0,
-                    retention_frequency: 1.0,
+                    retention_rate: 1.0,
                     mode: PartialWriteMode::Prefix,
                 })
                 .resize(0.5),
@@ -1431,7 +1433,7 @@ mod tests {
             let mut config = h.config.write();
             config.write_rate = Some(WriteConfig {
                 failure_rate: 1.0,
-                retention_frequency: 0.5,
+                retention_rate: 0.5,
                 mode: PartialWriteMode::Subset,
             });
         }
@@ -1510,7 +1512,7 @@ mod tests {
         for partial_write_mode in [PartialWriteMode::Prefix, PartialWriteMode::Subset] {
             let h = Harness::new(Config::default().write(WriteConfig {
                 failure_rate: 0.0,
-                retention_frequency: 1.0,
+                retention_rate: 1.0,
                 mode: PartialWriteMode::Prefix,
             }));
             let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
@@ -1524,7 +1526,7 @@ mod tests {
                 let mut config = h.config.write();
                 config.write_rate = Some(WriteConfig {
                     failure_rate: 1.0,
-                    retention_frequency: 0.5,
+                    retention_rate: 0.5,
                     mode: partial_write_mode,
                 });
             }
@@ -1571,9 +1573,9 @@ mod tests {
     }
 
     #[test]
-    fn test_write_retention_frequency_matches_fault_rate_bounds() {
+    fn test_write_retention_rate_matches_fault_rate_bounds() {
         let h = Harness::new(Config::default());
-        for (retention_frequency, expected) in [
+        for (retention_rate, expected) in [
             (f64::NEG_INFINITY, false),
             (-1.0, false),
             (0.0, false),
@@ -1582,10 +1584,10 @@ mod tests {
             (2.0, true),
             (f64::INFINITY, true),
         ] {
-            assert_eq!(h.storage.ctx.roll(Some(retention_frequency)), expected);
+            assert_eq!(h.storage.ctx.roll(Some(retention_rate)), expected);
             for mode in [PartialWriteMode::Prefix, PartialWriteMode::Subset] {
                 assert_eq!(
-                    h.storage.ctx.retained_bytes(4, (mode, retention_frequency)),
+                    h.storage.ctx.retained_bytes(4, (mode, retention_rate)),
                     [expected; 4]
                 );
             }
@@ -1593,7 +1595,7 @@ mod tests {
     }
 
     #[test]
-    fn test_prefix_retention_frequency_selects_inclusive_prefix() {
+    fn test_prefix_retention_rate_selects_inclusive_prefix() {
         let h = Harness::new(Config::default());
         let mut observed = [false; 5];
         for seed in 0..512 {
@@ -1620,7 +1622,7 @@ mod tests {
     async fn test_write_rejects_offset_overflow_before_retention() {
         let h = Harness::new(Config::default().write(WriteConfig {
             failure_rate: 1.0,
-            retention_frequency: 0.5,
+            retention_rate: 0.5,
             mode: PartialWriteMode::Subset,
         }));
         let (blob, _) = h.storage.open("partition", b"blob").await.unwrap();
@@ -1637,7 +1639,7 @@ mod tests {
     async fn test_failed_write_can_retain_every_byte() {
         let h = Harness::new(Config::default().write(WriteConfig {
             failure_rate: 1.0,
-            retention_frequency: 1.0,
+            retention_rate: 1.0,
             mode: PartialWriteMode::Prefix,
         }));
         let (blob, _) = h.storage.open("partition", b"blob").await.unwrap();
@@ -1669,7 +1671,7 @@ mod tests {
             Config::default()
                 .write(WriteConfig {
                     failure_rate: 0.0,
-                    retention_frequency: 1.0,
+                    retention_rate: 1.0,
                     mode: PartialWriteMode::Prefix,
                 })
                 .sync(1.0),
@@ -1689,7 +1691,7 @@ mod tests {
     async fn test_faulty_storage_write_always_fails() {
         let h = Harness::new(Config::default().write(WriteConfig {
             failure_rate: 1.0,
-            retention_frequency: 0.0,
+            retention_rate: 0.0,
             mode: PartialWriteMode::Prefix,
         }));
 
@@ -1706,7 +1708,7 @@ mod tests {
     async fn test_faulty_storage_write_at_sync_write_always_fails() {
         let h = Harness::new(Config::default().write(WriteConfig {
             failure_rate: 1.0,
-            retention_frequency: 0.0,
+            retention_rate: 0.0,
             mode: PartialWriteMode::Prefix,
         }));
 
@@ -1754,7 +1756,7 @@ mod tests {
     async fn test_empty_unsynced_write_does_not_create_crash_debt() {
         let h = Harness::new(Config::default().write(WriteConfig {
             failure_rate: 0.0,
-            retention_frequency: 1.0,
+            retention_rate: 1.0,
             mode: PartialWriteMode::Prefix,
         }));
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
@@ -1864,7 +1866,7 @@ mod tests {
             .open(0.1)
             .write(WriteConfig {
                 failure_rate: 0.3,
-                retention_frequency: 0.4,
+                retention_rate: 0.4,
                 mode: PartialWriteMode::Subset,
             })
             .resize(0.7)
@@ -1894,7 +1896,7 @@ mod tests {
     async fn test_write_retention_is_snapshotted_and_replayed_in_order() {
         let h = Harness::new(Config::default().write(WriteConfig {
             failure_rate: 0.0,
-            retention_frequency: 1.0,
+            retention_rate: 1.0,
             mode: PartialWriteMode::Prefix,
         }));
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
@@ -1911,7 +1913,7 @@ mod tests {
             .unwrap();
         h.config.write().write_rate = Some(WriteConfig {
             failure_rate: 0.0,
-            retention_frequency: 1.0,
+            retention_rate: 1.0,
             mode: PartialWriteMode::Prefix,
         });
         blob.write_at(1, b"XY", WriteOptions::default())
@@ -1961,7 +1963,7 @@ mod tests {
                     seed,
                     Config::default().write(WriteConfig {
                         failure_rate: 0.0,
-                        retention_frequency: 0.5,
+                        retention_rate: 0.5,
                         mode: PartialWriteMode::Subset,
                     }),
                 );
@@ -1976,7 +1978,7 @@ mod tests {
                     let mut config = h.config.write();
                     config.write_rate = Some(WriteConfig {
                         failure_rate: 1.0,
-                        retention_frequency: 0.5,
+                        retention_rate: 0.5,
                         mode: partial_write_mode,
                     });
                 }
@@ -2006,7 +2008,7 @@ mod tests {
                 seed,
                 Config::default().write(WriteConfig {
                     failure_rate: 0.0,
-                    retention_frequency: 0.5,
+                    retention_rate: 0.5,
                     mode: PartialWriteMode::Subset,
                 }),
             );
@@ -2039,7 +2041,7 @@ mod tests {
     async fn test_crash_journal_clears_only_after_completed_durability() {
         let h = Harness::new(Config::default().write(WriteConfig {
             failure_rate: 0.0,
-            retention_frequency: 1.0,
+            retention_rate: 1.0,
             mode: PartialWriteMode::Prefix,
         }));
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
@@ -2091,7 +2093,7 @@ mod tests {
             Config::default()
                 .write(WriteConfig {
                     failure_rate: 0.0,
-                    retention_frequency: 1.0,
+                    retention_rate: 1.0,
                     mode: PartialWriteMode::Prefix,
                 })
                 .sync(1.0),
@@ -2113,7 +2115,7 @@ mod tests {
     async fn test_faulty_storage_zero_write_retention_preserves_nothing() {
         let h = Harness::new(Config::default().write(WriteConfig {
             failure_rate: 1.0,
-            retention_frequency: 0.0,
+            retention_rate: 0.0,
             mode: PartialWriteMode::Prefix,
         }));
 
@@ -2160,8 +2162,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_faulty_storage_write_retention_frequency_edges() {
-        for (retention_frequency, expected) in [
+    async fn test_faulty_storage_write_retention_rate_edges() {
+        for (retention_rate, expected) in [
             (0.0, b"old".as_slice()),
             (f64::NAN, b"old".as_slice()),
             (1.0, b"new".as_slice()),
@@ -2169,7 +2171,7 @@ mod tests {
             for mode in [PartialWriteMode::Prefix, PartialWriteMode::Subset] {
                 let failed = Harness::new(Config::default().write(WriteConfig {
                     failure_rate: 1.0,
-                    retention_frequency,
+                    retention_rate,
                     mode,
                 }));
                 let (blob, _) = failed.storage.open("partition", b"failed").await.unwrap();
@@ -2177,7 +2179,7 @@ mod tests {
                     .await
                     .unwrap_err();
                 let (durable, len) = failed.inner.open("partition", b"failed").await.unwrap();
-                if retention_frequency >= 1.0 {
+                if retention_rate >= 1.0 {
                     assert_eq!(len, 3);
                     assert_eq!(durable.read_at(0, 3).await.unwrap().coalesce(), expected);
                 } else {
@@ -2186,7 +2188,7 @@ mod tests {
 
                 let crashed = Harness::new(Config::default().write(WriteConfig {
                     failure_rate: 0.0,
-                    retention_frequency,
+                    retention_rate,
                     mode,
                 }));
                 let (blob, _) = crashed.storage.open("partition", b"crashed").await.unwrap();

--- a/runtime/src/storage/faulty.rs
+++ b/runtime/src/storage/faulty.rs
@@ -2,12 +2,14 @@
 
 use crate::{Error, Handle, IoBufs, IoBufsMut, WriteOptions, deterministic::BoxDynRng};
 use bytes::Buf;
-use commonware_utils::sync::{Mutex, RwLock};
+use commonware_utils::sync::{AsyncMutex, Mutex, RwLock};
+use futures::{FutureExt as _, future::Shared};
 use rand::RngExt as _;
 use std::{
+    collections::{BTreeMap, HashSet},
     io::Error as IoError,
     sync::{
-        Arc,
+        Arc, OnceLock, Weak,
         atomic::{AtomicU64, Ordering},
     },
 };
@@ -24,6 +26,16 @@ enum Op {
     Scan,
 }
 
+/// Selects how retained bytes are arranged when a write is partially preserved.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PartialWriteMode {
+    /// Retain bytes from the beginning of the write until the first omitted byte.
+    Prefix,
+
+    /// Independently retain submitted byte positions.
+    Subset,
+}
+
 /// Configuration for deterministic storage fault injection.
 ///
 /// Each rate is a probability from 0.0 (never fail) to 1.0 (always fail).
@@ -35,20 +47,20 @@ pub struct Config {
     /// Failure rate for `read_at` operations.
     pub read_rate: Option<f64>,
 
-    /// Failure rate for `write_at` operations.
-    pub write_rate: Option<f64>,
-
-    /// Probability that a write failure is a partial write (some bytes written
-    /// before failure) rather than a complete failure (no bytes written).
-    /// Only applies when `write_rate` triggers a failure.
-    /// Value from 0.0 (always complete failure) to 1.0 (always partial write).
-    pub partial_write_rate: Option<f64>,
+    /// Failure rate and byte-retention policy for `write_at` operations.
+    ///
+    /// The outer tuple contains the failure rate and retention policy. The retention policy applies
+    /// to failed writes and successful unsynchronized writes at a simulated crash. Retention
+    /// frequencies that are `NaN` or at or below 0.0 retain no bytes, while frequencies at or above
+    /// 1.0 retain every byte.
+    pub write_rate: Option<(f64, (PartialWriteMode, f64))>,
 
     /// Failure rate for `sync` operations.
     pub sync_rate: Option<f64>,
 
-    /// Failure rate for `resize` operations.
-    pub resize_rate: Option<f64>,
+    /// Failure rate for `resize` operations and probability that a successful unsynchronized
+    /// resize survives a simulated crash.
+    pub resize_rate: Option<(f64, f64)>,
 
     /// Probability that a resize failure is partial (resized to an intermediate
     /// size before failure) rather than a complete failure (size unchanged).
@@ -69,9 +81,9 @@ impl Config {
         match op {
             Op::Open => self.open_rate,
             Op::Read => self.read_rate,
-            Op::Write => self.write_rate,
+            Op::Write => self.write_rate.map(|(failure_rate, _)| failure_rate),
             Op::Sync => self.sync_rate,
-            Op::Resize => self.resize_rate,
+            Op::Resize => self.resize_rate.map(|(failure_rate, _)| failure_rate),
             Op::Remove => self.remove_rate,
             Op::Scan => self.scan_rate,
         }
@@ -90,15 +102,9 @@ impl Config {
         self
     }
 
-    /// Set the write failure rate.
-    pub const fn write(mut self, rate: f64) -> Self {
-        self.write_rate = Some(rate);
-        self
-    }
-
-    /// Set the partial write rate (probability of partial vs complete write failure).
-    pub const fn partial_write(mut self, rate: f64) -> Self {
-        self.partial_write_rate = Some(rate);
+    /// Set the write failure rate and byte-retention policy.
+    pub const fn write(mut self, failure_rate: f64, retention: (PartialWriteMode, f64)) -> Self {
+        self.write_rate = Some((failure_rate, retention));
         self
     }
 
@@ -108,9 +114,9 @@ impl Config {
         self
     }
 
-    /// Set the resize failure rate.
-    pub const fn resize(mut self, rate: f64) -> Self {
-        self.resize_rate = Some(rate);
+    /// Set the resize failure and crash-retention rates.
+    pub const fn resize(mut self, failure_rate: f64, retention_rate: f64) -> Self {
+        self.resize_rate = Some((failure_rate, retention_rate));
         self
     }
 
@@ -140,26 +146,139 @@ struct Oracle {
     config: Arc<RwLock<Config>>,
 }
 
+enum PendingMutation<B> {
+    Write {
+        generation: Arc<FileGeneration>,
+        blob: B,
+        offset: u64,
+        bufs: IoBufs,
+        retention: Arc<PendingWriteRetention>,
+        selection_offset: usize,
+    },
+    Resize {
+        generation: Arc<FileGeneration>,
+        blob: B,
+        len: u64,
+    },
+    Sync {
+        sync: Arc<PendingSync>,
+    },
+}
+
+/// One initiated full sync owns its durability cut and is observed by both its caller and crash
+/// replay bookkeeping.
+struct PendingSync {
+    generation: Arc<FileGeneration>,
+    completion: Shared<Handle<()>>,
+}
+
+impl PendingSync {
+    fn completed_successfully(&self) -> bool {
+        matches!(self.completion.clone().now_or_never(), Some(Ok(())))
+    }
+}
+
+/// Retention choices belong to the issued write and are shared by fragments created by later
+/// durability barriers.
+struct PendingWriteRetention {
+    policy: (PartialWriteMode, f64),
+    len: usize,
+    selected: OnceLock<Vec<bool>>,
+}
+
+impl PendingWriteRetention {
+    const fn new(policy: (PartialWriteMode, f64), len: usize) -> Self {
+        Self {
+            policy,
+            len,
+            selected: OnceLock::new(),
+        }
+    }
+}
+
+impl<B> PendingMutation<B> {
+    fn generation(&self) -> &Arc<FileGeneration> {
+        match self {
+            Self::Write { generation, .. } | Self::Resize { generation, .. } => generation,
+            Self::Sync { sync } => &sync.generation,
+        }
+    }
+}
+
+type PendingMutations<B> = Arc<Mutex<Vec<PendingMutation<B>>>>;
+type FileKey = (String, Vec<u8>);
+struct FileGeneration {
+    mutation: AsyncMutex<()>,
+}
+
+impl FileGeneration {
+    fn new() -> Self {
+        Self {
+            mutation: AsyncMutex::new(()),
+        }
+    }
+}
+
+// Every handle for one live file generation shares its durability cut and pending-mutation epoch.
+// Replacements receive a new generation object.
+type FileGenerations = Arc<Mutex<BTreeMap<FileKey, Weak<FileGeneration>>>>;
+
+fn clear_pending<B>(pending: &PendingMutations<B>, generation: &Arc<FileGeneration>) {
+    pending
+        .lock()
+        .retain(|mutation| !Arc::ptr_eq(mutation.generation(), generation));
+}
+
+/// A successful full sync retires mutations issued before it while preserving later crash debt.
+fn resolve_pending_sync<B>(
+    pending: &PendingMutations<B>,
+    sync: &Arc<PendingSync>,
+    succeeded: bool,
+) {
+    let mut pending = pending.lock();
+    let Some(cut) = pending.iter().position(
+        |mutation| matches!(mutation, PendingMutation::Sync { sync: candidate, .. } if Arc::ptr_eq(candidate, sync)),
+    ) else {
+        return;
+    };
+    let mut index = 0;
+    pending.retain(|mutation| {
+        let is_target = matches!(mutation, PendingMutation::Sync { sync: candidate, .. } if Arc::ptr_eq(candidate, sync));
+        let retire = is_target
+            || (succeeded
+                && index < cut
+                && Arc::ptr_eq(mutation.generation(), &sync.generation));
+        index += 1;
+        !retire
+    });
+}
+
 impl Oracle {
     /// Check if a fault should be injected for the given operation.
     fn should_fail(&self, op: Op) -> bool {
         self.roll(Some(self.config.read().rate_for(op)))
     }
 
-    /// Check if a write fault should be injected. Returns (should_fail, partial_rate).
+    /// Check if a write fault should be injected.
     /// Reads config once to avoid nested lock acquisition.
-    fn check_write_fault(&self) -> (bool, Option<f64>) {
+    fn check_write_fault(&self) -> (bool, Option<(PartialWriteMode, f64)>) {
         let config = self.config.read();
         let fail = self.roll(Some(config.rate_for(Op::Write)));
-        (fail, config.partial_write_rate)
+        let retention = config
+            .write_rate
+            .map(|(_, retention)| retention)
+            .filter(|(_, frequency)| *frequency > 0.0);
+        (fail, retention)
     }
 
-    /// Check if a resize fault should be injected. Returns (should_fail, partial_rate).
+    /// Check if a resize fault should be injected and snapshot its crash outcome.
     /// Reads config once to avoid nested lock acquisition.
-    fn check_resize_fault(&self) -> (bool, Option<f64>) {
+    fn check_resize_fault(&self) -> (bool, Option<f64>, bool) {
         let config = self.config.read();
         let fail = self.roll(Some(config.rate_for(Op::Resize)));
-        (fail, config.partial_resize_rate)
+        let retention_rate = config.resize_rate.map(|(_, retention_rate)| retention_rate);
+        let retain = !fail && self.roll(retention_rate);
+        (fail, config.partial_resize_rate, retain)
     }
 
     /// Check if an event should occur based on a probability rate.
@@ -186,6 +305,25 @@ impl Oracle {
         Some(self.rng.lock().random_range(min + 1..max))
     }
 
+    /// Select retained byte positions according to a snapshotted write policy.
+    fn retained_bytes(&self, len: usize, (mode, frequency): (PartialWriteMode, f64)) -> Vec<bool> {
+        debug_assert!(frequency > 0.0);
+        if frequency >= 1.0 {
+            return vec![true; len];
+        }
+
+        let mut rng = self.rng.lock();
+        match mode {
+            PartialWriteMode::Prefix => {
+                let retained = (0..len).take_while(|_| rng.random_bool(frequency)).count();
+                let mut positions = vec![false; len];
+                positions[..retained].fill(true);
+                positions
+            }
+            PartialWriteMode::Subset => (0..len).map(|_| rng.random_bool(frequency)).collect(),
+        }
+    }
+
     /// Try to generate a partial operation target. Returns Some if both the rate
     /// check passes and an intermediate value exists between `from` and `to`.
     fn try_partial(&self, rate: Option<f64>, from: u64, to: u64) -> Option<u64> {
@@ -204,6 +342,8 @@ impl Oracle {
 pub struct Storage<S: crate::Storage> {
     inner: S,
     ctx: Oracle,
+    pending: PendingMutations<S::Blob>,
+    generations: FileGenerations,
 }
 
 impl<S: crate::Storage> Storage<S> {
@@ -212,6 +352,8 @@ impl<S: crate::Storage> Storage<S> {
         Self {
             inner,
             ctx: Oracle { rng, config },
+            pending: Arc::new(Mutex::new(Vec::new())),
+            generations: Arc::new(Mutex::new(BTreeMap::new())),
         }
     }
 
@@ -223,6 +365,107 @@ impl<S: crate::Storage> Storage<S> {
     /// Get access to the fault configuration for dynamic modification.
     pub fn config(&self) -> Arc<RwLock<Config>> {
         self.ctx.config.clone()
+    }
+
+    fn wrap_blob(&self, partition: &str, name: &[u8], inner: S::Blob, size: u64) -> Blob<S::Blob> {
+        let key = (partition.to_string(), name.to_vec());
+        let generation = {
+            let mut generations = self.generations.lock();
+            generations
+                .get(&key)
+                .and_then(Weak::upgrade)
+                .unwrap_or_else(|| {
+                    let generation = Arc::new(FileGeneration::new());
+                    generations.insert(key.clone(), Arc::downgrade(&generation));
+                    generation
+                })
+        };
+        Blob::new(
+            self.ctx.clone(),
+            self.pending.clone(),
+            generation,
+            inner,
+            size,
+        )
+    }
+
+    fn retire_names(&self, partition: &str, name: Option<&[u8]>) {
+        let retired = {
+            let mut generations = self.generations.lock();
+            match name {
+                Some(name) => generations
+                    .remove(&(partition.to_string(), name.to_vec()))
+                    .and_then(|generation| generation.upgrade())
+                    .into_iter()
+                    .collect::<Vec<_>>(),
+                None => {
+                    let keys = generations
+                        .keys()
+                        .filter(|(candidate, _)| candidate == partition)
+                        .cloned()
+                        .collect::<Vec<_>>();
+                    keys.into_iter()
+                        .filter_map(|key| generations.remove(&key)?.upgrade())
+                        .collect()
+                }
+            }
+        };
+        for generation in retired {
+            clear_pending(&self.pending, &generation);
+        }
+    }
+}
+
+impl Storage<crate::storage::memory::Storage> {
+    /// Replay selected crash outcomes in issue order.
+    pub(crate) fn crash(&self) -> Result<(), Error> {
+        let pending = std::mem::take(&mut *self.pending.lock());
+        let mut synced = HashSet::new();
+        let mut replay = Vec::with_capacity(pending.len());
+        for mutation in pending.into_iter().rev() {
+            match mutation {
+                PendingMutation::Sync { sync } => {
+                    if sync.completed_successfully() {
+                        synced.insert(Arc::as_ptr(&sync.generation));
+                    }
+                }
+                mutation => {
+                    if !synced.contains(&Arc::as_ptr(mutation.generation())) {
+                        replay.push(mutation);
+                    }
+                }
+            }
+        }
+        for mutation in replay.into_iter().rev() {
+            match mutation {
+                PendingMutation::Write {
+                    blob,
+                    offset,
+                    bufs,
+                    retention,
+                    selection_offset,
+                    ..
+                } => {
+                    let selected = retention
+                        .selected
+                        .get_or_init(|| self.ctx.retained_bytes(retention.len, retention.policy));
+                    let selection_end = selection_offset
+                        .checked_add(bufs.remaining())
+                        .expect("a pending-write fragment stays within its selection");
+                    let mut retained = selected[selection_offset..selection_end].iter().copied();
+                    blob.retain_crash_write(offset, bufs, || {
+                        retained
+                            .next()
+                            .expect("the retention policy covers every submitted byte")
+                    })?;
+                }
+                PendingMutation::Resize { blob, len, .. } => {
+                    blob.retain_crash_resize(len)?;
+                }
+                PendingMutation::Sync { .. } => unreachable!("sync markers are not replayed"),
+            }
+        }
+        Ok(())
     }
 }
 
@@ -243,19 +486,22 @@ impl<S: crate::Storage> crate::Storage for Storage<S> {
         if self.ctx.should_fail(Op::Open) {
             return Err(injected_io_error().into());
         }
-        self.inner
-            .open_versioned(partition, name, versions)
-            .await
-            .map(|(blob, len, blob_version)| {
-                (Blob::new(self.ctx.clone(), blob, len), len, blob_version)
-            })
+        let (blob, len, blob_version) =
+            self.inner.open_versioned(partition, name, versions).await?;
+        Ok((
+            self.wrap_blob(partition, name, blob, len),
+            len,
+            blob_version,
+        ))
     }
 
     async fn remove(&self, partition: &str, name: Option<&[u8]>) -> Result<(), Error> {
         if self.ctx.should_fail(Op::Remove) {
             return Err(injected_io_error().into());
         }
-        self.inner.remove(partition, name).await
+        self.inner.remove(partition, name).await?;
+        self.retire_names(partition, name);
+        Ok(())
     }
 
     async fn scan(&self, partition: &str) -> Result<Vec<Vec<u8>>, Error> {
@@ -271,17 +517,151 @@ impl<S: crate::Storage> crate::Storage for Storage<S> {
 pub struct Blob<B: crate::Blob> {
     inner: B,
     ctx: Oracle,
+    pending: PendingMutations<B>,
+    generation: Arc<FileGeneration>,
     /// Tracked size for partial resize support.
     size: Arc<AtomicU64>,
 }
 
 impl<B: crate::Blob> Blob<B> {
-    fn new(ctx: Oracle, inner: B, size: u64) -> Self {
+    fn new(
+        ctx: Oracle,
+        pending: PendingMutations<B>,
+        generation: Arc<FileGeneration>,
+        inner: B,
+        size: u64,
+    ) -> Self {
         Self {
             inner,
             ctx,
+            pending,
+            generation,
             size: Arc::new(AtomicU64::new(size)),
         }
+    }
+
+    fn record_pending(&self, offset: u64, bufs: IoBufs, retention: (PartialWriteMode, f64)) {
+        if bufs.is_empty() {
+            return;
+        }
+        let retention = Arc::new(PendingWriteRetention::new(retention, bufs.remaining()));
+        self.pending.lock().push(PendingMutation::Write {
+            generation: self.generation.clone(),
+            blob: self.inner.clone(),
+            offset,
+            bufs,
+            retention,
+            selection_offset: 0,
+        });
+    }
+
+    fn record_pending_resize(&self, len: u64) {
+        self.pending.lock().push(PendingMutation::Resize {
+            generation: self.generation.clone(),
+            blob: self.inner.clone(),
+            len,
+        });
+    }
+
+    /// Retire covered write debt and replay the durable range after any earlier resize debt.
+    fn record_durable_range(&self, offset: u64, durable: IoBufs) {
+        let len = durable.remaining() as u64;
+        if len == 0 {
+            return;
+        }
+        let end = offset
+            .checked_add(len)
+            .expect("submitted write range was validated before mutation");
+        let mut pending = self.pending.lock();
+        let mutations = std::mem::take(&mut *pending);
+        let mut retained = Vec::with_capacity(mutations.len() + 1);
+        let mut follows_resize = false;
+        for mutation in mutations {
+            if !Arc::ptr_eq(mutation.generation(), &self.generation) {
+                retained.push(mutation);
+                continue;
+            }
+            let (write_generation, write_blob, write_offset, bufs, retention, selection_offset) =
+                match mutation {
+                    PendingMutation::Write {
+                        generation,
+                        blob,
+                        offset,
+                        bufs,
+                        retention,
+                        selection_offset,
+                    } => (generation, blob, offset, bufs, retention, selection_offset),
+                    resize @ PendingMutation::Resize { .. } => {
+                        follows_resize = true;
+                        retained.push(resize);
+                        continue;
+                    }
+                    sync @ PendingMutation::Sync { .. } => {
+                        retained.push(sync);
+                        continue;
+                    }
+                };
+            let write_len = bufs.remaining() as u64;
+            let write_end = write_offset
+                .checked_add(write_len)
+                .expect("pending write ranges are validated before recording");
+            let overlap_start = write_offset.max(offset);
+            let overlap_end = write_end.min(end);
+            if overlap_start >= overlap_end {
+                retained.push(PendingMutation::Write {
+                    generation: write_generation,
+                    blob: write_blob,
+                    offset: write_offset,
+                    bufs,
+                    retention,
+                    selection_offset,
+                });
+                continue;
+            }
+
+            let bytes = bufs.coalesce();
+            if write_offset < overlap_start {
+                let prefix_len = usize::try_from(overlap_start - write_offset)
+                    .expect("a pending-write subrange fits its source buffer");
+                retained.push(PendingMutation::Write {
+                    generation: write_generation.clone(),
+                    blob: write_blob.clone(),
+                    offset: write_offset,
+                    bufs: bytes.slice(..prefix_len).into(),
+                    retention: retention.clone(),
+                    selection_offset,
+                });
+            }
+            if overlap_end < write_end {
+                let suffix_start = usize::try_from(overlap_end - write_offset)
+                    .expect("a pending-write subrange fits its source buffer");
+                retained.push(PendingMutation::Write {
+                    generation: write_generation,
+                    blob: write_blob,
+                    offset: overlap_end,
+                    bufs: bytes.slice(suffix_start..).into(),
+                    retention,
+                    selection_offset: selection_offset
+                        .checked_add(suffix_start)
+                        .expect("a pending-write fragment stays within its selection"),
+                });
+            }
+        }
+        if follows_resize {
+            let retention = Arc::new(PendingWriteRetention::new(
+                (PartialWriteMode::Prefix, 1.0),
+                durable.remaining(),
+            ));
+            retained.push(PendingMutation::Write {
+                generation: self.generation.clone(),
+                blob: self.inner.clone(),
+                offset,
+                bufs: durable,
+                retention,
+                selection_offset: 0,
+            });
+        }
+        *pending = retained;
     }
 }
 
@@ -317,52 +697,92 @@ impl<B: crate::Blob> crate::Blob for Blob<B> {
         if sync && total_bytes == 0 {
             return Ok(());
         }
-
-        let (should_fail, partial_rate) = self.ctx.check_write_fault();
+        offset
+            .checked_add(total_bytes)
+            .ok_or(Error::OffsetOverflow)?;
+        let (should_fail, write_retention) = self.ctx.check_write_fault();
+        let _mutation = self.generation.mutation.lock().await;
         if should_fail {
-            if let Some(bytes) = self.ctx.try_partial(partial_rate, 0, total_bytes) {
-                // Partial write: write some bytes, sync, then fail
-                let bufs = bufs.coalesce().slice(..bytes as usize);
-                self.inner.write_at(offset, bufs, options).await?;
-                if !sync {
-                    self.inner.sync().await?;
+            if let Some(retention) = write_retention {
+                let len = bufs.remaining();
+                let retained = self.ctx.retained_bytes(len, retention);
+                let bufs = bufs.coalesce();
+                let mut position = 0;
+                while position < len {
+                    if !retained[position] {
+                        position += 1;
+                        continue;
+                    }
+
+                    let start = position;
+                    while position < len && retained[position] {
+                        position += 1;
+                    }
+                    let end = position;
+                    let run_offset = offset
+                        .checked_add(start as u64)
+                        .ok_or(Error::OffsetOverflow)?;
+                    let run = bufs.slice(start..end);
+                    let durable = run.clone().into();
+                    self.inner
+                        .write_at(run_offset, run, options | WriteOptions::SYNC)
+                        .await?;
+                    self.record_durable_range(run_offset, durable);
+                    self.size.fetch_max(
+                        run_offset.saturating_add((end - start) as u64),
+                        Ordering::Relaxed,
+                    );
                 }
-                self.size
-                    .fetch_max(offset.saturating_add(bytes), Ordering::Relaxed);
-                return Err(injected_io_error().into());
             }
             return Err(injected_io_error().into());
         }
 
         if sync && self.ctx.should_fail(Op::Sync) {
+            let pending = write_retention.map(|retention| (bufs.clone(), retention));
             self.inner
                 .write_at(offset, bufs, options.without(WriteOptions::SYNC))
                 .await?;
             self.size
                 .fetch_max(offset.saturating_add(total_bytes), Ordering::Relaxed);
+            if let Some((bufs, retention)) = pending {
+                self.record_pending(offset, bufs, retention);
+            }
             return Err(injected_io_error().into());
         }
 
+        let pending = match (sync, write_retention) {
+            (false, Some(retention)) => Some((bufs.clone(), retention)),
+            _ => None,
+        };
+        let durable = sync.then(|| bufs.clone());
         self.inner.write_at(offset, bufs, options).await?;
         self.size
             .fetch_max(offset.saturating_add(total_bytes), Ordering::Relaxed);
+        if let Some(durable) = durable {
+            self.record_durable_range(offset, durable);
+        } else if let Some((bufs, retention)) = pending {
+            self.record_pending(offset, bufs, retention);
+        }
         Ok(())
     }
 
     async fn resize(&self, len: u64) -> Result<(), Error> {
-        let (should_fail, partial_rate) = self.ctx.check_resize_fault();
+        let (should_fail, partial_rate, retain) = self.ctx.check_resize_fault();
+        let _mutation = self.generation.mutation.lock().await;
         if should_fail {
             let current = self.size.load(Ordering::Relaxed);
             if let Some(len) = self.ctx.try_partial(partial_rate, current, len) {
-                // Partial resize: resize to an intermediate size, sync, then fail
                 self.inner.resize(len).await?;
-                self.inner.sync().await?;
+                self.record_pending_resize(len);
                 self.size.store(len, Ordering::Relaxed);
                 return Err(injected_io_error().into());
             }
             return Err(injected_io_error().into());
         }
         self.inner.resize(len).await?;
+        if retain {
+            self.record_pending_resize(len);
+        }
         self.size.store(len, Ordering::Relaxed);
         Ok(())
     }
@@ -371,14 +791,32 @@ impl<B: crate::Blob> crate::Blob for Blob<B> {
         if self.ctx.should_fail(Op::Sync) {
             return Err(injected_io_error().into());
         }
-        self.inner.sync().await
+        let _mutation = self.generation.mutation.lock().await;
+        self.inner.sync().await?;
+        clear_pending(&self.pending, &self.generation);
+        Ok(())
     }
 
     async fn start_sync(&self) -> Handle<()> {
         if self.ctx.should_fail(Op::Sync) {
             return Handle::ready(Err(injected_io_error().into()));
         }
-        self.inner.start_sync().await
+        let _mutation = self.generation.mutation.lock().await;
+        let sync = Arc::new(PendingSync {
+            generation: self.generation.clone(),
+            completion: self.inner.start_sync().await.shared(),
+        });
+        self.pending
+            .lock()
+            .push(PendingMutation::Sync { sync: sync.clone() });
+
+        let pending = self.pending.clone();
+        let completion = sync.completion.clone();
+        Handle::from_future(async move {
+            let result = completion.await;
+            resolve_pending_sync(&pending, &sync, result.is_ok());
+            result
+        })
     }
 }
 
@@ -390,7 +828,82 @@ mod tests {
         storage::{memory::Storage as MemStorage, tests::run_storage_tests},
         telemetry::metrics::Registry,
     };
+    use futures::task::noop_waker;
     use rand::{SeedableRng, rngs::StdRng};
+    use std::{
+        future::Future,
+        pin::Pin,
+        sync::atomic::AtomicBool,
+        task::{Context, Poll},
+    };
+
+    #[derive(Clone)]
+    struct OperationGate<B> {
+        inner: B,
+        pause_after_write: bool,
+        armed: Arc<AtomicBool>,
+        started: Arc<tokio::sync::Notify>,
+        release: Arc<tokio::sync::Notify>,
+    }
+
+    impl<B> OperationGate<B> {
+        async fn pause(&self, after_write: bool) {
+            if self.pause_after_write == after_write && self.armed.swap(false, Ordering::Relaxed) {
+                self.started.notify_one();
+                self.release.notified().await;
+            }
+        }
+    }
+
+    impl<B: crate::Blob> crate::Blob for OperationGate<B> {
+        async fn read_at_buf(
+            &self,
+            offset: u64,
+            len: usize,
+            bufs: impl Into<IoBufsMut> + Send,
+        ) -> Result<IoBufsMut, Error> {
+            self.inner.read_at_buf(offset, len, bufs).await
+        }
+
+        async fn read_at(&self, offset: u64, len: usize) -> Result<IoBufsMut, Error> {
+            self.inner.read_at(offset, len).await
+        }
+
+        async fn write_at(
+            &self,
+            offset: u64,
+            bufs: impl Into<IoBufs> + Send,
+            options: WriteOptions,
+        ) -> Result<(), Error> {
+            self.inner.write_at(offset, bufs, options).await?;
+            self.pause(true).await;
+            Ok(())
+        }
+
+        async fn resize(&self, len: u64) -> Result<(), Error> {
+            self.inner.resize(len).await
+        }
+
+        async fn sync(&self) -> Result<(), Error> {
+            self.inner.sync().await?;
+            self.pause(false).await;
+            Ok(())
+        }
+
+        async fn start_sync(&self) -> Handle<()> {
+            let gate = self.clone();
+            let (sender, receiver) = tokio::sync::oneshot::channel();
+            drop(tokio::spawn(async move {
+                let _ = sender.send(gate.sync().await);
+            }));
+            Handle::from_receiver(receiver)
+        }
+    }
+
+    fn poll_once<F: Future>(future: Pin<&mut F>) -> Poll<F::Output> {
+        let waker = noop_waker();
+        future.poll(&mut Context::from_waker(&waker))
+    }
 
     fn test_pool() -> BufferPool {
         let mut registry = Registry::default();
@@ -425,9 +938,605 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_start_sync_returns_before_backing_completion() {
+        let h = Harness::new(Config::default().write(0.0, (PartialWriteMode::Prefix, 1.0)));
+        let (inner, _) = h.inner.open("partition", b"start-sync").await.unwrap();
+        inner
+            .write_at(0, b"data", WriteOptions::SYNC)
+            .await
+            .unwrap();
+
+        let started = Arc::new(tokio::sync::Notify::new());
+        let release = Arc::new(tokio::sync::Notify::new());
+        let gated = OperationGate {
+            inner,
+            pause_after_write: false,
+            armed: Arc::new(AtomicBool::new(true)),
+            started: started.clone(),
+            release: release.clone(),
+        };
+        let pending = Arc::new(Mutex::new(Vec::new()));
+        let blob = Blob::new(
+            h.storage.ctx.clone(),
+            pending,
+            Arc::new(FileGeneration::new()),
+            gated,
+            4,
+        );
+
+        let mut start = Box::pin(blob.start_sync());
+        let Poll::Ready(mut completion) = poll_once(start.as_mut()) else {
+            panic!("start_sync waited for backing durability");
+        };
+        started.notified().await;
+        assert!(poll_once(Pin::new(&mut completion)).is_pending());
+        release.notify_one();
+        completion.await.unwrap();
+    }
+
+    async fn run_overlapping_barrier(start: bool) {
+        let h = Harness::new(Config::default().write(0.0, (PartialWriteMode::Prefix, 1.0)));
+        let (inner, _) = h.inner.open("partition", b"overlap").await.unwrap();
+        inner
+            .write_at(0, b"base", WriteOptions::SYNC)
+            .await
+            .unwrap();
+
+        let started = Arc::new(tokio::sync::Notify::new());
+        let release = Arc::new(tokio::sync::Notify::new());
+        let gated = OperationGate {
+            inner,
+            pause_after_write: false,
+            armed: Arc::new(AtomicBool::new(true)),
+            started: started.clone(),
+            release: release.clone(),
+        };
+        let pending = Arc::new(Mutex::new(Vec::new()));
+        let blob = Blob::new(
+            h.storage.ctx.clone(),
+            pending.clone(),
+            Arc::new(FileGeneration::new()),
+            gated,
+            4,
+        );
+
+        let barrier_blob = blob.clone();
+        let barrier = tokio::spawn(async move {
+            if start {
+                drop(barrier_blob.start_sync().await);
+            } else {
+                barrier_blob.sync().await.unwrap();
+            }
+        });
+        started.notified().await;
+
+        let mut late = Box::pin(blob.write_at(0, b"late", WriteOptions::default()));
+        if start {
+            let Poll::Ready(result) = poll_once(late.as_mut()) else {
+                panic!("a started sync blocked a later write");
+            };
+            result.unwrap();
+            release.notify_one();
+            barrier.await.unwrap();
+            tokio::task::yield_now().await;
+        } else {
+            assert!(poll_once(late.as_mut()).is_pending());
+            release.notify_one();
+            barrier.await.unwrap();
+            late.await.unwrap();
+        }
+
+        for mutation in std::mem::take(&mut *pending.lock()) {
+            match mutation {
+                PendingMutation::Write {
+                    blob,
+                    offset,
+                    bufs,
+                    retention,
+                    ..
+                } => {
+                    assert_eq!(retention.policy, (PartialWriteMode::Prefix, 1.0));
+                    blob.inner
+                        .retain_crash_write(offset, bufs, || true)
+                        .unwrap();
+                }
+                PendingMutation::Sync { .. } => {}
+                PendingMutation::Resize { .. } => panic!("write test recorded a resize"),
+            }
+        }
+        let (durable, len) = h.inner.open("partition", b"overlap").await.unwrap();
+        assert_eq!(len, 4);
+        assert_eq!(durable.read_at(0, 4).await.unwrap().coalesce(), b"late");
+    }
+
+    #[tokio::test]
+    async fn test_completed_backing_write_cannot_record_after_later_full_sync() {
+        let h = Harness::new(Config::default().write(0.0, (PartialWriteMode::Prefix, 1.0)));
+        let (inner, _) = h.inner.open("partition", b"late-record").await.unwrap();
+        inner
+            .write_at(0, b"base!", WriteOptions::SYNC)
+            .await
+            .unwrap();
+
+        let started = Arc::new(tokio::sync::Notify::new());
+        let release = Arc::new(tokio::sync::Notify::new());
+        let gated = OperationGate {
+            inner,
+            pause_after_write: true,
+            armed: Arc::new(AtomicBool::new(true)),
+            started: started.clone(),
+            release: release.clone(),
+        };
+        let pending = Arc::new(Mutex::new(Vec::new()));
+        let blob = Blob::new(
+            h.storage.ctx.clone(),
+            pending.clone(),
+            Arc::new(FileGeneration::new()),
+            gated,
+            5,
+        );
+
+        let mut stale = Box::pin(blob.write_at(0, b"stale", WriteOptions::default()));
+        assert!(poll_once(stale.as_mut()).is_pending());
+        started.notified().await;
+
+        *h.config.write() = Config::default();
+        let fresh_blob = blob.clone();
+        let mut fresh = Box::pin(async move {
+            fresh_blob
+                .write_at(0, b"fresh", WriteOptions::default())
+                .await?;
+            fresh_blob.sync().await
+        });
+        assert!(poll_once(fresh.as_mut()).is_pending());
+
+        release.notify_one();
+        stale.await.unwrap();
+        fresh.await.unwrap();
+
+        for mutation in std::mem::take(&mut *pending.lock()) {
+            let PendingMutation::Write {
+                blob,
+                offset,
+                bufs,
+                retention,
+                ..
+            } = mutation
+            else {
+                panic!("write test recorded a resize");
+            };
+            assert_eq!(retention.policy, (PartialWriteMode::Prefix, 1.0));
+            blob.inner
+                .retain_crash_write(offset, bufs, || true)
+                .unwrap();
+        }
+        let (durable, len) = h.inner.open("partition", b"late-record").await.unwrap();
+        assert_eq!(len, 5);
+        assert_eq!(durable.read_at(0, 5).await.unwrap().coalesce(), b"fresh");
+    }
+
+    async fn run_subset_overwrite(seed: u64, original: &[u8], replacement: &[u8]) -> Vec<u8> {
+        assert_eq!(original.len(), replacement.len());
+
+        let h = Harness::with_seed(
+            seed,
+            Config::default().write(0.0, (PartialWriteMode::Subset, 0.5)),
+        );
+        let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
+        blob.write_at(0, original.to_vec(), WriteOptions::default())
+            .await
+            .unwrap();
+        blob.sync().await.unwrap();
+
+        {
+            let mut config = h.config.write();
+            config.write_rate = Some((1.0, (PartialWriteMode::Subset, 0.5)));
+        }
+
+        let result = blob
+            .write_at(0, replacement.to_vec(), WriteOptions::default())
+            .await;
+        assert!(matches!(result, Err(Error::Io(_))));
+
+        let (inner_blob, size) = h.inner.open("partition", b"test").await.unwrap();
+        assert_eq!(size, original.len() as u64);
+        inner_blob
+            .read_at(0, original.len())
+            .await
+            .unwrap()
+            .coalesce()
+            .as_ref()
+            .to_vec()
+    }
+
+    async fn run_random_crash(seed: u64, len: usize) -> Vec<u8> {
+        let h = Harness::with_seed(
+            seed,
+            Config::default().write(0.0, (PartialWriteMode::Subset, 0.5)),
+        );
+        let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
+        blob.write_at(0, vec![0; len], WriteOptions::SYNC)
+            .await
+            .unwrap();
+        blob.write_at(0, vec![1; len], WriteOptions::default())
+            .await
+            .unwrap();
+
+        // The retention policy is part of the completed write, not a global crash-time choice.
+        h.config.write().write_rate = None;
+        h.storage.crash().unwrap();
+
+        let (blob, durable_len) = h.inner.open("partition", b"test").await.unwrap();
+        assert_eq!(durable_len, len as u64);
+        blob.read_at(0, len)
+            .await
+            .unwrap()
+            .coalesce()
+            .as_ref()
+            .to_vec()
+    }
+
+    #[tokio::test]
+    async fn test_reopened_sync_clears_prior_handle_crash_writes() {
+        let h = Harness::new(Config::default().write(0.0, (PartialWriteMode::Prefix, 1.0)));
+        let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
+        blob.write_at(0, b"stale", WriteOptions::default())
+            .await
+            .unwrap();
+        drop(blob);
+
+        let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
+        blob.write_at(0, b"fresh", WriteOptions::default())
+            .await
+            .unwrap();
+        blob.sync().await.unwrap();
+        drop(blob);
+
+        h.storage.crash().unwrap();
+        let (blob, len) = h.inner.open("partition", b"test").await.unwrap();
+        assert_eq!(len, 5);
+        assert_eq!(
+            blob.read_at(0, 5).await.unwrap().coalesce().as_ref(),
+            b"fresh"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_dropped_completed_start_sync_clears_the_crash_epoch() {
+        let h = Harness::new(Config::default().write(0.0, (PartialWriteMode::Prefix, 1.0)));
+        let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
+        blob.write_at(0, b"stale", WriteOptions::default())
+            .await
+            .unwrap();
+        h.config.write().write_rate = None;
+        blob.write_at(0, b"fresh", WriteOptions::default())
+            .await
+            .unwrap();
+
+        let completion = blob.start_sync().await;
+        drop(completion);
+
+        h.config.write().write_rate = Some((0.0, (PartialWriteMode::Prefix, 1.0)));
+        blob.write_at(5, b"later", WriteOptions::default())
+            .await
+            .unwrap();
+        h.storage.crash().unwrap();
+
+        let (blob, len) = h.inner.open("partition", b"test").await.unwrap();
+        assert_eq!(len, 10);
+        assert_eq!(
+            blob.read_at(0, 10).await.unwrap().coalesce().as_ref(),
+            b"freshlater"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_sync_write_does_not_barrier_disjoint_pending_write() {
+        let h = Harness::new(Config::default().write(0.0, (PartialWriteMode::Prefix, 1.0)));
+        let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
+        blob.write_at(0, b"........", WriteOptions::SYNC)
+            .await
+            .unwrap();
+
+        blob.write_at(0, b"A", WriteOptions::default())
+            .await
+            .unwrap();
+        blob.write_at(7, b"Z", WriteOptions::SYNC).await.unwrap();
+        h.storage.crash().unwrap();
+
+        let (durable, len) = h.inner.open("partition", b"test").await.unwrap();
+        assert_eq!(len, 8);
+        assert_eq!(durable.read_at(0, 8).await.unwrap().coalesce(), b"A......Z");
+    }
+
+    #[tokio::test]
+    async fn test_sync_write_retires_only_overlapping_pending_bytes() {
+        let h = Harness::new(Config::default().write(0.0, (PartialWriteMode::Prefix, 1.0)));
+        let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
+        let (other, _) = h.storage.open("partition", b"other").await.unwrap();
+        for candidate in [&blob, &other] {
+            candidate
+                .write_at(0, b"........", WriteOptions::SYNC)
+                .await
+                .unwrap();
+        }
+
+        blob.write_at(0, b"ABCDEFGH", WriteOptions::default())
+            .await
+            .unwrap();
+        other
+            .write_at(0, b"12345678", WriteOptions::default())
+            .await
+            .unwrap();
+        blob.write_at(3, b"xy", WriteOptions::SYNC).await.unwrap();
+        h.storage.crash().unwrap();
+
+        let (durable, _) = h.inner.open("partition", b"test").await.unwrap();
+        assert_eq!(durable.read_at(0, 8).await.unwrap().coalesce(), b"ABCxyFGH");
+        let (durable, _) = h.inner.open("partition", b"other").await.unwrap();
+        assert_eq!(durable.read_at(0, 8).await.unwrap().coalesce(), b"12345678");
+    }
+
+    #[tokio::test]
+    async fn test_range_sync_preserves_prefix_retention_across_pending_fragments() {
+        let mut exercised = false;
+        for seed in 0..64 {
+            let h = Harness::with_seed(
+                seed,
+                Config::default().write(0.0, (PartialWriteMode::Prefix, 0.5)),
+            );
+            let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
+            blob.write_at(0, b"........", WriteOptions::SYNC)
+                .await
+                .unwrap();
+            blob.write_at(0, b"ABCDEFGH", WriteOptions::default())
+                .await
+                .unwrap();
+            blob.write_at(3, b"xy", WriteOptions::SYNC).await.unwrap();
+
+            h.storage.crash().unwrap();
+            let (durable, _) = h.inner.open("partition", b"test").await.unwrap();
+            let durable = durable.read_at(0, 8).await.unwrap().coalesce();
+            if durable.as_ref()[..3].contains(&b'.') {
+                exercised = true;
+                assert_eq!(&durable.as_ref()[5..], b"...");
+            }
+        }
+        assert!(exercised, "seed sweep must exercise a partial prefix");
+    }
+
+    #[tokio::test]
+    async fn test_crash_replays_writes_and_resizes_in_issue_order() {
+        let h = Harness::new(
+            Config::default()
+                .write(0.0, (PartialWriteMode::Prefix, 1.0))
+                .resize(0.0, 1.0),
+        );
+        let (write_then_resize, _) = h.storage.open("partition", b"first").await.unwrap();
+        write_then_resize
+            .write_at(0, b"abcdef", WriteOptions::default())
+            .await
+            .unwrap();
+        write_then_resize.resize(3).await.unwrap();
+        write_then_resize.resize(5).await.unwrap();
+
+        let (resize_then_write, _) = h.storage.open("partition", b"second").await.unwrap();
+        resize_then_write
+            .write_at(0, b"abcdef", WriteOptions::SYNC)
+            .await
+            .unwrap();
+        resize_then_write.resize(3).await.unwrap();
+        resize_then_write
+            .write_at(5, b"X", WriteOptions::default())
+            .await
+            .unwrap();
+
+        h.storage.crash().unwrap();
+
+        let (first, len) = h.inner.open("partition", b"first").await.unwrap();
+        assert_eq!(len, 5);
+        assert_eq!(first.read_at(0, 5).await.unwrap().coalesce(), b"abc\0\0");
+        let (second, len) = h.inner.open("partition", b"second").await.unwrap();
+        assert_eq!(len, 6);
+        assert_eq!(second.read_at(0, 6).await.unwrap().coalesce(), b"abc\0\0X");
+    }
+
+    #[tokio::test]
+    async fn test_partial_sync_write_replays_after_retained_resize() {
+        let h = Harness::new(Config::default().resize(0.0, 1.0));
+        let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
+        blob.write_at(0, b"abcdefghij", WriteOptions::SYNC)
+            .await
+            .unwrap();
+        blob.resize(3).await.unwrap();
+        {
+            let mut config = h.config.write();
+            config.write_rate = Some((1.0, (PartialWriteMode::Subset, 0.5)));
+        }
+
+        assert!(blob.write_at(6, b"WXYZ", WriteOptions::SYNC).await.is_err());
+        let (before, _) = h.inner.open("partition", b"test").await.unwrap();
+        let before = before.read_at(0, 10).await.unwrap().coalesce();
+        let mut expected = b"abc".to_vec();
+        for (index, replacement) in b"WXYZ".iter().copied().enumerate() {
+            let index = index + 6;
+            if before.as_ref()[index] != replacement {
+                continue;
+            }
+            expected.resize(index + 1, 0);
+            expected[index] = replacement;
+        }
+        assert!(expected.len() > 3);
+
+        h.storage.crash().unwrap();
+
+        let (durable, len) = h.inner.open("partition", b"test").await.unwrap();
+        assert_eq!(len, expected.len() as u64);
+        assert_eq!(
+            durable
+                .read_at(0, expected.len())
+                .await
+                .unwrap()
+                .coalesce()
+                .as_ref(),
+            expected
+        );
+    }
+
+    #[tokio::test]
+    async fn test_preissued_sync_write_survives_failed_partial_resize() {
+        let h = Harness::new(Config::default().resize(1.0, 0.0).partial_resize(1.0));
+        let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
+        blob.write_at(0, b"abcdefghij", WriteOptions::SYNC)
+            .await
+            .unwrap();
+
+        let resize_blob = blob.clone();
+        let (resize, write) = tokio::join!(biased;
+            resize_blob.resize(0),
+            blob.write_at(10, b"X", WriteOptions::SYNC),
+        );
+        assert!(resize.is_err());
+        write.unwrap();
+
+        let retained_len = h
+            .storage
+            .pending
+            .lock()
+            .iter()
+            .find_map(|mutation| match mutation {
+                PendingMutation::Resize { len, .. } => Some(*len),
+                PendingMutation::Write { .. } | PendingMutation::Sync { .. } => None,
+            })
+            .unwrap();
+        h.storage.crash().unwrap();
+
+        let (durable, len) = h.inner.open("partition", b"test").await.unwrap();
+        assert_eq!(len, 11);
+        let mut expected = b"abcdefghij".to_vec();
+        expected.truncate(retained_len as usize);
+        expected.resize(10, 0);
+        expected.push(b'X');
+        assert_eq!(
+            durable.read_at(0, 11).await.unwrap().coalesce().as_ref(),
+            expected
+        );
+    }
+
+    #[tokio::test]
+    async fn test_partial_sync_write_retires_each_persisted_range() {
+        for partial_write_mode in [PartialWriteMode::Prefix, PartialWriteMode::Subset] {
+            let h = Harness::new(Config::default().write(0.0, (PartialWriteMode::Prefix, 1.0)));
+            let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
+            blob.write_at(0, b"........", WriteOptions::SYNC)
+                .await
+                .unwrap();
+            blob.write_at(0, b"ABCDEFGH", WriteOptions::default())
+                .await
+                .unwrap();
+            {
+                let mut config = h.config.write();
+                config.write_rate = Some((1.0, (partial_write_mode, 0.5)));
+            }
+
+            assert!(blob.write_at(2, b"wxyz", WriteOptions::SYNC).await.is_err());
+            let (before, _) = h.inner.open("partition", b"test").await.unwrap();
+            let before = before.read_at(0, 8).await.unwrap().coalesce();
+            h.storage.crash().unwrap();
+            let (after, _) = h.inner.open("partition", b"test").await.unwrap();
+            let after = after.read_at(0, 8).await.unwrap().coalesce();
+            for (index, (&before, &after)) in before
+                .as_ref()
+                .iter()
+                .zip(after.as_ref().iter())
+                .enumerate()
+            {
+                let expected = if before == b'.' {
+                    b'A' + index as u8
+                } else {
+                    before
+                };
+                assert_eq!(
+                    after, expected,
+                    "mode={partial_write_mode:?}, index={index}"
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_full_sync_epoch_is_linearized_with_overlapping_write() {
+        run_overlapping_barrier(false).await;
+    }
+
+    #[tokio::test]
+    async fn test_dropped_start_sync_epoch_is_linearized_with_overlapping_write() {
+        run_overlapping_barrier(true).await;
+    }
+
+    #[tokio::test]
     async fn test_faulty_storage_no_faults() {
         let h = Harness::new(Config::default());
         run_storage_tests(h.storage).await;
+    }
+
+    #[test]
+    fn test_write_retention_frequency_upper_bound() {
+        let h = Harness::new(Config::default());
+        for mode in [PartialWriteMode::Prefix, PartialWriteMode::Subset] {
+            for frequency in [1.0, 2.0, f64::INFINITY] {
+                assert_eq!(
+                    h.storage.ctx.retained_bytes(4, (mode, frequency)),
+                    [true; 4]
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_prefix_retention_stops_after_the_first_omission() {
+        for seed in 0..64 {
+            let h = Harness::with_seed(seed, Config::default());
+            let retained = h
+                .storage
+                .ctx
+                .retained_bytes(64, (PartialWriteMode::Prefix, 0.5));
+            let mut omitted = false;
+            for keep in retained {
+                if omitted {
+                    assert!(!keep);
+                } else if !keep {
+                    omitted = true;
+                }
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_write_rejects_offset_overflow_before_retention() {
+        let h = Harness::new(Config::default().write(1.0, (PartialWriteMode::Subset, 0.5)));
+        let (blob, _) = h.storage.open("partition", b"blob").await.unwrap();
+        assert!(matches!(
+            blob.write_at(u64::MAX, vec![1, 2], WriteOptions::default())
+                .await,
+            Err(Error::OffsetOverflow)
+        ));
+        let (_, len) = h.inner.open("partition", b"blob").await.unwrap();
+        assert_eq!(len, 0);
+    }
+
+    #[tokio::test]
+    async fn test_failed_write_can_retain_every_byte() {
+        let h = Harness::new(Config::default().write(1.0, (PartialWriteMode::Prefix, 1.0)));
+        let (blob, _) = h.storage.open("partition", b"blob").await.unwrap();
+
+        assert!(matches!(
+            blob.write_at(0, b"x", WriteOptions::default()).await,
+            Err(Error::Io(_))
+        ));
+        let (durable, len) = h.inner.open("partition", b"blob").await.unwrap();
+        assert_eq!(len, 1);
+        assert_eq!(durable.read_at(0, 1).await.unwrap().coalesce(), b"x");
     }
 
     #[tokio::test]
@@ -444,7 +1553,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_faulty_storage_start_sync_always_fails() {
-        let h = Harness::new(Config::default().sync(1.0));
+        let h = Harness::new(
+            Config::default()
+                .write(0.0, (PartialWriteMode::Prefix, 1.0))
+                .sync(1.0),
+        );
 
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
         blob.write_at(0, b"data".to_vec(), WriteOptions::default())
@@ -453,11 +1566,12 @@ mod tests {
 
         let result = blob.start_sync().await.await;
         assert!(matches!(result, Err(Error::Io(_))));
+        assert_eq!(h.storage.pending.lock().len(), 1);
     }
 
     #[tokio::test]
     async fn test_faulty_storage_write_always_fails() {
-        let h = Harness::new(Config::default().write(1.0));
+        let h = Harness::new(Config::default().write(1.0, (PartialWriteMode::Prefix, 0.0)));
 
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
 
@@ -470,7 +1584,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_faulty_storage_write_at_sync_write_always_fails() {
-        let h = Harness::new(Config::default().write(1.0));
+        let h = Harness::new(Config::default().write(1.0, (PartialWriteMode::Prefix, 0.0)));
 
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
 
@@ -510,6 +1624,16 @@ mod tests {
 
         let (_reopened, size) = h.inner.open("partition", b"test").await.unwrap();
         assert_eq!(size, 0);
+    }
+
+    #[tokio::test]
+    async fn test_empty_unsynced_write_does_not_create_crash_debt() {
+        let h = Harness::new(Config::default().write(0.0, (PartialWriteMode::Prefix, 1.0)));
+        let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
+        blob.write_at(0, Vec::<u8>::new(), WriteOptions::default())
+            .await
+            .unwrap();
+        assert!(h.storage.pending.lock().is_empty());
     }
 
     #[tokio::test]
@@ -608,11 +1732,16 @@ mod tests {
 
     #[tokio::test]
     async fn test_faulty_storage_rate_for() {
-        let config = Config::default().open(0.1).sync(0.9);
+        let config = Config::default()
+            .open(0.1)
+            .write(0.3, (PartialWriteMode::Subset, 0.4))
+            .resize(0.7, 0.8)
+            .sync(0.9);
 
         assert!((config.rate_for(Op::Open) - 0.1).abs() < f64::EPSILON);
+        assert!((config.rate_for(Op::Write) - 0.3).abs() < f64::EPSILON);
+        assert!((config.rate_for(Op::Resize) - 0.7).abs() < f64::EPSILON);
         assert!((config.rate_for(Op::Sync) - 0.9).abs() < f64::EPSILON);
-        assert!(config.rate_for(Op::Write).abs() < f64::EPSILON);
     }
 
     #[tokio::test]
@@ -630,8 +1759,199 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_faulty_storage_partial_write() {
-        let h = Harness::new(Config::default().write(1.0).partial_write(1.0));
+    async fn test_write_retention_is_snapshotted_and_replayed_in_order() {
+        let h = Harness::new(Config::default().write(0.0, (PartialWriteMode::Prefix, 1.0)));
+        let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
+        blob.write_at(0, b"........", WriteOptions::SYNC)
+            .await
+            .unwrap();
+
+        blob.write_at(0, b"AB", WriteOptions::default())
+            .await
+            .unwrap();
+        h.config.write().write_rate = None;
+        blob.write_at(2, b"CD", WriteOptions::default())
+            .await
+            .unwrap();
+        h.config.write().write_rate = Some((0.0, (PartialWriteMode::Prefix, 1.0)));
+        blob.write_at(1, b"XY", WriteOptions::default())
+            .await
+            .unwrap();
+        h.config.write().write_rate = None;
+
+        h.storage.crash().unwrap();
+        let (durable, _) = h.inner.open("partition", b"test").await.unwrap();
+        assert_eq!(durable.read_at(0, 8).await.unwrap().coalesce(), b"AXY.....");
+
+        durable.write_at(0, b"Q", WriteOptions::SYNC).await.unwrap();
+        h.storage.crash().unwrap();
+        let (durable, _) = h.inner.open("partition", b"test").await.unwrap();
+        assert_eq!(durable.read_at(0, 8).await.unwrap().coalesce(), b"QXY.....");
+    }
+
+    #[tokio::test]
+    async fn test_random_crash_write_is_deterministic_and_inclusive() {
+        let first = run_random_crash(12345, 64).await;
+        let second = run_random_crash(12345, 64).await;
+        let different = run_random_crash(54321, 64).await;
+        assert_eq!(first, second);
+        assert_ne!(first, different);
+        assert!(first.contains(&0));
+        assert!(first.contains(&1));
+
+        let mut saw_empty = false;
+        let mut saw_full = false;
+        for seed in 0..64 {
+            match run_random_crash(seed, 1).await.as_slice() {
+                [0] => saw_empty = true,
+                [1] => saw_full = true,
+                other => panic!("unexpected one-byte crash result: {other:?}"),
+            }
+        }
+        assert!(saw_empty && saw_full);
+    }
+
+    #[tokio::test]
+    async fn failed_partial_write_does_not_barrier_prior_crash_writes() {
+        for partial_write_mode in [PartialWriteMode::Prefix, PartialWriteMode::Subset] {
+            let mut saw_old = false;
+            let mut saw_new = false;
+            for seed in 0..64 {
+                let h = Harness::with_seed(
+                    seed,
+                    Config::default().write(0.0, (PartialWriteMode::Subset, 0.5)),
+                );
+                let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
+                blob.write_at(0, b"......", WriteOptions::SYNC)
+                    .await
+                    .unwrap();
+                blob.write_at(0, b"AAAA", WriteOptions::default())
+                    .await
+                    .unwrap();
+                {
+                    let mut config = h.config.write();
+                    config.write_rate = Some((1.0, (partial_write_mode, 0.5)));
+                }
+
+                assert!(
+                    blob.write_at(4, b"XY", WriteOptions::default())
+                        .await
+                        .is_err()
+                );
+                h.storage.crash().unwrap();
+
+                let (durable, _) = h.inner.open("partition", b"test").await.unwrap();
+                let durable = durable.read_at(0, 4).await.unwrap().coalesce();
+                saw_old |= durable.as_ref().contains(&b'.');
+                saw_new |= durable.as_ref().contains(&b'A');
+            }
+            assert!(saw_old && saw_new);
+        }
+    }
+
+    #[tokio::test]
+    async fn failed_partial_resize_does_not_barrier_prior_crash_writes() {
+        let mut saw_old = false;
+        let mut saw_new = false;
+        for seed in 0..64 {
+            let h = Harness::with_seed(
+                seed,
+                Config::default().write(0.0, (PartialWriteMode::Subset, 0.5)),
+            );
+            let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
+            blob.write_at(0, b"......", WriteOptions::SYNC)
+                .await
+                .unwrap();
+            blob.write_at(0, b"AAAA", WriteOptions::default())
+                .await
+                .unwrap();
+            {
+                let mut config = h.config.write();
+                config.resize_rate = Some((1.0, 0.0));
+                config.partial_resize_rate = Some(1.0);
+            }
+
+            assert!(blob.resize(8).await.is_err());
+            h.storage.crash().unwrap();
+
+            let (durable, len) = h.inner.open("partition", b"test").await.unwrap();
+            assert_eq!(len, 7);
+            let durable = durable.read_at(0, 4).await.unwrap().coalesce();
+            saw_old |= durable.as_ref().contains(&b'.');
+            saw_new |= durable.as_ref().contains(&b'A');
+        }
+        assert!(saw_old && saw_new);
+    }
+
+    #[tokio::test]
+    async fn test_crash_journal_clears_only_after_completed_durability() {
+        let h = Harness::new(Config::default().write(0.0, (PartialWriteMode::Prefix, 1.0)));
+        let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
+
+        blob.write_at(0, b"a", WriteOptions::default())
+            .await
+            .unwrap();
+        assert_eq!(h.storage.pending.lock().len(), 1);
+        h.config.write().sync_rate = Some(1.0);
+        assert!(matches!(blob.sync().await, Err(Error::Io(_))));
+        assert_eq!(h.storage.pending.lock().len(), 1);
+
+        h.config.write().sync_rate = None;
+        blob.sync().await.unwrap();
+        assert!(h.storage.pending.lock().is_empty());
+
+        let (other, _) = h.storage.open("partition", b"other").await.unwrap();
+        blob.write_at(0, b"b", WriteOptions::default())
+            .await
+            .unwrap();
+        other
+            .write_at(0, b"x", WriteOptions::default())
+            .await
+            .unwrap();
+        assert_eq!(h.storage.pending.lock().len(), 2);
+        blob.sync().await.unwrap();
+        assert_eq!(h.storage.pending.lock().len(), 1);
+        other.sync().await.unwrap();
+        assert!(h.storage.pending.lock().is_empty());
+
+        blob.write_at(0, b"b", WriteOptions::default())
+            .await
+            .unwrap();
+        assert_eq!(h.storage.pending.lock().len(), 1);
+        blob.start_sync().await.await.unwrap();
+        assert!(h.storage.pending.lock().is_empty());
+
+        blob.write_at(0, b"c", WriteOptions::default())
+            .await
+            .unwrap();
+        assert_eq!(h.storage.pending.lock().len(), 1);
+        blob.write_at(0, b"d", WriteOptions::SYNC).await.unwrap();
+        assert!(h.storage.pending.lock().is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_sync_failure_journals_the_successful_inner_write() {
+        let h = Harness::new(
+            Config::default()
+                .write(0.0, (PartialWriteMode::Prefix, 1.0))
+                .sync(1.0),
+        );
+        let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
+        assert!(matches!(
+            blob.write_at(0, b"data", WriteOptions::SYNC).await,
+            Err(Error::Io(_))
+        ));
+        assert_eq!(h.storage.pending.lock().len(), 1);
+
+        h.storage.crash().unwrap();
+        let (durable, len) = h.inner.open("partition", b"test").await.unwrap();
+        assert_eq!(len, 4);
+        assert_eq!(durable.read_at(0, 4).await.unwrap().coalesce(), b"data");
+    }
+
+    #[tokio::test]
+    async fn test_faulty_storage_zero_write_retention_preserves_nothing() {
+        let h = Harness::new(Config::default().write(1.0, (PartialWriteMode::Prefix, 0.0)));
 
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
         let data = b"hello world".to_vec();
@@ -641,54 +1961,91 @@ mod tests {
 
         assert!(matches!(result, Err(Error::Io(_))));
 
-        let (inner_blob, size) = h.inner.open("partition", b"test").await.unwrap();
-        let bytes_written = size as usize;
-        assert!(
-            bytes_written > 0 && bytes_written < data.len(),
-            "Expected partial write: {bytes_written} bytes out of {}",
-            data.len()
-        );
-
-        let read_result = inner_blob.read_at(0, bytes_written).await.unwrap();
-        assert_eq!(read_result.coalesce().as_ref(), &data[..bytes_written]);
+        let (_, size) = h.inner.open("partition", b"test").await.unwrap();
+        assert_eq!(size, 0);
     }
 
     #[tokio::test]
-    async fn test_faulty_storage_partial_write_disabled() {
-        let h = Harness::new(Config::default().write(1.0).partial_write(0.0));
+    async fn test_faulty_storage_partial_write_subset_can_be_non_prefix() {
+        let original = b"abcdefghijklmnop";
+        let replacement = b"ABCDEFGHIJKLMNOP";
+        let observed = run_subset_overwrite(42, original, replacement).await;
 
-        let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
-        let result = blob
-            .write_at(0, b"hello world".to_vec(), WriteOptions::default())
-            .await;
+        let retained: Vec<_> = observed
+            .iter()
+            .zip(original)
+            .zip(replacement)
+            .map(|((&actual, &old), &new)| {
+                assert!(actual == old || actual == new);
+                actual == new
+            })
+            .collect();
+        assert!(retained.iter().any(|&keep| keep));
+        assert!(retained.iter().any(|&keep| !keep));
 
-        assert!(matches!(result, Err(Error::Io(_))));
-
-        let (_, size) = h.inner.open("partition", b"test").await.unwrap();
-        assert_eq!(
-            size, 0,
-            "Expected no bytes written when partial_write_rate is 0"
-        );
+        let mut omitted = false;
+        let non_prefix = retained.into_iter().any(|keep| {
+            if keep {
+                omitted
+            } else {
+                omitted = true;
+                false
+            }
+        });
+        assert!(non_prefix, "expected a retained byte after an omitted byte");
     }
 
     #[tokio::test]
-    async fn test_faulty_storage_partial_write_single_byte() {
-        let h = Harness::new(Config::default().write(1.0).partial_write(1.0));
+    async fn test_faulty_storage_write_retention_frequency_edges() {
+        for mode in [PartialWriteMode::Prefix, PartialWriteMode::Subset] {
+            for (frequency, expected) in [
+                (0.0, b"old".as_slice()),
+                (f64::NAN, b"old".as_slice()),
+                (1.0, b"new".as_slice()),
+            ] {
+                let failed = Harness::new(Config::default().write(1.0, (mode, frequency)));
+                let (blob, _) = failed.storage.open("partition", b"failed").await.unwrap();
+                blob.write_at(0, b"new", WriteOptions::SYNC)
+                    .await
+                    .unwrap_err();
+                let (durable, len) = failed.inner.open("partition", b"failed").await.unwrap();
+                if frequency >= 1.0 {
+                    assert_eq!(len, 3);
+                    assert_eq!(durable.read_at(0, 3).await.unwrap().coalesce(), expected);
+                } else {
+                    assert_eq!(len, 0);
+                }
 
-        let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
-        let result = blob
-            .write_at(0, b"x".to_vec(), WriteOptions::default())
-            .await;
+                let crashed = Harness::new(Config::default().write(0.0, (mode, frequency)));
+                let (blob, _) = crashed.storage.open("partition", b"crashed").await.unwrap();
+                blob.write_at(0, b"old", WriteOptions::SYNC).await.unwrap();
+                blob.write_at(0, b"new", WriteOptions::default())
+                    .await
+                    .unwrap();
+                crashed.storage.crash().unwrap();
+                let (durable, len) = crashed.inner.open("partition", b"crashed").await.unwrap();
+                assert_eq!(len, 3);
+                assert_eq!(durable.read_at(0, 3).await.unwrap().coalesce(), expected);
+            }
+        }
+    }
 
-        assert!(matches!(result, Err(Error::Io(_))));
+    #[tokio::test]
+    async fn test_faulty_storage_partial_write_subset_same_seed_is_deterministic() {
+        let original = vec![0x11; 64];
+        let replacement = vec![0xAA; 64];
 
-        let (_, size) = h.inner.open("partition", b"test").await.unwrap();
-        assert_eq!(size, 0, "No partial write possible for single byte");
+        let first = run_subset_overwrite(12345, &original, &replacement).await;
+        let second = run_subset_overwrite(12345, &original, &replacement).await;
+
+        assert_eq!(first, second);
+        assert!(first.contains(&0x11));
+        assert!(first.contains(&0xAA));
     }
 
     #[tokio::test]
     async fn test_faulty_storage_partial_resize_grow() {
-        let h = Harness::new(Config::default().resize(1.0).partial_resize(1.0));
+        let h = Harness::new(Config::default().resize(1.0, 0.0).partial_resize(1.0));
 
         let (blob, initial_size) = h.storage.open("partition", b"test").await.unwrap();
         assert_eq!(initial_size, 0);
@@ -697,6 +2054,7 @@ mod tests {
         let result = blob.resize(target_size).await;
 
         assert!(matches!(result, Err(Error::Io(_))));
+        h.storage.crash().unwrap();
 
         let (_, actual_size) = h.inner.open("partition", b"test").await.unwrap();
         assert!(
@@ -715,7 +2073,7 @@ mod tests {
 
         {
             let mut cfg = h.config.write();
-            cfg.resize_rate = Some(1.0);
+            cfg.resize_rate = Some((1.0, 0.0));
             cfg.partial_resize_rate = Some(1.0);
         }
 
@@ -723,6 +2081,7 @@ mod tests {
         let result = blob.resize(target_size).await;
 
         assert!(matches!(result, Err(Error::Io(_))));
+        h.storage.crash().unwrap();
 
         let (_, actual_size) = h.inner.open("partition", b"test").await.unwrap();
         assert!(
@@ -733,7 +2092,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_faulty_storage_partial_resize_disabled() {
-        let h = Harness::new(Config::default().resize(1.0).partial_resize(0.0));
+        let h = Harness::new(Config::default().resize(1.0, 0.0).partial_resize(0.0));
 
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
         let result = blob.resize(100).await;
@@ -746,7 +2105,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_faulty_storage_partial_resize_same_size() {
-        let h = Harness::new(Config::default().resize(1.0).partial_resize(1.0));
+        let h = Harness::new(Config::default().resize(1.0, 0.0).partial_resize(1.0));
 
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
         let result = blob.resize(0).await;
@@ -774,7 +2133,7 @@ mod tests {
 
         {
             let mut cfg = h.config.write();
-            cfg.resize_rate = Some(1.0);
+            cfg.resize_rate = Some((1.0, 0.0));
             cfg.partial_resize_rate = Some(1.0);
         }
 
@@ -782,6 +2141,7 @@ mod tests {
         let result = blob.resize(target_size).await;
 
         assert!(matches!(result, Err(Error::Io(_))));
+        h.storage.crash().unwrap();
 
         let (_, actual_size) = h.inner.open("partition", b"test").await.unwrap();
         assert!(
@@ -792,7 +2152,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_faulty_storage_partial_resize_one_byte_difference() {
-        let h = Harness::new(Config::default().resize(1.0).partial_resize(1.0));
+        let h = Harness::new(Config::default().resize(1.0, 0.0).partial_resize(1.0));
 
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
         let result = blob.resize(1).await;

--- a/runtime/src/storage/faulty.rs
+++ b/runtime/src/storage/faulty.rs
@@ -2,7 +2,10 @@
 
 use crate::{Error, Handle, IoBufs, IoBufsMut, WriteOptions, deterministic::BoxDynRng};
 use bytes::Buf;
-use commonware_utils::sync::{AsyncMutex, Mutex, RwLock};
+use commonware_utils::{
+    Probability,
+    sync::{AsyncMutex, Mutex, RwLock},
+};
 use futures::{FutureExt as _, future::Shared};
 use rand::RngExt as _;
 use std::{
@@ -41,73 +44,75 @@ pub enum PartialWriteMode {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WriteConfig {
     /// Probability that `write_at` returns an injected failure.
-    pub failure_rate: f64,
+    pub failure_rate: Probability,
 
     /// Probability used by the selected mode when retaining submitted bytes.
-    pub retention_rate: f64,
+    pub retention_rate: Probability,
 
     /// Arrangement of bytes retained by the simulated storage device.
     pub mode: PartialWriteMode,
 }
 
+/// Fault configuration for `resize` operations and partial failure behavior.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct ResizeConfig {
+    /// Probability that `resize` returns an injected failure, also used independently as the
+    /// probability that a successful unsynchronized resize survives a simulated crash.
+    pub failure_rate: Probability,
+
+    /// Probability that an injected failure resizes to an intermediate size rather than leaving
+    /// the size unchanged.
+    pub partial_rate: Probability,
+}
+
 /// Configuration for deterministic storage fault injection.
-///
-/// Each rate is interpreted as a probability. Values that are `NaN` or at or below 0.0 never
-/// trigger, while values at or above 1.0 always trigger.
 #[derive(Clone, Debug, Default)]
 pub struct Config {
     /// Failure rate for `open_versioned` operations.
-    pub open_rate: Option<f64>,
+    pub open_rate: Option<Probability>,
 
     /// Failure rate for `read_at` operations.
-    pub read_rate: Option<f64>,
+    pub read_rate: Option<Probability>,
 
     /// Failure and byte-retention configuration for `write_at` operations.
     pub write_rate: Option<WriteConfig>,
 
     /// Failure rate for `sync` operations.
-    pub sync_rate: Option<f64>,
+    pub sync_rate: Option<Probability>,
 
-    /// Failure rate for `resize` operations and probability that a successful unsynchronized
-    /// resize survives a simulated crash.
-    pub resize_rate: Option<f64>,
-
-    /// Probability that a resize failure is partial (resized to an intermediate
-    /// size before failure) rather than a complete failure (size unchanged).
-    /// Only applies when `resize_rate` triggers a failure.
-    /// Value from 0.0 (always complete failure) to 1.0 (always partial resize).
-    pub partial_resize_rate: Option<f64>,
+    /// Failure and partial-failure configuration for `resize` operations.
+    pub resize_rate: Option<ResizeConfig>,
 
     /// Failure rate for `remove` operations.
-    pub remove_rate: Option<f64>,
+    pub remove_rate: Option<Probability>,
 
     /// Failure rate for `scan` operations.
-    pub scan_rate: Option<f64>,
+    pub scan_rate: Option<Probability>,
 }
 
 impl Config {
     /// Get the failure rate for an operation type.
-    fn rate_for(&self, op: Op) -> f64 {
+    fn rate_for(&self, op: Op) -> Probability {
         match op {
             Op::Open => self.open_rate,
             Op::Read => self.read_rate,
             Op::Write => self.write_rate.map(|config| config.failure_rate),
             Op::Sync => self.sync_rate,
-            Op::Resize => self.resize_rate,
+            Op::Resize => self.resize_rate.map(|config| config.failure_rate),
             Op::Remove => self.remove_rate,
             Op::Scan => self.scan_rate,
         }
-        .unwrap_or(0.0)
+        .unwrap_or(Probability!(0.0))
     }
 
     /// Set the open failure rate.
-    pub const fn open(mut self, rate: f64) -> Self {
+    pub const fn open(mut self, rate: Probability) -> Self {
         self.open_rate = Some(rate);
         self
     }
 
     /// Set the read failure rate.
-    pub const fn read(mut self, rate: f64) -> Self {
+    pub const fn read(mut self, rate: Probability) -> Self {
         self.read_rate = Some(rate);
         self
     }
@@ -119,31 +124,25 @@ impl Config {
     }
 
     /// Set the sync failure rate.
-    pub const fn sync(mut self, rate: f64) -> Self {
+    pub const fn sync(mut self, rate: Probability) -> Self {
         self.sync_rate = Some(rate);
         self
     }
 
-    /// Set the resize failure and crash-retention rate.
-    pub const fn resize(mut self, rate: f64) -> Self {
-        self.resize_rate = Some(rate);
-        self
-    }
-
-    /// Set the partial resize rate (probability of partial vs complete resize failure).
-    pub const fn partial_resize(mut self, rate: f64) -> Self {
-        self.partial_resize_rate = Some(rate);
+    /// Set the resize fault configuration.
+    pub const fn resize(mut self, config: ResizeConfig) -> Self {
+        self.resize_rate = Some(config);
         self
     }
 
     /// Set the remove failure rate.
-    pub const fn remove(mut self, rate: f64) -> Self {
+    pub const fn remove(mut self, rate: Probability) -> Self {
         self.remove_rate = Some(rate);
         self
     }
 
     /// Set the scan failure rate.
-    pub const fn scan(mut self, rate: f64) -> Self {
+    pub const fn scan(mut self, rate: Probability) -> Self {
         self.scan_rate = Some(rate);
         self
     }
@@ -194,13 +193,13 @@ impl PendingSync {
 /// Retention choices belong to the issued write and are shared by fragments created by later
 /// durability barriers.
 struct PendingWriteRetention {
-    policy: (PartialWriteMode, f64),
+    policy: (PartialWriteMode, Probability),
     len: usize,
     selected: OnceLock<Vec<bool>>,
 }
 
 impl PendingWriteRetention {
-    const fn new(policy: (PartialWriteMode, f64), len: usize) -> Self {
+    const fn new(policy: (PartialWriteMode, Probability), len: usize) -> Self {
         Self {
             policy,
             len,
@@ -273,41 +272,37 @@ fn resolve_pending_sync<B>(
 impl Oracle {
     /// Check if a fault should be injected for the given operation.
     fn should_fail(&self, op: Op) -> bool {
-        self.roll(Some(self.config.read().rate_for(op)))
+        self.roll(self.config.read().rate_for(op))
     }
 
     /// Check if a write fault should be injected.
     /// Reads config once to avoid nested lock acquisition.
-    fn check_write_fault(&self) -> (bool, Option<(PartialWriteMode, f64)>) {
+    fn check_write_fault(&self) -> (bool, Option<(PartialWriteMode, Probability)>) {
         let config = self.config.read();
-        let fail = self.roll(Some(config.rate_for(Op::Write)));
+        let fail = self.roll(config.rate_for(Op::Write));
         let retention = config
             .write_rate
             .map(|config| (config.mode, config.retention_rate))
-            .filter(|(_, retention_rate)| *retention_rate > 0.0);
+            .filter(|(_, retention_rate)| !retention_rate.is_zero());
         (fail, retention)
     }
 
     /// Check if a resize fault should be injected and snapshot its crash outcome.
     /// Reads config once to avoid nested lock acquisition.
-    fn check_resize_fault(&self) -> (bool, Option<f64>, bool) {
+    fn check_resize_fault(&self) -> (bool, Probability, bool) {
         let config = self.config.read();
+        let Some(resize_config) = config.resize_rate else {
+            return (false, Probability!(0.0), false);
+        };
         let failure_rate = config.rate_for(Op::Resize);
-        let fail = self.roll(Some(failure_rate));
-        let retain = !fail && self.roll(Some(failure_rate));
-        (fail, config.partial_resize_rate, retain)
+        let fail = self.roll(failure_rate);
+        let retain = !fail && self.roll(failure_rate);
+        (fail, resize_config.partial_rate, retain)
     }
 
     /// Check if an event should occur based on a probability rate.
-    fn roll(&self, rate: Option<f64>) -> bool {
-        let rate = rate.unwrap_or(0.0);
-        if rate <= 0.0 || rate.is_nan() {
-            return false;
-        }
-        if rate >= 1.0 {
-            return true;
-        }
-        self.rng.lock().random::<f64>() < rate
+    fn roll(&self, rate: Probability) -> bool {
+        rate.sample(&mut **self.rng.lock())
     }
 
     /// Generate a random value strictly between `from` and `to`, or None if not possible.
@@ -326,32 +321,27 @@ impl Oracle {
     fn retained_bytes(
         &self,
         len: usize,
-        (mode, retention_rate): (PartialWriteMode, f64),
+        (mode, retention_rate): (PartialWriteMode, Probability),
     ) -> Vec<bool> {
-        if retention_rate <= 0.0 || retention_rate.is_nan() {
-            return vec![false; len];
-        }
-        if retention_rate >= 1.0 {
-            return vec![true; len];
-        }
-
         let mut rng = self.rng.lock();
         match mode {
             PartialWriteMode::Prefix => {
                 let mut positions = vec![false; len];
                 let retained = (0..len)
-                    .take_while(|_| rng.random_bool(retention_rate))
+                    .take_while(|_| retention_rate.sample(&mut **rng))
                     .count();
                 positions[..retained].fill(true);
                 positions
             }
-            PartialWriteMode::Subset => (0..len).map(|_| rng.random_bool(retention_rate)).collect(),
+            PartialWriteMode::Subset => (0..len)
+                .map(|_| retention_rate.sample(&mut **rng))
+                .collect(),
         }
     }
 
     /// Try to generate a partial operation target. Returns Some if both the rate
     /// check passes and an intermediate value exists between `from` and `to`.
-    fn try_partial(&self, rate: Option<f64>, from: u64, to: u64) -> Option<u64> {
+    fn try_partial(&self, rate: Probability, from: u64, to: u64) -> Option<u64> {
         if self.roll(rate) {
             self.random_between(from, to)
         } else {
@@ -567,7 +557,12 @@ impl<B: crate::Blob> Blob<B> {
         }
     }
 
-    fn record_pending(&self, offset: u64, bufs: IoBufs, retention: (PartialWriteMode, f64)) {
+    fn record_pending(
+        &self,
+        offset: u64,
+        bufs: IoBufs,
+        retention: (PartialWriteMode, Probability),
+    ) {
         if bufs.is_empty() {
             return;
         }
@@ -676,7 +671,7 @@ impl<B: crate::Blob> Blob<B> {
         }
         if follows_resize {
             let retention = Arc::new(PendingWriteRetention::new(
-                (PartialWriteMode::Prefix, 1.0),
+                (PartialWriteMode::Prefix, Probability!(1.0)),
                 durable.remaining(),
             ));
             retained.push(PendingMutation::Write {
@@ -967,8 +962,8 @@ mod tests {
     #[tokio::test]
     async fn test_start_sync_returns_before_backing_completion() {
         let h = Harness::new(Config::default().write(WriteConfig {
-            failure_rate: 0.0,
-            retention_rate: 1.0,
+            failure_rate: Probability!(0.0),
+            retention_rate: Probability!(1.0),
             mode: PartialWriteMode::Prefix,
         }));
         let (inner, _) = h.inner.open("partition", b"start-sync").await.unwrap();
@@ -1007,8 +1002,8 @@ mod tests {
 
     async fn run_overlapping_barrier(start: bool) {
         let h = Harness::new(Config::default().write(WriteConfig {
-            failure_rate: 0.0,
-            retention_rate: 1.0,
+            failure_rate: Probability!(0.0),
+            retention_rate: Probability!(1.0),
             mode: PartialWriteMode::Prefix,
         }));
         let (inner, _) = h.inner.open("partition", b"overlap").await.unwrap();
@@ -1070,7 +1065,10 @@ mod tests {
                     retention,
                     ..
                 } => {
-                    assert_eq!(retention.policy, (PartialWriteMode::Prefix, 1.0));
+                    assert_eq!(
+                        retention.policy,
+                        (PartialWriteMode::Prefix, Probability!(1.0))
+                    );
                     blob.inner
                         .retain_crash_write(offset, bufs, || true)
                         .unwrap();
@@ -1087,8 +1085,8 @@ mod tests {
     #[tokio::test]
     async fn test_completed_backing_write_cannot_record_after_later_full_sync() {
         let h = Harness::new(Config::default().write(WriteConfig {
-            failure_rate: 0.0,
-            retention_rate: 1.0,
+            failure_rate: Probability!(0.0),
+            retention_rate: Probability!(1.0),
             mode: PartialWriteMode::Prefix,
         }));
         let (inner, _) = h.inner.open("partition", b"late-record").await.unwrap();
@@ -1144,7 +1142,10 @@ mod tests {
             else {
                 panic!("write test recorded a resize");
             };
-            assert_eq!(retention.policy, (PartialWriteMode::Prefix, 1.0));
+            assert_eq!(
+                retention.policy,
+                (PartialWriteMode::Prefix, Probability!(1.0))
+            );
             blob.inner
                 .retain_crash_write(offset, bufs, || true)
                 .unwrap();
@@ -1160,8 +1161,8 @@ mod tests {
         let h = Harness::with_seed(
             seed,
             Config::default().write(WriteConfig {
-                failure_rate: 0.0,
-                retention_rate: 0.5,
+                failure_rate: Probability!(0.0),
+                retention_rate: Probability!(0.5),
                 mode: PartialWriteMode::Subset,
             }),
         );
@@ -1174,8 +1175,8 @@ mod tests {
         {
             let mut config = h.config.write();
             config.write_rate = Some(WriteConfig {
-                failure_rate: 1.0,
-                retention_rate: 0.5,
+                failure_rate: Probability!(1.0),
+                retention_rate: Probability!(0.5),
                 mode: PartialWriteMode::Subset,
             });
         }
@@ -1200,8 +1201,8 @@ mod tests {
         let h = Harness::with_seed(
             seed,
             Config::default().write(WriteConfig {
-                failure_rate: 0.0,
-                retention_rate: 0.5,
+                failure_rate: Probability!(0.0),
+                retention_rate: Probability!(0.5),
                 mode: PartialWriteMode::Subset,
             }),
         );
@@ -1230,8 +1231,8 @@ mod tests {
     #[tokio::test]
     async fn test_reopened_sync_clears_prior_handle_crash_writes() {
         let h = Harness::new(Config::default().write(WriteConfig {
-            failure_rate: 0.0,
-            retention_rate: 1.0,
+            failure_rate: Probability!(0.0),
+            retention_rate: Probability!(1.0),
             mode: PartialWriteMode::Prefix,
         }));
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
@@ -1259,8 +1260,8 @@ mod tests {
     #[tokio::test]
     async fn test_dropped_completed_start_sync_clears_the_crash_epoch() {
         let h = Harness::new(Config::default().write(WriteConfig {
-            failure_rate: 0.0,
-            retention_rate: 1.0,
+            failure_rate: Probability!(0.0),
+            retention_rate: Probability!(1.0),
             mode: PartialWriteMode::Prefix,
         }));
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
@@ -1276,8 +1277,8 @@ mod tests {
         drop(completion);
 
         h.config.write().write_rate = Some(WriteConfig {
-            failure_rate: 0.0,
-            retention_rate: 1.0,
+            failure_rate: Probability!(0.0),
+            retention_rate: Probability!(1.0),
             mode: PartialWriteMode::Prefix,
         });
         blob.write_at(5, b"later", WriteOptions::default())
@@ -1296,8 +1297,8 @@ mod tests {
     #[tokio::test]
     async fn test_sync_write_does_not_barrier_disjoint_pending_write() {
         let h = Harness::new(Config::default().write(WriteConfig {
-            failure_rate: 0.0,
-            retention_rate: 1.0,
+            failure_rate: Probability!(0.0),
+            retention_rate: Probability!(1.0),
             mode: PartialWriteMode::Prefix,
         }));
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
@@ -1319,8 +1320,8 @@ mod tests {
     #[tokio::test]
     async fn test_sync_write_retires_only_overlapping_pending_bytes() {
         let h = Harness::new(Config::default().write(WriteConfig {
-            failure_rate: 0.0,
-            retention_rate: 1.0,
+            failure_rate: Probability!(0.0),
+            retention_rate: Probability!(1.0),
             mode: PartialWriteMode::Prefix,
         }));
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
@@ -1355,8 +1356,8 @@ mod tests {
             let h = Harness::with_seed(
                 seed,
                 Config::default().write(WriteConfig {
-                    failure_rate: 0.0,
-                    retention_rate: 0.5,
+                    failure_rate: Probability!(0.0),
+                    retention_rate: Probability!(0.5),
                     mode: PartialWriteMode::Prefix,
                 }),
             );
@@ -1386,11 +1387,14 @@ mod tests {
             83,
             Config::default()
                 .write(WriteConfig {
-                    failure_rate: 0.0,
-                    retention_rate: 1.0,
+                    failure_rate: Probability!(0.0),
+                    retention_rate: Probability!(1.0),
                     mode: PartialWriteMode::Prefix,
                 })
-                .resize(0.5),
+                .resize(ResizeConfig {
+                    failure_rate: Probability!(0.5),
+                    partial_rate: Probability!(0.0),
+                }),
         );
         let (write_then_resize, _) = h.storage.open("partition", b"first").await.unwrap();
         write_then_resize
@@ -1423,7 +1427,13 @@ mod tests {
 
     #[tokio::test]
     async fn test_partial_sync_write_replays_after_retained_resize() {
-        let h = Harness::with_seed(83, Config::default().resize(0.5));
+        let h = Harness::with_seed(
+            83,
+            Config::default().resize(ResizeConfig {
+                failure_rate: Probability!(0.5),
+                partial_rate: Probability!(0.0),
+            }),
+        );
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
         blob.write_at(0, b"abcdefghij", WriteOptions::SYNC)
             .await
@@ -1432,8 +1442,8 @@ mod tests {
         {
             let mut config = h.config.write();
             config.write_rate = Some(WriteConfig {
-                failure_rate: 1.0,
-                retention_rate: 0.5,
+                failure_rate: Probability!(1.0),
+                retention_rate: Probability!(0.5),
                 mode: PartialWriteMode::Subset,
             });
         }
@@ -1469,7 +1479,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_preissued_sync_write_survives_failed_partial_resize() {
-        let h = Harness::new(Config::default().resize(1.0).partial_resize(1.0));
+        let h = Harness::new(Config::default().resize(ResizeConfig {
+            failure_rate: Probability!(1.0),
+            partial_rate: Probability!(1.0),
+        }));
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
         blob.write_at(0, b"abcdefghij", WriteOptions::SYNC)
             .await
@@ -1511,8 +1524,8 @@ mod tests {
     async fn test_partial_sync_write_retires_each_persisted_range() {
         for partial_write_mode in [PartialWriteMode::Prefix, PartialWriteMode::Subset] {
             let h = Harness::new(Config::default().write(WriteConfig {
-                failure_rate: 0.0,
-                retention_rate: 1.0,
+                failure_rate: Probability!(0.0),
+                retention_rate: Probability!(1.0),
                 mode: PartialWriteMode::Prefix,
             }));
             let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
@@ -1525,8 +1538,8 @@ mod tests {
             {
                 let mut config = h.config.write();
                 config.write_rate = Some(WriteConfig {
-                    failure_rate: 1.0,
-                    retention_rate: 0.5,
+                    failure_rate: Probability!(1.0),
+                    retention_rate: Probability!(0.5),
                     mode: partial_write_mode,
                 });
             }
@@ -1573,34 +1586,21 @@ mod tests {
     }
 
     #[test]
-    fn test_write_retention_rate_matches_fault_rate_bounds() {
-        let h = Harness::new(Config::default());
-        for (retention_rate, expected) in [
-            (f64::NEG_INFINITY, false),
-            (-1.0, false),
-            (0.0, false),
-            (f64::NAN, false),
-            (1.0, true),
-            (2.0, true),
-            (f64::INFINITY, true),
-        ] {
-            assert_eq!(h.storage.ctx.roll(Some(retention_rate)), expected);
-            for mode in [PartialWriteMode::Prefix, PartialWriteMode::Subset] {
-                assert_eq!(
-                    h.storage.ctx.retained_bytes(4, (mode, retention_rate)),
-                    [expected; 4]
-                );
-            }
-        }
-    }
-
-    #[test]
-    fn test_nan_fault_rate_does_not_consume_randomness() {
+    fn test_probability_endpoints_do_not_consume_randomness() {
         let expected = Harness::with_seed(0, Config::default());
         let expected = expected.storage.ctx.rng.lock().random::<u64>();
 
         let h = Harness::with_seed(0, Config::default());
-        assert!(!h.storage.ctx.roll(Some(f64::NAN)));
+        for (probability, outcome) in [(Probability!(0.0), false), (Probability!(1.0), true)] {
+            assert_eq!(h.storage.ctx.roll(probability), outcome);
+            for mode in [PartialWriteMode::Prefix, PartialWriteMode::Subset] {
+                assert_eq!(
+                    h.storage.ctx.retained_bytes(4, (mode, probability)),
+                    [outcome; 4]
+                );
+            }
+        }
+
         assert_eq!(h.storage.ctx.rng.lock().random::<u64>(), expected);
     }
 
@@ -1613,7 +1613,7 @@ mod tests {
             let retained = h
                 .storage
                 .ctx
-                .retained_bytes(4, (PartialWriteMode::Prefix, 0.5));
+                .retained_bytes(4, (PartialWriteMode::Prefix, Probability!(0.5)));
             let prefix_len = retained.iter().take_while(|&&keep| keep).count();
             assert!(retained[prefix_len..].iter().all(|&keep| !keep));
             observed[prefix_len] = true;
@@ -1623,7 +1623,7 @@ mod tests {
         assert!(
             h.storage
                 .ctx
-                .retained_bytes(0, (PartialWriteMode::Prefix, 0.5))
+                .retained_bytes(0, (PartialWriteMode::Prefix, Probability!(0.5)))
                 .is_empty()
         );
     }
@@ -1631,8 +1631,8 @@ mod tests {
     #[tokio::test]
     async fn test_write_rejects_offset_overflow_before_retention() {
         let h = Harness::new(Config::default().write(WriteConfig {
-            failure_rate: 1.0,
-            retention_rate: 0.5,
+            failure_rate: Probability!(1.0),
+            retention_rate: Probability!(0.5),
             mode: PartialWriteMode::Subset,
         }));
         let (blob, _) = h.storage.open("partition", b"blob").await.unwrap();
@@ -1648,8 +1648,8 @@ mod tests {
     #[tokio::test]
     async fn test_failed_write_can_retain_every_byte() {
         let h = Harness::new(Config::default().write(WriteConfig {
-            failure_rate: 1.0,
-            retention_rate: 1.0,
+            failure_rate: Probability!(1.0),
+            retention_rate: Probability!(1.0),
             mode: PartialWriteMode::Prefix,
         }));
         let (blob, _) = h.storage.open("partition", b"blob").await.unwrap();
@@ -1665,7 +1665,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_faulty_storage_sync_always_fails() {
-        let h = Harness::new(Config::default().sync(1.0));
+        let h = Harness::new(Config::default().sync(Probability!(1.0)));
 
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
         blob.write_at(0, b"data".to_vec(), WriteOptions::default())
@@ -1680,11 +1680,11 @@ mod tests {
         let h = Harness::new(
             Config::default()
                 .write(WriteConfig {
-                    failure_rate: 0.0,
-                    retention_rate: 1.0,
+                    failure_rate: Probability!(0.0),
+                    retention_rate: Probability!(1.0),
                     mode: PartialWriteMode::Prefix,
                 })
-                .sync(1.0),
+                .sync(Probability!(1.0)),
         );
 
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
@@ -1700,8 +1700,8 @@ mod tests {
     #[tokio::test]
     async fn test_faulty_storage_write_always_fails() {
         let h = Harness::new(Config::default().write(WriteConfig {
-            failure_rate: 1.0,
-            retention_rate: 0.0,
+            failure_rate: Probability!(1.0),
+            retention_rate: Probability!(0.0),
             mode: PartialWriteMode::Prefix,
         }));
 
@@ -1717,8 +1717,8 @@ mod tests {
     #[tokio::test]
     async fn test_faulty_storage_write_at_sync_write_always_fails() {
         let h = Harness::new(Config::default().write(WriteConfig {
-            failure_rate: 1.0,
-            retention_rate: 0.0,
+            failure_rate: Probability!(1.0),
+            retention_rate: Probability!(0.0),
             mode: PartialWriteMode::Prefix,
         }));
 
@@ -1732,7 +1732,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_faulty_storage_write_at_sync_failure_is_not_durable() {
-        let h = Harness::new(Config::default().sync(1.0));
+        let h = Harness::new(Config::default().sync(Probability!(1.0)));
 
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
 
@@ -1747,7 +1747,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_faulty_storage_empty_write_at_sync_does_not_sync_prior_write() {
-        let h = Harness::new(Config::default().sync(1.0));
+        let h = Harness::new(Config::default().sync(Probability!(1.0)));
 
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
         blob.write_at(0, b"data".to_vec(), WriteOptions::default())
@@ -1765,8 +1765,8 @@ mod tests {
     #[tokio::test]
     async fn test_empty_unsynced_write_does_not_create_crash_debt() {
         let h = Harness::new(Config::default().write(WriteConfig {
-            failure_rate: 0.0,
-            retention_rate: 1.0,
+            failure_rate: Probability!(0.0),
+            retention_rate: Probability!(1.0),
             mode: PartialWriteMode::Prefix,
         }));
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
@@ -1788,14 +1788,14 @@ mod tests {
         blob.sync().await.unwrap();
 
         // Enable read faults
-        h.config.write().read_rate = Some(1.0);
+        h.config.write().read_rate = Some(Probability!(1.0));
 
         assert!(matches!(blob.read_at(0, 4).await, Err(Error::Io(_))));
     }
 
     #[tokio::test]
     async fn test_faulty_storage_open_always_fails() {
-        let h = Harness::new(Config::default().open(1.0));
+        let h = Harness::new(Config::default().open(Probability!(1.0)));
 
         assert!(matches!(
             h.storage.open("partition", b"test").await,
@@ -1816,7 +1816,7 @@ mod tests {
         drop(blob);
 
         // Enable remove faults
-        h.config.write().remove_rate = Some(1.0);
+        h.config.write().remove_rate = Some(Probability!(1.0));
 
         assert!(matches!(
             h.storage.remove("partition", Some(b"test")).await,
@@ -1839,7 +1839,7 @@ mod tests {
         }
 
         // Enable scan faults
-        h.config.write().scan_rate = Some(1.0);
+        h.config.write().scan_rate = Some(Probability!(1.0));
 
         assert!(matches!(
             h.storage.scan("partition").await,
@@ -1849,7 +1849,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_faulty_storage_determinism() {
-        async fn run_ops(seed: u64, rate: f64) -> Vec<bool> {
+        async fn run_ops(seed: u64, rate: Probability) -> Vec<bool> {
             let h = Harness::with_seed(seed, Config::default().open(rate));
             let mut results = Vec::new();
             for i in 0..20 {
@@ -1859,11 +1859,11 @@ mod tests {
             results
         }
 
-        let results1 = run_ops(42, 0.5).await;
-        let results2 = run_ops(42, 0.5).await;
+        let results1 = run_ops(42, Probability!(0.5)).await;
+        let results2 = run_ops(42, Probability!(0.5)).await;
         assert_eq!(results1, results2, "Same seed should produce same results");
 
-        let results3 = run_ops(999, 0.5).await;
+        let results3 = run_ops(999, Probability!(0.5)).await;
         assert_ne!(
             results1, results3,
             "Different seeds should produce different results"
@@ -1873,19 +1873,22 @@ mod tests {
     #[tokio::test]
     async fn test_faulty_storage_rate_for() {
         let config = Config::default()
-            .open(0.1)
+            .open(Probability!(0.1))
             .write(WriteConfig {
-                failure_rate: 0.3,
-                retention_rate: 0.4,
+                failure_rate: Probability!(0.3),
+                retention_rate: Probability!(0.4),
                 mode: PartialWriteMode::Subset,
             })
-            .resize(0.7)
-            .sync(0.9);
+            .resize(ResizeConfig {
+                failure_rate: Probability!(0.7),
+                partial_rate: Probability!(0.8),
+            })
+            .sync(Probability!(0.9));
 
-        assert!((config.rate_for(Op::Open) - 0.1).abs() < f64::EPSILON);
-        assert!((config.rate_for(Op::Write) - 0.3).abs() < f64::EPSILON);
-        assert!((config.rate_for(Op::Resize) - 0.7).abs() < f64::EPSILON);
-        assert!((config.rate_for(Op::Sync) - 0.9).abs() < f64::EPSILON);
+        assert_eq!(config.rate_for(Op::Open), Probability!(0.1));
+        assert_eq!(config.rate_for(Op::Write), Probability!(0.3));
+        assert_eq!(config.rate_for(Op::Resize), Probability!(0.7));
+        assert_eq!(config.rate_for(Op::Sync), Probability!(0.9));
     }
 
     #[tokio::test]
@@ -1895,18 +1898,18 @@ mod tests {
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
         blob.sync().await.unwrap();
 
-        h.config.write().sync_rate = Some(1.0);
+        h.config.write().sync_rate = Some(Probability!(1.0));
         assert!(matches!(blob.sync().await, Err(Error::Io(_))));
 
-        h.config.write().sync_rate = Some(0.0);
+        h.config.write().sync_rate = Some(Probability!(0.0));
         blob.sync().await.unwrap();
     }
 
     #[tokio::test]
     async fn test_write_retention_is_snapshotted_and_replayed_in_order() {
         let h = Harness::new(Config::default().write(WriteConfig {
-            failure_rate: 0.0,
-            retention_rate: 1.0,
+            failure_rate: Probability!(0.0),
+            retention_rate: Probability!(1.0),
             mode: PartialWriteMode::Prefix,
         }));
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
@@ -1922,8 +1925,8 @@ mod tests {
             .await
             .unwrap();
         h.config.write().write_rate = Some(WriteConfig {
-            failure_rate: 0.0,
-            retention_rate: 1.0,
+            failure_rate: Probability!(0.0),
+            retention_rate: Probability!(1.0),
             mode: PartialWriteMode::Prefix,
         });
         blob.write_at(1, b"XY", WriteOptions::default())
@@ -1972,8 +1975,8 @@ mod tests {
                 let h = Harness::with_seed(
                     seed,
                     Config::default().write(WriteConfig {
-                        failure_rate: 0.0,
-                        retention_rate: 0.5,
+                        failure_rate: Probability!(0.0),
+                        retention_rate: Probability!(0.5),
                         mode: PartialWriteMode::Subset,
                     }),
                 );
@@ -1987,8 +1990,8 @@ mod tests {
                 {
                     let mut config = h.config.write();
                     config.write_rate = Some(WriteConfig {
-                        failure_rate: 1.0,
-                        retention_rate: 0.5,
+                        failure_rate: Probability!(1.0),
+                        retention_rate: Probability!(0.5),
                         mode: partial_write_mode,
                     });
                 }
@@ -2017,8 +2020,8 @@ mod tests {
             let h = Harness::with_seed(
                 seed,
                 Config::default().write(WriteConfig {
-                    failure_rate: 0.0,
-                    retention_rate: 0.5,
+                    failure_rate: Probability!(0.0),
+                    retention_rate: Probability!(0.5),
                     mode: PartialWriteMode::Subset,
                 }),
             );
@@ -2031,8 +2034,10 @@ mod tests {
                 .unwrap();
             {
                 let mut config = h.config.write();
-                config.resize_rate = Some(1.0);
-                config.partial_resize_rate = Some(1.0);
+                config.resize_rate = Some(ResizeConfig {
+                    failure_rate: Probability!(1.0),
+                    partial_rate: Probability!(1.0),
+                });
             }
 
             assert!(blob.resize(8).await.is_err());
@@ -2050,8 +2055,8 @@ mod tests {
     #[tokio::test]
     async fn test_crash_journal_clears_only_after_completed_durability() {
         let h = Harness::new(Config::default().write(WriteConfig {
-            failure_rate: 0.0,
-            retention_rate: 1.0,
+            failure_rate: Probability!(0.0),
+            retention_rate: Probability!(1.0),
             mode: PartialWriteMode::Prefix,
         }));
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
@@ -2060,7 +2065,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(h.storage.pending.lock().len(), 1);
-        h.config.write().sync_rate = Some(1.0);
+        h.config.write().sync_rate = Some(Probability!(1.0));
         assert!(matches!(blob.sync().await, Err(Error::Io(_))));
         assert_eq!(h.storage.pending.lock().len(), 1);
 
@@ -2102,11 +2107,11 @@ mod tests {
         let h = Harness::new(
             Config::default()
                 .write(WriteConfig {
-                    failure_rate: 0.0,
-                    retention_rate: 1.0,
+                    failure_rate: Probability!(0.0),
+                    retention_rate: Probability!(1.0),
                     mode: PartialWriteMode::Prefix,
                 })
-                .sync(1.0),
+                .sync(Probability!(1.0)),
         );
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
         assert!(matches!(
@@ -2124,8 +2129,8 @@ mod tests {
     #[tokio::test]
     async fn test_faulty_storage_zero_write_retention_preserves_nothing() {
         let h = Harness::new(Config::default().write(WriteConfig {
-            failure_rate: 1.0,
-            retention_rate: 0.0,
+            failure_rate: Probability!(1.0),
+            retention_rate: Probability!(0.0),
             mode: PartialWriteMode::Prefix,
         }));
 
@@ -2172,15 +2177,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_faulty_storage_write_retention_rate_edges() {
+    async fn test_faulty_storage_write_retention_rate_endpoints() {
         for (retention_rate, expected) in [
-            (0.0, b"old".as_slice()),
-            (f64::NAN, b"old".as_slice()),
-            (1.0, b"new".as_slice()),
+            (Probability!(0.0), b"old".as_slice()),
+            (Probability!(1.0), b"new".as_slice()),
         ] {
             for mode in [PartialWriteMode::Prefix, PartialWriteMode::Subset] {
                 let failed = Harness::new(Config::default().write(WriteConfig {
-                    failure_rate: 1.0,
+                    failure_rate: Probability!(1.0),
                     retention_rate,
                     mode,
                 }));
@@ -2189,7 +2193,7 @@ mod tests {
                     .await
                     .unwrap_err();
                 let (durable, len) = failed.inner.open("partition", b"failed").await.unwrap();
-                if retention_rate >= 1.0 {
+                if retention_rate.is_one() {
                     assert_eq!(len, 3);
                     assert_eq!(durable.read_at(0, 3).await.unwrap().coalesce(), expected);
                 } else {
@@ -2197,7 +2201,7 @@ mod tests {
                 }
 
                 let crashed = Harness::new(Config::default().write(WriteConfig {
-                    failure_rate: 0.0,
+                    failure_rate: Probability!(0.0),
                     retention_rate,
                     mode,
                 }));
@@ -2229,7 +2233,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_faulty_storage_partial_resize_grow() {
-        let h = Harness::new(Config::default().resize(1.0).partial_resize(1.0));
+        let h = Harness::new(Config::default().resize(ResizeConfig {
+            failure_rate: Probability!(1.0),
+            partial_rate: Probability!(1.0),
+        }));
 
         let (blob, initial_size) = h.storage.open("partition", b"test").await.unwrap();
         assert_eq!(initial_size, 0);
@@ -2257,8 +2264,10 @@ mod tests {
 
         {
             let mut cfg = h.config.write();
-            cfg.resize_rate = Some(1.0);
-            cfg.partial_resize_rate = Some(1.0);
+            cfg.resize_rate = Some(ResizeConfig {
+                failure_rate: Probability!(1.0),
+                partial_rate: Probability!(1.0),
+            });
         }
 
         let target_size = 10u64;
@@ -2276,7 +2285,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_faulty_storage_partial_resize_disabled() {
-        let h = Harness::new(Config::default().resize(1.0).partial_resize(0.0));
+        let h = Harness::new(Config::default().resize(ResizeConfig {
+            failure_rate: Probability!(1.0),
+            partial_rate: Probability!(0.0),
+        }));
 
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
         let result = blob.resize(100).await;
@@ -2284,12 +2296,15 @@ mod tests {
         assert!(matches!(result, Err(Error::Io(_))));
 
         let (_, size) = h.inner.open("partition", b"test").await.unwrap();
-        assert_eq!(size, 0, "Expected no resize when partial_resize_rate is 0");
+        assert_eq!(size, 0, "Expected no resize when partial rate is 0");
     }
 
     #[tokio::test]
     async fn test_faulty_storage_partial_resize_same_size() {
-        let h = Harness::new(Config::default().resize(1.0).partial_resize(1.0));
+        let h = Harness::new(Config::default().resize(ResizeConfig {
+            failure_rate: Probability!(1.0),
+            partial_rate: Probability!(1.0),
+        }));
 
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
         let result = blob.resize(0).await;
@@ -2317,8 +2332,10 @@ mod tests {
 
         {
             let mut cfg = h.config.write();
-            cfg.resize_rate = Some(1.0);
-            cfg.partial_resize_rate = Some(1.0);
+            cfg.resize_rate = Some(ResizeConfig {
+                failure_rate: Probability!(1.0),
+                partial_rate: Probability!(1.0),
+            });
         }
 
         let target_size = 10u64;
@@ -2336,7 +2353,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_faulty_storage_partial_resize_one_byte_difference() {
-        let h = Harness::new(Config::default().resize(1.0).partial_resize(1.0));
+        let h = Harness::new(Config::default().resize(ResizeConfig {
+            failure_rate: Probability!(1.0),
+            partial_rate: Probability!(1.0),
+        }));
 
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
         let result = blob.resize(1).await;

--- a/runtime/src/storage/faulty.rs
+++ b/runtime/src/storage/faulty.rs
@@ -17,6 +17,48 @@ use std::{
     },
 };
 
+/// A bounded RNG for tests that require explicit probability outcomes.
+#[cfg(test)]
+pub(crate) struct ScriptedRng {
+    samples: std::vec::IntoIter<u64>,
+}
+
+#[cfg(test)]
+impl ScriptedRng {
+    pub(crate) const EVENT_OCCURS: u64 = 0;
+    pub(crate) const EVENT_DOES_NOT_OCCUR: u64 = u64::MAX;
+
+    pub(crate) fn new(samples: impl IntoIterator<Item = u64>) -> Self {
+        Self {
+            samples: samples.into_iter().collect::<Vec<_>>().into_iter(),
+        }
+    }
+}
+
+#[cfg(test)]
+impl rand::TryRng for ScriptedRng {
+    type Error = std::convert::Infallible;
+
+    fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
+        panic!("fault script should only sample u64 probabilities");
+    }
+
+    fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
+        Ok(self
+            .samples
+            .next()
+            .expect("fault script consumed more samples than expected"))
+    }
+
+    fn try_fill_bytes(&mut self, _dst: &mut [u8]) -> Result<(), Self::Error> {
+        panic!("fault script should only sample u64 probabilities");
+    }
+}
+
+// ScriptedRng is test-only; this marker satisfies the deterministic runtime's RNG bound.
+#[cfg(test)]
+impl rand::TryCryptoRng for ScriptedRng {}
+
 /// Operation types for fault injection.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Op {
@@ -945,10 +987,12 @@ mod tests {
         }
 
         fn with_seed(seed: u64, config: Config) -> Self {
+            Self::with_rng(Box::new(StdRng::seed_from_u64(seed)), config)
+        }
+
+        fn with_rng(rng: BoxDynRng, config: Config) -> Self {
             let inner = MemStorage::new(test_pool());
-            let rng = Arc::new(Mutex::new(
-                Box::new(StdRng::seed_from_u64(seed)) as BoxDynRng
-            ));
+            let rng = Arc::new(Mutex::new(rng));
             let config = Arc::new(RwLock::new(config));
             let storage = Storage::new(inner.clone(), rng, config.clone());
             Self {
@@ -1383,8 +1427,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_crash_replays_writes_and_resizes_in_issue_order() {
-        let h = Harness::with_seed(
-            83,
+        let retained_resizes =
+            [ScriptedRng::EVENT_DOES_NOT_OCCUR, ScriptedRng::EVENT_OCCURS].repeat(3);
+        let h = Harness::with_rng(
+            Box::new(ScriptedRng::new(retained_resizes)),
             Config::default()
                 .write(WriteConfig {
                     failure_rate: Probability!(0.0),
@@ -1427,8 +1473,17 @@ mod tests {
 
     #[tokio::test]
     async fn test_partial_sync_write_replays_after_retained_resize() {
-        let h = Harness::with_seed(
-            83,
+        let retained_resize = [ScriptedRng::EVENT_DOES_NOT_OCCUR, ScriptedRng::EVENT_OCCURS];
+        let retained_write_bytes = [
+            ScriptedRng::EVENT_OCCURS,
+            ScriptedRng::EVENT_DOES_NOT_OCCUR,
+            ScriptedRng::EVENT_OCCURS,
+            ScriptedRng::EVENT_DOES_NOT_OCCUR,
+        ];
+        let h = Harness::with_rng(
+            Box::new(ScriptedRng::new(
+                retained_resize.into_iter().chain(retained_write_bytes),
+            )),
             Config::default().resize(ResizeConfig {
                 failure_rate: Probability!(0.5),
                 partial_rate: Probability!(0.0),

--- a/runtime/src/storage/faulty.rs
+++ b/runtime/src/storage/faulty.rs
@@ -26,14 +26,14 @@ enum Op {
     Scan,
 }
 
-/// Selects which submitted bytes are retained from a write.
-#[derive(Clone, Copy, Debug, PartialEq)]
+/// Selects how submitted bytes are retained from a write.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum PartialWriteMode {
-    /// Retain a uniformly selected prefix, including the empty and full prefixes.
+    /// Retain bytes from the beginning of the write until the first omitted byte.
     Prefix,
 
-    /// Independently retain each submitted byte at the supplied retention frequency.
-    Subset(f64),
+    /// Independently select each submitted byte for retention.
+    Subset,
 }
 
 /// Fault configuration for `write_at` operations.
@@ -44,6 +44,9 @@ pub enum PartialWriteMode {
 pub struct WriteConfig {
     /// Probability that `write_at` returns an injected failure.
     pub failure_rate: f64,
+
+    /// Probability used by the selected mode when retaining submitted bytes.
+    pub retention_frequency: f64,
 
     /// Arrangement of bytes retained by the simulated storage device.
     pub mode: PartialWriteMode,
@@ -195,13 +198,13 @@ impl PendingSync {
 /// Retention choices belong to the issued write and are shared by fragments created by later
 /// durability barriers.
 struct PendingWriteRetention {
-    policy: PartialWriteMode,
+    policy: (PartialWriteMode, f64),
     len: usize,
     selected: OnceLock<Vec<bool>>,
 }
 
 impl PendingWriteRetention {
-    const fn new(policy: PartialWriteMode, len: usize) -> Self {
+    const fn new(policy: (PartialWriteMode, f64), len: usize) -> Self {
         Self {
             policy,
             len,
@@ -275,16 +278,13 @@ impl Oracle {
 
     /// Check if a write fault should be injected.
     /// Reads config once to avoid nested lock acquisition.
-    fn check_write_fault(&self) -> (bool, Option<PartialWriteMode>) {
+    fn check_write_fault(&self) -> (bool, Option<(PartialWriteMode, f64)>) {
         let config = self.config.read();
         let fail = self.roll(Some(config.rate_for(Op::Write)));
         let retention = config
             .write_rate
-            .map(|config| config.mode)
-            .filter(|mode| match mode {
-                PartialWriteMode::Prefix => true,
-                PartialWriteMode::Subset(retention_frequency) => *retention_frequency > 0.0,
-            });
+            .map(|config| (config.mode, config.retention_frequency))
+            .filter(|(_, retention_frequency)| *retention_frequency > 0.0);
         (fail, retention)
     }
 
@@ -323,27 +323,31 @@ impl Oracle {
     }
 
     /// Select retained byte positions according to a snapshotted write policy.
-    fn retained_bytes(&self, len: usize, mode: PartialWriteMode) -> Vec<bool> {
+    fn retained_bytes(
+        &self,
+        len: usize,
+        (mode, retention_frequency): (PartialWriteMode, f64),
+    ) -> Vec<bool> {
+        if retention_frequency <= 0.0 || retention_frequency.is_nan() {
+            return vec![false; len];
+        }
+        if retention_frequency >= 1.0 {
+            return vec![true; len];
+        }
+
+        let mut rng = self.rng.lock();
         match mode {
             PartialWriteMode::Prefix => {
                 let mut positions = vec![false; len];
-                let retained = self.rng.lock().random_range(0..=len);
+                let retained = (0..len)
+                    .take_while(|_| rng.random_bool(retention_frequency))
+                    .count();
                 positions[..retained].fill(true);
                 positions
             }
-            PartialWriteMode::Subset(retention_frequency) => {
-                if retention_frequency <= 0.0 || retention_frequency.is_nan() {
-                    return vec![false; len];
-                }
-                if retention_frequency >= 1.0 {
-                    return vec![true; len];
-                }
-
-                let mut rng = self.rng.lock();
-                (0..len)
-                    .map(|_| rng.random_bool(retention_frequency))
-                    .collect()
-            }
+            PartialWriteMode::Subset => (0..len)
+                .map(|_| rng.random_bool(retention_frequency))
+                .collect(),
         }
     }
 
@@ -563,7 +567,7 @@ impl<B: crate::Blob> Blob<B> {
         }
     }
 
-    fn record_pending(&self, offset: u64, bufs: IoBufs, retention: PartialWriteMode) {
+    fn record_pending(&self, offset: u64, bufs: IoBufs, retention: (PartialWriteMode, f64)) {
         if bufs.is_empty() {
             return;
         }
@@ -672,7 +676,7 @@ impl<B: crate::Blob> Blob<B> {
         }
         if follows_resize {
             let retention = Arc::new(PendingWriteRetention::new(
-                PartialWriteMode::Subset(1.0),
+                (PartialWriteMode::Prefix, 1.0),
                 durable.remaining(),
             ));
             retained.push(PendingMutation::Write {
@@ -964,7 +968,8 @@ mod tests {
     async fn test_start_sync_returns_before_backing_completion() {
         let h = Harness::new(Config::default().write(WriteConfig {
             failure_rate: 0.0,
-            mode: PartialWriteMode::Subset(1.0),
+            retention_frequency: 1.0,
+            mode: PartialWriteMode::Prefix,
         }));
         let (inner, _) = h.inner.open("partition", b"start-sync").await.unwrap();
         inner
@@ -1003,7 +1008,8 @@ mod tests {
     async fn run_overlapping_barrier(start: bool) {
         let h = Harness::new(Config::default().write(WriteConfig {
             failure_rate: 0.0,
-            mode: PartialWriteMode::Subset(1.0),
+            retention_frequency: 1.0,
+            mode: PartialWriteMode::Prefix,
         }));
         let (inner, _) = h.inner.open("partition", b"overlap").await.unwrap();
         inner
@@ -1064,7 +1070,7 @@ mod tests {
                     retention,
                     ..
                 } => {
-                    assert_eq!(retention.policy, PartialWriteMode::Subset(1.0));
+                    assert_eq!(retention.policy, (PartialWriteMode::Prefix, 1.0));
                     blob.inner
                         .retain_crash_write(offset, bufs, || true)
                         .unwrap();
@@ -1082,7 +1088,8 @@ mod tests {
     async fn test_completed_backing_write_cannot_record_after_later_full_sync() {
         let h = Harness::new(Config::default().write(WriteConfig {
             failure_rate: 0.0,
-            mode: PartialWriteMode::Subset(1.0),
+            retention_frequency: 1.0,
+            mode: PartialWriteMode::Prefix,
         }));
         let (inner, _) = h.inner.open("partition", b"late-record").await.unwrap();
         inner
@@ -1137,7 +1144,7 @@ mod tests {
             else {
                 panic!("write test recorded a resize");
             };
-            assert_eq!(retention.policy, PartialWriteMode::Subset(1.0));
+            assert_eq!(retention.policy, (PartialWriteMode::Prefix, 1.0));
             blob.inner
                 .retain_crash_write(offset, bufs, || true)
                 .unwrap();
@@ -1154,7 +1161,8 @@ mod tests {
             seed,
             Config::default().write(WriteConfig {
                 failure_rate: 0.0,
-                mode: PartialWriteMode::Subset(0.5),
+                retention_frequency: 0.5,
+                mode: PartialWriteMode::Subset,
             }),
         );
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
@@ -1167,7 +1175,8 @@ mod tests {
             let mut config = h.config.write();
             config.write_rate = Some(WriteConfig {
                 failure_rate: 1.0,
-                mode: PartialWriteMode::Subset(0.5),
+                retention_frequency: 0.5,
+                mode: PartialWriteMode::Subset,
             });
         }
 
@@ -1192,7 +1201,8 @@ mod tests {
             seed,
             Config::default().write(WriteConfig {
                 failure_rate: 0.0,
-                mode: PartialWriteMode::Subset(0.5),
+                retention_frequency: 0.5,
+                mode: PartialWriteMode::Subset,
             }),
         );
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
@@ -1221,7 +1231,8 @@ mod tests {
     async fn test_reopened_sync_clears_prior_handle_crash_writes() {
         let h = Harness::new(Config::default().write(WriteConfig {
             failure_rate: 0.0,
-            mode: PartialWriteMode::Subset(1.0),
+            retention_frequency: 1.0,
+            mode: PartialWriteMode::Prefix,
         }));
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
         blob.write_at(0, b"stale", WriteOptions::default())
@@ -1249,7 +1260,8 @@ mod tests {
     async fn test_dropped_completed_start_sync_clears_the_crash_epoch() {
         let h = Harness::new(Config::default().write(WriteConfig {
             failure_rate: 0.0,
-            mode: PartialWriteMode::Subset(1.0),
+            retention_frequency: 1.0,
+            mode: PartialWriteMode::Prefix,
         }));
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
         blob.write_at(0, b"stale", WriteOptions::default())
@@ -1265,7 +1277,8 @@ mod tests {
 
         h.config.write().write_rate = Some(WriteConfig {
             failure_rate: 0.0,
-            mode: PartialWriteMode::Subset(1.0),
+            retention_frequency: 1.0,
+            mode: PartialWriteMode::Prefix,
         });
         blob.write_at(5, b"later", WriteOptions::default())
             .await
@@ -1284,7 +1297,8 @@ mod tests {
     async fn test_sync_write_does_not_barrier_disjoint_pending_write() {
         let h = Harness::new(Config::default().write(WriteConfig {
             failure_rate: 0.0,
-            mode: PartialWriteMode::Subset(1.0),
+            retention_frequency: 1.0,
+            mode: PartialWriteMode::Prefix,
         }));
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
         blob.write_at(0, b"........", WriteOptions::SYNC)
@@ -1306,7 +1320,8 @@ mod tests {
     async fn test_sync_write_retires_only_overlapping_pending_bytes() {
         let h = Harness::new(Config::default().write(WriteConfig {
             failure_rate: 0.0,
-            mode: PartialWriteMode::Subset(1.0),
+            retention_frequency: 1.0,
+            mode: PartialWriteMode::Prefix,
         }));
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
         let (other, _) = h.storage.open("partition", b"other").await.unwrap();
@@ -1341,6 +1356,7 @@ mod tests {
                 seed,
                 Config::default().write(WriteConfig {
                     failure_rate: 0.0,
+                    retention_frequency: 0.5,
                     mode: PartialWriteMode::Prefix,
                 }),
             );
@@ -1371,7 +1387,8 @@ mod tests {
             Config::default()
                 .write(WriteConfig {
                     failure_rate: 0.0,
-                    mode: PartialWriteMode::Subset(1.0),
+                    retention_frequency: 1.0,
+                    mode: PartialWriteMode::Prefix,
                 })
                 .resize(0.5),
         );
@@ -1416,7 +1433,8 @@ mod tests {
             let mut config = h.config.write();
             config.write_rate = Some(WriteConfig {
                 failure_rate: 1.0,
-                mode: PartialWriteMode::Subset(0.5),
+                retention_frequency: 0.5,
+                mode: PartialWriteMode::Subset,
             });
         }
 
@@ -1491,10 +1509,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_partial_sync_write_retires_each_persisted_range() {
-        for partial_write_mode in [PartialWriteMode::Prefix, PartialWriteMode::Subset(0.5)] {
+        for partial_write_mode in [PartialWriteMode::Prefix, PartialWriteMode::Subset] {
             let h = Harness::new(Config::default().write(WriteConfig {
                 failure_rate: 0.0,
-                mode: PartialWriteMode::Subset(1.0),
+                retention_frequency: 1.0,
+                mode: PartialWriteMode::Prefix,
             }));
             let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
             blob.write_at(0, b"........", WriteOptions::SYNC)
@@ -1507,6 +1526,7 @@ mod tests {
                 let mut config = h.config.write();
                 config.write_rate = Some(WriteConfig {
                     failure_rate: 1.0,
+                    retention_frequency: 0.5,
                     mode: partial_write_mode,
                 });
             }
@@ -1553,7 +1573,7 @@ mod tests {
     }
 
     #[test]
-    fn test_subset_retention_frequency_matches_fault_rate_bounds() {
+    fn test_write_retention_frequency_matches_fault_rate_bounds() {
         let h = Harness::new(Config::default());
         for (retention_frequency, expected) in [
             (f64::NEG_INFINITY, false),
@@ -1565,35 +1585,35 @@ mod tests {
             (f64::INFINITY, true),
         ] {
             assert_eq!(h.storage.ctx.roll(Some(retention_frequency)), expected);
-            assert_eq!(
-                h.storage
-                    .ctx
-                    .retained_bytes(4, PartialWriteMode::Subset(retention_frequency),),
-                [expected; 4]
-            );
+            for mode in [PartialWriteMode::Prefix, PartialWriteMode::Subset] {
+                assert_eq!(
+                    h.storage.ctx.retained_bytes(4, (mode, retention_frequency)),
+                    [expected; 4]
+                );
+            }
         }
     }
 
     #[test]
-    fn test_prefix_retention_selects_inclusive_prefix() {
-        let mut saw_empty = false;
-        let mut saw_full = false;
+    fn test_prefix_retention_frequency_selects_inclusive_prefix() {
+        let h = Harness::new(Config::default());
+        let mut observed = [false; 5];
         for seed in 0..512 {
             let h = Harness::with_seed(seed, Config::default());
-            let retained = h.storage.ctx.retained_bytes(64, PartialWriteMode::Prefix);
+            let retained = h
+                .storage
+                .ctx
+                .retained_bytes(4, (PartialWriteMode::Prefix, 0.5));
             let prefix_len = retained.iter().take_while(|&&keep| keep).count();
             assert!(retained[prefix_len..].iter().all(|&keep| !keep));
-            saw_empty |= prefix_len == 0;
-            saw_full |= prefix_len == retained.len();
+            observed[prefix_len] = true;
         }
-        assert!(saw_empty, "expected an empty prefix");
-        assert!(saw_full, "expected a full prefix");
+        assert!(observed.iter().all(|&seen| seen));
 
-        let h = Harness::new(Config::default());
         assert!(
             h.storage
                 .ctx
-                .retained_bytes(0, PartialWriteMode::Prefix)
+                .retained_bytes(0, (PartialWriteMode::Prefix, 0.5))
                 .is_empty()
         );
     }
@@ -1602,7 +1622,8 @@ mod tests {
     async fn test_write_rejects_offset_overflow_before_retention() {
         let h = Harness::new(Config::default().write(WriteConfig {
             failure_rate: 1.0,
-            mode: PartialWriteMode::Subset(0.5),
+            retention_frequency: 0.5,
+            mode: PartialWriteMode::Subset,
         }));
         let (blob, _) = h.storage.open("partition", b"blob").await.unwrap();
         assert!(matches!(
@@ -1618,7 +1639,8 @@ mod tests {
     async fn test_failed_write_can_retain_every_byte() {
         let h = Harness::new(Config::default().write(WriteConfig {
             failure_rate: 1.0,
-            mode: PartialWriteMode::Subset(1.0),
+            retention_frequency: 1.0,
+            mode: PartialWriteMode::Prefix,
         }));
         let (blob, _) = h.storage.open("partition", b"blob").await.unwrap();
 
@@ -1649,7 +1671,8 @@ mod tests {
             Config::default()
                 .write(WriteConfig {
                     failure_rate: 0.0,
-                    mode: PartialWriteMode::Subset(1.0),
+                    retention_frequency: 1.0,
+                    mode: PartialWriteMode::Prefix,
                 })
                 .sync(1.0),
         );
@@ -1668,7 +1691,8 @@ mod tests {
     async fn test_faulty_storage_write_always_fails() {
         let h = Harness::new(Config::default().write(WriteConfig {
             failure_rate: 1.0,
-            mode: PartialWriteMode::Subset(0.0),
+            retention_frequency: 0.0,
+            mode: PartialWriteMode::Prefix,
         }));
 
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
@@ -1684,7 +1708,8 @@ mod tests {
     async fn test_faulty_storage_write_at_sync_write_always_fails() {
         let h = Harness::new(Config::default().write(WriteConfig {
             failure_rate: 1.0,
-            mode: PartialWriteMode::Subset(0.0),
+            retention_frequency: 0.0,
+            mode: PartialWriteMode::Prefix,
         }));
 
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
@@ -1731,7 +1756,8 @@ mod tests {
     async fn test_empty_unsynced_write_does_not_create_crash_debt() {
         let h = Harness::new(Config::default().write(WriteConfig {
             failure_rate: 0.0,
-            mode: PartialWriteMode::Subset(1.0),
+            retention_frequency: 1.0,
+            mode: PartialWriteMode::Prefix,
         }));
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
         blob.write_at(0, Vec::<u8>::new(), WriteOptions::default())
@@ -1840,7 +1866,8 @@ mod tests {
             .open(0.1)
             .write(WriteConfig {
                 failure_rate: 0.3,
-                mode: PartialWriteMode::Subset(0.4),
+                retention_frequency: 0.4,
+                mode: PartialWriteMode::Subset,
             })
             .resize(0.7)
             .sync(0.9);
@@ -1869,7 +1896,8 @@ mod tests {
     async fn test_write_retention_is_snapshotted_and_replayed_in_order() {
         let h = Harness::new(Config::default().write(WriteConfig {
             failure_rate: 0.0,
-            mode: PartialWriteMode::Subset(1.0),
+            retention_frequency: 1.0,
+            mode: PartialWriteMode::Prefix,
         }));
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
         blob.write_at(0, b"........", WriteOptions::SYNC)
@@ -1885,7 +1913,8 @@ mod tests {
             .unwrap();
         h.config.write().write_rate = Some(WriteConfig {
             failure_rate: 0.0,
-            mode: PartialWriteMode::Subset(1.0),
+            retention_frequency: 1.0,
+            mode: PartialWriteMode::Prefix,
         });
         blob.write_at(1, b"XY", WriteOptions::default())
             .await
@@ -1926,7 +1955,7 @@ mod tests {
 
     #[tokio::test]
     async fn failed_partial_write_does_not_barrier_prior_crash_writes() {
-        for partial_write_mode in [PartialWriteMode::Prefix, PartialWriteMode::Subset(0.5)] {
+        for partial_write_mode in [PartialWriteMode::Prefix, PartialWriteMode::Subset] {
             let mut saw_old = false;
             let mut saw_new = false;
             for seed in 0..64 {
@@ -1934,7 +1963,8 @@ mod tests {
                     seed,
                     Config::default().write(WriteConfig {
                         failure_rate: 0.0,
-                        mode: PartialWriteMode::Subset(0.5),
+                        retention_frequency: 0.5,
+                        mode: PartialWriteMode::Subset,
                     }),
                 );
                 let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
@@ -1948,6 +1978,7 @@ mod tests {
                     let mut config = h.config.write();
                     config.write_rate = Some(WriteConfig {
                         failure_rate: 1.0,
+                        retention_frequency: 0.5,
                         mode: partial_write_mode,
                     });
                 }
@@ -1977,7 +2008,8 @@ mod tests {
                 seed,
                 Config::default().write(WriteConfig {
                     failure_rate: 0.0,
-                    mode: PartialWriteMode::Subset(0.5),
+                    retention_frequency: 0.5,
+                    mode: PartialWriteMode::Subset,
                 }),
             );
             let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
@@ -2009,7 +2041,8 @@ mod tests {
     async fn test_crash_journal_clears_only_after_completed_durability() {
         let h = Harness::new(Config::default().write(WriteConfig {
             failure_rate: 0.0,
-            mode: PartialWriteMode::Subset(1.0),
+            retention_frequency: 1.0,
+            mode: PartialWriteMode::Prefix,
         }));
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
 
@@ -2060,7 +2093,8 @@ mod tests {
             Config::default()
                 .write(WriteConfig {
                     failure_rate: 0.0,
-                    mode: PartialWriteMode::Subset(1.0),
+                    retention_frequency: 1.0,
+                    mode: PartialWriteMode::Prefix,
                 })
                 .sync(1.0),
         );
@@ -2081,7 +2115,8 @@ mod tests {
     async fn test_faulty_storage_zero_write_retention_preserves_nothing() {
         let h = Harness::new(Config::default().write(WriteConfig {
             failure_rate: 1.0,
-            mode: PartialWriteMode::Subset(0.0),
+            retention_frequency: 0.0,
+            mode: PartialWriteMode::Prefix,
         }));
 
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
@@ -2133,36 +2168,39 @@ mod tests {
             (f64::NAN, b"old".as_slice()),
             (1.0, b"new".as_slice()),
         ] {
-            let mode = PartialWriteMode::Subset(retention_frequency);
-            let failed = Harness::new(Config::default().write(WriteConfig {
-                failure_rate: 1.0,
-                mode,
-            }));
-            let (blob, _) = failed.storage.open("partition", b"failed").await.unwrap();
-            blob.write_at(0, b"new", WriteOptions::SYNC)
-                .await
-                .unwrap_err();
-            let (durable, len) = failed.inner.open("partition", b"failed").await.unwrap();
-            if retention_frequency >= 1.0 {
+            for mode in [PartialWriteMode::Prefix, PartialWriteMode::Subset] {
+                let failed = Harness::new(Config::default().write(WriteConfig {
+                    failure_rate: 1.0,
+                    retention_frequency,
+                    mode,
+                }));
+                let (blob, _) = failed.storage.open("partition", b"failed").await.unwrap();
+                blob.write_at(0, b"new", WriteOptions::SYNC)
+                    .await
+                    .unwrap_err();
+                let (durable, len) = failed.inner.open("partition", b"failed").await.unwrap();
+                if retention_frequency >= 1.0 {
+                    assert_eq!(len, 3);
+                    assert_eq!(durable.read_at(0, 3).await.unwrap().coalesce(), expected);
+                } else {
+                    assert_eq!(len, 0);
+                }
+
+                let crashed = Harness::new(Config::default().write(WriteConfig {
+                    failure_rate: 0.0,
+                    retention_frequency,
+                    mode,
+                }));
+                let (blob, _) = crashed.storage.open("partition", b"crashed").await.unwrap();
+                blob.write_at(0, b"old", WriteOptions::SYNC).await.unwrap();
+                blob.write_at(0, b"new", WriteOptions::default())
+                    .await
+                    .unwrap();
+                crashed.storage.crash().unwrap();
+                let (durable, len) = crashed.inner.open("partition", b"crashed").await.unwrap();
                 assert_eq!(len, 3);
                 assert_eq!(durable.read_at(0, 3).await.unwrap().coalesce(), expected);
-            } else {
-                assert_eq!(len, 0);
             }
-
-            let crashed = Harness::new(Config::default().write(WriteConfig {
-                failure_rate: 0.0,
-                mode,
-            }));
-            let (blob, _) = crashed.storage.open("partition", b"crashed").await.unwrap();
-            blob.write_at(0, b"old", WriteOptions::SYNC).await.unwrap();
-            blob.write_at(0, b"new", WriteOptions::default())
-                .await
-                .unwrap();
-            crashed.storage.crash().unwrap();
-            let (durable, len) = crashed.inner.open("partition", b"crashed").await.unwrap();
-            assert_eq!(len, 3);
-            assert_eq!(durable.read_at(0, 3).await.unwrap().coalesce(), expected);
         }
     }
 

--- a/runtime/src/storage/memory.rs
+++ b/runtime/src/storage/memory.rs
@@ -15,19 +15,71 @@ fn resolve_header(
     super::header::resolve(raw, content.len() as u64, versions, partition, name)
 }
 
+type BlobKey = (String, Vec<u8>);
+type Partition = BTreeMap<Vec<u8>, Vec<u8>>;
+
+/// Durable contents detached from all live storage and blob handles.
+pub(crate) struct Snapshot(BTreeMap<String, Partition>);
+
+#[derive(Default)]
+struct Generations {
+    next: u64,
+    current: BTreeMap<BlobKey, u64>,
+}
+
+impl Generations {
+    fn get_or_insert(&mut self, key: &BlobKey) -> u64 {
+        if let Some(generation) = self.current.get(key) {
+            return *generation;
+        }
+        self.rotate(key)
+    }
+
+    fn rotate(&mut self, key: &BlobKey) -> u64 {
+        let generation = self.next;
+        self.next = self.next.checked_add(1).expect("blob generation overflow");
+        self.current.insert(key.clone(), generation);
+        generation
+    }
+
+    fn remove_partition(&mut self, partition: &str) {
+        self.current
+            .retain(|(current_partition, _), _| current_partition != partition);
+    }
+}
+
 /// In-memory storage implementation for the commonware runtime.
 #[derive(Clone)]
 pub struct Storage {
     partitions: Arc<Mutex<BTreeMap<String, Partition>>>,
+    generations: Arc<Mutex<Generations>>,
     pool: BufferPool,
 }
 
 impl Storage {
     pub fn new(pool: BufferPool) -> Self {
+        Self::with_partitions(BTreeMap::new(), pool)
+    }
+
+    fn with_partitions(partitions: BTreeMap<String, Partition>, pool: BufferPool) -> Self {
         Self {
-            partitions: Arc::new(Mutex::new(BTreeMap::new())),
+            partitions: Arc::new(Mutex::new(partitions)),
+            generations: Arc::new(Mutex::new(Generations::default())),
             pool,
         }
+    }
+
+    /// Transfer durable contents and retire every live blob generation.
+    pub(crate) fn take_snapshot(&self) -> Snapshot {
+        let mut generations = self.generations.lock();
+        generations.current.clear();
+        let mut partitions = self.partitions.lock();
+        Snapshot(std::mem::take(&mut *partitions))
+    }
+
+    /// Rebuild storage from detached durable contents.
+    pub(crate) fn from_snapshot(snapshot: Snapshot, pool: BufferPool) -> Self {
+        Self::with_partitions(snapshot.0, pool)
     }
 }
 
@@ -64,6 +116,8 @@ impl crate::Storage for Storage {
     ) -> Result<(Self::Blob, u64, u16), crate::Error> {
         super::validate_partition_name(partition)?;
 
+        let key = (partition.to_string(), name.to_vec());
+        let mut generations = self.generations.lock();
         let mut partitions = self.partitions.lock();
         let partition_entry = partitions.entry(partition.into()).or_default();
         let content = partition_entry.entry(name.into()).or_default();
@@ -71,22 +125,31 @@ impl crate::Storage for Storage {
         // Handle header: existing blobs have their header read; new blobs and blobs left torn
         // by an interrupted creation get a fresh header written.
         let existing = resolve_header(content, &versions, partition, name)?;
-        let (logical_size, blob_version, data_offset) = existing.unwrap_or_else(|| {
-            let (region, blob_version) = Header::create(&versions);
-            let data_offset = region.len() as u64;
-            content.clear();
-            content.extend_from_slice(&region);
-            (0, blob_version, data_offset)
-        });
+        let (logical_size, blob_version, data_offset, generation) = match existing {
+            Some((logical_size, blob_version, data_offset)) => (
+                logical_size,
+                blob_version,
+                data_offset,
+                generations.get_or_insert(&key),
+            ),
+            None => {
+                let (region, blob_version) = Header::create(&versions);
+                let data_offset = region.len() as u64;
+                content.clear();
+                content.extend_from_slice(&region);
+                (0, blob_version, data_offset, generations.rotate(&key))
+            }
+        };
 
         Ok((
             Blob::new(
                 self.partitions.clone(),
-                partition.into(),
-                name,
+                self.generations.clone(),
+                key,
                 content.clone(),
                 self.pool.clone(),
                 data_offset,
+                generation,
             ),
             logical_size,
             blob_version,
@@ -96,6 +159,7 @@ impl crate::Storage for Storage {
     async fn remove(&self, partition: &str, name: Option<&[u8]>) -> Result<(), crate::Error> {
         super::validate_partition_name(partition)?;
 
+        let mut generations = self.generations.lock();
         let mut partitions = self.partitions.lock();
         match name {
             Some(name) => {
@@ -104,11 +168,15 @@ impl crate::Storage for Storage {
                     .ok_or(crate::Error::PartitionMissing(partition.into()))?
                     .remove(name)
                     .ok_or(crate::Error::BlobMissing(partition.into(), hex(name)))?;
+                generations
+                    .current
+                    .remove(&(partition.to_string(), name.to_vec()));
             }
             None => {
                 partitions
                     .remove(partition)
                     .ok_or(crate::Error::PartitionMissing(partition.into()))?;
+                generations.remove_partition(partition);
             }
         }
         Ok(())
@@ -130,36 +198,51 @@ impl crate::Storage for Storage {
     }
 }
 
-type Partition = BTreeMap<Vec<u8>, Vec<u8>>;
-
 #[derive(Clone)]
 pub struct Blob {
     partitions: Arc<Mutex<BTreeMap<String, Partition>>>,
+    generations: Arc<Mutex<Generations>>,
     partition: String,
     name: Vec<u8>,
     content: Arc<RwLock<Vec<u8>>>,
     pool: BufferPool,
     /// Physical offset where logical offset 0 begins (the size of the header region).
     data_offset: u64,
+    /// Namespace generation captured when this handle was opened.
+    generation: u64,
 }
 
 impl Blob {
     fn new(
         partitions: Arc<Mutex<BTreeMap<String, Partition>>>,
-        partition: String,
-        name: &[u8],
+        generations: Arc<Mutex<Generations>>,
+        (partition, name): BlobKey,
         content: Vec<u8>,
         pool: BufferPool,
         data_offset: u64,
+        generation: u64,
     ) -> Self {
         Self {
             partitions,
+            generations,
             partition,
-            name: name.into(),
+            name,
             content: Arc::new(RwLock::new(content)),
             pool,
             data_offset,
+            generation,
         }
+    }
+
+    fn ensure_current(&self, generations: &Generations) -> Result<(), crate::Error> {
+        let key = (self.partition.clone(), self.name.clone());
+        if generations.current.get(&key) == Some(&self.generation) {
+            return Ok(());
+        }
+        Err(crate::Error::BlobMissing(
+            self.partition.clone(),
+            hex(&self.name),
+        ))
     }
 
     fn sync_inner(&self) -> Result<(), crate::Error> {
@@ -167,6 +250,8 @@ impl Blob {
         let new_content = self.content.read().clone();
 
         // Update partition content
+        let generations = self.generations.lock();
+        self.ensure_current(&generations)?;
         let mut partitions = self.partitions.lock();
         let partition = partitions
             .get_mut(&self.partition)
@@ -178,6 +263,105 @@ impl Blob {
                 hex(&self.name),
             ))?;
         *content = new_content;
+        Ok(())
+    }
+
+    fn sync_range_inner(&self, offset: usize, buf: &[u8]) -> Result<(), crate::Error> {
+        let end = offset
+            .checked_add(buf.len())
+            .ok_or(crate::Error::OffsetOverflow)?;
+        let generations = self.generations.lock();
+        self.ensure_current(&generations)?;
+        let mut partitions = self.partitions.lock();
+        let content = partitions
+            .get_mut(&self.partition)
+            .and_then(|partition| partition.get_mut(&self.name))
+            .expect("a current blob generation has durable content");
+        if end > content.len() {
+            content.resize(end, 0);
+        }
+        content[offset..end].copy_from_slice(buf);
+        Ok(())
+    }
+
+    /// Merge selected bytes into durable storage without changing this handle's live contents.
+    pub(crate) fn retain_crash_write(
+        &self,
+        offset: u64,
+        mut bufs: IoBufs,
+        mut keep: impl FnMut() -> bool,
+    ) -> Result<(), crate::Error> {
+        let offset = offset
+            .checked_add(self.data_offset)
+            .ok_or(crate::Error::OffsetOverflow)?;
+        let offset: usize = offset
+            .try_into()
+            .map_err(|_| crate::Error::OffsetOverflow)?;
+        offset
+            .checked_add(bufs.remaining())
+            .ok_or(crate::Error::OffsetOverflow)?;
+
+        let generations = self.generations.lock();
+        if self.ensure_current(&generations).is_err() {
+            return Ok(());
+        }
+        let mut partitions = self.partitions.lock();
+        let content = partitions
+            .get_mut(&self.partition)
+            .and_then(|partition| partition.get_mut(&self.name))
+            .expect("a current blob generation has durable content");
+
+        let mut position = 0usize;
+        while bufs.has_remaining() {
+            let chunk = bufs.chunk();
+            let chunk_len = chunk.len();
+            let mut run_start = None;
+
+            let mut retain_run = |run_start: usize, run_end: usize| {
+                let physical_start = offset + position + run_start;
+                let physical_end = offset + position + run_end;
+                if physical_end > content.len() {
+                    content.resize(physical_end, 0);
+                }
+                content[physical_start..physical_end].copy_from_slice(&chunk[run_start..run_end]);
+            };
+
+            for index in 0..chunk_len {
+                if keep() {
+                    if run_start.is_none() {
+                        run_start = Some(index);
+                    }
+                } else if let Some(start) = run_start.take() {
+                    retain_run(start, index);
+                }
+            }
+            if let Some(start) = run_start {
+                retain_run(start, chunk_len);
+            }
+
+            position += chunk_len;
+            bufs.advance(chunk_len);
+        }
+        Ok(())
+    }
+
+    /// Apply a retained resize to durable storage without changing this handle's live contents.
+    pub(crate) fn retain_crash_resize(&self, len: u64) -> Result<(), crate::Error> {
+        let len = len
+            .checked_add(self.data_offset)
+            .ok_or(crate::Error::OffsetOverflow)?;
+        let len: usize = len.try_into().map_err(|_| crate::Error::OffsetOverflow)?;
+
+        let generations = self.generations.lock();
+        if self.ensure_current(&generations).is_err() {
+            return Ok(());
+        }
+        let mut partitions = self.partitions.lock();
+        let content = partitions
+            .get_mut(&self.partition)
+            .and_then(|partition| partition.get_mut(&self.name))
+            .expect("a current blob generation has durable content");
+        content.resize(len, 0);
         Ok(())
     }
 }
@@ -229,15 +413,21 @@ impl crate::Blob for Blob {
         let offset: usize = offset
             .try_into()
             .map_err(|_| crate::Error::OffsetOverflow)?;
+        let required = offset
+            .checked_add(buf.len())
+            .ok_or(crate::Error::OffsetOverflow)?;
         {
             let mut content = self.content.write();
-            let required = offset + buf.len();
             if required > content.len() {
                 content.resize(required, 0);
             }
             content[offset..offset + buf.len()].copy_from_slice(buf.as_ref());
         }
-        if sync { self.sync().await } else { Ok(()) }
+        if sync {
+            self.sync_range_inner(offset, buf.as_ref())
+        } else {
+            Ok(())
+        }
     }
 
     async fn resize(&self, len: u64) -> Result<(), crate::Error> {
@@ -300,6 +490,64 @@ mod tests {
         drop(sync);
         let (_, sync_len) = storage.open("partition", b"sync").await.unwrap();
         assert_eq!(sync_len, 0);
+    }
+
+    #[tokio::test]
+    async fn test_crash_write_merges_durable_bytes_only() {
+        let storage = Storage::new(test_pool());
+        let (blob, _) = storage.open("partition", b"blob").await.unwrap();
+        blob.write_at(0, b"abcdefgh", WriteOptions::default())
+            .await
+            .unwrap();
+        blob.sync().await.unwrap();
+        blob.write_at(0, b"ABCDEFGH", WriteOptions::default())
+            .await
+            .unwrap();
+
+        let mut index = 0usize;
+        blob.retain_crash_write(0, IoBufs::from(&b"12345678"[..]), || {
+            let keep = index % 2 == 1;
+            index += 1;
+            keep
+        })
+        .unwrap();
+
+        let live = blob.read_at(0, 8).await.unwrap();
+        assert_eq!(live.coalesce(), b"ABCDEFGH");
+        let (reopened, len) = storage.open("partition", b"blob").await.unwrap();
+        assert_eq!(len, 8);
+        let durable = reopened.read_at(0, 8).await.unwrap();
+        assert_eq!(durable.coalesce(), b"a2c4e6g8");
+
+        let (sparse, _) = storage.open("partition", b"sparse").await.unwrap();
+        let mut index = 0usize;
+        sparse
+            .retain_crash_write(4, IoBufs::from(&b"xyz"[..]), || {
+                let keep = index == 1;
+                index += 1;
+                keep
+            })
+            .unwrap();
+        let (sparse, len) = storage.open("partition", b"sparse").await.unwrap();
+        assert_eq!(len, 6);
+        assert_eq!(
+            sparse.read_at(0, 6).await.unwrap().coalesce(),
+            b"\0\0\0\0\0y"
+        );
+
+        let (removed, _) = storage.open("partition", b"removed").await.unwrap();
+        storage.remove("partition", Some(b"removed")).await.unwrap();
+        let (replacement, _) = storage.open("partition", b"removed").await.unwrap();
+        replacement
+            .write_at(0, b"new!", WriteOptions::SYNC)
+            .await
+            .unwrap();
+        removed
+            .retain_crash_write(0, IoBufs::from(&b"lost"[..]), || true)
+            .unwrap();
+        let (replacement, len) = storage.open("partition", b"removed").await.unwrap();
+        assert_eq!(len, 4);
+        assert_eq!(replacement.read_at(0, 4).await.unwrap().coalesce(), b"new!");
     }
 
     #[tokio::test]

--- a/runtime/src/tokio/runtime.rs
+++ b/runtime/src/tokio/runtime.rs
@@ -39,11 +39,15 @@ use std::{
     future::Future,
     net::{IpAddr, SocketAddr},
     num::NonZeroUsize,
+    panic::{AssertUnwindSafe, catch_unwind, resume_unwind},
     path::PathBuf,
     sync::Arc,
     time::{Duration, SystemTime},
 };
-use tokio::runtime::{Builder, Runtime};
+use tokio::{
+    runtime::{Builder, Handle as RuntimeHandle},
+    sync::Notify,
+};
 
 #[cfg(feature = "iouring-network")]
 cfg_if::cfg_if! {
@@ -338,10 +342,63 @@ impl Default for Config {
 pub struct Executor {
     registry: Registry,
     metrics: Arc<Metrics>,
-    runtime: Runtime,
+    runtime: RuntimeHandle,
+    tasks: Arc<TaskTracker>,
     shutdown: Mutex<Stopper>,
     panicker: Panicker,
     thread_stack_size: usize,
+}
+
+/// Closes task admission and tracks wrappers through user-future drop and descendant cleanup.
+#[derive(Default)]
+struct TaskTracker {
+    state: Mutex<TaskTrackerState>,
+    idle: Notify,
+}
+
+#[derive(Default)]
+struct TaskTrackerState {
+    active: usize,
+    closed: bool,
+}
+
+impl TaskTracker {
+    fn admit(self: &Arc<Self>) -> Option<TaskGuard> {
+        let mut state = self.state.lock();
+        if state.closed {
+            return None;
+        }
+        state.active = state.active.checked_add(1).expect("active task overflow");
+        Some(TaskGuard(Arc::clone(self)))
+    }
+
+    fn close(&self) {
+        self.state.lock().closed = true;
+    }
+
+    async fn wait(&self) {
+        loop {
+            // Subscribe before checking so the final task cannot notify between the check and wait.
+            let idle = self.idle.notified();
+            if self.state.lock().active == 0 {
+                return;
+            }
+            idle.await;
+        }
+    }
+}
+
+struct TaskGuard(Arc<TaskTracker>);
+
+impl Drop for TaskGuard {
+    fn drop(&mut self) {
+        let mut state = self.0.state.lock();
+        state.active = state.active.checked_sub(1).expect("active task underflow");
+        if state.active == 0 {
+            drop(state);
+            self.0.idle.notify_one();
+        }
+    }
 }
 
 /// Implementation of [crate::Runner] for the `tokio` runtime.
@@ -492,7 +549,8 @@ impl crate::Runner for Runner {
         let executor = Arc::new(Executor {
             registry,
             metrics,
-            runtime,
+            runtime: runtime.handle().clone(),
+            tasks: Arc::new(TaskTracker::default()),
             shutdown: Mutex::new(Stopper::default()),
             panicker,
             thread_stack_size: self.cfg.thread_stack_size,
@@ -504,6 +562,7 @@ impl crate::Runner for Runner {
         let gauge = executor.metrics.tasks_running.get_or_create(&label).clone();
 
         // Run the future
+        let tree = Tree::root();
         let context = Context {
             storage,
             name: label.name(),
@@ -512,13 +571,21 @@ impl crate::Runner for Runner {
             network,
             network_buffer_pool,
             storage_buffer_pool,
-            tree: Tree::root(),
+            tree: Arc::clone(&tree),
             execution: Execution::default(),
         };
-        let output = executor.runtime.block_on(panicked.interrupt(f(context)));
+        let output = catch_unwind(AssertUnwindSafe(|| {
+            runtime.block_on(panicked.interrupt(f(context)))
+        }));
+        executor.tasks.close();
+        tree.abort();
+        runtime.block_on(executor.tasks.wait());
         gauge.dec();
 
-        output
+        match output {
+            Ok(output) => output,
+            Err(panic) => resume_unwind(panic),
+        }
     }
 }
 
@@ -592,6 +659,9 @@ impl crate::Spawner for Context {
 
         // Spawn the task
         let executor = self.executor.clone();
+        let Some(task_guard) = executor.tasks.admit() else {
+            return Handle::closed(metric);
+        };
         let future = f(self);
         let (f, handle) = Handle::init(
             future,
@@ -599,11 +669,15 @@ impl crate::Spawner for Context {
             executor.panicker.clone(),
             Arc::clone(&parent),
         );
+        let f = async move {
+            let _task_guard = task_guard;
+            f.await;
+        };
 
         if matches!(past, Execution::Dedicated) {
             utils::thread::spawn(executor.thread_stack_size, {
                 // Ensure the task can access the tokio runtime
-                let handle = executor.runtime.handle().clone();
+                let handle = executor.runtime.clone();
                 move || {
                     handle.block_on(f);
                 }
@@ -611,7 +685,7 @@ impl crate::Spawner for Context {
         } else if matches!(past, Execution::Shared(true)) {
             executor.runtime.spawn_blocking({
                 // Ensure the task can access the tokio runtime
-                let handle = executor.runtime.handle().clone();
+                let handle = executor.runtime.clone();
                 move || {
                     handle.block_on(f);
                 }
@@ -861,6 +935,106 @@ mod tests {
     };
     use tracing::{Level, error};
 
+    struct TaskDropGate {
+        entered: std::sync::mpsc::Sender<()>,
+        release: std::sync::mpsc::Receiver<()>,
+    }
+
+    impl Drop for TaskDropGate {
+        fn drop(&mut self) {
+            let _ = self.entered.send(());
+            let _ = self.release.recv();
+        }
+    }
+
+    #[derive(Clone, Copy, Debug)]
+    enum RootExit {
+        Return,
+        FuturePanic,
+        ConstructorPanic,
+    }
+
+    fn spawn_drop_gated_task(
+        context: Context,
+        execution: Execution,
+        drop_gate: TaskDropGate,
+        ready: Option<commonware_utils::channel::oneshot::Sender<()>>,
+    ) {
+        let child = match execution {
+            Execution::Dedicated => context.dedicated(),
+            Execution::Shared(blocking) => context.shared(blocking),
+        };
+        child.spawn(move |context| async move {
+            let _context = context;
+            let _drop_gate = drop_gate;
+            if let Some(ready) = ready {
+                ready.send(()).unwrap();
+            }
+            futures::future::pending::<()>().await;
+        });
+    }
+
+    fn assert_runner_drains_spawned_task(execution: Execution, root_exit: RootExit) {
+        let cfg = Config::new();
+        let storage_directory = cfg.storage_directory().clone();
+        let (ready_tx, ready_rx) = commonware_utils::channel::oneshot::channel();
+        let (drop_entered_tx, drop_entered_rx) = std::sync::mpsc::channel();
+        let (drop_release_tx, drop_release_rx) = std::sync::mpsc::channel();
+        let (runner_done_tx, runner_done_rx) = std::sync::mpsc::channel();
+        let runner = std::thread::spawn(move || {
+            let result = std::panic::catch_unwind(AssertUnwindSafe(|| {
+                let drop_gate = TaskDropGate {
+                    entered: drop_entered_tx,
+                    release: drop_release_rx,
+                };
+                match root_exit {
+                    RootExit::ConstructorPanic => {
+                        Runner::new(cfg).start(move |context| -> futures::future::Pending<()> {
+                            spawn_drop_gated_task(context, execution, drop_gate, None);
+                            panic!("root constructor panic after spawning child");
+                        })
+                    }
+                    RootExit::Return | RootExit::FuturePanic => {
+                        Runner::new(cfg).start(move |context| async move {
+                            spawn_drop_gated_task(context, execution, drop_gate, Some(ready_tx));
+                            ready_rx.await.unwrap();
+                            assert!(
+                                matches!(root_exit, RootExit::Return),
+                                "root future panic after spawning child"
+                            );
+                        })
+                    }
+                }
+            }));
+            runner_done_tx.send(result.is_err()).unwrap();
+        });
+
+        drop_entered_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("spawned task was not canceled after the root returned");
+        let early = runner_done_rx.recv_timeout(Duration::from_millis(250));
+        let returned_before_cleanup = match early {
+            Ok(panicked) => Some(panicked),
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => None,
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                panic!("Runner::start exited without reporting its result")
+            }
+        };
+        drop_release_tx.send(()).unwrap();
+        let panicked = returned_before_cleanup.unwrap_or_else(|| {
+            runner_done_rx
+                .recv_timeout(Duration::from_secs(5))
+                .expect("Runner::start did not return after task cleanup completed")
+        });
+        runner.join().unwrap();
+        let _ = std::fs::remove_dir_all(storage_directory);
+        assert!(
+            returned_before_cleanup.is_none(),
+            "Runner::start returned before {execution:?} task cleanup completed"
+        );
+        assert_eq!(panicked, !matches!(root_exit, RootExit::Return));
+    }
+
     #[test]
     fn test_worker_threads_updates_default_buffer_pool_parallelism() {
         let cfg = Config::new().with_worker_threads(8);
@@ -887,6 +1061,77 @@ mod tests {
         assert_eq!(
             cfg.thread_stack_size(),
             utils::thread::system_thread_stack_size()
+        );
+    }
+
+    #[test]
+    fn test_runner_waits_for_spawned_task_cancellation() {
+        for execution in [
+            Execution::Shared(false),
+            Execution::Shared(true),
+            Execution::Dedicated,
+        ] {
+            for root_exit in [
+                RootExit::Return,
+                RootExit::FuturePanic,
+                RootExit::ConstructorPanic,
+            ] {
+                assert_runner_drains_spawned_task(execution, root_exit);
+            }
+        }
+    }
+
+    #[test]
+    fn test_runner_owns_runtime_when_context_escapes() {
+        let cfg = Config::new();
+        let storage_directory = cfg.storage_directory().clone();
+        let (ready_tx, ready_rx) = commonware_utils::channel::oneshot::channel();
+        let (drop_entered_tx, drop_entered_rx) = std::sync::mpsc::channel();
+        let (drop_release_tx, drop_release_rx) = std::sync::mpsc::channel();
+        let (runner_returned_tx, runner_returned_rx) = std::sync::mpsc::channel();
+        let (context_release_tx, context_release_rx) = std::sync::mpsc::channel();
+        let runner = std::thread::spawn(move || {
+            let context = Runner::new(cfg).start(move |context| async move {
+                context.executor.runtime.spawn(async move {
+                    let _drop_gate = TaskDropGate {
+                        entered: drop_entered_tx,
+                        release: drop_release_rx,
+                    };
+                    ready_tx.send(()).unwrap();
+                    futures::future::pending::<()>().await;
+                });
+                ready_rx.await.unwrap();
+                context
+            });
+            runner_returned_tx.send(()).unwrap();
+            context_release_rx.recv().unwrap();
+            drop(context);
+        });
+
+        let returned_early = runner_returned_rx
+            .recv_timeout(Duration::from_millis(500))
+            .is_ok();
+        if returned_early {
+            drop_release_tx.send(()).unwrap();
+            context_release_tx.send(()).unwrap();
+            drop_entered_rx
+                .recv_timeout(Duration::from_secs(5))
+                .expect("escaped Context did not retain the raw runtime task");
+        } else {
+            drop_entered_rx
+                .recv_timeout(Duration::from_secs(5))
+                .expect("Runner did not cancel its raw runtime task");
+            drop_release_tx.send(()).unwrap();
+            runner_returned_rx
+                .recv_timeout(Duration::from_secs(5))
+                .expect("Runner did not return after raw task cleanup");
+            context_release_tx.send(()).unwrap();
+        }
+        runner.join().unwrap();
+        let _ = std::fs::remove_dir_all(storage_directory);
+        assert!(
+            !returned_early,
+            "a returned Context kept the Tokio runtime alive after Runner::start"
         );
     }
 

--- a/runtime/src/tokio/runtime.rs
+++ b/runtime/src/tokio/runtime.rs
@@ -8,7 +8,7 @@ use crate::storage::iouring::{Config as IoUringConfig, Storage as IoUringStorage
 use crate::storage::tokio::{Config as TokioStorageConfig, Storage as TokioStorage};
 use crate::{
     BufferPool, BufferPoolConfig, Clock, Error, Execution, Handle, METRICS_PREFIX, Name, SinkOf,
-    Spawner as _, StreamOf, Supervisor as _, child_label,
+    StreamOf, child_label,
     network::metered::Network as MeteredNetwork,
     prefixed_name,
     process::metered::Metrics as MeteredProcess,
@@ -732,14 +732,7 @@ impl crate::Strategizer for Context {
     fn strategy(&self, parallelism: NonZeroUsize) -> Rayon {
         let pool = ThreadPoolBuilder::new()
             .num_threads(parallelism.get())
-            .spawn_handler(move |thread| {
-                // Tasks spawned in a thread pool are expected to run longer than any single
-                // task and thus should be provisioned as a dedicated thread.
-                self.child("rayon_thread")
-                    .dedicated()
-                    .spawn(move |_| async move { thread.run() });
-                Ok(())
-            })
+            .stack_size(self.executor.thread_stack_size)
             .build()
             .expect("failed to create Tokio Rayon thread pool");
         Rayon::with_pool(Arc::new(pool))
@@ -923,10 +916,11 @@ impl crate::BufferPooler for Context {
 mod tests {
     use super::*;
     use crate::{
-        Metrics, Network, Resolver, Runner as _, Sink, Stream, telemetry::metrics::raw::Counter,
-        tokio::telemetry,
+        Metrics, Network, Resolver, Runner as _, Sink, Spawner as _, Strategizer as _, Stream,
+        Supervisor as _, telemetry::metrics::raw::Counter, tokio::telemetry,
     };
     use bytes::Bytes;
+    use commonware_parallel::Strategy as _;
     use std::{
         self,
         collections::HashMap,
@@ -1035,6 +1029,27 @@ mod tests {
         assert_eq!(panicked, !matches!(root_exit, RootExit::Return));
     }
 
+    fn run_with_returned_strategy(retain: bool) -> Option<Rayon> {
+        let cfg = Config::new();
+        let storage_directory = cfg.storage_directory().clone();
+        let (strategy_tx, strategy_rx) = std::sync::mpsc::channel();
+        let runner = std::thread::spawn(move || {
+            let strategy = Runner::new(cfg).start(move |context| async move {
+                let strategy = context.strategy(NZUsize!(2));
+                strategy.spawn(|_| ()).await;
+                retain.then_some(strategy)
+            });
+            strategy_tx.send(strategy).unwrap();
+        });
+
+        let strategy = strategy_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("Runner::start did not return after the strategy completed work");
+        runner.join().unwrap();
+        let _ = std::fs::remove_dir_all(storage_directory);
+        strategy
+    }
+
     #[test]
     fn test_worker_threads_updates_default_buffer_pool_parallelism() {
         let cfg = Config::new().with_worker_threads(8);
@@ -1133,6 +1148,43 @@ mod tests {
             !returned_early,
             "a returned Context kept the Tokio runtime alive after Runner::start"
         );
+    }
+
+    #[test]
+    fn test_runner_returns_strategy_after_pool_work() {
+        assert!(run_with_returned_strategy(false).is_none());
+
+        let strategy = run_with_returned_strategy(true).unwrap();
+        assert_eq!(futures::executor::block_on(strategy.spawn(|_| 42)), 42);
+    }
+
+    #[test]
+    fn test_runner_resumes_strategy_panic_payload_after_pool_work() {
+        let cfg = Config::new();
+        let storage_directory = cfg.storage_directory().clone();
+        let (strategy_tx, strategy_rx) = std::sync::mpsc::channel();
+        let runner = std::thread::spawn(move || {
+            let result: std::thread::Result<()> =
+                std::panic::catch_unwind(AssertUnwindSafe(|| {
+                    Runner::new(cfg).start(move |context| async move {
+                        let strategy = context.strategy(NZUsize!(2));
+                        strategy.spawn(|_| ()).await;
+                        std::panic::panic_any(strategy);
+                    });
+                }));
+            let strategy = result
+                .expect_err("Runner::start did not resume the root panic")
+                .downcast::<Rayon>()
+                .expect("Runner::start changed the root panic payload");
+            strategy_tx.send(*strategy).unwrap();
+        });
+
+        let strategy = strategy_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("Runner::start did not resume the strategy panic payload");
+        runner.join().unwrap();
+        let _ = std::fs::remove_dir_all(storage_directory);
+        assert_eq!(futures::executor::block_on(strategy.spawn(|_| 42)), 42);
     }
 
     #[test]

--- a/runtime/src/tokio/tracing.rs
+++ b/runtime/src/tokio/tracing.rs
@@ -1,5 +1,6 @@
 //! Utilities to export traces to an OTLP endpoint.
 
+use commonware_utils::Probability;
 use opentelemetry::{global, trace::TracerProvider};
 use opentelemetry_otlp::{ExporterBuildError, SpanExporter, WithExportConfig};
 use opentelemetry_sdk::{
@@ -18,7 +19,7 @@ pub struct Config {
     /// The service name to use for the traces.
     pub name: String,
     /// The sampling rate to use for the traces.
-    pub rate: f64,
+    pub rate: Probability,
 }
 
 /// Export traces to an OTLP endpoint.
@@ -39,7 +40,7 @@ pub fn export(cfg: Config) -> Result<Tracer, ExporterBuildError> {
         .build();
 
     // Build the tracer provider
-    let sampler = Sampler::TraceIdRatioBased(cfg.rate);
+    let sampler = Sampler::TraceIdRatioBased(cfg.rate.as_f64());
     let tracer_provider = SdkTracerProvider::builder()
         .with_span_processor(batch_processor)
         .with_resource(resource)

--- a/storage/fuzz/fuzz_targets/current_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/current_crash_recovery.rs
@@ -229,10 +229,10 @@ fn fuzz_family<F: Graftable>(input: &FuzzInput, suffix_base: &str) {
             let fault_cfg = ctx.storage_fault_config();
             *fault_cfg.write() = deterministic::FaultConfig {
                 sync_rate: Some(sync_failure_rate),
-                write_rate: Some((
-                    write_failure_rate,
-                    (deterministic::PartialWriteMode::Prefix, 0.0),
-                )),
+                write_rate: Some(deterministic::WriteConfig {
+                    failure_rate: write_failure_rate,
+                    mode: deterministic::PartialWriteMode::Subset(0.0),
+                }),
                 ..Default::default()
             };
 

--- a/storage/fuzz/fuzz_targets/current_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/current_crash_recovery.rs
@@ -231,7 +231,8 @@ fn fuzz_family<F: Graftable>(input: &FuzzInput, suffix_base: &str) {
                 sync_rate: Some(sync_failure_rate),
                 write_rate: Some(deterministic::WriteConfig {
                     failure_rate: write_failure_rate,
-                    mode: deterministic::PartialWriteMode::Subset(0.0),
+                    retention_frequency: 0.0,
+                    mode: deterministic::PartialWriteMode::Prefix,
                 }),
                 ..Default::default()
             };

--- a/storage/fuzz/fuzz_targets/current_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/current_crash_recovery.rs
@@ -231,7 +231,7 @@ fn fuzz_family<F: Graftable>(input: &FuzzInput, suffix_base: &str) {
                 sync_rate: Some(sync_failure_rate),
                 write_rate: Some(deterministic::WriteConfig {
                     failure_rate: write_failure_rate,
-                    retention_frequency: 0.0,
+                    retention_rate: 0.0,
                     mode: deterministic::PartialWriteMode::Prefix,
                 }),
                 ..Default::default()

--- a/storage/fuzz/fuzz_targets/current_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/current_crash_recovery.rs
@@ -20,7 +20,7 @@ use commonware_storage::{
     qmdb::current::{VariableConfig, unordered::variable::Db as Current},
     translator::TwoCap,
 };
-use commonware_utils::{NZU64, NZUsize, sequence::FixedBytes};
+use commonware_utils::{NZU64, NZUsize, Probability, sequence::FixedBytes};
 use libfuzzer_sys::fuzz_target;
 use std::{
     collections::HashMap,
@@ -53,9 +53,9 @@ fn bounded_write_buffer(u: &mut Unstructured<'_>) -> Result<usize> {
     u.int_in_range(1..=MAX_WRITE_BUF)
 }
 
-fn bounded_nonzero_rate(u: &mut Unstructured<'_>) -> Result<f64> {
+fn bounded_nonzero_rate(u: &mut Unstructured<'_>) -> Result<Probability> {
     let percent: u8 = u.int_in_range(1..=100)?;
-    Ok(f64::from(percent) / 100.0)
+    Ok(Probability!(u64::from(percent), 100))
 }
 
 /// State-changing operations that exercise disk writes.
@@ -82,9 +82,9 @@ struct FuzzInput {
     #[arbitrary(with = bounded_write_buffer)]
     write_buffer: usize,
     #[arbitrary(with = bounded_nonzero_rate)]
-    sync_failure_rate: f64,
+    sync_failure_rate: Probability,
     #[arbitrary(with = bounded_nonzero_rate)]
-    write_failure_rate: f64,
+    write_failure_rate: Probability,
     operations: Vec<CurrentOperation>,
 }
 
@@ -231,7 +231,7 @@ fn fuzz_family<F: Graftable>(input: &FuzzInput, suffix_base: &str) {
                 sync_rate: Some(sync_failure_rate),
                 write_rate: Some(deterministic::WriteConfig {
                     failure_rate: write_failure_rate,
-                    retention_rate: 0.0,
+                    retention_rate: Probability!(0.0),
                     mode: deterministic::PartialWriteMode::Prefix,
                 }),
                 ..Default::default()

--- a/storage/fuzz/fuzz_targets/current_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/current_crash_recovery.rs
@@ -229,7 +229,10 @@ fn fuzz_family<F: Graftable>(input: &FuzzInput, suffix_base: &str) {
             let fault_cfg = ctx.storage_fault_config();
             *fault_cfg.write() = deterministic::FaultConfig {
                 sync_rate: Some(sync_failure_rate),
-                write_rate: Some(write_failure_rate),
+                write_rate: Some((
+                    write_failure_rate,
+                    (deterministic::PartialWriteMode::Prefix, 0.0),
+                )),
                 ..Default::default()
             };
 

--- a/storage/fuzz/fuzz_targets/journal_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/journal_crash_recovery.rs
@@ -52,7 +52,7 @@ use commonware_storage::journal::{
         variable::{Config as VariableConfig, Journal as VariableJournal},
     },
 };
-use commonware_utils::{NZU64, NZUsize, sequence::FixedBytes};
+use commonware_utils::{NZU64, NZUsize, Probability, sequence::FixedBytes};
 use futures::StreamExt;
 use libfuzzer_sys::fuzz_target;
 use std::{
@@ -100,9 +100,9 @@ fn bounded_write_buffer(u: &mut Unstructured<'_>) -> arbitrary::Result<usize> {
 }
 
 /// A fault rate in [0.0, 1.0]. Allows 0 so the fuzzer can disable individual fault types.
-fn bounded_rate(u: &mut Unstructured<'_>) -> arbitrary::Result<f64> {
+fn bounded_rate(u: &mut Unstructured<'_>) -> arbitrary::Result<Probability> {
     let percent: u8 = u.int_in_range(0..=100)?;
-    Ok(f64::from(percent) / 100.0)
+    Ok(Probability!(u64::from(percent), 100))
 }
 
 /// Op sequence capped at `MAX_OPERATIONS`; a derived `Vec` would instead grow with input length.
@@ -166,19 +166,19 @@ struct FuzzInput {
     write_buffer: usize,
     /// Failure rate for write operations.
     #[arbitrary(with = bounded_rate)]
-    write_failure_rate: f64,
+    write_failure_rate: Probability,
     /// Probability used to retain bytes from a failed or unsynchronized write.
     #[arbitrary(with = bounded_rate)]
-    write_retention_rate: f64,
+    write_retention_rate: Probability,
     /// Failure rate for sync operations.
     #[arbitrary(with = bounded_rate)]
-    sync_failure_rate: f64,
+    sync_failure_rate: Probability,
     /// Failure rate for resize operations (truncation during rewind/prune).
     #[arbitrary(with = bounded_rate)]
-    resize_failure_rate: f64,
+    resize_failure_rate: Probability,
     /// Probability that a resize failure is partial.
     #[arbitrary(with = bounded_rate)]
-    partial_resize_rate: f64,
+    partial_resize_rate: Probability,
     /// Operations to execute, split into one `ops` list per cycle at each `Crash` marker.
     #[arbitrary(with = bounded_operations)]
     operations: Vec<JournalOperation>,
@@ -191,11 +191,11 @@ struct Params {
     page_cache_size: NonZeroUsize,
     items_per_section: u64,
     write_buffer: NonZeroUsize,
-    write_rate: f64,
-    write_retention_rate: f64,
-    sync_rate: f64,
-    resize_rate: f64,
-    partial_resize_rate: f64,
+    write_rate: Probability,
+    write_retention_rate: Probability,
+    sync_rate: Probability,
+    resize_rate: Probability,
+    partial_resize_rate: Probability,
 }
 
 impl Params {
@@ -208,8 +208,10 @@ impl Params {
                 mode: deterministic::PartialWriteMode::Prefix,
             }),
             sync_rate: Some(self.sync_rate),
-            resize_rate: Some(self.resize_rate),
-            partial_resize_rate: Some(self.partial_resize_rate),
+            resize_rate: Some(deterministic::ResizeConfig {
+                failure_rate: self.resize_rate,
+                partial_rate: self.partial_resize_rate,
+            }),
             ..Default::default()
         }
     }

--- a/storage/fuzz/fuzz_targets/journal_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/journal_crash_recovery.rs
@@ -31,7 +31,7 @@
 //! # Faults
 //!
 //! The operation phase runs under write/sync/resize fault injection. `write_retention_frequency`
-//! independently selects which bytes survive a failed or unsynchronized write, while
+//! controls the prefix of a failed or unsynchronized write that survives, while
 //! `partial_resize_rate` can stop a failed truncation at an intermediate length.
 //!
 //! # Positions
@@ -204,7 +204,8 @@ impl Params {
         deterministic::FaultConfig {
             write_rate: Some(deterministic::WriteConfig {
                 failure_rate: self.write_rate,
-                mode: deterministic::PartialWriteMode::Subset(self.write_retention_frequency),
+                retention_frequency: self.write_retention_frequency,
+                mode: deterministic::PartialWriteMode::Prefix,
             }),
             sync_rate: Some(self.sync_rate),
             resize_rate: Some(self.resize_rate),

--- a/storage/fuzz/fuzz_targets/journal_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/journal_crash_recovery.rs
@@ -30,7 +30,7 @@
 //!
 //! # Faults
 //!
-//! The operation phase runs under write/sync/resize fault injection. `write_retention_frequency`
+//! The operation phase runs under write/sync/resize fault injection. `write_retention_rate`
 //! controls the prefix of a failed or unsynchronized write that survives, while
 //! `partial_resize_rate` can stop a failed truncation at an intermediate length.
 //!
@@ -167,9 +167,9 @@ struct FuzzInput {
     /// Failure rate for write operations.
     #[arbitrary(with = bounded_rate)]
     write_failure_rate: f64,
-    /// Frequency with which bytes survive a failed or unsynchronized write.
+    /// Probability used to retain bytes from a failed or unsynchronized write.
     #[arbitrary(with = bounded_rate)]
-    write_retention_frequency: f64,
+    write_retention_rate: f64,
     /// Failure rate for sync operations.
     #[arbitrary(with = bounded_rate)]
     sync_failure_rate: f64,
@@ -192,7 +192,7 @@ struct Params {
     items_per_section: u64,
     write_buffer: NonZeroUsize,
     write_rate: f64,
-    write_retention_frequency: f64,
+    write_retention_rate: f64,
     sync_rate: f64,
     resize_rate: f64,
     partial_resize_rate: f64,
@@ -204,7 +204,7 @@ impl Params {
         deterministic::FaultConfig {
             write_rate: Some(deterministic::WriteConfig {
                 failure_rate: self.write_rate,
-                retention_frequency: self.write_retention_frequency,
+                retention_rate: self.write_retention_rate,
                 mode: deterministic::PartialWriteMode::Prefix,
             }),
             sync_rate: Some(self.sync_rate),
@@ -825,7 +825,7 @@ where
         items_per_section: input.items_per_section,
         write_buffer: NonZeroUsize::new(input.write_buffer).unwrap(),
         write_rate: input.write_failure_rate,
-        write_retention_frequency: input.write_retention_frequency,
+        write_retention_rate: input.write_retention_rate,
         sync_rate: input.sync_failure_rate,
         resize_rate: input.resize_failure_rate,
         partial_resize_rate: input.partial_resize_rate,

--- a/storage/fuzz/fuzz_targets/journal_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/journal_crash_recovery.rs
@@ -2,10 +2,10 @@
 
 //! Fuzz target contiguous journal crash recovery.
 //!
-//! A journal is an append-only log of items. Appends are buffered; `sync` and `commit` push data
-//! to storage, and an unclean shutdown loses anything not yet durable. On the next `init()` the
-//! journal must rebuild a consistent state from whatever survived. This target tests recovering
-//! after storage faults.
+//! A journal is an append-only log of items. Appends are buffered; `sync` and `commit` establish
+//! durability, while the configured crash policy may retain unsynchronized storage mutations. On
+//! the next `init()` the journal must rebuild a consistent state from whatever survived. This
+//! target tests recovering after storage faults.
 //!
 //! # Cycles
 //!
@@ -14,7 +14,8 @@
 //!   1. `init()` recovers the journal left by the previous cycle's crash.
 //!   2. Check it against the `Expected` carried from that crash.
 //!   3. Append and query under fault injection (the cycle's `ops`).
-//!   4. Drop the journal without a clean shutdown: the crash. Unsynced data is lost.
+//!   4. Drop the journal without a clean shutdown: the crash. Unsynchronized bytes survive
+//!      according to the configured write-retention policy.
 //!
 //! `Crash` markers split the op list into one `ops` list per cycle. Driving recovery repeatedly on
 //! the same journal is the point: watermark, pruning-metadata, and section-layout bugs often need a
@@ -29,9 +30,9 @@
 //!
 //! # Faults
 //!
-//! The operation phase runs under write/sync/resize fault injection. The torn-write modes
-//! (`partial_write_rate`, `partial_resize_rate`) cut a write or truncation short, leaving the
-//! half-finished bytes a real crash would.
+//! The operation phase runs under write/sync/resize fault injection. The torn-write settings
+//! (`write_retention_frequency`, `partial_resize_rate`) cut a write or truncation short, leaving
+//! the half-finished bytes a real crash would.
 //!
 //! # Positions
 //!
@@ -166,9 +167,9 @@ struct FuzzInput {
     /// Failure rate for write operations.
     #[arbitrary(with = bounded_rate)]
     write_failure_rate: f64,
-    /// Probability that a write failure is a partial (torn) write.
+    /// Frequency with which bytes survive a failed or unsynchronized write.
     #[arbitrary(with = bounded_rate)]
-    partial_write_rate: f64,
+    write_retention_frequency: f64,
     /// Failure rate for sync operations.
     #[arbitrary(with = bounded_rate)]
     sync_failure_rate: f64,
@@ -191,7 +192,7 @@ struct Params {
     items_per_section: u64,
     write_buffer: NonZeroUsize,
     write_rate: f64,
-    partial_write_rate: f64,
+    write_retention_frequency: f64,
     sync_rate: f64,
     resize_rate: f64,
     partial_resize_rate: f64,
@@ -201,10 +202,15 @@ impl Params {
     /// The fault config applied during the operation phase of each cycle.
     fn fault_config(&self) -> deterministic::FaultConfig {
         deterministic::FaultConfig {
-            write_rate: Some(self.write_rate),
-            partial_write_rate: Some(self.partial_write_rate),
+            write_rate: Some((
+                self.write_rate,
+                (
+                    deterministic::PartialWriteMode::Prefix,
+                    self.write_retention_frequency,
+                ),
+            )),
             sync_rate: Some(self.sync_rate),
-            resize_rate: Some(self.resize_rate),
+            resize_rate: Some((self.resize_rate, 0.0)),
             partial_resize_rate: Some(self.partial_resize_rate),
             ..Default::default()
         }
@@ -821,7 +827,7 @@ where
         items_per_section: input.items_per_section,
         write_buffer: NonZeroUsize::new(input.write_buffer).unwrap(),
         write_rate: input.write_failure_rate,
-        partial_write_rate: input.partial_write_rate,
+        write_retention_frequency: input.write_retention_frequency,
         sync_rate: input.sync_failure_rate,
         resize_rate: input.resize_failure_rate,
         partial_resize_rate: input.partial_resize_rate,

--- a/storage/fuzz/fuzz_targets/journal_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/journal_crash_recovery.rs
@@ -30,9 +30,9 @@
 //!
 //! # Faults
 //!
-//! The operation phase runs under write/sync/resize fault injection. The torn-write settings
-//! (`write_retention_frequency`, `partial_resize_rate`) cut a write or truncation short, leaving
-//! the half-finished bytes a real crash would.
+//! The operation phase runs under write/sync/resize fault injection. `write_retention_frequency`
+//! independently selects which bytes survive a failed or unsynchronized write, while
+//! `partial_resize_rate` can stop a failed truncation at an intermediate length.
 //!
 //! # Positions
 //!
@@ -202,15 +202,12 @@ impl Params {
     /// The fault config applied during the operation phase of each cycle.
     fn fault_config(&self) -> deterministic::FaultConfig {
         deterministic::FaultConfig {
-            write_rate: Some((
-                self.write_rate,
-                (
-                    deterministic::PartialWriteMode::Prefix,
-                    self.write_retention_frequency,
-                ),
-            )),
+            write_rate: Some(deterministic::WriteConfig {
+                failure_rate: self.write_rate,
+                mode: deterministic::PartialWriteMode::Subset(self.write_retention_frequency),
+            }),
             sync_rate: Some(self.sync_rate),
-            resize_rate: Some((self.resize_rate, 0.0)),
+            resize_rate: Some(self.resize_rate),
             partial_resize_rate: Some(self.partial_resize_rate),
             ..Default::default()
         }

--- a/storage/fuzz/fuzz_targets/merkle_full_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/merkle_full_crash_recovery.rs
@@ -252,7 +252,10 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
             let storage_fault_cfg = ctx.storage_fault_config();
             *storage_fault_cfg.write() = deterministic::FaultConfig {
                 sync_rate: Some(sync_failure_rate),
-                write_rate: Some(write_failure_rate),
+                write_rate: Some((
+                    write_failure_rate,
+                    (deterministic::PartialWriteMode::Prefix, 0.0),
+                )),
                 ..Default::default()
             };
 

--- a/storage/fuzz/fuzz_targets/merkle_full_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/merkle_full_crash_recovery.rs
@@ -252,10 +252,10 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
             let storage_fault_cfg = ctx.storage_fault_config();
             *storage_fault_cfg.write() = deterministic::FaultConfig {
                 sync_rate: Some(sync_failure_rate),
-                write_rate: Some((
-                    write_failure_rate,
-                    (deterministic::PartialWriteMode::Prefix, 0.0),
-                )),
+                write_rate: Some(deterministic::WriteConfig {
+                    failure_rate: write_failure_rate,
+                    mode: deterministic::PartialWriteMode::Subset(0.0),
+                }),
                 ..Default::default()
             };
 

--- a/storage/fuzz/fuzz_targets/merkle_full_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/merkle_full_crash_recovery.rs
@@ -254,7 +254,8 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
                 sync_rate: Some(sync_failure_rate),
                 write_rate: Some(deterministic::WriteConfig {
                     failure_rate: write_failure_rate,
-                    mode: deterministic::PartialWriteMode::Subset(0.0),
+                    retention_frequency: 0.0,
+                    mode: deterministic::PartialWriteMode::Prefix,
                 }),
                 ..Default::default()
             };

--- a/storage/fuzz/fuzz_targets/merkle_full_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/merkle_full_crash_recovery.rs
@@ -13,7 +13,7 @@ use commonware_storage::merkle::{
     Bagging::ForwardFold, Family as MerkleFamily, Location, full::Config,
     hasher::Standard as StandardHasher, mmb, mmr,
 };
-use commonware_utils::NZU64;
+use commonware_utils::{NZU64, Probability};
 use libfuzzer_sys::fuzz_target;
 use std::num::{NonZeroU16, NonZeroUsize};
 
@@ -42,9 +42,9 @@ fn bounded_write_buffer(u: &mut Unstructured<'_>) -> Result<usize> {
     u.int_in_range(1..=MAX_WRITE_BUF)
 }
 
-fn bounded_nonzero_rate(u: &mut Unstructured<'_>) -> Result<f64> {
+fn bounded_nonzero_rate(u: &mut Unstructured<'_>) -> Result<Probability> {
     let percent: u8 = u.int_in_range(1..=100)?;
-    Ok(f64::from(percent) / 100.0)
+    Ok(Probability!(u64::from(percent), 100))
 }
 
 /// Operations that can be performed on the Merkle structure.
@@ -79,10 +79,10 @@ struct FuzzInput {
     write_buffer: usize,
     /// Failure rate for sync operations (0, 1].
     #[arbitrary(with = bounded_nonzero_rate)]
-    sync_failure_rate: f64,
+    sync_failure_rate: Probability,
     /// Failure rate for write operations (0, 1].
     #[arbitrary(with = bounded_nonzero_rate)]
-    write_failure_rate: f64,
+    write_failure_rate: Probability,
     /// Sequence of operations to execute.
     operations: Vec<MerkleOperation>,
 }
@@ -254,7 +254,7 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
                 sync_rate: Some(sync_failure_rate),
                 write_rate: Some(deterministic::WriteConfig {
                     failure_rate: write_failure_rate,
-                    retention_rate: 0.0,
+                    retention_rate: Probability!(0.0),
                     mode: deterministic::PartialWriteMode::Prefix,
                 }),
                 ..Default::default()

--- a/storage/fuzz/fuzz_targets/merkle_full_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/merkle_full_crash_recovery.rs
@@ -254,7 +254,7 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
                 sync_rate: Some(sync_failure_rate),
                 write_rate: Some(deterministic::WriteConfig {
                     failure_rate: write_failure_rate,
-                    retention_frequency: 0.0,
+                    retention_rate: 0.0,
                     mode: deterministic::PartialWriteMode::Prefix,
                 }),
                 ..Default::default()

--- a/storage/fuzz/fuzz_targets/queue_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/queue_crash_recovery.rs
@@ -485,7 +485,10 @@ fn fuzz(input: FuzzInput) {
             // Enable fault injection
             let fault_config = deterministic::FaultConfig {
                 sync_rate: Some(sync_failure_rate),
-                write_rate: Some(write_failure_rate),
+                write_rate: Some((
+                    write_failure_rate,
+                    (deterministic::PartialWriteMode::Prefix, 0.0),
+                )),
                 ..Default::default()
             };
             let faults = ctx.storage_fault_config();

--- a/storage/fuzz/fuzz_targets/queue_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/queue_crash_recovery.rs
@@ -11,6 +11,7 @@
 use arbitrary::{Arbitrary, Result, Unstructured};
 use commonware_runtime::{Runner, Supervisor as _, buffer::paged::CacheRef, deterministic};
 use commonware_storage::queue::{Config, Queue};
+use commonware_utils::Probability;
 use libfuzzer_sys::fuzz_target;
 use std::{
     collections::BTreeMap,
@@ -39,9 +40,9 @@ fn bounded_write_buffer(u: &mut Unstructured<'_>) -> Result<usize> {
     u.int_in_range(1..=MAX_WRITE_BUF)
 }
 
-fn bounded_nonzero_rate(u: &mut Unstructured<'_>) -> Result<f64> {
+fn bounded_nonzero_rate(u: &mut Unstructured<'_>) -> Result<Probability> {
     let percent: u8 = u.int_in_range(1..=100)?;
-    Ok(f64::from(percent) / 100.0)
+    Ok(Probability!(u64::from(percent), 100))
 }
 
 /// Operations that can be performed on the queue.
@@ -86,10 +87,10 @@ struct FuzzInput {
     write_buffer: usize,
     /// Failure rate for sync operations (0, 1].
     #[arbitrary(with = bounded_nonzero_rate)]
-    sync_failure_rate: f64,
+    sync_failure_rate: Probability,
     /// Failure rate for write operations (0, 1].
     #[arbitrary(with = bounded_nonzero_rate)]
-    write_failure_rate: f64,
+    write_failure_rate: Probability,
     /// Sequence of operations to execute.
     operations: Vec<QueueOperation>,
 }
@@ -487,7 +488,7 @@ fn fuzz(input: FuzzInput) {
                 sync_rate: Some(sync_failure_rate),
                 write_rate: Some(deterministic::WriteConfig {
                     failure_rate: write_failure_rate,
-                    retention_rate: 0.0,
+                    retention_rate: Probability!(0.0),
                     mode: deterministic::PartialWriteMode::Prefix,
                 }),
                 ..Default::default()

--- a/storage/fuzz/fuzz_targets/queue_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/queue_crash_recovery.rs
@@ -487,7 +487,7 @@ fn fuzz(input: FuzzInput) {
                 sync_rate: Some(sync_failure_rate),
                 write_rate: Some(deterministic::WriteConfig {
                     failure_rate: write_failure_rate,
-                    retention_frequency: 0.0,
+                    retention_rate: 0.0,
                     mode: deterministic::PartialWriteMode::Prefix,
                 }),
                 ..Default::default()

--- a/storage/fuzz/fuzz_targets/queue_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/queue_crash_recovery.rs
@@ -485,10 +485,10 @@ fn fuzz(input: FuzzInput) {
             // Enable fault injection
             let fault_config = deterministic::FaultConfig {
                 sync_rate: Some(sync_failure_rate),
-                write_rate: Some((
-                    write_failure_rate,
-                    (deterministic::PartialWriteMode::Prefix, 0.0),
-                )),
+                write_rate: Some(deterministic::WriteConfig {
+                    failure_rate: write_failure_rate,
+                    mode: deterministic::PartialWriteMode::Subset(0.0),
+                }),
                 ..Default::default()
             };
             let faults = ctx.storage_fault_config();

--- a/storage/fuzz/fuzz_targets/queue_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/queue_crash_recovery.rs
@@ -487,7 +487,8 @@ fn fuzz(input: FuzzInput) {
                 sync_rate: Some(sync_failure_rate),
                 write_rate: Some(deterministic::WriteConfig {
                     failure_rate: write_failure_rate,
-                    mode: deterministic::PartialWriteMode::Subset(0.0),
+                    retention_frequency: 0.0,
+                    mode: deterministic::PartialWriteMode::Prefix,
                 }),
                 ..Default::default()
             };

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -2104,7 +2104,7 @@ mod tests {
             // handle unobserved.
             journal.append(&0).await.unwrap();
             *context.storage_fault_config().write() = deterministic::FaultConfig {
-                write_rate: Some(1.0),
+                write_rate: Some((1.0, (deterministic::PartialWriteMode::Prefix, 0.0))),
                 ..Default::default()
             };
             let (mut journal, handle) = journal.start_sync().await.unwrap();

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -1754,7 +1754,7 @@ mod tests {
             fail_pending_syncs, release_pending_syncs,
         },
     };
-    use commonware_utils::{NZU16, NZU64, NZUsize};
+    use commonware_utils::{NZU16, NZU64, NZUsize, Probability};
     use futures::{StreamExt, pin_mut};
     use std::num::NonZeroU16;
 
@@ -2105,8 +2105,8 @@ mod tests {
             journal.append(&0).await.unwrap();
             *context.storage_fault_config().write() = deterministic::FaultConfig {
                 write_rate: Some(deterministic::WriteConfig {
-                    failure_rate: 1.0,
-                    retention_rate: 0.0,
+                    failure_rate: Probability!(1.0),
+                    retention_rate: Probability!(0.0),
                     mode: deterministic::PartialWriteMode::Prefix,
                 }),
                 ..Default::default()
@@ -2232,7 +2232,7 @@ mod tests {
             // Regression: commit() must force a data sync before callers can rely on recovered
             // bytes beyond the persisted recovery watermark.
             *context.storage_fault_config().write() = deterministic::FaultConfig {
-                sync_rate: Some(1.0),
+                sync_rate: Some(Probability!(1.0)),
                 ..Default::default()
             };
             assert!(
@@ -3301,7 +3301,7 @@ mod tests {
             // Inject sync faults. If commit skipped the recovered tail sync, it would succeed
             // despite the fault.
             *context.storage_fault_config().write() = deterministic::FaultConfig {
-                sync_rate: Some(1.0),
+                sync_rate: Some(Probability!(1.0)),
                 ..Default::default()
             };
             assert!(

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -2104,7 +2104,10 @@ mod tests {
             // handle unobserved.
             journal.append(&0).await.unwrap();
             *context.storage_fault_config().write() = deterministic::FaultConfig {
-                write_rate: Some((1.0, (deterministic::PartialWriteMode::Prefix, 0.0))),
+                write_rate: Some(deterministic::WriteConfig {
+                    failure_rate: 1.0,
+                    mode: deterministic::PartialWriteMode::Subset(0.0),
+                }),
                 ..Default::default()
             };
             let (mut journal, handle) = journal.start_sync().await.unwrap();

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -2106,7 +2106,8 @@ mod tests {
             *context.storage_fault_config().write() = deterministic::FaultConfig {
                 write_rate: Some(deterministic::WriteConfig {
                     failure_rate: 1.0,
-                    mode: deterministic::PartialWriteMode::Subset(0.0),
+                    retention_frequency: 0.0,
+                    mode: deterministic::PartialWriteMode::Prefix,
                 }),
                 ..Default::default()
             };

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -2106,7 +2106,7 @@ mod tests {
             *context.storage_fault_config().write() = deterministic::FaultConfig {
                 write_rate: Some(deterministic::WriteConfig {
                     failure_rate: 1.0,
-                    retention_frequency: 0.0,
+                    retention_rate: 0.0,
                     mode: deterministic::PartialWriteMode::Prefix,
                 }),
                 ..Default::default()

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -2850,7 +2850,7 @@ mod tests {
             *context.storage_fault_config().write() = deterministic::FaultConfig {
                 write_rate: Some(deterministic::WriteConfig {
                     failure_rate: 1.0,
-                    retention_frequency: 0.0,
+                    retention_rate: 0.0,
                     mode: deterministic::PartialWriteMode::Prefix,
                 }),
                 ..Default::default()

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -2587,7 +2587,7 @@ mod tests {
             next_pending_sync, release_pending_syncs,
         },
     };
-    use commonware_utils::{NZU16, NZU64, NZUsize, sequence::FixedBytes};
+    use commonware_utils::{NZU16, NZU64, NZUsize, Probability, sequence::FixedBytes};
     use futures::StreamExt as _;
     use std::num::NonZeroU16;
 
@@ -2849,8 +2849,8 @@ mod tests {
             journal.append(&0).await.unwrap();
             *context.storage_fault_config().write() = deterministic::FaultConfig {
                 write_rate: Some(deterministic::WriteConfig {
-                    failure_rate: 1.0,
-                    retention_rate: 0.0,
+                    failure_rate: Probability!(1.0),
+                    retention_rate: Probability!(0.0),
                     mode: deterministic::PartialWriteMode::Prefix,
                 }),
                 ..Default::default()
@@ -6134,7 +6134,7 @@ mod tests {
                 drop(journal);
 
                 *context.storage_fault_config().write() = deterministic::FaultConfig {
-                    sync_rate: Some(1.0),
+                    sync_rate: Some(Probability!(1.0)),
                     ..Default::default()
                 };
                 assert!(
@@ -6195,7 +6195,7 @@ mod tests {
                 // Fail the offsets metadata sync inside `stage_clear_intent` so `clear_to_size`
                 // aborts before any data is cleared. The reset intent never becomes durable.
                 *context.storage_fault_config().write() = deterministic::FaultConfig {
-                    sync_rate: Some(1.0),
+                    sync_rate: Some(Probability!(1.0)),
                     ..Default::default()
                 };
                 assert!(journal.0.clear_to_size(7).await.is_err());
@@ -6253,7 +6253,7 @@ mod tests {
                 // subsequent `data.clear()` (a blob remove) so `clear_to_size` aborts after the
                 // intent is durable but before the data is cleared.
                 *context.storage_fault_config().write() = deterministic::FaultConfig {
-                    remove_rate: Some(1.0),
+                    remove_rate: Some(Probability!(1.0)),
                     ..Default::default()
                 };
                 assert!(journal.0.clear_to_size(7).await.is_err());

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -2848,7 +2848,10 @@ mod tests {
             // handle unobserved.
             journal.append(&0).await.unwrap();
             *context.storage_fault_config().write() = deterministic::FaultConfig {
-                write_rate: Some((1.0, (deterministic::PartialWriteMode::Prefix, 0.0))),
+                write_rate: Some(deterministic::WriteConfig {
+                    failure_rate: 1.0,
+                    mode: deterministic::PartialWriteMode::Subset(0.0),
+                }),
                 ..Default::default()
             };
             let (mut journal, handle) = journal.start_sync().await.unwrap();

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -2848,7 +2848,7 @@ mod tests {
             // handle unobserved.
             journal.append(&0).await.unwrap();
             *context.storage_fault_config().write() = deterministic::FaultConfig {
-                write_rate: Some(1.0),
+                write_rate: Some((1.0, (deterministic::PartialWriteMode::Prefix, 0.0))),
                 ..Default::default()
             };
             let (mut journal, handle) = journal.start_sync().await.unwrap();

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -2850,7 +2850,8 @@ mod tests {
             *context.storage_fault_config().write() = deterministic::FaultConfig {
                 write_rate: Some(deterministic::WriteConfig {
                     failure_rate: 1.0,
-                    mode: deterministic::PartialWriteMode::Subset(0.0),
+                    retention_frequency: 0.0,
+                    mode: deterministic::PartialWriteMode::Prefix,
                 }),
                 ..Default::default()
             };

--- a/storage/src/journal/segmented/variable.rs
+++ b/storage/src/journal/segmented/variable.rs
@@ -1385,7 +1385,7 @@ mod tests {
                 .await
                 .expect("Failed to re-initialize journal");
             *context.storage_fault_config().write() = deterministic::FaultConfig {
-                resize_rate: Some(1.0),
+                resize_rate: Some((1.0, 0.0)),
                 ..Default::default()
             };
 
@@ -1447,7 +1447,7 @@ mod tests {
                 .await
                 .expect("Failed to re-initialize journal");
             *context.storage_fault_config().write() = deterministic::FaultConfig {
-                resize_rate: Some(1.0),
+                resize_rate: Some((1.0, 0.0)),
                 ..Default::default()
             };
 

--- a/storage/src/journal/segmented/variable.rs
+++ b/storage/src/journal/segmented/variable.rs
@@ -801,7 +801,7 @@ mod tests {
         Blob, BufMut, Runner, Storage, Supervisor as _, WriteOptions, deterministic,
         mocks::{DelayedSyncContext, PendingSyncs, release_pending_syncs},
     };
-    use commonware_utils::{NZU16, NZUsize};
+    use commonware_utils::{NZU16, NZUsize, Probability};
     use std::num::NonZeroU16;
 
     const PAGE_SIZE: NonZeroU16 = NZU16!(1024);
@@ -1385,7 +1385,10 @@ mod tests {
                 .await
                 .expect("Failed to re-initialize journal");
             *context.storage_fault_config().write() = deterministic::FaultConfig {
-                resize_rate: Some(1.0),
+                resize_rate: Some(deterministic::ResizeConfig {
+                    failure_rate: Probability!(1.0),
+                    partial_rate: Probability!(0.0),
+                }),
                 ..Default::default()
             };
 
@@ -1447,7 +1450,10 @@ mod tests {
                 .await
                 .expect("Failed to re-initialize journal");
             *context.storage_fault_config().write() = deterministic::FaultConfig {
-                resize_rate: Some(1.0),
+                resize_rate: Some(deterministic::ResizeConfig {
+                    failure_rate: Probability!(1.0),
+                    partial_rate: Probability!(0.0),
+                }),
                 ..Default::default()
             };
 

--- a/storage/src/journal/segmented/variable.rs
+++ b/storage/src/journal/segmented/variable.rs
@@ -1385,7 +1385,7 @@ mod tests {
                 .await
                 .expect("Failed to re-initialize journal");
             *context.storage_fault_config().write() = deterministic::FaultConfig {
-                resize_rate: Some((1.0, 0.0)),
+                resize_rate: Some(1.0),
                 ..Default::default()
             };
 
@@ -1447,7 +1447,7 @@ mod tests {
                 .await
                 .expect("Failed to re-initialize journal");
             *context.storage_fault_config().write() = deterministic::FaultConfig {
-                resize_rate: Some((1.0, 0.0)),
+                resize_rate: Some(1.0),
                 ..Default::default()
             };
 

--- a/storage/src/qmdb/any/ordered/fixed.rs
+++ b/storage/src/qmdb/any/ordered/fixed.rs
@@ -168,7 +168,7 @@ pub(crate) mod test {
         Runner as _, Supervisor as _,
         deterministic::{self, Context},
     };
-    use commonware_utils::{NZU64, NZUsize, TestRng, sequence::FixedBytes};
+    use commonware_utils::{NZU64, NZUsize, Probability, TestRng, sequence::FixedBytes};
     use futures::StreamExt as _;
     use rand::{Rng, seq::IteratorRandom};
     use std::{
@@ -790,7 +790,7 @@ pub(crate) mod test {
             // across configs, never cached pages), so replay's first item forces a storage read,
             // and with far fewer ops than the routing batch size no batch reaches a worker, so
             // workers never read the log themselves.
-            context.storage_fault_config().write().read_rate = Some(1.0);
+            context.storage_fault_config().write().read_rate = Some(Probability!(1.0));
             let result = index
                 .build_snapshot(
                     context.child("build"),

--- a/storage/src/qmdb/any/unordered/fixed.rs
+++ b/storage/src/qmdb/any/unordered/fixed.rs
@@ -161,7 +161,7 @@ pub(crate) mod test {
         mocks::{DelayedSyncContext, PendingSyncs, drive_pending_syncs},
         reschedule,
     };
-    use commonware_utils::{NZU16, NZU64, NZUsize, TestRng};
+    use commonware_utils::{NZU16, NZU64, NZUsize, Probability, TestRng};
     use core::num::NonZeroUsize;
     use futures::{FutureExt as _, Stream};
     use rand::Rng;
@@ -878,7 +878,7 @@ pub(crate) mod test {
             // across configs, never cached pages), so replay's first item forces a storage read,
             // and with far fewer ops than the routing batch size no batch reaches a worker, so
             // workers never read the log themselves.
-            context.storage_fault_config().write().read_rate = Some(1.0);
+            context.storage_fault_config().write().read_rate = Some(Probability!(1.0));
             let result = index
                 .build_snapshot(
                     context.child("build"),

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -29,6 +29,8 @@ commonware_macros::stability_scope!(BETA {
     pub mod bitmap;
     pub mod cache;
     pub mod ordered;
+    pub mod probability;
+    pub use probability::Probability;
     pub mod range;
 
     use bytes::Buf;

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -7,7 +7,7 @@
 #![cfg_attr(not(any(feature = "std", test)), no_std)]
 
 commonware_macros::stability_scope!(ALPHA, cfg(feature = "std") {
-    pub use rng::{FuzzRng, TestRng, test_rng};
+    pub use rng::{FuzzRng, ScriptedRng, TestRng, test_rng};
 });
 commonware_macros::stability_scope!(BETA {
     #[cfg(not(feature = "std"))]

--- a/utils/src/probability.rs
+++ b/utils/src/probability.rs
@@ -1,5 +1,6 @@
 //! A platform-independent probability value and sampler.
 
+use core::fmt;
 use rand::Rng;
 
 // Number of possible `u64` samples and denominator of the threshold grid.
@@ -20,7 +21,8 @@ pub struct InvalidProbability;
 /// Ratios are rounded down to the nearest multiple of 2^-64. Sampling consumes one `u64` for
 /// probabilities strictly between zero and one, and consumes no randomness for either endpoint.
 /// Given the same sequence of `u64` samples, decisions are identical on every platform.
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Probability(u64);
 
 impl Probability {
@@ -125,6 +127,12 @@ impl TryFrom<f64> for Probability {
 
     fn try_from(value: f64) -> Result<Self, Self::Error> {
         Self::from_f64(value).ok_or(InvalidProbability)
+    }
+}
+
+impl fmt::Debug for Probability {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&self.as_f64(), f)
     }
 }
 

--- a/utils/src/probability.rs
+++ b/utils/src/probability.rs
@@ -1,0 +1,323 @@
+//! A platform-independent probability value and sampler.
+
+use rand::Rng;
+
+// Number of possible `u64` samples and denominator of the threshold grid.
+const SCALE: u128 = 1u128 << u64::BITS;
+
+// Biased `f64` exponent where scaling by 2^64 leaves the 53-bit significand unshifted.
+const SCALED_EXPONENT: u64 = 1023 + 52 - 64;
+
+/// Error returned when an `f64` cannot be represented as a probability.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
+#[error(
+    "probability must be finite, within [0, 1], and exactly representable as a 64-bit threshold"
+)]
+pub struct InvalidProbability;
+
+/// A probability represented as a threshold over all possible `u64` samples.
+///
+/// Ratios are rounded down to the nearest multiple of 2^-64. Sampling consumes one `u64` for
+/// probabilities strictly between zero and one, and consumes no randomness for either endpoint.
+/// Given the same sequence of `u64` samples, decisions are identical on every platform.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct Probability(u64);
+
+impl Probability {
+    /// Creates a probability from `numerator / denominator`.
+    ///
+    /// Returns [`None`] if the denominator is zero or the numerator exceeds the denominator.
+    pub const fn new(numerator: u64, denominator: u64) -> Option<Self> {
+        if denominator == 0 || numerator > denominator {
+            return None;
+        }
+
+        if numerator == denominator {
+            return Some(Self(u64::MAX));
+        }
+
+        let threshold = ((numerator as u128) << u64::BITS) / denominator as u128;
+
+        // A proper fraction with a `u64` denominator is at least 2^-64 below one, so its rounded
+        // threshold cannot collide with the sentinel reserved for probability one.
+        assert!(threshold < u64::MAX as u128);
+        Some(Self(threshold as u64))
+    }
+
+    /// Creates a probability from an `f64` that maps exactly to a 64-bit threshold.
+    ///
+    /// Returns [`None`] if `value` is not finite, is outside `[0, 1]`, or would require rounding.
+    /// The exact IEEE-754 value is preserved rather than interpreting its source spelling as a
+    /// decimal ratio. Use [`TryFrom`] when const evaluation is not required.
+    pub const fn from_f64(value: f64) -> Option<Self> {
+        let bits = value.to_bits();
+        let magnitude = bits & (u64::MAX >> 1);
+
+        if magnitude == 0 {
+            return Some(Self(0));
+        }
+        if bits != magnitude || magnitude > 1.0f64.to_bits() {
+            return None;
+        }
+
+        let exponent = magnitude >> 52;
+        if exponent == 0 {
+            return None;
+        }
+        let significand = (1u64 << 52) | (magnitude & ((1u64 << 52) - 1));
+        if exponent < SCALED_EXPONENT {
+            let shift = (SCALED_EXPONENT - exponent) as u32;
+            if significand.trailing_zeros() < shift {
+                return None;
+            }
+            return Some(Self(significand >> shift));
+        }
+
+        let threshold = (significand as u128) << (exponent - SCALED_EXPONENT);
+        if threshold == SCALE {
+            return Some(Self(u64::MAX));
+        }
+
+        // Exact one is handled above, so the narrowed threshold cannot use its reserved sentinel.
+        assert!(threshold < u64::MAX as u128);
+        Some(Self(threshold as u64))
+    }
+
+    /// Returns whether this probability never occurs.
+    pub const fn is_zero(self) -> bool {
+        self.0 == 0
+    }
+
+    /// Returns whether this probability always occurs.
+    pub const fn is_one(self) -> bool {
+        self.0 == u64::MAX
+    }
+
+    /// Converts this probability to an `f64` in the inclusive range `[0, 1]`.
+    ///
+    /// This conversion is intended for APIs that require floating-point probabilities. Interior
+    /// probabilities remain strictly below one even when rounding to `f64`.
+    pub fn as_f64(self) -> f64 {
+        if self.is_one() {
+            return 1.0;
+        }
+
+        let value = self.0 as f64 / SCALE as f64;
+        if value == 1.0 {
+            f64::from_bits(1.0f64.to_bits() - 1)
+        } else {
+            value
+        }
+    }
+
+    /// Samples this probability using the next `u64` from `rng`.
+    pub fn sample<R: Rng + ?Sized>(self, rng: &mut R) -> bool {
+        match self.0 {
+            0 => false,
+            u64::MAX => true,
+            threshold => rng.next_u64() < threshold,
+        }
+    }
+}
+
+impl TryFrom<f64> for Probability {
+    type Error = InvalidProbability;
+
+    fn try_from(value: f64) -> Result<Self, Self::Error> {
+        Self::from_f64(value).ok_or(InvalidProbability)
+    }
+}
+
+/// Creates a [`Probability`] from an integer ratio or an exactly representable `f64`.
+///
+/// The two-argument form preserves the exact ratio. The one-argument form preserves the exact
+/// IEEE-754 value and accepts only a literal that maps exactly to a 64-bit threshold. Ratio
+/// literals are validated at compile time; ratio expressions are validated at runtime.
+///
+/// # Panics
+///
+/// The ratio expression form panics if its denominator is zero or its numerator exceeds the
+/// denominator. Use [`Probability::new`] or [`Probability::try_from`] to validate untrusted values
+/// without panicking.
+///
+/// # Examples
+///
+/// ```
+/// use commonware_utils::Probability;
+///
+/// const HALF: Probability = Probability!(1, 2);
+/// const NINETY_EIGHT_PERCENT: Probability = Probability!(0.98);
+/// assert_eq!(HALF.as_f64(), 0.5);
+/// assert_eq!(NINETY_EIGHT_PERCENT.as_f64(), 0.98);
+/// ```
+///
+/// ```compile_fail
+/// use commonware_utils::Probability;
+///
+/// const INVALID: Probability = Probability!(2, 1);
+/// ```
+///
+/// ```compile_fail
+/// use commonware_utils::Probability;
+///
+/// const REQUIRES_ROUNDING: Probability = Probability!(1e-20);
+/// ```
+#[cfg(not(any(
+    commonware_stability_GAMMA,
+    commonware_stability_DELTA,
+    commonware_stability_EPSILON,
+    commonware_stability_RESERVED
+)))] // BETA
+#[macro_export]
+macro_rules! Probability {
+    ($value:literal) => {
+        const {
+            $crate::Probability::from_f64($value).expect(
+                "probability requires a value in [0, 1] exactly representable as a 64-bit threshold",
+            )
+        }
+    };
+    ($numerator:literal, $denominator:literal) => {
+        const {
+            $crate::Probability::new($numerator, $denominator)
+                .expect("probability requires a non-zero denominator and numerator <= denominator")
+        }
+    };
+    ($numerator:expr, $denominator:expr) => {
+        $crate::Probability::new($numerator, $denominator)
+            .expect("probability requires a non-zero denominator and numerator <= denominator")
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::convert::Infallible;
+    use rand::TryRng;
+
+    struct CountingRng {
+        value: u64,
+        calls: usize,
+    }
+
+    impl TryRng for CountingRng {
+        type Error = Infallible;
+
+        fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
+            self.calls += 1;
+            Ok(self.value as u32)
+        }
+
+        fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
+            self.calls += 1;
+            Ok(self.value)
+        }
+
+        fn try_fill_bytes(&mut self, dst: &mut [u8]) -> Result<(), Self::Error> {
+            self.calls += 1;
+            dst.fill(0);
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn construction() {
+        assert_eq!(Probability::new(0, u64::MAX), Some(Probability!(0.0)));
+        assert_eq!(
+            Probability::new(u64::MAX, u64::MAX),
+            Some(Probability!(1.0))
+        );
+        assert_eq!(Probability!(1, 2), Probability!(2, 4));
+        assert_eq!(Probability!(1, 2).as_f64(), 0.5);
+        assert!(Probability::new(1, 0).is_none());
+        assert!(Probability::new(2, 1).is_none());
+    }
+
+    #[test]
+    fn f64_construction_preserves_clean_binary_value() {
+        const FROM_LITERAL: Probability = Probability!(0.98);
+        const MINIMUM_INTERIOR: f64 = f64::from_bits(959u64 << 52);
+
+        assert_eq!(FROM_LITERAL.0, 18_077_809_192_235_360_256);
+        assert_eq!(FROM_LITERAL.as_f64(), 0.98);
+        assert_ne!(FROM_LITERAL, Probability!(49, 50));
+        assert_eq!(Probability!(0.5), Probability!(1, 2));
+        assert_eq!(Probability::try_from(0.5), Ok(Probability!(0.5)));
+        assert_eq!(Probability::from_f64(0.0), Some(Probability!(0.0)));
+        assert_eq!(Probability::from_f64(-0.0), Some(Probability!(0.0)));
+        assert_eq!(Probability::from_f64(1.0), Some(Probability!(1.0)));
+        assert_eq!(
+            Probability::from_f64(MINIMUM_INTERIOR),
+            Some(Probability(1))
+        );
+
+        let below_one = f64::from_bits(1.0f64.to_bits() - 1);
+        assert_eq!(
+            Probability::from_f64(below_one).unwrap().as_f64(),
+            below_one
+        );
+    }
+
+    #[test]
+    fn f64_construction_rejects_lossy_or_invalid_values() {
+        const BELOW_MINIMUM: f64 = f64::from_bits(958u64 << 52);
+        const MINIMUM_INTERIOR_BITS: u64 = 959u64 << 52;
+
+        for value in [
+            BELOW_MINIMUM,
+            f64::from_bits(MINIMUM_INTERIOR_BITS + 1),
+            f64::from_bits(1),
+            -0.1,
+            1.1,
+            f64::from_bits(1.0f64.to_bits() + 1),
+            f64::NAN,
+            f64::from_bits(f64::NAN.to_bits() | (1u64 << 63)),
+            f64::INFINITY,
+            f64::NEG_INFINITY,
+        ] {
+            assert!(Probability::from_f64(value).is_none());
+            assert_eq!(Probability::try_from(value), Err(InvalidProbability));
+        }
+    }
+
+    #[test]
+    fn representation_matches_a_raw_rate() {
+        assert_eq!(core::mem::size_of::<Probability>(), size_of::<u64>());
+    }
+
+    #[test]
+    fn ratios_use_platform_independent_thresholds() {
+        assert_eq!(Probability!(1, 3).0 as u128, SCALE / 3);
+        assert_eq!(Probability!(2, 3).0 as u128, (2 * SCALE) / 3);
+
+        let below_one = Probability::new(u64::MAX - 1, u64::MAX).unwrap();
+        assert_eq!(below_one.0, u64::MAX - 1);
+        assert!(below_one.as_f64() < 1.0);
+    }
+
+    #[test]
+    fn sampling_uses_threshold_and_skips_endpoints() {
+        let mut rng = CountingRng { value: 0, calls: 0 };
+        assert!(!Probability!(0.0).sample(&mut rng));
+        assert!(Probability!(1.0).sample(&mut rng));
+        assert_eq!(rng.calls, 0);
+
+        rng.value = (1u64 << 63) - 1;
+        assert!(Probability!(1, 2).sample(&mut rng));
+        assert_eq!(rng.calls, 1);
+
+        rng.value = 1u64 << 63;
+        assert!(!Probability!(1, 2).sample(&mut rng));
+        assert_eq!(rng.calls, 2);
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "probability requires a non-zero denominator and numerator <= denominator"
+    )]
+    fn expression_macro_rejects_invalid_probability() {
+        let numerator = 2;
+        let denominator = 1;
+        let _ = Probability!(numerator, denominator);
+    }
+}

--- a/utils/src/rng.rs
+++ b/utils/src/rng.rs
@@ -70,6 +70,53 @@ pub fn test_rng() -> TestRng {
     TestRng::new(0)
 }
 
+/// A bounded deterministic RNG that returns a caller-supplied sequence of `u64` samples.
+///
+/// Each `u32` consumes one sample and returns its low 32 bits. Byte fills encode samples in
+/// little-endian order and discard unused bytes from the final sample.
+///
+/// Sampling beyond the supplied sequence panics.
+#[stability(ALPHA)]
+#[derive(Debug)]
+pub struct ScriptedRng {
+    samples: std::vec::IntoIter<u64>,
+}
+
+#[stability(ALPHA)]
+impl ScriptedRng {
+    /// Creates a bounded RNG from the provided samples.
+    pub fn new(samples: impl IntoIterator<Item = u64>) -> Self {
+        Self {
+            samples: samples.into_iter().collect::<Vec<_>>().into_iter(),
+        }
+    }
+}
+
+#[stability(ALPHA)]
+impl TryRng for ScriptedRng {
+    type Error = Infallible;
+
+    fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
+        Ok(self.try_next_u64()? as u32)
+    }
+
+    fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
+        Ok(self
+            .samples
+            .next()
+            .expect("scripted RNG consumed more samples than expected"))
+    }
+
+    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Self::Error> {
+        rand::rand_core::utils::fill_bytes_via_next_word(dest, || self.try_next_u64())
+    }
+}
+
+// SAFETY: ScriptedRng is not cryptographically secure. It implements CryptoRng only because test
+// runtimes require CryptoRng-bounded RNGs. This type must never be used outside tests.
+#[stability(ALPHA)]
+impl TryCryptoRng for ScriptedRng {}
+
 /// Applies a SplitMix64-style finalizer to a deterministic input word.
 ///
 /// This is useful for cheaply decorrelating derived deterministic seeds while
@@ -243,6 +290,22 @@ impl TryCryptoRng for FuzzRng {}
 mod tests {
     use super::*;
     use rand::Rng;
+
+    #[test]
+    fn test_scripted_rng_output_forms() {
+        let mut rng = ScriptedRng::new([
+            0x0123_4567_89ab_cdef,
+            0xfedc_ba98_7654_3210,
+            0x0807_0605_0403_0201,
+        ]);
+
+        assert_eq!(rng.try_next_u64().unwrap(), 0x0123_4567_89ab_cdef);
+        assert_eq!(rng.try_next_u32().unwrap(), 0x7654_3210);
+
+        let mut bytes = [0; 5];
+        rng.try_fill_bytes(&mut bytes).unwrap();
+        assert_eq!(bytes, [1, 2, 3, 4, 5]);
+    }
 
     #[test]
     fn test_empty_bytes_not_constant() {


### PR DESCRIPTION
## Summary

Adds the non-atomic crash, durability, and runtime substrate required by atomic blob storage. The layer makes deterministic crashes faithful to pending storage mutations, gives in-memory storage generation-aware durable snapshots, and makes the Tokio runner own and drain spawned tasks during shutdown.

This is a standalone prerequisite targeting `main`, which already contains #4489. It contains no atomic storage API or engine code; the cohesive engine remains in the separate stack beginning with #4490.

The layer owns:

- grouped write and resize fault configuration, with independent operation-failure and crash-retention rates;
- ordered faulty-storage journals for writes, resizes, full-sync durability cuts, and unlinks, with one prefix/subset byte-retention policy shared by failed writes and successful unsynchronized writes;
- generation-aware in-memory snapshots, durable ranges, stale-handle isolation, and crash reconstruction;
- deterministic runtime checkpoint/recovery of storage state, fault configuration, and RNG state; and
- Tokio task admission, ownership, cancellation, and shutdown draining.

## Review focus

- Failure and crash-retention rates remain independent even though each operation groups them in one configuration tuple.
- `start_sync` returns after initiation; its completion handle observes durability without owning or canceling the backing work, and completed cuts retire only earlier debt from the same file generation.
- Crash replay preserves mutation issue order and never exposes a state that the configured retention mode could not produce.
- Replacing or unlinking a generation cannot let an escaped stale handle mutate the new generation.
- Deterministic checkpoints restore storage and fault state together.
- The Tokio runner retains ownership until spawned tasks have been canceled and drained.

## Diff size

| Kind | Added | Removed |
|---|---:|---:|
| Production code | `834` | `101` |
| Tests and test infrastructure | `1,313` | `65` |
| Total | `2,147` | `166` |

Counts are physical diff lines, including comments and blank lines. Test-only files, hooks, and lines inside `#[cfg(test)]` modules are counted as tests; everything else is counted as production code.
