### PR TITLE
[utils] Add `Probability`

### DIFF
--- a/broadcast/fuzz/fuzz_targets/broadcast_engine_operations.rs
+++ b/broadcast/fuzz/fuzz_targets/broadcast_engine_operations.rs
@@ -13,7 +13,9 @@ use commonware_cryptography::{
 };
 use commonware_p2p::{Recipients, simulated::Network};
 use commonware_runtime::{Buf, BufMut, Clock, Quota, Runner, Supervisor as _, deterministic};
-use commonware_utils::{NZUsize, TestRng, channel::oneshot, futures::Pool, vec::Bounded};
+use commonware_utils::{
+    NZUsize, Probability, TestRng, channel::oneshot, futures::Pool, vec::Bounded,
+};
 use futures::FutureExt as _;
 use libfuzzer_sys::fuzz_target;
 use rand::seq::SliceRandom;
@@ -150,7 +152,7 @@ impl<'a> Arbitrary<'a> for BroadcastAction {
 #[derive(Debug)]
 pub struct FuzzInput {
     peer_seeds: Vec<u64>,
-    network_success_rate: f64,
+    network_success_rate: Probability,
     network_latency_ms: u64,
     network_jitter_ms: u64,
     cache_size: usize,
@@ -161,7 +163,7 @@ impl<'a> arbitrary::Arbitrary<'a> for FuzzInput {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         let num_peers = u.int_in_range(1..=5)?;
         let peer_seeds = (0..num_peers).collect::<Vec<_>>(); // avoid duplicate seeds
-        let network_success_rate = u.int_in_range(30..=100)? as f64 / 100.0;
+        let network_success_rate = Probability!(u.int_in_range(30..=100)?, 100);
         let network_latency_ms = u.int_in_range(1..=100)?;
         let network_jitter_ms = u.int_in_range(0..=50)?;
         let cache_size = u.int_in_range(5..=10)?;

--- a/broadcast/src/buffered/mod.rs
+++ b/broadcast/src/buffered/mod.rs
@@ -513,7 +513,7 @@ mod tests {
         let runner = deterministic::Runner::timed(Duration::from_secs(30));
         runner.start(|context| async move {
             let (peers, mut registrations, oracle) =
-                initialize_simulation(context.child("network"), 10, Probability!(1, 10)).await;
+                initialize_simulation(context.child("network"), 10, Probability!(0.1)).await;
             let mailboxes =
                 spawn_peer_engines(context.child("peers"), &oracle, &mut registrations).await;
 

--- a/broadcast/src/buffered/mod.rs
+++ b/broadcast/src/buffered/mod.rs
@@ -379,7 +379,7 @@ mod tests {
         let runner = deterministic::Runner::timed(Duration::from_secs(5));
         runner.start(|context| async move {
             let (peers, mut registrations, oracle) =
-                initialize_simulation(context.child("network"), 4, Probability::ONE).await;
+                initialize_simulation(context.child("network"), 4, Probability!(1.0)).await;
             let mailboxes =
                 spawn_peer_engines(context.child("peers"), &oracle, &mut registrations).await;
 
@@ -436,7 +436,7 @@ mod tests {
         runner.start(|context| async move {
             // Initialize simulation with 1 peer
             let (peers, mut registrations, oracle) =
-                initialize_simulation(context.child("network"), 1, Probability::ONE).await;
+                initialize_simulation(context.child("network"), 1, Probability!(1.0)).await;
             let mailboxes =
                 spawn_peer_engines(context.child("peers"), &oracle, &mut registrations).await;
 
@@ -490,7 +490,7 @@ mod tests {
         let runner = deterministic::Runner::timed(Duration::from_secs(5));
         runner.start(|context| async move {
             let (peers, mut registrations, oracle) =
-                initialize_simulation(context.child("network"), 1, Probability::ONE).await;
+                initialize_simulation(context.child("network"), 1, Probability!(1.0)).await;
             let mailboxes =
                 spawn_peer_engines(context.child("peers"), &oracle, &mut registrations).await;
             let mailbox = mailboxes.get(&peers[0]).unwrap();
@@ -559,7 +559,7 @@ mod tests {
         let runner = deterministic::Runner::timed(Duration::from_secs(5));
         runner.start(|context| async move {
             let (peers, mut registrations, oracle) =
-                initialize_simulation(context.child("network"), 2, Probability::ONE).await;
+                initialize_simulation(context.child("network"), 2, Probability!(1.0)).await;
             let mailboxes =
                 spawn_peer_engines(context.child("peers"), &oracle, &mut registrations).await;
 
@@ -592,7 +592,7 @@ mod tests {
         let runner = deterministic::Runner::timed(Duration::from_secs(5));
         runner.start(|context| async move {
             let (peers, mut registrations, oracle) =
-                initialize_simulation(context.child("network"), 2, Probability::ONE).await;
+                initialize_simulation(context.child("network"), 2, Probability!(1.0)).await;
             let mailboxes =
                 spawn_peer_engines(context.child("peers"), &oracle, &mut registrations).await;
 
@@ -630,7 +630,7 @@ mod tests {
         let runner = deterministic::Runner::timed(Duration::from_secs(5));
         runner.start(|context| async move {
             let (peers, mut registrations, oracle) =
-                initialize_simulation(context.child("network"), 2, Probability::ONE).await;
+                initialize_simulation(context.child("network"), 2, Probability!(1.0)).await;
             let mailboxes =
                 spawn_peer_engines(context.child("peers"), &oracle, &mut registrations).await;
 
@@ -674,7 +674,7 @@ mod tests {
         runner.start(|context| async move {
             // Initialize simulation with 3 peers
             let (peers, mut registrations, oracle) =
-                initialize_simulation(context.child("network"), 3, Probability::ONE).await;
+                initialize_simulation(context.child("network"), 3, Probability!(1.0)).await;
             let mailboxes =
                 spawn_peer_engines(context.child("peers"), &oracle, &mut registrations).await;
 
@@ -735,7 +735,7 @@ mod tests {
         let runner = deterministic::Runner::timed(Duration::from_secs(5));
         runner.start(|context| async move {
             let (peers, mut registrations, oracle) =
-                initialize_simulation(context.child("network"), 4, Probability::ONE).await;
+                initialize_simulation(context.child("network"), 4, Probability!(1.0)).await;
 
             let sender_pk = peers[0].clone();
             let target_peer = peers[1].clone();
@@ -780,7 +780,7 @@ mod tests {
         runner.start(|context| async move {
             // three peers so we can observe from a third
             let (peers, mut registrations, oracle) =
-                initialize_simulation(context.child("network"), 3, Probability::ONE).await;
+                initialize_simulation(context.child("network"), 3, Probability!(1.0)).await;
             let mailboxes =
                 spawn_peer_engines(context.child("peers"), &oracle, &mut registrations).await;
 
@@ -831,7 +831,7 @@ mod tests {
             let runner = deterministic::Runner::new(config);
             runner.start(|context| async move {
                 let (peers, mut registrations, oracle) =
-                    initialize_simulation(context.child("network"), 1, Probability::ONE).await;
+                    initialize_simulation(context.child("network"), 1, Probability!(1.0)).await;
                 let mailboxes =
                     spawn_peer_engines(context.child("peers"), &oracle, &mut registrations).await;
 
@@ -869,7 +869,7 @@ mod tests {
         let runner = deterministic::Runner::timed(Duration::from_secs(10));
         runner.start(|context| async move {
             let (peers, mut registrations, oracle) =
-                initialize_simulation(context.child("network"), 3, Probability::ONE).await;
+                initialize_simulation(context.child("network"), 3, Probability!(1.0)).await;
 
             let attacker = peers[0].clone();
             let honest = peers[1].clone();
@@ -912,7 +912,7 @@ mod tests {
         let runner = deterministic::Runner::timed(Duration::from_secs(10));
         runner.start(|context| async move {
             let (peers, mut registrations, oracle) =
-                initialize_simulation(context.child("network"), 1, Probability::ONE).await;
+                initialize_simulation(context.child("network"), 1, Probability!(1.0)).await;
             let peer = peers[0].clone();
             let (sender, receiver) = registrations.remove(&peer).unwrap();
 
@@ -1027,7 +1027,7 @@ mod tests {
         let runner = deterministic::Runner::timed(Duration::from_secs(5));
         runner.start(|context| async move {
             let (peers, mut registrations, oracle) =
-                initialize_simulation(context.child("network"), 2, Probability::ONE).await;
+                initialize_simulation(context.child("network"), 2, Probability!(1.0)).await;
             let (mut mailboxes, handles) = spawn_peer_engines_with_handles(
                 context.child("peers"),
                 &oracle,
@@ -1082,7 +1082,7 @@ mod tests {
         let runner = deterministic::Runner::new(cfg);
         runner.start(|context| async move {
             let (peers, mut registrations, oracle) =
-                initialize_simulation(context.child("network"), 2, Probability::ONE).await;
+                initialize_simulation(context.child("network"), 2, Probability!(1.0)).await;
 
             let (mailboxes, handles) = spawn_peer_engines_with_handles(
                 context.child("peers"),
@@ -1146,7 +1146,7 @@ mod tests {
         let runner = deterministic::Runner::timed(Duration::from_secs(5));
         runner.start(|context| async move {
             let (peers, mut registrations, oracle) =
-                initialize_simulation(context.child("network"), 3, Probability::ONE).await;
+                initialize_simulation(context.child("network"), 3, Probability!(1.0)).await;
 
             let peer_a = peers[0].clone();
             let peer_b = peers[1].clone();
@@ -1249,7 +1249,7 @@ mod tests {
             let link = Link {
                 latency: NETWORK_SPEED,
                 jitter: Duration::ZERO,
-                success_rate: Probability::ONE,
+                success_rate: Probability!(1.0),
             };
             for p1 in peers.iter() {
                 for p2 in peers.iter() {
@@ -1378,7 +1378,7 @@ mod tests {
             let link = Link {
                 latency: NETWORK_SPEED,
                 jitter: Duration::ZERO,
-                success_rate: Probability::ONE,
+                success_rate: Probability!(1.0),
             };
             for p1 in &peers {
                 for p2 in &peers {
@@ -1450,7 +1450,7 @@ mod tests {
         runner.start(|context| async move {
             // Add a sole peer (self) to the network
             let (peers, mut registrations, oracle) =
-                initialize_simulation(context.child("network"), 1, Probability::ONE).await;
+                initialize_simulation(context.child("network"), 1, Probability!(1.0)).await;
             let peer = peers[0].clone();
             let network = registrations.remove(&peer).unwrap();
             let config = Config {
@@ -1517,7 +1517,7 @@ mod tests {
             let link = Link {
                 latency: NETWORK_SPEED,
                 jitter: Duration::ZERO,
-                success_rate: Probability::ONE,
+                success_rate: Probability!(1.0),
             };
             for p1 in &peers {
                 for p2 in &peers {
@@ -1591,7 +1591,7 @@ mod tests {
         let runner = deterministic::Runner::timed(Duration::from_secs(5));
         runner.start(|context| async move {
             let (peers, mut registrations, oracle) =
-                initialize_simulation(context.child("network"), 3, Probability::ONE).await;
+                initialize_simulation(context.child("network"), 3, Probability!(1.0)).await;
 
             let peer_a = peers[0].clone();
             let peer_b = peers[1].clone();

--- a/broadcast/src/buffered/mod.rs
+++ b/broadcast/src/buffered/mod.rs
@@ -56,7 +56,7 @@ mod tests {
         Clock, Error, IoBuf, Metrics as _, Quota, Runner, Supervisor as _, deterministic,
         telemetry::metrics::count_running_tasks,
     };
-    use commonware_utils::NZUsize;
+    use commonware_utils::{NZUsize, Probability};
     use std::{
         collections::{BTreeMap, VecDeque},
         num::NonZeroU32,
@@ -91,7 +91,7 @@ mod tests {
     async fn initialize_simulation(
         context: deterministic::Context,
         num_peers: usize,
-        success_rate: f64,
+        success_rate: Probability,
     ) -> (
         Vec<PublicKey>,
         Registrations,
@@ -379,7 +379,7 @@ mod tests {
         let runner = deterministic::Runner::timed(Duration::from_secs(5));
         runner.start(|context| async move {
             let (peers, mut registrations, oracle) =
-                initialize_simulation(context.child("network"), 4, 1.0).await;
+                initialize_simulation(context.child("network"), 4, Probability::ONE).await;
             let mailboxes =
                 spawn_peer_engines(context.child("peers"), &oracle, &mut registrations).await;
 
@@ -436,7 +436,7 @@ mod tests {
         runner.start(|context| async move {
             // Initialize simulation with 1 peer
             let (peers, mut registrations, oracle) =
-                initialize_simulation(context.child("network"), 1, 1.0).await;
+                initialize_simulation(context.child("network"), 1, Probability::ONE).await;
             let mailboxes =
                 spawn_peer_engines(context.child("peers"), &oracle, &mut registrations).await;
 
@@ -490,7 +490,7 @@ mod tests {
         let runner = deterministic::Runner::timed(Duration::from_secs(5));
         runner.start(|context| async move {
             let (peers, mut registrations, oracle) =
-                initialize_simulation(context.child("network"), 1, 1.0).await;
+                initialize_simulation(context.child("network"), 1, Probability::ONE).await;
             let mailboxes =
                 spawn_peer_engines(context.child("peers"), &oracle, &mut registrations).await;
             let mailbox = mailboxes.get(&peers[0]).unwrap();
@@ -513,7 +513,7 @@ mod tests {
         let runner = deterministic::Runner::timed(Duration::from_secs(30));
         runner.start(|context| async move {
             let (peers, mut registrations, oracle) =
-                initialize_simulation(context.child("network"), 10, 0.1).await;
+                initialize_simulation(context.child("network"), 10, Probability!(1, 10)).await;
             let mailboxes =
                 spawn_peer_engines(context.child("peers"), &oracle, &mut registrations).await;
 
@@ -559,7 +559,7 @@ mod tests {
         let runner = deterministic::Runner::timed(Duration::from_secs(5));
         runner.start(|context| async move {
             let (peers, mut registrations, oracle) =
-                initialize_simulation(context.child("network"), 2, 1.0).await;
+                initialize_simulation(context.child("network"), 2, Probability::ONE).await;
             let mailboxes =
                 spawn_peer_engines(context.child("peers"), &oracle, &mut registrations).await;
 
@@ -592,7 +592,7 @@ mod tests {
         let runner = deterministic::Runner::timed(Duration::from_secs(5));
         runner.start(|context| async move {
             let (peers, mut registrations, oracle) =
-                initialize_simulation(context.child("network"), 2, 1.0).await;
+                initialize_simulation(context.child("network"), 2, Probability::ONE).await;
             let mailboxes =
                 spawn_peer_engines(context.child("peers"), &oracle, &mut registrations).await;
 
@@ -630,7 +630,7 @@ mod tests {
         let runner = deterministic::Runner::timed(Duration::from_secs(5));
         runner.start(|context| async move {
             let (peers, mut registrations, oracle) =
-                initialize_simulation(context.child("network"), 2, 1.0).await;
+                initialize_simulation(context.child("network"), 2, Probability::ONE).await;
             let mailboxes =
                 spawn_peer_engines(context.child("peers"), &oracle, &mut registrations).await;
 
@@ -674,7 +674,7 @@ mod tests {
         runner.start(|context| async move {
             // Initialize simulation with 3 peers
             let (peers, mut registrations, oracle) =
-                initialize_simulation(context.child("network"), 3, 1.0).await;
+                initialize_simulation(context.child("network"), 3, Probability::ONE).await;
             let mailboxes =
                 spawn_peer_engines(context.child("peers"), &oracle, &mut registrations).await;
 
@@ -735,7 +735,7 @@ mod tests {
         let runner = deterministic::Runner::timed(Duration::from_secs(5));
         runner.start(|context| async move {
             let (peers, mut registrations, oracle) =
-                initialize_simulation(context.child("network"), 4, 1.0).await;
+                initialize_simulation(context.child("network"), 4, Probability::ONE).await;
 
             let sender_pk = peers[0].clone();
             let target_peer = peers[1].clone();
@@ -780,7 +780,7 @@ mod tests {
         runner.start(|context| async move {
             // three peers so we can observe from a third
             let (peers, mut registrations, oracle) =
-                initialize_simulation(context.child("network"), 3, 1.0).await;
+                initialize_simulation(context.child("network"), 3, Probability::ONE).await;
             let mailboxes =
                 spawn_peer_engines(context.child("peers"), &oracle, &mut registrations).await;
 
@@ -831,7 +831,7 @@ mod tests {
             let runner = deterministic::Runner::new(config);
             runner.start(|context| async move {
                 let (peers, mut registrations, oracle) =
-                    initialize_simulation(context.child("network"), 1, 1.0).await;
+                    initialize_simulation(context.child("network"), 1, Probability::ONE).await;
                 let mailboxes =
                     spawn_peer_engines(context.child("peers"), &oracle, &mut registrations).await;
 
@@ -869,7 +869,7 @@ mod tests {
         let runner = deterministic::Runner::timed(Duration::from_secs(10));
         runner.start(|context| async move {
             let (peers, mut registrations, oracle) =
-                initialize_simulation(context.child("network"), 3, 1.0).await;
+                initialize_simulation(context.child("network"), 3, Probability::ONE).await;
 
             let attacker = peers[0].clone();
             let honest = peers[1].clone();
@@ -912,7 +912,7 @@ mod tests {
         let runner = deterministic::Runner::timed(Duration::from_secs(10));
         runner.start(|context| async move {
             let (peers, mut registrations, oracle) =
-                initialize_simulation(context.child("network"), 1, 1.0).await;
+                initialize_simulation(context.child("network"), 1, Probability::ONE).await;
             let peer = peers[0].clone();
             let (sender, receiver) = registrations.remove(&peer).unwrap();
 
@@ -1027,7 +1027,7 @@ mod tests {
         let runner = deterministic::Runner::timed(Duration::from_secs(5));
         runner.start(|context| async move {
             let (peers, mut registrations, oracle) =
-                initialize_simulation(context.child("network"), 2, 1.0).await;
+                initialize_simulation(context.child("network"), 2, Probability::ONE).await;
             let (mut mailboxes, handles) = spawn_peer_engines_with_handles(
                 context.child("peers"),
                 &oracle,
@@ -1082,7 +1082,7 @@ mod tests {
         let runner = deterministic::Runner::new(cfg);
         runner.start(|context| async move {
             let (peers, mut registrations, oracle) =
-                initialize_simulation(context.child("network"), 2, 1.0).await;
+                initialize_simulation(context.child("network"), 2, Probability::ONE).await;
 
             let (mailboxes, handles) = spawn_peer_engines_with_handles(
                 context.child("peers"),
@@ -1146,7 +1146,7 @@ mod tests {
         let runner = deterministic::Runner::timed(Duration::from_secs(5));
         runner.start(|context| async move {
             let (peers, mut registrations, oracle) =
-                initialize_simulation(context.child("network"), 3, 1.0).await;
+                initialize_simulation(context.child("network"), 3, Probability::ONE).await;
 
             let peer_a = peers[0].clone();
             let peer_b = peers[1].clone();
@@ -1249,7 +1249,7 @@ mod tests {
             let link = Link {
                 latency: NETWORK_SPEED,
                 jitter: Duration::ZERO,
-                success_rate: 1.0,
+                success_rate: Probability::ONE,
             };
             for p1 in peers.iter() {
                 for p2 in peers.iter() {
@@ -1378,7 +1378,7 @@ mod tests {
             let link = Link {
                 latency: NETWORK_SPEED,
                 jitter: Duration::ZERO,
-                success_rate: 1.0,
+                success_rate: Probability::ONE,
             };
             for p1 in &peers {
                 for p2 in &peers {
@@ -1450,7 +1450,7 @@ mod tests {
         runner.start(|context| async move {
             // Add a sole peer (self) to the network
             let (peers, mut registrations, oracle) =
-                initialize_simulation(context.child("network"), 1, 1.0).await;
+                initialize_simulation(context.child("network"), 1, Probability::ONE).await;
             let peer = peers[0].clone();
             let network = registrations.remove(&peer).unwrap();
             let config = Config {
@@ -1517,7 +1517,7 @@ mod tests {
             let link = Link {
                 latency: NETWORK_SPEED,
                 jitter: Duration::ZERO,
-                success_rate: 1.0,
+                success_rate: Probability::ONE,
             };
             for p1 in &peers {
                 for p2 in &peers {
@@ -1591,7 +1591,7 @@ mod tests {
         let runner = deterministic::Runner::timed(Duration::from_secs(5));
         runner.start(|context| async move {
             let (peers, mut registrations, oracle) =
-                initialize_simulation(context.child("network"), 3, 1.0).await;
+                initialize_simulation(context.child("network"), 3, Probability::ONE).await;
 
             let peer_a = peers[0].clone();
             let peer_b = peers[1].clone();

--- a/collector/src/p2p/mod.rs
+++ b/collector/src/p2p/mod.rs
@@ -76,12 +76,12 @@ mod tests {
     const LINK: Link = Link {
         latency: Duration::from_millis(10),
         jitter: Duration::from_millis(1),
-        success_rate: Probability::ONE,
+        success_rate: Probability!(1.0),
     };
     const LINK_SLOW: Link = Link {
         latency: Duration::from_secs(1),
         jitter: Duration::from_millis(1),
-        success_rate: Probability::ONE,
+        success_rate: Probability!(1.0),
     };
 
     async fn setup_network_and_peers(

--- a/collector/src/p2p/mod.rs
+++ b/collector/src/p2p/mod.rs
@@ -66,7 +66,7 @@ mod tests {
         Clock, Quota, Runner, Supervisor as _, deterministic,
         telemetry::metrics::count_running_tasks,
     };
-    use commonware_utils::{NZU32, NZUsize, ordered::Set};
+    use commonware_utils::{NZU32, NZUsize, Probability, ordered::Set};
     use std::{num::NonZeroUsize, time::Duration};
 
     /// Default rate limit quota for tests (high enough to not interfere with normal operation)
@@ -76,12 +76,12 @@ mod tests {
     const LINK: Link = Link {
         latency: Duration::from_millis(10),
         jitter: Duration::from_millis(1),
-        success_rate: 1.0,
+        success_rate: Probability::ONE,
     };
     const LINK_SLOW: Link = Link {
         latency: Duration::from_secs(1),
         jitter: Duration::from_millis(1),
-        success_rate: 1.0,
+        success_rate: Probability::ONE,
     };
 
     async fn setup_network_and_peers(

--- a/consensus/fuzz/src/lib.rs
+++ b/consensus/fuzz/src/lib.rs
@@ -36,7 +36,7 @@ use commonware_parallel::Sequential;
 use commonware_runtime::{
     Clock, IoBuf, Runner, Spawner, Supervisor as _, buffer::paged::CacheRef, deterministic,
 };
-use commonware_utils::{FuzzRng, NZU16, NZU32, NZUsize, channel::mpsc::Receiver};
+use commonware_utils::{FuzzRng, NZU16, NZU32, NZUsize, Probability, channel::mpsc::Receiver};
 use futures::future::join_all;
 pub use simplex::{
     SimplexBls12381MinPk, SimplexBls12381MinSig, SimplexBls12381MultisigMinPk,
@@ -100,7 +100,7 @@ async fn setup_degraded_network<E: Clock>(
     let degraded = Link {
         latency: Duration::from_millis(50),
         jitter: Duration::from_millis(50),
-        success_rate: 0.6,
+        success_rate: Probability!(3, 5),
     };
     for (peer_idx, peer) in participants.iter().enumerate() {
         if peer_idx == victim_idx {
@@ -269,7 +269,7 @@ async fn setup_network<P: simplex::Simplex>(
     let link = Link {
         latency: Duration::from_millis(10),
         jitter: Duration::from_millis(1),
-        success_rate: 1.0,
+        success_rate: Probability::ONE,
     };
     link_peers(
         &mut oracle,
@@ -542,7 +542,7 @@ fn run_with_twin_mutator<P: simplex::Simplex>(input: FuzzInput) {
             Action::Update(Link {
                 latency: Duration::from_millis(500),
                 jitter: Duration::from_millis(500),
-                success_rate: 1.0,
+                success_rate: Probability::ONE,
             }),
             input.partition.filter(),
         )

--- a/consensus/fuzz/src/lib.rs
+++ b/consensus/fuzz/src/lib.rs
@@ -269,7 +269,7 @@ async fn setup_network<P: simplex::Simplex>(
     let link = Link {
         latency: Duration::from_millis(10),
         jitter: Duration::from_millis(1),
-        success_rate: Probability::ONE,
+        success_rate: Probability!(1.0),
     };
     link_peers(
         &mut oracle,
@@ -542,7 +542,7 @@ fn run_with_twin_mutator<P: simplex::Simplex>(input: FuzzInput) {
             Action::Update(Link {
                 latency: Duration::from_millis(500),
                 jitter: Duration::from_millis(500),
-                success_rate: Probability::ONE,
+                success_rate: Probability!(1.0),
             }),
             input.partition.filter(),
         )

--- a/consensus/fuzz/src/lib.rs
+++ b/consensus/fuzz/src/lib.rs
@@ -100,7 +100,7 @@ async fn setup_degraded_network<E: Clock>(
     let degraded = Link {
         latency: Duration::from_millis(50),
         jitter: Duration::from_millis(50),
-        success_rate: Probability!(3, 5),
+        success_rate: Probability!(0.6),
     };
     for (peer_idx, peer) in participants.iter().enumerate() {
         if peer_idx == victim_idx {

--- a/consensus/src/aggregation/mod.rs
+++ b/consensus/src/aggregation/mod.rs
@@ -177,7 +177,7 @@ mod tests {
     const RELIABLE_LINK: Link = Link {
         latency: Duration::from_millis(10),
         jitter: Duration::from_millis(1),
-        success_rate: Probability::ONE,
+        success_rate: Probability!(1.0),
     };
 
     /// Register all participants with the network oracle.

--- a/consensus/src/aggregation/mod.rs
+++ b/consensus/src/aggregation/mod.rs
@@ -812,7 +812,7 @@ mod tests {
             let degraded_link = Link {
                 latency: Duration::from_millis(200),
                 jitter: Duration::from_millis(150),
-                success_rate: Probability!(1, 2),
+                success_rate: Probability!(0.5),
             };
 
             let (mut oracle, mut registrations) =
@@ -1119,7 +1119,7 @@ mod tests {
             let delayed_link = Link {
                 latency: Duration::from_millis(80),
                 jitter: Duration::from_millis(10),
-                success_rate: Probability!(49, 50),
+                success_rate: Probability!(0.98),
             };
 
             // Initialize the simulated network

--- a/consensus/src/aggregation/mod.rs
+++ b/consensus/src/aggregation/mod.rs
@@ -120,7 +120,7 @@ mod tests {
         deterministic::{self, Context},
     };
     use commonware_utils::{
-        NZU16, NZUsize, NonZeroDuration, TestRng,
+        NZU16, NZUsize, NonZeroDuration, Probability, TestRng,
         channel::{fallible::OneshotExt, oneshot},
         test_rng,
     };
@@ -177,7 +177,7 @@ mod tests {
     const RELIABLE_LINK: Link = Link {
         latency: Duration::from_millis(10),
         jitter: Duration::from_millis(1),
-        success_rate: 1.0,
+        success_rate: Probability::ONE,
     };
 
     /// Register all participants with the network oracle.
@@ -812,7 +812,7 @@ mod tests {
             let degraded_link = Link {
                 latency: Duration::from_millis(200),
                 jitter: Duration::from_millis(150),
-                success_rate: 0.5,
+                success_rate: Probability!(1, 2),
             };
 
             let (mut oracle, mut registrations) =
@@ -1119,7 +1119,7 @@ mod tests {
             let delayed_link = Link {
                 latency: Duration::from_millis(80),
                 jitter: Duration::from_millis(10),
-                success_rate: 0.98,
+                success_rate: Probability!(49, 50),
             };
 
             // Initialize the simulated network

--- a/consensus/src/marshal/coding/shards/engine.rs
+++ b/consensus/src/marshal/coding/shards/engine.rs
@@ -1899,7 +1899,8 @@ mod tests {
     use commonware_parallel::Sequential;
     use commonware_runtime::{Quota, Runner, Supervisor as _, deterministic};
     use commonware_utils::{
-        N3f1, NZUsize, Participant, channel::oneshot::error::TryRecvError, ordered::Set,
+        N3f1, NZUsize, Participant, Probability, channel::oneshot::error::TryRecvError,
+        ordered::Set,
     };
     use std::{
         future::Future,
@@ -1940,7 +1941,7 @@ mod tests {
     const DEFAULT_LINK: Link = Link {
         latency: Duration::from_millis(50),
         jitter: Duration::ZERO,
-        success_rate: 1.0,
+        success_rate: Probability::ONE,
     };
 
     /// Rate limit quota for tests (effectively unlimited).

--- a/consensus/src/marshal/coding/shards/engine.rs
+++ b/consensus/src/marshal/coding/shards/engine.rs
@@ -1941,7 +1941,7 @@ mod tests {
     const DEFAULT_LINK: Link = Link {
         latency: Duration::from_millis(50),
         jitter: Duration::ZERO,
-        success_rate: Probability::ONE,
+        success_rate: Probability!(1.0),
     };
 
     /// Rate limit quota for tests (effectively unlimited).

--- a/consensus/src/marshal/mocks/harness.rs
+++ b/consensus/src/marshal/mocks/harness.rs
@@ -88,7 +88,7 @@ pub const BLOCKS_PER_EPOCH: NonZeroU64 = NZU64!(20);
 pub const LINK: Link = Link {
     latency: Duration::from_millis(100),
     jitter: Duration::from_millis(1),
-    success_rate: Probability::ONE,
+    success_rate: Probability!(1.0),
 };
 pub const UNRELIABLE_LINK: Link = Link {
     latency: Duration::from_millis(200),

--- a/consensus/src/marshal/mocks/harness.rs
+++ b/consensus/src/marshal/mocks/harness.rs
@@ -49,7 +49,7 @@ use commonware_storage::{
     archive::{immutable, prunable},
     translator::EightCap,
 };
-use commonware_utils::{NZU16, NZU64, NZUsize, TestRng, test_rng, vec::NonEmptyVec};
+use commonware_utils::{NZU16, NZU64, NZUsize, Probability, TestRng, test_rng, vec::NonEmptyVec};
 use futures::StreamExt;
 use rand::{
     RngExt as _,
@@ -88,12 +88,12 @@ pub const BLOCKS_PER_EPOCH: NonZeroU64 = NZU64!(20);
 pub const LINK: Link = Link {
     latency: Duration::from_millis(100),
     jitter: Duration::from_millis(1),
-    success_rate: 1.0,
+    success_rate: Probability::ONE,
 };
 pub const UNRELIABLE_LINK: Link = Link {
     latency: Duration::from_millis(200),
     jitter: Duration::from_millis(50),
-    success_rate: 0.7,
+    success_rate: Probability!(7, 10),
 };
 pub const TEST_QUOTA: Quota = Quota::per_second(NonZeroU32::MAX);
 

--- a/consensus/src/marshal/mocks/harness.rs
+++ b/consensus/src/marshal/mocks/harness.rs
@@ -93,7 +93,7 @@ pub const LINK: Link = Link {
 pub const UNRELIABLE_LINK: Link = Link {
     latency: Duration::from_millis(200),
     jitter: Duration::from_millis(50),
-    success_rate: Probability!(7, 10),
+    success_rate: Probability!(0.7),
 };
 pub const TEST_QUOTA: Quota = Quota::per_second(NonZeroU32::MAX);
 

--- a/consensus/src/marshal/standard/mod.rs
+++ b/consensus/src/marshal/standard/mod.rs
@@ -3546,7 +3546,7 @@ mod tests {
 
             // Sync failures are fatal to the local storage state. They must not be
             // converted into a `false` certification/verification verdict.
-            context.storage_fault_config().write().sync_rate = Some(Probability::ONE);
+            context.storage_fault_config().write().sync_rate = Some(Probability!(1.0));
 
             let genesis = make_raw_block(Sha256::hash(&[b""]), Height::zero(), 0);
             let round = Round::new(Epoch::zero(), View::new(1));
@@ -3600,7 +3600,7 @@ mod tests {
             assert_eq!(application.acknowledged().await, Height::zero());
             context.sleep(Duration::from_millis(10)).await;
 
-            context.storage_fault_config().write().sync_rate = Some(Probability::ONE);
+            context.storage_fault_config().write().sync_rate = Some(Probability!(1.0));
 
             let genesis = make_raw_block(Sha256::hash(&[b""]), Height::zero(), 0);
             let round = Round::new(Epoch::zero(), View::new(1));
@@ -3653,7 +3653,7 @@ mod tests {
             assert_eq!(application.acknowledged().await, Height::zero());
             context.sleep(Duration::from_millis(10)).await;
 
-            context.storage_fault_config().write().sync_rate = Some(Probability::ONE);
+            context.storage_fault_config().write().sync_rate = Some(Probability!(1.0));
 
             let genesis = make_raw_block(Sha256::hash(&[b""]), Height::zero(), 0);
             let round = Round::new(Epoch::zero(), View::new(1));

--- a/consensus/src/marshal/standard/mod.rs
+++ b/consensus/src/marshal/standard/mod.rs
@@ -101,7 +101,7 @@ mod tests {
         translator::{EightCap, TwoCap},
     };
     use commonware_utils::{
-        Acknowledgement as _, NZU16, NZU64, NZUsize,
+        Acknowledgement as _, NZU16, NZU64, NZUsize, Probability,
         acknowledgement::Exact,
         channel::{fallible::OneshotExt, mpsc, oneshot, oneshot::error::TryRecvError},
         ordered::{Quorum as _, Set},
@@ -3546,7 +3546,7 @@ mod tests {
 
             // Sync failures are fatal to the local storage state. They must not be
             // converted into a `false` certification/verification verdict.
-            context.storage_fault_config().write().sync_rate = Some(1.0);
+            context.storage_fault_config().write().sync_rate = Some(Probability::ONE);
 
             let genesis = make_raw_block(Sha256::hash(&[b""]), Height::zero(), 0);
             let round = Round::new(Epoch::zero(), View::new(1));
@@ -3600,7 +3600,7 @@ mod tests {
             assert_eq!(application.acknowledged().await, Height::zero());
             context.sleep(Duration::from_millis(10)).await;
 
-            context.storage_fault_config().write().sync_rate = Some(1.0);
+            context.storage_fault_config().write().sync_rate = Some(Probability::ONE);
 
             let genesis = make_raw_block(Sha256::hash(&[b""]), Height::zero(), 0);
             let round = Round::new(Epoch::zero(), View::new(1));
@@ -3653,7 +3653,7 @@ mod tests {
             assert_eq!(application.acknowledged().await, Height::zero());
             context.sleep(Duration::from_millis(10)).await;
 
-            context.storage_fault_config().write().sync_rate = Some(1.0);
+            context.storage_fault_config().write().sync_rate = Some(Probability::ONE);
 
             let genesis = make_raw_block(Sha256::hash(&[b""]), Height::zero(), 0);
             let round = Round::new(Epoch::zero(), View::new(1));

--- a/consensus/src/ordered_broadcast/mod.rs
+++ b/consensus/src/ordered_broadcast/mod.rs
@@ -203,7 +203,7 @@ mod tests {
     const RELIABLE_LINK: Link = Link {
         latency: Duration::from_millis(10),
         jitter: Duration::from_millis(1),
-        success_rate: Probability::ONE,
+        success_rate: Probability!(1.0),
     };
 
     async fn initialize_simulation<S: certificate::Scheme>(

--- a/consensus/src/ordered_broadcast/mod.rs
+++ b/consensus/src/ordered_broadcast/mod.rs
@@ -98,7 +98,7 @@ mod tests {
         deterministic::{self, Context},
     };
     use commonware_utils::{
-        NZU16, NZU64, NZUsize,
+        NZU16, NZU64, NZUsize, Probability,
         channel::{fallible::OneshotExt, oneshot},
     };
     use futures::future::join_all;
@@ -203,7 +203,7 @@ mod tests {
     const RELIABLE_LINK: Link = Link {
         latency: Duration::from_millis(10),
         jitter: Duration::from_millis(1),
-        success_rate: 1.0,
+        success_rate: Probability::ONE,
     };
 
     async fn initialize_simulation<S: certificate::Scheme>(
@@ -576,7 +576,7 @@ mod tests {
             let delayed_link = Link {
                 latency: Duration::from_millis(50),
                 jitter: Duration::from_millis(40),
-                success_rate: 0.5,
+                success_rate: Probability!(1, 2),
             };
             link_participants(
                 &mut oracle,
@@ -1026,7 +1026,7 @@ mod tests {
             let delayed_link = Link {
                 latency: Duration::from_millis(80),
                 jitter: Duration::from_millis(10),
-                success_rate: 0.98,
+                success_rate: Probability!(49, 50),
             };
 
             let (mut oracle, mut registrations) =

--- a/consensus/src/ordered_broadcast/mod.rs
+++ b/consensus/src/ordered_broadcast/mod.rs
@@ -576,7 +576,7 @@ mod tests {
             let delayed_link = Link {
                 latency: Duration::from_millis(50),
                 jitter: Duration::from_millis(40),
-                success_rate: Probability!(1, 2),
+                success_rate: Probability!(0.5),
             };
             link_participants(
                 &mut oracle,
@@ -1026,7 +1026,7 @@ mod tests {
             let delayed_link = Link {
                 latency: Duration::from_millis(80),
                 jitter: Duration::from_millis(10),
-                success_rate: Probability!(49, 50),
+                success_rate: Probability!(0.98),
             };
 
             let (mut oracle, mut registrations) =

--- a/consensus/src/simplex/actors/batcher/mod.rs
+++ b/consensus/src/simplex/actors/batcher/mod.rs
@@ -173,7 +173,7 @@ mod tests {
                 Link {
                     latency,
                     jitter: Duration::from_millis(0),
-                    success_rate: Probability::ONE,
+                    success_rate: Probability!(1.0),
                 },
             )
             .await
@@ -1765,7 +1765,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: Probability::ONE,
+                success_rate: Probability!(1.0),
             };
             oracle
                 .add_link(injector_pk.clone(), me.clone(), link)
@@ -1917,7 +1917,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: Probability::ONE,
+                success_rate: Probability!(1.0),
             };
             let mut finalize_senders = Vec::new();
             for (i, participant) in participants
@@ -2518,7 +2518,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: Probability::ONE,
+                success_rate: Probability!(1.0),
             };
             let mut participant_senders = Vec::new();
             for (i, pk) in participants.iter().enumerate() {
@@ -2722,7 +2722,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: Probability::ONE,
+                success_rate: Probability!(1.0),
             };
             let mut participant_senders = Vec::new();
             for (i, pk) in participants.iter().enumerate() {
@@ -2889,7 +2889,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: Probability::ONE,
+                success_rate: Probability!(1.0),
             };
             let mut participant_senders = Vec::new();
             for (i, pk) in participants.iter().enumerate() {
@@ -3117,7 +3117,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: Probability::ONE,
+                success_rate: Probability!(1.0),
             };
             let mut participant_senders = Vec::new();
             for (i, pk) in participants.iter().enumerate() {
@@ -3330,7 +3330,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: Probability::ONE,
+                success_rate: Probability!(1.0),
             };
             let injector_pk = PrivateKey::from_seed(3_000_000).public_key();
             let (mut injector_sender, _injector_receiver) = oracle
@@ -3496,7 +3496,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: Probability::ONE,
+                success_rate: Probability!(1.0),
             };
             let mut participant_senders = Vec::new();
             for (i, pk) in participants.iter().enumerate() {
@@ -3705,7 +3705,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: Probability::ONE,
+                success_rate: Probability!(1.0),
             };
             let mut participant_senders = Vec::new();
             for (i, pk) in participants.iter().enumerate() {
@@ -3899,7 +3899,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: Probability::ONE,
+                success_rate: Probability!(1.0),
             };
             let mut participant_senders = Vec::new();
             for (i, pk) in participants.iter().enumerate() {
@@ -4086,7 +4086,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: Probability::ONE,
+                success_rate: Probability!(1.0),
             };
             let mut participant_senders = Vec::new();
             for (i, pk) in participants.iter().enumerate() {
@@ -4283,7 +4283,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: Probability::ONE,
+                success_rate: Probability!(1.0),
             };
             let leader_pk = participants[1].clone();
             let (mut leader_sender, _leader_receiver) = oracle
@@ -4405,7 +4405,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: Probability::ONE,
+                success_rate: Probability!(1.0),
             };
             let leader_pk = participants[1].clone();
             let (mut leader_sender, _leader_receiver) = oracle
@@ -4636,7 +4636,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: Probability::ONE,
+                success_rate: Probability!(1.0),
             };
             let mut peer_senders = Vec::new();
             for (i, pk) in participants.iter().enumerate().skip(1) {
@@ -5008,7 +5008,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: Probability::ONE,
+                success_rate: Probability!(1.0),
             };
             let leader_pk = participants[1].clone();
             let (mut leader_sender, _leader_receiver) = oracle
@@ -5153,7 +5153,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: Probability::ONE,
+                success_rate: Probability!(1.0),
             };
             let leader = Participant::new(1);
             let leader_pk = participants[usize::from(leader)].clone();
@@ -5318,7 +5318,7 @@ mod tests {
                     Link {
                         latency: Duration::from_millis(0),
                         jitter: Duration::from_millis(0),
-                        success_rate: Probability::ONE,
+                        success_rate: Probability!(1.0),
                     },
                 )
                 .await
@@ -5435,7 +5435,7 @@ mod tests {
                     Link {
                         latency: Duration::from_millis(0),
                         jitter: Duration::from_millis(0),
-                        success_rate: Probability::ONE,
+                        success_rate: Probability!(1.0),
                     },
                 )
                 .await
@@ -5808,7 +5808,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: Probability::ONE,
+                success_rate: Probability!(1.0),
             };
             let mut participant_senders = Vec::new();
             for (i, pk) in participants.iter().enumerate() {
@@ -5989,7 +5989,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: Probability::ONE,
+                success_rate: Probability!(1.0),
             };
             let (mut peer_sender, _receiver) = oracle
                 .control(participants[1].clone())
@@ -6128,7 +6128,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: Probability::ONE,
+                success_rate: Probability!(1.0),
             };
             let (mut peer_sender, _receiver) = oracle
                 .control(participants[1].clone())
@@ -6436,7 +6436,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: Probability::ONE,
+                success_rate: Probability!(1.0),
             };
             let mut participant_senders = Vec::new();
             for (i, pk) in participants.iter().enumerate() {
@@ -6658,7 +6658,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: Probability::ONE,
+                success_rate: Probability!(1.0),
             };
             oracle
                 .add_link(sender_pk.clone(), me.clone(), link)
@@ -6851,7 +6851,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: Probability::ONE,
+                success_rate: Probability!(1.0),
             };
             oracle
                 .add_link(sender_pk.clone(), me.clone(), link)

--- a/consensus/src/simplex/actors/batcher/mod.rs
+++ b/consensus/src/simplex/actors/batcher/mod.rs
@@ -88,7 +88,7 @@ mod tests {
         telemetry::traces::{TracedExt as _, collector::TraceStorage},
         tokio,
     };
-    use commonware_utils::{NZUsize, TestRng, ordered::Set, sync::Mutex, test_rng};
+    use commonware_utils::{NZUsize, Probability, TestRng, ordered::Set, sync::Mutex, test_rng};
     use std::{marker::PhantomData, num::NonZeroU32, sync::Arc, time::Duration};
     use tracing::{Level, Span};
 
@@ -173,7 +173,7 @@ mod tests {
                 Link {
                     latency,
                     jitter: Duration::from_millis(0),
-                    success_rate: 1.0,
+                    success_rate: Probability::ONE,
                 },
             )
             .await
@@ -1765,7 +1765,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: 1.0,
+                success_rate: Probability::ONE,
             };
             oracle
                 .add_link(injector_pk.clone(), me.clone(), link)
@@ -1917,7 +1917,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: 1.0,
+                success_rate: Probability::ONE,
             };
             let mut finalize_senders = Vec::new();
             for (i, participant) in participants
@@ -2518,7 +2518,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: 1.0,
+                success_rate: Probability::ONE,
             };
             let mut participant_senders = Vec::new();
             for (i, pk) in participants.iter().enumerate() {
@@ -2722,7 +2722,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: 1.0,
+                success_rate: Probability::ONE,
             };
             let mut participant_senders = Vec::new();
             for (i, pk) in participants.iter().enumerate() {
@@ -2889,7 +2889,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: 1.0,
+                success_rate: Probability::ONE,
             };
             let mut participant_senders = Vec::new();
             for (i, pk) in participants.iter().enumerate() {
@@ -3117,7 +3117,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: 1.0,
+                success_rate: Probability::ONE,
             };
             let mut participant_senders = Vec::new();
             for (i, pk) in participants.iter().enumerate() {
@@ -3330,7 +3330,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: 1.0,
+                success_rate: Probability::ONE,
             };
             let injector_pk = PrivateKey::from_seed(3_000_000).public_key();
             let (mut injector_sender, _injector_receiver) = oracle
@@ -3496,7 +3496,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: 1.0,
+                success_rate: Probability::ONE,
             };
             let mut participant_senders = Vec::new();
             for (i, pk) in participants.iter().enumerate() {
@@ -3705,7 +3705,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: 1.0,
+                success_rate: Probability::ONE,
             };
             let mut participant_senders = Vec::new();
             for (i, pk) in participants.iter().enumerate() {
@@ -3899,7 +3899,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: 1.0,
+                success_rate: Probability::ONE,
             };
             let mut participant_senders = Vec::new();
             for (i, pk) in participants.iter().enumerate() {
@@ -4086,7 +4086,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: 1.0,
+                success_rate: Probability::ONE,
             };
             let mut participant_senders = Vec::new();
             for (i, pk) in participants.iter().enumerate() {
@@ -4283,7 +4283,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: 1.0,
+                success_rate: Probability::ONE,
             };
             let leader_pk = participants[1].clone();
             let (mut leader_sender, _leader_receiver) = oracle
@@ -4405,7 +4405,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: 1.0,
+                success_rate: Probability::ONE,
             };
             let leader_pk = participants[1].clone();
             let (mut leader_sender, _leader_receiver) = oracle
@@ -4636,7 +4636,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: 1.0,
+                success_rate: Probability::ONE,
             };
             let mut peer_senders = Vec::new();
             for (i, pk) in participants.iter().enumerate().skip(1) {
@@ -5008,7 +5008,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: 1.0,
+                success_rate: Probability::ONE,
             };
             let leader_pk = participants[1].clone();
             let (mut leader_sender, _leader_receiver) = oracle
@@ -5153,7 +5153,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: 1.0,
+                success_rate: Probability::ONE,
             };
             let leader = Participant::new(1);
             let leader_pk = participants[usize::from(leader)].clone();
@@ -5318,7 +5318,7 @@ mod tests {
                     Link {
                         latency: Duration::from_millis(0),
                         jitter: Duration::from_millis(0),
-                        success_rate: 1.0,
+                        success_rate: Probability::ONE,
                     },
                 )
                 .await
@@ -5435,7 +5435,7 @@ mod tests {
                     Link {
                         latency: Duration::from_millis(0),
                         jitter: Duration::from_millis(0),
-                        success_rate: 1.0,
+                        success_rate: Probability::ONE,
                     },
                 )
                 .await
@@ -5808,7 +5808,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: 1.0,
+                success_rate: Probability::ONE,
             };
             let mut participant_senders = Vec::new();
             for (i, pk) in participants.iter().enumerate() {
@@ -5989,7 +5989,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: 1.0,
+                success_rate: Probability::ONE,
             };
             let (mut peer_sender, _receiver) = oracle
                 .control(participants[1].clone())
@@ -6128,7 +6128,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: 1.0,
+                success_rate: Probability::ONE,
             };
             let (mut peer_sender, _receiver) = oracle
                 .control(participants[1].clone())
@@ -6436,7 +6436,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: 1.0,
+                success_rate: Probability::ONE,
             };
             let mut participant_senders = Vec::new();
             for (i, pk) in participants.iter().enumerate() {
@@ -6658,7 +6658,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: 1.0,
+                success_rate: Probability::ONE,
             };
             oracle
                 .add_link(sender_pk.clone(), me.clone(), link)
@@ -6851,7 +6851,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: 1.0,
+                success_rate: Probability::ONE,
             };
             oracle
                 .add_link(sender_pk.clone(), me.clone(), link)

--- a/consensus/src/simplex/actors/resolver/actor.rs
+++ b/consensus/src/simplex/actors/resolver/actor.rs
@@ -649,7 +649,9 @@ mod tests {
     use commonware_p2p::simulated::{Config as NetworkConfig, Link, Network};
     use commonware_parallel::Sequential;
     use commonware_runtime::{Quota, Runner, Supervisor, deterministic};
-    use commonware_utils::{NZU32, NZUsize, channel::oneshot, non_empty_vec, sync::Mutex};
+    use commonware_utils::{
+        NZU32, NZUsize, Probability, channel::oneshot, non_empty_vec, sync::Mutex,
+    };
     use std::{collections::BTreeSet, sync::Arc};
 
     const NAMESPACE: &[u8] = b"resolver-actor";
@@ -831,7 +833,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: 1.0,
+                success_rate: Probability::ONE,
             };
             oracle
                 .add_link(
@@ -1016,7 +1018,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: 1.0,
+                success_rate: Probability::ONE,
             };
             oracle
                 .add_link(

--- a/consensus/src/simplex/actors/resolver/actor.rs
+++ b/consensus/src/simplex/actors/resolver/actor.rs
@@ -833,7 +833,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: Probability::ONE,
+                success_rate: Probability!(1.0),
             };
             oracle
                 .add_link(
@@ -1018,7 +1018,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: Probability::ONE,
+                success_rate: Probability!(1.0),
             };
             oracle
                 .add_link(

--- a/consensus/src/simplex/actors/voter/mod.rs
+++ b/consensus/src/simplex/actors/voter/mod.rs
@@ -2572,7 +2572,7 @@ mod tests {
                     Link {
                         latency: Duration::ZERO,
                         jitter: Duration::ZERO,
-                        success_rate: Probability::ONE,
+                        success_rate: Probability!(1.0),
                     },
                 )
                 .await
@@ -4949,7 +4949,7 @@ mod tests {
                     Link {
                         latency: Duration::from_millis(0),
                         jitter: Duration::from_millis(0),
-                        success_rate: Probability::ONE,
+                        success_rate: Probability!(1.0),
                     },
                 )
                 .await
@@ -9725,7 +9725,7 @@ mod tests {
                     Link {
                         latency: Duration::ZERO,
                         jitter: Duration::ZERO,
-                        success_rate: Probability::ONE,
+                        success_rate: Probability!(1.0),
                     },
                 )
                 .await

--- a/consensus/src/simplex/actors/voter/mod.rs
+++ b/consensus/src/simplex/actors/voter/mod.rs
@@ -95,7 +95,7 @@ mod tests {
         telemetry::traces::collector::{RecordedEvents, TraceStorage},
     };
     use commonware_storage::journal::segmented::variable::{Config as JConfig, Journal};
-    use commonware_utils::{NZU16, NZU32, NZUsize, sync::Mutex};
+    use commonware_utils::{NZU16, NZU32, NZUsize, Probability, sync::Mutex};
     use futures::FutureExt;
     use rand_core::CryptoRng;
     use std::{
@@ -2572,7 +2572,7 @@ mod tests {
                     Link {
                         latency: Duration::ZERO,
                         jitter: Duration::ZERO,
-                        success_rate: 1.0,
+                        success_rate: Probability::ONE,
                     },
                 )
                 .await
@@ -4949,7 +4949,7 @@ mod tests {
                     Link {
                         latency: Duration::from_millis(0),
                         jitter: Duration::from_millis(0),
-                        success_rate: 1.0,
+                        success_rate: Probability::ONE,
                     },
                 )
                 .await
@@ -9725,7 +9725,7 @@ mod tests {
                     Link {
                         latency: Duration::ZERO,
                         jitter: Duration::ZERO,
-                        success_rate: 1.0,
+                        success_rate: Probability::ONE,
                     },
                 )
                 .await

--- a/consensus/src/simplex/mod.rs
+++ b/consensus/src/simplex/mod.rs
@@ -697,7 +697,8 @@ mod tests {
         buffer::paged::CacheRef, deterministic, telemetry::metrics::count_running_tasks,
     };
     use commonware_utils::{
-        Faults, N3f1, NZU16, NZU32, NZUsize, TestRng, ordered::Set, sync::Mutex, test_rng,
+        Faults, N3f1, NZU16, NZU32, NZUsize, Probability, TestRng, ordered::Set, sync::Mutex,
+        test_rng,
     };
     use engine::Engine;
     use futures::future::join_all;
@@ -1083,7 +1084,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(200),
                 jitter: Duration::from_millis(1),
-                success_rate: 1.0,
+                success_rate: Probability::ONE,
             };
             link_validators(&mut oracle, &participants, Action::Link(link), None).await;
 
@@ -1336,7 +1337,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: 1.0,
+                success_rate: Probability::ONE,
             };
             link_validators(&mut oracle, active, Action::Link(link.clone()), None).await;
 
@@ -1604,7 +1605,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: 1.0,
+                success_rate: Probability::ONE,
             };
             link_validators(&mut oracle, &participants, Action::Link(link), None).await;
 
@@ -1844,7 +1845,7 @@ mod tests {
                 Link {
                     latency: link_latency,
                     jitter: Duration::from_millis(0),
-                    success_rate: 1.0,
+                    success_rate: Probability::ONE,
                 },
                 TermLength::new(NZU32!(128)),
                 ViewDelta::new(128),
@@ -1895,7 +1896,7 @@ mod tests {
                 Link {
                     latency: Duration::from_millis(1_000),
                     jitter: Duration::from_millis(1),
-                    success_rate: 1.0,
+                    success_rate: Probability::ONE,
                 },
                 TermLength::new(NZU32!(1000)),
                 ViewDelta::new(100),
@@ -2031,7 +2032,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: 1.0,
+                success_rate: Probability::ONE,
             };
             link_validators(&mut oracle, &all_validators, Action::Link(link), None).await;
 
@@ -2201,7 +2202,7 @@ mod tests {
                 let link = Link {
                     latency: Duration::from_millis(50),
                     jitter: Duration::from_millis(50),
-                    success_rate: 1.0,
+                    success_rate: Probability::ONE,
                 };
                 link_validators(&mut oracle, &participants, Action::Link(link), None).await;
 
@@ -2396,7 +2397,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: 1.0,
+                success_rate: Probability::ONE,
             };
             link_validators(
                 &mut oracle,
@@ -2496,7 +2497,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_secs(3),
                 jitter: Duration::from_millis(0),
-                success_rate: 1.0,
+                success_rate: Probability::ONE,
             };
             link_validators(
                 &mut oracle,
@@ -2535,7 +2536,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(3),
-                success_rate: 1.0,
+                success_rate: Probability::ONE,
             };
             link_validators(
                 &mut oracle,
@@ -2669,7 +2670,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: 1.0,
+                success_rate: Probability::ONE,
             };
             link_validators(
                 &mut oracle,
@@ -2906,7 +2907,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: 1.0,
+                success_rate: Probability::ONE,
             };
             link_validators(&mut oracle, &participants, Action::Link(link), None).await;
 
@@ -3078,7 +3079,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_secs(3),
                 jitter: Duration::from_millis(0),
-                success_rate: 1.0,
+                success_rate: Probability::ONE,
             };
             link_validators(&mut oracle, &participants, Action::Link(link), None).await;
 
@@ -3186,7 +3187,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: 1.0,
+                success_rate: Probability::ONE,
             };
             link_validators(&mut oracle, &participants, Action::Link(link), None).await;
 
@@ -3380,7 +3381,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: 1.0,
+                success_rate: Probability::ONE,
             };
             link_validators(
                 &mut oracle,
@@ -3516,7 +3517,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: 1.0,
+                success_rate: Probability::ONE,
             };
             link_validators(&mut oracle, &participants, Action::Link(link.clone()), None).await;
 
@@ -3723,7 +3724,7 @@ mod tests {
             let degraded_link = Link {
                 latency: Duration::from_millis(200),
                 jitter: Duration::from_millis(150),
-                success_rate: 0.5,
+                success_rate: Probability!(1, 2),
             };
             link_validators(
                 &mut oracle,
@@ -3926,7 +3927,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: 1.0,
+                success_rate: Probability::ONE,
             };
             link_validators(&mut oracle, &participants, Action::Link(link), None).await;
 
@@ -4106,7 +4107,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: 1.0,
+                success_rate: Probability::ONE,
             };
             link_validators(&mut oracle, &participants, Action::Link(link), None).await;
 
@@ -4261,7 +4262,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(100),
                 jitter: Duration::from_millis(1),
-                success_rate: 1.0,
+                success_rate: Probability::ONE,
             };
             fn link_graph(_: usize, i: usize, j: usize) -> bool {
                 if i == 0 || j == 0 {
@@ -4421,7 +4422,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(0),
                 jitter: Duration::from_millis(0),
-                success_rate: 1.0,
+                success_rate: Probability::ONE,
             };
             oracle
                 .add_link(injector_pk.clone(), me.clone(), link)
@@ -4562,7 +4563,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: 1.0,
+                success_rate: Probability::ONE,
             };
             link_validators(&mut oracle, &participants, Action::Link(link), None).await;
 
@@ -4720,7 +4721,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: 1.0,
+                success_rate: Probability::ONE,
             };
             link_validators(&mut oracle, &participants, Action::Link(link), None).await;
 
@@ -4989,7 +4990,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: 1.0,
+                success_rate: Probability::ONE,
             };
             link_validators(&mut oracle, &participants, Action::Link(link), None).await;
 
@@ -5137,7 +5138,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: 1.0,
+                success_rate: Probability::ONE,
             };
             link_validators(&mut oracle, &participants, Action::Link(link), None).await;
 
@@ -5298,7 +5299,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: 1.0,
+                success_rate: Probability::ONE,
             };
             link_validators(&mut oracle, &participants, Action::Link(link), None).await;
 
@@ -5437,7 +5438,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(80),
                 jitter: Duration::from_millis(10),
-                success_rate: 0.98,
+                success_rate: Probability!(49, 50),
             };
             link_validators(&mut oracle, &participants, Action::Link(link), None).await;
 
@@ -5571,7 +5572,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: 1.0,
+                success_rate: Probability::ONE,
             };
             link_validators(&mut oracle, &participants, Action::Link(link), None).await;
 
@@ -5727,7 +5728,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: 1.0,
+                success_rate: Probability::ONE,
             };
             link_validators(&mut oracle, &participants, Action::Link(link), None).await;
 
@@ -6001,7 +6002,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(0),
-                success_rate: 1.0,
+                success_rate: Probability::ONE,
             };
             for p in participants.iter() {
                 oracle
@@ -6331,7 +6332,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(0),
-                success_rate: 1.0,
+                success_rate: Probability::ONE,
             };
             for p in participants.iter() {
                 oracle
@@ -6616,7 +6617,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(0),
-                success_rate: 1.0,
+                success_rate: Probability::ONE,
             };
             for p in participants.iter() {
                 oracle
@@ -6905,7 +6906,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(0),
-                success_rate: 1.0,
+                success_rate: Probability::ONE,
             };
             for p in participants.iter() {
                 oracle
@@ -7141,7 +7142,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(5),
-                success_rate: 1.0,
+                success_rate: Probability::ONE,
             };
             link_validators(&mut oracle, &participants, Action::Link(link), None).await;
 
@@ -7293,7 +7294,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: 1.0,
+                success_rate: Probability::ONE,
             };
             link_validators(&mut oracle, &participants, Action::Link(link), None).await;
 
@@ -8106,7 +8107,7 @@ mod tests {
     const TWINS_LINK: Link = Link {
         latency: Duration::from_millis(500),
         jitter: Duration::from_millis(500),
-        success_rate: 1.0,
+        success_rate: Probability::ONE,
     };
 
     /// Runs `campaign` with `elector` over a fast link and the slow [TWINS_LINK].
@@ -8115,7 +8116,7 @@ mod tests {
             Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(10),
-                success_rate: 1.0,
+                success_rate: Probability::ONE,
             },
             TWINS_LINK,
         ] {

--- a/consensus/src/simplex/mod.rs
+++ b/consensus/src/simplex/mod.rs
@@ -1084,7 +1084,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(200),
                 jitter: Duration::from_millis(1),
-                success_rate: Probability::ONE,
+                success_rate: Probability!(1.0),
             };
             link_validators(&mut oracle, &participants, Action::Link(link), None).await;
 
@@ -1337,7 +1337,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: Probability::ONE,
+                success_rate: Probability!(1.0),
             };
             link_validators(&mut oracle, active, Action::Link(link.clone()), None).await;
 
@@ -1605,7 +1605,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: Probability::ONE,
+                success_rate: Probability!(1.0),
             };
             link_validators(&mut oracle, &participants, Action::Link(link), None).await;
 
@@ -1845,7 +1845,7 @@ mod tests {
                 Link {
                     latency: link_latency,
                     jitter: Duration::from_millis(0),
-                    success_rate: Probability::ONE,
+                    success_rate: Probability!(1.0),
                 },
                 TermLength::new(NZU32!(128)),
                 ViewDelta::new(128),
@@ -1896,7 +1896,7 @@ mod tests {
                 Link {
                     latency: Duration::from_millis(1_000),
                     jitter: Duration::from_millis(1),
-                    success_rate: Probability::ONE,
+                    success_rate: Probability!(1.0),
                 },
                 TermLength::new(NZU32!(1000)),
                 ViewDelta::new(100),
@@ -2032,7 +2032,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: Probability::ONE,
+                success_rate: Probability!(1.0),
             };
             link_validators(&mut oracle, &all_validators, Action::Link(link), None).await;
 
@@ -2202,7 +2202,7 @@ mod tests {
                 let link = Link {
                     latency: Duration::from_millis(50),
                     jitter: Duration::from_millis(50),
-                    success_rate: Probability::ONE,
+                    success_rate: Probability!(1.0),
                 };
                 link_validators(&mut oracle, &participants, Action::Link(link), None).await;
 
@@ -2397,7 +2397,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: Probability::ONE,
+                success_rate: Probability!(1.0),
             };
             link_validators(
                 &mut oracle,
@@ -2497,7 +2497,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_secs(3),
                 jitter: Duration::from_millis(0),
-                success_rate: Probability::ONE,
+                success_rate: Probability!(1.0),
             };
             link_validators(
                 &mut oracle,
@@ -2536,7 +2536,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(3),
-                success_rate: Probability::ONE,
+                success_rate: Probability!(1.0),
             };
             link_validators(
                 &mut oracle,
@@ -2670,7 +2670,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: Probability::ONE,
+                success_rate: Probability!(1.0),
             };
             link_validators(
                 &mut oracle,
@@ -2907,7 +2907,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: Probability::ONE,
+                success_rate: Probability!(1.0),
             };
             link_validators(&mut oracle, &participants, Action::Link(link), None).await;
 
@@ -3079,7 +3079,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_secs(3),
                 jitter: Duration::from_millis(0),
-                success_rate: Probability::ONE,
+                success_rate: Probability!(1.0),
             };
             link_validators(&mut oracle, &participants, Action::Link(link), None).await;
 
@@ -3187,7 +3187,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: Probability::ONE,
+                success_rate: Probability!(1.0),
             };
             link_validators(&mut oracle, &participants, Action::Link(link), None).await;
 
@@ -3381,7 +3381,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: Probability::ONE,
+                success_rate: Probability!(1.0),
             };
             link_validators(
                 &mut oracle,
@@ -3517,7 +3517,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: Probability::ONE,
+                success_rate: Probability!(1.0),
             };
             link_validators(&mut oracle, &participants, Action::Link(link.clone()), None).await;
 
@@ -3927,7 +3927,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: Probability::ONE,
+                success_rate: Probability!(1.0),
             };
             link_validators(&mut oracle, &participants, Action::Link(link), None).await;
 
@@ -4107,7 +4107,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: Probability::ONE,
+                success_rate: Probability!(1.0),
             };
             link_validators(&mut oracle, &participants, Action::Link(link), None).await;
 
@@ -4262,7 +4262,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(100),
                 jitter: Duration::from_millis(1),
-                success_rate: Probability::ONE,
+                success_rate: Probability!(1.0),
             };
             fn link_graph(_: usize, i: usize, j: usize) -> bool {
                 if i == 0 || j == 0 {
@@ -4422,7 +4422,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(0),
                 jitter: Duration::from_millis(0),
-                success_rate: Probability::ONE,
+                success_rate: Probability!(1.0),
             };
             oracle
                 .add_link(injector_pk.clone(), me.clone(), link)
@@ -4563,7 +4563,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: Probability::ONE,
+                success_rate: Probability!(1.0),
             };
             link_validators(&mut oracle, &participants, Action::Link(link), None).await;
 
@@ -4721,7 +4721,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: Probability::ONE,
+                success_rate: Probability!(1.0),
             };
             link_validators(&mut oracle, &participants, Action::Link(link), None).await;
 
@@ -4990,7 +4990,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: Probability::ONE,
+                success_rate: Probability!(1.0),
             };
             link_validators(&mut oracle, &participants, Action::Link(link), None).await;
 
@@ -5138,7 +5138,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: Probability::ONE,
+                success_rate: Probability!(1.0),
             };
             link_validators(&mut oracle, &participants, Action::Link(link), None).await;
 
@@ -5299,7 +5299,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: Probability::ONE,
+                success_rate: Probability!(1.0),
             };
             link_validators(&mut oracle, &participants, Action::Link(link), None).await;
 
@@ -5572,7 +5572,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: Probability::ONE,
+                success_rate: Probability!(1.0),
             };
             link_validators(&mut oracle, &participants, Action::Link(link), None).await;
 
@@ -5728,7 +5728,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: Probability::ONE,
+                success_rate: Probability!(1.0),
             };
             link_validators(&mut oracle, &participants, Action::Link(link), None).await;
 
@@ -6002,7 +6002,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(0),
-                success_rate: Probability::ONE,
+                success_rate: Probability!(1.0),
             };
             for p in participants.iter() {
                 oracle
@@ -6332,7 +6332,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(0),
-                success_rate: Probability::ONE,
+                success_rate: Probability!(1.0),
             };
             for p in participants.iter() {
                 oracle
@@ -6617,7 +6617,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(0),
-                success_rate: Probability::ONE,
+                success_rate: Probability!(1.0),
             };
             for p in participants.iter() {
                 oracle
@@ -6906,7 +6906,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(0),
-                success_rate: Probability::ONE,
+                success_rate: Probability!(1.0),
             };
             for p in participants.iter() {
                 oracle
@@ -7142,7 +7142,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(5),
-                success_rate: Probability::ONE,
+                success_rate: Probability!(1.0),
             };
             link_validators(&mut oracle, &participants, Action::Link(link), None).await;
 
@@ -7294,7 +7294,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: Probability::ONE,
+                success_rate: Probability!(1.0),
             };
             link_validators(&mut oracle, &participants, Action::Link(link), None).await;
 
@@ -8107,7 +8107,7 @@ mod tests {
     const TWINS_LINK: Link = Link {
         latency: Duration::from_millis(500),
         jitter: Duration::from_millis(500),
-        success_rate: Probability::ONE,
+        success_rate: Probability!(1.0),
     };
 
     /// Runs `campaign` with `elector` over a fast link and the slow [TWINS_LINK].
@@ -8116,7 +8116,7 @@ mod tests {
             Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(10),
-                success_rate: Probability::ONE,
+                success_rate: Probability!(1.0),
             },
             TWINS_LINK,
         ] {

--- a/consensus/src/simplex/mod.rs
+++ b/consensus/src/simplex/mod.rs
@@ -3724,7 +3724,7 @@ mod tests {
             let degraded_link = Link {
                 latency: Duration::from_millis(200),
                 jitter: Duration::from_millis(150),
-                success_rate: Probability!(1, 2),
+                success_rate: Probability!(0.5),
             };
             link_validators(
                 &mut oracle,
@@ -5438,7 +5438,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(80),
                 jitter: Duration::from_millis(10),
-                success_rate: Probability!(49, 50),
+                success_rate: Probability!(0.98),
             };
             link_validators(&mut oracle, &participants, Action::Link(link), None).await;
 

--- a/examples/estimator/src/main.rs
+++ b/examples/estimator/src/main.rs
@@ -36,7 +36,7 @@ const DEFAULT_QUOTA: Quota = Quota::per_second(NonZeroU32::MAX);
 const DEFAULT_CHANNEL: u64 = 0;
 
 /// The success probability over all links (100%).
-const DEFAULT_SUCCESS_RATE: Probability = Probability::ONE;
+const DEFAULT_SUCCESS_RATE: Probability = Probability!(1.0);
 
 /// Returns a network configuration that accepts every supported application payload size.
 const fn network_config(max_peers_per_set: usize) -> Config {

--- a/examples/estimator/src/main.rs
+++ b/examples/estimator/src/main.rs
@@ -13,7 +13,7 @@ use commonware_runtime::{
     deterministic,
 };
 use commonware_utils::{
-    NZUsize,
+    NZUsize, Probability,
     channel::{mpsc, oneshot},
 };
 use estimator::{
@@ -35,8 +35,8 @@ const DEFAULT_QUOTA: Quota = Quota::per_second(NonZeroU32::MAX);
 /// The channel to use for all messages
 const DEFAULT_CHANNEL: u64 = 0;
 
-/// The success rate over all links (1.0 = 100%)
-const DEFAULT_SUCCESS_RATE: f64 = 1.0;
+/// The success probability over all links (100%).
+const DEFAULT_SUCCESS_RATE: Probability = Probability::ONE;
 
 /// Returns a network configuration that accepts every supported application payload size.
 const fn network_config(max_peers_per_set: usize) -> Config {

--- a/examples/flood/src/bin/flood.rs
+++ b/examples/flood/src/bin/flood.rs
@@ -82,7 +82,7 @@ fn main() {
             Some(tokio::tracing::Config {
                 endpoint: format!("http://{}:4318/v1/traces", hosts.monitoring.private),
                 name: public_key.to_string(),
-                rate: Probability::ONE,
+                rate: Probability!(1.0),
             })
         } else {
             None

--- a/examples/flood/src/bin/flood.rs
+++ b/examples/flood/src/bin/flood.rs
@@ -16,7 +16,7 @@ use commonware_runtime::{
     telemetry::metrics::{HistogramExt as _, MetricsExt as _},
     tokio,
 };
-use commonware_utils::{TryCollect, ordered::Set, union};
+use commonware_utils::{Probability, TryCollect, ordered::Set, union};
 use rand::{Rng, SeedableRng, rngs::SmallRng};
 use std::{
     collections::HashMap,
@@ -82,7 +82,7 @@ fn main() {
             Some(tokio::tracing::Config {
                 endpoint: format!("http://{}:4318/v1/traces", hosts.monitoring.private),
                 name: public_key.to_string(),
-                rate: 1.0,
+                rate: Probability::ONE,
             })
         } else {
             None

--- a/glue/src/dkg/orchestrator/mod.rs
+++ b/glue/src/dkg/orchestrator/mod.rs
@@ -107,8 +107,8 @@ mod tests {
     };
     use commonware_storage::archive::immutable;
     use commonware_utils::{
-        Acknowledgement, N3f1, NZU16, NZU32, NZU64, NZUsize, TestRng, acknowledgement::Exact,
-        ordered::Set, sequence::Unit,
+        Acknowledgement, N3f1, NZU16, NZU32, NZU64, NZUsize, Probability, TestRng,
+        acknowledgement::Exact, ordered::Set, sequence::Unit,
     };
     use std::{
         net::{IpAddr, Ipv4Addr, SocketAddr},
@@ -124,7 +124,7 @@ mod tests {
     const LINK: Link = Link {
         latency: Duration::from_millis(1),
         jitter: Duration::ZERO,
-        success_rate: 1.0,
+        success_rate: Probability::ONE,
     };
     type TestStateSync = StateSync<mocks::TestScheme, mocks::TestDigest, mocks::TestBlsVariant>;
 

--- a/glue/src/dkg/orchestrator/mod.rs
+++ b/glue/src/dkg/orchestrator/mod.rs
@@ -124,7 +124,7 @@ mod tests {
     const LINK: Link = Link {
         latency: Duration::from_millis(1),
         jitter: Duration::ZERO,
-        success_rate: Probability::ONE,
+        success_rate: Probability!(1.0),
     };
     type TestStateSync = StateSync<mocks::TestScheme, mocks::TestDigest, mocks::TestBlsVariant>;
 

--- a/glue/src/dkg/probe/mod.rs
+++ b/glue/src/dkg/probe/mod.rs
@@ -267,8 +267,8 @@ mod tests {
     };
     use commonware_storage::archive::immutable;
     use commonware_utils::{
-        N3f1, NZDuration, NZU16, NZU32, NZU64, NZUsize, TestRng, channel::oneshot, ordered::Set,
-        sequence::Unit,
+        N3f1, NZDuration, NZU16, NZU32, NZU64, NZUsize, Probability, TestRng, channel::oneshot,
+        ordered::Set, sequence::Unit,
     };
     use std::{num::NonZeroU64, time::Duration};
 
@@ -279,7 +279,7 @@ mod tests {
     const LINK: Link = Link {
         latency: Duration::from_millis(1),
         jitter: Duration::ZERO,
-        success_rate: 1.0,
+        success_rate: Probability::ONE,
     };
 
     struct Harness {

--- a/glue/src/dkg/probe/mod.rs
+++ b/glue/src/dkg/probe/mod.rs
@@ -279,7 +279,7 @@ mod tests {
     const LINK: Link = Link {
         latency: Duration::from_millis(1),
         jitter: Duration::ZERO,
-        success_rate: Probability::ONE,
+        success_rate: Probability!(1.0),
     };
 
     struct Harness {

--- a/glue/src/dkg/tests/dkg/harness.rs
+++ b/glue/src/dkg/tests/dkg/harness.rs
@@ -342,7 +342,7 @@ pub(super) fn good_link() -> Link {
     Link {
         latency: Duration::from_millis(20),
         jitter: Duration::from_millis(5),
-        success_rate: Probability::ONE,
+        success_rate: Probability!(1.0),
     }
 }
 

--- a/glue/src/dkg/tests/dkg/harness.rs
+++ b/glue/src/dkg/tests/dkg/harness.rs
@@ -39,8 +39,8 @@ use commonware_runtime::{
     telemetry::metrics::count_running_tasks,
 };
 use commonware_utils::{
-    NZU32, NZU64, NZUsize, Participant, channel::oneshot, ordered::Set, sequence::Unit,
-    sync::Mutex, test_rng,
+    NZU32, NZU64, NZUsize, Participant, Probability, channel::oneshot, ordered::Set,
+    sequence::Unit, sync::Mutex, test_rng,
 };
 use futures::future::pending;
 use std::{
@@ -342,7 +342,7 @@ pub(super) fn good_link() -> Link {
     Link {
         latency: Duration::from_millis(20),
         jitter: Duration::from_millis(5),
-        success_rate: 1.0,
+        success_rate: Probability::ONE,
     }
 }
 

--- a/glue/src/dkg/tests/dkg/mod.rs
+++ b/glue/src/dkg/tests/dkg/mod.rs
@@ -4,6 +4,7 @@ mod properties;
 use crate::simulate::action::{Action, Crash, Schedule};
 use commonware_macros::{test_group, test_traced};
 use commonware_p2p::simulated::Link;
+use commonware_utils::Probability;
 use harness::{
     DkgEngine, good_link, run_activation_failure_completes_empty, run_closed_network_receiver,
     run_plan, run_restart_completion_state_is_fresh,
@@ -29,7 +30,7 @@ fn dkg_e2e_lossy_network() {
         Link {
             latency: Duration::from_millis(60),
             jitter: Duration::from_millis(20),
-            success_rate: 0.75,
+            success_rate: Probability!(3, 4),
         },
         vec![],
         ExpectedOutcome::Success,

--- a/glue/src/dkg/tests/dkg/mod.rs
+++ b/glue/src/dkg/tests/dkg/mod.rs
@@ -30,7 +30,7 @@ fn dkg_e2e_lossy_network() {
         Link {
             latency: Duration::from_millis(60),
             jitter: Duration::from_millis(20),
-            success_rate: Probability!(3, 4),
+            success_rate: Probability!(0.75),
         },
         vec![],
         ExpectedOutcome::Success,

--- a/glue/src/dkg/tests/reshare/mod.rs
+++ b/glue/src/dkg/tests/reshare/mod.rs
@@ -648,7 +648,7 @@ fn reshare_e2e_lossy_network(#[case] network: Network) {
     .link(Link {
         latency: Duration::from_millis(100),
         jitter: Duration::from_millis(50),
-        success_rate: Probability!(7, 10),
+        success_rate: Probability!(0.7),
     })
     .timeout(Duration::from_secs(720))
     .run()

--- a/glue/src/dkg/tests/reshare/mod.rs
+++ b/glue/src/dkg/tests/reshare/mod.rs
@@ -483,7 +483,7 @@ fn reshare_e2e_state_sync_restart_before_epoch_boundary(#[case] network: Network
     .link(Link {
         latency: Duration::from_millis(4),
         jitter: Duration::from_millis(1),
-        success_rate: Probability::ONE,
+        success_rate: Probability!(1.0),
     })
     .crash(Crash::ProcessedHeight {
         participant: delayed.clone(),

--- a/glue/src/dkg/tests/reshare/mod.rs
+++ b/glue/src/dkg/tests/reshare/mod.rs
@@ -3,6 +3,7 @@ use commonware_consensus::types::{Epoch, Epocher, FixedEpocher, Height};
 use commonware_cryptography::{bls12381::primitives::sharing::Mode, ed25519};
 use commonware_macros::{test_group, test_traced};
 use commonware_p2p::simulated::Link;
+use commonware_utils::Probability;
 use rstest::rstest;
 use std::time::Duration;
 
@@ -482,7 +483,7 @@ fn reshare_e2e_state_sync_restart_before_epoch_boundary(#[case] network: Network
     .link(Link {
         latency: Duration::from_millis(4),
         jitter: Duration::from_millis(1),
-        success_rate: 1.0,
+        success_rate: Probability::ONE,
     })
     .crash(Crash::ProcessedHeight {
         participant: delayed.clone(),
@@ -647,7 +648,7 @@ fn reshare_e2e_lossy_network(#[case] network: Network) {
     .link(Link {
         latency: Duration::from_millis(100),
         jitter: Duration::from_millis(50),
-        success_rate: 0.7,
+        success_rate: Probability!(7, 10),
     })
     .timeout(Duration::from_secs(720))
     .run()

--- a/glue/src/simulate/plan.rs
+++ b/glue/src/simulate/plan.rs
@@ -16,7 +16,7 @@ use commonware_p2p::{
     simulated::{self, Link, Network},
 };
 use commonware_runtime::{Clock, Runner as _, Spawner, Supervisor as _, deterministic};
-use commonware_utils::{NZUsize, TryCollect, channel::mpsc, ordered::Set};
+use commonware_utils::{NZUsize, Probability, TryCollect, channel::mpsc, ordered::Set};
 use rand::seq::IndexedRandom;
 use std::{
     collections::HashSet,
@@ -147,7 +147,7 @@ impl<D: EngineDefinition> PlanBuilder<D> {
             link: Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(5),
-                success_rate: 1.0,
+                success_rate: Probability::ONE,
             },
             max_message_size: 1024 * 1024,
             engine,
@@ -979,7 +979,8 @@ mod tests {
             &self,
             ctx: super::super::engine::InitContext<'_, Self::PublicKey>,
         ) -> impl Future<Output = (Self::Engine, Self::State)> + Send {
-            let saw_fault = ctx.context.storage_fault_config().read().open_rate == Some(1.0);
+            let saw_fault =
+                ctx.context.storage_fault_config().read().open_rate == Some(Probability::ONE);
             async move {
                 (
                     FaultObservingNode {
@@ -1086,7 +1087,7 @@ mod tests {
         let link = Link {
             latency: Duration::from_millis(10),
             jitter: Duration::from_millis(0),
-            success_rate: 1.0,
+            success_rate: Probability::ONE,
         };
         let result = PlanBuilder::new(FinalizingEngine::new(1, Duration::from_millis(100), 1))
             .required_finalizations(1)
@@ -1113,7 +1114,7 @@ mod tests {
         let link = Link {
             latency: Duration::from_millis(10),
             jitter: Duration::from_millis(0),
-            success_rate: 1.0,
+            success_rate: Probability::ONE,
         };
         let engine = FinalizingEngine::new(2, Duration::from_millis(100), 2);
         let delayed = engine.participants[0].clone();
@@ -1199,7 +1200,7 @@ mod tests {
     #[test]
     fn storage_fault_is_visible_during_engine_init() {
         PlanBuilder::new(FaultObservingEngine::new(1))
-            .with_storage_fault(deterministic::FaultConfig::default().open(1.0))
+            .with_storage_fault(deterministic::FaultConfig::default().open(Probability::ONE))
             .timeout(Duration::from_secs(1))
             .required_finalizations(1)
             .property(AllStatesSawFault)

--- a/glue/src/simulate/plan.rs
+++ b/glue/src/simulate/plan.rs
@@ -147,7 +147,7 @@ impl<D: EngineDefinition> PlanBuilder<D> {
             link: Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(5),
-                success_rate: Probability::ONE,
+                success_rate: Probability!(1.0),
             },
             max_message_size: 1024 * 1024,
             engine,
@@ -980,7 +980,7 @@ mod tests {
             ctx: super::super::engine::InitContext<'_, Self::PublicKey>,
         ) -> impl Future<Output = (Self::Engine, Self::State)> + Send {
             let saw_fault =
-                ctx.context.storage_fault_config().read().open_rate == Some(Probability::ONE);
+                ctx.context.storage_fault_config().read().open_rate == Some(Probability!(1.0));
             async move {
                 (
                     FaultObservingNode {
@@ -1087,7 +1087,7 @@ mod tests {
         let link = Link {
             latency: Duration::from_millis(10),
             jitter: Duration::from_millis(0),
-            success_rate: Probability::ONE,
+            success_rate: Probability!(1.0),
         };
         let result = PlanBuilder::new(FinalizingEngine::new(1, Duration::from_millis(100), 1))
             .required_finalizations(1)
@@ -1114,7 +1114,7 @@ mod tests {
         let link = Link {
             latency: Duration::from_millis(10),
             jitter: Duration::from_millis(0),
-            success_rate: Probability::ONE,
+            success_rate: Probability!(1.0),
         };
         let engine = FinalizingEngine::new(2, Duration::from_millis(100), 2);
         let delayed = engine.participants[0].clone();
@@ -1200,7 +1200,7 @@ mod tests {
     #[test]
     fn storage_fault_is_visible_during_engine_init() {
         PlanBuilder::new(FaultObservingEngine::new(1))
-            .with_storage_fault(deterministic::FaultConfig::default().open(Probability::ONE))
+            .with_storage_fault(deterministic::FaultConfig::default().open(Probability!(1.0)))
             .timeout(Duration::from_secs(1))
             .required_finalizations(1)
             .property(AllStatesSawFault)

--- a/glue/src/stateful/probe/mod.rs
+++ b/glue/src/stateful/probe/mod.rs
@@ -185,7 +185,7 @@ mod test {
     const LINK: Link = Link {
         latency: Duration::from_millis(10),
         jitter: Duration::from_millis(1),
-        success_rate: Probability::ONE,
+        success_rate: Probability!(1.0),
     };
     const PROBE_CHANNEL: u64 = 0;
     const BACKFILL_CHANNEL: u64 = 1;

--- a/glue/src/stateful/probe/mod.rs
+++ b/glue/src/stateful/probe/mod.rs
@@ -169,7 +169,7 @@ mod test {
     };
     use commonware_storage::archive::immutable;
     use commonware_utils::{
-        Acknowledgement, NZDuration, NZU16, NZU64, NZUsize, NonZeroDuration, TestRng,
+        Acknowledgement, NZDuration, NZU16, NZU64, NZUsize, NonZeroDuration, Probability, TestRng,
         channel::oneshot, sync::Mutex, test_rng,
     };
     use std::{
@@ -185,7 +185,7 @@ mod test {
     const LINK: Link = Link {
         latency: Duration::from_millis(10),
         jitter: Duration::from_millis(1),
-        success_rate: 1.0,
+        success_rate: Probability::ONE,
     };
     const PROBE_CHANNEL: u64 = 0;
     const BACKFILL_CHANNEL: u64 = 1;

--- a/glue/src/stateful/tests/mod.rs
+++ b/glue/src/stateful/tests/mod.rs
@@ -55,7 +55,7 @@ use commonware_storage::{
     },
 };
 use commonware_utils::{
-    Acknowledgement as _, NZU64, NZUsize, acknowledgement::Exact, channel::oneshot,
+    Acknowledgement as _, NZU64, NZUsize, Probability, acknowledgement::Exact, channel::oneshot,
     non_empty_range, sync::Mutex,
 };
 use properties::{
@@ -156,7 +156,7 @@ fn state_sync_lossy_network() {
     let link = Link {
         latency: Duration::from_millis(200),
         jitter: Duration::from_millis(150),
-        success_rate: 0.7,
+        success_rate: Probability!(7, 10),
     };
     run_state_sync_lossy(
         SingleDbEngine::new(NUM_VALIDATORS).with_state_sync(),
@@ -171,7 +171,7 @@ fn lossy_network() {
     let link = Link {
         latency: Duration::from_millis(200),
         jitter: Duration::from_millis(150),
-        success_rate: 0.7,
+        success_rate: Probability!(7, 10),
     };
     run_lossy(SingleDbEngine::new(NUM_VALIDATORS), link.clone());
     run_lossy(MultiDbEngine::new(NUM_VALIDATORS), link);
@@ -290,7 +290,7 @@ where
 }
 
 fn storage_fault_config() -> deterministic::FaultConfig {
-    deterministic::FaultConfig::default().sync(0.01)
+    deterministic::FaultConfig::default().sync(Probability!(1, 100))
 }
 
 fn default_storage_fault_schedule<P>(restart_order: impl IntoIterator<Item = P>) -> Schedule<P>
@@ -493,7 +493,7 @@ where
     let dead_link = Link {
         latency: Duration::from_secs(1),
         jitter: Duration::ZERO,
-        success_rate: 0.0,
+        success_rate: Probability::ZERO,
     };
 
     let mut schedule = Schedule::new();
@@ -598,7 +598,7 @@ where
         .link(Link {
             latency: Duration::from_millis(100),
             jitter: Duration::from_millis(5),
-            success_rate: 1.0,
+            success_rate: Probability::ONE,
         })
         .crash(Crash::Random {
             // A full-cluster crash discards all in-flight votes, and a
@@ -796,12 +796,12 @@ where
     let good_link = Link {
         latency: Duration::from_millis(10),
         jitter: Duration::from_millis(5),
-        success_rate: 1.0,
+        success_rate: Probability::ONE,
     };
     let dead_link = Link {
         latency: Duration::from_secs(1),
         jitter: Duration::ZERO,
-        success_rate: 0.0,
+        success_rate: Probability::ZERO,
     };
 
     // Build a schedule that kills all links to/from the isolated node at

--- a/glue/src/stateful/tests/mod.rs
+++ b/glue/src/stateful/tests/mod.rs
@@ -493,7 +493,7 @@ where
     let dead_link = Link {
         latency: Duration::from_secs(1),
         jitter: Duration::ZERO,
-        success_rate: Probability::ZERO,
+        success_rate: Probability!(0.0),
     };
 
     let mut schedule = Schedule::new();
@@ -598,7 +598,7 @@ where
         .link(Link {
             latency: Duration::from_millis(100),
             jitter: Duration::from_millis(5),
-            success_rate: Probability::ONE,
+            success_rate: Probability!(1.0),
         })
         .crash(Crash::Random {
             // A full-cluster crash discards all in-flight votes, and a
@@ -796,12 +796,12 @@ where
     let good_link = Link {
         latency: Duration::from_millis(10),
         jitter: Duration::from_millis(5),
-        success_rate: Probability::ONE,
+        success_rate: Probability!(1.0),
     };
     let dead_link = Link {
         latency: Duration::from_secs(1),
         jitter: Duration::ZERO,
-        success_rate: Probability::ZERO,
+        success_rate: Probability!(0.0),
     };
 
     // Build a schedule that kills all links to/from the isolated node at

--- a/glue/src/stateful/tests/mod.rs
+++ b/glue/src/stateful/tests/mod.rs
@@ -156,7 +156,7 @@ fn state_sync_lossy_network() {
     let link = Link {
         latency: Duration::from_millis(200),
         jitter: Duration::from_millis(150),
-        success_rate: Probability!(7, 10),
+        success_rate: Probability!(0.7),
     };
     run_state_sync_lossy(
         SingleDbEngine::new(NUM_VALIDATORS).with_state_sync(),
@@ -171,7 +171,7 @@ fn lossy_network() {
     let link = Link {
         latency: Duration::from_millis(200),
         jitter: Duration::from_millis(150),
-        success_rate: Probability!(7, 10),
+        success_rate: Probability!(0.7),
     };
     run_lossy(SingleDbEngine::new(NUM_VALIDATORS), link.clone());
     run_lossy(MultiDbEngine::new(NUM_VALIDATORS), link);
@@ -290,7 +290,7 @@ where
 }
 
 fn storage_fault_config() -> deterministic::FaultConfig {
-    deterministic::FaultConfig::default().sync(Probability!(1, 100))
+    deterministic::FaultConfig::default().sync(Probability!(0.01))
 }
 
 fn default_storage_fault_schedule<P>(restart_order: impl IntoIterator<Item = P>) -> Schedule<P>

--- a/p2p/TESTING.md
+++ b/p2p/TESTING.md
@@ -28,7 +28,7 @@ let (certificate_sender, certificate_receiver) = oracle
 oracle.add_link(pk1, pk2, Link {
     latency: Duration::from_millis(10),
     jitter: Duration::from_millis(3),
-    success_rate: 0.95,
+    success_rate: commonware_utils::Probability!(19, 20),
 }).await.unwrap();
 ```
 

--- a/p2p/TESTING.md
+++ b/p2p/TESTING.md
@@ -28,7 +28,7 @@ let (certificate_sender, certificate_receiver) = oracle
 oracle.add_link(pk1, pk2, Link {
     latency: Duration::from_millis(10),
     jitter: Duration::from_millis(3),
-    success_rate: commonware_utils::Probability!(19, 20),
+    success_rate: commonware_utils::Probability!(0.95),
 }).await.unwrap();
 ```
 

--- a/p2p/fuzz/fuzz_targets/simulated.rs
+++ b/p2p/fuzz/fuzz_targets/simulated.rs
@@ -7,7 +7,7 @@ use commonware_p2p::{
     Channel, Receiver as ReceiverTrait, Recipients, Sender as SenderTrait, simulated,
 };
 use commonware_runtime::{Clock, IoBuf, Quota, Runner, Supervisor as _, deterministic};
-use commonware_utils::NZUsize;
+use commonware_utils::{NZUsize, Probability};
 use libfuzzer_sys::fuzz_target;
 use rand::RngExt as _;
 use std::{
@@ -58,7 +58,7 @@ enum Operation {
         latency_ms: u16,
         /// Latency jitter in milliseconds.
         jitter: u16,
-        /// Success rate (0-255 maps to 0.0-1.0).
+        /// Success rate as a numerator over 255.
         success_rate: u8,
     },
     /// Remove a network link between two peers.
@@ -279,12 +279,11 @@ fn fuzz(input: FuzzInput) {
                     let from_idx = (from_idx as usize) % peer_pks.len();
                     let to_idx = (to_idx as usize) % peer_pks.len();
 
-                    // Create link with specified characteristics
-                    // success_rate is normalized from u8 (0-255) to f64 (0.0-1.0)
+                    // Create link with specified characteristics.
                     let link = simulated::Link {
                         latency: Duration::from_millis(latency_ms as u64),
                         jitter: Duration::from_millis(jitter as u64),
-                        success_rate: (success_rate as f64) / 255.0,
+                        success_rate: Probability!(u64::from(success_rate), u64::from(u8::MAX)),
                     };
                     let _ = oracle
                         .add_link(peer_pks[from_idx].clone(), peer_pks[to_idx].clone(), link)

--- a/p2p/src/simulated/ingress.rs
+++ b/p2p/src/simulated/ingress.rs
@@ -6,6 +6,7 @@ use commonware_actor::Feedback;
 use commonware_cryptography::PublicKey;
 use commonware_runtime::{Clock, IoBuf, Quota};
 use commonware_utils::{
+    Probability,
     channel::{fallible::FallibleExt, mpsc, oneshot, ring},
     ordered::Map,
 };
@@ -52,7 +53,7 @@ pub enum Message<P: PublicKey, E: Clock> {
         sender: P,
         receiver: P,
         sampler: Normal<f64>,
-        success_rate: f64,
+        success_rate: Probability,
         result: oneshot::Sender<Result<(), Error>>,
     },
     RemoveLink {
@@ -138,8 +139,8 @@ pub struct Link {
     /// Standard deviation of the latency for the delivery of a message.
     pub jitter: Duration,
 
-    /// Probability of a message being delivered successfully (in range \[0,1\]).
-    pub success_rate: f64,
+    /// Probability of a message being delivered successfully.
+    pub success_rate: Probability,
 }
 
 /// Interface for modifying the simulated network.
@@ -230,9 +231,6 @@ impl<P: PublicKey, E: Clock> Oracle<P, E> {
         // Sanity checks
         if sender == receiver {
             return Err(Error::LinkingSelf);
-        }
-        if config.success_rate < 0.0 || config.success_rate > 1.0 {
-            return Err(Error::InvalidSuccessRate(config.success_rate));
         }
 
         // Convert Duration to milliseconds as f64 for the Normal distribution

--- a/p2p/src/simulated/mod.rs
+++ b/p2p/src/simulated/mod.rs
@@ -462,7 +462,7 @@ mod tests {
                     Link {
                         latency: Duration::from_millis(10),
                         jitter: Duration::from_millis(1),
-                        success_rate: Probability::ONE,
+                        success_rate: Probability!(1.0),
                     },
                 )
                 .await
@@ -474,7 +474,7 @@ mod tests {
                     Link {
                         latency: Duration::from_millis(10),
                         jitter: Duration::from_millis(1),
-                        success_rate: Probability::ONE,
+                        success_rate: Probability!(1.0),
                     },
                 )
                 .await
@@ -567,7 +567,7 @@ mod tests {
                     Link {
                         latency: Duration::ZERO,
                         jitter: Duration::ZERO,
-                        success_rate: Probability::ONE,
+                        success_rate: Probability!(1.0),
                     },
                 )
                 .await
@@ -647,7 +647,7 @@ mod tests {
                     Link {
                         latency: Duration::from_millis(5),
                         jitter: Duration::from_millis(2),
-                        success_rate: Probability::ONE,
+                        success_rate: Probability!(1.0),
                     },
                 )
                 .await
@@ -659,7 +659,7 @@ mod tests {
                     Link {
                         latency: Duration::from_millis(5),
                         jitter: Duration::from_millis(2),
-                        success_rate: Probability::ONE,
+                        success_rate: Probability!(1.0),
                     },
                 )
                 .await
@@ -722,7 +722,7 @@ mod tests {
                     Link {
                         latency: Duration::from_millis(5),
                         jitter: Duration::ZERO,
-                        success_rate: Probability::ONE,
+                        success_rate: Probability!(1.0),
                     },
                 )
                 .await
@@ -783,7 +783,7 @@ mod tests {
                     Link {
                         latency: Duration::from_millis(5),
                         jitter: Duration::from_millis(2),
-                        success_rate: Probability::ONE,
+                        success_rate: Probability!(1.0),
                     },
                 )
                 .await
@@ -795,7 +795,7 @@ mod tests {
                     Link {
                         latency: Duration::from_millis(5),
                         jitter: Duration::from_millis(2),
-                        success_rate: Probability::ONE,
+                        success_rate: Probability!(1.0),
                     },
                 )
                 .await
@@ -875,7 +875,7 @@ mod tests {
                     Link {
                         latency: Duration::from_millis(5),
                         jitter: Duration::from_millis(2),
-                        success_rate: Probability::ONE,
+                        success_rate: Probability!(1.0),
                     },
                 )
                 .await
@@ -887,7 +887,7 @@ mod tests {
                     Link {
                         latency: Duration::from_millis(5),
                         jitter: Duration::from_millis(2),
-                        success_rate: Probability::ONE,
+                        success_rate: Probability!(1.0),
                     },
                 )
                 .await
@@ -978,7 +978,7 @@ mod tests {
                     // No latency so it doesn't interfere with bandwidth delay calculation
                     latency: Duration::ZERO,
                     jitter: Duration::ZERO,
-                    success_rate: Probability::ONE,
+                    success_rate: Probability!(1.0),
                 },
             )
             .await
@@ -1161,7 +1161,7 @@ mod tests {
                         Link {
                             latency: Duration::ZERO,
                             jitter: Duration::ZERO,
-                            success_rate: Probability::ONE,
+                            success_rate: Probability!(1.0),
                         },
                     )
                     .await
@@ -1173,7 +1173,7 @@ mod tests {
                         Link {
                             latency: Duration::ZERO,
                             jitter: Duration::ZERO,
-                            success_rate: Probability::ONE,
+                            success_rate: Probability!(1.0),
                         },
                     )
                     .await
@@ -1294,7 +1294,7 @@ mod tests {
                     Link {
                         latency: Duration::from_millis(50),
                         jitter: Duration::from_millis(40),
-                        success_rate: Probability::ONE,
+                        success_rate: Probability!(1.0),
                     },
                 )
                 .await
@@ -1361,7 +1361,7 @@ mod tests {
                     Link {
                         latency: Duration::from_millis(5_000),
                         jitter: Duration::ZERO,
-                        success_rate: Probability::ONE,
+                        success_rate: Probability!(1.0),
                     },
                 )
                 .await
@@ -1382,7 +1382,7 @@ mod tests {
                     Link {
                         latency: Duration::from_millis(1),
                         jitter: Duration::ZERO,
-                        success_rate: Probability::ONE,
+                        success_rate: Probability!(1.0),
                     },
                 )
                 .await
@@ -1485,7 +1485,7 @@ mod tests {
                         Link {
                             latency: Duration::ZERO,
                             jitter: Duration::ZERO,
-                            success_rate: Probability::ONE,
+                            success_rate: Probability!(1.0),
                         },
                     )
                     .await
@@ -1575,7 +1575,7 @@ mod tests {
                         Link {
                             latency: Duration::ZERO,
                             jitter: Duration::ZERO,
-                            success_rate: Probability::ONE,
+                            success_rate: Probability!(1.0),
                         },
                     )
                     .await
@@ -1672,7 +1672,7 @@ mod tests {
                         Link {
                             latency: Duration::ZERO,
                             jitter: Duration::ZERO,
-                            success_rate: Probability::ONE,
+                            success_rate: Probability!(1.0),
                         },
                     )
                     .await
@@ -1769,7 +1769,7 @@ mod tests {
                         Link {
                             latency: Duration::from_millis(1),
                             jitter: Duration::ZERO,
-                            success_rate: Probability::ONE,
+                            success_rate: Probability!(1.0),
                         },
                     )
                     .await
@@ -1915,7 +1915,7 @@ mod tests {
                         Link {
                             latency: Duration::from_millis(1),
                             jitter: Duration::ZERO,
-                            success_rate: Probability::ONE,
+                            success_rate: Probability!(1.0),
                         },
                     )
                     .await
@@ -2013,7 +2013,7 @@ mod tests {
                     Link {
                         latency: Duration::from_secs(1), // 1 second latency
                         jitter: Duration::ZERO,
-                        success_rate: Probability::ONE,
+                        success_rate: Probability!(1.0),
                     },
                 )
                 .await
@@ -2104,7 +2104,7 @@ mod tests {
                     Link {
                         latency: Duration::from_millis(1), // Small latency
                         jitter: Duration::ZERO,
-                        success_rate: Probability::ONE,
+                        success_rate: Probability!(1.0),
                     },
                 )
                 .await
@@ -2195,7 +2195,7 @@ mod tests {
                     Link {
                         latency: Duration::ZERO,
                         jitter: Duration::ZERO,
-                        success_rate: Probability::ONE,
+                        success_rate: Probability!(1.0),
                     },
                 )
                 .await
@@ -2274,7 +2274,7 @@ mod tests {
                     Link {
                         latency: Duration::ZERO,
                         jitter: Duration::ZERO,
-                        success_rate: Probability::ONE,
+                        success_rate: Probability!(1.0),
                     },
                 )
                 .await
@@ -2679,7 +2679,7 @@ mod tests {
                                 Link {
                                     latency: Duration::from_millis(1),
                                     jitter: Duration::ZERO,
-                                    success_rate: Probability::ONE,
+                                    success_rate: Probability!(1.0),
                                 },
                             )
                             .await
@@ -2820,7 +2820,7 @@ mod tests {
                     Link {
                         latency: Duration::from_millis(1),
                         jitter: Duration::ZERO,
-                        success_rate: Probability::ONE,
+                        success_rate: Probability!(1.0),
                     },
                 )
                 .await
@@ -3161,7 +3161,7 @@ mod tests {
             let link = ingress::Link {
                 latency: Duration::from_millis(0),
                 jitter: Duration::from_millis(0),
-                success_rate: Probability::ONE,
+                success_rate: Probability!(1.0),
             };
             oracle
                 .add_link(pk1.clone(), pk2.clone(), link.clone())
@@ -3229,7 +3229,7 @@ mod tests {
             let link = ingress::Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(0),
-                success_rate: Probability::ONE,
+                success_rate: Probability!(1.0),
             };
             oracle
                 .add_link(pk1.clone(), pk2.clone(), link.clone())
@@ -3295,7 +3295,7 @@ mod tests {
             let link = ingress::Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(0),
-                success_rate: Probability::ONE,
+                success_rate: Probability!(1.0),
             };
             oracle
                 .add_link(pk1.clone(), pk2.clone(), link.clone())

--- a/p2p/src/simulated/mod.rs
+++ b/p2p/src/simulated/mod.rs
@@ -111,7 +111,7 @@
 //!         Link {
 //!             latency: Duration::from_millis(5),
 //!             jitter: Duration::from_millis(2),
-//!             success_rate: Probability!(3, 4),
+//!             success_rate: Probability!(0.75),
 //!         },
 //!     ).await.unwrap();
 //!
@@ -128,7 +128,7 @@
 //!         Link {
 //!             latency: Duration::from_millis(100),
 //!             jitter: Duration::from_millis(25),
-//!             success_rate: Probability!(4, 5),
+//!             success_rate: Probability!(0.8),
 //!         },
 //!     ).await.unwrap();
 //!
@@ -289,7 +289,7 @@ mod tests {
                             Link {
                                 latency: Duration::from_millis(5),
                                 jitter: Duration::from_millis(2),
-                                success_rate: Probability!(3, 4),
+                                success_rate: Probability!(0.75),
                             },
                         )
                         .await;
@@ -424,7 +424,7 @@ mod tests {
                     Link {
                         latency: Duration::from_millis(5),
                         jitter: Duration::from_millis(2),
-                        success_rate: Probability!(3, 4),
+                        success_rate: Probability!(0.75),
                     },
                 )
                 .await;

--- a/p2p/src/simulated/mod.rs
+++ b/p2p/src/simulated/mod.rs
@@ -62,7 +62,7 @@
 //! use commonware_p2p::simulated::{Config, Link, Network};
 //! use commonware_cryptography::{ed25519, PrivateKey, Signer as _, PublicKey as _, };
 //! use commonware_runtime::{deterministic, Metrics, Quota, Runner, Spawner, Supervisor};
-//! use commonware_utils::{NZU32, NZUsize};
+//! use commonware_utils::{NZU32, NZUsize, Probability};
 //! use std::time::Duration;
 //!
 //! // Generate peers
@@ -111,7 +111,7 @@
 //!         Link {
 //!             latency: Duration::from_millis(5),
 //!             jitter: Duration::from_millis(2),
-//!             success_rate: 0.75,
+//!             success_rate: Probability!(3, 4),
 //!         },
 //!     ).await.unwrap();
 //!
@@ -128,7 +128,7 @@
 //!         Link {
 //!             latency: Duration::from_millis(100),
 //!             jitter: Duration::from_millis(25),
-//!             success_rate: 0.8,
+//!             success_rate: Probability!(4, 5),
 //!         },
 //!     ).await.unwrap();
 //!
@@ -158,8 +158,6 @@ pub enum Error {
     LinkExists,
     #[error("link missing")]
     LinkMissing,
-    #[error("invalid success rate (must be in [0, 1]): {0}")]
-    InvalidSuccessRate(f64),
     #[error("send_frame failed")]
     SendFrameFailed,
     #[error("recv_frame failed")]
@@ -197,7 +195,7 @@ mod tests {
         telemetry::metrics::count_running_tasks,
     };
     use commonware_utils::{
-        NZU32, NZUsize,
+        NZU32, NZUsize, Probability,
         channel::mpsc,
         hostname, ordered,
         ordered::{Map, Set},
@@ -291,7 +289,7 @@ mod tests {
                             Link {
                                 latency: Duration::from_millis(5),
                                 jitter: Duration::from_millis(2),
-                                success_rate: 0.75,
+                                success_rate: Probability!(3, 4),
                             },
                         )
                         .await;
@@ -426,7 +424,7 @@ mod tests {
                     Link {
                         latency: Duration::from_millis(5),
                         jitter: Duration::from_millis(2),
-                        success_rate: 0.75,
+                        success_rate: Probability!(3, 4),
                     },
                 )
                 .await;
@@ -464,7 +462,7 @@ mod tests {
                     Link {
                         latency: Duration::from_millis(10),
                         jitter: Duration::from_millis(1),
-                        success_rate: 1.0,
+                        success_rate: Probability::ONE,
                     },
                 )
                 .await
@@ -476,7 +474,7 @@ mod tests {
                     Link {
                         latency: Duration::from_millis(10),
                         jitter: Duration::from_millis(1),
-                        success_rate: 1.0,
+                        success_rate: Probability::ONE,
                     },
                 )
                 .await
@@ -540,56 +538,6 @@ mod tests {
     }
 
     #[test]
-    fn test_invalid_success_rate() {
-        let executor = deterministic::Runner::default();
-        executor.start(|context| async move {
-            // Create simulated network
-            let (network, oracle) = Network::new(
-                context.child("network"),
-                Config {
-                    max_size: 1024 * 1024,
-                    max_peers_per_set: NZUsize!(1),
-                    disconnect_on_block: true,
-                    tracked_peer_sets: NZUsize!(1),
-                },
-            );
-
-            // Start network
-            network.start();
-
-            // Register agents
-            let pk1 = PrivateKey::from_seed(0).public_key();
-            let pk2 = PrivateKey::from_seed(1).public_key();
-            oracle
-                .control(pk1.clone())
-                .register(0, TEST_QUOTA)
-                .await
-                .unwrap();
-            oracle
-                .control(pk2.clone())
-                .register(0, TEST_QUOTA)
-                .await
-                .unwrap();
-
-            // Attempt to link with invalid success rate
-            let result = oracle
-                .add_link(
-                    pk1,
-                    pk2,
-                    Link {
-                        latency: Duration::from_millis(5),
-                        jitter: Duration::from_millis(2),
-                        success_rate: 1.5,
-                    },
-                )
-                .await;
-
-            // Confirm error is correct
-            assert!(matches!(result, Err(Error::InvalidSuccessRate(_))));
-        });
-    }
-
-    #[test]
     fn test_add_link_before_channel_registration() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
@@ -619,7 +567,7 @@ mod tests {
                     Link {
                         latency: Duration::ZERO,
                         jitter: Duration::ZERO,
-                        success_rate: 1.0,
+                        success_rate: Probability::ONE,
                     },
                 )
                 .await
@@ -699,7 +647,7 @@ mod tests {
                     Link {
                         latency: Duration::from_millis(5),
                         jitter: Duration::from_millis(2),
-                        success_rate: 1.0,
+                        success_rate: Probability::ONE,
                     },
                 )
                 .await
@@ -711,7 +659,7 @@ mod tests {
                     Link {
                         latency: Duration::from_millis(5),
                         jitter: Duration::from_millis(2),
-                        success_rate: 1.0,
+                        success_rate: Probability::ONE,
                     },
                 )
                 .await
@@ -774,7 +722,7 @@ mod tests {
                     Link {
                         latency: Duration::from_millis(5),
                         jitter: Duration::ZERO,
-                        success_rate: 1.0,
+                        success_rate: Probability::ONE,
                     },
                 )
                 .await
@@ -835,7 +783,7 @@ mod tests {
                     Link {
                         latency: Duration::from_millis(5),
                         jitter: Duration::from_millis(2),
-                        success_rate: 1.0,
+                        success_rate: Probability::ONE,
                     },
                 )
                 .await
@@ -847,7 +795,7 @@ mod tests {
                     Link {
                         latency: Duration::from_millis(5),
                         jitter: Duration::from_millis(2),
-                        success_rate: 1.0,
+                        success_rate: Probability::ONE,
                     },
                 )
                 .await
@@ -927,7 +875,7 @@ mod tests {
                     Link {
                         latency: Duration::from_millis(5),
                         jitter: Duration::from_millis(2),
-                        success_rate: 1.0,
+                        success_rate: Probability::ONE,
                     },
                 )
                 .await
@@ -939,7 +887,7 @@ mod tests {
                     Link {
                         latency: Duration::from_millis(5),
                         jitter: Duration::from_millis(2),
-                        success_rate: 1.0,
+                        success_rate: Probability::ONE,
                     },
                 )
                 .await
@@ -1030,7 +978,7 @@ mod tests {
                     // No latency so it doesn't interfere with bandwidth delay calculation
                     latency: Duration::ZERO,
                     jitter: Duration::ZERO,
-                    success_rate: 1.0,
+                    success_rate: Probability::ONE,
                 },
             )
             .await
@@ -1213,7 +1161,7 @@ mod tests {
                         Link {
                             latency: Duration::ZERO,
                             jitter: Duration::ZERO,
-                            success_rate: 1.0,
+                            success_rate: Probability::ONE,
                         },
                     )
                     .await
@@ -1225,7 +1173,7 @@ mod tests {
                         Link {
                             latency: Duration::ZERO,
                             jitter: Duration::ZERO,
-                            success_rate: 1.0,
+                            success_rate: Probability::ONE,
                         },
                     )
                     .await
@@ -1346,7 +1294,7 @@ mod tests {
                     Link {
                         latency: Duration::from_millis(50),
                         jitter: Duration::from_millis(40),
-                        success_rate: 1.0,
+                        success_rate: Probability::ONE,
                     },
                 )
                 .await
@@ -1413,7 +1361,7 @@ mod tests {
                     Link {
                         latency: Duration::from_millis(5_000),
                         jitter: Duration::ZERO,
-                        success_rate: 1.0,
+                        success_rate: Probability::ONE,
                     },
                 )
                 .await
@@ -1434,7 +1382,7 @@ mod tests {
                     Link {
                         latency: Duration::from_millis(1),
                         jitter: Duration::ZERO,
-                        success_rate: 1.0,
+                        success_rate: Probability::ONE,
                     },
                 )
                 .await
@@ -1537,7 +1485,7 @@ mod tests {
                         Link {
                             latency: Duration::ZERO,
                             jitter: Duration::ZERO,
-                            success_rate: 1.0,
+                            success_rate: Probability::ONE,
                         },
                     )
                     .await
@@ -1627,7 +1575,7 @@ mod tests {
                         Link {
                             latency: Duration::ZERO,
                             jitter: Duration::ZERO,
-                            success_rate: 1.0,
+                            success_rate: Probability::ONE,
                         },
                     )
                     .await
@@ -1724,7 +1672,7 @@ mod tests {
                         Link {
                             latency: Duration::ZERO,
                             jitter: Duration::ZERO,
-                            success_rate: 1.0,
+                            success_rate: Probability::ONE,
                         },
                     )
                     .await
@@ -1821,7 +1769,7 @@ mod tests {
                         Link {
                             latency: Duration::from_millis(1),
                             jitter: Duration::ZERO,
-                            success_rate: 1.0,
+                            success_rate: Probability::ONE,
                         },
                     )
                     .await
@@ -1967,7 +1915,7 @@ mod tests {
                         Link {
                             latency: Duration::from_millis(1),
                             jitter: Duration::ZERO,
-                            success_rate: 1.0,
+                            success_rate: Probability::ONE,
                         },
                     )
                     .await
@@ -2065,7 +2013,7 @@ mod tests {
                     Link {
                         latency: Duration::from_secs(1), // 1 second latency
                         jitter: Duration::ZERO,
-                        success_rate: 1.0,
+                        success_rate: Probability::ONE,
                     },
                 )
                 .await
@@ -2156,7 +2104,7 @@ mod tests {
                     Link {
                         latency: Duration::from_millis(1), // Small latency
                         jitter: Duration::ZERO,
-                        success_rate: 1.0,
+                        success_rate: Probability::ONE,
                     },
                 )
                 .await
@@ -2247,7 +2195,7 @@ mod tests {
                     Link {
                         latency: Duration::ZERO,
                         jitter: Duration::ZERO,
-                        success_rate: 1.0,
+                        success_rate: Probability::ONE,
                     },
                 )
                 .await
@@ -2326,7 +2274,7 @@ mod tests {
                     Link {
                         latency: Duration::ZERO,
                         jitter: Duration::ZERO,
-                        success_rate: 1.0,
+                        success_rate: Probability::ONE,
                     },
                 )
                 .await
@@ -2731,7 +2679,7 @@ mod tests {
                                 Link {
                                     latency: Duration::from_millis(1),
                                     jitter: Duration::ZERO,
-                                    success_rate: 1.0,
+                                    success_rate: Probability::ONE,
                                 },
                             )
                             .await
@@ -2872,7 +2820,7 @@ mod tests {
                     Link {
                         latency: Duration::from_millis(1),
                         jitter: Duration::ZERO,
-                        success_rate: 1.0,
+                        success_rate: Probability::ONE,
                     },
                 )
                 .await
@@ -3213,7 +3161,7 @@ mod tests {
             let link = ingress::Link {
                 latency: Duration::from_millis(0),
                 jitter: Duration::from_millis(0),
-                success_rate: 1.0,
+                success_rate: Probability::ONE,
             };
             oracle
                 .add_link(pk1.clone(), pk2.clone(), link.clone())
@@ -3281,7 +3229,7 @@ mod tests {
             let link = ingress::Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(0),
-                success_rate: 1.0,
+                success_rate: Probability::ONE,
             };
             oracle
                 .add_link(pk1.clone(), pk2.clone(), link.clone())
@@ -3347,7 +3295,7 @@ mod tests {
             let link = ingress::Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(0),
-                success_rate: 1.0,
+                success_rate: Probability::ONE,
             };
             oracle
                 .add_link(pk1.clone(), pk2.clone(), link.clone())

--- a/p2p/src/simulated/network.rs
+++ b/p2p/src/simulated/network.rs
@@ -1569,7 +1569,7 @@ mod tests {
             let link = ingress::Link {
                 latency: Duration::from_millis(2),
                 jitter: Duration::from_millis(1),
-                success_rate: Probability!(9, 10),
+                success_rate: Probability!(0.9),
             };
             oracle
                 .add_link(pk1.clone(), pk2.clone(), link.clone())

--- a/p2p/src/simulated/network.rs
+++ b/p2p/src/simulated/network.rs
@@ -1646,7 +1646,7 @@ mod tests {
                     ingress::Link {
                         latency: Duration::ZERO,
                         jitter: Duration::ZERO,
-                        success_rate: Probability::ONE,
+                        success_rate: Probability!(1.0),
                     },
                 )
                 .await
@@ -1918,7 +1918,7 @@ mod tests {
             let link = ingress::Link {
                 latency: Duration::from_millis(0),
                 jitter: Duration::from_millis(0),
-                success_rate: Probability::ONE,
+                success_rate: Probability!(1.0),
             };
             oracle
                 .add_link(peer_a.clone(), twin.clone(), link.clone())
@@ -2005,7 +2005,7 @@ mod tests {
             let link = ingress::Link {
                 latency: Duration::from_millis(0),
                 jitter: Duration::from_millis(0),
-                success_rate: Probability::ONE,
+                success_rate: Probability!(1.0),
             };
             oracle
                 .add_link(peer_c.clone(), twin.clone(), link.clone())
@@ -2075,7 +2075,7 @@ mod tests {
             let link = ingress::Link {
                 latency: Duration::from_millis(0),
                 jitter: Duration::from_millis(0),
-                success_rate: Probability::ONE,
+                success_rate: Probability!(1.0),
             };
             oracle
                 .add_link(peer_c.clone(), twin.clone(), link.clone())
@@ -2306,7 +2306,7 @@ mod tests {
                     ingress::Link {
                         latency: Duration::from_millis(0),
                         jitter: Duration::from_millis(0),
-                        success_rate: Probability::ONE,
+                        success_rate: Probability!(1.0),
                     },
                 )
                 .await
@@ -2392,7 +2392,7 @@ mod tests {
             let link = ingress::Link {
                 latency: Duration::from_millis(0),
                 jitter: Duration::from_millis(0),
-                success_rate: Probability::ONE,
+                success_rate: Probability!(1.0),
             };
             oracle
                 .add_link(sender_pk.clone(), recipient_a.clone(), link.clone())
@@ -2480,7 +2480,7 @@ mod tests {
             let link = ingress::Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::ZERO,
-                success_rate: Probability::ONE,
+                success_rate: Probability!(1.0),
             };
             for (a, b) in [(&pk1, &pk2), (&pk1, &pk3), (&pk2, &pk3)] {
                 oracle
@@ -2631,7 +2631,7 @@ mod tests {
             let link = ingress::Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::ZERO,
-                success_rate: Probability::ONE,
+                success_rate: Probability!(1.0),
             };
             oracle
                 .add_link(primary_1.clone(), secondary_0.clone(), link.clone())

--- a/p2p/src/simulated/network.rs
+++ b/p2p/src/simulated/network.rs
@@ -26,13 +26,13 @@ use commonware_runtime::{
 };
 use commonware_stream::utils::codec::{recv_frame, send_frame};
 use commonware_utils::{
-    NZUsize, TryCollect,
+    NZUsize, Probability, TryCollect,
     channel::{fallible::FallibleExt, mpsc, oneshot, ring},
     ordered::Set,
 };
 use either::Either;
 use futures::{Sink, future};
-use rand::{Rng, RngExt as _};
+use rand::Rng;
 use rand_distr::{Distribution, Normal};
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap, VecDeque},
@@ -813,7 +813,7 @@ impl<E: RNetwork + Spawner + Rng + Clock + Metrics, P: PublicKey> Network<E, P> 
             let latency = Duration::from_millis(link.sampler.sample(self.context.as_mut()) as u64);
 
             // Determine if the message should be delivered
-            let should_deliver = self.context.random_bool(link.success_rate);
+            let should_deliver = link.success_rate.sample(self.context.as_mut());
 
             // Enqueue message for delivery
             let completions = self.transmitter.enqueue(
@@ -1428,7 +1428,7 @@ impl<P: PublicKey> Peer<P> {
 // Messages can be sent over the link with a given latency, jitter, and success rate.
 struct Link {
     sampler: Normal<f64>,
-    success_rate: f64,
+    success_rate: Probability,
     // Messages with their receive time for ordered delivery
     inbox: mpsc::UnboundedSender<(Channel, IoBuf, SystemTime)>,
 }
@@ -1442,7 +1442,7 @@ impl Link {
         receiver: P,
         socket: SocketAddr,
         sampler: Normal<f64>,
-        success_rate: f64,
+        success_rate: Probability,
         max_frame_size: u32,
         received_messages: CounterFamily<metrics::Message>,
     ) -> Self {
@@ -1569,7 +1569,7 @@ mod tests {
             let link = ingress::Link {
                 latency: Duration::from_millis(2),
                 jitter: Duration::from_millis(1),
-                success_rate: 0.9,
+                success_rate: Probability!(9, 10),
             };
             oracle
                 .add_link(pk1.clone(), pk2.clone(), link.clone())
@@ -1646,7 +1646,7 @@ mod tests {
                     ingress::Link {
                         latency: Duration::ZERO,
                         jitter: Duration::ZERO,
-                        success_rate: 1.0,
+                        success_rate: Probability::ONE,
                     },
                 )
                 .await
@@ -1918,7 +1918,7 @@ mod tests {
             let link = ingress::Link {
                 latency: Duration::from_millis(0),
                 jitter: Duration::from_millis(0),
-                success_rate: 1.0,
+                success_rate: Probability::ONE,
             };
             oracle
                 .add_link(peer_a.clone(), twin.clone(), link.clone())
@@ -2005,7 +2005,7 @@ mod tests {
             let link = ingress::Link {
                 latency: Duration::from_millis(0),
                 jitter: Duration::from_millis(0),
-                success_rate: 1.0,
+                success_rate: Probability::ONE,
             };
             oracle
                 .add_link(peer_c.clone(), twin.clone(), link.clone())
@@ -2075,7 +2075,7 @@ mod tests {
             let link = ingress::Link {
                 latency: Duration::from_millis(0),
                 jitter: Duration::from_millis(0),
-                success_rate: 1.0,
+                success_rate: Probability::ONE,
             };
             oracle
                 .add_link(peer_c.clone(), twin.clone(), link.clone())
@@ -2306,7 +2306,7 @@ mod tests {
                     ingress::Link {
                         latency: Duration::from_millis(0),
                         jitter: Duration::from_millis(0),
-                        success_rate: 1.0,
+                        success_rate: Probability::ONE,
                     },
                 )
                 .await
@@ -2392,7 +2392,7 @@ mod tests {
             let link = ingress::Link {
                 latency: Duration::from_millis(0),
                 jitter: Duration::from_millis(0),
-                success_rate: 1.0,
+                success_rate: Probability::ONE,
             };
             oracle
                 .add_link(sender_pk.clone(), recipient_a.clone(), link.clone())
@@ -2480,7 +2480,7 @@ mod tests {
             let link = ingress::Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::ZERO,
-                success_rate: 1.0,
+                success_rate: Probability::ONE,
             };
             for (a, b) in [(&pk1, &pk2), (&pk1, &pk3), (&pk2, &pk3)] {
                 oracle
@@ -2631,7 +2631,7 @@ mod tests {
             let link = ingress::Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::ZERO,
-                success_rate: 1.0,
+                success_rate: Probability::ONE,
             };
             oracle
                 .add_link(primary_1.clone(), secondary_0.clone(), link.clone())

--- a/p2p/src/utils/codec.rs
+++ b/p2p/src/utils/codec.rs
@@ -315,7 +315,7 @@ mod tests {
     const LINK: Link = Link {
         latency: Duration::from_millis(0),
         jitter: Duration::from_millis(0),
-        success_rate: Probability::ONE,
+        success_rate: Probability!(1.0),
     };
 
     const TEST_QUOTA: Quota = Quota::per_second(NonZeroU32::MAX);

--- a/p2p/src/utils/codec.rs
+++ b/p2p/src/utils/codec.rs
@@ -301,7 +301,7 @@ mod tests {
     use commonware_macros::test_traced;
     use commonware_parallel::{Manual, Sequential, Strategy};
     use commonware_runtime::{Clock as _, IoBuf, Quota, Runner, Supervisor as _, deterministic};
-    use commonware_utils::{NZUsize, channel::mpsc, ordered::Set};
+    use commonware_utils::{NZUsize, Probability, channel::mpsc, ordered::Set};
     use std::{
         io,
         num::{NonZeroU32, NonZeroUsize},
@@ -315,7 +315,7 @@ mod tests {
     const LINK: Link = Link {
         latency: Duration::from_millis(0),
         jitter: Duration::from_millis(0),
-        success_rate: 1.0,
+        success_rate: Probability::ONE,
     };
 
     const TEST_QUOTA: Quota = Quota::per_second(NonZeroU32::MAX);

--- a/p2p/src/utils/mux.rs
+++ b/p2p/src/utils/mux.rs
@@ -505,7 +505,7 @@ mod tests {
     };
     use commonware_macros::{select, test_traced};
     use commonware_runtime::{IoBuf, Quota, Runner, Supervisor as _, deterministic};
-    use commonware_utils::{NZUsize, ordered::Set};
+    use commonware_utils::{NZUsize, Probability, ordered::Set};
     use std::{
         num::NonZeroU32,
         time::{Duration, SystemTime},
@@ -514,7 +514,7 @@ mod tests {
     const LINK: Link = Link {
         latency: Duration::from_millis(0),
         jitter: Duration::from_millis(0),
-        success_rate: 1.0,
+        success_rate: Probability::ONE,
     };
     const CAPACITY: usize = 5usize;
 

--- a/p2p/src/utils/mux.rs
+++ b/p2p/src/utils/mux.rs
@@ -514,7 +514,7 @@ mod tests {
     const LINK: Link = Link {
         latency: Duration::from_millis(0),
         jitter: Duration::from_millis(0),
-        success_rate: Probability::ONE,
+        success_rate: Probability!(1.0),
     };
     const CAPACITY: usize = 5usize;
 

--- a/resolver/src/p2p/mod.rs
+++ b/resolver/src/p2p/mod.rs
@@ -156,7 +156,7 @@ mod tests {
     const LINK_UNRELIABLE: Link = Link {
         latency: Duration::from_millis(10),
         jitter: Duration::from_millis(1),
-        success_rate: Probability!(1, 2),
+        success_rate: Probability!(0.5),
     };
 
     fn status_metric_total(metrics: &str, name: &str, status: &str) -> u64 {

--- a/resolver/src/p2p/mod.rs
+++ b/resolver/src/p2p/mod.rs
@@ -127,7 +127,7 @@ mod tests {
         telemetry::metrics::count_running_tasks,
     };
     use commonware_utils::{
-        NZU32, NZUsize,
+        NZU32, NZUsize, Probability,
         channel::{
             fallible::{FallibleExt, OneshotExt},
             mpsc, oneshot,
@@ -151,12 +151,12 @@ mod tests {
     const LINK: Link = Link {
         latency: Duration::from_millis(10),
         jitter: Duration::from_millis(1),
-        success_rate: 1.0,
+        success_rate: Probability::ONE,
     };
     const LINK_UNRELIABLE: Link = Link {
         latency: Duration::from_millis(10),
         jitter: Duration::from_millis(1),
-        success_rate: 0.5,
+        success_rate: Probability!(1, 2),
     };
 
     fn status_metric_total(metrics: &str, name: &str, status: &str) -> u64 {

--- a/resolver/src/p2p/mod.rs
+++ b/resolver/src/p2p/mod.rs
@@ -151,7 +151,7 @@ mod tests {
     const LINK: Link = Link {
         latency: Duration::from_millis(10),
         jitter: Duration::from_millis(1),
-        success_rate: Probability::ONE,
+        success_rate: Probability!(1.0),
     };
     const LINK_UNRELIABLE: Link = Link {
         latency: Duration::from_millis(10),

--- a/runtime/src/deterministic.rs
+++ b/runtime/src/deterministic.rs
@@ -1919,7 +1919,7 @@ mod tests {
         let (stale_config, checkpoint) =
             deterministic::Runner::default().start_and_recover(|context| async move {
                 let config = context.storage_fault_config();
-                *config.write() = FaultConfig::default().open(Probability::ONE);
+                *config.write() = FaultConfig::default().open(Probability!(1.0));
                 config
             });
         *stale_config.write() = FaultConfig::default();
@@ -1959,7 +1959,7 @@ mod tests {
             let cfg = deterministic::Config::default()
                 .with_seed(seed)
                 .with_storage_fault_config(FaultConfig::default().write(WriteConfig {
-                    failure_rate: Probability::ZERO,
+                    failure_rate: Probability!(0.0),
                     retention_rate: Probability!(0.5),
                     mode: PartialWriteMode::Subset,
                 }));
@@ -2336,7 +2336,7 @@ mod tests {
     fn test_storage_fault_injection_and_recovery() {
         // Phase 1: Run with 100% sync failure rate
         let cfg = deterministic::Config::default().with_storage_fault_config(FaultConfig {
-            sync_rate: Some(Probability::ONE),
+            sync_rate: Some(Probability!(1.0)),
             ..Default::default()
         });
 
@@ -2389,7 +2389,7 @@ mod tests {
 
             // Enable sync faults dynamically
             let storage_fault_cfg = ctx.storage_fault_config();
-            storage_fault_cfg.write().sync_rate = Some(Probability::ONE);
+            storage_fault_cfg.write().sync_rate = Some(Probability!(1.0));
 
             // Now sync should fail
             blob.write_at(0, b"updated".to_vec(), WriteOptions::default())
@@ -2399,7 +2399,7 @@ mod tests {
             assert!(result.is_err(), "sync should fail with faults enabled");
 
             // Disable faults
-            storage_fault_cfg.write().sync_rate = Some(Probability::ZERO);
+            storage_fault_cfg.write().sync_rate = Some(Probability!(0.0));
 
             // Sync should succeed again
             blob.sync()
@@ -2456,7 +2456,7 @@ mod tests {
                     open_rate: Some(Probability!(0.5)),
                     write_rate: Some(WriteConfig {
                         failure_rate: Probability!(0.3),
-                        retention_rate: Probability::ZERO,
+                        retention_rate: Probability!(0.0),
                         mode: PartialWriteMode::Prefix,
                     }),
                     sync_rate: Some(Probability!(0.2)),

--- a/runtime/src/deterministic.rs
+++ b/runtime/src/deterministic.rs
@@ -1648,7 +1648,7 @@ mod tests {
     use commonware_parallel::Strategy;
     #[cfg(feature = "external")]
     use commonware_utils::channel::mpsc;
-    use commonware_utils::{NZUsize, channel::oneshot};
+    use commonware_utils::{NZUsize, Probability, channel::oneshot};
     #[cfg(feature = "external")]
     use futures::StreamExt;
     #[cfg(not(feature = "external"))]
@@ -1919,7 +1919,7 @@ mod tests {
         let (stale_config, checkpoint) =
             deterministic::Runner::default().start_and_recover(|context| async move {
                 let config = context.storage_fault_config();
-                *config.write() = FaultConfig::default().open(1.0);
+                *config.write() = FaultConfig::default().open(Probability::ONE);
                 config
             });
         *stale_config.write() = FaultConfig::default();
@@ -1933,7 +1933,7 @@ mod tests {
     fn test_recover_retained_successful_resize() {
         let cfg = deterministic::Config::default()
             .with_seed(83)
-            .with_storage_fault_config(FaultConfig::default().resize(0.5));
+            .with_storage_fault_config(FaultConfig::default().resize(Probability!(1, 2)));
         let (_, checkpoint) =
             deterministic::Runner::new(cfg).start_and_recover(|context| async move {
                 let (blob, _) = context.open("crash_resize", b"blob").await.unwrap();
@@ -1959,8 +1959,8 @@ mod tests {
             let cfg = deterministic::Config::default()
                 .with_seed(seed)
                 .with_storage_fault_config(FaultConfig::default().write(WriteConfig {
-                    failure_rate: 0.0,
-                    retention_rate: 0.5,
+                    failure_rate: Probability::ZERO,
+                    retention_rate: Probability!(1, 2),
                     mode: PartialWriteMode::Subset,
                 }));
             let (_, checkpoint) =
@@ -2336,7 +2336,7 @@ mod tests {
     fn test_storage_fault_injection_and_recovery() {
         // Phase 1: Run with 100% sync failure rate
         let cfg = deterministic::Config::default().with_storage_fault_config(FaultConfig {
-            sync_rate: Some(1.0),
+            sync_rate: Some(Probability::ONE),
             ..Default::default()
         });
 
@@ -2389,7 +2389,7 @@ mod tests {
 
             // Enable sync faults dynamically
             let storage_fault_cfg = ctx.storage_fault_config();
-            storage_fault_cfg.write().sync_rate = Some(1.0);
+            storage_fault_cfg.write().sync_rate = Some(Probability::ONE);
 
             // Now sync should fail
             blob.write_at(0, b"updated".to_vec(), WriteOptions::default())
@@ -2399,7 +2399,7 @@ mod tests {
             assert!(result.is_err(), "sync should fail with faults enabled");
 
             // Disable faults
-            storage_fault_cfg.write().sync_rate = Some(0.0);
+            storage_fault_cfg.write().sync_rate = Some(Probability::ZERO);
 
             // Sync should succeed again
             blob.sync()
@@ -2415,7 +2415,7 @@ mod tests {
             let cfg = deterministic::Config::default()
                 .with_seed(seed)
                 .with_storage_fault_config(FaultConfig {
-                    open_rate: Some(0.5),
+                    open_rate: Some(Probability!(1, 2)),
                     ..Default::default()
                 });
 
@@ -2453,13 +2453,13 @@ mod tests {
             let cfg = deterministic::Config::default()
                 .with_seed(seed)
                 .with_storage_fault_config(FaultConfig {
-                    open_rate: Some(0.5),
+                    open_rate: Some(Probability!(1, 2)),
                     write_rate: Some(WriteConfig {
-                        failure_rate: 0.3,
-                        retention_rate: 0.0,
+                        failure_rate: Probability!(3, 10),
+                        retention_rate: Probability::ZERO,
                         mode: PartialWriteMode::Prefix,
                     }),
-                    sync_rate: Some(0.2),
+                    sync_rate: Some(Probability!(1, 5)),
                     ..Default::default()
                 });
 

--- a/runtime/src/deterministic.rs
+++ b/runtime/src/deterministic.rs
@@ -42,7 +42,9 @@
 //! });
 //! ```
 
-pub use crate::storage::faulty::{Config as FaultConfig, PartialWriteMode, WriteConfig};
+pub use crate::storage::faulty::{
+    Config as FaultConfig, PartialWriteMode, ResizeConfig, WriteConfig,
+};
 #[cfg(feature = "external")]
 use crate::{Blocker, Pacer};
 use crate::{
@@ -1933,7 +1935,10 @@ mod tests {
     fn test_recover_retained_successful_resize() {
         let cfg = deterministic::Config::default()
             .with_seed(83)
-            .with_storage_fault_config(FaultConfig::default().resize(Probability!(0.5)));
+            .with_storage_fault_config(FaultConfig::default().resize(ResizeConfig {
+                failure_rate: Probability!(0.5),
+                partial_rate: Probability!(0.0),
+            }));
         let (_, checkpoint) =
             deterministic::Runner::new(cfg).start_and_recover(|context| async move {
                 let (blob, _) = context.open("crash_resize", b"blob").await.unwrap();

--- a/runtime/src/deterministic.rs
+++ b/runtime/src/deterministic.rs
@@ -1933,7 +1933,7 @@ mod tests {
     fn test_recover_retained_successful_resize() {
         let cfg = deterministic::Config::default()
             .with_seed(83)
-            .with_storage_fault_config(FaultConfig::default().resize(Probability!(1, 2)));
+            .with_storage_fault_config(FaultConfig::default().resize(Probability!(0.5)));
         let (_, checkpoint) =
             deterministic::Runner::new(cfg).start_and_recover(|context| async move {
                 let (blob, _) = context.open("crash_resize", b"blob").await.unwrap();
@@ -1960,7 +1960,7 @@ mod tests {
                 .with_seed(seed)
                 .with_storage_fault_config(FaultConfig::default().write(WriteConfig {
                     failure_rate: Probability::ZERO,
-                    retention_rate: Probability!(1, 2),
+                    retention_rate: Probability!(0.5),
                     mode: PartialWriteMode::Subset,
                 }));
             let (_, checkpoint) =
@@ -2415,7 +2415,7 @@ mod tests {
             let cfg = deterministic::Config::default()
                 .with_seed(seed)
                 .with_storage_fault_config(FaultConfig {
-                    open_rate: Some(Probability!(1, 2)),
+                    open_rate: Some(Probability!(0.5)),
                     ..Default::default()
                 });
 
@@ -2453,13 +2453,13 @@ mod tests {
             let cfg = deterministic::Config::default()
                 .with_seed(seed)
                 .with_storage_fault_config(FaultConfig {
-                    open_rate: Some(Probability!(1, 2)),
+                    open_rate: Some(Probability!(0.5)),
                     write_rate: Some(WriteConfig {
-                        failure_rate: Probability!(3, 10),
+                        failure_rate: Probability!(0.3),
                         retention_rate: Probability::ZERO,
                         mode: PartialWriteMode::Prefix,
                     }),
-                    sync_rate: Some(Probability!(1, 5)),
+                    sync_rate: Some(Probability!(0.2)),
                     ..Default::default()
                 });
 

--- a/runtime/src/storage/faulty.rs
+++ b/runtime/src/storage/faulty.rs
@@ -96,7 +96,7 @@ impl Config {
             Op::Remove => self.remove_rate,
             Op::Scan => self.scan_rate,
         }
-        .unwrap_or(Probability::ZERO)
+        .unwrap_or(Probability!(0.0))
     }
 
     /// Set the open failure rate.
@@ -668,7 +668,7 @@ impl<B: crate::Blob> Blob<B> {
         }
         if follows_resize {
             let retention = Arc::new(PendingWriteRetention::new(
-                (PartialWriteMode::Prefix, Probability::ONE),
+                (PartialWriteMode::Prefix, Probability!(1.0)),
                 durable.remaining(),
             ));
             retained.push(PendingMutation::Write {
@@ -959,8 +959,8 @@ mod tests {
     #[tokio::test]
     async fn test_start_sync_returns_before_backing_completion() {
         let h = Harness::new(Config::default().write(WriteConfig {
-            failure_rate: Probability::ZERO,
-            retention_rate: Probability::ONE,
+            failure_rate: Probability!(0.0),
+            retention_rate: Probability!(1.0),
             mode: PartialWriteMode::Prefix,
         }));
         let (inner, _) = h.inner.open("partition", b"start-sync").await.unwrap();
@@ -999,8 +999,8 @@ mod tests {
 
     async fn run_overlapping_barrier(start: bool) {
         let h = Harness::new(Config::default().write(WriteConfig {
-            failure_rate: Probability::ZERO,
-            retention_rate: Probability::ONE,
+            failure_rate: Probability!(0.0),
+            retention_rate: Probability!(1.0),
             mode: PartialWriteMode::Prefix,
         }));
         let (inner, _) = h.inner.open("partition", b"overlap").await.unwrap();
@@ -1064,7 +1064,7 @@ mod tests {
                 } => {
                     assert_eq!(
                         retention.policy,
-                        (PartialWriteMode::Prefix, Probability::ONE)
+                        (PartialWriteMode::Prefix, Probability!(1.0))
                     );
                     blob.inner
                         .retain_crash_write(offset, bufs, || true)
@@ -1082,8 +1082,8 @@ mod tests {
     #[tokio::test]
     async fn test_completed_backing_write_cannot_record_after_later_full_sync() {
         let h = Harness::new(Config::default().write(WriteConfig {
-            failure_rate: Probability::ZERO,
-            retention_rate: Probability::ONE,
+            failure_rate: Probability!(0.0),
+            retention_rate: Probability!(1.0),
             mode: PartialWriteMode::Prefix,
         }));
         let (inner, _) = h.inner.open("partition", b"late-record").await.unwrap();
@@ -1141,7 +1141,7 @@ mod tests {
             };
             assert_eq!(
                 retention.policy,
-                (PartialWriteMode::Prefix, Probability::ONE)
+                (PartialWriteMode::Prefix, Probability!(1.0))
             );
             blob.inner
                 .retain_crash_write(offset, bufs, || true)
@@ -1158,7 +1158,7 @@ mod tests {
         let h = Harness::with_seed(
             seed,
             Config::default().write(WriteConfig {
-                failure_rate: Probability::ZERO,
+                failure_rate: Probability!(0.0),
                 retention_rate: Probability!(0.5),
                 mode: PartialWriteMode::Subset,
             }),
@@ -1172,7 +1172,7 @@ mod tests {
         {
             let mut config = h.config.write();
             config.write_rate = Some(WriteConfig {
-                failure_rate: Probability::ONE,
+                failure_rate: Probability!(1.0),
                 retention_rate: Probability!(0.5),
                 mode: PartialWriteMode::Subset,
             });
@@ -1198,7 +1198,7 @@ mod tests {
         let h = Harness::with_seed(
             seed,
             Config::default().write(WriteConfig {
-                failure_rate: Probability::ZERO,
+                failure_rate: Probability!(0.0),
                 retention_rate: Probability!(0.5),
                 mode: PartialWriteMode::Subset,
             }),
@@ -1228,8 +1228,8 @@ mod tests {
     #[tokio::test]
     async fn test_reopened_sync_clears_prior_handle_crash_writes() {
         let h = Harness::new(Config::default().write(WriteConfig {
-            failure_rate: Probability::ZERO,
-            retention_rate: Probability::ONE,
+            failure_rate: Probability!(0.0),
+            retention_rate: Probability!(1.0),
             mode: PartialWriteMode::Prefix,
         }));
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
@@ -1257,8 +1257,8 @@ mod tests {
     #[tokio::test]
     async fn test_dropped_completed_start_sync_clears_the_crash_epoch() {
         let h = Harness::new(Config::default().write(WriteConfig {
-            failure_rate: Probability::ZERO,
-            retention_rate: Probability::ONE,
+            failure_rate: Probability!(0.0),
+            retention_rate: Probability!(1.0),
             mode: PartialWriteMode::Prefix,
         }));
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
@@ -1274,8 +1274,8 @@ mod tests {
         drop(completion);
 
         h.config.write().write_rate = Some(WriteConfig {
-            failure_rate: Probability::ZERO,
-            retention_rate: Probability::ONE,
+            failure_rate: Probability!(0.0),
+            retention_rate: Probability!(1.0),
             mode: PartialWriteMode::Prefix,
         });
         blob.write_at(5, b"later", WriteOptions::default())
@@ -1294,8 +1294,8 @@ mod tests {
     #[tokio::test]
     async fn test_sync_write_does_not_barrier_disjoint_pending_write() {
         let h = Harness::new(Config::default().write(WriteConfig {
-            failure_rate: Probability::ZERO,
-            retention_rate: Probability::ONE,
+            failure_rate: Probability!(0.0),
+            retention_rate: Probability!(1.0),
             mode: PartialWriteMode::Prefix,
         }));
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
@@ -1317,8 +1317,8 @@ mod tests {
     #[tokio::test]
     async fn test_sync_write_retires_only_overlapping_pending_bytes() {
         let h = Harness::new(Config::default().write(WriteConfig {
-            failure_rate: Probability::ZERO,
-            retention_rate: Probability::ONE,
+            failure_rate: Probability!(0.0),
+            retention_rate: Probability!(1.0),
             mode: PartialWriteMode::Prefix,
         }));
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
@@ -1353,7 +1353,7 @@ mod tests {
             let h = Harness::with_seed(
                 seed,
                 Config::default().write(WriteConfig {
-                    failure_rate: Probability::ZERO,
+                    failure_rate: Probability!(0.0),
                     retention_rate: Probability!(0.5),
                     mode: PartialWriteMode::Prefix,
                 }),
@@ -1384,8 +1384,8 @@ mod tests {
             83,
             Config::default()
                 .write(WriteConfig {
-                    failure_rate: Probability::ZERO,
-                    retention_rate: Probability::ONE,
+                    failure_rate: Probability!(0.0),
+                    retention_rate: Probability!(1.0),
                     mode: PartialWriteMode::Prefix,
                 })
                 .resize(Probability!(0.5)),
@@ -1430,7 +1430,7 @@ mod tests {
         {
             let mut config = h.config.write();
             config.write_rate = Some(WriteConfig {
-                failure_rate: Probability::ONE,
+                failure_rate: Probability!(1.0),
                 retention_rate: Probability!(0.5),
                 mode: PartialWriteMode::Subset,
             });
@@ -1469,8 +1469,8 @@ mod tests {
     async fn test_preissued_sync_write_survives_failed_partial_resize() {
         let h = Harness::new(
             Config::default()
-                .resize(Probability::ONE)
-                .partial_resize(Probability::ONE),
+                .resize(Probability!(1.0))
+                .partial_resize(Probability!(1.0)),
         );
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
         blob.write_at(0, b"abcdefghij", WriteOptions::SYNC)
@@ -1513,8 +1513,8 @@ mod tests {
     async fn test_partial_sync_write_retires_each_persisted_range() {
         for partial_write_mode in [PartialWriteMode::Prefix, PartialWriteMode::Subset] {
             let h = Harness::new(Config::default().write(WriteConfig {
-                failure_rate: Probability::ZERO,
-                retention_rate: Probability::ONE,
+                failure_rate: Probability!(0.0),
+                retention_rate: Probability!(1.0),
                 mode: PartialWriteMode::Prefix,
             }));
             let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
@@ -1527,7 +1527,7 @@ mod tests {
             {
                 let mut config = h.config.write();
                 config.write_rate = Some(WriteConfig {
-                    failure_rate: Probability::ONE,
+                    failure_rate: Probability!(1.0),
                     retention_rate: Probability!(0.5),
                     mode: partial_write_mode,
                 });
@@ -1580,7 +1580,7 @@ mod tests {
         let expected = expected.storage.ctx.rng.lock().random::<u64>();
 
         let h = Harness::with_seed(0, Config::default());
-        for (probability, outcome) in [(Probability::ZERO, false), (Probability::ONE, true)] {
+        for (probability, outcome) in [(Probability!(0.0), false), (Probability!(1.0), true)] {
             assert_eq!(h.storage.ctx.roll(probability), outcome);
             for mode in [PartialWriteMode::Prefix, PartialWriteMode::Subset] {
                 assert_eq!(
@@ -1620,7 +1620,7 @@ mod tests {
     #[tokio::test]
     async fn test_write_rejects_offset_overflow_before_retention() {
         let h = Harness::new(Config::default().write(WriteConfig {
-            failure_rate: Probability::ONE,
+            failure_rate: Probability!(1.0),
             retention_rate: Probability!(0.5),
             mode: PartialWriteMode::Subset,
         }));
@@ -1637,8 +1637,8 @@ mod tests {
     #[tokio::test]
     async fn test_failed_write_can_retain_every_byte() {
         let h = Harness::new(Config::default().write(WriteConfig {
-            failure_rate: Probability::ONE,
-            retention_rate: Probability::ONE,
+            failure_rate: Probability!(1.0),
+            retention_rate: Probability!(1.0),
             mode: PartialWriteMode::Prefix,
         }));
         let (blob, _) = h.storage.open("partition", b"blob").await.unwrap();
@@ -1654,7 +1654,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_faulty_storage_sync_always_fails() {
-        let h = Harness::new(Config::default().sync(Probability::ONE));
+        let h = Harness::new(Config::default().sync(Probability!(1.0)));
 
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
         blob.write_at(0, b"data".to_vec(), WriteOptions::default())
@@ -1669,11 +1669,11 @@ mod tests {
         let h = Harness::new(
             Config::default()
                 .write(WriteConfig {
-                    failure_rate: Probability::ZERO,
-                    retention_rate: Probability::ONE,
+                    failure_rate: Probability!(0.0),
+                    retention_rate: Probability!(1.0),
                     mode: PartialWriteMode::Prefix,
                 })
-                .sync(Probability::ONE),
+                .sync(Probability!(1.0)),
         );
 
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
@@ -1689,8 +1689,8 @@ mod tests {
     #[tokio::test]
     async fn test_faulty_storage_write_always_fails() {
         let h = Harness::new(Config::default().write(WriteConfig {
-            failure_rate: Probability::ONE,
-            retention_rate: Probability::ZERO,
+            failure_rate: Probability!(1.0),
+            retention_rate: Probability!(0.0),
             mode: PartialWriteMode::Prefix,
         }));
 
@@ -1706,8 +1706,8 @@ mod tests {
     #[tokio::test]
     async fn test_faulty_storage_write_at_sync_write_always_fails() {
         let h = Harness::new(Config::default().write(WriteConfig {
-            failure_rate: Probability::ONE,
-            retention_rate: Probability::ZERO,
+            failure_rate: Probability!(1.0),
+            retention_rate: Probability!(0.0),
             mode: PartialWriteMode::Prefix,
         }));
 
@@ -1721,7 +1721,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_faulty_storage_write_at_sync_failure_is_not_durable() {
-        let h = Harness::new(Config::default().sync(Probability::ONE));
+        let h = Harness::new(Config::default().sync(Probability!(1.0)));
 
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
 
@@ -1736,7 +1736,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_faulty_storage_empty_write_at_sync_does_not_sync_prior_write() {
-        let h = Harness::new(Config::default().sync(Probability::ONE));
+        let h = Harness::new(Config::default().sync(Probability!(1.0)));
 
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
         blob.write_at(0, b"data".to_vec(), WriteOptions::default())
@@ -1754,8 +1754,8 @@ mod tests {
     #[tokio::test]
     async fn test_empty_unsynced_write_does_not_create_crash_debt() {
         let h = Harness::new(Config::default().write(WriteConfig {
-            failure_rate: Probability::ZERO,
-            retention_rate: Probability::ONE,
+            failure_rate: Probability!(0.0),
+            retention_rate: Probability!(1.0),
             mode: PartialWriteMode::Prefix,
         }));
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
@@ -1777,14 +1777,14 @@ mod tests {
         blob.sync().await.unwrap();
 
         // Enable read faults
-        h.config.write().read_rate = Some(Probability::ONE);
+        h.config.write().read_rate = Some(Probability!(1.0));
 
         assert!(matches!(blob.read_at(0, 4).await, Err(Error::Io(_))));
     }
 
     #[tokio::test]
     async fn test_faulty_storage_open_always_fails() {
-        let h = Harness::new(Config::default().open(Probability::ONE));
+        let h = Harness::new(Config::default().open(Probability!(1.0)));
 
         assert!(matches!(
             h.storage.open("partition", b"test").await,
@@ -1805,7 +1805,7 @@ mod tests {
         drop(blob);
 
         // Enable remove faults
-        h.config.write().remove_rate = Some(Probability::ONE);
+        h.config.write().remove_rate = Some(Probability!(1.0));
 
         assert!(matches!(
             h.storage.remove("partition", Some(b"test")).await,
@@ -1828,7 +1828,7 @@ mod tests {
         }
 
         // Enable scan faults
-        h.config.write().scan_rate = Some(Probability::ONE);
+        h.config.write().scan_rate = Some(Probability!(1.0));
 
         assert!(matches!(
             h.storage.scan("partition").await,
@@ -1884,18 +1884,18 @@ mod tests {
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
         blob.sync().await.unwrap();
 
-        h.config.write().sync_rate = Some(Probability::ONE);
+        h.config.write().sync_rate = Some(Probability!(1.0));
         assert!(matches!(blob.sync().await, Err(Error::Io(_))));
 
-        h.config.write().sync_rate = Some(Probability::ZERO);
+        h.config.write().sync_rate = Some(Probability!(0.0));
         blob.sync().await.unwrap();
     }
 
     #[tokio::test]
     async fn test_write_retention_is_snapshotted_and_replayed_in_order() {
         let h = Harness::new(Config::default().write(WriteConfig {
-            failure_rate: Probability::ZERO,
-            retention_rate: Probability::ONE,
+            failure_rate: Probability!(0.0),
+            retention_rate: Probability!(1.0),
             mode: PartialWriteMode::Prefix,
         }));
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
@@ -1911,8 +1911,8 @@ mod tests {
             .await
             .unwrap();
         h.config.write().write_rate = Some(WriteConfig {
-            failure_rate: Probability::ZERO,
-            retention_rate: Probability::ONE,
+            failure_rate: Probability!(0.0),
+            retention_rate: Probability!(1.0),
             mode: PartialWriteMode::Prefix,
         });
         blob.write_at(1, b"XY", WriteOptions::default())
@@ -1961,7 +1961,7 @@ mod tests {
                 let h = Harness::with_seed(
                     seed,
                     Config::default().write(WriteConfig {
-                        failure_rate: Probability::ZERO,
+                        failure_rate: Probability!(0.0),
                         retention_rate: Probability!(0.5),
                         mode: PartialWriteMode::Subset,
                     }),
@@ -1976,7 +1976,7 @@ mod tests {
                 {
                     let mut config = h.config.write();
                     config.write_rate = Some(WriteConfig {
-                        failure_rate: Probability::ONE,
+                        failure_rate: Probability!(1.0),
                         retention_rate: Probability!(0.5),
                         mode: partial_write_mode,
                     });
@@ -2006,7 +2006,7 @@ mod tests {
             let h = Harness::with_seed(
                 seed,
                 Config::default().write(WriteConfig {
-                    failure_rate: Probability::ZERO,
+                    failure_rate: Probability!(0.0),
                     retention_rate: Probability!(0.5),
                     mode: PartialWriteMode::Subset,
                 }),
@@ -2020,8 +2020,8 @@ mod tests {
                 .unwrap();
             {
                 let mut config = h.config.write();
-                config.resize_rate = Some(Probability::ONE);
-                config.partial_resize_rate = Some(Probability::ONE);
+                config.resize_rate = Some(Probability!(1.0));
+                config.partial_resize_rate = Some(Probability!(1.0));
             }
 
             assert!(blob.resize(8).await.is_err());
@@ -2039,8 +2039,8 @@ mod tests {
     #[tokio::test]
     async fn test_crash_journal_clears_only_after_completed_durability() {
         let h = Harness::new(Config::default().write(WriteConfig {
-            failure_rate: Probability::ZERO,
-            retention_rate: Probability::ONE,
+            failure_rate: Probability!(0.0),
+            retention_rate: Probability!(1.0),
             mode: PartialWriteMode::Prefix,
         }));
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
@@ -2049,7 +2049,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(h.storage.pending.lock().len(), 1);
-        h.config.write().sync_rate = Some(Probability::ONE);
+        h.config.write().sync_rate = Some(Probability!(1.0));
         assert!(matches!(blob.sync().await, Err(Error::Io(_))));
         assert_eq!(h.storage.pending.lock().len(), 1);
 
@@ -2091,11 +2091,11 @@ mod tests {
         let h = Harness::new(
             Config::default()
                 .write(WriteConfig {
-                    failure_rate: Probability::ZERO,
-                    retention_rate: Probability::ONE,
+                    failure_rate: Probability!(0.0),
+                    retention_rate: Probability!(1.0),
                     mode: PartialWriteMode::Prefix,
                 })
-                .sync(Probability::ONE),
+                .sync(Probability!(1.0)),
         );
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
         assert!(matches!(
@@ -2113,8 +2113,8 @@ mod tests {
     #[tokio::test]
     async fn test_faulty_storage_zero_write_retention_preserves_nothing() {
         let h = Harness::new(Config::default().write(WriteConfig {
-            failure_rate: Probability::ONE,
-            retention_rate: Probability::ZERO,
+            failure_rate: Probability!(1.0),
+            retention_rate: Probability!(0.0),
             mode: PartialWriteMode::Prefix,
         }));
 
@@ -2163,12 +2163,12 @@ mod tests {
     #[tokio::test]
     async fn test_faulty_storage_write_retention_rate_endpoints() {
         for (retention_rate, expected) in [
-            (Probability::ZERO, b"old".as_slice()),
-            (Probability::ONE, b"new".as_slice()),
+            (Probability!(0.0), b"old".as_slice()),
+            (Probability!(1.0), b"new".as_slice()),
         ] {
             for mode in [PartialWriteMode::Prefix, PartialWriteMode::Subset] {
                 let failed = Harness::new(Config::default().write(WriteConfig {
-                    failure_rate: Probability::ONE,
+                    failure_rate: Probability!(1.0),
                     retention_rate,
                     mode,
                 }));
@@ -2185,7 +2185,7 @@ mod tests {
                 }
 
                 let crashed = Harness::new(Config::default().write(WriteConfig {
-                    failure_rate: Probability::ZERO,
+                    failure_rate: Probability!(0.0),
                     retention_rate,
                     mode,
                 }));
@@ -2219,8 +2219,8 @@ mod tests {
     async fn test_faulty_storage_partial_resize_grow() {
         let h = Harness::new(
             Config::default()
-                .resize(Probability::ONE)
-                .partial_resize(Probability::ONE),
+                .resize(Probability!(1.0))
+                .partial_resize(Probability!(1.0)),
         );
 
         let (blob, initial_size) = h.storage.open("partition", b"test").await.unwrap();
@@ -2249,8 +2249,8 @@ mod tests {
 
         {
             let mut cfg = h.config.write();
-            cfg.resize_rate = Some(Probability::ONE);
-            cfg.partial_resize_rate = Some(Probability::ONE);
+            cfg.resize_rate = Some(Probability!(1.0));
+            cfg.partial_resize_rate = Some(Probability!(1.0));
         }
 
         let target_size = 10u64;
@@ -2270,8 +2270,8 @@ mod tests {
     async fn test_faulty_storage_partial_resize_disabled() {
         let h = Harness::new(
             Config::default()
-                .resize(Probability::ONE)
-                .partial_resize(Probability::ZERO),
+                .resize(Probability!(1.0))
+                .partial_resize(Probability!(0.0)),
         );
 
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
@@ -2287,8 +2287,8 @@ mod tests {
     async fn test_faulty_storage_partial_resize_same_size() {
         let h = Harness::new(
             Config::default()
-                .resize(Probability::ONE)
-                .partial_resize(Probability::ONE),
+                .resize(Probability!(1.0))
+                .partial_resize(Probability!(1.0)),
         );
 
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
@@ -2317,8 +2317,8 @@ mod tests {
 
         {
             let mut cfg = h.config.write();
-            cfg.resize_rate = Some(Probability::ONE);
-            cfg.partial_resize_rate = Some(Probability::ONE);
+            cfg.resize_rate = Some(Probability!(1.0));
+            cfg.partial_resize_rate = Some(Probability!(1.0));
         }
 
         let target_size = 10u64;
@@ -2338,8 +2338,8 @@ mod tests {
     async fn test_faulty_storage_partial_resize_one_byte_difference() {
         let h = Harness::new(
             Config::default()
-                .resize(Probability::ONE)
-                .partial_resize(Probability::ONE),
+                .resize(Probability!(1.0))
+                .partial_resize(Probability!(1.0)),
         );
 
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();

--- a/runtime/src/storage/faulty.rs
+++ b/runtime/src/storage/faulty.rs
@@ -53,6 +53,18 @@ pub struct WriteConfig {
     pub mode: PartialWriteMode,
 }
 
+/// Fault configuration for `resize` operations and partial failure behavior.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct ResizeConfig {
+    /// Probability that `resize` returns an injected failure, also used independently as the
+    /// probability that a successful unsynchronized resize survives a simulated crash.
+    pub failure_rate: Probability,
+
+    /// Probability that an injected failure resizes to an intermediate size rather than leaving
+    /// the size unchanged.
+    pub partial_rate: Probability,
+}
+
 /// Configuration for deterministic storage fault injection.
 #[derive(Clone, Debug, Default)]
 pub struct Config {
@@ -68,14 +80,8 @@ pub struct Config {
     /// Failure rate for `sync` operations.
     pub sync_rate: Option<Probability>,
 
-    /// Failure rate for `resize` operations and probability that a successful unsynchronized
-    /// resize survives a simulated crash.
-    pub resize_rate: Option<Probability>,
-
-    /// Probability that a resize failure is partial (resized to an intermediate
-    /// size before failure) rather than a complete failure (size unchanged).
-    /// Only applies when `resize_rate` triggers a failure.
-    pub partial_resize_rate: Option<Probability>,
+    /// Failure and partial-failure configuration for `resize` operations.
+    pub resize_rate: Option<ResizeConfig>,
 
     /// Failure rate for `remove` operations.
     pub remove_rate: Option<Probability>,
@@ -92,7 +98,7 @@ impl Config {
             Op::Read => self.read_rate,
             Op::Write => self.write_rate.map(|config| config.failure_rate),
             Op::Sync => self.sync_rate,
-            Op::Resize => self.resize_rate,
+            Op::Resize => self.resize_rate.map(|config| config.failure_rate),
             Op::Remove => self.remove_rate,
             Op::Scan => self.scan_rate,
         }
@@ -123,15 +129,9 @@ impl Config {
         self
     }
 
-    /// Set the resize failure and crash-retention rate.
-    pub const fn resize(mut self, rate: Probability) -> Self {
-        self.resize_rate = Some(rate);
-        self
-    }
-
-    /// Set the partial resize rate (probability of partial vs complete resize failure).
-    pub const fn partial_resize(mut self, rate: Probability) -> Self {
-        self.partial_resize_rate = Some(rate);
+    /// Set the resize fault configuration.
+    pub const fn resize(mut self, config: ResizeConfig) -> Self {
+        self.resize_rate = Some(config);
         self
     }
 
@@ -289,12 +289,15 @@ impl Oracle {
 
     /// Check if a resize fault should be injected and snapshot its crash outcome.
     /// Reads config once to avoid nested lock acquisition.
-    fn check_resize_fault(&self) -> (bool, Option<Probability>, bool) {
+    fn check_resize_fault(&self) -> (bool, Probability, bool) {
         let config = self.config.read();
+        let Some(resize_config) = config.resize_rate else {
+            return (false, Probability!(0.0), false);
+        };
         let failure_rate = config.rate_for(Op::Resize);
         let fail = self.roll(failure_rate);
         let retain = !fail && self.roll(failure_rate);
-        (fail, config.partial_resize_rate, retain)
+        (fail, resize_config.partial_rate, retain)
     }
 
     /// Check if an event should occur based on a probability rate.
@@ -338,8 +341,8 @@ impl Oracle {
 
     /// Try to generate a partial operation target. Returns Some if both the rate
     /// check passes and an intermediate value exists between `from` and `to`.
-    fn try_partial(&self, rate: Option<Probability>, from: u64, to: u64) -> Option<u64> {
-        if rate.is_some_and(|rate| self.roll(rate)) {
+    fn try_partial(&self, rate: Probability, from: u64, to: u64) -> Option<u64> {
+        if self.roll(rate) {
             self.random_between(from, to)
         } else {
             None
@@ -1388,7 +1391,10 @@ mod tests {
                     retention_rate: Probability!(1.0),
                     mode: PartialWriteMode::Prefix,
                 })
-                .resize(Probability!(0.5)),
+                .resize(ResizeConfig {
+                    failure_rate: Probability!(0.5),
+                    partial_rate: Probability!(0.0),
+                }),
         );
         let (write_then_resize, _) = h.storage.open("partition", b"first").await.unwrap();
         write_then_resize
@@ -1421,7 +1427,13 @@ mod tests {
 
     #[tokio::test]
     async fn test_partial_sync_write_replays_after_retained_resize() {
-        let h = Harness::with_seed(83, Config::default().resize(Probability!(0.5)));
+        let h = Harness::with_seed(
+            83,
+            Config::default().resize(ResizeConfig {
+                failure_rate: Probability!(0.5),
+                partial_rate: Probability!(0.0),
+            }),
+        );
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
         blob.write_at(0, b"abcdefghij", WriteOptions::SYNC)
             .await
@@ -1467,11 +1479,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_preissued_sync_write_survives_failed_partial_resize() {
-        let h = Harness::new(
-            Config::default()
-                .resize(Probability!(1.0))
-                .partial_resize(Probability!(1.0)),
-        );
+        let h = Harness::new(Config::default().resize(ResizeConfig {
+            failure_rate: Probability!(1.0),
+            partial_rate: Probability!(1.0),
+        }));
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
         blob.write_at(0, b"abcdefghij", WriteOptions::SYNC)
             .await
@@ -1868,7 +1879,10 @@ mod tests {
                 retention_rate: Probability!(0.4),
                 mode: PartialWriteMode::Subset,
             })
-            .resize(Probability!(0.7))
+            .resize(ResizeConfig {
+                failure_rate: Probability!(0.7),
+                partial_rate: Probability!(0.8),
+            })
             .sync(Probability!(0.9));
 
         assert_eq!(config.rate_for(Op::Open), Probability!(0.1));
@@ -2020,8 +2034,10 @@ mod tests {
                 .unwrap();
             {
                 let mut config = h.config.write();
-                config.resize_rate = Some(Probability!(1.0));
-                config.partial_resize_rate = Some(Probability!(1.0));
+                config.resize_rate = Some(ResizeConfig {
+                    failure_rate: Probability!(1.0),
+                    partial_rate: Probability!(1.0),
+                });
             }
 
             assert!(blob.resize(8).await.is_err());
@@ -2217,11 +2233,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_faulty_storage_partial_resize_grow() {
-        let h = Harness::new(
-            Config::default()
-                .resize(Probability!(1.0))
-                .partial_resize(Probability!(1.0)),
-        );
+        let h = Harness::new(Config::default().resize(ResizeConfig {
+            failure_rate: Probability!(1.0),
+            partial_rate: Probability!(1.0),
+        }));
 
         let (blob, initial_size) = h.storage.open("partition", b"test").await.unwrap();
         assert_eq!(initial_size, 0);
@@ -2249,8 +2264,10 @@ mod tests {
 
         {
             let mut cfg = h.config.write();
-            cfg.resize_rate = Some(Probability!(1.0));
-            cfg.partial_resize_rate = Some(Probability!(1.0));
+            cfg.resize_rate = Some(ResizeConfig {
+                failure_rate: Probability!(1.0),
+                partial_rate: Probability!(1.0),
+            });
         }
 
         let target_size = 10u64;
@@ -2268,11 +2285,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_faulty_storage_partial_resize_disabled() {
-        let h = Harness::new(
-            Config::default()
-                .resize(Probability!(1.0))
-                .partial_resize(Probability!(0.0)),
-        );
+        let h = Harness::new(Config::default().resize(ResizeConfig {
+            failure_rate: Probability!(1.0),
+            partial_rate: Probability!(0.0),
+        }));
 
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
         let result = blob.resize(100).await;
@@ -2280,16 +2296,15 @@ mod tests {
         assert!(matches!(result, Err(Error::Io(_))));
 
         let (_, size) = h.inner.open("partition", b"test").await.unwrap();
-        assert_eq!(size, 0, "Expected no resize when partial_resize_rate is 0");
+        assert_eq!(size, 0, "Expected no resize when partial rate is 0");
     }
 
     #[tokio::test]
     async fn test_faulty_storage_partial_resize_same_size() {
-        let h = Harness::new(
-            Config::default()
-                .resize(Probability!(1.0))
-                .partial_resize(Probability!(1.0)),
-        );
+        let h = Harness::new(Config::default().resize(ResizeConfig {
+            failure_rate: Probability!(1.0),
+            partial_rate: Probability!(1.0),
+        }));
 
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
         let result = blob.resize(0).await;
@@ -2317,8 +2332,10 @@ mod tests {
 
         {
             let mut cfg = h.config.write();
-            cfg.resize_rate = Some(Probability!(1.0));
-            cfg.partial_resize_rate = Some(Probability!(1.0));
+            cfg.resize_rate = Some(ResizeConfig {
+                failure_rate: Probability!(1.0),
+                partial_rate: Probability!(1.0),
+            });
         }
 
         let target_size = 10u64;
@@ -2336,11 +2353,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_faulty_storage_partial_resize_one_byte_difference() {
-        let h = Harness::new(
-            Config::default()
-                .resize(Probability!(1.0))
-                .partial_resize(Probability!(1.0)),
-        );
+        let h = Harness::new(Config::default().resize(ResizeConfig {
+            failure_rate: Probability!(1.0),
+            partial_rate: Probability!(1.0),
+        }));
 
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
         let result = blob.resize(1).await;

--- a/runtime/src/storage/faulty.rs
+++ b/runtime/src/storage/faulty.rs
@@ -1159,7 +1159,7 @@ mod tests {
             seed,
             Config::default().write(WriteConfig {
                 failure_rate: Probability::ZERO,
-                retention_rate: Probability!(1, 2),
+                retention_rate: Probability!(0.5),
                 mode: PartialWriteMode::Subset,
             }),
         );
@@ -1173,7 +1173,7 @@ mod tests {
             let mut config = h.config.write();
             config.write_rate = Some(WriteConfig {
                 failure_rate: Probability::ONE,
-                retention_rate: Probability!(1, 2),
+                retention_rate: Probability!(0.5),
                 mode: PartialWriteMode::Subset,
             });
         }
@@ -1199,7 +1199,7 @@ mod tests {
             seed,
             Config::default().write(WriteConfig {
                 failure_rate: Probability::ZERO,
-                retention_rate: Probability!(1, 2),
+                retention_rate: Probability!(0.5),
                 mode: PartialWriteMode::Subset,
             }),
         );
@@ -1354,7 +1354,7 @@ mod tests {
                 seed,
                 Config::default().write(WriteConfig {
                     failure_rate: Probability::ZERO,
-                    retention_rate: Probability!(1, 2),
+                    retention_rate: Probability!(0.5),
                     mode: PartialWriteMode::Prefix,
                 }),
             );
@@ -1388,7 +1388,7 @@ mod tests {
                     retention_rate: Probability::ONE,
                     mode: PartialWriteMode::Prefix,
                 })
-                .resize(Probability!(1, 2)),
+                .resize(Probability!(0.5)),
         );
         let (write_then_resize, _) = h.storage.open("partition", b"first").await.unwrap();
         write_then_resize
@@ -1421,7 +1421,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_partial_sync_write_replays_after_retained_resize() {
-        let h = Harness::with_seed(83, Config::default().resize(Probability!(1, 2)));
+        let h = Harness::with_seed(83, Config::default().resize(Probability!(0.5)));
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
         blob.write_at(0, b"abcdefghij", WriteOptions::SYNC)
             .await
@@ -1431,7 +1431,7 @@ mod tests {
             let mut config = h.config.write();
             config.write_rate = Some(WriteConfig {
                 failure_rate: Probability::ONE,
-                retention_rate: Probability!(1, 2),
+                retention_rate: Probability!(0.5),
                 mode: PartialWriteMode::Subset,
             });
         }
@@ -1528,7 +1528,7 @@ mod tests {
                 let mut config = h.config.write();
                 config.write_rate = Some(WriteConfig {
                     failure_rate: Probability::ONE,
-                    retention_rate: Probability!(1, 2),
+                    retention_rate: Probability!(0.5),
                     mode: partial_write_mode,
                 });
             }
@@ -1602,7 +1602,7 @@ mod tests {
             let retained = h
                 .storage
                 .ctx
-                .retained_bytes(4, (PartialWriteMode::Prefix, Probability!(1, 2)));
+                .retained_bytes(4, (PartialWriteMode::Prefix, Probability!(0.5)));
             let prefix_len = retained.iter().take_while(|&&keep| keep).count();
             assert!(retained[prefix_len..].iter().all(|&keep| !keep));
             observed[prefix_len] = true;
@@ -1612,7 +1612,7 @@ mod tests {
         assert!(
             h.storage
                 .ctx
-                .retained_bytes(0, (PartialWriteMode::Prefix, Probability!(1, 2)))
+                .retained_bytes(0, (PartialWriteMode::Prefix, Probability!(0.5)))
                 .is_empty()
         );
     }
@@ -1621,7 +1621,7 @@ mod tests {
     async fn test_write_rejects_offset_overflow_before_retention() {
         let h = Harness::new(Config::default().write(WriteConfig {
             failure_rate: Probability::ONE,
-            retention_rate: Probability!(1, 2),
+            retention_rate: Probability!(0.5),
             mode: PartialWriteMode::Subset,
         }));
         let (blob, _) = h.storage.open("partition", b"blob").await.unwrap();
@@ -1848,11 +1848,11 @@ mod tests {
             results
         }
 
-        let results1 = run_ops(42, Probability!(1, 2)).await;
-        let results2 = run_ops(42, Probability!(1, 2)).await;
+        let results1 = run_ops(42, Probability!(0.5)).await;
+        let results2 = run_ops(42, Probability!(0.5)).await;
         assert_eq!(results1, results2, "Same seed should produce same results");
 
-        let results3 = run_ops(999, Probability!(1, 2)).await;
+        let results3 = run_ops(999, Probability!(0.5)).await;
         assert_ne!(
             results1, results3,
             "Different seeds should produce different results"
@@ -1862,19 +1862,19 @@ mod tests {
     #[tokio::test]
     async fn test_faulty_storage_rate_for() {
         let config = Config::default()
-            .open(Probability!(1, 10))
+            .open(Probability!(0.1))
             .write(WriteConfig {
-                failure_rate: Probability!(3, 10),
-                retention_rate: Probability!(2, 5),
+                failure_rate: Probability!(0.3),
+                retention_rate: Probability!(0.4),
                 mode: PartialWriteMode::Subset,
             })
-            .resize(Probability!(7, 10))
-            .sync(Probability!(9, 10));
+            .resize(Probability!(0.7))
+            .sync(Probability!(0.9));
 
-        assert_eq!(config.rate_for(Op::Open), Probability!(1, 10));
-        assert_eq!(config.rate_for(Op::Write), Probability!(3, 10));
-        assert_eq!(config.rate_for(Op::Resize), Probability!(7, 10));
-        assert_eq!(config.rate_for(Op::Sync), Probability!(9, 10));
+        assert_eq!(config.rate_for(Op::Open), Probability!(0.1));
+        assert_eq!(config.rate_for(Op::Write), Probability!(0.3));
+        assert_eq!(config.rate_for(Op::Resize), Probability!(0.7));
+        assert_eq!(config.rate_for(Op::Sync), Probability!(0.9));
     }
 
     #[tokio::test]
@@ -1962,7 +1962,7 @@ mod tests {
                     seed,
                     Config::default().write(WriteConfig {
                         failure_rate: Probability::ZERO,
-                        retention_rate: Probability!(1, 2),
+                        retention_rate: Probability!(0.5),
                         mode: PartialWriteMode::Subset,
                     }),
                 );
@@ -1977,7 +1977,7 @@ mod tests {
                     let mut config = h.config.write();
                     config.write_rate = Some(WriteConfig {
                         failure_rate: Probability::ONE,
-                        retention_rate: Probability!(1, 2),
+                        retention_rate: Probability!(0.5),
                         mode: partial_write_mode,
                     });
                 }
@@ -2007,7 +2007,7 @@ mod tests {
                 seed,
                 Config::default().write(WriteConfig {
                     failure_rate: Probability::ZERO,
-                    retention_rate: Probability!(1, 2),
+                    retention_rate: Probability!(0.5),
                     mode: PartialWriteMode::Subset,
                 }),
             );

--- a/runtime/src/storage/faulty.rs
+++ b/runtime/src/storage/faulty.rs
@@ -2,7 +2,10 @@
 
 use crate::{Error, Handle, IoBufs, IoBufsMut, WriteOptions, deterministic::BoxDynRng};
 use bytes::Buf;
-use commonware_utils::sync::{AsyncMutex, Mutex, RwLock};
+use commonware_utils::{
+    Probability,
+    sync::{AsyncMutex, Mutex, RwLock},
+};
 use futures::{FutureExt as _, future::Shared};
 use rand::RngExt as _;
 use std::{
@@ -41,53 +44,49 @@ pub enum PartialWriteMode {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct WriteConfig {
     /// Probability that `write_at` returns an injected failure.
-    pub failure_rate: f64,
+    pub failure_rate: Probability,
 
     /// Probability used by the selected mode when retaining submitted bytes.
-    pub retention_rate: f64,
+    pub retention_rate: Probability,
 
     /// Arrangement of bytes retained by the simulated storage device.
     pub mode: PartialWriteMode,
 }
 
 /// Configuration for deterministic storage fault injection.
-///
-/// Each rate is interpreted as a probability. Values that are `NaN` or at or below 0.0 never
-/// trigger, while values at or above 1.0 always trigger.
 #[derive(Clone, Debug, Default)]
 pub struct Config {
     /// Failure rate for `open_versioned` operations.
-    pub open_rate: Option<f64>,
+    pub open_rate: Option<Probability>,
 
     /// Failure rate for `read_at` operations.
-    pub read_rate: Option<f64>,
+    pub read_rate: Option<Probability>,
 
     /// Failure and byte-retention configuration for `write_at` operations.
     pub write_rate: Option<WriteConfig>,
 
     /// Failure rate for `sync` operations.
-    pub sync_rate: Option<f64>,
+    pub sync_rate: Option<Probability>,
 
     /// Failure rate for `resize` operations and probability that a successful unsynchronized
     /// resize survives a simulated crash.
-    pub resize_rate: Option<f64>,
+    pub resize_rate: Option<Probability>,
 
     /// Probability that a resize failure is partial (resized to an intermediate
     /// size before failure) rather than a complete failure (size unchanged).
     /// Only applies when `resize_rate` triggers a failure.
-    /// Value from 0.0 (always complete failure) to 1.0 (always partial resize).
-    pub partial_resize_rate: Option<f64>,
+    pub partial_resize_rate: Option<Probability>,
 
     /// Failure rate for `remove` operations.
-    pub remove_rate: Option<f64>,
+    pub remove_rate: Option<Probability>,
 
     /// Failure rate for `scan` operations.
-    pub scan_rate: Option<f64>,
+    pub scan_rate: Option<Probability>,
 }
 
 impl Config {
     /// Get the failure rate for an operation type.
-    fn rate_for(&self, op: Op) -> f64 {
+    fn rate_for(&self, op: Op) -> Probability {
         match op {
             Op::Open => self.open_rate,
             Op::Read => self.read_rate,
@@ -97,17 +96,17 @@ impl Config {
             Op::Remove => self.remove_rate,
             Op::Scan => self.scan_rate,
         }
-        .unwrap_or(0.0)
+        .unwrap_or(Probability::ZERO)
     }
 
     /// Set the open failure rate.
-    pub const fn open(mut self, rate: f64) -> Self {
+    pub const fn open(mut self, rate: Probability) -> Self {
         self.open_rate = Some(rate);
         self
     }
 
     /// Set the read failure rate.
-    pub const fn read(mut self, rate: f64) -> Self {
+    pub const fn read(mut self, rate: Probability) -> Self {
         self.read_rate = Some(rate);
         self
     }
@@ -119,31 +118,31 @@ impl Config {
     }
 
     /// Set the sync failure rate.
-    pub const fn sync(mut self, rate: f64) -> Self {
+    pub const fn sync(mut self, rate: Probability) -> Self {
         self.sync_rate = Some(rate);
         self
     }
 
     /// Set the resize failure and crash-retention rate.
-    pub const fn resize(mut self, rate: f64) -> Self {
+    pub const fn resize(mut self, rate: Probability) -> Self {
         self.resize_rate = Some(rate);
         self
     }
 
     /// Set the partial resize rate (probability of partial vs complete resize failure).
-    pub const fn partial_resize(mut self, rate: f64) -> Self {
+    pub const fn partial_resize(mut self, rate: Probability) -> Self {
         self.partial_resize_rate = Some(rate);
         self
     }
 
     /// Set the remove failure rate.
-    pub const fn remove(mut self, rate: f64) -> Self {
+    pub const fn remove(mut self, rate: Probability) -> Self {
         self.remove_rate = Some(rate);
         self
     }
 
     /// Set the scan failure rate.
-    pub const fn scan(mut self, rate: f64) -> Self {
+    pub const fn scan(mut self, rate: Probability) -> Self {
         self.scan_rate = Some(rate);
         self
     }
@@ -194,13 +193,13 @@ impl PendingSync {
 /// Retention choices belong to the issued write and are shared by fragments created by later
 /// durability barriers.
 struct PendingWriteRetention {
-    policy: (PartialWriteMode, f64),
+    policy: (PartialWriteMode, Probability),
     len: usize,
     selected: OnceLock<Vec<bool>>,
 }
 
 impl PendingWriteRetention {
-    const fn new(policy: (PartialWriteMode, f64), len: usize) -> Self {
+    const fn new(policy: (PartialWriteMode, Probability), len: usize) -> Self {
         Self {
             policy,
             len,
@@ -273,41 +272,34 @@ fn resolve_pending_sync<B>(
 impl Oracle {
     /// Check if a fault should be injected for the given operation.
     fn should_fail(&self, op: Op) -> bool {
-        self.roll(Some(self.config.read().rate_for(op)))
+        self.roll(self.config.read().rate_for(op))
     }
 
     /// Check if a write fault should be injected.
     /// Reads config once to avoid nested lock acquisition.
-    fn check_write_fault(&self) -> (bool, Option<(PartialWriteMode, f64)>) {
+    fn check_write_fault(&self) -> (bool, Option<(PartialWriteMode, Probability)>) {
         let config = self.config.read();
-        let fail = self.roll(Some(config.rate_for(Op::Write)));
+        let fail = self.roll(config.rate_for(Op::Write));
         let retention = config
             .write_rate
             .map(|config| (config.mode, config.retention_rate))
-            .filter(|(_, retention_rate)| *retention_rate > 0.0);
+            .filter(|(_, retention_rate)| !retention_rate.is_zero());
         (fail, retention)
     }
 
     /// Check if a resize fault should be injected and snapshot its crash outcome.
     /// Reads config once to avoid nested lock acquisition.
-    fn check_resize_fault(&self) -> (bool, Option<f64>, bool) {
+    fn check_resize_fault(&self) -> (bool, Option<Probability>, bool) {
         let config = self.config.read();
         let failure_rate = config.rate_for(Op::Resize);
-        let fail = self.roll(Some(failure_rate));
-        let retain = !fail && self.roll(Some(failure_rate));
+        let fail = self.roll(failure_rate);
+        let retain = !fail && self.roll(failure_rate);
         (fail, config.partial_resize_rate, retain)
     }
 
     /// Check if an event should occur based on a probability rate.
-    fn roll(&self, rate: Option<f64>) -> bool {
-        let rate = rate.unwrap_or(0.0);
-        if rate <= 0.0 || rate.is_nan() {
-            return false;
-        }
-        if rate >= 1.0 {
-            return true;
-        }
-        self.rng.lock().random::<f64>() < rate
+    fn roll(&self, rate: Probability) -> bool {
+        rate.sample(&mut **self.rng.lock())
     }
 
     /// Generate a random value strictly between `from` and `to`, or None if not possible.
@@ -326,33 +318,28 @@ impl Oracle {
     fn retained_bytes(
         &self,
         len: usize,
-        (mode, retention_rate): (PartialWriteMode, f64),
+        (mode, retention_rate): (PartialWriteMode, Probability),
     ) -> Vec<bool> {
-        if retention_rate <= 0.0 || retention_rate.is_nan() {
-            return vec![false; len];
-        }
-        if retention_rate >= 1.0 {
-            return vec![true; len];
-        }
-
         let mut rng = self.rng.lock();
         match mode {
             PartialWriteMode::Prefix => {
                 let mut positions = vec![false; len];
                 let retained = (0..len)
-                    .take_while(|_| rng.random_bool(retention_rate))
+                    .take_while(|_| retention_rate.sample(&mut **rng))
                     .count();
                 positions[..retained].fill(true);
                 positions
             }
-            PartialWriteMode::Subset => (0..len).map(|_| rng.random_bool(retention_rate)).collect(),
+            PartialWriteMode::Subset => (0..len)
+                .map(|_| retention_rate.sample(&mut **rng))
+                .collect(),
         }
     }
 
     /// Try to generate a partial operation target. Returns Some if both the rate
     /// check passes and an intermediate value exists between `from` and `to`.
-    fn try_partial(&self, rate: Option<f64>, from: u64, to: u64) -> Option<u64> {
-        if self.roll(rate) {
+    fn try_partial(&self, rate: Option<Probability>, from: u64, to: u64) -> Option<u64> {
+        if rate.is_some_and(|rate| self.roll(rate)) {
             self.random_between(from, to)
         } else {
             None
@@ -567,7 +554,12 @@ impl<B: crate::Blob> Blob<B> {
         }
     }
 
-    fn record_pending(&self, offset: u64, bufs: IoBufs, retention: (PartialWriteMode, f64)) {
+    fn record_pending(
+        &self,
+        offset: u64,
+        bufs: IoBufs,
+        retention: (PartialWriteMode, Probability),
+    ) {
         if bufs.is_empty() {
             return;
         }
@@ -676,7 +668,7 @@ impl<B: crate::Blob> Blob<B> {
         }
         if follows_resize {
             let retention = Arc::new(PendingWriteRetention::new(
-                (PartialWriteMode::Prefix, 1.0),
+                (PartialWriteMode::Prefix, Probability::ONE),
                 durable.remaining(),
             ));
             retained.push(PendingMutation::Write {
@@ -967,8 +959,8 @@ mod tests {
     #[tokio::test]
     async fn test_start_sync_returns_before_backing_completion() {
         let h = Harness::new(Config::default().write(WriteConfig {
-            failure_rate: 0.0,
-            retention_rate: 1.0,
+            failure_rate: Probability::ZERO,
+            retention_rate: Probability::ONE,
             mode: PartialWriteMode::Prefix,
         }));
         let (inner, _) = h.inner.open("partition", b"start-sync").await.unwrap();
@@ -1007,8 +999,8 @@ mod tests {
 
     async fn run_overlapping_barrier(start: bool) {
         let h = Harness::new(Config::default().write(WriteConfig {
-            failure_rate: 0.0,
-            retention_rate: 1.0,
+            failure_rate: Probability::ZERO,
+            retention_rate: Probability::ONE,
             mode: PartialWriteMode::Prefix,
         }));
         let (inner, _) = h.inner.open("partition", b"overlap").await.unwrap();
@@ -1070,7 +1062,10 @@ mod tests {
                     retention,
                     ..
                 } => {
-                    assert_eq!(retention.policy, (PartialWriteMode::Prefix, 1.0));
+                    assert_eq!(
+                        retention.policy,
+                        (PartialWriteMode::Prefix, Probability::ONE)
+                    );
                     blob.inner
                         .retain_crash_write(offset, bufs, || true)
                         .unwrap();
@@ -1087,8 +1082,8 @@ mod tests {
     #[tokio::test]
     async fn test_completed_backing_write_cannot_record_after_later_full_sync() {
         let h = Harness::new(Config::default().write(WriteConfig {
-            failure_rate: 0.0,
-            retention_rate: 1.0,
+            failure_rate: Probability::ZERO,
+            retention_rate: Probability::ONE,
             mode: PartialWriteMode::Prefix,
         }));
         let (inner, _) = h.inner.open("partition", b"late-record").await.unwrap();
@@ -1144,7 +1139,10 @@ mod tests {
             else {
                 panic!("write test recorded a resize");
             };
-            assert_eq!(retention.policy, (PartialWriteMode::Prefix, 1.0));
+            assert_eq!(
+                retention.policy,
+                (PartialWriteMode::Prefix, Probability::ONE)
+            );
             blob.inner
                 .retain_crash_write(offset, bufs, || true)
                 .unwrap();
@@ -1160,8 +1158,8 @@ mod tests {
         let h = Harness::with_seed(
             seed,
             Config::default().write(WriteConfig {
-                failure_rate: 0.0,
-                retention_rate: 0.5,
+                failure_rate: Probability::ZERO,
+                retention_rate: Probability!(1, 2),
                 mode: PartialWriteMode::Subset,
             }),
         );
@@ -1174,8 +1172,8 @@ mod tests {
         {
             let mut config = h.config.write();
             config.write_rate = Some(WriteConfig {
-                failure_rate: 1.0,
-                retention_rate: 0.5,
+                failure_rate: Probability::ONE,
+                retention_rate: Probability!(1, 2),
                 mode: PartialWriteMode::Subset,
             });
         }
@@ -1200,8 +1198,8 @@ mod tests {
         let h = Harness::with_seed(
             seed,
             Config::default().write(WriteConfig {
-                failure_rate: 0.0,
-                retention_rate: 0.5,
+                failure_rate: Probability::ZERO,
+                retention_rate: Probability!(1, 2),
                 mode: PartialWriteMode::Subset,
             }),
         );
@@ -1230,8 +1228,8 @@ mod tests {
     #[tokio::test]
     async fn test_reopened_sync_clears_prior_handle_crash_writes() {
         let h = Harness::new(Config::default().write(WriteConfig {
-            failure_rate: 0.0,
-            retention_rate: 1.0,
+            failure_rate: Probability::ZERO,
+            retention_rate: Probability::ONE,
             mode: PartialWriteMode::Prefix,
         }));
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
@@ -1259,8 +1257,8 @@ mod tests {
     #[tokio::test]
     async fn test_dropped_completed_start_sync_clears_the_crash_epoch() {
         let h = Harness::new(Config::default().write(WriteConfig {
-            failure_rate: 0.0,
-            retention_rate: 1.0,
+            failure_rate: Probability::ZERO,
+            retention_rate: Probability::ONE,
             mode: PartialWriteMode::Prefix,
         }));
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
@@ -1276,8 +1274,8 @@ mod tests {
         drop(completion);
 
         h.config.write().write_rate = Some(WriteConfig {
-            failure_rate: 0.0,
-            retention_rate: 1.0,
+            failure_rate: Probability::ZERO,
+            retention_rate: Probability::ONE,
             mode: PartialWriteMode::Prefix,
         });
         blob.write_at(5, b"later", WriteOptions::default())
@@ -1296,8 +1294,8 @@ mod tests {
     #[tokio::test]
     async fn test_sync_write_does_not_barrier_disjoint_pending_write() {
         let h = Harness::new(Config::default().write(WriteConfig {
-            failure_rate: 0.0,
-            retention_rate: 1.0,
+            failure_rate: Probability::ZERO,
+            retention_rate: Probability::ONE,
             mode: PartialWriteMode::Prefix,
         }));
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
@@ -1319,8 +1317,8 @@ mod tests {
     #[tokio::test]
     async fn test_sync_write_retires_only_overlapping_pending_bytes() {
         let h = Harness::new(Config::default().write(WriteConfig {
-            failure_rate: 0.0,
-            retention_rate: 1.0,
+            failure_rate: Probability::ZERO,
+            retention_rate: Probability::ONE,
             mode: PartialWriteMode::Prefix,
         }));
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
@@ -1355,8 +1353,8 @@ mod tests {
             let h = Harness::with_seed(
                 seed,
                 Config::default().write(WriteConfig {
-                    failure_rate: 0.0,
-                    retention_rate: 0.5,
+                    failure_rate: Probability::ZERO,
+                    retention_rate: Probability!(1, 2),
                     mode: PartialWriteMode::Prefix,
                 }),
             );
@@ -1386,11 +1384,11 @@ mod tests {
             83,
             Config::default()
                 .write(WriteConfig {
-                    failure_rate: 0.0,
-                    retention_rate: 1.0,
+                    failure_rate: Probability::ZERO,
+                    retention_rate: Probability::ONE,
                     mode: PartialWriteMode::Prefix,
                 })
-                .resize(0.5),
+                .resize(Probability!(1, 2)),
         );
         let (write_then_resize, _) = h.storage.open("partition", b"first").await.unwrap();
         write_then_resize
@@ -1423,7 +1421,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_partial_sync_write_replays_after_retained_resize() {
-        let h = Harness::with_seed(83, Config::default().resize(0.5));
+        let h = Harness::with_seed(83, Config::default().resize(Probability!(1, 2)));
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
         blob.write_at(0, b"abcdefghij", WriteOptions::SYNC)
             .await
@@ -1432,8 +1430,8 @@ mod tests {
         {
             let mut config = h.config.write();
             config.write_rate = Some(WriteConfig {
-                failure_rate: 1.0,
-                retention_rate: 0.5,
+                failure_rate: Probability::ONE,
+                retention_rate: Probability!(1, 2),
                 mode: PartialWriteMode::Subset,
             });
         }
@@ -1469,7 +1467,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_preissued_sync_write_survives_failed_partial_resize() {
-        let h = Harness::new(Config::default().resize(1.0).partial_resize(1.0));
+        let h = Harness::new(
+            Config::default()
+                .resize(Probability::ONE)
+                .partial_resize(Probability::ONE),
+        );
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
         blob.write_at(0, b"abcdefghij", WriteOptions::SYNC)
             .await
@@ -1511,8 +1513,8 @@ mod tests {
     async fn test_partial_sync_write_retires_each_persisted_range() {
         for partial_write_mode in [PartialWriteMode::Prefix, PartialWriteMode::Subset] {
             let h = Harness::new(Config::default().write(WriteConfig {
-                failure_rate: 0.0,
-                retention_rate: 1.0,
+                failure_rate: Probability::ZERO,
+                retention_rate: Probability::ONE,
                 mode: PartialWriteMode::Prefix,
             }));
             let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
@@ -1525,8 +1527,8 @@ mod tests {
             {
                 let mut config = h.config.write();
                 config.write_rate = Some(WriteConfig {
-                    failure_rate: 1.0,
-                    retention_rate: 0.5,
+                    failure_rate: Probability::ONE,
+                    retention_rate: Probability!(1, 2),
                     mode: partial_write_mode,
                 });
             }
@@ -1573,34 +1575,21 @@ mod tests {
     }
 
     #[test]
-    fn test_write_retention_rate_matches_fault_rate_bounds() {
-        let h = Harness::new(Config::default());
-        for (retention_rate, expected) in [
-            (f64::NEG_INFINITY, false),
-            (-1.0, false),
-            (0.0, false),
-            (f64::NAN, false),
-            (1.0, true),
-            (2.0, true),
-            (f64::INFINITY, true),
-        ] {
-            assert_eq!(h.storage.ctx.roll(Some(retention_rate)), expected);
-            for mode in [PartialWriteMode::Prefix, PartialWriteMode::Subset] {
-                assert_eq!(
-                    h.storage.ctx.retained_bytes(4, (mode, retention_rate)),
-                    [expected; 4]
-                );
-            }
-        }
-    }
-
-    #[test]
-    fn test_nan_fault_rate_does_not_consume_randomness() {
+    fn test_probability_endpoints_do_not_consume_randomness() {
         let expected = Harness::with_seed(0, Config::default());
         let expected = expected.storage.ctx.rng.lock().random::<u64>();
 
         let h = Harness::with_seed(0, Config::default());
-        assert!(!h.storage.ctx.roll(Some(f64::NAN)));
+        for (probability, outcome) in [(Probability::ZERO, false), (Probability::ONE, true)] {
+            assert_eq!(h.storage.ctx.roll(probability), outcome);
+            for mode in [PartialWriteMode::Prefix, PartialWriteMode::Subset] {
+                assert_eq!(
+                    h.storage.ctx.retained_bytes(4, (mode, probability)),
+                    [outcome; 4]
+                );
+            }
+        }
+
         assert_eq!(h.storage.ctx.rng.lock().random::<u64>(), expected);
     }
 
@@ -1613,7 +1602,7 @@ mod tests {
             let retained = h
                 .storage
                 .ctx
-                .retained_bytes(4, (PartialWriteMode::Prefix, 0.5));
+                .retained_bytes(4, (PartialWriteMode::Prefix, Probability!(1, 2)));
             let prefix_len = retained.iter().take_while(|&&keep| keep).count();
             assert!(retained[prefix_len..].iter().all(|&keep| !keep));
             observed[prefix_len] = true;
@@ -1623,7 +1612,7 @@ mod tests {
         assert!(
             h.storage
                 .ctx
-                .retained_bytes(0, (PartialWriteMode::Prefix, 0.5))
+                .retained_bytes(0, (PartialWriteMode::Prefix, Probability!(1, 2)))
                 .is_empty()
         );
     }
@@ -1631,8 +1620,8 @@ mod tests {
     #[tokio::test]
     async fn test_write_rejects_offset_overflow_before_retention() {
         let h = Harness::new(Config::default().write(WriteConfig {
-            failure_rate: 1.0,
-            retention_rate: 0.5,
+            failure_rate: Probability::ONE,
+            retention_rate: Probability!(1, 2),
             mode: PartialWriteMode::Subset,
         }));
         let (blob, _) = h.storage.open("partition", b"blob").await.unwrap();
@@ -1648,8 +1637,8 @@ mod tests {
     #[tokio::test]
     async fn test_failed_write_can_retain_every_byte() {
         let h = Harness::new(Config::default().write(WriteConfig {
-            failure_rate: 1.0,
-            retention_rate: 1.0,
+            failure_rate: Probability::ONE,
+            retention_rate: Probability::ONE,
             mode: PartialWriteMode::Prefix,
         }));
         let (blob, _) = h.storage.open("partition", b"blob").await.unwrap();
@@ -1665,7 +1654,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_faulty_storage_sync_always_fails() {
-        let h = Harness::new(Config::default().sync(1.0));
+        let h = Harness::new(Config::default().sync(Probability::ONE));
 
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
         blob.write_at(0, b"data".to_vec(), WriteOptions::default())
@@ -1680,11 +1669,11 @@ mod tests {
         let h = Harness::new(
             Config::default()
                 .write(WriteConfig {
-                    failure_rate: 0.0,
-                    retention_rate: 1.0,
+                    failure_rate: Probability::ZERO,
+                    retention_rate: Probability::ONE,
                     mode: PartialWriteMode::Prefix,
                 })
-                .sync(1.0),
+                .sync(Probability::ONE),
         );
 
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
@@ -1700,8 +1689,8 @@ mod tests {
     #[tokio::test]
     async fn test_faulty_storage_write_always_fails() {
         let h = Harness::new(Config::default().write(WriteConfig {
-            failure_rate: 1.0,
-            retention_rate: 0.0,
+            failure_rate: Probability::ONE,
+            retention_rate: Probability::ZERO,
             mode: PartialWriteMode::Prefix,
         }));
 
@@ -1717,8 +1706,8 @@ mod tests {
     #[tokio::test]
     async fn test_faulty_storage_write_at_sync_write_always_fails() {
         let h = Harness::new(Config::default().write(WriteConfig {
-            failure_rate: 1.0,
-            retention_rate: 0.0,
+            failure_rate: Probability::ONE,
+            retention_rate: Probability::ZERO,
             mode: PartialWriteMode::Prefix,
         }));
 
@@ -1732,7 +1721,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_faulty_storage_write_at_sync_failure_is_not_durable() {
-        let h = Harness::new(Config::default().sync(1.0));
+        let h = Harness::new(Config::default().sync(Probability::ONE));
 
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
 
@@ -1747,7 +1736,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_faulty_storage_empty_write_at_sync_does_not_sync_prior_write() {
-        let h = Harness::new(Config::default().sync(1.0));
+        let h = Harness::new(Config::default().sync(Probability::ONE));
 
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
         blob.write_at(0, b"data".to_vec(), WriteOptions::default())
@@ -1765,8 +1754,8 @@ mod tests {
     #[tokio::test]
     async fn test_empty_unsynced_write_does_not_create_crash_debt() {
         let h = Harness::new(Config::default().write(WriteConfig {
-            failure_rate: 0.0,
-            retention_rate: 1.0,
+            failure_rate: Probability::ZERO,
+            retention_rate: Probability::ONE,
             mode: PartialWriteMode::Prefix,
         }));
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
@@ -1788,14 +1777,14 @@ mod tests {
         blob.sync().await.unwrap();
 
         // Enable read faults
-        h.config.write().read_rate = Some(1.0);
+        h.config.write().read_rate = Some(Probability::ONE);
 
         assert!(matches!(blob.read_at(0, 4).await, Err(Error::Io(_))));
     }
 
     #[tokio::test]
     async fn test_faulty_storage_open_always_fails() {
-        let h = Harness::new(Config::default().open(1.0));
+        let h = Harness::new(Config::default().open(Probability::ONE));
 
         assert!(matches!(
             h.storage.open("partition", b"test").await,
@@ -1816,7 +1805,7 @@ mod tests {
         drop(blob);
 
         // Enable remove faults
-        h.config.write().remove_rate = Some(1.0);
+        h.config.write().remove_rate = Some(Probability::ONE);
 
         assert!(matches!(
             h.storage.remove("partition", Some(b"test")).await,
@@ -1839,7 +1828,7 @@ mod tests {
         }
 
         // Enable scan faults
-        h.config.write().scan_rate = Some(1.0);
+        h.config.write().scan_rate = Some(Probability::ONE);
 
         assert!(matches!(
             h.storage.scan("partition").await,
@@ -1849,7 +1838,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_faulty_storage_determinism() {
-        async fn run_ops(seed: u64, rate: f64) -> Vec<bool> {
+        async fn run_ops(seed: u64, rate: Probability) -> Vec<bool> {
             let h = Harness::with_seed(seed, Config::default().open(rate));
             let mut results = Vec::new();
             for i in 0..20 {
@@ -1859,11 +1848,11 @@ mod tests {
             results
         }
 
-        let results1 = run_ops(42, 0.5).await;
-        let results2 = run_ops(42, 0.5).await;
+        let results1 = run_ops(42, Probability!(1, 2)).await;
+        let results2 = run_ops(42, Probability!(1, 2)).await;
         assert_eq!(results1, results2, "Same seed should produce same results");
 
-        let results3 = run_ops(999, 0.5).await;
+        let results3 = run_ops(999, Probability!(1, 2)).await;
         assert_ne!(
             results1, results3,
             "Different seeds should produce different results"
@@ -1873,19 +1862,19 @@ mod tests {
     #[tokio::test]
     async fn test_faulty_storage_rate_for() {
         let config = Config::default()
-            .open(0.1)
+            .open(Probability!(1, 10))
             .write(WriteConfig {
-                failure_rate: 0.3,
-                retention_rate: 0.4,
+                failure_rate: Probability!(3, 10),
+                retention_rate: Probability!(2, 5),
                 mode: PartialWriteMode::Subset,
             })
-            .resize(0.7)
-            .sync(0.9);
+            .resize(Probability!(7, 10))
+            .sync(Probability!(9, 10));
 
-        assert!((config.rate_for(Op::Open) - 0.1).abs() < f64::EPSILON);
-        assert!((config.rate_for(Op::Write) - 0.3).abs() < f64::EPSILON);
-        assert!((config.rate_for(Op::Resize) - 0.7).abs() < f64::EPSILON);
-        assert!((config.rate_for(Op::Sync) - 0.9).abs() < f64::EPSILON);
+        assert_eq!(config.rate_for(Op::Open), Probability!(1, 10));
+        assert_eq!(config.rate_for(Op::Write), Probability!(3, 10));
+        assert_eq!(config.rate_for(Op::Resize), Probability!(7, 10));
+        assert_eq!(config.rate_for(Op::Sync), Probability!(9, 10));
     }
 
     #[tokio::test]
@@ -1895,18 +1884,18 @@ mod tests {
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
         blob.sync().await.unwrap();
 
-        h.config.write().sync_rate = Some(1.0);
+        h.config.write().sync_rate = Some(Probability::ONE);
         assert!(matches!(blob.sync().await, Err(Error::Io(_))));
 
-        h.config.write().sync_rate = Some(0.0);
+        h.config.write().sync_rate = Some(Probability::ZERO);
         blob.sync().await.unwrap();
     }
 
     #[tokio::test]
     async fn test_write_retention_is_snapshotted_and_replayed_in_order() {
         let h = Harness::new(Config::default().write(WriteConfig {
-            failure_rate: 0.0,
-            retention_rate: 1.0,
+            failure_rate: Probability::ZERO,
+            retention_rate: Probability::ONE,
             mode: PartialWriteMode::Prefix,
         }));
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
@@ -1922,8 +1911,8 @@ mod tests {
             .await
             .unwrap();
         h.config.write().write_rate = Some(WriteConfig {
-            failure_rate: 0.0,
-            retention_rate: 1.0,
+            failure_rate: Probability::ZERO,
+            retention_rate: Probability::ONE,
             mode: PartialWriteMode::Prefix,
         });
         blob.write_at(1, b"XY", WriteOptions::default())
@@ -1972,8 +1961,8 @@ mod tests {
                 let h = Harness::with_seed(
                     seed,
                     Config::default().write(WriteConfig {
-                        failure_rate: 0.0,
-                        retention_rate: 0.5,
+                        failure_rate: Probability::ZERO,
+                        retention_rate: Probability!(1, 2),
                         mode: PartialWriteMode::Subset,
                     }),
                 );
@@ -1987,8 +1976,8 @@ mod tests {
                 {
                     let mut config = h.config.write();
                     config.write_rate = Some(WriteConfig {
-                        failure_rate: 1.0,
-                        retention_rate: 0.5,
+                        failure_rate: Probability::ONE,
+                        retention_rate: Probability!(1, 2),
                         mode: partial_write_mode,
                     });
                 }
@@ -2017,8 +2006,8 @@ mod tests {
             let h = Harness::with_seed(
                 seed,
                 Config::default().write(WriteConfig {
-                    failure_rate: 0.0,
-                    retention_rate: 0.5,
+                    failure_rate: Probability::ZERO,
+                    retention_rate: Probability!(1, 2),
                     mode: PartialWriteMode::Subset,
                 }),
             );
@@ -2031,8 +2020,8 @@ mod tests {
                 .unwrap();
             {
                 let mut config = h.config.write();
-                config.resize_rate = Some(1.0);
-                config.partial_resize_rate = Some(1.0);
+                config.resize_rate = Some(Probability::ONE);
+                config.partial_resize_rate = Some(Probability::ONE);
             }
 
             assert!(blob.resize(8).await.is_err());
@@ -2050,8 +2039,8 @@ mod tests {
     #[tokio::test]
     async fn test_crash_journal_clears_only_after_completed_durability() {
         let h = Harness::new(Config::default().write(WriteConfig {
-            failure_rate: 0.0,
-            retention_rate: 1.0,
+            failure_rate: Probability::ZERO,
+            retention_rate: Probability::ONE,
             mode: PartialWriteMode::Prefix,
         }));
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
@@ -2060,7 +2049,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(h.storage.pending.lock().len(), 1);
-        h.config.write().sync_rate = Some(1.0);
+        h.config.write().sync_rate = Some(Probability::ONE);
         assert!(matches!(blob.sync().await, Err(Error::Io(_))));
         assert_eq!(h.storage.pending.lock().len(), 1);
 
@@ -2102,11 +2091,11 @@ mod tests {
         let h = Harness::new(
             Config::default()
                 .write(WriteConfig {
-                    failure_rate: 0.0,
-                    retention_rate: 1.0,
+                    failure_rate: Probability::ZERO,
+                    retention_rate: Probability::ONE,
                     mode: PartialWriteMode::Prefix,
                 })
-                .sync(1.0),
+                .sync(Probability::ONE),
         );
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
         assert!(matches!(
@@ -2124,8 +2113,8 @@ mod tests {
     #[tokio::test]
     async fn test_faulty_storage_zero_write_retention_preserves_nothing() {
         let h = Harness::new(Config::default().write(WriteConfig {
-            failure_rate: 1.0,
-            retention_rate: 0.0,
+            failure_rate: Probability::ONE,
+            retention_rate: Probability::ZERO,
             mode: PartialWriteMode::Prefix,
         }));
 
@@ -2172,15 +2161,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_faulty_storage_write_retention_rate_edges() {
+    async fn test_faulty_storage_write_retention_rate_endpoints() {
         for (retention_rate, expected) in [
-            (0.0, b"old".as_slice()),
-            (f64::NAN, b"old".as_slice()),
-            (1.0, b"new".as_slice()),
+            (Probability::ZERO, b"old".as_slice()),
+            (Probability::ONE, b"new".as_slice()),
         ] {
             for mode in [PartialWriteMode::Prefix, PartialWriteMode::Subset] {
                 let failed = Harness::new(Config::default().write(WriteConfig {
-                    failure_rate: 1.0,
+                    failure_rate: Probability::ONE,
                     retention_rate,
                     mode,
                 }));
@@ -2189,7 +2177,7 @@ mod tests {
                     .await
                     .unwrap_err();
                 let (durable, len) = failed.inner.open("partition", b"failed").await.unwrap();
-                if retention_rate >= 1.0 {
+                if retention_rate.is_one() {
                     assert_eq!(len, 3);
                     assert_eq!(durable.read_at(0, 3).await.unwrap().coalesce(), expected);
                 } else {
@@ -2197,7 +2185,7 @@ mod tests {
                 }
 
                 let crashed = Harness::new(Config::default().write(WriteConfig {
-                    failure_rate: 0.0,
+                    failure_rate: Probability::ZERO,
                     retention_rate,
                     mode,
                 }));
@@ -2229,7 +2217,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_faulty_storage_partial_resize_grow() {
-        let h = Harness::new(Config::default().resize(1.0).partial_resize(1.0));
+        let h = Harness::new(
+            Config::default()
+                .resize(Probability::ONE)
+                .partial_resize(Probability::ONE),
+        );
 
         let (blob, initial_size) = h.storage.open("partition", b"test").await.unwrap();
         assert_eq!(initial_size, 0);
@@ -2257,8 +2249,8 @@ mod tests {
 
         {
             let mut cfg = h.config.write();
-            cfg.resize_rate = Some(1.0);
-            cfg.partial_resize_rate = Some(1.0);
+            cfg.resize_rate = Some(Probability::ONE);
+            cfg.partial_resize_rate = Some(Probability::ONE);
         }
 
         let target_size = 10u64;
@@ -2276,7 +2268,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_faulty_storage_partial_resize_disabled() {
-        let h = Harness::new(Config::default().resize(1.0).partial_resize(0.0));
+        let h = Harness::new(
+            Config::default()
+                .resize(Probability::ONE)
+                .partial_resize(Probability::ZERO),
+        );
 
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
         let result = blob.resize(100).await;
@@ -2289,7 +2285,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_faulty_storage_partial_resize_same_size() {
-        let h = Harness::new(Config::default().resize(1.0).partial_resize(1.0));
+        let h = Harness::new(
+            Config::default()
+                .resize(Probability::ONE)
+                .partial_resize(Probability::ONE),
+        );
 
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
         let result = blob.resize(0).await;
@@ -2317,8 +2317,8 @@ mod tests {
 
         {
             let mut cfg = h.config.write();
-            cfg.resize_rate = Some(1.0);
-            cfg.partial_resize_rate = Some(1.0);
+            cfg.resize_rate = Some(Probability::ONE);
+            cfg.partial_resize_rate = Some(Probability::ONE);
         }
 
         let target_size = 10u64;
@@ -2336,7 +2336,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_faulty_storage_partial_resize_one_byte_difference() {
-        let h = Harness::new(Config::default().resize(1.0).partial_resize(1.0));
+        let h = Harness::new(
+            Config::default()
+                .resize(Probability::ONE)
+                .partial_resize(Probability::ONE),
+        );
 
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
         let result = blob.resize(1).await;

--- a/runtime/src/tokio/tracing.rs
+++ b/runtime/src/tokio/tracing.rs
@@ -1,5 +1,6 @@
 //! Utilities to export traces to an OTLP endpoint.
 
+use commonware_utils::Probability;
 use opentelemetry::{global, trace::TracerProvider};
 use opentelemetry_otlp::{ExporterBuildError, SpanExporter, WithExportConfig};
 use opentelemetry_sdk::{
@@ -18,7 +19,7 @@ pub struct Config {
     /// The service name to use for the traces.
     pub name: String,
     /// The sampling rate to use for the traces.
-    pub rate: f64,
+    pub rate: Probability,
 }
 
 /// Export traces to an OTLP endpoint.
@@ -39,7 +40,7 @@ pub fn export(cfg: Config) -> Result<Tracer, ExporterBuildError> {
         .build();
 
     // Build the tracer provider
-    let sampler = Sampler::TraceIdRatioBased(cfg.rate);
+    let sampler = Sampler::TraceIdRatioBased(cfg.rate.as_f64());
     let tracer_provider = SdkTracerProvider::builder()
         .with_span_processor(batch_processor)
         .with_resource(resource)

--- a/storage/fuzz/fuzz_targets/current_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/current_crash_recovery.rs
@@ -20,7 +20,7 @@ use commonware_storage::{
     qmdb::current::{VariableConfig, unordered::variable::Db as Current},
     translator::TwoCap,
 };
-use commonware_utils::{NZU64, NZUsize, sequence::FixedBytes};
+use commonware_utils::{NZU64, NZUsize, Probability, sequence::FixedBytes};
 use libfuzzer_sys::fuzz_target;
 use std::{
     collections::HashMap,
@@ -53,9 +53,9 @@ fn bounded_write_buffer(u: &mut Unstructured<'_>) -> Result<usize> {
     u.int_in_range(1..=MAX_WRITE_BUF)
 }
 
-fn bounded_nonzero_rate(u: &mut Unstructured<'_>) -> Result<f64> {
+fn bounded_nonzero_rate(u: &mut Unstructured<'_>) -> Result<Probability> {
     let percent: u8 = u.int_in_range(1..=100)?;
-    Ok(f64::from(percent) / 100.0)
+    Ok(Probability!(u64::from(percent), 100))
 }
 
 /// State-changing operations that exercise disk writes.
@@ -82,9 +82,9 @@ struct FuzzInput {
     #[arbitrary(with = bounded_write_buffer)]
     write_buffer: usize,
     #[arbitrary(with = bounded_nonzero_rate)]
-    sync_failure_rate: f64,
+    sync_failure_rate: Probability,
     #[arbitrary(with = bounded_nonzero_rate)]
-    write_failure_rate: f64,
+    write_failure_rate: Probability,
     operations: Vec<CurrentOperation>,
 }
 
@@ -231,7 +231,7 @@ fn fuzz_family<F: Graftable>(input: &FuzzInput, suffix_base: &str) {
                 sync_rate: Some(sync_failure_rate),
                 write_rate: Some(deterministic::WriteConfig {
                     failure_rate: write_failure_rate,
-                    retention_rate: 0.0,
+                    retention_rate: Probability::ZERO,
                     mode: deterministic::PartialWriteMode::Prefix,
                 }),
                 ..Default::default()

--- a/storage/fuzz/fuzz_targets/current_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/current_crash_recovery.rs
@@ -231,7 +231,7 @@ fn fuzz_family<F: Graftable>(input: &FuzzInput, suffix_base: &str) {
                 sync_rate: Some(sync_failure_rate),
                 write_rate: Some(deterministic::WriteConfig {
                     failure_rate: write_failure_rate,
-                    retention_rate: Probability::ZERO,
+                    retention_rate: Probability!(0.0),
                     mode: deterministic::PartialWriteMode::Prefix,
                 }),
                 ..Default::default()

--- a/storage/fuzz/fuzz_targets/journal_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/journal_crash_recovery.rs
@@ -208,8 +208,10 @@ impl Params {
                 mode: deterministic::PartialWriteMode::Prefix,
             }),
             sync_rate: Some(self.sync_rate),
-            resize_rate: Some(self.resize_rate),
-            partial_resize_rate: Some(self.partial_resize_rate),
+            resize_rate: Some(deterministic::ResizeConfig {
+                failure_rate: self.resize_rate,
+                partial_rate: self.partial_resize_rate,
+            }),
             ..Default::default()
         }
     }

--- a/storage/fuzz/fuzz_targets/journal_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/journal_crash_recovery.rs
@@ -52,7 +52,7 @@ use commonware_storage::journal::{
         variable::{Config as VariableConfig, Journal as VariableJournal},
     },
 };
-use commonware_utils::{NZU64, NZUsize, sequence::FixedBytes};
+use commonware_utils::{NZU64, NZUsize, Probability, sequence::FixedBytes};
 use futures::StreamExt;
 use libfuzzer_sys::fuzz_target;
 use std::{
@@ -100,9 +100,9 @@ fn bounded_write_buffer(u: &mut Unstructured<'_>) -> arbitrary::Result<usize> {
 }
 
 /// A fault rate in [0.0, 1.0]. Allows 0 so the fuzzer can disable individual fault types.
-fn bounded_rate(u: &mut Unstructured<'_>) -> arbitrary::Result<f64> {
+fn bounded_rate(u: &mut Unstructured<'_>) -> arbitrary::Result<Probability> {
     let percent: u8 = u.int_in_range(0..=100)?;
-    Ok(f64::from(percent) / 100.0)
+    Ok(Probability!(u64::from(percent), 100))
 }
 
 /// Op sequence capped at `MAX_OPERATIONS`; a derived `Vec` would instead grow with input length.
@@ -166,19 +166,19 @@ struct FuzzInput {
     write_buffer: usize,
     /// Failure rate for write operations.
     #[arbitrary(with = bounded_rate)]
-    write_failure_rate: f64,
+    write_failure_rate: Probability,
     /// Probability used to retain bytes from a failed or unsynchronized write.
     #[arbitrary(with = bounded_rate)]
-    write_retention_rate: f64,
+    write_retention_rate: Probability,
     /// Failure rate for sync operations.
     #[arbitrary(with = bounded_rate)]
-    sync_failure_rate: f64,
+    sync_failure_rate: Probability,
     /// Failure rate for resize operations (truncation during rewind/prune).
     #[arbitrary(with = bounded_rate)]
-    resize_failure_rate: f64,
+    resize_failure_rate: Probability,
     /// Probability that a resize failure is partial.
     #[arbitrary(with = bounded_rate)]
-    partial_resize_rate: f64,
+    partial_resize_rate: Probability,
     /// Operations to execute, split into one `ops` list per cycle at each `Crash` marker.
     #[arbitrary(with = bounded_operations)]
     operations: Vec<JournalOperation>,
@@ -191,11 +191,11 @@ struct Params {
     page_cache_size: NonZeroUsize,
     items_per_section: u64,
     write_buffer: NonZeroUsize,
-    write_rate: f64,
-    write_retention_rate: f64,
-    sync_rate: f64,
-    resize_rate: f64,
-    partial_resize_rate: f64,
+    write_rate: Probability,
+    write_retention_rate: Probability,
+    sync_rate: Probability,
+    resize_rate: Probability,
+    partial_resize_rate: Probability,
 }
 
 impl Params {

--- a/storage/fuzz/fuzz_targets/merkle_full_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/merkle_full_crash_recovery.rs
@@ -254,7 +254,7 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
                 sync_rate: Some(sync_failure_rate),
                 write_rate: Some(deterministic::WriteConfig {
                     failure_rate: write_failure_rate,
-                    retention_rate: Probability::ZERO,
+                    retention_rate: Probability!(0.0),
                     mode: deterministic::PartialWriteMode::Prefix,
                 }),
                 ..Default::default()

--- a/storage/fuzz/fuzz_targets/merkle_full_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/merkle_full_crash_recovery.rs
@@ -13,7 +13,7 @@ use commonware_storage::merkle::{
     Bagging::ForwardFold, Family as MerkleFamily, Location, full::Config,
     hasher::Standard as StandardHasher, mmb, mmr,
 };
-use commonware_utils::NZU64;
+use commonware_utils::{NZU64, Probability};
 use libfuzzer_sys::fuzz_target;
 use std::num::{NonZeroU16, NonZeroUsize};
 
@@ -42,9 +42,9 @@ fn bounded_write_buffer(u: &mut Unstructured<'_>) -> Result<usize> {
     u.int_in_range(1..=MAX_WRITE_BUF)
 }
 
-fn bounded_nonzero_rate(u: &mut Unstructured<'_>) -> Result<f64> {
+fn bounded_nonzero_rate(u: &mut Unstructured<'_>) -> Result<Probability> {
     let percent: u8 = u.int_in_range(1..=100)?;
-    Ok(f64::from(percent) / 100.0)
+    Ok(Probability!(u64::from(percent), 100))
 }
 
 /// Operations that can be performed on the Merkle structure.
@@ -79,10 +79,10 @@ struct FuzzInput {
     write_buffer: usize,
     /// Failure rate for sync operations (0, 1].
     #[arbitrary(with = bounded_nonzero_rate)]
-    sync_failure_rate: f64,
+    sync_failure_rate: Probability,
     /// Failure rate for write operations (0, 1].
     #[arbitrary(with = bounded_nonzero_rate)]
-    write_failure_rate: f64,
+    write_failure_rate: Probability,
     /// Sequence of operations to execute.
     operations: Vec<MerkleOperation>,
 }
@@ -254,7 +254,7 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
                 sync_rate: Some(sync_failure_rate),
                 write_rate: Some(deterministic::WriteConfig {
                     failure_rate: write_failure_rate,
-                    retention_rate: 0.0,
+                    retention_rate: Probability::ZERO,
                     mode: deterministic::PartialWriteMode::Prefix,
                 }),
                 ..Default::default()

--- a/storage/fuzz/fuzz_targets/queue_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/queue_crash_recovery.rs
@@ -488,7 +488,7 @@ fn fuzz(input: FuzzInput) {
                 sync_rate: Some(sync_failure_rate),
                 write_rate: Some(deterministic::WriteConfig {
                     failure_rate: write_failure_rate,
-                    retention_rate: Probability::ZERO,
+                    retention_rate: Probability!(0.0),
                     mode: deterministic::PartialWriteMode::Prefix,
                 }),
                 ..Default::default()

--- a/storage/fuzz/fuzz_targets/queue_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/queue_crash_recovery.rs
@@ -11,6 +11,7 @@
 use arbitrary::{Arbitrary, Result, Unstructured};
 use commonware_runtime::{Runner, Supervisor as _, buffer::paged::CacheRef, deterministic};
 use commonware_storage::queue::{Config, Queue};
+use commonware_utils::Probability;
 use libfuzzer_sys::fuzz_target;
 use std::{
     collections::BTreeMap,
@@ -39,9 +40,9 @@ fn bounded_write_buffer(u: &mut Unstructured<'_>) -> Result<usize> {
     u.int_in_range(1..=MAX_WRITE_BUF)
 }
 
-fn bounded_nonzero_rate(u: &mut Unstructured<'_>) -> Result<f64> {
+fn bounded_nonzero_rate(u: &mut Unstructured<'_>) -> Result<Probability> {
     let percent: u8 = u.int_in_range(1..=100)?;
-    Ok(f64::from(percent) / 100.0)
+    Ok(Probability!(u64::from(percent), 100))
 }
 
 /// Operations that can be performed on the queue.
@@ -86,10 +87,10 @@ struct FuzzInput {
     write_buffer: usize,
     /// Failure rate for sync operations (0, 1].
     #[arbitrary(with = bounded_nonzero_rate)]
-    sync_failure_rate: f64,
+    sync_failure_rate: Probability,
     /// Failure rate for write operations (0, 1].
     #[arbitrary(with = bounded_nonzero_rate)]
-    write_failure_rate: f64,
+    write_failure_rate: Probability,
     /// Sequence of operations to execute.
     operations: Vec<QueueOperation>,
 }
@@ -487,7 +488,7 @@ fn fuzz(input: FuzzInput) {
                 sync_rate: Some(sync_failure_rate),
                 write_rate: Some(deterministic::WriteConfig {
                     failure_rate: write_failure_rate,
-                    retention_rate: 0.0,
+                    retention_rate: Probability::ZERO,
                     mode: deterministic::PartialWriteMode::Prefix,
                 }),
                 ..Default::default()

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -2105,8 +2105,8 @@ mod tests {
             journal.append(&0).await.unwrap();
             *context.storage_fault_config().write() = deterministic::FaultConfig {
                 write_rate: Some(deterministic::WriteConfig {
-                    failure_rate: Probability::ONE,
-                    retention_rate: Probability::ZERO,
+                    failure_rate: Probability!(1.0),
+                    retention_rate: Probability!(0.0),
                     mode: deterministic::PartialWriteMode::Prefix,
                 }),
                 ..Default::default()
@@ -2232,7 +2232,7 @@ mod tests {
             // Regression: commit() must force a data sync before callers can rely on recovered
             // bytes beyond the persisted recovery watermark.
             *context.storage_fault_config().write() = deterministic::FaultConfig {
-                sync_rate: Some(Probability::ONE),
+                sync_rate: Some(Probability!(1.0)),
                 ..Default::default()
             };
             assert!(
@@ -3301,7 +3301,7 @@ mod tests {
             // Inject sync faults. If commit skipped the recovered tail sync, it would succeed
             // despite the fault.
             *context.storage_fault_config().write() = deterministic::FaultConfig {
-                sync_rate: Some(Probability::ONE),
+                sync_rate: Some(Probability!(1.0)),
                 ..Default::default()
             };
             assert!(

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -1754,7 +1754,7 @@ mod tests {
             fail_pending_syncs, release_pending_syncs,
         },
     };
-    use commonware_utils::{NZU16, NZU64, NZUsize};
+    use commonware_utils::{NZU16, NZU64, NZUsize, Probability};
     use futures::{StreamExt, pin_mut};
     use std::num::NonZeroU16;
 
@@ -2105,8 +2105,8 @@ mod tests {
             journal.append(&0).await.unwrap();
             *context.storage_fault_config().write() = deterministic::FaultConfig {
                 write_rate: Some(deterministic::WriteConfig {
-                    failure_rate: 1.0,
-                    retention_rate: 0.0,
+                    failure_rate: Probability::ONE,
+                    retention_rate: Probability::ZERO,
                     mode: deterministic::PartialWriteMode::Prefix,
                 }),
                 ..Default::default()
@@ -2232,7 +2232,7 @@ mod tests {
             // Regression: commit() must force a data sync before callers can rely on recovered
             // bytes beyond the persisted recovery watermark.
             *context.storage_fault_config().write() = deterministic::FaultConfig {
-                sync_rate: Some(1.0),
+                sync_rate: Some(Probability::ONE),
                 ..Default::default()
             };
             assert!(
@@ -3301,7 +3301,7 @@ mod tests {
             // Inject sync faults. If commit skipped the recovered tail sync, it would succeed
             // despite the fault.
             *context.storage_fault_config().write() = deterministic::FaultConfig {
-                sync_rate: Some(1.0),
+                sync_rate: Some(Probability::ONE),
                 ..Default::default()
             };
             assert!(

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -2587,7 +2587,7 @@ mod tests {
             next_pending_sync, release_pending_syncs,
         },
     };
-    use commonware_utils::{NZU16, NZU64, NZUsize, sequence::FixedBytes};
+    use commonware_utils::{NZU16, NZU64, NZUsize, Probability, sequence::FixedBytes};
     use futures::StreamExt as _;
     use std::num::NonZeroU16;
 
@@ -2849,8 +2849,8 @@ mod tests {
             journal.append(&0).await.unwrap();
             *context.storage_fault_config().write() = deterministic::FaultConfig {
                 write_rate: Some(deterministic::WriteConfig {
-                    failure_rate: 1.0,
-                    retention_rate: 0.0,
+                    failure_rate: Probability::ONE,
+                    retention_rate: Probability::ZERO,
                     mode: deterministic::PartialWriteMode::Prefix,
                 }),
                 ..Default::default()
@@ -6134,7 +6134,7 @@ mod tests {
                 drop(journal);
 
                 *context.storage_fault_config().write() = deterministic::FaultConfig {
-                    sync_rate: Some(1.0),
+                    sync_rate: Some(Probability::ONE),
                     ..Default::default()
                 };
                 assert!(
@@ -6195,7 +6195,7 @@ mod tests {
                 // Fail the offsets metadata sync inside `stage_clear_intent` so `clear_to_size`
                 // aborts before any data is cleared. The reset intent never becomes durable.
                 *context.storage_fault_config().write() = deterministic::FaultConfig {
-                    sync_rate: Some(1.0),
+                    sync_rate: Some(Probability::ONE),
                     ..Default::default()
                 };
                 assert!(journal.0.clear_to_size(7).await.is_err());
@@ -6253,7 +6253,7 @@ mod tests {
                 // subsequent `data.clear()` (a blob remove) so `clear_to_size` aborts after the
                 // intent is durable but before the data is cleared.
                 *context.storage_fault_config().write() = deterministic::FaultConfig {
-                    remove_rate: Some(1.0),
+                    remove_rate: Some(Probability::ONE),
                     ..Default::default()
                 };
                 assert!(journal.0.clear_to_size(7).await.is_err());

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -2849,8 +2849,8 @@ mod tests {
             journal.append(&0).await.unwrap();
             *context.storage_fault_config().write() = deterministic::FaultConfig {
                 write_rate: Some(deterministic::WriteConfig {
-                    failure_rate: Probability::ONE,
-                    retention_rate: Probability::ZERO,
+                    failure_rate: Probability!(1.0),
+                    retention_rate: Probability!(0.0),
                     mode: deterministic::PartialWriteMode::Prefix,
                 }),
                 ..Default::default()
@@ -6134,7 +6134,7 @@ mod tests {
                 drop(journal);
 
                 *context.storage_fault_config().write() = deterministic::FaultConfig {
-                    sync_rate: Some(Probability::ONE),
+                    sync_rate: Some(Probability!(1.0)),
                     ..Default::default()
                 };
                 assert!(
@@ -6195,7 +6195,7 @@ mod tests {
                 // Fail the offsets metadata sync inside `stage_clear_intent` so `clear_to_size`
                 // aborts before any data is cleared. The reset intent never becomes durable.
                 *context.storage_fault_config().write() = deterministic::FaultConfig {
-                    sync_rate: Some(Probability::ONE),
+                    sync_rate: Some(Probability!(1.0)),
                     ..Default::default()
                 };
                 assert!(journal.0.clear_to_size(7).await.is_err());
@@ -6253,7 +6253,7 @@ mod tests {
                 // subsequent `data.clear()` (a blob remove) so `clear_to_size` aborts after the
                 // intent is durable but before the data is cleared.
                 *context.storage_fault_config().write() = deterministic::FaultConfig {
-                    remove_rate: Some(Probability::ONE),
+                    remove_rate: Some(Probability!(1.0)),
                     ..Default::default()
                 };
                 assert!(journal.0.clear_to_size(7).await.is_err());

--- a/storage/src/journal/segmented/variable.rs
+++ b/storage/src/journal/segmented/variable.rs
@@ -801,7 +801,7 @@ mod tests {
         Blob, BufMut, Runner, Storage, Supervisor as _, WriteOptions, deterministic,
         mocks::{DelayedSyncContext, PendingSyncs, release_pending_syncs},
     };
-    use commonware_utils::{NZU16, NZUsize};
+    use commonware_utils::{NZU16, NZUsize, Probability};
     use std::num::NonZeroU16;
 
     const PAGE_SIZE: NonZeroU16 = NZU16!(1024);
@@ -1385,7 +1385,7 @@ mod tests {
                 .await
                 .expect("Failed to re-initialize journal");
             *context.storage_fault_config().write() = deterministic::FaultConfig {
-                resize_rate: Some(1.0),
+                resize_rate: Some(Probability::ONE),
                 ..Default::default()
             };
 
@@ -1447,7 +1447,7 @@ mod tests {
                 .await
                 .expect("Failed to re-initialize journal");
             *context.storage_fault_config().write() = deterministic::FaultConfig {
-                resize_rate: Some(1.0),
+                resize_rate: Some(Probability::ONE),
                 ..Default::default()
             };
 

--- a/storage/src/journal/segmented/variable.rs
+++ b/storage/src/journal/segmented/variable.rs
@@ -1385,7 +1385,7 @@ mod tests {
                 .await
                 .expect("Failed to re-initialize journal");
             *context.storage_fault_config().write() = deterministic::FaultConfig {
-                resize_rate: Some(Probability::ONE),
+                resize_rate: Some(Probability!(1.0)),
                 ..Default::default()
             };
 
@@ -1447,7 +1447,7 @@ mod tests {
                 .await
                 .expect("Failed to re-initialize journal");
             *context.storage_fault_config().write() = deterministic::FaultConfig {
-                resize_rate: Some(Probability::ONE),
+                resize_rate: Some(Probability!(1.0)),
                 ..Default::default()
             };
 

--- a/storage/src/journal/segmented/variable.rs
+++ b/storage/src/journal/segmented/variable.rs
@@ -1385,7 +1385,10 @@ mod tests {
                 .await
                 .expect("Failed to re-initialize journal");
             *context.storage_fault_config().write() = deterministic::FaultConfig {
-                resize_rate: Some(Probability!(1.0)),
+                resize_rate: Some(deterministic::ResizeConfig {
+                    failure_rate: Probability!(1.0),
+                    partial_rate: Probability!(0.0),
+                }),
                 ..Default::default()
             };
 
@@ -1447,7 +1450,10 @@ mod tests {
                 .await
                 .expect("Failed to re-initialize journal");
             *context.storage_fault_config().write() = deterministic::FaultConfig {
-                resize_rate: Some(Probability!(1.0)),
+                resize_rate: Some(deterministic::ResizeConfig {
+                    failure_rate: Probability!(1.0),
+                    partial_rate: Probability!(0.0),
+                }),
                 ..Default::default()
             };
 

--- a/storage/src/qmdb/any/ordered/fixed.rs
+++ b/storage/src/qmdb/any/ordered/fixed.rs
@@ -168,7 +168,7 @@ pub(crate) mod test {
         Runner as _, Supervisor as _,
         deterministic::{self, Context},
     };
-    use commonware_utils::{NZU64, NZUsize, TestRng, sequence::FixedBytes};
+    use commonware_utils::{NZU64, NZUsize, Probability, TestRng, sequence::FixedBytes};
     use futures::StreamExt as _;
     use rand::{Rng, seq::IteratorRandom};
     use std::{
@@ -790,7 +790,7 @@ pub(crate) mod test {
             // across configs, never cached pages), so replay's first item forces a storage read,
             // and with far fewer ops than the routing batch size no batch reaches a worker, so
             // workers never read the log themselves.
-            context.storage_fault_config().write().read_rate = Some(1.0);
+            context.storage_fault_config().write().read_rate = Some(Probability::ONE);
             let result = index
                 .build_snapshot(
                     context.child("build"),

--- a/storage/src/qmdb/any/ordered/fixed.rs
+++ b/storage/src/qmdb/any/ordered/fixed.rs
@@ -790,7 +790,7 @@ pub(crate) mod test {
             // across configs, never cached pages), so replay's first item forces a storage read,
             // and with far fewer ops than the routing batch size no batch reaches a worker, so
             // workers never read the log themselves.
-            context.storage_fault_config().write().read_rate = Some(Probability::ONE);
+            context.storage_fault_config().write().read_rate = Some(Probability!(1.0));
             let result = index
                 .build_snapshot(
                     context.child("build"),

--- a/storage/src/qmdb/any/unordered/fixed.rs
+++ b/storage/src/qmdb/any/unordered/fixed.rs
@@ -878,7 +878,7 @@ pub(crate) mod test {
             // across configs, never cached pages), so replay's first item forces a storage read,
             // and with far fewer ops than the routing batch size no batch reaches a worker, so
             // workers never read the log themselves.
-            context.storage_fault_config().write().read_rate = Some(Probability::ONE);
+            context.storage_fault_config().write().read_rate = Some(Probability!(1.0));
             let result = index
                 .build_snapshot(
                     context.child("build"),

--- a/storage/src/qmdb/any/unordered/fixed.rs
+++ b/storage/src/qmdb/any/unordered/fixed.rs
@@ -161,7 +161,7 @@ pub(crate) mod test {
         mocks::{DelayedSyncContext, PendingSyncs, drive_pending_syncs},
         reschedule,
     };
-    use commonware_utils::{NZU16, NZU64, NZUsize, TestRng};
+    use commonware_utils::{NZU16, NZU64, NZUsize, Probability, TestRng};
     use core::num::NonZeroUsize;
     use futures::{FutureExt as _, Stream};
     use rand::Rng;
@@ -878,7 +878,7 @@ pub(crate) mod test {
             // across configs, never cached pages), so replay's first item forces a storage read,
             // and with far fewer ops than the routing batch size no batch reaches a worker, so
             // workers never read the log themselves.
-            context.storage_fault_config().write().read_rate = Some(1.0);
+            context.storage_fault_config().write().read_rate = Some(Probability::ONE);
             let result = index
                 .build_snapshot(
                     context.child("build"),

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -29,6 +29,8 @@ commonware_macros::stability_scope!(BETA {
     pub mod bitmap;
     pub mod cache;
     pub mod ordered;
+    pub mod probability;
+    pub use probability::Probability;
     pub mod range;
 
     use bytes::Buf;

--- a/utils/src/probability.rs
+++ b/utils/src/probability.rs
@@ -1,0 +1,204 @@
+//! A platform-independent probability value and sampler.
+
+use rand::Rng;
+
+const SCALE: u128 = 1u128 << u64::BITS;
+
+/// A probability represented as a threshold over all possible `u64` samples.
+///
+/// Ratios are rounded down to the nearest multiple of 2^-64. Sampling consumes one `u64` for
+/// probabilities strictly between zero and one, and consumes no randomness for either endpoint.
+/// Given the same sequence of `u64` samples, decisions are identical on every platform.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct Probability(u64);
+
+impl Probability {
+    /// A probability that never occurs.
+    pub const ZERO: Self = Self(0);
+
+    /// A probability that always occurs.
+    pub const ONE: Self = Self(u64::MAX);
+
+    /// Creates a probability from `numerator / denominator`.
+    ///
+    /// Returns [`None`] if the denominator is zero or the numerator exceeds the denominator.
+    pub const fn new(numerator: u64, denominator: u64) -> Option<Self> {
+        if denominator == 0 || numerator > denominator {
+            return None;
+        }
+
+        if numerator == denominator {
+            return Some(Self::ONE);
+        }
+
+        let threshold = ((numerator as u128) << u64::BITS) / denominator as u128;
+
+        // A proper fraction with a `u64` denominator is at least 2^-64 below one, so its rounded
+        // threshold cannot collide with the sentinel reserved for `ONE`.
+        debug_assert!(threshold < u64::MAX as u128);
+        Some(Self(threshold as u64))
+    }
+
+    /// Returns whether this probability never occurs.
+    pub const fn is_zero(self) -> bool {
+        self.0 == Self::ZERO.0
+    }
+
+    /// Returns whether this probability always occurs.
+    pub const fn is_one(self) -> bool {
+        self.0 == Self::ONE.0
+    }
+
+    /// Converts this probability to an `f64` in the inclusive range `[0, 1]`.
+    ///
+    /// This conversion is intended for APIs that require floating-point probabilities. Interior
+    /// probabilities remain strictly below one even when rounding to `f64`.
+    pub fn as_f64(self) -> f64 {
+        if self.is_one() {
+            return 1.0;
+        }
+
+        let value = self.0 as f64 / SCALE as f64;
+        if value == 1.0 {
+            f64::from_bits(1.0f64.to_bits() - 1)
+        } else {
+            value
+        }
+    }
+
+    /// Samples this probability using the next `u64` from `rng`.
+    pub fn sample(self, rng: &mut (impl Rng + ?Sized)) -> bool {
+        match self.0 {
+            0 => false,
+            u64::MAX => true,
+            threshold => rng.next_u64() < threshold,
+        }
+    }
+}
+
+/// Creates a [`Probability`] from an integer numerator and denominator.
+///
+/// Literal arguments are validated at compile time. Expression arguments are validated at
+/// runtime.
+///
+/// # Panics
+///
+/// The expression form panics if the denominator is zero or the numerator exceeds the
+/// denominator. Use [`Probability::new`] to validate untrusted values without panicking.
+///
+/// # Examples
+///
+/// ```
+/// use commonware_utils::Probability;
+///
+/// const HALF: Probability = Probability!(1, 2);
+/// assert_eq!(HALF.as_f64(), 0.5);
+/// ```
+///
+/// ```compile_fail
+/// use commonware_utils::Probability;
+///
+/// const INVALID: Probability = Probability!(2, 1);
+/// ```
+#[cfg(not(any(
+    commonware_stability_GAMMA,
+    commonware_stability_DELTA,
+    commonware_stability_EPSILON,
+    commonware_stability_RESERVED
+)))] // BETA
+#[macro_export]
+macro_rules! Probability {
+    ($numerator:literal, $denominator:literal) => {
+        const {
+            $crate::Probability::new($numerator, $denominator)
+                .expect("probability requires a non-zero denominator and numerator <= denominator")
+        }
+    };
+    ($numerator:expr, $denominator:expr) => {
+        $crate::Probability::new($numerator, $denominator)
+            .expect("probability requires a non-zero denominator and numerator <= denominator")
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::convert::Infallible;
+    use rand::TryRng;
+
+    struct CountingRng {
+        value: u64,
+        calls: usize,
+    }
+
+    impl TryRng for CountingRng {
+        type Error = Infallible;
+
+        fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
+            self.calls += 1;
+            Ok(self.value as u32)
+        }
+
+        fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
+            self.calls += 1;
+            Ok(self.value)
+        }
+
+        fn try_fill_bytes(&mut self, dst: &mut [u8]) -> Result<(), Self::Error> {
+            self.calls += 1;
+            dst.fill(0);
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn construction() {
+        assert_eq!(Probability::new(0, u64::MAX), Some(Probability::ZERO));
+        assert_eq!(Probability::new(u64::MAX, u64::MAX), Some(Probability::ONE));
+        assert_eq!(Probability!(1, 2), Probability!(2, 4));
+        assert_eq!(Probability!(1, 2).as_f64(), 0.5);
+        assert!(Probability::new(1, 0).is_none());
+        assert!(Probability::new(2, 1).is_none());
+    }
+
+    #[test]
+    fn representation_matches_a_raw_rate() {
+        assert_eq!(core::mem::size_of::<Probability>(), size_of::<u64>());
+    }
+
+    #[test]
+    fn ratios_use_platform_independent_thresholds() {
+        assert_eq!(Probability!(1, 3).0 as u128, SCALE / 3);
+        assert_eq!(Probability!(2, 3).0 as u128, (2 * SCALE) / 3);
+
+        let below_one = Probability::new(u64::MAX - 1, u64::MAX).unwrap();
+        assert_eq!(below_one.0, u64::MAX - 1);
+        assert!(below_one.as_f64() < 1.0);
+    }
+
+    #[test]
+    fn sampling_uses_threshold_and_skips_endpoints() {
+        let mut rng = CountingRng { value: 0, calls: 0 };
+        assert!(!Probability::ZERO.sample(&mut rng));
+        assert!(Probability::ONE.sample(&mut rng));
+        assert_eq!(rng.calls, 0);
+
+        rng.value = (1u64 << 63) - 1;
+        assert!(Probability!(1, 2).sample(&mut rng));
+        assert_eq!(rng.calls, 1);
+
+        rng.value = 1u64 << 63;
+        assert!(!Probability!(1, 2).sample(&mut rng));
+        assert_eq!(rng.calls, 2);
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "probability requires a non-zero denominator and numerator <= denominator"
+    )]
+    fn expression_macro_rejects_invalid_probability() {
+        let numerator = 2;
+        let denominator = 1;
+        let _ = Probability!(numerator, denominator);
+    }
+}

--- a/utils/src/probability.rs
+++ b/utils/src/probability.rs
@@ -2,7 +2,11 @@
 
 use rand::Rng;
 
+// Number of possible `u64` samples and denominator of the threshold grid.
 const SCALE: u128 = 1u128 << u64::BITS;
+
+// Biased `f64` exponent where scaling by 2^64 leaves the 53-bit significand unshifted.
+const SCALED_EXPONENT: u64 = 1023 + 52 - 64;
 
 /// A probability represented as a threshold over all possible `u64` samples.
 ///
@@ -29,7 +33,7 @@ impl Probability {
 
         // A proper fraction with a `u64` denominator is at least 2^-64 below one, so its rounded
         // threshold cannot collide with the sentinel reserved for probability one.
-        debug_assert!(threshold < u64::MAX as u128);
+        assert!(threshold < u64::MAX as u128);
         Some(Self(threshold as u64))
     }
 
@@ -54,10 +58,6 @@ impl Probability {
             return None;
         }
         let significand = (1u64 << 52) | (magnitude & ((1u64 << 52) - 1));
-
-        // Scaling the decoded binary value by 2^64 makes exponent 1011 the point where the
-        // significand needs neither a left nor right shift.
-        const SCALED_EXPONENT: u64 = 1023 + 52 - 64;
         if exponent < SCALED_EXPONENT {
             let shift = (SCALED_EXPONENT - exponent) as u32;
             if significand.trailing_zeros() < shift {
@@ -71,7 +71,7 @@ impl Probability {
             return Some(Self(u64::MAX));
         }
 
-        debug_assert!(threshold < u64::MAX as u128);
+        assert!(threshold < u64::MAX as u128);
         Some(Self(threshold as u64))
     }
 
@@ -103,7 +103,7 @@ impl Probability {
     }
 
     /// Samples this probability using the next `u64` from `rng`.
-    pub fn sample(self, rng: &mut (impl Rng + ?Sized)) -> bool {
+    pub fn sample<R: Rng + ?Sized>(self, rng: &mut R) -> bool {
         match self.0 {
             0 => false,
             u64::MAX => true,

--- a/utils/src/probability.rs
+++ b/utils/src/probability.rs
@@ -39,6 +39,48 @@ impl Probability {
         Some(Self(threshold as u64))
     }
 
+    /// Creates a probability from an `f64` that maps exactly to a 64-bit threshold.
+    ///
+    /// Returns [`None`] if `value` is not finite, is outside `[0, 1]`, or would require rounding.
+    /// The exact IEEE-754 value is preserved rather than interpreting its source spelling as a
+    /// decimal ratio.
+    pub const fn from_f64(value: f64) -> Option<Self> {
+        let bits = value.to_bits();
+        let magnitude = bits & (u64::MAX >> 1);
+
+        if magnitude == 0 {
+            return Some(Self::ZERO);
+        }
+        if bits != magnitude || magnitude > 1.0f64.to_bits() {
+            return None;
+        }
+
+        let exponent = magnitude >> 52;
+        if exponent == 0 {
+            return None;
+        }
+        let significand = (1u64 << 52) | (magnitude & ((1u64 << 52) - 1));
+
+        // Scaling the decoded binary value by 2^64 makes exponent 1011 the point where the
+        // significand needs neither a left nor right shift.
+        const SCALED_EXPONENT: u64 = 1023 + 52 - 64;
+        if exponent < SCALED_EXPONENT {
+            let shift = (SCALED_EXPONENT - exponent) as u32;
+            if significand.trailing_zeros() < shift {
+                return None;
+            }
+            return Some(Self(significand >> shift));
+        }
+
+        let threshold = (significand as u128) << (exponent - SCALED_EXPONENT);
+        if threshold == SCALE {
+            return Some(Self::ONE);
+        }
+
+        debug_assert!(threshold < u64::MAX as u128);
+        Some(Self(threshold as u64))
+    }
+
     /// Returns whether this probability never occurs.
     pub const fn is_zero(self) -> bool {
         self.0 == Self::ZERO.0
@@ -76,15 +118,17 @@ impl Probability {
     }
 }
 
-/// Creates a [`Probability`] from an integer numerator and denominator.
+/// Creates a [`Probability`] from an integer ratio or an exactly representable `f64`.
 ///
-/// Literal arguments are validated at compile time. Expression arguments are validated at
-/// runtime.
+/// The two-argument form preserves the exact ratio. The one-argument form preserves the exact
+/// IEEE-754 value and accepts only a literal that maps exactly to a 64-bit threshold. Ratio
+/// literals are validated at compile time; ratio expressions are validated at runtime.
 ///
 /// # Panics
 ///
-/// The expression form panics if the denominator is zero or the numerator exceeds the
-/// denominator. Use [`Probability::new`] to validate untrusted values without panicking.
+/// The ratio expression form panics if its denominator is zero or its numerator exceeds the
+/// denominator. Use [`Probability::new`] or [`Probability::from_f64`] to validate untrusted values
+/// without panicking.
 ///
 /// # Examples
 ///
@@ -92,13 +136,21 @@ impl Probability {
 /// use commonware_utils::Probability;
 ///
 /// const HALF: Probability = Probability!(1, 2);
+/// const NINETY_EIGHT_PERCENT: Probability = Probability!(0.98);
 /// assert_eq!(HALF.as_f64(), 0.5);
+/// assert_eq!(NINETY_EIGHT_PERCENT.as_f64(), 0.98);
 /// ```
 ///
 /// ```compile_fail
 /// use commonware_utils::Probability;
 ///
 /// const INVALID: Probability = Probability!(2, 1);
+/// ```
+///
+/// ```compile_fail
+/// use commonware_utils::Probability;
+///
+/// const REQUIRES_ROUNDING: Probability = Probability!(1e-20);
 /// ```
 #[cfg(not(any(
     commonware_stability_GAMMA,
@@ -108,6 +160,13 @@ impl Probability {
 )))] // BETA
 #[macro_export]
 macro_rules! Probability {
+    ($value:literal) => {
+        const {
+            $crate::Probability::from_f64($value).expect(
+                "probability requires a value in [0, 1] exactly representable as a 64-bit threshold",
+            )
+        }
+    };
     ($numerator:literal, $denominator:literal) => {
         const {
             $crate::Probability::new($numerator, $denominator)
@@ -159,6 +218,51 @@ mod tests {
         assert_eq!(Probability!(1, 2).as_f64(), 0.5);
         assert!(Probability::new(1, 0).is_none());
         assert!(Probability::new(2, 1).is_none());
+    }
+
+    #[test]
+    fn f64_construction_preserves_clean_binary_value() {
+        const FROM_LITERAL: Probability = Probability!(0.98);
+        const MINIMUM_INTERIOR: f64 = f64::from_bits(959u64 << 52);
+
+        assert_eq!(FROM_LITERAL.0, 18_077_809_192_235_360_256);
+        assert_eq!(FROM_LITERAL.as_f64(), 0.98);
+        assert_ne!(FROM_LITERAL, Probability!(49, 50));
+        assert_eq!(Probability!(0.5), Probability!(1, 2));
+        assert_eq!(Probability::from_f64(0.0), Some(Probability::ZERO));
+        assert_eq!(Probability::from_f64(-0.0), Some(Probability::ZERO));
+        assert_eq!(Probability::from_f64(1.0), Some(Probability::ONE));
+        assert_eq!(
+            Probability::from_f64(MINIMUM_INTERIOR),
+            Some(Probability(1))
+        );
+
+        let below_one = f64::from_bits(1.0f64.to_bits() - 1);
+        assert_eq!(
+            Probability::from_f64(below_one).unwrap().as_f64(),
+            below_one
+        );
+    }
+
+    #[test]
+    fn f64_construction_rejects_lossy_or_invalid_values() {
+        const BELOW_MINIMUM: f64 = f64::from_bits(958u64 << 52);
+        const MINIMUM_INTERIOR_BITS: u64 = 959u64 << 52;
+
+        for value in [
+            BELOW_MINIMUM,
+            f64::from_bits(MINIMUM_INTERIOR_BITS + 1),
+            f64::from_bits(1),
+            -0.1,
+            1.1,
+            f64::from_bits(1.0f64.to_bits() + 1),
+            f64::NAN,
+            f64::from_bits(f64::NAN.to_bits() | (1u64 << 63)),
+            f64::INFINITY,
+            f64::NEG_INFINITY,
+        ] {
+            assert!(Probability::from_f64(value).is_none());
+        }
     }
 
     #[test]

--- a/utils/src/probability.rs
+++ b/utils/src/probability.rs
@@ -8,6 +8,13 @@ const SCALE: u128 = 1u128 << u64::BITS;
 // Biased `f64` exponent where scaling by 2^64 leaves the 53-bit significand unshifted.
 const SCALED_EXPONENT: u64 = 1023 + 52 - 64;
 
+/// Error returned when an `f64` cannot be represented as a probability.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
+#[error(
+    "probability must be finite, within [0, 1], and exactly representable as a 64-bit threshold"
+)]
+pub struct InvalidProbability;
+
 /// A probability represented as a threshold over all possible `u64` samples.
 ///
 /// Ratios are rounded down to the nearest multiple of 2^-64. Sampling consumes one `u64` for
@@ -41,7 +48,7 @@ impl Probability {
     ///
     /// Returns [`None`] if `value` is not finite, is outside `[0, 1]`, or would require rounding.
     /// The exact IEEE-754 value is preserved rather than interpreting its source spelling as a
-    /// decimal ratio.
+    /// decimal ratio. Use [`TryFrom`] when const evaluation is not required.
     pub const fn from_f64(value: f64) -> Option<Self> {
         let bits = value.to_bits();
         let magnitude = bits & (u64::MAX >> 1);
@@ -71,6 +78,7 @@ impl Probability {
             return Some(Self(u64::MAX));
         }
 
+        // Exact one is handled above, so the narrowed threshold cannot use its reserved sentinel.
         assert!(threshold < u64::MAX as u128);
         Some(Self(threshold as u64))
     }
@@ -112,6 +120,14 @@ impl Probability {
     }
 }
 
+impl TryFrom<f64> for Probability {
+    type Error = InvalidProbability;
+
+    fn try_from(value: f64) -> Result<Self, Self::Error> {
+        Self::from_f64(value).ok_or(InvalidProbability)
+    }
+}
+
 /// Creates a [`Probability`] from an integer ratio or an exactly representable `f64`.
 ///
 /// The two-argument form preserves the exact ratio. The one-argument form preserves the exact
@@ -121,7 +137,7 @@ impl Probability {
 /// # Panics
 ///
 /// The ratio expression form panics if its denominator is zero or its numerator exceeds the
-/// denominator. Use [`Probability::new`] or [`Probability::from_f64`] to validate untrusted values
+/// denominator. Use [`Probability::new`] or [`Probability::try_from`] to validate untrusted values
 /// without panicking.
 ///
 /// # Examples
@@ -226,6 +242,7 @@ mod tests {
         assert_eq!(FROM_LITERAL.as_f64(), 0.98);
         assert_ne!(FROM_LITERAL, Probability!(49, 50));
         assert_eq!(Probability!(0.5), Probability!(1, 2));
+        assert_eq!(Probability::try_from(0.5), Ok(Probability!(0.5)));
         assert_eq!(Probability::from_f64(0.0), Some(Probability!(0.0)));
         assert_eq!(Probability::from_f64(-0.0), Some(Probability!(0.0)));
         assert_eq!(Probability::from_f64(1.0), Some(Probability!(1.0)));
@@ -259,6 +276,7 @@ mod tests {
             f64::NEG_INFINITY,
         ] {
             assert!(Probability::from_f64(value).is_none());
+            assert_eq!(Probability::try_from(value), Err(InvalidProbability));
         }
     }
 

--- a/utils/src/probability.rs
+++ b/utils/src/probability.rs
@@ -13,12 +13,6 @@ const SCALE: u128 = 1u128 << u64::BITS;
 pub struct Probability(u64);
 
 impl Probability {
-    /// A probability that never occurs.
-    pub const ZERO: Self = Self(0);
-
-    /// A probability that always occurs.
-    pub const ONE: Self = Self(u64::MAX);
-
     /// Creates a probability from `numerator / denominator`.
     ///
     /// Returns [`None`] if the denominator is zero or the numerator exceeds the denominator.
@@ -28,13 +22,13 @@ impl Probability {
         }
 
         if numerator == denominator {
-            return Some(Self::ONE);
+            return Some(Self(u64::MAX));
         }
 
         let threshold = ((numerator as u128) << u64::BITS) / denominator as u128;
 
         // A proper fraction with a `u64` denominator is at least 2^-64 below one, so its rounded
-        // threshold cannot collide with the sentinel reserved for `ONE`.
+        // threshold cannot collide with the sentinel reserved for probability one.
         debug_assert!(threshold < u64::MAX as u128);
         Some(Self(threshold as u64))
     }
@@ -49,7 +43,7 @@ impl Probability {
         let magnitude = bits & (u64::MAX >> 1);
 
         if magnitude == 0 {
-            return Some(Self::ZERO);
+            return Some(Self(0));
         }
         if bits != magnitude || magnitude > 1.0f64.to_bits() {
             return None;
@@ -74,7 +68,7 @@ impl Probability {
 
         let threshold = (significand as u128) << (exponent - SCALED_EXPONENT);
         if threshold == SCALE {
-            return Some(Self::ONE);
+            return Some(Self(u64::MAX));
         }
 
         debug_assert!(threshold < u64::MAX as u128);
@@ -83,12 +77,12 @@ impl Probability {
 
     /// Returns whether this probability never occurs.
     pub const fn is_zero(self) -> bool {
-        self.0 == Self::ZERO.0
+        self.0 == 0
     }
 
     /// Returns whether this probability always occurs.
     pub const fn is_one(self) -> bool {
-        self.0 == Self::ONE.0
+        self.0 == u64::MAX
     }
 
     /// Converts this probability to an `f64` in the inclusive range `[0, 1]`.
@@ -212,8 +206,11 @@ mod tests {
 
     #[test]
     fn construction() {
-        assert_eq!(Probability::new(0, u64::MAX), Some(Probability::ZERO));
-        assert_eq!(Probability::new(u64::MAX, u64::MAX), Some(Probability::ONE));
+        assert_eq!(Probability::new(0, u64::MAX), Some(Probability!(0.0)));
+        assert_eq!(
+            Probability::new(u64::MAX, u64::MAX),
+            Some(Probability!(1.0))
+        );
         assert_eq!(Probability!(1, 2), Probability!(2, 4));
         assert_eq!(Probability!(1, 2).as_f64(), 0.5);
         assert!(Probability::new(1, 0).is_none());
@@ -229,9 +226,9 @@ mod tests {
         assert_eq!(FROM_LITERAL.as_f64(), 0.98);
         assert_ne!(FROM_LITERAL, Probability!(49, 50));
         assert_eq!(Probability!(0.5), Probability!(1, 2));
-        assert_eq!(Probability::from_f64(0.0), Some(Probability::ZERO));
-        assert_eq!(Probability::from_f64(-0.0), Some(Probability::ZERO));
-        assert_eq!(Probability::from_f64(1.0), Some(Probability::ONE));
+        assert_eq!(Probability::from_f64(0.0), Some(Probability!(0.0)));
+        assert_eq!(Probability::from_f64(-0.0), Some(Probability!(0.0)));
+        assert_eq!(Probability::from_f64(1.0), Some(Probability!(1.0)));
         assert_eq!(
             Probability::from_f64(MINIMUM_INTERIOR),
             Some(Probability(1))
@@ -283,8 +280,8 @@ mod tests {
     #[test]
     fn sampling_uses_threshold_and_skips_endpoints() {
         let mut rng = CountingRng { value: 0, calls: 0 };
-        assert!(!Probability::ZERO.sample(&mut rng));
-        assert!(Probability::ONE.sample(&mut rng));
+        assert!(!Probability!(0.0).sample(&mut rng));
+        assert!(Probability!(1.0).sample(&mut rng));
         assert_eq!(rng.calls, 0);
 
         rng.value = (1u64 << 63) - 1;


### PR DESCRIPTION
## Summary

- Add a BETA `commonware_utils::Probability`, an 8-byte validated threshold type with integer-ratio construction, lossless compile-time-checked floating-point literals, and deterministic `u64` sampling.
- Make invalid probabilities unrepresentable while preserving no-draw `ZERO` and `ONE` endpoints; convert back to `f64` only at foreign API boundaries.
- Migrate simulated P2P delivery, deterministic storage faults, tracing sampling, and downstream examples, tests, and fuzz targets from raw `f64`.
- Preserve existing behavior: decimal literals retain their IEEE-754 threshold, dynamic percentages use exact integer arithmetic, and storage Prefix/Subset retention and independent resize rolls are unchanged.

## Semantics

`Probability!(0.98)` preserves the evaluated IEEE-754 value when it maps losslessly to the 2^-64 threshold grid. `Probability!(49, 50)` instead maps the integer ratio to that grid with defined round-down behavior. `from_f64` rejects values that require rounding, as well as NaN, infinity, negatives, and values above one.

Interior sampling consumes one `next_u64`; `ZERO` and `ONE` consume none. This makes decisions platform-independent for the same `u64` stream.

## Change size

- Production: 333 changed LOC (+253/-80)
- Tests/test infrastructure: 985 changed LOC (+541/-444)

Counts are additions plus deletions against `atomic-blobs-runtime-prerequisites`; fuzz, tests, mocks, and `TESTING.md` files plus lines inside `mod test(s)` are test infrastructure. All other changed lines are production.
