### PR TITLE
[simplex] Revalidate locally built proposal ancestry

### DIFF
--- a/consensus/src/simplex/actors/voter/actor.rs
+++ b/consensus/src/simplex/actors/voter/actor.rs
@@ -13,7 +13,7 @@ use crate::{
         scheme::Scheme,
         types::{
             Activity, Artifact, Certificate, Context, Finalization, Finalize, Notarization,
-            Notarize, Nullification, Nullify, Proposal, Vote,
+            Notarize, Nullification, Nullify, Vote,
         },
     },
     types::{Round as Rnd, View},
@@ -657,9 +657,9 @@ impl<
             return None;
         }
 
-        // Construct proposal
-        let proposal = Proposal::new(context.round, context.parent.0, proposed);
-        if !self.state.proposed(proposal) {
+        // Record the proposal only if the parent captured for the build is
+        // still valid.
+        if !self.state.proposed(&context, proposed) {
             warn!(round = ?context.round, "dropped our proposal");
             return None;
         }

--- a/consensus/src/simplex/actors/voter/actor.rs
+++ b/consensus/src/simplex/actors/voter/actor.rs
@@ -1082,11 +1082,9 @@ impl<
         select_loop! {
             self.context,
             on_start => {
-                // Drop a pending proposal request after its view exits. Retain
-                // requests for the current view and optimistic future views. Also
-                // drop a request when its captured ancestry is invalid and a
-                // replacement parent is available. Run these checks before
-                // rebuilding waiters so the actor cannot poll a stale completion.
+                // Poll only proposal work that can still be adopted. A request
+                // becomes obsolete when its view exits or a replacement
+                // supersedes its captured parent.
                 if pending_propose.as_ref().is_some_and(|pp| {
                     pp.view() < self.state.current_view()
                         || self.state.supersede_proposal_request(&pp.0)

--- a/consensus/src/simplex/actors/voter/actor.rs
+++ b/consensus/src/simplex/actors/voter/actor.rs
@@ -1082,11 +1082,11 @@ impl<
         select_loop! {
             self.context,
             on_start => {
-                // Drop work after exiting its view while retaining optimistic
-                // future work. Proposal construction also captures ancestry, so
-                // replace it once that ancestry is invalid and another parent is
-                // available. This runs before rebuilding waiters, preventing a
-                // stale completion from being polled after the state transition.
+                // Drop a pending proposal request after its view exits. Retain
+                // requests for the current view and optimistic future views. Also
+                // drop a request when its captured ancestry is invalid and a
+                // replacement parent is available. Run these checks before
+                // rebuilding waiters so the actor cannot poll a stale completion.
                 if pending_propose.as_ref().is_some_and(|pp| {
                     pp.view() < self.state.current_view()
                         || self.state.supersede_proposal_request(&pp.0)

--- a/consensus/src/simplex/actors/voter/actor.rs
+++ b/consensus/src/simplex/actors/voter/actor.rs
@@ -1082,19 +1082,23 @@ impl<
         select_loop! {
             self.context,
             on_start => {
-                // Drop any pending items if we have moved past their view (work
-                // for optimistic future views is kept). This runs before the
-                // waiters are rebuilt, so a verification completion cannot be
-                // polled after another branch exits its view. A view is exited
-                // only on successful certification, nullification, or finalization.
-                // Nullification does not cancel certification work for the
-                // exited view, so the automaton must tolerate a dropped verify
-                // receiver while certify still wants the result.
-                if let Some(ref pp) = pending_propose
-                    && pp.view() < self.state.current_view()
-                {
+                // Drop work after exiting its view while retaining optimistic
+                // future work. Proposal construction also captures ancestry, so
+                // replace it once that ancestry is invalid and another parent is
+                // available. This runs before rebuilding waiters, preventing a
+                // stale completion from being polled after the state transition.
+                if pending_propose.as_ref().is_some_and(|pp| {
+                    pp.view() < self.state.current_view()
+                        || self.state.supersede_proposal_request(&pp.0)
+                }) {
                     pending_propose = None;
                 }
+
+                // A view is exited only on successful certification,
+                // nullification, or finalization. Nullification does not cancel
+                // certification work for the exited view, so the automaton must
+                // tolerate a dropped verify receiver while certify still wants
+                // the result.
                 if let Some(ref pv) = pending_verify
                     && pv.view() < self.state.current_view()
                 {

--- a/consensus/src/simplex/actors/voter/mod.rs
+++ b/consensus/src/simplex/actors/voter/mod.rs
@@ -106,6 +106,7 @@ mod tests {
     const PAGE_SIZE: NonZeroU16 = NZU16!(1024);
     const PAGE_CACHE_SIZE: NonZeroUsize = NZUsize!(10);
     const TEST_QUOTA: Quota = Quota::per_second(NonZeroU32::MAX);
+    type ProposeRequests = Arc<Mutex<Vec<(View, View)>>>;
 
     async fn start_test_network_with_peers<I>(
         context: deterministic::Context,
@@ -196,6 +197,10 @@ mod tests {
         verify_latency_ms: f64,
         /// Mock application certify latency, in milliseconds.
         certify_latency_ms: f64,
+        /// Views and parents supplied to mock application proposal requests.
+        propose_requests: Option<ProposeRequests>,
+        /// Whether mock application proposal requests should remain pending.
+        stall_proposals: bool,
         /// Views whose verification requests reached the mock application.
         verify_requests: Option<Arc<Mutex<Vec<View>>>>,
         /// Whether every mock application verification should fail.
@@ -215,6 +220,8 @@ mod tests {
                 propose_latency_ms: 1.0,
                 verify_latency_ms: 1.0,
                 certify_latency_ms: 1.0,
+                propose_requests: None,
+                stall_proposals: false,
                 verify_requests: None,
                 fail_verification: false,
                 certifier: mocks::application::Certifier::Always,
@@ -251,6 +258,7 @@ mod tests {
         let reporter = mocks::reporter::Reporter::new(context.child("reporter"), reporter_cfg);
         let relay = Arc::new(mocks::relay::Relay::<Sha256Digest, _>::new());
         let elector = elector.build(signing.participants());
+        let propose_requests = options.propose_requests;
         let verify_requests = options.verify_requests;
 
         let application_cfg = mocks::application::Config::<Sha256, _> {
@@ -264,6 +272,14 @@ mod tests {
         let (mut actor, application) =
             mocks::application::Application::new(context.child("app"), application_cfg);
         actor.set_fail_verification(options.fail_verification);
+        actor.set_stall_proposals(options.stall_proposals);
+        if let Some(propose_requests) = propose_requests {
+            actor.set_propose_observer(Box::new(move |context| {
+                propose_requests
+                    .lock()
+                    .push((context.view(), context.parent.0));
+            }));
+        }
         if let Some(verify_requests) = verify_requests {
             actor.set_verify_observer(Box::new(move |context, _| {
                 verify_requests.lock().push(context.view());
@@ -322,6 +338,103 @@ mod tests {
             relay,
             reporter,
         )
+    }
+
+    /// Certifies view 1 and drives a follower through its notarize vote for
+    /// view 2, leaving the outgoing tip uncertified for handoff tests.
+    async fn prepare_pipelined_handoff_tip(
+        context: &mut deterministic::Context,
+        schemes: &[ed25519::Scheme],
+        outgoing: &PublicKey,
+        voter_mailbox: &mut Mailbox<ed25519::Scheme, Sha256Digest>,
+        batcher_receiver: &mut mailbox::Receiver<batcher::Message<ed25519::Scheme, Sha256Digest>>,
+        resolver_receiver: &mut mailbox::Receiver<
+            resolver::MailboxMessage<ed25519::Scheme, Sha256Digest>,
+        >,
+        relay: &Arc<mocks::relay::Relay<Sha256Digest, PublicKey>>,
+    ) -> Proposal<Sha256Digest> {
+        let epoch = Epoch::new(333);
+        let quorum = quorum(u32::try_from(schemes.len()).expect("test fixture must fit u32"));
+        assert!(matches!(
+            batcher_receiver.recv().await.unwrap(),
+            batcher::Message::Update { .. }
+        ));
+
+        let genesis = mocks::application::genesis::<Sha256>(epoch);
+        let proposal_1 = Proposal::new(
+            Round::new(epoch, View::new(1)),
+            View::zero(),
+            Sha256::hash(&[b"pipelined_test_view_1"]),
+        );
+        relay.broadcast(
+            outgoing,
+            Recipients::All,
+            (
+                proposal_1.payload,
+                (proposal_1.round, genesis, 0u64).encode(),
+            ),
+        );
+        let (_, notarization_1) = build_notarization(schemes, &proposal_1, quorum);
+        voter_mailbox.recovered(Certificate::Notarization(notarization_1));
+
+        let mut certified_view_1 = false;
+        let mut entered_view_2 = false;
+        while !certified_view_1 || !entered_view_2 {
+            select! {
+                message = batcher_receiver.recv() => {
+                    if matches!(
+                        message.unwrap(),
+                        batcher::Message::Update { current, .. } if current == View::new(2)
+                    ) {
+                        entered_view_2 = true;
+                    }
+                },
+                message = resolver_receiver.recv() => {
+                    if matches!(
+                        message.unwrap(),
+                        MailboxMessage::Certified { view, success: true, .. }
+                            if view == View::new(1)
+                    ) {
+                        certified_view_1 = true;
+                    }
+                },
+                _ = context.sleep(Duration::from_secs(5)) => {
+                    panic!("view 1 did not certify before the handoff");
+                }
+            }
+        }
+
+        let proposal_2 = Proposal::new(
+            Round::new(epoch, View::new(2)),
+            View::new(1),
+            Sha256::hash(&[b"pipelined_test_view_2"]),
+        );
+        relay.broadcast(
+            outgoing,
+            Recipients::All,
+            (
+                proposal_2.payload,
+                (proposal_2.round, proposal_1.payload, 1u64).encode(),
+            ),
+        );
+        voter_mailbox.proposal(proposal_2.clone());
+
+        loop {
+            select! {
+                message = batcher_receiver.recv() => {
+                    if matches!(
+                        message.unwrap(),
+                        batcher::Message::Constructed(Vote::Notarize(notarize))
+                            if notarize.view() == View::new(2)
+                    ) {
+                        return proposal_2;
+                    }
+                },
+                _ = context.sleep(Duration::from_secs(5)) => {
+                    panic!("view 2 was not notarized before the handoff");
+                }
+            }
+        }
     }
 
     async fn seed_voter_journal<S>(
@@ -3185,6 +3298,207 @@ mod tests {
                     },
                     _ = context.sleep(Duration::from_secs(8)) => {
                         panic!("expected pipelined handoff notarize for view 3");
+                    }
+                }
+            }
+        });
+    }
+
+    /// A stalled proposal build on an abandoned outgoing tip must be
+    /// superseded while the incoming term-start view is still live.
+    #[test_traced]
+    fn test_pipelined_handoff_reissues_stalled_proposal_after_parent_nullification() {
+        let n = 5;
+        let quorum = quorum(n);
+        let namespace = b"pipelined_handoff_reissues_stalled_proposal".to_vec();
+        let epoch = Epoch::new(333);
+        let term_length = TermLength::new(NZU32!(2));
+        let executor = deterministic::Runner::timed(Duration::from_secs(20));
+        executor.start(|mut context| async move {
+            let Fixture {
+                participants,
+                schemes,
+                ..
+            } = ed25519::fixture(&mut context, &namespace, n);
+            let oracle =
+                start_test_network_with_peers(context.child("network"), participants.clone(), true)
+                    .await;
+
+            let elector = RoundRobin::<Sha256>::default()
+                .with_term(term_length, Duration::from_secs(30), ViewDelta::new(1))
+                .with_pipelined_handoff();
+            let built_elector: elector::RoundRobinElector<ed25519::Scheme> =
+                elector.clone().build(schemes[0].participants());
+            let local_index =
+                usize::from(built_elector.elect(Round::new(epoch, View::new(3)), None));
+            let outgoing_index =
+                usize::from(built_elector.elect(Round::new(epoch, View::new(1)), None));
+            let outgoing = participants[outgoing_index].clone();
+            let propose_requests = Arc::new(Mutex::new(Vec::new()));
+
+            let (mut mailbox, mut batcher_receiver, mut resolver_receiver, relay, _) = setup_voter(
+                &mut context,
+                &oracle,
+                &participants,
+                &schemes,
+                elector,
+                VoterOptions {
+                    leader_timeout: Duration::from_secs(10),
+                    certification_timeout: Duration::from_secs(10),
+                    timeout_retry: Duration::from_secs(30),
+                    local_index,
+                    propose_requests: Some(propose_requests.clone()),
+                    stall_proposals: true,
+                    ..Default::default()
+                },
+            )
+            .await;
+
+            // Certify view 1 so it remains a usable fallback after view 2 is
+            // abandoned, then let the outgoing leader issue view 2.
+            prepare_pipelined_handoff_tip(
+                &mut context,
+                &schemes,
+                &outgoing,
+                &mut mailbox,
+                &mut batcher_receiver,
+                &mut resolver_receiver,
+                &relay,
+            )
+            .await;
+
+            let deadline = context.current() + Duration::from_secs(2);
+            while propose_requests.lock().is_empty() {
+                assert!(
+                    context.current() < deadline,
+                    "initial handoff proposal was not requested"
+                );
+                context.sleep(Duration::from_millis(10)).await;
+            }
+            assert_eq!(
+                propose_requests.lock().as_slice(),
+                &[(View::new(3), View::new(2))]
+            );
+
+            // Nullifying the captured parent enters view 3. The still-pending
+            // build must be replaced immediately with one on certified view 1.
+            let (_, nullification_2) =
+                build_nullification(&schemes, Round::new(epoch, View::new(2)), quorum);
+            mailbox.recovered(Certificate::Nullification(nullification_2));
+
+            let deadline = context.current() + Duration::from_secs(2);
+            while propose_requests.lock().len() < 2 {
+                assert!(
+                    context.current() < deadline,
+                    "proposal was not reissued on the certified fallback"
+                );
+                context.sleep(Duration::from_millis(10)).await;
+            }
+            let expected = [(View::new(3), View::new(2)), (View::new(3), View::new(1))];
+            assert_eq!(propose_requests.lock().as_slice(), &expected);
+        });
+    }
+
+    /// A follower repairing a raw pipelined term-start proposal targets its
+    /// proposer, containing retries when the parent certificate never forms.
+    #[test_traced]
+    fn test_pipelined_handoff_parent_repair_targets_proposer() {
+        let n = 5;
+        let namespace = b"pipelined_handoff_parent_repair_targets_proposer".to_vec();
+        let epoch = Epoch::new(333);
+        let term_length = TermLength::new(NZU32!(2));
+        let executor = deterministic::Runner::timed(Duration::from_secs(20));
+        executor.start(|mut context| async move {
+            let Fixture {
+                participants,
+                schemes,
+                ..
+            } = ed25519::fixture(&mut context, &namespace, n);
+            let oracle =
+                start_test_network_with_peers(context.child("network"), participants.clone(), true)
+                    .await;
+
+            let elector = RoundRobin::<Sha256>::default()
+                .with_term(term_length, Duration::from_secs(30), ViewDelta::new(1))
+                .with_pipelined_handoff();
+            let built_elector: elector::RoundRobinElector<ed25519::Scheme> =
+                elector.clone().build(schemes[0].participants());
+            let outgoing_index =
+                usize::from(built_elector.elect(Round::new(epoch, View::new(1)), None));
+            let incoming_index =
+                usize::from(built_elector.elect(Round::new(epoch, View::new(3)), None));
+            let local_index = (0..participants.len())
+                .find(|index| *index != outgoing_index && *index != incoming_index)
+                .expect("a follower must exist");
+            let outgoing = participants[outgoing_index].clone();
+            let incoming = participants[incoming_index].clone();
+
+            let (mut mailbox, mut batcher_receiver, mut resolver_receiver, relay, _) = setup_voter(
+                &mut context,
+                &oracle,
+                &participants,
+                &schemes,
+                elector,
+                VoterOptions {
+                    leader_timeout: Duration::from_secs(10),
+                    certification_timeout: Duration::from_secs(10),
+                    timeout_retry: Duration::from_secs(30),
+                    local_index,
+                    ..Default::default()
+                },
+            )
+            .await;
+
+            let proposal_2 = prepare_pipelined_handoff_tip(
+                &mut context,
+                &schemes,
+                &outgoing,
+                &mut mailbox,
+                &mut batcher_receiver,
+                &mut resolver_receiver,
+                &relay,
+            )
+            .await;
+
+            let proposal_3 = Proposal::new(
+                Round::new(epoch, View::new(3)),
+                View::new(2),
+                Sha256::hash(&[b"targeted_repair_view_3"]),
+            );
+            relay.broadcast(
+                &incoming,
+                Recipients::All,
+                (
+                    proposal_3.payload,
+                    (proposal_3.round, proposal_2.payload, 2u64).encode(),
+                ),
+            );
+            mailbox.proposal(proposal_3);
+
+            loop {
+                select! {
+                    message = resolver_receiver.recv() => {
+                        let MailboxMessage::Resolve {
+                            proposal,
+                            view,
+                            kind,
+                            target,
+                            ..
+                        } = message.unwrap() else {
+                            continue;
+                        };
+                        assert_eq!(proposal, View::new(3));
+                        assert_eq!(view, View::new(2));
+                        assert!(matches!(kind, crate::simplex::actors::Kind::Notarization));
+                        assert_eq!(
+                            target.as_ref(),
+                            Some(&incoming),
+                            "raw term-start parent repair must target its proposer"
+                        );
+                        break;
+                    },
+                    _ = context.sleep(Duration::from_secs(5)) => {
+                        panic!("voter never requested the outgoing parent certificate");
                     }
                 }
             }

--- a/consensus/src/simplex/actors/voter/mod.rs
+++ b/consensus/src/simplex/actors/voter/mod.rs
@@ -3399,8 +3399,8 @@ mod tests {
         });
     }
 
-    /// A follower repairing a raw pipelined term-start proposal targets its
-    /// proposer, containing retries when the parent certificate never forms.
+    /// A follower requests a missing parent certificate from the term-start
+    /// proposer. Targeting one peer limits retries if the certificate never forms.
     #[test_traced]
     fn test_pipelined_handoff_parent_repair_targets_proposer() {
         let n = 5;

--- a/consensus/src/simplex/actors/voter/round.rs
+++ b/consensus/src/simplex/actors/voter/round.rs
@@ -134,6 +134,11 @@ impl<S: Scheme, D: Digest> Round<S, D> {
         Some(leader)
     }
 
+    /// Clears an unrecorded local proposal request so it can be issued again.
+    pub const fn clear_proposal_request(&mut self) {
+        self.proposal.clear_request();
+    }
+
     /// Returns the leader info if we should verify a proposal.
     fn verify_ready(&self) -> Option<&Leader<S::PublicKey>> {
         let leader = self.leader.as_ref()?;

--- a/consensus/src/simplex/actors/voter/slot.rs
+++ b/consensus/src/simplex/actors/voter/slot.rs
@@ -82,9 +82,9 @@ where
         self.requested_build = true;
     }
 
-    /// Clears the build request if no proposal was recorded meanwhile.
+    /// Clears the build request unless the slot already has a proposal.
     pub const fn clear_request(&mut self) {
-        // A learned proposal makes the slot terminal for local construction.
+        // A recorded proposal already prevents another local build.
         if self.proposal.is_some() {
             return;
         }

--- a/consensus/src/simplex/actors/voter/slot.rs
+++ b/consensus/src/simplex/actors/voter/slot.rs
@@ -82,6 +82,15 @@ where
         self.requested_build = true;
     }
 
+    /// Clears the build request if no proposal was recorded meanwhile.
+    pub const fn clear_request(&mut self) {
+        // A learned proposal makes the slot terminal for local construction.
+        if self.proposal.is_some() {
+            return;
+        }
+        self.requested_build = false;
+    }
+
     /// Returns whether verification has yet to be requested for this slot.
     ///
     /// Unlike [`Self::should_build`], this does not test for an absent
@@ -214,11 +223,14 @@ mod tests {
         assert!(slot.should_build());
         slot.set_building();
         assert!(!slot.should_build());
+        slot.clear_request();
+        assert!(slot.should_build());
 
         let mut slot = Slot::<Sha256Digest>::new();
         let round = Rnd::new(Epoch::new(7), View::new(3));
         let proposal = Proposal::new(round, View::new(2), Sha256Digest::from([1u8; 32]));
         slot.built(proposal);
+        slot.clear_request();
         assert!(!slot.should_build());
     }
 

--- a/consensus/src/simplex/actors/voter/state.rs
+++ b/consensus/src/simplex/actors/voter/state.rs
@@ -960,6 +960,11 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
                 .parent_payload(&proposal)
                 .is_ok_and(|payload| payload == context.parent.1)
         {
+            // The build latch covers one asynchronous request. An invalid
+            // result leaves the slot empty, so release it for a new context.
+            if let Some(round) = self.views.get_mut(&context.view()) {
+                round.clear_proposal_request();
+            }
             return false;
         }
 
@@ -6875,6 +6880,53 @@ mod tests {
             assert!(state.add_nullification(nullification));
             assert!(!state.proposed(&ctx, ours.payload));
             assert!(state.construct_notarize(View::new(6)).is_none());
+        });
+    }
+
+    #[test]
+    fn pipelined_handoff_retries_after_parent_invalidation() {
+        let runtime = deterministic::Runner::default();
+        runtime.start(|mut context| async move {
+            // Prepare the outgoing tip and claim the incoming view's build on
+            // that speculative parent.
+            let (
+                Fixture {
+                    schemes, verifier, ..
+                },
+                mut state,
+            ) = setup_state_with_handoff(&mut context, 4, 3, 9, handoff_terms());
+            let (certified, _) = prepare_term_boundary(&mut state, &verifier, &schemes);
+
+            let initial = state
+                .try_propose()
+                .expect("handoff proposal should use the outgoing tip");
+            assert_eq!(initial.parent.0, View::new(5));
+            assert!(state.try_propose().is_none());
+
+            // Abandoning the captured parent rejects the pending build. The
+            // incoming view must remain eligible to rebuild on certified ancestry.
+            let nullification =
+                build_nullification(&verifier, &schemes, Rnd::new(Epoch::new(9), View::new(5)));
+            assert!(state.add_nullification(nullification));
+            assert!(!state.proposed(&initial, fetch_proposal(6, 5, 66).payload));
+
+            // Re-resolving ancestry for the same incoming view selects the
+            // certified fallback and still permits only one pending build.
+            let retry = state
+                .try_propose()
+                .expect("rejected handoff should retry on certified ancestry");
+            assert_eq!(retry.round.view(), View::new(6));
+            assert_eq!(retry.parent, (View::new(4), certified.payload));
+            assert!(state.try_propose().is_none());
+
+            // Completing the replacement build produces a vote on the
+            // fallback branch.
+            let rebuilt = fetch_proposal(6, 4, 67);
+            assert!(state.proposed(&retry, rebuilt.payload));
+            let notarize = state
+                .construct_notarize(View::new(6))
+                .expect("rebuilt proposal should be votable");
+            assert_eq!(notarize.proposal, rebuilt);
         });
     }
 

--- a/consensus/src/simplex/actors/voter/state.rs
+++ b/consensus/src/simplex/actors/voter/state.rs
@@ -1413,12 +1413,12 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
     /// before the certificate that unlocks the view exists.
     ///
     /// `None` when `view` does not start a term or the elector does not elect
-    /// ahead (see [`Elector::speculate`]).
+    /// early (see [`Elector::elect_early`]).
     fn handoff_leader(&self, view: View) -> Option<Participant> {
         if !view.is_term_start(self.term_length()) {
             return None;
         }
-        self.elector.speculate(Rnd::new(self.epoch, view))
+        self.elector.elect_early(Rnd::new(self.epoch, view))
     }
 
     /// Returns true when a pipelined handoff may build on `parent`: `parent`
@@ -1511,8 +1511,8 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
         }
 
         // Crossing a term boundary requires our notarize vote for the outgoing
-        // view. Receiving its proposal is not enough to speculate the incoming
-        // leader.
+        // view. Receiving its proposal is not enough to elect the incoming
+        // leader early.
         if !self
             .views
             .get(&view)
@@ -1521,7 +1521,7 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
             return;
         }
 
-        // Stamp the speculative leader once so repeated proposal, vote, and
+        // Stamp the early-elected leader once so repeated proposal, vote, and
         // replay events remain idempotent.
         if let Some(leader) = self.handoff_leader(next)
             && !self.leader_is_set(next)

--- a/consensus/src/simplex/actors/voter/state.rs
+++ b/consensus/src/simplex/actors/voter/state.rs
@@ -692,14 +692,14 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
             return None;
         }
 
-        // Check the cheap round-local eligibility before the ancestry gates
-        // below, which re-resolve parent payloads on every event otherwise.
+        // Check round-local eligibility before the ancestry check, which
+        // resolves the parent payload on every event.
         if !self.views.get(&view)?.can_construct_notarize() {
             return None;
         }
 
-        // Optimistic views wait for local evidence of their parent; anything
-        // outside the issuance window carries certified ancestry already.
+        // An optimistic view requires local evidence for its parent. A view
+        // outside the issuance window already has certified ancestry.
         if self.in_issuance_window(view) && !self.optimistic_parent_ready(view) {
             return None;
         }
@@ -947,27 +947,26 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
     /// preferred for the view or is still valid ancestry for the completed
     /// proposal. Conflicting or invalidated ancestry is rejected.
     pub fn proposed(&mut self, context: &Context<D, S::PublicKey>, payload: D) -> bool {
-        // Reconstruct the proposal from the round and parent captured when the
-        // asynchronous build began.
         let proposal = Proposal::new(context.round, context.parent.0, payload);
 
-        // Parent preference can advance while the automaton builds without
-        // invalidating the captured fallback.
+        // Accept the captured parent if it is still preferred or remains valid
+        // ancestry.
         if !self
             .find_parent(context.view())
             .is_ok_and(|parent| parent == context.parent)
             && !self.captured_parent_valid(context)
         {
-            // The build latch covers one asynchronous request. An invalid
-            // result leaves the slot empty, so release it for a new context.
+            // The build latch covers one asynchronous request. If the slot
+            // remains empty, release the latch so the voter can request a new
+            // context.
             if let Some(round) = self.views.get_mut(&context.view()) {
                 round.clear_proposal_request();
             }
             return false;
         }
 
-        // The captured ancestry passed one of the validity paths, so the
-        // proposal can enter the round as locally verified.
+        // Record the proposal as locally verified after accepting its captured
+        // parent.
         self.record_proposed(proposal)
     }
 
@@ -1521,8 +1520,8 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
             return;
         }
 
-        // Stamp the early-elected leader once so repeated proposal, vote, and
-        // replay events remain idempotent.
+        // Set the early leader once to keep proposal, vote, and replay handling
+        // idempotent.
         if let Some(leader) = self.handoff_leader(next)
             && !self.leader_is_set(next)
         {
@@ -6748,7 +6747,7 @@ mod tests {
     }
 
     #[test]
-    fn pipelined_handoff_replay_restores_speculative_leader() {
+    fn pipelined_handoff_replay_restores_early_leader() {
         let runtime = deterministic::Runner::default();
         runtime.start(|mut context| async move {
             let (
@@ -6772,7 +6771,7 @@ mod tests {
             let local_vote = Notarize::sign(&schemes[3], tip.clone()).expect("local notarize vote");
             assert_eq!(state.leader_index(View::new(6)), None);
 
-            // Replaying the vote must restore both the speculative leader and
+            // Replaying the vote must restore both the early leader and
             // the outgoing tip as usable handoff ancestry.
             state.replay(&Artifact::Notarize(local_vote));
             assert_eq!(state.leader_index(View::new(6)), Some(Participant::new(3)));

--- a/consensus/src/simplex/actors/voter/state.rs
+++ b/consensus/src/simplex/actors/voter/state.rs
@@ -6710,6 +6710,52 @@ mod tests {
     }
 
     #[test]
+    fn pipelined_handoff_replay_restores_speculative_leader() {
+        let runtime = deterministic::Runner::default();
+        runtime.start(|mut context| async move {
+            let (
+                Fixture {
+                    schemes, verifier, ..
+                },
+                mut state,
+            ) = setup_state_with_handoff(&mut context, 4, 3, 9, handoff_terms());
+
+            // Restore the certified anchor that precedes the outgoing vote in
+            // the journal.
+            let certified = fetch_proposal(4, 3, 64);
+            let notarization = build_notarization(&verifier, &schemes, &certified);
+            assert!(state.add_notarization(notarization).0);
+            assert!(state.certified(View::new(4), true).is_some());
+            assert_eq!(state.current_view(), View::new(5));
+
+            // The outgoing vote is durable, but its derived incoming leader is
+            // absent before replay.
+            let tip = fetch_proposal(5, 4, 65);
+            let local_vote = Notarize::sign(&schemes[3], tip.clone()).expect("local notarize vote");
+            assert_eq!(state.leader_index(View::new(6)), None);
+
+            // Replaying the vote must restore both the speculative leader and
+            // the outgoing tip as usable handoff ancestry.
+            state.replay(&Artifact::Notarize(local_vote));
+            assert_eq!(state.leader_index(View::new(6)), Some(Participant::new(3)));
+            let ctx = state
+                .try_propose()
+                .expect("replayed outgoing vote should restore the handoff");
+            assert_eq!(ctx.round.view(), View::new(6));
+            assert_eq!(ctx.parent, (View::new(5), tip.payload));
+
+            // Completing the recovered request must still produce the
+            // incoming term's notarize vote.
+            let ours = fetch_proposal(6, 5, 66);
+            assert!(state.proposed(&ctx, ours.payload));
+            let notarize = state
+                .construct_notarize(View::new(6))
+                .expect("recovered handoff proposal should be votable");
+            assert_eq!(notarize.proposal, ours);
+        });
+    }
+
+    #[test]
     fn pipelined_handoff_requires_optin() {
         let runtime = deterministic::Runner::default();
         runtime.start(|mut context| async move {

--- a/consensus/src/simplex/actors/voter/state.rs
+++ b/consensus/src/simplex/actors/voter/state.rs
@@ -949,16 +949,14 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
     pub fn proposed(&mut self, context: &Context<D, S::PublicKey>, payload: D) -> bool {
         let proposal = Proposal::new(context.round, context.parent.0, payload);
 
-        // Accept the captured parent if it is still preferred or remains valid
+        // Reject the captured parent only when it is neither preferred nor valid
         // ancestry.
         if !self
             .find_parent(context.view())
             .is_ok_and(|parent| parent == context.parent)
             && !self.captured_parent_valid(context)
         {
-            // The build latch covers one asynchronous request. If the slot
-            // remains empty, release the latch so the voter can request a new
-            // context.
+            // Rejection leaves the proposal slot empty, so allow the round to retry.
             if let Some(round) = self.views.get_mut(&context.view()) {
                 round.clear_proposal_request();
             }

--- a/consensus/src/simplex/actors/voter/state.rs
+++ b/consensus/src/simplex/actors/voter/state.rs
@@ -684,58 +684,23 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
         self.optimistic_ancestry_payload(parent).is_some()
     }
 
-    /// Returns true when `view`'s proposal does not rest on a pipelined
-    /// handoff, or when its cross-term parent still has locally usable
-    /// ancestry.
-    ///
-    /// Mirrors [`Self::optimistic_parent_ready`] for the term-start proposal
-    /// a pipelined handoff builds on the outgoing term's uncertified final
-    /// view. Proposals verified through explicit ancestry pass unconditionally
-    /// (their parent is certified or finalized, and stays so).
-    fn handoff_parent_ready(&self, view: View) -> bool {
-        if self.handoff_leader(view).is_none() {
-            return true;
-        }
-        let Some(parent) = view.previous() else {
-            return true;
-        };
-        let Some(proposal) = self.views.get(&view).and_then(|round| round.proposal()) else {
-            return true;
-        };
-        if proposal.parent != parent {
-            return true;
-        }
-        if self.explicit_ancestry_payload(parent).is_some() {
-            return true;
-        }
-        self.handoff_ancestry_payload(parent).is_some()
-    }
-
-    /// Returns true when `view`'s parent evidence permits our notarize vote.
-    ///
-    /// Views inside the issuance window use the optimistic rule
-    /// ([`Self::optimistic_parent_ready`]). Views outside it carry certified
-    /// ancestry already. The exception is a pipelined-handoff proposal, which
-    /// waits for evidence of its cross-term parent
-    /// ([`Self::handoff_parent_ready`]).
-    fn notarize_parent_ready(&self, view: View) -> bool {
-        if self.in_issuance_window(view) {
-            return self.optimistic_parent_ready(view);
-        }
-        self.handoff_parent_ready(view)
-    }
-
     /// Construct a notarize vote for this view when we're ready to sign.
     pub fn construct_notarize(&mut self, view: View) -> Option<Notarize<S, D>> {
+        // Certificates can create rounds arbitrarily far ahead. Do not vote
+        // until the view is admissible under this node's lookahead policy.
         if !self.admits_outbound(view) {
             return None;
         }
-        // Check cheap round-local eligibility first because the ancestry gate
-        // re-resolves parent payloads on every event.
+
+        // Check the cheap round-local eligibility before the ancestry gates
+        // below, which re-resolve parent payloads on every event otherwise.
         if !self.views.get(&view)?.can_construct_notarize() {
             return None;
         }
-        if !self.notarize_parent_ready(view) {
+
+        // Optimistic views wait for local evidence of their parent; anything
+        // outside the issuance window carries certified ancestry already.
+        if self.in_issuance_window(view) && !self.optimistic_parent_ready(view) {
             return None;
         }
         if !self.verification_matches(view) {
@@ -974,8 +939,37 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
         None
     }
 
-    /// Records a locally constructed proposal once the automaton finishes building it.
-    pub fn proposed(&mut self, proposal: Proposal<D>) -> bool {
+    /// Records a proposal built by the automaton if its captured parent remains
+    /// valid.
+    ///
+    /// Proposal construction is asynchronous, so parent evidence may change
+    /// while the automaton runs. The captured parent is accepted if it remains
+    /// preferred for the view or is still valid ancestry for the completed
+    /// proposal. Conflicting or invalidated ancestry is rejected.
+    pub fn proposed(&mut self, context: &Context<D, S::PublicKey>, payload: D) -> bool {
+        // Reconstruct the proposal from the round and parent captured when the
+        // asynchronous build began.
+        let proposal = Proposal::new(context.round, context.parent.0, payload);
+
+        // Parent preference can advance while the automaton builds without
+        // invalidating the captured fallback.
+        if !self
+            .find_parent(context.view())
+            .is_ok_and(|parent| parent == context.parent)
+            && !self
+                .parent_payload(&proposal)
+                .is_ok_and(|payload| payload == context.parent.1)
+        {
+            return false;
+        }
+
+        // The captured ancestry passed one of the validity paths, so the
+        // proposal can enter the round as locally verified.
+        self.record_proposed(proposal)
+    }
+
+    /// Records a proposal without applying ancestry checks.
+    fn record_proposed(&mut self, proposal: Proposal<D>) -> bool {
         let now = self.context.current();
         self.views
             .get_mut(&proposal.view())
@@ -1331,10 +1325,9 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
     //
     // The `*_parent_ready` predicates answer whether a view's immediate parent
     // is settled enough to act on. Certification and finalization require
-    // `explicit_parent_ready`. Notarize issuance uses `notarize_parent_ready`,
-    // which selects `optimistic_parent_ready` inside the issuance window and
-    // `handoff_parent_ready` outside it; both delegate to their ancestry
-    // resolver so issuance and proposal construction share one ancestry rule.
+    // `explicit_parent_ready`. Notarize issuance inside the optimistic window
+    // uses `optimistic_parent_ready`, which delegates to its ancestry resolver
+    // so issuance and proposal construction share one ancestry rule.
 
     /// Returns the payload of `view`'s explicitly certified (or finalized)
     /// proposal, the strongest form of ancestry.
@@ -1389,12 +1382,12 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
     /// before the certificate that unlocks the view exists.
     ///
     /// `None` when `view` does not start a term or the elector does not elect
-    /// ahead (see [`Elector::elect_ahead`]).
+    /// ahead (see [`Elector::speculate`]).
     fn handoff_leader(&self, view: View) -> Option<Participant> {
         if !view.is_term_start(self.term_length()) {
             return None;
         }
-        self.elector.elect_ahead(Rnd::new(self.epoch, view))
+        self.elector.speculate(Rnd::new(self.epoch, view))
     }
 
     /// Returns true when a pipelined handoff may build on `parent`: `parent`
@@ -1472,17 +1465,33 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
     }
 
     /// Pushes the optimistic frontier one view, so stable leaders can chain
-    /// proposals. Called when we sign a notarize vote or receive the leader's
-    /// proposal for a view.
+    /// proposals. Same-term successors can be prepared when we sign a
+    /// notarize vote or receive the leader's proposal.
     ///
-    /// At a term end, a pipelined handoff sets the incoming leader before the
-    /// certificate exists. This lets the leader propose across the boundary.
+    /// At a term end, only our notarize vote may prepare the incoming leader
+    /// before the certificate exists.
     fn prepare_optimistic_successor(&mut self, view: View) {
+        // Same-term successors inherit the current leader as soon as the
+        // optimistic issuance window reaches them.
         let next = view.next();
         if self.in_issuance_window(next) {
             self.inherit_leader(view, next);
             return;
         }
+
+        // Crossing a term boundary requires our notarize vote for the outgoing
+        // view. Receiving its proposal is not enough to speculate the incoming
+        // leader.
+        if !self
+            .views
+            .get(&view)
+            .is_some_and(|round| round.broadcast_notarize())
+        {
+            return;
+        }
+
+        // Stamp the speculative leader once so repeated proposal, vote, and
+        // replay events remain idempotent.
         if let Some(leader) = self.handoff_leader(next)
             && !self.leader_is_set(next)
         {
@@ -2001,7 +2010,7 @@ mod tests {
             Sha256Digest::from([payload; 32]),
         );
         state.create_round(View::new(1));
-        assert!(state.proposed(proposal.clone()));
+        assert!(state.record_proposed(proposal.clone()));
         assert!(state.construct_notarize(View::new(1)).is_some());
         proposal
     }
@@ -3837,7 +3846,7 @@ mod tests {
                 first_payload,
             );
             state.create_round(View::new(1));
-            assert!(state.proposed(first));
+            assert!(state.record_proposed(first));
 
             let second = Proposal::new(
                 Rnd::new(Epoch::new(9), View::new(2)),
@@ -4381,7 +4390,7 @@ mod tests {
                 child_context.parent.0,
                 Sha256Digest::from([119u8; 32]),
             );
-            assert!(state.proposed(child));
+            assert!(!state.proposed(&child_context, child.payload));
             assert!(
                 state.construct_notarize(View::new(2)).is_none(),
                 "failed-certified parent must block a locally proposed optimistic child"
@@ -4810,7 +4819,7 @@ mod tests {
                 Sha256Digest::from([112u8; 32]),
             );
             state.create_round(View::new(2));
-            assert!(state.proposed(view2));
+            assert!(state.record_proposed(view2));
             assert!(state.construct_notarize(View::new(2)).is_some());
             let conflicting_view2 = Proposal::new(
                 Rnd::new(Epoch::new(11), View::new(2)),
@@ -4854,7 +4863,7 @@ mod tests {
                 Sha256Digest::from([118u8; 32]),
             );
             state.create_round(View::new(2));
-            assert!(state.proposed(proposal_v2));
+            assert!(state.record_proposed(proposal_v2));
             assert!(state.construct_notarize(View::new(2)).is_none());
 
             let proposal_v1 = Proposal::new(
@@ -4863,7 +4872,7 @@ mod tests {
                 Sha256Digest::from([119u8; 32]),
             );
             state.create_round(View::new(1));
-            assert!(state.proposed(proposal_v1));
+            assert!(state.record_proposed(proposal_v1));
             assert!(state.construct_notarize(View::new(1)).is_some());
             assert!(state.construct_notarize(View::new(2)).is_some());
         });
@@ -5864,7 +5873,7 @@ mod tests {
             );
             state.set_genesis(test_genesis());
             state.create_round(View::new(1));
-            assert!(state.proposed(ancestor));
+            assert!(state.record_proposed(ancestor));
             let local_vote = state
                 .construct_notarize(View::new(1))
                 .expect("local notarize vote");
@@ -6645,6 +6654,7 @@ mod tests {
         assert!(state.set_proposal(View::new(5), tip.clone()));
         assert!(matches!(state.try_verify(), Verify::Ready(..)));
         assert!(state.verified(View::new(5)));
+        assert_eq!(state.leader_index(View::new(6)), None);
         assert!(state.construct_notarize(View::new(5)).is_some());
         (certified, tip)
     }
@@ -6675,7 +6685,7 @@ mod tests {
 
             // The built proposal broadcasts its notarize vote immediately.
             let ours = fetch_proposal(6, 5, 66);
-            assert!(state.proposed(ours.clone()));
+            assert!(state.proposed(&ctx, ours.payload));
             let notarize = state
                 .construct_notarize(View::new(6))
                 .expect("handoff proposal should notarize before the tip certifies");
@@ -6755,6 +6765,48 @@ mod tests {
     }
 
     #[test]
+    fn pipelined_handoff_keeps_valid_fallback_after_late_certification() {
+        let runtime = deterministic::Runner::default();
+        runtime.start(|mut context| async move {
+            let (
+                Fixture {
+                    schemes, verifier, ..
+                },
+                mut state,
+            ) = setup_state_with_handoff(&mut context, 4, 3, 9, handoff_terms());
+            let (certified, tip) = prepare_term_boundary(&mut state, &verifier, &schemes);
+
+            let tip_notarization = build_notarization(&verifier, &schemes, &tip);
+            assert!(state.add_notarization(tip_notarization).0);
+            assert_eq!(state.certify_candidates().0, vec![tip]);
+            let mut pool = AbortablePool::<()>::default();
+            let handle = pool.push(futures::future::pending());
+            state.set_certify_handle(View::new(5), handle);
+
+            let nullification =
+                build_nullification(&verifier, &schemes, Rnd::new(Epoch::new(9), View::new(5)));
+            assert!(state.add_nullification(nullification));
+            assert_eq!(state.current_view(), View::new(6));
+
+            let ctx = state
+                .try_propose()
+                .expect("term-start proposal should use the certified fallback");
+            assert_eq!(ctx.parent, (View::new(4), certified.payload));
+
+            // Late certification makes the outgoing tip preferred, but the
+            // captured fallback remains valid under the formed nullification.
+            assert!(state.certified(View::new(5), true).is_some());
+            let ours = fetch_proposal(6, 4, 66);
+            assert_eq!(state.parent_payload(&ours), Ok(certified.payload));
+            assert!(state.proposed(&ctx, ours.payload));
+            let notarize = state
+                .construct_notarize(View::new(6))
+                .expect("still-valid fallback should remain votable");
+            assert_eq!(notarize.proposal, ours);
+        });
+    }
+
+    #[test]
     fn pipelined_handoff_withholds_notarize_after_nullification() {
         let runtime = deterministic::Runner::default();
         runtime.start(|mut context| async move {
@@ -6766,15 +6818,16 @@ mod tests {
             ) = setup_state_with_handoff(&mut context, 4, 3, 9, handoff_terms());
             prepare_term_boundary(&mut state, &verifier, &schemes);
 
-            assert!(state.try_propose().is_some());
+            let ctx = state
+                .try_propose()
+                .expect("handoff proposal should use the outgoing tip");
             let ours = fetch_proposal(6, 5, 66);
-            assert!(state.proposed(ours));
 
-            // The tip's term is abandoned between building and voting: the
-            // vote must be withheld.
+            // The tip's term is abandoned while the application is building.
             let nullification =
                 build_nullification(&verifier, &schemes, Rnd::new(Epoch::new(9), View::new(5)));
             assert!(state.add_nullification(nullification));
+            assert!(!state.proposed(&ctx, ours.payload));
             assert!(state.construct_notarize(View::new(6)).is_none());
         });
     }
@@ -6791,15 +6844,16 @@ mod tests {
             ) = setup_state_with_handoff(&mut context, 4, 3, 9, handoff_terms());
             let (_, tip) = prepare_term_boundary(&mut state, &verifier, &schemes);
 
-            assert!(state.try_propose().is_some());
+            let ctx = state
+                .try_propose()
+                .expect("handoff proposal should use the outgoing tip");
             let ours = fetch_proposal(6, 5, 66);
-            assert!(state.proposed(ours));
 
-            // Local certification rejects the tip between building and
-            // voting: the vote must be withheld.
+            // Local certification rejects the tip while the application is building.
             let tip_notarization = build_notarization(&verifier, &schemes, &tip);
             assert!(state.add_notarization(tip_notarization).0);
             assert!(state.certified(View::new(5), false).is_some());
+            assert!(!state.proposed(&ctx, ours.payload));
             assert!(state.construct_notarize(View::new(6)).is_none());
         });
     }
@@ -6816,13 +6870,46 @@ mod tests {
             ) = setup_state_with_handoff(&mut context, 4, 3, 9, handoff_terms());
             prepare_term_boundary(&mut state, &verifier, &schemes);
 
-            assert!(state.try_propose().is_some());
+            let ctx = state
+                .try_propose()
+                .expect("handoff proposal should use the outgoing tip");
             let ours = fetch_proposal(6, 5, 66);
-            assert!(state.proposed(ours));
 
-            // The outgoing leader equivocates on the tip between building and
-            // voting: the vote must be withheld.
+            // The outgoing leader equivocates while the application is building.
             assert!(!state.set_proposal(View::new(5), fetch_proposal(5, 4, 99)));
+            assert!(!state.proposed(&ctx, ours.payload));
+            assert!(state.construct_notarize(View::new(6)).is_none());
+        });
+    }
+
+    #[test]
+    fn pipelined_handoff_withholds_notarize_after_conflicting_parent_certificate() {
+        let runtime = deterministic::Runner::default();
+        runtime.start(|mut context| async move {
+            let (
+                Fixture {
+                    schemes, verifier, ..
+                },
+                mut state,
+            ) = setup_state_with_handoff(&mut context, 4, 3, 9, handoff_terms());
+            let (_, tip) = prepare_term_boundary(&mut state, &verifier, &schemes);
+
+            let proposal_context = state
+                .try_propose()
+                .expect("handoff proposal should use the outgoing tip");
+            assert_eq!(proposal_context.parent, (View::new(5), tip.payload));
+
+            // A certificate from the other three validators replaces the tip
+            // while our application is still building on the original payload.
+            let conflicting = fetch_proposal(5, 4, 99);
+            let notarization = build_notarization(&verifier, &schemes[..3], &conflicting);
+            let (added, equivocator) = state.add_notarization(notarization);
+            assert!(added);
+            assert!(equivocator.is_some());
+            assert_eq!(state.current_view(), View::new(5));
+
+            let ours = fetch_proposal(6, 5, 66);
+            assert!(!state.proposed(&proposal_context, ours.payload));
             assert!(state.construct_notarize(View::new(6)).is_none());
         });
     }

--- a/consensus/src/simplex/actors/voter/state.rs
+++ b/consensus/src/simplex/actors/voter/state.rs
@@ -956,9 +956,7 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
         if !self
             .find_parent(context.view())
             .is_ok_and(|parent| parent == context.parent)
-            && !self
-                .parent_payload(&proposal)
-                .is_ok_and(|payload| payload == context.parent.1)
+            && !self.captured_parent_valid(context)
         {
             // The build latch covers one asynchronous request. An invalid
             // result leaves the slot empty, so release it for a new context.
@@ -971,6 +969,34 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
         // The captured ancestry passed one of the validity paths, so the
         // proposal can enter the round as locally verified.
         self.record_proposed(proposal)
+    }
+
+    /// Releases a proposal's build latch when its captured ancestry is invalid
+    /// and a replacement parent is available. Returns true when the caller
+    /// should drop the pending receiver.
+    pub fn supersede_proposal_request(&mut self, context: &Context<D, S::PublicKey>) -> bool {
+        let Ok(preferred) = self.find_parent(context.view()) else {
+            return false;
+        };
+        if preferred == context.parent || self.captured_parent_valid(context) {
+            return false;
+        }
+        let Some(round) = self.views.get_mut(&context.view()) else {
+            return false;
+        };
+        round.clear_proposal_request();
+        true
+    }
+
+    /// Returns whether a captured parent remains valid ancestry independent of
+    /// the currently preferred parent.
+    fn captured_parent_valid(&self, context: &Context<D, S::PublicKey>) -> bool {
+        let view = context.view();
+        let parent = context.parent.0;
+        self.validate_parent_span(view, parent).is_ok()
+            && self
+                .ancestry_payload_for_child(view, parent)
+                .is_some_and(|payload| *payload == context.parent.1)
     }
 
     /// Records a proposal without applying ancestry checks.
@@ -1627,8 +1653,8 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
     /// - It is certified (or finalized, which implies certification).
     /// - All views between it and the proposal view have been nullified.
     fn parent_payload(&self, proposal: &Proposal<D>) -> Result<D, ParentPayloadError> {
-        self.validate_parent_span(proposal)?;
         let (view, parent) = (proposal.view(), proposal.parent);
+        self.validate_parent_span(view, parent)?;
 
         // May return `None` if the parent view is not yet either:
         // - notarized and certified
@@ -1665,7 +1691,7 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
 
         // Intra-term views share the structural rules (the nullification check
         // is trivially satisfied once contiguity holds).
-        self.validate_parent_span(proposal)?;
+        self.validate_parent_span(view, parent)?;
 
         if self.explicit_parent_ready(view) {
             return Ok(());
@@ -1697,8 +1723,7 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
     }
 
     /// Validates the structural link between a proposal and its parent view.
-    fn validate_parent_span(&self, proposal: &Proposal<D>) -> Result<(), ParentPayloadError> {
-        let (view, parent) = (proposal.view(), proposal.parent);
+    fn validate_parent_span(&self, view: View, parent: View) -> Result<(), ParentPayloadError> {
         Self::ensure_parent_precedes(view, parent)?;
 
         // Ignore any requests for outdated parent views.
@@ -3455,11 +3480,19 @@ mod tests {
                 View::new(2),
                 Sha256Digest::from([44u8; 32]),
             );
+            let expected_leader = state.term_leader(View::new(6)).expect("term leader").key;
             assert!(state.set_proposal(View::new(6), child.clone()));
             assert!(matches!(
                 state.try_verify(),
-                Verify::Resolve { proposal, view, kind: Kind::Notarization, .. }
-                    if proposal == View::new(6) && view == View::new(2)
+                Verify::Resolve {
+                    proposal,
+                    view,
+                    kind: Kind::Notarization,
+                    target,
+                }
+                    if proposal == View::new(6)
+                        && view == View::new(2)
+                        && target == expected_leader
             ));
 
             // The round deduplicates the request while it is outstanding.
@@ -6849,6 +6882,7 @@ mod tests {
             assert!(state.certified(View::new(5), true).is_some());
             let ours = fetch_proposal(6, 4, 66);
             assert_eq!(state.parent_payload(&ours), Ok(certified.payload));
+            assert!(!state.supersede_proposal_request(&ctx));
             assert!(state.proposed(&ctx, ours.payload));
             let notarize = state
                 .construct_notarize(View::new(6))
@@ -7027,11 +7061,19 @@ mod tests {
             // A validator that receives the pipelined proposal early still
             // waits for the tip's certification before verifying it.
             let child = fetch_proposal(6, 5, 66);
+            let expected_leader = state.term_leader(View::new(6)).expect("term leader").key;
             assert!(state.set_proposal(View::new(6), child.clone()));
             assert!(matches!(
                 state.try_verify(),
-                Verify::Resolve { proposal, view, kind: Kind::Notarization, .. }
-                    if proposal == View::new(6) && view == View::new(5)
+                Verify::Resolve {
+                    proposal,
+                    view,
+                    kind: Kind::Notarization,
+                    target,
+                }
+                    if proposal == View::new(6)
+                        && view == View::new(5)
+                        && target == expected_leader
             ));
 
             let tip_notarization = build_notarization(&verifier, &schemes, &tip);

--- a/consensus/src/simplex/elector.rs
+++ b/consensus/src/simplex/elector.rs
@@ -18,7 +18,7 @@
 //! Applications can implement [`Config`] and [`Elector`] for custom leader
 //! selection logic such as stake-weighted selection or other application-specific strategies.
 //! An elector can support pipelined handoffs when it can select a leader before the round's
-//! unlocking certificate exists. See [`Elector::speculate`].
+//! unlocking certificate exists. See [`Elector::elect_early`].
 //!
 //! # Usage
 //!
@@ -240,7 +240,7 @@ pub trait Elector<S: Scheme>: Clone + Send + 'static {
     /// Return `Some` only when the leader is derivable without a certificate:
     /// the result must equal [`Self::elect`] for every certificate that can
     /// unlock the round. Certificate-derived electors such as
-    /// [`RandomElector`] cannot speculate.
+    /// [`RandomElector`] cannot elect early.
     ///
     /// The voter may call this method several times per view. Electors should
     /// return a precomputed result.
@@ -249,7 +249,7 @@ pub trait Elector<S: Scheme>: Clone + Send + 'static {
     /// The default opts out.
     ///
     /// [Pipelined Handoff]: crate::simplex#pipelined-handoff
-    fn speculate(&self, _round: Round) -> Option<Participant> {
+    fn elect_early(&self, _round: Round) -> Option<Participant> {
         None
     }
 }
@@ -385,9 +385,9 @@ impl<S: Scheme> Elector<S> for RoundRobinElector<S> {
         self.permutation[idx]
     }
 
-    fn speculate(&self, round: Round) -> Option<Participant> {
-        // Round-robin election never reads the certificate, so speculation is
-        // always consistent with `elect`.
+    fn elect_early(&self, round: Round) -> Option<Participant> {
+        // Round-robin election never reads the certificate, so electing early
+        // is always consistent with `elect`.
         self.pipelined_handoff.then(|| self.elect(round, None))
     }
 }
@@ -615,7 +615,7 @@ mod tests {
     }
 
     #[test]
-    fn round_robin_speculate_requires_optin_and_matches_elect() {
+    fn round_robin_elect_early_requires_optin_and_matches_elect() {
         let mut rng = test_rng();
         let Fixture { participants, .. } = ed25519::fixture(&mut rng, NAMESPACE, 4);
         let participants = Set::try_from_iter(participants).unwrap();
@@ -631,8 +631,11 @@ mod tests {
         for epoch in [0u64, 7] {
             for view in 1..=9u64 {
                 let round = Round::new(Epoch::new(epoch), View::new(view));
-                assert_eq!(opted_out.speculate(round), None);
-                assert_eq!(opted_in.speculate(round), Some(opted_in.elect(round, None)));
+                assert_eq!(opted_out.elect_early(round), None);
+                assert_eq!(
+                    opted_in.elect_early(round),
+                    Some(opted_in.elect(round, None))
+                );
             }
         }
     }

--- a/consensus/src/simplex/elector.rs
+++ b/consensus/src/simplex/elector.rs
@@ -18,7 +18,7 @@
 //! Applications can implement [`Config`] and [`Elector`] for custom leader
 //! selection logic such as stake-weighted selection or other application-specific strategies.
 //! An elector can support pipelined handoffs when it can select a leader before the round's
-//! unlocking certificate exists. See [`Elector::elect_ahead`].
+//! unlocking certificate exists. See [`Elector::speculate`].
 //!
 //! # Usage
 //!
@@ -240,7 +240,7 @@ pub trait Elector<S: Scheme>: Clone + Send + 'static {
     /// Return `Some` only when the leader is derivable without a certificate:
     /// the result must equal [`Self::elect`] for every certificate that can
     /// unlock the round. Certificate-derived electors such as
-    /// [`RandomElector`] cannot elect ahead.
+    /// [`RandomElector`] cannot speculate.
     ///
     /// The voter may call this method several times per view. Electors should
     /// return a precomputed result.
@@ -249,8 +249,7 @@ pub trait Elector<S: Scheme>: Clone + Send + 'static {
     /// The default opts out.
     ///
     /// [Pipelined Handoff]: crate::simplex#pipelined-handoff
-    fn elect_ahead(&self, round: Round) -> Option<Participant> {
-        let _ = round;
+    fn speculate(&self, _round: Round) -> Option<Participant> {
         None
     }
 }
@@ -386,9 +385,9 @@ impl<S: Scheme> Elector<S> for RoundRobinElector<S> {
         self.permutation[idx]
     }
 
-    fn elect_ahead(&self, round: Round) -> Option<Participant> {
-        // Round-robin election never reads the certificate, so electing ahead
-        // is always consistent with `elect`.
+    fn speculate(&self, round: Round) -> Option<Participant> {
+        // Round-robin election never reads the certificate, so speculation is
+        // always consistent with `elect`.
         self.pipelined_handoff.then(|| self.elect(round, None))
     }
 }
@@ -616,7 +615,7 @@ mod tests {
     }
 
     #[test]
-    fn round_robin_elect_ahead_requires_optin_and_matches_elect() {
+    fn round_robin_speculate_requires_optin_and_matches_elect() {
         let mut rng = test_rng();
         let Fixture { participants, .. } = ed25519::fixture(&mut rng, NAMESPACE, 4);
         let participants = Set::try_from_iter(participants).unwrap();
@@ -632,11 +631,8 @@ mod tests {
         for epoch in [0u64, 7] {
             for view in 1..=9u64 {
                 let round = Round::new(Epoch::new(epoch), View::new(view));
-                assert_eq!(opted_out.elect_ahead(round), None);
-                assert_eq!(
-                    opted_in.elect_ahead(round),
-                    Some(opted_in.elect(round, None))
-                );
+                assert_eq!(opted_out.speculate(round), None);
+                assert_eq!(opted_in.speculate(round), Some(opted_in.elect(round, None)));
             }
         }
     }

--- a/consensus/src/simplex/mod.rs
+++ b/consensus/src/simplex/mod.rs
@@ -248,7 +248,7 @@
 //! A term's first proposal waits for certified ancestry from the prior term. This delays proposal
 //! distribution by one network trip at every term boundary. An elector that can name a term's
 //! leader before the term starts (see
-//! [`elector::Elector::elect_ahead`]) can opt into pipelining the handoff. The incoming leader
+//! [`elector::Elector::speculate`]) can opt into pipelining the handoff. The incoming leader
 //! then proposes on the outgoing term's final view as soon as it holds a valid proposal for that
 //! view. It does not wait for the view to certify. If no such proposal arrives, the leader
 //! proposes on entering the term as usual. Non-leader validators keep the same behavior: they

--- a/consensus/src/simplex/mod.rs
+++ b/consensus/src/simplex/mod.rs
@@ -248,7 +248,7 @@
 //! A term's first proposal waits for certified ancestry from the prior term. This delays proposal
 //! distribution by one network trip at every term boundary. An elector that can name a term's
 //! leader before the term starts (see
-//! [`elector::Elector::speculate`]) can opt into pipelining the handoff. The incoming leader
+//! [`elector::Elector::elect_early`]) can opt into pipelining the handoff. The incoming leader
 //! then proposes on the outgoing term's final view as soon as it holds a valid proposal for that
 //! view. It does not wait for the view to certify. If no such proposal arrives, the leader
 //! proposes on entering the term as usual. Non-leader validators keep the same behavior: they


### PR DESCRIPTION
Follow-up to #4480.

Proposal construction is asynchronous. A parent captured when construction starts can become invalid before the application returns a payload. `State::proposed` records the completed proposal if its parent remains preferred or remains valid ancestry. Otherwise, the voter rejects the proposal before relay and permits a new build if the slot remains empty.

- Moves local ancestry validation into `State::proposed`.
- Retains the same-term optimistic vote check and removes the cross-term signing check made redundant by proposal validation.
- Requires a local `notarize` vote for the outgoing view before installing the next term’s leader early. Receiving the outgoing proposal alone does not enable the handoff.
- Renames `Elector::elect_ahead` to `Elector::elect_early`.
- Adds tests for late fallback validity, nullification, certification failure, equivocation, conflicting-certificate invalidation, and proposal retries.
