### PR TITLE
[storage] Evict superseded locations from the snapshot-build cache

### DIFF
--- a/storage/src/qmdb/any/unordered/fixed.rs
+++ b/storage/src/qmdb/any/unordered/fixed.rs
@@ -635,23 +635,42 @@ pub(crate) mod test {
     }
 
     /// The init-time `(location -> key)` cache only memoizes log reads, so rebuilding the snapshot
-    /// with the cache disabled (`init_cache_size = None`) or enabled must produce the identical root.
+    /// with the cache disabled (`init_cache_size = None`) or enabled must produce the identical
+    /// root and key-value state.
     #[test_traced("WARN")]
     fn test_unordered_fixed_init_cache_equivalence() {
         deterministic::Runner::default().start(|context| async move {
-            // Populate a database with churny operations (repeated updates and deletes drive the
-            // collision resolution that the cache accelerates), then commit and drop it.
+            // Populate a database with enough keys to drive collision resolution in the compressed
+            // index, then commit and drop it.
             let cfg = fixed_db_config::<TwoCap>("cache_equiv", &context);
             let db = AnyTest::init(context.child("populate"), cfg).await.unwrap();
-            let db = apply_ops(db, create_test_ops(10_000)).await;
+
+            // Track the expected key-value state alongside the applied ops. The `any` root is a
+            // pure function of the immutable log, so only a state check can catch a snapshot
+            // rebuilt into the wrong index.
+            let ops = create_test_ops(10_000);
+            let mut expected = HashMap::new();
+            for op in &ops {
+                match op {
+                    Operation::Update(Update(key, value)) => {
+                        expected.insert(*key, Some(*value));
+                    }
+                    Operation::Delete(key) => {
+                        expected.insert(*key, None);
+                    }
+                    Operation::CommitFloor(_, _) => unreachable!(),
+                }
+            }
+            let db = apply_ops(db, ops).await;
             let db = db.commit().await.unwrap();
             let db = db.sync().await.unwrap();
             let root = db.root();
             drop(db);
 
-            // Reopen with the cache disabled and with a large cache; both rebuild the snapshot by
-            // replaying the same immutable log, so both roots must equal the pre-drop root.
-            for cache_size in [None, Some(NZUsize!(1 << 20))] {
+            // Reopen with the cache disabled, with a tiny multi-entry cache that evicts throughout
+            // replay, and with a large cache. All rebuild the snapshot from the same immutable log,
+            // so every root and key-value result must match the pre-drop state.
+            for cache_size in [None, Some(NZUsize!(2)), Some(NZUsize!(1 << 20))] {
                 let mut cfg = fixed_db_config::<TwoCap>("cache_equiv", &context);
                 cfg.init_cache_size = cache_size;
                 let ctx = context
@@ -663,6 +682,13 @@ pub(crate) mod test {
                     root,
                     "root mismatch at cache_size={cache_size:?}"
                 );
+                for (key, value) in &expected {
+                    assert_eq!(
+                        db.get(key).await.unwrap(),
+                        *value,
+                        "state mismatch at cache_size={cache_size:?}"
+                    );
+                }
                 drop(db);
             }
         });

--- a/storage/src/qmdb/mod.rs
+++ b/storage/src/qmdb/mod.rs
@@ -343,12 +343,13 @@ where
 }
 
 /// Delete `key` at `cursor` (obtained from a `get_mut` lookup of `key`), returning its location if
-/// it was present among the cursor's conflicts.
+/// it was present among the cursor's conflicts. When supplied, the matched location is removed
+/// from `cache` with the snapshot deletion.
 async fn delete_at_cursor<F, C, R>(
     mut cursor: C,
     reader: &R,
     key: &<R::Item as Operation<F>>::Key,
-    cache: Option<&mut Clock<u64, <R::Item as Operation<F>>::Key>>,
+    mut cache: Option<&mut Clock<u64, <R::Item as Operation<F>>::Key>>,
 ) -> Result<Option<Location<F>>, Error<F>>
 where
     F: Family,
@@ -357,10 +358,17 @@ where
     R::Item: Operation<F>,
 {
     // Find the matching key among all conflicts, then delete it.
-    let Some(loc) = find_update_op::<F, _>(reader, &mut cursor, key, cache).await? else {
+    let Some(loc) = find_update_op::<F, _>(reader, &mut cursor, key, cache.as_deref_mut()).await?
+    else {
         return Ok(None);
     };
+
+    // Cache entries mirror current snapshot locations, so invalidate the matched location with
+    // the authoritative deletion.
     cursor.delete();
+    if let Some(cache) = cache {
+        cache.remove(&*loc);
+    }
 
     Ok(Some(loc))
 }
@@ -389,13 +397,14 @@ where
 
 /// Update `key` to `new_loc` at `cursor` (obtained from a `get_mut_or_insert` lookup of `key`),
 /// returning its old location if it was present among the cursor's conflicts; otherwise `new_loc`
-/// is inserted at the cursor.
+/// is inserted at the cursor. When supplied, the matched old location is removed from `cache` with
+/// the snapshot update.
 async fn update_at_cursor<F, C, R>(
     mut cursor: C,
     reader: &R,
     key: &<R::Item as Operation<F>>::Key,
     new_loc: Location<F>,
-    cache: Option<&mut Clock<u64, <R::Item as Operation<F>>::Key>>,
+    mut cache: Option<&mut Clock<u64, <R::Item as Operation<F>>::Key>>,
 ) -> Result<Option<Location<F>>, Error<F>>
 where
     F: Family,
@@ -404,9 +413,16 @@ where
     R::Item: Operation<F>,
 {
     // Find the matching key among all conflicts, then update its location.
-    if let Some(loc) = find_update_op::<F, _>(reader, &mut cursor, key, cache).await? {
+    if let Some(loc) =
+        find_update_op::<F, _>(reader, &mut cursor, key, cache.as_deref_mut()).await?
+    {
+        // Removing the superseded cache entry with the snapshot update lets the caller reuse its
+        // slot for `new_loc` instead of evicting another live entry.
         assert!(new_loc > loc);
         cursor.update(new_loc);
+        if let Some(cache) = cache {
+            cache.remove(&*loc);
+        }
         return Ok(Some(loc));
     }
 
@@ -437,7 +453,10 @@ where
             let op = reader.read(*loc).await?;
             let k = op.key().expect("operation without key");
             let matches = *k == *key;
-            if let Some(cache) = cache.as_deref_mut() {
+
+            // Every caller immediately mutates a match. Admitting it here could evict a live
+            // candidate before the caller invalidates this location.
+            if !matches && let Some(cache) = cache.as_deref_mut() {
                 cache.put(*loc, k.clone());
             }
             matches


### PR DESCRIPTION
## Summary

During snapshot init, every replayed update inserts its `(location -> key)` mapping into the init cache, but the location it supersedes stayed resident until CLOCK eviction happened to recycle it. This PR removes the superseded entry eagerly on update (and likewise on delete) since the old location is no longer active.

The cache now holds at most one entry per active key instead of one per replayed update. This changes what `init_cache_size` buys: capacity maps directly to live keys, the eviction victim pool contains only live entries, and effective coverage equals capacity instead of capacity minus whatever fraction is superseded dead weight at any moment.

## Benchmarks

Same matrix as #4098 (100K elements, 1M updates and deletes, `cargo bench -p commonware-storage --bench qmdb --features test-traits -- init`), baseline vs this branch back to back: no performance change when the cache is large enough to hold all live keys (24 cache-enabled variants, median change roughly 0%, every delta within the noise floor set by the inert `cache=0` rows). At that provisioning the baseline recycles superseded entries nearly for free, so eager removal has nothing to save; the win appears in the underprovisioned regime below.

The undersized regime is where the change matters most. Setup: two snapshot builds from the same database copy, base vs this PR, each given a 32 minute window. The log is a 451GB Ethereum pre-merge operations log whose live-key count reaches 679M, far beyond the 268M-entry cache (split across 7 init workers). Init probes are the only source of journal reads during a build, so the journal read counters measure cache misses directly.

Two comparisons, differing in what is held equal:

| comparison | base | this PR |
|---|---|---|
| cache misses after replaying the same amount of log (up to the 613M-live-key mark) | 26.6M | roughly 20.5M (-23%) |
| amount of log replayed in the same 32 minutes | 613M live keys reached | 679M live keys reached (+11%) |

The first row holds the work equal and isolates cache effectiveness. The second row is its throughput consequence: misses compete with the replay stream for disk reads, so fewer misses means the build moves through the log faster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PG6CDm2eHLMgiVupMECBiU


