### PR TITLE
[parallel] Pin spawned jobs to their submitter's LLC domain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1794,6 +1794,7 @@ dependencies = [
  "commonware-macros",
  "dashmap",
  "futures",
+ "libc",
  "proptest",
  "rayon",
 ]

--- a/parallel/Cargo.toml
+++ b/parallel/Cargo.toml
@@ -20,7 +20,7 @@ futures = { workspace = true, optional = true }
 rayon = { workspace = true, optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-libc = { workspace = true }
+libc.workspace = true
 
 [dev-dependencies]
 dashmap.workspace = true

--- a/parallel/Cargo.toml
+++ b/parallel/Cargo.toml
@@ -19,6 +19,9 @@ dashmap = { workspace = true, optional = true }
 futures = { workspace = true, optional = true }
 rayon = { workspace = true, optional = true }
 
+[target.'cfg(target_os = "linux")'.dependencies]
+libc = { workspace = true }
+
 [dev-dependencies]
 dashmap.workspace = true
 futures.workspace = true

--- a/parallel/src/lib.rs
+++ b/parallel/src/lib.rs
@@ -1082,9 +1082,10 @@ commonware_macros::stability_scope!(BETA, cfg(any(feature = "std", test)) {
             // Offload: hand the job to the pool. The worker times the job's own wall so we can
             // estimate the inline cost; the returned future times the residual wait once joined.
             let setup_start = measure.then(Instant::now);
-            // The executor pins itself to the submitter's LLC domain for the job's
-            // duration: spawned jobs exchange data with their caller, and a one-time
-            // migration is orders cheaper than cross-domain traffic for the job's life.
+
+            // The executor pins itself to the submitter's LLC domain for the job's duration:
+            // spawned jobs exchange data with their caller, and a one-time migration is orders
+            // cheaper than cross-domain traffic for the job's life.
             let domain = topology::spawn_domain();
             let (tx, mut rx) = oneshot::channel();
             let s = self.clone();

--- a/parallel/src/lib.rs
+++ b/parallel/src/lib.rs
@@ -89,6 +89,7 @@ commonware_macros::stability_scope!(BETA {
             };
 
             mod policy;
+            mod topology;
         } else {
             extern crate alloc;
             use alloc::vec::Vec;
@@ -1081,10 +1082,15 @@ commonware_macros::stability_scope!(BETA, cfg(any(feature = "std", test)) {
             // Offload: hand the job to the pool. The worker times the job's own wall so we can
             // estimate the inline cost; the returned future times the residual wait once joined.
             let setup_start = measure.then(Instant::now);
+            // The executor pins itself to the submitter's LLC domain for the job's
+            // duration: spawned jobs exchange data with their caller, and a one-time
+            // migration is orders cheaper than cross-domain traffic for the job's life.
+            let domain = topology::spawn_domain();
             let (tx, mut rx) = oneshot::channel();
             let s = self.clone();
             let pool = self.thread_pool.clone();
             self.thread_pool.spawn(move || {
+                let _affinity = topology::AffinityGuard::pin(domain);
                 let job_start = measure.then(Instant::now);
                 let result = panic::catch_unwind(AssertUnwindSafe(|| f(s)));
                 let job_wall = job_start.map(|start| start.elapsed());

--- a/parallel/src/topology.rs
+++ b/parallel/src/topology.rs
@@ -1,0 +1,255 @@
+//! Last-level-cache topology and executor affinity for spawned jobs.
+//!
+//! Threads that exchange cache lines pay far more when they sit in different last-level
+//! cache (L3) domains: on multi-CCD parts a cross-domain transfer costs several times a
+//! shared-domain one, and the scheduler's thread placement is a sticky per-process
+//! lottery it never revisits. A spawned job usually has a data relationship with its
+//! submitter (it consumes what the caller just built, and the caller consumes what it
+//! produces), so the job's executor pins itself to the submitter's domain for the job's
+//! duration via [`AffinityGuard`]: one migration the first time (tens of microseconds,
+//! against per-line fabric traffic for the job's lifetime otherwise), and a no-op
+//! afterwards because the restored-wide executor tends to stay where it ran.
+//!
+//! Domains come from the kernel's cache topology (never from vendor core-layout
+//! assumptions, which lie: this was built on a machine whose spec sheet implied 8-core L3
+//! groups while the kernel reported 4-core ones). On non-Linux platforms the stub below
+//! reports a single domain and pinning is a no-op; the same stub serves miri (the
+//! affinity syscalls are unshimmed).
+
+cfg_if::cfg_if! {
+    if #[cfg(all(target_os = "linux", not(miri)))] {
+        use std::sync::OnceLock;
+
+        /// The process-wide topology, detected on first use.
+        fn topology() -> &'static Topology {
+            static TOPOLOGY: OnceLock<Topology> = OnceLock::new();
+            TOPOLOGY.get_or_init(Topology::detect)
+        }
+
+        /// Map from CPU id to last-level-cache domain id, plus each domain's CPU set.
+        pub(crate) struct Topology {
+            /// `cpu_to_domain[cpu]` is the domain of `cpu`; CPUs beyond the table
+            /// (offline or hot-added) map to domain 0.
+            cpu_to_domain: Box<[u16]>,
+            /// The CPUs of each domain, as ready-to-use affinity sets.
+            domain_sets: Box<[libc::cpu_set_t]>,
+        }
+
+        impl Topology {
+            /// Detects the LLC topology; `None` when unreadable or single-domain.
+            fn detect() -> Self {
+                Self::from_sysfs().unwrap_or(Self {
+                    cpu_to_domain: Box::new([]),
+                    domain_sets: Box::new([]),
+                })
+            }
+
+            /// Number of distinct domains (0 or 1 disables the preference and pinning).
+            pub(crate) fn domains(&self) -> usize {
+                self.domain_sets.len()
+            }
+
+            /// The domain of `cpu`.
+            fn domain_of(&self, cpu: usize) -> u16 {
+                self.cpu_to_domain.get(cpu).copied().unwrap_or(0)
+            }
+
+            /// The domain of the CPU the calling thread is currently running on.
+            /// Advisory: the thread may migrate immediately after.
+            pub(crate) fn current_domain(&self) -> u16 {
+                // SAFETY: sched_getcpu takes no arguments and only returns a value; -1
+                // on error (mapped to domain 0 by the table fallback).
+                let cpu = unsafe { libc::sched_getcpu() };
+                if cpu >= 0 {
+                    return self.domain_of(cpu as usize);
+                }
+                0
+            }
+
+            /// Builds the table from
+            /// `/sys/devices/system/cpu/cpu*/cache/index3/shared_cpu_list`. Returns
+            /// `None` if nothing was readable or only one domain exists.
+            fn from_sysfs() -> Option<Self> {
+                let mut lists: Vec<(usize, String)> = Vec::new();
+                let entries = std::fs::read_dir("/sys/devices/system/cpu").ok()?;
+                for entry in entries.flatten() {
+                    let name = entry.file_name();
+                    let name = name.to_string_lossy();
+                    let Some(id) = name
+                        .strip_prefix("cpu")
+                        .and_then(|s| s.parse::<usize>().ok())
+                    else {
+                        continue;
+                    };
+                    let path = entry.path().join("cache/index3/shared_cpu_list");
+                    if let Ok(list) = std::fs::read_to_string(path) {
+                        lists.push((id, list.trim().to_string()));
+                    }
+                }
+                Self::from_lists(&lists)
+            }
+
+            /// Builds the tables from `(cpu, shared_cpu_list)` pairs; each distinct list
+            /// string is one domain. Separated from sysfs reading for testability.
+            fn from_lists(lists: &[(usize, String)]) -> Option<Self> {
+                if lists.is_empty() {
+                    return None;
+                }
+                let max_cpu = lists.iter().map(|(cpu, _)| *cpu).max()?;
+                let mut table = vec![0u16; max_cpu + 1];
+                let mut domains: Vec<&str> = Vec::new();
+                // SAFETY: an all-zero cpu_set_t is the valid empty set.
+                let empty: libc::cpu_set_t = unsafe { std::mem::zeroed() };
+                let mut sets: Vec<libc::cpu_set_t> = Vec::new();
+                for (cpu, list) in lists {
+                    let list = list.as_str();
+                    let domain = match domains.iter().position(|&d| d == list) {
+                        Some(i) => i,
+                        None => {
+                            domains.push(list);
+                            sets.push(empty);
+                            domains.len() - 1
+                        }
+                    };
+                    table[*cpu] = u16::try_from(domain).ok()?;
+                    if *cpu < libc::CPU_SETSIZE as usize {
+                        // SAFETY: cpu is within CPU_SETSIZE and the set is initialized.
+                        unsafe { libc::CPU_SET(*cpu, &mut sets[domain]) };
+                    }
+                }
+                if domains.len() <= 1 {
+                    return None;
+                }
+                Some(Self {
+                    cpu_to_domain: table.into_boxed_slice(),
+                    domain_sets: sets.into_boxed_slice(),
+                })
+            }
+        }
+
+        /// The submitting caller's current LLC domain, captured at spawn time and
+        /// consumed by [`AffinityGuard::pin`] on whichever thread executes the job.
+        /// `None` when the topology has fewer than two domains.
+        #[derive(Clone, Copy)]
+        pub(crate) struct SpawnDomain(u16);
+
+        /// Captures the calling thread's current domain (`None` disables pinning).
+        pub(crate) fn spawn_domain() -> Option<SpawnDomain> {
+            let topology = topology();
+            (topology.domains() > 1).then(|| SpawnDomain(topology.current_domain()))
+        }
+
+        /// Pins the calling thread to a domain's CPU set for its lifetime, restoring the
+        /// previous affinity mask on drop (including unwinds).
+        pub(crate) struct AffinityGuard {
+            saved: libc::cpu_set_t,
+        }
+
+        impl AffinityGuard {
+            /// Pins the calling thread to `domain`'s CPUs. Returns `None` (no pin) if
+            /// the previous mask cannot be read or the new one cannot be applied; the
+            /// job then simply runs wherever it was.
+            pub(crate) fn pin(domain: Option<SpawnDomain>) -> Option<Self> {
+                let domain = domain?;
+                let topology = topology();
+                let target = topology.domain_sets.get(domain.0 as usize)?;
+                // SAFETY: an all-zero cpu_set_t is the valid empty set, filled by
+                // sched_getaffinity below.
+                let mut saved: libc::cpu_set_t = unsafe { std::mem::zeroed() };
+                let size = std::mem::size_of::<libc::cpu_set_t>();
+                // SAFETY: pid 0 is the calling thread; `saved` is a valid set of `size`.
+                if unsafe { libc::sched_getaffinity(0, size, &mut saved) } != 0 {
+                    return None;
+                }
+                // SAFETY: pid 0 is the calling thread; `target` is a valid set of `size`.
+                if unsafe { libc::sched_setaffinity(0, size, target) } != 0 {
+                    return None;
+                }
+                Some(Self { saved })
+            }
+        }
+
+        impl Drop for AffinityGuard {
+            fn drop(&mut self) {
+                let size = std::mem::size_of::<libc::cpu_set_t>();
+                // SAFETY: pid 0 is the calling thread; `saved` is the mask read at pin
+                // time. Restoring wide does not migrate the thread, so a worker that
+                // served a caller tends to stay in that caller's domain: repeat spawns
+                // pin without moving anyone.
+                unsafe { libc::sched_setaffinity(0, size, &self.saved) };
+            }
+        }
+
+        #[cfg(test)]
+        mod tests {
+            use super::*;
+
+            #[test]
+            fn from_lists_groups_and_masks() {
+                let lists: Vec<(usize, String)> = (0..8)
+                    .map(|cpu| {
+                        let list = if cpu < 4 { "0-3" } else { "4-7" };
+                        (cpu, list.to_string())
+                    })
+                    .collect();
+                let topology = Topology::from_lists(&lists).unwrap();
+                assert_eq!(topology.domains(), 2);
+                assert_ne!(topology.domain_of(0), topology.domain_of(4));
+                let d0 = topology.domain_of(0) as usize;
+                for cpu in 0..4 {
+                    // SAFETY: cpu < CPU_SETSIZE; the set was built by from_lists.
+                    assert!(unsafe { libc::CPU_ISSET(cpu, &topology.domain_sets[d0]) });
+                }
+                // SAFETY: as above.
+                assert!(!unsafe { libc::CPU_ISSET(4, &topology.domain_sets[d0]) });
+            }
+
+            #[test]
+            fn from_lists_single_domain_is_none() {
+                let lists: Vec<(usize, String)> =
+                    (0..4).map(|cpu| (cpu, "0-3".to_string())).collect();
+                assert!(Topology::from_lists(&lists).is_none());
+            }
+
+            #[test]
+            fn pin_and_restore_roundtrip() {
+                // Pin to the current domain (a no-op move) and verify the mask restores.
+                // SAFETY: an all-zero cpu_set_t is a valid empty set for getaffinity.
+                let mut before: libc::cpu_set_t = unsafe { std::mem::zeroed() };
+                let size = std::mem::size_of::<libc::cpu_set_t>();
+                // SAFETY: pid 0 = calling thread, valid set.
+                assert_eq!(unsafe { libc::sched_getaffinity(0, size, &mut before) }, 0);
+                {
+                    let _guard = AffinityGuard::pin(spawn_domain());
+                }
+                // SAFETY: as above.
+                let mut after: libc::cpu_set_t = unsafe { std::mem::zeroed() };
+                assert_eq!(unsafe { libc::sched_getaffinity(0, size, &mut after) }, 0);
+                for cpu in 0..(libc::CPU_SETSIZE as usize) {
+                    // SAFETY: cpu < CPU_SETSIZE, valid sets.
+                    let (b, a) = unsafe { (libc::CPU_ISSET(cpu, &before), libc::CPU_ISSET(cpu, &after)) };
+                    assert_eq!(b, a, "mask not restored at cpu {cpu}");
+                }
+            }
+        }
+    } else {
+        /// Single-domain stub: pinning is unavailable and compiles to a no-op.
+        #[derive(Clone, Copy)]
+        pub(crate) struct SpawnDomain;
+
+        /// Always `None`: no multi-domain topology to pin within.
+        pub(crate) fn spawn_domain() -> Option<SpawnDomain> {
+            None
+        }
+
+        /// No-op guard on platforms without affinity control.
+        pub(crate) struct AffinityGuard;
+
+        impl AffinityGuard {
+            /// Never pins.
+            pub(crate) fn pin(_domain: Option<SpawnDomain>) -> Option<Self> {
+                None
+            }
+        }
+    }
+}

--- a/parallel/src/topology.rs
+++ b/parallel/src/topology.rs
@@ -1,20 +1,18 @@
 //! Last-level-cache topology and executor affinity for spawned jobs.
 //!
-//! Threads that exchange cache lines pay far more when they sit in different last-level
-//! cache (L3) domains: on multi-CCD parts a cross-domain transfer costs several times a
-//! shared-domain one, and the scheduler's thread placement is a sticky per-process
-//! lottery it never revisits. A spawned job usually has a data relationship with its
-//! submitter (it consumes what the caller just built, and the caller consumes what it
-//! produces), so the job's executor pins itself to the submitter's domain for the job's
-//! duration via [`AffinityGuard`]: one migration the first time (tens of microseconds,
-//! against per-line fabric traffic for the job's lifetime otherwise), and a no-op
+//! Threads that exchange cache lines pay far more when they sit in different last-level cache (L3)
+//! domains: on multi-CCD parts a cross-domain transfer costs several times a shared-domain one, and
+//! the scheduler's thread placement is a sticky per-process lottery it never revisits. A spawned
+//! job usually has a data relationship with its submitter (it consumes what the caller just built,
+//! and the caller consumes what it produces), so the job's executor pins itself to the submitter's
+//! domain for the job's duration via [`AffinityGuard`]: one migration the first time (tens of
+//! microseconds, against per-line fabric traffic for the job's lifetime otherwise), and a no-op
 //! afterwards because the restored-wide executor tends to stay where it ran.
 //!
-//! Domains come from the kernel's cache topology (never from vendor core-layout
-//! assumptions, which lie: this was built on a machine whose spec sheet implied 8-core L3
-//! groups while the kernel reported 4-core ones). On non-Linux platforms the stub below
-//! reports a single domain and pinning is a no-op; the same stub serves miri (the
-//! affinity syscalls are unshimmed).
+//! Domains come from the kernel's cache topology (never from vendor core-layout assumptions, which
+//! lie: this was built on a machine whose spec sheet implied 8-core L3 groups while the kernel
+//! reported 4-core ones). On non-Linux platforms the stub below reports a single domain and pinning
+//! is a no-op; the same stub serves miri (the affinity syscalls are unshimmed).
 
 cfg_if::cfg_if! {
     if #[cfg(all(target_os = "linux", not(miri)))] {
@@ -98,6 +96,7 @@ cfg_if::cfg_if! {
                 let max_cpu = lists.iter().map(|(cpu, _)| *cpu).max()?;
                 let mut table = vec![0u16; max_cpu + 1];
                 let mut domains: Vec<&str> = Vec::new();
+
                 // SAFETY: an all-zero cpu_set_t is the valid empty set.
                 let empty: libc::cpu_set_t = unsafe { std::mem::zeroed() };
                 let mut sets: Vec<libc::cpu_set_t> = Vec::new();
@@ -127,9 +126,9 @@ cfg_if::cfg_if! {
             }
         }
 
-        /// The submitting caller's current LLC domain, captured at spawn time and
-        /// consumed by [`AffinityGuard::pin`] on whichever thread executes the job.
-        /// `None` when the topology has fewer than two domains.
+        /// The submitting caller's current LLC domain, captured at spawn time and consumed by
+        /// [`AffinityGuard::pin`] on whichever thread executes the job. `None` when the topology
+        /// has fewer than two domains.
         #[derive(Clone, Copy)]
         pub(crate) struct SpawnDomain(u16);
 
@@ -139,33 +138,37 @@ cfg_if::cfg_if! {
             (topology.domains() > 1).then(|| SpawnDomain(topology.current_domain()))
         }
 
-        /// Pins the calling thread to a domain's CPU set for its lifetime, restoring the
-        /// previous affinity mask on drop (including unwinds).
+        /// Pins the calling thread to a domain's CPU set for its lifetime, restoring the previous
+        /// affinity mask on drop (including unwinds).
         pub(crate) struct AffinityGuard {
             saved: libc::cpu_set_t,
         }
 
         impl AffinityGuard {
-            /// Pins the calling thread to the CPUs of `domain` that its current
-            /// affinity mask already allows, so the pin narrows placement and never
-            /// widens it past an operator's restrictions (taskset, numactl, isolated
-            /// cores). Returns `None` (no pin) if the mask cannot be read or applied,
-            /// or if the allowed intersection is empty; the job then simply runs
+            /// Pins the calling thread to the CPUs of `domain` that its current affinity mask
+            /// already allows, so the pin narrows placement and never widens it past an operator's
+            /// restrictions (taskset, numactl, isolated cores). Returns `None` (no pin) if the mask
+            /// cannot be read or applied, or if the allowed intersection is empty; the job then
+            /// simply runs
             /// wherever it was.
             pub(crate) fn pin(domain: Option<SpawnDomain>) -> Option<Self> {
                 let domain = domain?;
                 let topology = topology();
                 let target = topology.domain_sets.get(domain.0 as usize)?;
-                // SAFETY: an all-zero cpu_set_t is the valid empty set, filled by
-                // sched_getaffinity below.
+
+                // SAFETY: an all-zero cpu_set_t is the valid empty set, filled by sched_getaffinity
+                // below.
                 let mut saved: libc::cpu_set_t = unsafe { std::mem::zeroed() };
                 let size = std::mem::size_of::<libc::cpu_set_t>();
+
                 // SAFETY: pid 0 is the calling thread; `saved` is a valid set of `size`.
                 if unsafe { libc::sched_getaffinity(0, size, &mut saved) } != 0 {
                     return None;
                 }
-                // Intersect the domain with the thread's current allowance.
-                // SAFETY: an all-zero cpu_set_t is the valid empty set.
+
+                // Intersect the domain with the thread's current allowance so the pin narrows
+                // placement and never widens it past operator restrictions. SAFETY: an all-zero
+                // cpu_set_t is the valid empty set.
                 let mut effective: libc::cpu_set_t = unsafe { std::mem::zeroed() };
                 let mut allowed = 0usize;
                 for cpu in 0..(libc::CPU_SETSIZE as usize) {
@@ -180,8 +183,8 @@ cfg_if::cfg_if! {
                 if allowed == 0 {
                     return None;
                 }
-                // SAFETY: pid 0 is the calling thread; `effective` is a valid set of
-                // `size`.
+
+                // SAFETY: pid 0 is the calling thread; `effective` is a valid set of `size`.
                 if unsafe { libc::sched_setaffinity(0, size, &effective) } != 0 {
                     return None;
                 }
@@ -192,10 +195,10 @@ cfg_if::cfg_if! {
         impl Drop for AffinityGuard {
             fn drop(&mut self) {
                 let size = std::mem::size_of::<libc::cpu_set_t>();
-                // SAFETY: pid 0 is the calling thread; `saved` is the mask read at pin
-                // time. Restoring wide does not migrate the thread, so a worker that
-                // served a caller tends to stay in that caller's domain: repeat spawns
-                // pin without moving anyone.
+
+                // SAFETY: pid 0 is the calling thread; `saved` is the mask read at pin time.
+                // Restoring wide does not migrate the thread, so a worker that served a caller
+                // tends to stay in that caller's domain: repeat spawns pin without moving anyone.
                 unsafe { libc::sched_setaffinity(0, size, &self.saved) };
             }
         }
@@ -220,6 +223,7 @@ cfg_if::cfg_if! {
                     // SAFETY: cpu < CPU_SETSIZE; the set was built by from_lists.
                     assert!(unsafe { libc::CPU_ISSET(cpu, &topology.domain_sets[d0]) });
                 }
+
                 // SAFETY: as above.
                 assert!(!unsafe { libc::CPU_ISSET(4, &topology.domain_sets[d0]) });
             }
@@ -237,12 +241,15 @@ cfg_if::cfg_if! {
                     // Restrict this thread to its current CPU only.
                     // SAFETY: valid empty set, filled below.
                     let mut only: libc::cpu_set_t = unsafe { std::mem::zeroed() };
+
                     // SAFETY: no arguments; returns a value.
                     let cpu = unsafe { libc::sched_getcpu() };
                     assert!(cpu >= 0);
+
                     // SAFETY: cpu < CPU_SETSIZE (kernel CPU ids are small), valid set.
                     unsafe { libc::CPU_SET(cpu as usize, &mut only) };
                     let size = std::mem::size_of::<libc::cpu_set_t>();
+
                     // SAFETY: pid 0 = this thread, valid set.
                     assert_eq!(unsafe { libc::sched_setaffinity(0, size, &only) }, 0);
 
@@ -272,6 +279,7 @@ cfg_if::cfg_if! {
                 {
                     let _guard = AffinityGuard::pin(spawn_domain());
                 }
+
                 // SAFETY: as above.
                 let mut after: libc::cpu_set_t = unsafe { std::mem::zeroed() };
                 assert_eq!(unsafe { libc::sched_getaffinity(0, size, &mut after) }, 0);

--- a/parallel/src/topology.rs
+++ b/parallel/src/topology.rs
@@ -380,10 +380,12 @@ cfg_if::cfg_if! {
                     unsafe { libc::sched_setaffinity(0, size, &self.saved) };
                 }
 
-                // Release the thread's pin and the domain slot unconditionally. Both
-                // syscalls above proved viable at pin time with the same arguments, so a
-                // failure here can only come from a concurrent external rewrite, which
-                // means the pin's confinement is already gone.
+                // Release the thread's pin and the domain slot unconditionally: cleanup is
+                // best effort. If a call above fails, the likeliest cause is a concurrent
+                // external rewrite that already replaced the confinement, and the worst
+                // case (a worker left narrow with its slot freed) transiently crowds one
+                // domain, whereas retaining the slot on any hiccup would strand domain
+                // capacity for the process lifetime.
                 PINNED.set(false);
                 self.topology.pins[self.domain].fetch_sub(1, Ordering::AcqRel);
             }
@@ -421,10 +423,14 @@ cfg_if::cfg_if! {
             /// real topology, it exists on any machine with four allowed CPUs (each half
             /// needs two so pins can engage), which standard CI runners have.
             fn synthetic_split() -> Option<(&'static Topology, Vec<usize>, Vec<usize>)> {
-                let cpus = allowed_cpus();
+                let mut cpus = allowed_cpus();
                 if cpus.len() < 4 {
                     return None;
                 }
+
+                // Bound the domains so the cap and stress tests spawn a handful of threads
+                // on any machine, rather than hundreds on a wide builder.
+                cpus.truncate(8);
                 let (a, b) = cpus.split_at(cpus.len() / 2);
                 let lists: Vec<(usize, String)> = a
                     .iter()
@@ -759,7 +765,7 @@ cfg_if::cfg_if! {
 
             #[test]
             fn nested_pin_is_refused() {
-                // Success-side assertions live in the synthetic-topology tests below: on the
+                // Success-side assertions live in the synthetic-topology tests: on the
                 // process-global topology, concurrently running tests contend for the same
                 // pin slots, so only a refusal can be asserted deterministically here.
                 std::thread::spawn(|| {

--- a/parallel/src/topology.rs
+++ b/parallel/src/topology.rs
@@ -15,9 +15,11 @@
 //! as this was built on a machine whose spec sheet implied 8-core L3 groups while the kernel
 //! reported 4-core ones). Pinning is skipped whenever it cannot be done safely and profitably: a
 //! single or undetectable domain, a CPU the snapshot does not cover, a failed CPU query, an
-//! operator restriction (taskset, numactl, isolated cores) leaving no allowed CPU in the domain,
-//! or a domain already at its pin cap. On non-Linux platforms the stub below reports no domains
-//! and pinning is a no-op; the same stub serves miri (the affinity syscalls are unshimmed).
+//! operator restriction (taskset, numactl, isolated cores) leaving fewer than two allowed CPUs in
+//! the domain (the caller needs one and the job another), or a domain already holding its cap of
+//! live pins (the allowed CPUs minus one, reserving one for the caller). On non-Linux platforms
+//! the stub below reports no domains and pinning is a no-op; the same stub serves miri (the
+//! affinity syscalls are unshimmed).
 
 cfg_if::cfg_if! {
     if #[cfg(all(target_os = "linux", not(miri)))] {
@@ -41,8 +43,10 @@ cfg_if::cfg_if! {
             cpu_to_domain: Box<[Option<u16>]>,
             /// The CPUs of each domain, as ready-to-use affinity sets.
             domain_sets: Box<[libc::cpu_set_t]>,
-            /// Live pins per domain. Capped so pinned jobs can never crowd a domain: past the
-            /// cap, a job simply runs unpinned wherever the scheduler likes.
+            /// Live pins per domain. Each pin reserves a slot against the domain's effective
+            /// width (its CPUs the pinning thread may use) minus one, so pinned jobs can never
+            /// crowd a domain or the caller working in it: past the cap, a job simply runs
+            /// unpinned wherever the scheduler likes.
             pins: Box<[AtomicUsize]>,
         }
 
@@ -54,15 +58,6 @@ cfg_if::cfg_if! {
                     domain_sets: Box::new([]),
                     pins: Box::new([]),
                 })
-            }
-
-            /// The most live pins a domain accepts: its width minus one, reserving a core for
-            /// the submitting caller (who is usually in the domain and working).
-            fn pin_cap(&self, domain: usize) -> usize {
-                let set = &self.domain_sets[domain];
-                // SAFETY: `set` is a valid cpu_set_t built at detection time.
-                let width = unsafe { libc::CPU_COUNT(set) } as usize;
-                width.saturating_sub(1).max(1)
             }
 
             /// Number of distinct domains (0 or 1 disables the preference and pinning).
@@ -212,28 +207,6 @@ cfg_if::cfg_if! {
                 let topology = topology();
                 let target = topology.domain_sets.get(domain)?;
 
-                // Take a pin slot: a domain accepts at most width minus one live pins, so
-                // concurrent pinned jobs can never crowd it (nor evict the caller). Past the
-                // cap the job runs unpinned.
-                let cap = topology.pin_cap(domain);
-                let pins = &topology.pins[domain];
-                let mut live = pins.load(Ordering::Acquire);
-                loop {
-                    if live >= cap {
-                        return None;
-                    }
-                    match pins.compare_exchange_weak(
-                        live,
-                        live + 1,
-                        Ordering::AcqRel,
-                        Ordering::Acquire,
-                    ) {
-                        Ok(_) => break,
-                        Err(current) => live = current,
-                    }
-                }
-                let slot = PinSlot { domain };
-
                 // SAFETY: an all-zero cpu_set_t is the valid empty set, filled by sched_getaffinity
                 // below.
                 let mut saved: libc::cpu_set_t = unsafe { std::mem::zeroed() };
@@ -258,9 +231,35 @@ cfg_if::cfg_if! {
                         }
                     }
                 }
-                if allowed == 0 {
+
+                // A one-CPU effective set would co-locate the job on the caller's only core
+                // with zero placement freedom; require room for the caller plus this job.
+                if allowed <= 1 {
                     return None;
                 }
+
+                // Take a pin slot against the effective width (not the sysfs domain width,
+                // which operator restrictions may shrink): at most `allowed - 1` live pins,
+                // reserving a CPU for the submitting caller. Past the cap the job runs
+                // unpinned.
+                let cap = allowed - 1;
+                let pins = &topology.pins[domain];
+                let mut live = pins.load(Ordering::Acquire);
+                loop {
+                    if live >= cap {
+                        return None;
+                    }
+                    match pins.compare_exchange_weak(
+                        live,
+                        live + 1,
+                        Ordering::AcqRel,
+                        Ordering::Acquire,
+                    ) {
+                        Ok(_) => break,
+                        Err(current) => live = current,
+                    }
+                }
+                let slot = PinSlot { domain };
 
                 // SAFETY: pid 0 is the calling thread; `effective` is a valid set of `size`.
                 if unsafe { libc::sched_setaffinity(0, size, &effective) } != 0 {
@@ -286,13 +285,18 @@ cfg_if::cfg_if! {
 
         impl Drop for AffinityGuard {
             fn drop(&mut self) {
-                topology().pins[self.domain].fetch_sub(1, Ordering::AcqRel);
                 let size = std::mem::size_of::<libc::cpu_set_t>();
 
-                // SAFETY: pid 0 is the calling thread; `saved` is the mask read at pin time.
-                // Restoring wide does not migrate the thread, so a worker that served a caller
-                // tends to stay in that caller's domain: repeat spawns pin without moving anyone.
-                unsafe { libc::sched_setaffinity(0, size, &self.saved) };
+                // Restore before releasing the slot, so the counter never advertises capacity
+                // while this worker is still pinned. SAFETY: pid 0 is the calling thread;
+                // `saved` is the mask read at pin time. Restoring wide does not migrate the
+                // thread, so a worker that served a caller tends to stay in that caller's
+                // domain: repeat spawns pin without moving anyone.
+                if unsafe { libc::sched_setaffinity(0, size, &self.saved) } == 0 {
+                    topology().pins[self.domain].fetch_sub(1, Ordering::AcqRel);
+                }
+                // A failed restore leaves the worker pinned; its slot stays occupied so the
+                // domain's cap keeps reflecting reality.
             }
         }
 
@@ -375,7 +379,10 @@ cfg_if::cfg_if! {
                     // SAFETY: pid 0 = this thread, valid set.
                     assert_eq!(unsafe { libc::sched_setaffinity(0, size, &only) }, 0);
 
-                    let _guard = AffinityGuard::pin(spawn_domain());
+                    // A one-CPU allowance leaves no room for the caller plus a job, so the
+                    // pin must be skipped outright.
+                    let guard = AffinityGuard::pin(spawn_domain());
+                    assert!(guard.is_none());
 
                     // SAFETY: an all-zero cpu_set_t is the valid empty set.
                     let mut now: libc::cpu_set_t = unsafe { std::mem::zeroed() };

--- a/parallel/src/topology.rs
+++ b/parallel/src/topology.rs
@@ -405,6 +405,13 @@ cfg_if::cfg_if! {
                 let Some(domain) = spawn_domain() else {
                     return;
                 };
+
+                // The environment may forbid pinning outright (e.g. a taskset restriction
+                // leaving fewer than two allowed CPUs in the domain); leak detection needs
+                // an environment where a pin can succeed at all.
+                if AffinityGuard::pin(Some(domain)).is_none() {
+                    return;
+                }
                 for _ in 0..100 {
                     drop(AffinityGuard::pin(Some(domain)));
                 }

--- a/parallel/src/topology.rs
+++ b/parallel/src/topology.rs
@@ -204,8 +204,8 @@ cfg_if::cfg_if! {
             /// Pins the calling thread to the CPUs of `domain` that its current affinity mask
             /// already allows, so the pin narrows placement and never widens it past an operator's
             /// restrictions (taskset, numactl, isolated cores). Returns `None` (no pin) if the mask
-            /// cannot be read or applied, or if the allowed intersection is empty; the job then
-            /// simply runs wherever it was.
+            /// cannot be read or applied, if the allowed intersection is empty, or if the domain is
+            /// already at its pin cap; the job then simply runs wherever it was.
             pub(crate) fn pin(domain: Option<SpawnDomain>) -> Option<Self> {
                 let domain = domain?.0 as usize;
                 let topology = topology();

--- a/parallel/src/topology.rs
+++ b/parallel/src/topology.rs
@@ -16,10 +16,11 @@
 //! reported 4-core ones). Machines whose possible-CPU count exceeds `cpu_set_t`'s capacity report
 //! no domains, since the affinity syscalls could never engage there. Pinning is skipped whenever
 //! it cannot be done safely and profitably: a single or undetectable domain, a CPU the snapshot
-//! does not cover, a failed CPU query, an operator restriction (taskset, numactl, isolated cores)
-//! leaving fewer than two allowed CPUs in the domain (the caller needs one and the job another),
-//! a domain already holding its cap of live pins (the allowed CPUs minus one, reserving one for
-//! the caller), or a thread already pinned by an enclosing job. A mask rewritten mid-job to CPUs
+//! does not cover, a failed CPU query, a mask that cannot be read or applied, an operator
+//! restriction (taskset, numactl, isolated cores) leaving fewer than two allowed CPUs in the
+//! domain (the caller needs one and the job another), a domain already holding its cap of live
+//! pins (the allowed CPUs minus one, reserving one for the caller), or a thread already pinned
+//! by an enclosing job. A mask rewritten mid-job to CPUs
 //! outside the pin is left in place at unpin: the newer placement wins over the pin-time
 //! snapshot. On non-Linux platforms the stub below reports no domains and pinning is a no-op; the
 //! same stub serves miri (the affinity syscalls are unshimmed).
@@ -38,7 +39,7 @@ cfg_if::cfg_if! {
         }
 
         /// Map from CPU id to last-level-cache domain id, plus each domain's CPU set.
-        pub(crate) struct Topology {
+        struct Topology {
             /// `cpu_to_domain[cpu]` is the domain of `cpu`; `None` beyond the table or for CPUs
             /// whose cache topology was unreadable at detection time. Unknown CPUs skip pinning
             /// rather than guess: domain numbering is an artifact of iteration order, so a guess
@@ -82,7 +83,7 @@ cfg_if::cfg_if! {
             }
 
             /// Number of distinct domains (0 or 1 disables the preference and pinning).
-            pub(crate) fn domains(&self) -> usize {
+            fn domains(&self) -> usize {
                 self.domain_sets.len()
             }
 
@@ -94,7 +95,7 @@ cfg_if::cfg_if! {
             /// The domain of the CPU the calling thread is currently running on, or `None` when
             /// the query fails or the snapshot does not cover the CPU. Advisory: the thread may
             /// migrate immediately after.
-            pub(crate) fn current_domain(&self) -> Option<u16> {
+            fn current_domain(&self) -> Option<u16> {
                 // SAFETY: sched_getcpu takes no arguments and only returns a value; -1 on error.
                 let cpu = unsafe { libc::sched_getcpu() };
                 if cpu < 0 {
@@ -382,10 +383,10 @@ cfg_if::cfg_if! {
 
                 // Release the thread's pin and the domain slot unconditionally: cleanup is
                 // best effort. If a call above fails, the likeliest cause is a concurrent
-                // external rewrite that already replaced the confinement, and the worst
-                // case (a worker left narrow with its slot freed) transiently crowds one
-                // domain, whereas retaining the slot on any hiccup would strand domain
-                // capacity for the process lifetime.
+                // external rewrite that already replaced the confinement, but the worst
+                // case may leave this worker narrowed for the rest of the process with its
+                // slot freed. That is still preferred over retaining the slot on any
+                // hiccup, which would strand domain capacity for the process lifetime.
                 PINNED.set(false);
                 self.topology.pins[self.domain].fetch_sub(1, Ordering::AcqRel);
             }
@@ -663,14 +664,17 @@ cfg_if::cfg_if! {
             #[test]
             fn synthetic_nested_pin_refused_then_released() {
                 std::thread::spawn(|| {
-                    let Some((topology, half_a, _)) = synthetic_split() else {
+                    let Some((topology, half_a, half_b)) = synthetic_split() else {
                         return;
                     };
                     let domain = topology.domain_of(half_a[0]).unwrap() as usize;
+                    let other = topology.domain_of(half_b[0]).unwrap() as usize;
                     let outer = AffinityGuard::pin_in(topology, domain).unwrap();
 
-                    // A pinned thread must not pin again, in any domain of any topology.
+                    // A pinned thread must not pin again, in any domain: nested jobs stay
+                    // within the outer confinement.
                     assert!(AffinityGuard::pin_in(topology, domain).is_none());
+                    assert!(AffinityGuard::pin_in(topology, other).is_none());
 
                     // Dropping the outer guard releases the thread's pin and the slot.
                     drop(outer);

--- a/parallel/src/topology.rs
+++ b/parallel/src/topology.rs
@@ -9,10 +9,14 @@
 //! microseconds, against per-line fabric traffic for the job's lifetime otherwise), and a no-op
 //! afterwards because the restored-wide executor tends to stay where it ran.
 //!
-//! Domains come from the kernel's cache topology (never from vendor core-layout assumptions, which
-//! lie: this was built on a machine whose spec sheet implied 8-core L3 groups while the kernel
-//! reported 4-core ones). On non-Linux platforms the stub below reports a single domain and pinning
-//! is a no-op; the same stub serves miri (the affinity syscalls are unshimmed).
+//! Domains come from the kernel's cache topology: for each CPU, the highest-level Data or Unified
+//! leaf under `cache/index*` in sysfs is its last-level cache (the leaf index varies by
+//! architecture, so it is discovered rather than assumed; vendor core-layout assumptions also lie,
+//! as this was built on a machine whose spec sheet implied 8-core L3 groups while the kernel
+//! reported 4-core ones). Pinning is skipped whenever the picture is incomplete: a single or
+//! undetectable domain, a CPU the snapshot does not cover, or a failed CPU query. On non-Linux
+//! platforms the stub below reports no domains and pinning is a no-op; the same stub serves miri
+//! (the affinity syscalls are unshimmed).
 
 cfg_if::cfg_if! {
     if #[cfg(all(target_os = "linux", not(miri)))] {
@@ -26,9 +30,11 @@ cfg_if::cfg_if! {
 
         /// Map from CPU id to last-level-cache domain id, plus each domain's CPU set.
         pub(crate) struct Topology {
-            /// `cpu_to_domain[cpu]` is the domain of `cpu`; CPUs beyond the table
-            /// (offline or hot-added) map to domain 0.
-            cpu_to_domain: Box<[u16]>,
+            /// `cpu_to_domain[cpu]` is the domain of `cpu`; `None` beyond the table or for CPUs
+            /// whose cache topology was unreadable at detection time. Unknown CPUs skip pinning
+            /// rather than guess: domain numbering is an artifact of iteration order, so a guess
+            /// could deliberately migrate a job somewhere unrelated.
+            cpu_to_domain: Box<[Option<u16>]>,
             /// The CPUs of each domain, as ready-to-use affinity sets.
             domain_sets: Box<[libc::cpu_set_t]>,
         }
@@ -47,26 +53,58 @@ cfg_if::cfg_if! {
                 self.domain_sets.len()
             }
 
-            /// The domain of `cpu`.
-            fn domain_of(&self, cpu: usize) -> u16 {
-                self.cpu_to_domain.get(cpu).copied().unwrap_or(0)
+            /// The domain of `cpu`, or `None` when the snapshot does not cover it.
+            fn domain_of(&self, cpu: usize) -> Option<u16> {
+                self.cpu_to_domain.get(cpu).copied().flatten()
             }
 
-            /// The domain of the CPU the calling thread is currently running on.
-            /// Advisory: the thread may migrate immediately after.
-            pub(crate) fn current_domain(&self) -> u16 {
-                // SAFETY: sched_getcpu takes no arguments and only returns a value; -1
-                // on error (mapped to domain 0 by the table fallback).
+            /// The domain of the CPU the calling thread is currently running on, or `None` when
+            /// the query fails or the snapshot does not cover the CPU. Advisory: the thread may
+            /// migrate immediately after.
+            pub(crate) fn current_domain(&self) -> Option<u16> {
+                // SAFETY: sched_getcpu takes no arguments and only returns a value; -1 on error.
                 let cpu = unsafe { libc::sched_getcpu() };
-                if cpu >= 0 {
-                    return self.domain_of(cpu as usize);
+                if cpu < 0 {
+                    return None;
                 }
-                0
+                self.domain_of(cpu as usize)
             }
 
-            /// Builds the table from
-            /// `/sys/devices/system/cpu/cpu*/cache/index3/shared_cpu_list`. Returns
-            /// `None` if nothing was readable or only one domain exists.
+            /// The `shared_cpu_list` of `cpu`'s last-level cache: the highest-level Data or
+            /// Unified leaf under its `cache/index*` directory. The leaf index varies by
+            /// architecture and cache layout, so every leaf is inspected.
+            fn llc_list(cpu_dir: &std::path::Path) -> Option<String> {
+                let mut best: Option<(u32, String)> = None;
+                for entry in std::fs::read_dir(cpu_dir.join("cache")).ok()?.flatten() {
+                    if !entry.file_name().to_string_lossy().starts_with("index") {
+                        continue;
+                    }
+                    let leaf = entry.path();
+                    let Ok(kind) = std::fs::read_to_string(leaf.join("type")) else {
+                        continue;
+                    };
+                    let kind = kind.trim();
+                    if kind != "Data" && kind != "Unified" {
+                        continue;
+                    }
+                    let Some(level) = std::fs::read_to_string(leaf.join("level"))
+                        .ok()
+                        .and_then(|s| s.trim().parse::<u32>().ok())
+                    else {
+                        continue;
+                    };
+                    let Ok(list) = std::fs::read_to_string(leaf.join("shared_cpu_list")) else {
+                        continue;
+                    };
+                    if best.as_ref().is_none_or(|(l, _)| level > *l) {
+                        best = Some((level, list.trim().to_string()));
+                    }
+                }
+                best.map(|(_, list)| list)
+            }
+
+            /// Builds the tables from each CPU's discovered LLC sharing list. Returns `None` if
+            /// nothing was readable or only one domain exists.
             fn from_sysfs() -> Option<Self> {
                 let mut lists: Vec<(usize, String)> = Vec::new();
                 let entries = std::fs::read_dir("/sys/devices/system/cpu").ok()?;
@@ -79,9 +117,8 @@ cfg_if::cfg_if! {
                     else {
                         continue;
                     };
-                    let path = entry.path().join("cache/index3/shared_cpu_list");
-                    if let Ok(list) = std::fs::read_to_string(path) {
-                        lists.push((id, list.trim().to_string()));
+                    if let Some(list) = Self::llc_list(&entry.path()) {
+                        lists.push((id, list));
                     }
                 }
                 Self::from_lists(&lists)
@@ -94,7 +131,7 @@ cfg_if::cfg_if! {
                     return None;
                 }
                 let max_cpu = lists.iter().map(|(cpu, _)| *cpu).max()?;
-                let mut table = vec![0u16; max_cpu + 1];
+                let mut table: Vec<Option<u16>> = vec![None; max_cpu + 1];
                 let mut domains: Vec<&str> = Vec::new();
 
                 // SAFETY: an all-zero cpu_set_t is the valid empty set.
@@ -102,15 +139,12 @@ cfg_if::cfg_if! {
                 let mut sets: Vec<libc::cpu_set_t> = Vec::new();
                 for (cpu, list) in lists {
                     let list = list.as_str();
-                    let domain = match domains.iter().position(|&d| d == list) {
-                        Some(i) => i,
-                        None => {
-                            domains.push(list);
-                            sets.push(empty);
-                            domains.len() - 1
-                        }
-                    };
-                    table[*cpu] = u16::try_from(domain).ok()?;
+                    let domain = domains.iter().position(|&d| d == list).unwrap_or_else(|| {
+                        domains.push(list);
+                        sets.push(empty);
+                        domains.len() - 1
+                    });
+                    table[*cpu] = Some(u16::try_from(domain).ok()?);
                     if *cpu < libc::CPU_SETSIZE as usize {
                         // SAFETY: cpu is within CPU_SETSIZE and the set is initialized.
                         unsafe { libc::CPU_SET(*cpu, &mut sets[domain]) };
@@ -128,14 +162,17 @@ cfg_if::cfg_if! {
 
         /// The submitting caller's current LLC domain, captured at spawn time and consumed by
         /// [`AffinityGuard::pin`] on whichever thread executes the job. `None` when the topology
-        /// has fewer than two domains.
+        /// has fewer than two domains or the caller's position is unknown.
         #[derive(Clone, Copy)]
         pub(crate) struct SpawnDomain(u16);
 
         /// Captures the calling thread's current domain (`None` disables pinning).
         pub(crate) fn spawn_domain() -> Option<SpawnDomain> {
             let topology = topology();
-            (topology.domains() > 1).then(|| SpawnDomain(topology.current_domain()))
+            if topology.domains() <= 1 {
+                return None;
+            }
+            topology.current_domain().map(SpawnDomain)
         }
 
         /// Pins the calling thread to a domain's CPU set for its lifetime, restoring the previous
@@ -149,8 +186,7 @@ cfg_if::cfg_if! {
             /// already allows, so the pin narrows placement and never widens it past an operator's
             /// restrictions (taskset, numactl, isolated cores). Returns `None` (no pin) if the mask
             /// cannot be read or applied, or if the allowed intersection is empty; the job then
-            /// simply runs
-            /// wherever it was.
+            /// simply runs wherever it was.
             pub(crate) fn pin(domain: Option<SpawnDomain>) -> Option<Self> {
                 let domain = domain?;
                 let topology = topology();
@@ -218,7 +254,7 @@ cfg_if::cfg_if! {
                 let topology = Topology::from_lists(&lists).unwrap();
                 assert_eq!(topology.domains(), 2);
                 assert_ne!(topology.domain_of(0), topology.domain_of(4));
-                let d0 = topology.domain_of(0) as usize;
+                let d0 = topology.domain_of(0).unwrap() as usize;
                 for cpu in 0..4 {
                     // SAFETY: cpu < CPU_SETSIZE; the set was built by from_lists.
                     assert!(unsafe { libc::CPU_ISSET(cpu, &topology.domain_sets[d0]) });
@@ -226,6 +262,35 @@ cfg_if::cfg_if! {
 
                 // SAFETY: as above.
                 assert!(!unsafe { libc::CPU_ISSET(4, &topology.domain_sets[d0]) });
+            }
+
+            #[test]
+            fn unknown_cpus_have_no_domain() {
+                // CPU 5 is missing from the snapshot; CPUs beyond the table are unknown too.
+                let lists: Vec<(usize, String)> = [0, 1, 2, 3, 4, 6, 7]
+                    .into_iter()
+                    .map(|cpu| {
+                        let list = if cpu < 4 { "0-3" } else { "4-7" };
+                        (cpu, list.to_string())
+                    })
+                    .collect();
+                let topology = Topology::from_lists(&lists).unwrap();
+                assert_eq!(topology.domain_of(5), None);
+                assert_eq!(topology.domain_of(64), None);
+                assert!(topology.domain_of(6).is_some());
+            }
+
+            #[test]
+            fn llc_discovery_reads_a_real_cpu() {
+                // On any Linux machine with a readable cache topology, discovery must return a
+                // non-empty sharing list for cpu0 (or nothing at all, never a panic).
+                let dir = std::path::Path::new("/sys/devices/system/cpu/cpu0");
+                if !dir.exists() {
+                    return;
+                }
+                if let Some(list) = Topology::llc_list(dir) {
+                    assert!(!list.is_empty());
+                }
             }
 
             #[test]
@@ -296,7 +361,7 @@ cfg_if::cfg_if! {
         pub(crate) struct SpawnDomain;
 
         /// Always `None`: no multi-domain topology to pin within.
-        pub(crate) fn spawn_domain() -> Option<SpawnDomain> {
+        pub(crate) const fn spawn_domain() -> Option<SpawnDomain> {
             None
         }
 
@@ -305,7 +370,7 @@ cfg_if::cfg_if! {
 
         impl AffinityGuard {
             /// Never pins.
-            pub(crate) fn pin(_domain: Option<SpawnDomain>) -> Option<Self> {
+            pub(crate) const fn pin(_domain: Option<SpawnDomain>) -> Option<Self> {
                 None
             }
         }

--- a/parallel/src/topology.rs
+++ b/parallel/src/topology.rs
@@ -13,13 +13,16 @@
 //! leaf under `cache/index*` in sysfs is its last-level cache (the leaf index varies by
 //! architecture, so it is discovered rather than assumed; vendor core-layout assumptions also lie,
 //! as this was built on a machine whose spec sheet implied 8-core L3 groups while the kernel
-//! reported 4-core ones). Pinning is skipped whenever it cannot be done safely and profitably: a
-//! single or undetectable domain, a CPU the snapshot does not cover, a failed CPU query, an
-//! operator restriction (taskset, numactl, isolated cores) leaving fewer than two allowed CPUs in
-//! the domain (the caller needs one and the job another), or a domain already holding its cap of
-//! live pins (the allowed CPUs minus one, reserving one for the caller). On non-Linux platforms
-//! the stub below reports no domains and pinning is a no-op; the same stub serves miri (the
-//! affinity syscalls are unshimmed).
+//! reported 4-core ones). Machines whose possible-CPU count exceeds `cpu_set_t`'s capacity report
+//! no domains, since the affinity syscalls could never engage there. Pinning is skipped whenever
+//! it cannot be done safely and profitably: a single or undetectable domain, a CPU the snapshot
+//! does not cover, a failed CPU query, an operator restriction (taskset, numactl, isolated cores)
+//! leaving fewer than two allowed CPUs in the domain (the caller needs one and the job another),
+//! a domain already holding its cap of live pins (the allowed CPUs minus one, reserving one for
+//! the caller), or a thread already pinned by an enclosing job. A mask rewritten mid-job to CPUs
+//! outside the pin is left in place at unpin: the newer placement wins over the pin-time
+//! snapshot. On non-Linux platforms the stub below reports no domains and pinning is a no-op; the
+//! same stub serves miri (the affinity syscalls are unshimmed).
 
 cfg_if::cfg_if! {
     if #[cfg(all(target_os = "linux", not(miri)))] {
@@ -51,13 +54,31 @@ cfg_if::cfg_if! {
         }
 
         impl Topology {
-            /// Detects the LLC topology; `None` when unreadable or single-domain.
+            /// Detects the LLC topology; empty when unreadable, single-domain, or unpinnable.
             fn detect() -> Self {
-                Self::from_sysfs().unwrap_or(Self {
+                // One probe before reading sysfs: when the kernel's possible-CPU count
+                // exceeds cpu_set_t's capacity, sched_getaffinity fails outright (even if
+                // every CPU id visible in sysfs is small), so pinning could never engage.
+                // Report no domains rather than charge every spawn for a doomed syscall
+                // sequence.
+                // SAFETY: an all-zero cpu_set_t is the valid empty set, filled below.
+                let mut probe: libc::cpu_set_t = unsafe { std::mem::zeroed() };
+                let size = std::mem::size_of::<libc::cpu_set_t>();
+
+                // SAFETY: pid 0 is the calling thread; `probe` is a valid set of `size`.
+                if unsafe { libc::sched_getaffinity(0, size, &mut probe) } != 0 {
+                    return Self::empty();
+                }
+                Self::from_sysfs().unwrap_or_else(Self::empty)
+            }
+
+            /// A topology with no domains: the preference and pinning are disabled.
+            fn empty() -> Self {
+                Self {
                     cpu_to_domain: Box::new([]),
                     domain_sets: Box::new([]),
                     pins: Box::new([]),
-                })
+                }
             }
 
             /// Number of distinct domains (0 or 1 disables the preference and pinning).
@@ -142,6 +163,15 @@ cfg_if::cfg_if! {
                 if lists.is_empty() {
                     return None;
                 }
+
+                // cpu_set_t cannot represent CPUs past CPU_SETSIZE, so a topology containing
+                // one could never be pinned within faithfully: report none.
+                if lists
+                    .iter()
+                    .any(|(cpu, _)| *cpu >= libc::CPU_SETSIZE as usize)
+                {
+                    return None;
+                }
                 let max_cpu = lists.iter().map(|(cpu, _)| *cpu).max()?;
                 let mut table: Vec<Option<u16>> = vec![None; max_cpu + 1];
                 let mut domains: Vec<&str> = Vec::new();
@@ -157,10 +187,10 @@ cfg_if::cfg_if! {
                         domains.len() - 1
                     });
                     table[*cpu] = Some(u16::try_from(domain).ok()?);
-                    if *cpu < libc::CPU_SETSIZE as usize {
-                        // SAFETY: cpu is within CPU_SETSIZE and the set is initialized.
-                        unsafe { libc::CPU_SET(*cpu, &mut sets[domain]) };
-                    }
+
+                    // SAFETY: cpu is within CPU_SETSIZE (checked above) and the set is
+                    // initialized.
+                    unsafe { libc::CPU_SET(*cpu, &mut sets[domain]) };
                 }
                 if domains.len() <= 1 {
                     return None;
@@ -189,22 +219,43 @@ cfg_if::cfg_if! {
             topology.current_domain().map(SpawnDomain)
         }
 
+        std::thread_local! {
+            /// Whether this thread currently holds a live [`AffinityGuard`]. A worker that
+            /// picks up nested jobs while pinned must not pin again: the thread occupies one
+            /// CPU no matter how deep its stack of jobs, so a second guard would burn a
+            /// second cap slot and cap-reject a genuinely distinct worker.
+            static PINNED: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+        }
+
         /// Pins the calling thread to a domain's CPU set for its lifetime, restoring the previous
-        /// affinity mask on drop (including unwinds).
+        /// affinity mask on drop (including unwinds) unless the thread's mask was rewritten
+        /// mid-job to CPUs outside the pin, in which case that newer placement is left in place.
         pub(crate) struct AffinityGuard {
             saved: libc::cpu_set_t,
+            effective: libc::cpu_set_t,
+            topology: &'static Topology,
             domain: usize,
         }
 
         impl AffinityGuard {
             /// Pins the calling thread to the CPUs of `domain` that its current affinity mask
             /// already allows, so the pin narrows placement and never widens it past an operator's
-            /// restrictions (taskset, numactl, isolated cores). Returns `None` (no pin) if the mask
-            /// cannot be read or applied, if the allowed intersection is empty, or if the domain is
-            /// already at its pin cap; the job then simply runs wherever it was.
+            /// restrictions (taskset, numactl, isolated cores). Returns `None` (no pin) if the
+            /// thread already holds a pin (nested jobs stay within the outer confinement), if the
+            /// mask cannot be read or applied, if the allowed intersection has fewer than two
+            /// CPUs, or if the domain is already at its pin cap; the job then simply runs
+            /// wherever it was.
             pub(crate) fn pin(domain: Option<SpawnDomain>) -> Option<Self> {
-                let domain = domain?.0 as usize;
-                let topology = topology();
+                Self::pin_in(topology(), domain?.0 as usize)
+            }
+
+            /// [`Self::pin`] against an explicit topology, letting tests drive the full pin
+            /// protocol (intersection, cap accounting, apply and restore) on synthetic
+            /// domains.
+            fn pin_in(topology: &'static Topology, domain: usize) -> Option<Self> {
+                if PINNED.get() {
+                    return None;
+                }
                 let target = topology.domain_sets.get(domain)?;
 
                 // SAFETY: an all-zero cpu_set_t is the valid empty set, filled by sched_getaffinity
@@ -259,7 +310,7 @@ cfg_if::cfg_if! {
                         Err(current) => live = current,
                     }
                 }
-                let slot = PinSlot { domain };
+                let slot = PinSlot { topology, domain };
 
                 // SAFETY: pid 0 is the calling thread; `effective` is a valid set of `size`.
                 if unsafe { libc::sched_setaffinity(0, size, &effective) } != 0 {
@@ -268,18 +319,25 @@ cfg_if::cfg_if! {
 
                 // The mask is applied: the guard now owns both the restore and the slot.
                 core::mem::forget(slot);
-                Some(Self { saved, domain })
+                PINNED.set(true);
+                Some(Self {
+                    saved,
+                    effective,
+                    topology,
+                    domain,
+                })
             }
         }
 
         /// Releases a reserved pin slot if `pin` bails before the mask is applied.
         struct PinSlot {
+            topology: &'static Topology,
             domain: usize,
         }
 
         impl Drop for PinSlot {
             fn drop(&mut self) {
-                topology().pins[self.domain].fetch_sub(1, Ordering::AcqRel);
+                self.topology.pins[self.domain].fetch_sub(1, Ordering::AcqRel);
             }
         }
 
@@ -287,16 +345,47 @@ cfg_if::cfg_if! {
             fn drop(&mut self) {
                 let size = std::mem::size_of::<libc::cpu_set_t>();
 
-                // Restore before releasing the slot, so the counter never advertises capacity
-                // while this worker is still pinned. SAFETY: pid 0 is the calling thread;
-                // `saved` is the mask read at pin time. Restoring wide does not migrate the
-                // thread, so a worker that served a caller tends to stay in that caller's
-                // domain: repeat spawns pin without moving anyone.
-                if unsafe { libc::sched_setaffinity(0, size, &self.saved) } == 0 {
-                    topology().pins[self.domain].fetch_sub(1, Ordering::AcqRel);
+                // Restore only if the thread's mask is still within the one this pin applied:
+                // equal in the common case, or clamped to a subset by the kernel while a CPU
+                // is offline (sched_getaffinity reports only online CPUs, and an offline CPU
+                // does not rewrite the stored mask). A mask straying outside the pin means an
+                // operator or the kernel rewrote it mid-job (taskset -pa, a cgroup cpuset
+                // migration), and that newer placement wins: writing the pin-time snapshot
+                // back would resurrect an allowance the operator may have just revoked. (A
+                // rewrite landing within the pin's own CPUs is indistinguishable from the pin
+                // and gets restored over.)
+                // SAFETY: an all-zero cpu_set_t is the valid empty set, filled below.
+                let mut current: libc::cpu_set_t = unsafe { std::mem::zeroed() };
+
+                // SAFETY: pid 0 is the calling thread; `current` is a valid set of `size`.
+                let mut ours = unsafe { libc::sched_getaffinity(0, size, &mut current) } == 0;
+                if ours {
+                    for cpu in 0..(libc::CPU_SETSIZE as usize) {
+                        // SAFETY: cpu is within CPU_SETSIZE; both sets are valid.
+                        let strayed = unsafe {
+                            libc::CPU_ISSET(cpu, &current)
+                                && !libc::CPU_ISSET(cpu, &self.effective)
+                        };
+                        if strayed {
+                            ours = false;
+                            break;
+                        }
+                    }
                 }
-                // A failed restore leaves the worker pinned; its slot stays occupied so the
-                // domain's cap keeps reflecting reality.
+                if ours {
+                    // SAFETY: pid 0 is the calling thread; `saved` is the mask read at pin
+                    // time. Restoring wide does not migrate the thread, so a worker that
+                    // served a caller tends to stay in that caller's domain: repeat spawns
+                    // pin without moving anyone.
+                    unsafe { libc::sched_setaffinity(0, size, &self.saved) };
+                }
+
+                // Release the thread's pin and the domain slot unconditionally. Both
+                // syscalls above proved viable at pin time with the same arguments, so a
+                // failure here can only come from a concurrent external rewrite, which
+                // means the pin's confinement is already gone.
+                PINNED.set(false);
+                self.topology.pins[self.domain].fetch_sub(1, Ordering::AcqRel);
             }
         }
 
@@ -362,6 +451,17 @@ cfg_if::cfg_if! {
             }
 
             #[test]
+            fn from_lists_rejects_cpus_past_setsize() {
+                // cpu_set_t cannot represent such CPUs, so the machine must report no
+                // topology instead of pinning within a truncated view of it.
+                let lists = vec![
+                    (0, "a".to_string()),
+                    (libc::CPU_SETSIZE as usize, "b".to_string()),
+                ];
+                assert!(Topology::from_lists(&lists).is_none());
+            }
+
+            #[test]
             fn pin_never_widens_a_restricted_mask() {
                 std::thread::spawn(|| {
                     // Restrict this thread to its current CPU only.
@@ -372,7 +472,14 @@ cfg_if::cfg_if! {
                     let cpu = unsafe { libc::sched_getcpu() };
                     assert!(cpu >= 0);
 
-                    // SAFETY: cpu < CPU_SETSIZE (kernel CPU ids are small), valid set.
+                    // The libc crate's CPU_SET is unguarded past CPU_SETSIZE; such ids also
+                    // mean the machine cannot pin at all (see from_lists), so there is
+                    // nothing to test.
+                    if cpu as usize >= libc::CPU_SETSIZE as usize {
+                        return;
+                    }
+
+                    // SAFETY: cpu was bounds-checked against CPU_SETSIZE above; valid set.
                     unsafe { libc::CPU_SET(cpu as usize, &mut only) };
                     let size = std::mem::size_of::<libc::cpu_set_t>();
 
@@ -416,6 +523,27 @@ cfg_if::cfg_if! {
                     drop(AffinityGuard::pin(Some(domain)));
                 }
                 assert!(AffinityGuard::pin(Some(domain)).is_some());
+            }
+
+            #[test]
+            fn nested_pin_is_refused() {
+                // Success-side assertions live in the synthetic-topology tests below: on the
+                // process-global topology, concurrently running tests contend for the same
+                // pin slots, so only a refusal can be asserted deterministically here.
+                std::thread::spawn(|| {
+                    let Some(domain) = spawn_domain() else {
+                        return;
+                    };
+                    let Some(_outer) = AffinityGuard::pin(Some(domain)) else {
+                        return;
+                    };
+
+                    // A pinned thread occupies one CPU regardless of nesting depth; a nested
+                    // pin must be refused rather than burn a second cap slot.
+                    assert!(AffinityGuard::pin(Some(domain)).is_none());
+                })
+                .join()
+                .unwrap();
             }
 
             #[test]

--- a/parallel/src/topology.rs
+++ b/parallel/src/topology.rs
@@ -392,6 +392,48 @@ cfg_if::cfg_if! {
         #[cfg(test)]
         mod tests {
             use super::*;
+            use std::sync::atomic::AtomicBool;
+
+            /// The calling thread's current affinity mask.
+            fn current_mask() -> libc::cpu_set_t {
+                // SAFETY: an all-zero cpu_set_t is the valid empty set, filled below.
+                let mut mask: libc::cpu_set_t = unsafe { std::mem::zeroed() };
+                let size = std::mem::size_of::<libc::cpu_set_t>();
+
+                // SAFETY: pid 0 is the calling thread; `mask` is a valid set of `size`.
+                assert_eq!(unsafe { libc::sched_getaffinity(0, size, &mut mask) }, 0);
+                mask
+            }
+
+            /// The CPUs the calling thread may currently use.
+            fn allowed_cpus() -> Vec<usize> {
+                let mask = current_mask();
+                (0..(libc::CPU_SETSIZE as usize))
+                    // SAFETY: cpu is within CPU_SETSIZE; the set is valid.
+                    .filter(|&cpu| unsafe { libc::CPU_ISSET(cpu, &mask) })
+                    .collect()
+            }
+
+            /// A leaked two-domain topology splitting this process's allowed CPUs in half,
+            /// plus the CPUs of each half. Unlike the process-global topology, each call
+            /// returns private pin counters, so tests can assert pin success and exact
+            /// counter values without racing concurrently running tests; and unlike the
+            /// real topology, it exists on any machine with four allowed CPUs (each half
+            /// needs two so pins can engage), which standard CI runners have.
+            fn synthetic_split() -> Option<(&'static Topology, Vec<usize>, Vec<usize>)> {
+                let cpus = allowed_cpus();
+                if cpus.len() < 4 {
+                    return None;
+                }
+                let (a, b) = cpus.split_at(cpus.len() / 2);
+                let lists: Vec<(usize, String)> = a
+                    .iter()
+                    .map(|&cpu| (cpu, "a".to_string()))
+                    .chain(b.iter().map(|&cpu| (cpu, "b".to_string())))
+                    .collect();
+                let topology = Box::leak(Box::new(Topology::from_lists(&lists)?));
+                Some((topology, a.to_vec(), b.to_vec()))
+            }
 
             #[test]
             fn from_lists_groups_and_masks() {
@@ -451,6 +493,28 @@ cfg_if::cfg_if! {
             }
 
             #[test]
+            fn from_lists_smt_discontiguous_domains() {
+                // SMT siblings share the LLC, so real sharing lists are discontiguous:
+                // physical cores 0-3 pair with logical CPUs 64-67.
+                let mut lists: Vec<(usize, String)> = Vec::new();
+                for cpu in (0..4).chain(64..68) {
+                    lists.push((cpu, "0-3,64-67".to_string()));
+                }
+                for cpu in (4..8).chain(68..72) {
+                    lists.push((cpu, "4-7,68-71".to_string()));
+                }
+                let topology = Topology::from_lists(&lists).unwrap();
+                assert_eq!(topology.domains(), 2);
+                assert_eq!(topology.domain_of(0), topology.domain_of(64));
+                assert_eq!(topology.domain_of(4), topology.domain_of(68));
+                assert_ne!(topology.domain_of(0), topology.domain_of(4));
+                let d0 = topology.domain_of(0).unwrap() as usize;
+
+                // SAFETY: cpu is within CPU_SETSIZE; the set was built by from_lists.
+                assert!(unsafe { libc::CPU_ISSET(64, &topology.domain_sets[d0]) });
+            }
+
+            #[test]
             fn from_lists_rejects_cpus_past_setsize() {
                 // cpu_set_t cannot represent such CPUs, so the machine must report no
                 // topology instead of pinning within a truncated view of it.
@@ -459,6 +523,44 @@ cfg_if::cfg_if! {
                     (libc::CPU_SETSIZE as usize, "b".to_string()),
                 ];
                 assert!(Topology::from_lists(&lists).is_none());
+            }
+
+            #[test]
+            fn llc_list_picks_highest_level_data_or_unified_leaf() {
+                // A synthetic sysfs cache directory: the LLC is the level-3 Unified leaf,
+                // and neither the level-1 Data leaf (first in directory order), the
+                // Instruction leaf, nor a fixed index number may win instead.
+                let dir =
+                    std::env::temp_dir().join(format!("commonware_llc_{}", std::process::id()));
+                let cache = dir.join("cache");
+                let leaves = [
+                    ("index0", "Data", "1", "0"),
+                    ("index1", "Instruction", "1", "0"),
+                    ("index2", "Unified", "2", "0-1"),
+                    ("index3", "Unified", "3", "0-7,64-71"),
+                ];
+                for (leaf, kind, level, list) in leaves {
+                    let path = cache.join(leaf);
+                    std::fs::create_dir_all(&path).unwrap();
+                    std::fs::write(path.join("type"), kind).unwrap();
+                    std::fs::write(path.join("level"), level).unwrap();
+                    std::fs::write(path.join("shared_cpu_list"), list).unwrap();
+                }
+                assert_eq!(Topology::llc_list(&dir).as_deref(), Some("0-7,64-71"));
+                std::fs::remove_dir_all(&dir).unwrap();
+            }
+
+            #[test]
+            fn llc_list_ignores_instruction_only_caches() {
+                let dir =
+                    std::env::temp_dir().join(format!("commonware_llc_i_{}", std::process::id()));
+                let path = dir.join("cache").join("index0");
+                std::fs::create_dir_all(&path).unwrap();
+                std::fs::write(path.join("type"), "Instruction").unwrap();
+                std::fs::write(path.join("level"), "1").unwrap();
+                std::fs::write(path.join("shared_cpu_list"), "0").unwrap();
+                assert_eq!(Topology::llc_list(&dir), None);
+                std::fs::remove_dir_all(&dir).unwrap();
             }
 
             #[test]
@@ -506,23 +608,153 @@ cfg_if::cfg_if! {
             }
 
             #[test]
-            fn pin_slots_do_not_leak() {
+            fn synthetic_pin_narrows_to_domain_and_restores() {
+                std::thread::spawn(|| {
+                    let Some((topology, half_a, _)) = synthetic_split() else {
+                        return;
+                    };
+                    let domain = topology.domain_of(half_a[0]).unwrap() as usize;
+                    let before = current_mask();
+                    {
+                        let _guard = AffinityGuard::pin_in(topology, domain).unwrap();
+
+                        // The pin narrows the mask to exactly the domain's allowed CPUs.
+                        let now = current_mask();
+                        for cpu in 0..(libc::CPU_SETSIZE as usize) {
+                            // SAFETY: cpu is within CPU_SETSIZE; the set is valid.
+                            let set = unsafe { libc::CPU_ISSET(cpu, &now) };
+                            assert_eq!(set, half_a.contains(&cpu), "mask mismatch at cpu {cpu}");
+                        }
+                    }
+
+                    // Dropping the guard restores the pre-pin mask exactly.
+                    let after = current_mask();
+                    // SAFETY: both sets are valid; CPU_EQUAL only compares their bits.
+                    assert!(unsafe { libc::CPU_EQUAL(&before, &after) });
+                })
+                .join()
+                .unwrap();
+            }
+
+            #[test]
+            fn synthetic_pin_slots_do_not_leak() {
                 // Repeated pin and release must not consume permanent slots: if the counter
                 // leaked, pins would start failing after about a domain's width of cycles.
-                let Some(domain) = spawn_domain() else {
+                std::thread::spawn(|| {
+                    let Some((topology, half_a, _)) = synthetic_split() else {
+                        return;
+                    };
+                    let domain = topology.domain_of(half_a[0]).unwrap() as usize;
+                    for _ in 0..100 {
+                        assert!(AffinityGuard::pin_in(topology, domain).is_some());
+                    }
+                    assert_eq!(topology.pins[domain].load(Ordering::Acquire), 0);
+                })
+                .join()
+                .unwrap();
+            }
+
+            #[test]
+            fn synthetic_nested_pin_refused_then_released() {
+                std::thread::spawn(|| {
+                    let Some((topology, half_a, _)) = synthetic_split() else {
+                        return;
+                    };
+                    let domain = topology.domain_of(half_a[0]).unwrap() as usize;
+                    let outer = AffinityGuard::pin_in(topology, domain).unwrap();
+
+                    // A pinned thread must not pin again, in any domain of any topology.
+                    assert!(AffinityGuard::pin_in(topology, domain).is_none());
+
+                    // Dropping the outer guard releases the thread's pin and the slot.
+                    drop(outer);
+                    assert_eq!(topology.pins[domain].load(Ordering::Acquire), 0);
+                    assert!(AffinityGuard::pin_in(topology, domain).is_some());
+                })
+                .join()
+                .unwrap();
+            }
+
+            #[test]
+            fn synthetic_cap_bounds_pins_and_returns_to_zero() {
+                let Some((topology, half_a, _)) = synthetic_split() else {
                     return;
                 };
+                let domain = topology.domain_of(half_a[0]).unwrap() as usize;
 
-                // The environment may forbid pinning outright (e.g. a taskset restriction
-                // leaving fewer than two allowed CPUs in the domain); leak detection needs
-                // an environment where a pin can succeed at all.
-                if AffinityGuard::pin(Some(domain)).is_none() {
+                // Every spawned thread is unrestricted, so each sees the same effective
+                // width and the same cap: the domain's CPUs minus the caller reservation.
+                let cap = half_a.len() - 1;
+
+                // No assertions run on the worker threads and no thread waits on anything
+                // the main thread's unwind would strand: workers spin on `released`, which
+                // a drop guard sets even if an assertion below panics, so a failing test
+                // fails instead of deadlocking the scope's implicit join.
+                let granted = AtomicUsize::new(0);
+                let settled = AtomicUsize::new(0);
+                let released = AtomicBool::new(false);
+                struct ReleaseOnDrop<'a>(&'a AtomicBool);
+                impl Drop for ReleaseOnDrop<'_> {
+                    fn drop(&mut self) {
+                        self.0.store(true, Ordering::Release);
+                    }
+                }
+                std::thread::scope(|s| {
+                    let _release = ReleaseOnDrop(&released);
+                    for _ in 0..cap {
+                        s.spawn(|| {
+                            let guard = AffinityGuard::pin_in(topology, domain);
+                            if guard.is_some() {
+                                granted.fetch_add(1, Ordering::AcqRel);
+                            }
+                            settled.fetch_add(1, Ordering::AcqRel);
+                            while !released.load(Ordering::Acquire) {
+                                std::thread::yield_now();
+                            }
+                        });
+                    }
+                    while settled.load(Ordering::Acquire) < cap {
+                        std::thread::yield_now();
+                    }
+
+                    // Every slot is taken: each pin under the cap succeeded, the counter
+                    // sits at the cap, and a further pin is refused.
+                    assert_eq!(granted.load(Ordering::Acquire), cap);
+                    assert_eq!(topology.pins[domain].load(Ordering::Acquire), cap);
+                    assert!(AffinityGuard::pin_in(topology, domain).is_none());
+                });
+
+                // All guards dropped: the counter returns exactly to zero and pins engage
+                // again.
+                assert_eq!(topology.pins[domain].load(Ordering::Acquire), 0);
+                std::thread::spawn(move || {
+                    assert!(AffinityGuard::pin_in(topology, domain).is_some());
+                })
+                .join()
+                .unwrap();
+            }
+
+            #[test]
+            fn synthetic_pin_stress_never_exceeds_cap() {
+                let Some((topology, half_a, _)) = synthetic_split() else {
                     return;
-                }
-                for _ in 0..100 {
-                    drop(AffinityGuard::pin(Some(domain)));
-                }
-                assert!(AffinityGuard::pin(Some(domain)).is_some());
+                };
+                let domain = topology.domain_of(half_a[0]).unwrap() as usize;
+                let cap = half_a.len() - 1;
+                std::thread::scope(|s| {
+                    for _ in 0..(4 * half_a.len()) {
+                        s.spawn(|| {
+                            for _ in 0..200 {
+                                let guard = AffinityGuard::pin_in(topology, domain);
+
+                                // An underflowed counter would wrap far past the cap.
+                                assert!(topology.pins[domain].load(Ordering::Acquire) <= cap);
+                                drop(guard);
+                            }
+                        });
+                    }
+                });
+                assert_eq!(topology.pins[domain].load(Ordering::Acquire), 0);
             }
 
             #[test]

--- a/parallel/src/topology.rs
+++ b/parallel/src/topology.rs
@@ -215,11 +215,22 @@ cfg_if::cfg_if! {
                 // concurrent pinned jobs can never crowd it (nor evict the caller). Past the
                 // cap the job runs unpinned.
                 let cap = topology.pin_cap(domain);
-                topology.pins[domain]
-                    .fetch_update(Ordering::AcqRel, Ordering::Acquire, |live| {
-                        (live < cap).then_some(live + 1)
-                    })
-                    .ok()?;
+                let pins = &topology.pins[domain];
+                let mut live = pins.load(Ordering::Acquire);
+                loop {
+                    if live >= cap {
+                        return None;
+                    }
+                    match pins.compare_exchange_weak(
+                        live,
+                        live + 1,
+                        Ordering::AcqRel,
+                        Ordering::Acquire,
+                    ) {
+                        Ok(_) => break,
+                        Err(current) => live = current,
+                    }
+                }
                 let slot = PinSlot { domain };
 
                 // SAFETY: an all-zero cpu_set_t is the valid empty set, filled by sched_getaffinity

--- a/parallel/src/topology.rs
+++ b/parallel/src/topology.rs
@@ -13,10 +13,11 @@
 //! leaf under `cache/index*` in sysfs is its last-level cache (the leaf index varies by
 //! architecture, so it is discovered rather than assumed; vendor core-layout assumptions also lie,
 //! as this was built on a machine whose spec sheet implied 8-core L3 groups while the kernel
-//! reported 4-core ones). Pinning is skipped whenever the picture is incomplete: a single or
-//! undetectable domain, a CPU the snapshot does not cover, or a failed CPU query. On non-Linux
-//! platforms the stub below reports no domains and pinning is a no-op; the same stub serves miri
-//! (the affinity syscalls are unshimmed).
+//! reported 4-core ones). Pinning is skipped whenever it cannot be done safely and profitably: a
+//! single or undetectable domain, a CPU the snapshot does not cover, a failed CPU query, an
+//! operator restriction (taskset, numactl, isolated cores) leaving no allowed CPU in the domain,
+//! or a domain already at its pin cap. On non-Linux platforms the stub below reports no domains
+//! and pinning is a no-op; the same stub serves miri (the affinity syscalls are unshimmed).
 
 cfg_if::cfg_if! {
     if #[cfg(all(target_os = "linux", not(miri)))] {

--- a/parallel/src/topology.rs
+++ b/parallel/src/topology.rs
@@ -146,9 +146,12 @@ cfg_if::cfg_if! {
         }
 
         impl AffinityGuard {
-            /// Pins the calling thread to `domain`'s CPUs. Returns `None` (no pin) if
-            /// the previous mask cannot be read or the new one cannot be applied; the
-            /// job then simply runs wherever it was.
+            /// Pins the calling thread to the CPUs of `domain` that its current
+            /// affinity mask already allows, so the pin narrows placement and never
+            /// widens it past an operator's restrictions (taskset, numactl, isolated
+            /// cores). Returns `None` (no pin) if the mask cannot be read or applied,
+            /// or if the allowed intersection is empty; the job then simply runs
+            /// wherever it was.
             pub(crate) fn pin(domain: Option<SpawnDomain>) -> Option<Self> {
                 let domain = domain?;
                 let topology = topology();
@@ -161,8 +164,25 @@ cfg_if::cfg_if! {
                 if unsafe { libc::sched_getaffinity(0, size, &mut saved) } != 0 {
                     return None;
                 }
-                // SAFETY: pid 0 is the calling thread; `target` is a valid set of `size`.
-                if unsafe { libc::sched_setaffinity(0, size, target) } != 0 {
+                // Intersect the domain with the thread's current allowance.
+                // SAFETY: an all-zero cpu_set_t is the valid empty set.
+                let mut effective: libc::cpu_set_t = unsafe { std::mem::zeroed() };
+                let mut allowed = 0usize;
+                for cpu in 0..(libc::CPU_SETSIZE as usize) {
+                    // SAFETY: cpu is within CPU_SETSIZE; all three sets are valid.
+                    unsafe {
+                        if libc::CPU_ISSET(cpu, target) && libc::CPU_ISSET(cpu, &saved) {
+                            libc::CPU_SET(cpu, &mut effective);
+                            allowed += 1;
+                        }
+                    }
+                }
+                if allowed == 0 {
+                    return None;
+                }
+                // SAFETY: pid 0 is the calling thread; `effective` is a valid set of
+                // `size`.
+                if unsafe { libc::sched_setaffinity(0, size, &effective) } != 0 {
                     return None;
                 }
                 Some(Self { saved })
@@ -209,6 +229,36 @@ cfg_if::cfg_if! {
                 let lists: Vec<(usize, String)> =
                     (0..4).map(|cpu| (cpu, "0-3".to_string())).collect();
                 assert!(Topology::from_lists(&lists).is_none());
+            }
+
+            #[test]
+            fn pin_never_widens_a_restricted_mask() {
+                std::thread::spawn(|| {
+                    // Restrict this thread to its current CPU only.
+                    // SAFETY: valid empty set, filled below.
+                    let mut only: libc::cpu_set_t = unsafe { std::mem::zeroed() };
+                    // SAFETY: no arguments; returns a value.
+                    let cpu = unsafe { libc::sched_getcpu() };
+                    assert!(cpu >= 0);
+                    // SAFETY: cpu < CPU_SETSIZE (kernel CPU ids are small), valid set.
+                    unsafe { libc::CPU_SET(cpu as usize, &mut only) };
+                    let size = std::mem::size_of::<libc::cpu_set_t>();
+                    // SAFETY: pid 0 = this thread, valid set.
+                    assert_eq!(unsafe { libc::sched_setaffinity(0, size, &only) }, 0);
+
+                    let _guard = AffinityGuard::pin(spawn_domain());
+
+                    // SAFETY: as above.
+                    let mut now: libc::cpu_set_t = unsafe { std::mem::zeroed() };
+                    assert_eq!(unsafe { libc::sched_getaffinity(0, size, &mut now) }, 0);
+                    for c in 0..(libc::CPU_SETSIZE as usize) {
+                        // SAFETY: c < CPU_SETSIZE, valid sets.
+                        let (n, o) = unsafe { (libc::CPU_ISSET(c, &now), libc::CPU_ISSET(c, &only)) };
+                        assert!(!n || o, "pin widened the mask at cpu {c}");
+                    }
+                })
+                .join()
+                .unwrap();
             }
 
             #[test]

--- a/parallel/src/topology.rs
+++ b/parallel/src/topology.rs
@@ -320,8 +320,9 @@ cfg_if::cfg_if! {
 
                     let _guard = AffinityGuard::pin(spawn_domain());
 
-                    // SAFETY: as above.
+                    // SAFETY: an all-zero cpu_set_t is the valid empty set.
                     let mut now: libc::cpu_set_t = unsafe { std::mem::zeroed() };
+                    // SAFETY: pid 0 = this thread; `now` is a valid set of `size`.
                     assert_eq!(unsafe { libc::sched_getaffinity(0, size, &mut now) }, 0);
                     for c in 0..(libc::CPU_SETSIZE as usize) {
                         // SAFETY: c < CPU_SETSIZE, valid sets.
@@ -345,8 +346,9 @@ cfg_if::cfg_if! {
                     let _guard = AffinityGuard::pin(spawn_domain());
                 }
 
-                // SAFETY: as above.
+                // SAFETY: an all-zero cpu_set_t is the valid empty set.
                 let mut after: libc::cpu_set_t = unsafe { std::mem::zeroed() };
+                // SAFETY: pid 0 = calling thread; `after` is a valid set of `size`.
                 assert_eq!(unsafe { libc::sched_getaffinity(0, size, &mut after) }, 0);
                 for cpu in 0..(libc::CPU_SETSIZE as usize) {
                     // SAFETY: cpu < CPU_SETSIZE, valid sets.

--- a/parallel/src/topology.rs
+++ b/parallel/src/topology.rs
@@ -20,7 +20,10 @@
 
 cfg_if::cfg_if! {
     if #[cfg(all(target_os = "linux", not(miri)))] {
-        use std::sync::OnceLock;
+        use std::sync::{
+            OnceLock,
+            atomic::{AtomicUsize, Ordering},
+        };
 
         /// The process-wide topology, detected on first use.
         fn topology() -> &'static Topology {
@@ -37,6 +40,9 @@ cfg_if::cfg_if! {
             cpu_to_domain: Box<[Option<u16>]>,
             /// The CPUs of each domain, as ready-to-use affinity sets.
             domain_sets: Box<[libc::cpu_set_t]>,
+            /// Live pins per domain. Capped so pinned jobs can never crowd a domain: past the
+            /// cap, a job simply runs unpinned wherever the scheduler likes.
+            pins: Box<[AtomicUsize]>,
         }
 
         impl Topology {
@@ -45,7 +51,17 @@ cfg_if::cfg_if! {
                 Self::from_sysfs().unwrap_or(Self {
                     cpu_to_domain: Box::new([]),
                     domain_sets: Box::new([]),
+                    pins: Box::new([]),
                 })
+            }
+
+            /// The most live pins a domain accepts: its width minus one, reserving a core for
+            /// the submitting caller (who is usually in the domain and working).
+            fn pin_cap(&self, domain: usize) -> usize {
+                let set = &self.domain_sets[domain];
+                // SAFETY: `set` is a valid cpu_set_t built at detection time.
+                let width = unsafe { libc::CPU_COUNT(set) } as usize;
+                width.saturating_sub(1).max(1)
             }
 
             /// Number of distinct domains (0 or 1 disables the preference and pinning).
@@ -153,9 +169,11 @@ cfg_if::cfg_if! {
                 if domains.len() <= 1 {
                     return None;
                 }
+                let pins = (0..sets.len()).map(|_| AtomicUsize::new(0)).collect();
                 Some(Self {
                     cpu_to_domain: table.into_boxed_slice(),
                     domain_sets: sets.into_boxed_slice(),
+                    pins,
                 })
             }
         }
@@ -179,6 +197,7 @@ cfg_if::cfg_if! {
         /// affinity mask on drop (including unwinds).
         pub(crate) struct AffinityGuard {
             saved: libc::cpu_set_t,
+            domain: usize,
         }
 
         impl AffinityGuard {
@@ -188,9 +207,20 @@ cfg_if::cfg_if! {
             /// cannot be read or applied, or if the allowed intersection is empty; the job then
             /// simply runs wherever it was.
             pub(crate) fn pin(domain: Option<SpawnDomain>) -> Option<Self> {
-                let domain = domain?;
+                let domain = domain?.0 as usize;
                 let topology = topology();
-                let target = topology.domain_sets.get(domain.0 as usize)?;
+                let target = topology.domain_sets.get(domain)?;
+
+                // Take a pin slot: a domain accepts at most width minus one live pins, so
+                // concurrent pinned jobs can never crowd it (nor evict the caller). Past the
+                // cap the job runs unpinned.
+                let cap = topology.pin_cap(domain);
+                topology.pins[domain]
+                    .fetch_update(Ordering::AcqRel, Ordering::Acquire, |live| {
+                        (live < cap).then_some(live + 1)
+                    })
+                    .ok()?;
+                let slot = PinSlot { domain };
 
                 // SAFETY: an all-zero cpu_set_t is the valid empty set, filled by sched_getaffinity
                 // below.
@@ -224,12 +254,27 @@ cfg_if::cfg_if! {
                 if unsafe { libc::sched_setaffinity(0, size, &effective) } != 0 {
                     return None;
                 }
-                Some(Self { saved })
+
+                // The mask is applied: the guard now owns both the restore and the slot.
+                core::mem::forget(slot);
+                Some(Self { saved, domain })
+            }
+        }
+
+        /// Releases a reserved pin slot if `pin` bails before the mask is applied.
+        struct PinSlot {
+            domain: usize,
+        }
+
+        impl Drop for PinSlot {
+            fn drop(&mut self) {
+                topology().pins[self.domain].fetch_sub(1, Ordering::AcqRel);
             }
         }
 
         impl Drop for AffinityGuard {
             fn drop(&mut self) {
+                topology().pins[self.domain].fetch_sub(1, Ordering::AcqRel);
                 let size = std::mem::size_of::<libc::cpu_set_t>();
 
                 // SAFETY: pid 0 is the calling thread; `saved` is the mask read at pin time.
@@ -332,6 +377,19 @@ cfg_if::cfg_if! {
                 })
                 .join()
                 .unwrap();
+            }
+
+            #[test]
+            fn pin_slots_do_not_leak() {
+                // Repeated pin and release must not consume permanent slots: if the counter
+                // leaked, pins would start failing after about a domain's width of cycles.
+                let Some(domain) = spawn_domain() else {
+                    return;
+                };
+                for _ in 0..100 {
+                    drop(AffinityGuard::pin(Some(domain)));
+                }
+                assert!(AffinityGuard::pin(Some(domain)).is_some());
             }
 
             #[test]


### PR DESCRIPTION
## What

Spawned jobs now pin their executing thread to the last level cache (L3) domain
the submitter occupied at spawn time, restoring the previous affinity mask when
the job completes (including unwinds), unless the mask was rewritten mid-job
to CPUs outside the pin. Domains are discovered once per process from the
kernel's cache topology: for each CPU, the `shared_cpu_list` of the
highest-level Data or Unified leaf under its `cache/index*` directory in
sysfs (the leaf index varies by architecture, so it is discovered rather than
assumed). Non-Linux platforms and miri compile the mechanism to a no-op.

All libc FFI funnels through a small safe `CpuSet` wrapper (seven one-line
unsafe blocks); the pin protocol itself is safe code.

Closes #4540.

## Why

A spawned job usually exchanges data with its submitter: it reads what the
caller just built and the caller later reads what it wrote. If the executor
runs in a different L3 domain than the submitter, every shared cache line pays
a cross-domain transfer for the job's lifetime. The OS places threads once per
process, effectively at random, and never revisits the choice.

The effect is easiest to see on a benchmark whose commit path hands index
application to a single spawned job (`constantinople`, kind
`any::unordered::fixed::mmb`: 1M keys, 32k reads and 32k updates per iteration,
p50 commit latency over 100 iterations, 8 threads). Machine: AMD EPYC 9354P,
32 cores, SMT off, eight 4-core L3 domains per the kernel.

Eight consecutive runs of the same binary on the same input, before this
change:

| run | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 |
|---|---|---|---|---|---|---|---|---|
| p50 (ms) | 26.6 | 26.6 | 18.0 | 27.2 | 18.3 | 27.2 | 19.0 | 26.8 |

Each process lands in one of two modes and stays there for its lifetime. The
mode is set by where the scheduler seated the job's executor relative to the
submitting thread. Hardware counters show the slow mode is pure memory
stalling, not extra work:

| mode | instructions | cycles | IPC |
|---|---|---|---|
| fast (p50 ~18.5) | 31.5B | 31.0B to 33.4B | ~1.00 |
| slow (p50 ~26.9) | 31.6B | 34.5B to 36.8B | ~0.88 |

The same eight-run experiment with this change:

| run | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 |
|---|---|---|---|---|---|---|---|---|
| p50 (ms) | 15.2 | 18.1 | 19.2 | 17.1 | 16.4 | 16.9 | 19.3 | 15.4 |

The lottery is gone, and the median (16.9ms) is better than the old lucky mode
because the pin also keeps the executor from drifting away mid-run. For
reference, the same benchmark without the spawned index job at all runs at
23.5ms, and single-threaded at 26.7ms.

## Cost

The first pin migrates the worker once, costing tens of microseconds.
Afterwards the restored-wide worker tends to stay where it ran, so repeat pins
move nothing. The spawn round-trip microbenchmark measures no change (82.5us
with the pin versus 83.7us without, within run-to-run noise). Jobs below the
size threshold are unaffected: the adaptive spawn policy (#4423) keeps
them inline, so the pin only executes for jobs large enough that a one-time
migration is noise. Concurrent pinned jobs cannot crowd a domain: the cap on live
pins is the domain's effective width (the CPUs the pinning thread may actually
use there) minus one, reserving one for the submitting caller. Past the cap, or
when fewer than two CPUs are allowed, a job simply runs unpinned.
A worker already pinned by an enclosing job does not pin again: a thread-local
marks the thread as pinned, so nested jobs stay within the outer confinement
instead of burning a second cap slot for one CPU of occupancy. Machines whose
possible-CPU count exceeds `cpu_set_t`'s capacity report no domains at all,
disabling the feature up front rather than charging every spawn for affinity
syscalls that could never engage.

Restore defers to external rewrites: a mask moved outside the pin mid-job
(taskset -pa, a cgroup cpuset migration) is left in place, since writing the
pin-time snapshot back would resurrect an allowance the operator may have just
revoked. Cleanup is best effort: the pin slot is always released, so the worst
case may leave a worker narrowed with its slot freed rather than stranding
domain capacity for the process lifetime.

## Benchmarks at tip

With #4423 merged, only policy-approved offloads ever execute the pin, so the
change was re-measured at the current tip against main (AMD EPYC 9354P, eth
mainnet replay in follower mode, 8 threads, two interleaved runs per arm,
means shown):

| window | metric | main | this PR |
|---|---|---|---|
| 500k blocks, fresh db | wall | 13.66s | 13.14s (-3.8%) |
| | writes/s | 126.6k | 131.5k (+3.9%) |
| 50k blocks onto a 30GB db | wall | 123.25s | 114.82s (-6.8%) |
| | merkleize | 73.78s | 67.50s (-8.5%) |
| | apply | 18.64s | 17.11s (-8.2%) |
| | writes/s | 175.0k | 189.5k (+8.3%) |

Single-threaded runs are unchanged: a single-worker pool runs every job inline,
so the pin never engages. The deeper-state window benefits most because its
offloaded merkleize and apply jobs are the largest and longest-lived, exactly
the traffic that pays for cross-domain lines.

## Testing

Tests drive the full pin protocol (intersection, cap accounting, apply, and
restore) against synthetic two-domain topologies built by splitting the
process's allowed CPUs in half, with private pin counters per test. This makes
the coverage real on CI runners, which expose a single L3 domain and would
otherwise skip every pin path. Topology parsing is likewise exercised against
synthetic sysfs cache directories, SMT-style discontiguous sharing lists, and
CPUs past `cpu_set_t`'s capacity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q4BFdANo2LhVEr2ko3FK9n






