### PR TITLE
feat(cryptography): batched G1 subgroup-membership checks

### DIFF
--- a/cryptography/BATCHED_SUBGROUP.md
+++ b/cryptography/BATCHED_SUBGROUP.md
@@ -6,15 +6,21 @@ The shipping implementation is `bls12381::primitives::subgroup::batch_in_g1`
 (Strategy C below); a naive-bucketing prototype (Strategy B) is preserved on
 `gv/subgroup-bucketed-prototype`.
 
-All timings in this document are from an 18-core Apple Silicon machine.
+Unless stated otherwise, timings in this document come from a 4-core Intel
+Xeon (Cascade Lake, 2.8 GHz, 1 MiB L2 per core, 33 MiB L3) and are single-shot
+best-of-three medians from the manual harnesses in `subgroup.rs`. On that
+machine one exact per-point check costs ~52 µs, one field multiplication
+~43 ns, and one batch-affine point addition ~344 ns, so a check is worth about
+150 point additions — the ratio that decides every number below.
 
 ## The problem
 
 A decoded curve point can lie outside the prime-order subgroup; using it in a
 pairing or scalar multiplication enables small-subgroup attacks. blst's exact
 per-point check (Scott, [2021/1130](https://eprint.iacr.org/2021/1130), the
-endomorphism test) costs **~22 µs per point**, so a 6000-point batch costs
-~127 ms checked one at a time.
+endomorphism test) costs a ~128-bit scalar multiplication — about 1200 field
+multiplications, or ~52 µs here — so a 100 000-point batch costs 5.2 s checked
+one at a time.
 
 Every point splits as `P = G + T` with `G` in-subgroup and `T` a "cofactor
 part" in the group of order
@@ -47,12 +53,12 @@ Verified footguns:
   insufficient. The code divides by a strict lower bound on `log₂3`.
 - **Coefficient uniformity.** The margin is 0.38 bits. A biased `byte % 3`
   (max probability 86/256) yields 127.5 bits — below target. The implementation
-  rejection-samples (bytes < 243 → five exact trits); this is load-bearing.
+  rejection-samples (words < 3²⁰ → twenty exact trits); this is load-bearing.
 - **Odd cofactor required.** An order-2 part `T` has `2T = 0`: escape
   probability 2/3 per combination. BLS12-377 G1 (`2^92 | h`) cannot use this
   scheme as-is.
 
-## Strategy A — one combination per round (previous implementation)
+## Strategy A — one combination per round (first implementation)
 
 Per round: draw `c_i ∈ {0,1,2}` per point, evaluate `Q = Σ c_i·P_i` as one
 2-bit Pippenger MSM (blst), check `Q`. Needs 81 rounds — i.e. **81 full
@@ -62,13 +68,12 @@ accumulation passes over the `n` points**, one check each.
 
 Per round: assign each point a uniform bucket in `{0,…,B−1}`, sum each bucket,
 check **each** bucket sum. A cancelling pair escapes a round only by colliding
-in one bucket → `1/B` per round → `⌈security/log₂B⌉` rounds (32 at B=16).
+in one bucket → `1/B` per round → `⌈security/log₂B⌉` rounds.
 
-Fewer accumulation passes, but a fixed `rounds × B` check floor (512 × 22 µs ≈
-11.3 ms serial at B=16) plus — implemented naively with one `blst_p1s_add` per
-bucket — one field-inversion chain per bucket per round. **Measured: loses to A
-at n=1000 (15.9 vs 12.1 ms serial) and wins only ~1.35× at n=6000 (46 vs
-63 ms).** Rejected; prototype preserved for reference.
+Fewer accumulation passes, but a fixed `rounds × B` check floor that dwarfs
+everything else: at 128-bit security the round count falls only as `1/log₂B`
+while the check count grows as `B`. Rejected; prototype preserved for
+reference.
 
 ## Strategy C — m parallel combinations per round (shipping)
 
@@ -80,76 +85,132 @@ trits = a base-3 bucket id in `[0, 3^m)`), and evaluate all m combinations
    together — `3^m` buckets, but still only `n` point additions total (each
    point lands in exactly one bucket). This is the key: *one accumulation pass
    serves m combinations.*
-2. **Batch-affine accumulation (the inversion trick).** Each pass pairs up the
-   remaining points of every bucket and completes all pairs with a single
-   shared field inversion (Montgomery's trick): ~6 field multiplications per
-   addition instead of an inversion (~150 ns/point measured, flat in bucket
-   count). Hand-rolled over `blst_fp`; blst's Pippenger does not expose bucket
-   sums.
-3. **Combine deterministically.** `Q_j = Σ_{v_j=1} S_v + 2·Σ_{v_j=2} S_v`,
+2. **Combine deterministically.** `Q_j = Σ_{v_j=1} S_v + 2·Σ_{v_j=2} S_v`,
    where `v_j` is the j-th base-3 digit of the bucket index. The weights are
    deterministic digits — all randomness is in the vector assignment — so this
    evaluates exactly the m combinations (it is *not* the unsound re-randomized
    sum over bucket sums, which would collapse back to one combination).
-4. **Check the m outputs.** Soundness per round = `3^-m` (product of m
-   independent 1/3 bounds); `r = ⌈81/m⌉` rounds at 128-bit.
+3. **Check the m outputs.** Soundness per round = `3^-m` (product of m
+   independent 1/3 bounds); `r ≈ 81/m` rounds at 128-bit.
 
 `m` (and whether to batch at all) is chosen per batch by a cost model;
 soundness holds for every choice, so the model's constants only affect
-performance. In practice: n=1000 → m=3 (27 rounds), n=6000 → m=4 (21 rounds);
-n ≲ 120 falls back to per-point checks (run through the strategy, so they
-still parallelize).
+performance.
 
 ### Why C dominates B
 
 At equal per-round soundness (`B = 3^m` buckets), B checks all `3^m` bucket
 sums where C checks only `m` combinations — C's total check count stays at
-`r·m ≈ 81–85` for any m (the same as A), while B's grows as `rounds × B`. And
-C's shared-inversion accumulation removes B's per-bucket inversion chains.
+`r·m ≈ 81` for any m (the same as A), while B's grows as `rounds × B`.
 
-## Cost accounting (128-bit security)
+## What the cost actually is
 
-| quantity                    | A (one RLC) | B naive (B=16) | C (m=4, shipping) |
-|-----------------------------|:-----------:|:--------------:|:-----------------:|
-| accumulation passes over n  | 81          | 32             | **21**            |
-| subgroup checks             | 81          | **512**        | 84                |
-| shared-inversion adds       | yes (blst)  | no             | yes (hand-rolled) |
+A pass over the points buys at most `log₂(3^m)` bits of soundness, whatever
+the round does with its bucket sums: a lone bad point escapes whenever its
+coefficient vector is the zero vector, which has probability `3^-m`. So the
+additions per point are
 
-## Measured results (criterion medians, same machine)
+```
+adds/point ≈ (128 / log₂B) · (1 + B/n),     B = 3^m
+```
 
-| n    | per-point | A serial | A parallel | C serial          | C parallel         |
-|------|-----------|----------|------------|-------------------|--------------------|
-| 100  | 2.14 ms   | 2.18 ms* | 2.19 ms*   | 2.13 ms (fallback)| **0.31 ms (7×)**   |
-| 1000 | 21.4 ms   | 12.1 ms  | 1.59 ms    | **6.50 ms (3.3×)**| **1.16 ms (18.5×)**|
-| 6000 | 126.6 ms  | 63.1 ms  | 6.9 ms     | **22.6 ms (5.6×)**| **4.10 ms (30.9×)**|
+— one addition per point per pass for the accumulation, plus about two per
+occupied bucket for the combine. Minimizing over `B` gives ~10.8 additions per
+point at n = 100 000 and ~9.2 at n = 10⁶; the floor is 9 passes, because
+`⌈81/m⌉ = 9` for every width the cost model will accept. At six field
+multiplications per batch-affine addition, that is 55–65 multiplications per
+point against ~1200 for an exact check — a ceiling of 18–21×, which the
+implementation reaches to within about 15%.
 
-Speedups in parentheses are vs per-point serial. (*) A's n=100 numbers predate
-routing the per-point fallback through the parallel strategy; C's 0.31 ms at
-n=100 comes from that routing, not from batching.
+This is why the speedup grows with the batch and then flattens: the `B/n` term
+and the fixed costs (converting to affine, drawing coefficients) amortize away,
+but nine passes do not.
 
-Isolated accumulator throughput: 146–178 ns/point, flat across 27–243 buckets
-and n up to 100 000 (confirming accumulation cost is independent of bucket
-count, with no cache cliff at large n).
+## The engine
 
-Same-engine strategy comparison (`measure_strategies` harness, single-shot; A
-and B are emulated on the shipped accumulation engine so the comparison
-isolates the strategy — blst's MSM engine runs A's passes ~15% faster):
+Three implementation choices carry most of the constant:
 
-| n       | per-point | A (81 passes)   | B (best of 16/64/256) | C (shipping)          |
-|---------|-----------|-----------------|-----------------------|-----------------------|
-| 1 000   | 21.4 ms   | 15.5 / 2.38 ms  | 15.9 / 2.40 (B=16)    | **6.6 / 1.13 ms**     |
-| 6 000   | 126.5 ms  | 74.9 / 8.86 ms  | 40.1 / 4.49 (B=16)    | **22.4 / 3.62 ms**    |
-| 100 000 | 2 126 ms  | 1 249 / 138 ms  | 353 / 47.8 (B=256)    | **298 / 49.6 ms**     |
+- **Streaming accumulation with shared inversions.** A bucket's slot holds its
+  running sum; additions are queued, and a chunk of 1024 of them shares one
+  field inversion (Montgomery's trick), about six field multiplications per
+  addition. A bucket with a queued addition is closed until its chunk
+  completes, and a point arriving meanwhile is carried to the next pass — with
+  uniform bucket ids only ~5% of points ever are. A point is therefore read
+  once, added once, and never copied to a work list. Slots are touched in
+  random order, so the accumulator prefetches the slot each point will land in
+  a couple of dozen iterations ahead.
+- **A shared collapse for the combine.** Recovering the `m` combinations one at
+  a time touches `2·3^(m-1)` bucket sums each, which caps `m` where the combine
+  costs more than the accumulation it saves. Summing away one digit at a time
+  instead (level `j+1` is level `j` with its lowest remaining digit collapsed)
+  yields every digit's marginals for about two additions per bucket in total,
+  and the marginals of all levels reduce together so a handful of inversions
+  cover the whole combine. This is what makes `m = 9` affordable — and `m = 9`
+  is what turns 17 passes into 9.
+- **Field arithmetic without ceremony.** `blst_fp_add`/`blst_fp_sub` are
+  replaced by inlined carry chains (the call and the mandatory zeroing of the
+  out-parameter cost more than the arithmetic), multiplications write into
+  `MaybeUninit` rather than a zeroed temporary, and each addition consumes its
+  inverse where the inversion's backward walk produces it, so no inverse is
+  ever written to memory.
 
-(serial / parallel per cell.) C wins serially at every size — 7.1× over
-per-point and 4.2× over A at n=100 000 (42.8× parallel). One caveat: at
-n=100 000 parallel, B=256 ties C within noise. B's optimal bucket count grows
-with n, and C's width cap (`m ≤ 5`, u8 bucket ids) binds there — the model puts
-m=6 (u16 ids, 729 buckets) ~13% ahead at that size, a possible follow-up.
+A round's bucket slots are the accumulator's working set, so the cost model
+caps the width at what fits a 2 MiB budget (`3^9` slots). Measured one step
+past it, cost per addition rises 20% at `m = 10` and 34% at `m = 11` — more
+than the extra combinations repay.
 
-External reference: zexe's own batched check (Strategy B with shared
-inversions, arkworks field arithmetic, pre-2021 `[r]P` per-bucket check)
-measured on this machine at n=8192: 207 ms naive → 30.7 ms batched parallel.
+## Measured results
+
+Serial (single-threaded) and parallel (4 threads), against per-point checking:
+
+| n         | per-point | C serial          | C parallel         |
+|-----------|-----------|-------------------|--------------------|
+| 200       | 10.5 ms   | 7.2 ms (1.5×)     | 3.2 ms (3.3×)      |
+| 1 000     | 54.0 ms   | 12.7 ms (4.2×)    | 5.4 ms (10.0×)     |
+| 6 000     | 318 ms    | 39.2 ms (8.1×)    | 19.3 ms (16.5×)    |
+| 100 000   | 5.21 s    | 430 ms (12.1×)    | 174 ms (29.9×)     |
+| 300 000   | 15.6 s    | 1.11 s (14.1×)    | 465 ms (33.6×)     |
+| 1 000 000 | 53.0 s    | **3.52 s (15.1×)**| 1.56 s (34.0×)     |
+| 3 000 000 | 157 s     | 10.8 s (14.5×)    | 4.42 s (35.6×)     |
+
+Run-to-run spread on this (shared, virtualized) machine is ±5% — the large
+sizes have measured anywhere from 14.5× to 15.3× serial across runs — so read
+them as "about 15× serial", not as a sharp figure. The `n = 200` row sits just
+above the per-point fallback threshold: below it the cost model declines to
+batch at all.
+
+For reference, the previous implementation of this same strategy measured
+4.7× serial at n = 100 000 on this machine (1.15 s), against 430 ms now.
+
+Chosen plans: 14 rounds of width 6/5 at n = 200, 13 rounds of width 7/6 at
+n = 6 000, 9 rounds of width 9 from n = 100 000 up.
+
+Phase breakdown at n = 10⁶ (3.5 s total): 3.2 s in the nine rounds, 0.38 s
+converting the batch to affine, 0.04 s drawing coefficients. The conversion is
+7 field multiplications per point against 54 for the rounds, and it disappears
+entirely for callers whose points arrive already affine (as decoded points do).
+
+## Same-engine strategy comparison
+
+All three strategies run on the shipped accumulation engine (`measure_strategies`,
+single-shot), so the comparison isolates the strategy rather than the engine:
+
+| n       | per-point | A (81 passes) | B, best width      | C (shipping)      |
+|---------|-----------|---------------|--------------------|-------------------|
+| 6 000   | 315 ms    | ~167 ms*      | 144 ms (B=81, r=21)| **38.7 ms**       |
+| 100 000 | 5.16 s    | ~2.79 s*      | 1.02 s (B=81, r=21)| **0.41 s**        |
+
+(*) A's row is projected, not measured: `81 · n` additions at the engine's
+measured 344 ns. Running A on this engine literally (`m = 1`) measures 13.4 s at
+n = 100 000, because three buckets leave at most three additions in flight and
+the shared inversion has nothing to amortize over — a batch-affine engine is
+simply the wrong engine for a one-combination round, which is why the original
+Strategy A used blst's Jacobian MSM. Either way A needs 81 passes where C needs
+9.
+
+B was measured at `B ∈ {9, 81, 729}` with `rounds = ⌈81/log₃B⌉`; 81 is its best
+width at both sizes, and its check floor (`rounds × B` exact checks — 1701
+checks at B=81, r=21) is what keeps it 2.5× behind C.
 
 ## Related work
 
@@ -180,24 +241,33 @@ round) reach the target. Points of comparison, from the paper itself:
   appear in the paper.
 
 Strategy C therefore fills exactly the gap their cost model assumes away: it
-makes the no-prefilter multi-combination route cost `⌈81/m⌉` passes instead of
+makes the no-prefilter multi-combination route cost `≈81/m` passes instead of
 81 MSMs, which is what turns batch SMT on **unmodified BLS12-381** from "slower
-than naive" (their result) into 3.2–7.1× serial (7.1–7.4 across runs at
-n=100 000) and 18–43× parallel (ours, at a stronger 2⁻¹²⁸ target). Their binary-coefficient variant also shows how C
+than naive" (their result) into 8–15× serial and 19–37× parallel (ours, at a
+stronger 2⁻¹²⁸ target). Their binary-coefficient variant also shows how C
 extends to even-cofactor curves (e.g. BLS12-377): use `{0,1}` coefficient
 vectors (2^m buckets, 1 bit per combination, 128 total) instead of trits.
+
+Note that a faster field multiplication would *lower* these ratios, not raise
+them: the exact check is almost pure multiplication while the batched path is
+part multiplication and part memory traffic. The multiplication-count ceiling
+above (18–21×) is the machine-independent statement.
 
 ## Status
 
 Strategy C is implemented in `subgroup::batch_in_g1` with:
 
 - soundness-bearing details in the module docs (odd-cofactor proof, exact-trit
-  requirement, deterministic-combine clarification);
+  requirement, deterministic-combine clarification, and why a pass cannot beat
+  `3^-m`);
 - an accumulator oracle test (fuzz vs naive G1 addition over mixed
   good/bad/identity/negated/duplicated points) plus deterministic tests for
   every special-case branch (cancelling pairs, doubling chains, identity
-  inputs, odd leftovers, empty buckets);
-- adversarial batch tests (cancelling bad pair, repeated bad point);
+  inputs, wide plans, empty buckets);
+- an oracle test for the inlined field arithmetic against `blst_fp_add` /
+  `blst_fp_sub`, and for the affine conversion against `blst_p1s_to_affine`;
+- adversarial batch tests (cancelling bad pair, repeated bad point, identity
+  padding);
 - `cargo miri` cannot run the module (blst FFI is unsupported by miri); the
-  unsafe surface is thin per-call FFI wrappers, with all pass-scheduling logic
-  in safe Rust under the oracle tests.
+  unsafe surface is thin per-call FFI wrappers plus prefetch hints, with all
+  pass-scheduling logic in safe Rust under the oracle tests.

--- a/cryptography/BATCHED_SUBGROUP.md
+++ b/cryptography/BATCHED_SUBGROUP.md
@@ -266,10 +266,20 @@ Strategy C is implemented in `subgroup::batch_in_g1` with:
 - soundness-bearing details in the module docs (odd-cofactor proof, exact-trit
   requirement, deterministic-combine clarification, and why a pass cannot beat
   `3^-m`);
+- a differential fuzz of the whole round against a direct computation: every
+  combination is rebuilt from the round's marginals and compared value for
+  value with a direct sum over the coefficient digits, across 400 seeds of
+  adversarial point and id distributions and every width up to 9;
 - an accumulator oracle test (fuzz vs naive G1 addition over mixed
   good/bad/identity/negated/duplicated points) plus deterministic tests for
   every special-case branch (cancelling pairs, doubling chains, identity
-  inputs, wide plans, empty buckets);
+  inputs, single-bucket contention, wide plans, empty buckets);
+- a chi-square bound on the drawn coefficients — overall, per digit position,
+  per adjacent pair, and per slot in the word that produced them; both
+  mutations it is meant to catch (one id too many per word, a widened rejection
+  bound) do fail it;
+- the bounded round-plan search pinned against the exhaustive one it replaces,
+  and against absurd soundness targets;
 - an oracle test for the inlined field arithmetic against `blst_fp_add` /
   `blst_fp_sub`, and for the affine conversion against `blst_p1s_to_affine`;
 - adversarial batch tests (cancelling bad pair, repeated bad point, identity

--- a/cryptography/BATCHED_SUBGROUP.md
+++ b/cryptography/BATCHED_SUBGROUP.md
@@ -182,8 +182,8 @@ round) reach the target. Points of comparison, from the paper itself:
 Strategy C therefore fills exactly the gap their cost model assumes away: it
 makes the no-prefilter multi-combination route cost `⌈81/m⌉` passes instead of
 81 MSMs, which is what turns batch SMT on **unmodified BLS12-381** from "slower
-than naive" (their result) into 3.2–7.4× serial / 18–43× parallel (ours, at a
-stronger 2⁻¹²⁸ target). Their binary-coefficient variant also shows how C
+than naive" (their result) into 3.2–7.1× serial (7.1–7.4 across runs at
+n=100 000) and 18–43× parallel (ours, at a stronger 2⁻¹²⁸ target). Their binary-coefficient variant also shows how C
 extends to even-cofactor curves (e.g. BLS12-377): use `{0,1}` coefficient
 vectors (2^m buckets, 1 bit per combination, 128 total) instead of trits.
 

--- a/cryptography/BATCHED_SUBGROUP.md
+++ b/cryptography/BATCHED_SUBGROUP.md
@@ -154,10 +154,14 @@ Three implementation choices carry most of the constant:
   inverse where the inversion's backward walk produces it, so no inverse is
   ever written to memory.
 
-A round's bucket slots are the accumulator's working set, so the cost model
-caps the width at what fits a 2 MiB budget (`3^9` slots). Measured one step
-past it, cost per addition rises 20% at `m = 10` and 34% at `m = 11` — more
-than the extra combinations repay.
+A round's bucket slots are the accumulator's working set (and its collapse
+workspace is half as large again), so the cost model caps the width at what fits
+a 2 MiB budget — `3^9` slots. Past it, cost per addition rises about 8% at
+`m = 10` and 15% at `m = 11`, while the workspace grows threefold per step, per
+thread: `m = 9` asks for 2.8 MB, `m = 11` for 25 MB. At a million points the
+best plan `m = 11` allows (eight rounds, widths 11/10) measures within run-to-run
+noise of the nine-round plan chosen here; at a hundred thousand it is 36% worse.
+The budget buys the memory bound for no measurable speed.
 
 ## Measured results
 

--- a/cryptography/BATCHED_SUBGROUP.md
+++ b/cryptography/BATCHED_SUBGROUP.md
@@ -120,7 +120,15 @@ sums where C checks only `m` combinations — C's total check count stays at
 
 A pass over the points buys at most `log₂(3^m)` bits of soundness, whatever
 the round does with its bucket sums: a lone bad point escapes whenever its
-coefficient vector is the zero vector, which has probability `3^-m`. So the
+coefficient vector is the zero vector, which has probability `3^-m`. The bound
+is not about the zero vector in particular. Two points with cancelling cofactor
+parts (`T` and `-T`) that land in the same bucket with the same sign vanish in
+that bucket's sum, and nothing done with the sums afterwards can see them; this
+happens with probability `1/3^m` for *any* rule that adds each point once into
+one of `3^m/2` signed buckets, whatever the alphabet, however the buckets are
+combined, and whichever component of the cofactor group the points live in.
+So a pass is worth at most `log₂(2 · slots)` bits, and the slot count is bounded
+by the combine, which costs about two additions per occupied slot. So the
 additions per point are
 
 ```
@@ -141,13 +149,46 @@ batch-affine addition, seven passes is ~45 multiplications per point against
 ~1200 for an exact check — a ceiling around 22×, which the implementation now
 reaches to within about 6%.
 
+Put the other way round: with `B ≈ n/10` slots the floor is
+`⌈128 / log₂(2B)⌉` passes — nine at a hundred thousand points, eight at a
+million, seven at three million — and the plans above are already there. What
+remains between the measured speedup and the multiplication count is the
+constant per addition (see "The engine" and "What did not pay"), not the
+schedule. The ideas that look like they escape the bound do not:
+
+- **Handling the 3-torsion separately** (a cubic-residue test of one line
+  evaluation per point, batched multiplicatively at one field multiplication
+  per point per pass) removes the reason the alphabet is ternary, but the
+  cancelling-pair bound is indifferent to the alphabet: the elliptic passes
+  still need `128 / log₂(2B)` of them, and the multiplicative passes come on
+  top.
+- **Folding by the cube-root endomorphism** (`φ(x, y) = (ωx, y)`, one
+  multiplication or a precomputed coordinate) would let six vectors share a
+  slot instead of two, for `log₂ 3` more bits per pass. But `φ` acts trivially
+  on the order-3 component, so a coefficient alphabet closed under `φ` is
+  not uniform modulo 3 there: a cancelling 3-torsion pair escapes a digit with
+  probability `19/49` rather than `1/3`, and the pass buys fewer bits per slot
+  than plain trits do. It only pays once the 3-torsion is handled separately,
+  whose cost (above) is about the pass it saves.
+- **Tate pairings for the whole cofactor.** Every prime of `h` divides `p - 1`
+  (`x - 1` does), so a reduced Tate pairing into `μ_ℓ ⊂ F_p` exists for each,
+  and its final exponentiation batches multiplicatively. The Miller loop does
+  not: it is `~4` multiplications per bit of `ℓ` per point, some 250 for the
+  26-bit prime alone and more for the two generators the `(Z/ℓ)²` torsion
+  needs — several times the whole batched check.
+- **Sparser or shared accumulation** — pre-summing pairs, reusing a pass's
+  bucket sums as the next pass's inputs, tensoring two passes' buckets — either
+  correlates the coefficients a pair of points receives (a shared sum hides a
+  cancelling pair inside it forever) or costs as much to marginalize as it saves
+  to accumulate.
+
 This is why the speedup grows with the batch and then flattens: the `K/n` term
 and the fixed costs (converting to affine, drawing coefficients) amortize away,
 and the pass count steps down only twice more after nine.
 
 ## The engine
 
-Three implementation choices carry most of the constant:
+Four implementation choices carry most of the constant:
 
 - **Streaming accumulation with shared inversions.** A bucket's slot holds its
   running sum; additions are queued, and a chunk of 1024 of them shares one
@@ -181,6 +222,18 @@ Three implementation choices carry most of the constant:
   and the marginals of all levels reduce together so a handful of inversions
   cover the whole combine. This is what makes `m = 9` affordable — and `m = 9`
   is what turns 17 passes into 9.
+- **Interleaved inversion chains.** A field multiplication's latency (19 ns
+  here) is well above its throughput (14 ns), and the engine had two serial
+  chains of them: the running product Montgomery's trick unwinds, and the
+  three dependent multiplications of each addition, with the out-of-order
+  window too short to overlap one addition's chain with the next. The queue
+  now keeps four interleaved running products (entry `i` continues entry
+  `i - 4`), one inversion serves all four for six extra multiplications per
+  chunk, and the completing walk finishes four additions side by side, taking
+  each step for all four before the next step for any. That takes the
+  isolated inversion walk from 52 to 44 ns per element and an addition from
+  ~145 to ~130 ns; the whole round is 8% faster at a hundred thousand points.
+  Four chains measured the same as eight.
 - **Field arithmetic without ceremony.** `blst_fp_add`/`blst_fp_sub` are
   replaced by inlined carry chains (the call and the mandatory zeroing of the
   out-parameter cost more than the arithmetic), multiplications write into
@@ -303,6 +356,44 @@ against per-point checking.
   and which partitioning does not touch. The premise is worth re-testing on a
   machine with a smaller last-level cache, where the Xeon's own numbers (8% per
   addition one step past its 2 MiB, 15% two steps) suggest it would bind.
+
+- **Vectorizing the field arithmetic (NEON).** Apple silicon issues about
+  three 64×64→128 products per cycle (0.15 ns per `mul`+`umulh` pair measured
+  with independent chains), which blst's hand-scheduled multiplication uses to
+  within about 25% — its 14 ns is ~400 instructions at the core's issue width.
+  NEON has no 64-bit lane multiply: `umull` (two 32×32 products per
+  instruction) measured 0.17 ns per instruction, no more product bandwidth
+  than the scalar pipes once carries are handled in 26-bit limbs, and 64-bit
+  floating-point FMA (0.067 ns per two-lane instruction) needs three
+  operations per exact 52-bit limb product plus conversions, which puts an
+  8-limb Montgomery multiplication near 25 ns per lane-pair — slower than the
+  scalar code it would replace. Without an IFMA-style instruction the vector
+  units cannot beat three scalar multipliers on this field size.
+- **A pure-Rust Montgomery multiplication, to inline it.** Six `blst` calls
+  per addition each cost a Rust wrapper, a C wrapper and an assembly prologue
+  that saves ten registers — around 9% of the instructions — and an inlined
+  multiplication would also let the compiler schedule across the three
+  dependent ones. Both a product-then-reduce and a CIOS form in `u128`
+  arithmetic compile to 20.8 ns per multiplication against blst's 14.3 (the
+  latency is the same, 20.5 vs 19.3 ns; the throughput is not — LLVM's carry
+  handling is bulkier than the hand-written `adcs` chains). A 44% slower
+  multiplication cannot be repaid by the glue it removes. A dedicated
+  squaring got to 18.0 ns against 14.6 for blst's, which has no separate
+  squaring on aarch64; not enough either.
+- **Prefetching the point stream.** The accumulation at a million points costs
+  ~130 ns per addition against ~120 at a hundred and fifty thousand, and the
+  step is exactly where the point array stops fitting the 16 MB second-level
+  cache (150k points is 14.4 MB; 300k is 28.8). Software prefetch of the
+  stream, whether 24 points ahead into L1 or 128 ahead into L2, in the
+  accumulation loop and the completing walk both, moved nothing outside noise:
+  the hardware prefetcher already has the stream, and whatever the remaining
+  7% is, it is not exposed latency the software can hide.
+- **Recomputing the denominators in the walk (again).** Recorded above as a
+  3% loss because it put the serial running product behind a random load.
+  With four independent chains that argument lapses, but so does the gain: the
+  chain's latency is already hidden by the other three, so the 96 bytes of
+  traffic it would save are worth about what the subtraction it adds costs.
+  Not retried.
 
 ## Same-engine strategy comparison
 

--- a/cryptography/BATCHED_SUBGROUP.md
+++ b/cryptography/BATCHED_SUBGROUP.md
@@ -142,10 +142,22 @@ Three implementation choices carry most of the constant:
   reopens those same slots in the same random order a chunk later — long after
   the accumulator's read of them has been evicted. The hint is an intrinsic on
   x86_64 and inline assembly on aarch64, where the intrinsic is still unstable.
+- **Signed coefficients, folded buckets.** Coefficients are drawn from
+  `{-1,0,1}` rather than `{0,1,2}`, which leaves the `1/3` bound untouched (the
+  cofactor's order is odd and at least 3, so it divides neither difference a
+  three-element set admits) but lets a vector share a bucket with its negation:
+  negating an affine point is the sign of its `y`, so the point is stored
+  negated and the bucket count falls to `(3^m+1)/2`. Reading a bucket index as a
+  balanced-ternary *value* makes the canonical vectors exactly the non-negative
+  ones, so the bucket is `|value|` and the sign falls out of the residue the
+  sampler already draws. That halves the combine and the slot footprint, and
+  costs nothing per addition: negating the second operand negates the chord's
+  numerator, so taking its denominator the other way round cancels the sign.
 - **A shared collapse for the combine.** Recovering the `m` combinations one at
-  a time touches `2·3^(m-1)` bucket sums each, which caps `m` where the combine
-  costs more than the accumulation it saves. Summing away one digit at a time
-  instead (level `j+1` is level `j` with its lowest remaining digit collapsed)
+  a time touches most of the bucket sums each, which caps `m` where the combine
+  costs more than the accumulation it saves. Folding away one digit at a time
+  instead (level `j+1` is level `j` with its top remaining digit collapsed, as
+  `L[a] = S[a] + S[H+a] - S[H-a]`, whose three terms are all canonical)
   yields every digit's marginals for about two additions per bucket in total,
   and the marginals of all levels reduce together so a handful of inversions
   cover the whole combine. This is what makes `m = 9` affordable — and `m = 9`
@@ -215,20 +227,23 @@ exactly linear:
 
 | n         | per-point | previous engine | C serial            |
 |-----------|-----------|-----------------|---------------------|
-| 1 000     | 22.5 ms   | 6.81 ms (3.3×)  | 5.28 ms (4.3×)      |
-| 6 000     | 135 ms    | 24.0 ms (5.6×)  | 15.6 ms (8.7×)      |
-| 100 000   | 2.26 s    | 299 ms (7.5×)   | 154 ms (14.7×)      |
-| 1 000 000 | 22.6 s    | 3.19 s (7.0×)   | **1.30 s (17.3×)**  |
+| 1 000     | 22.3 ms   | 6.81 ms (3.3×)  | 4.90 ms (4.6×)      |
+| 6 000     | 133 ms    | 24.0 ms (5.6×)  | 14.3 ms (9.3×)      |
+| 100 000   | 2.22 s    | 299 ms (7.5×)   | 141 ms (15.7×)      |
+| 1 000 000 | 22.1 s    | 3.19 s (7.0×)   | **1.17 s (18.9×)**  |
 
 "Previous engine" is the single-combination-per-round implementation this
 strategy replaced, measured on the same batches in the same session. Run-to-run
 spread here is ±2%, tighter than the virtualized Xeon's ±5%.
 
-The million-point row is above the Xeon's ~15× because this machine's ratio of
-addition cost to check cost is slightly better and its cache holds a round's
-`3^9` slots more comfortably; the shape — flat below a thousand points, still
-climbing at a hundred thousand, flattening toward the nine-pass floor after a
-million — is the same on both.
+Every row is above the Xeon's, and the last two by more than the ratio of
+addition to check cost explains. Two of the choices above are worth more on a
+machine with this much cache: folding halves a round's slots, and the budget
+that bounds them is set here to admit width 11, which is the one step that buys
+a pass — eight rather than nine at a million points. On the Xeon both were left
+where its smaller L2 wants them. The shape is the same on both: flat below a
+thousand points, still climbing at a hundred thousand, flattening toward the
+pass floor after a million.
 
 ## What did not pay
 
@@ -256,6 +271,17 @@ against per-point checking.
   resident and the point array is read sequentially either way. Nine passes
   over a million points is 864 MB of sequential reads against ~1.3 s of
   arithmetic — under 2% of the time at this machine's bandwidth.
+- **Radix-partitioning the accumulation.** The proposal is to scatter points
+  into `3^k` contiguous ranges by their top digits first, so the random-access
+  working set becomes one partition's slots rather than the whole array, and
+  the width stops being bounded by cache. It is a real fix for a real problem,
+  but not one this machine has: raising the slot budget straight to 16 MiB —
+  an 8.5 MB slot array, four times what the old budget allowed — costs nothing
+  measurable per addition and buys 9% at a million points, so cache was not
+  what bounded the width. What bounds it is the combine, which grows as `3^m`
+  and which partitioning does not touch. The premise is worth re-testing on a
+  machine with a smaller last-level cache, where the Xeon's own numbers (8% per
+  addition one step past its 2 MiB, 15% two steps) suggest it would bind.
 
 ## Same-engine strategy comparison
 

--- a/cryptography/BATCHED_SUBGROUP.md
+++ b/cryptography/BATCHED_SUBGROUP.md
@@ -128,11 +128,64 @@ routing the per-point fallback through the parallel strategy; C's 0.31 ms at
 n=100 comes from that routing, not from batching.
 
 Isolated accumulator throughput: 146–178 ns/point, flat across 27–243 buckets
-(confirming accumulation cost is independent of bucket count).
+and n up to 100 000 (confirming accumulation cost is independent of bucket
+count, with no cache cliff at large n).
+
+Same-engine strategy comparison (`measure_strategies` harness, single-shot; A
+and B are emulated on the shipped accumulation engine so the comparison
+isolates the strategy — blst's MSM engine runs A's passes ~15% faster):
+
+| n       | per-point | A (81 passes)   | B (best of 16/64/256) | C (shipping)          |
+|---------|-----------|-----------------|-----------------------|-----------------------|
+| 1 000   | 21.4 ms   | 15.5 / 2.38 ms  | 15.9 / 2.40 (B=16)    | **6.6 / 1.13 ms**     |
+| 6 000   | 126.5 ms  | 74.9 / 8.86 ms  | 40.1 / 4.49 (B=16)    | **22.4 / 3.62 ms**    |
+| 100 000 | 2 126 ms  | 1 249 / 138 ms  | 353 / 47.8 (B=256)    | **298 / 49.6 ms**     |
+
+(serial / parallel per cell.) C wins serially at every size — 7.1× over
+per-point and 4.2× over A at n=100 000 (42.8× parallel). One caveat: at
+n=100 000 parallel, B=256 ties C within noise. B's optimal bucket count grows
+with n, and C's width cap (`m ≤ 5`, u8 bucket ids) binds there — the model puts
+m=6 (u16 ids, 729 buckets) ~13% ahead at that size, a possible follow-up.
 
 External reference: zexe's own batched check (Strategy B with shared
 inversions, arkworks field arithmetic, pre-2021 `[r]P` per-bucket check)
 measured on this machine at n=8192: 207 ms naive → 30.7 ms batched parallel.
+
+## Related work
+
+The current state of the art in the literature is Koshelev–El Housni–Fotiadis,
+"Batch subgroup membership testing on pairing-friendly curves"
+([eprint 2025/1311](https://eprint.iacr.org/2025/1311), gnark-crypto-based Go
+implementation). Their construction is a two-step procedure: a per-point
+Tate-pairing/power-residue prefilter removes the small-torsion components
+(3- and 11-torsion on BLS12-381), after which the smallest remaining cofactor
+prime is 10177 and a few rounds of a 13-bit-coefficient RLC (one full MSM per
+round) reach the target. Points of comparison, from the paper itself:
+
+- They state the same barrier (soundness of one combination ≤ `1/p` for the
+  smallest cofactor prime `p`, i.e. 1/3 on BLS12-381) and the same multi-round
+  escape (`n = ⌈µ/log₂ m⌉` rounds of small coefficients), but their cost model
+  charges **one full MSM per round**, which is why they judge the multi-round
+  route impractical and reach for the prefilter instead.
+- **On BLS12-381 their end-to-end method is slower than naive per-point
+  checking on valid inputs** (their words: the first-stage Tate/residue checks
+  dominate; Step 2 alone would be 9.6–47× but is unsound without Step 1). Their
+  remedy is generating new curves (BLS12-376, a new BLS12-377) where the
+  prefilter shrinks — gaining 1.1–1.5× end-to-end, single-threaded, at a
+  2⁻⁶⁰ target (vs 2⁻¹²⁸ here).
+- Their multi-round variant (old BLS12-377, 60 rounds of `{0,1}` coefficients)
+  uses running-sum mixed additions; they name affine additions with
+  Montgomery batch inversion as *future work*. The cross-round vector-bucketing
+  used here — one accumulation pass serving all `m` combinations — does not
+  appear in the paper.
+
+Strategy C therefore fills exactly the gap their cost model assumes away: it
+makes the no-prefilter multi-combination route cost `⌈81/m⌉` passes instead of
+81 MSMs, which is what turns batch SMT on **unmodified BLS12-381** from "slower
+than naive" (their result) into 3.2–7.4× serial / 18–43× parallel (ours, at a
+stronger 2⁻¹²⁸ target). Their binary-coefficient variant also shows how C
+extends to even-cofactor curves (e.g. BLS12-377): use `{0,1}` coefficient
+vectors (2^m buckets, 1 bit per combination, 128 total) instead of trits.
 
 ## Status
 

--- a/cryptography/BATCHED_SUBGROUP.md
+++ b/cryptography/BATCHED_SUBGROUP.md
@@ -169,25 +169,27 @@ Serial (single-threaded) and parallel (4 threads), against per-point checking:
 
 | n         | per-point | C serial          | C parallel         |
 |-----------|-----------|-------------------|--------------------|
-| 200       | 10.5 ms   | 7.2 ms (1.5×)     | 3.2 ms (3.3×)      |
-| 1 000     | 54.0 ms   | 12.7 ms (4.2×)    | 5.4 ms (10.0×)     |
-| 6 000     | 318 ms    | 39.2 ms (8.1×)    | 19.3 ms (16.5×)    |
-| 100 000   | 5.21 s    | 430 ms (12.1×)    | 174 ms (29.9×)     |
-| 300 000   | 15.6 s    | 1.11 s (14.1×)    | 465 ms (33.6×)     |
-| 1 000 000 | 53.0 s    | **3.52 s (15.1×)**| 1.56 s (34.0×)     |
-| 3 000 000 | 157 s     | 10.8 s (14.5×)    | 4.42 s (35.6×)     |
+| 200       | 10.5 ms   | 7.3 ms (1.4×)     | 2.4 ms (4.3×)      |
+| 1 000     | 52.0 ms   | 12.5 ms (4.2×)    | 4.4 ms (11.9×)     |
+| 6 000     | 321 ms    | 39.5 ms (8.1×)    | 14.3 ms (22.5×)    |
+| 100 000   | 5.24 s    | 429 ms (12.2×)    | 166 ms (31.6×)     |
+| 300 000   | 15.8 s    | 1.13 s (14.0×)    | 444 ms (35.5×)     |
+| 1 000 000 | 52.3 s    | **3.57 s (14.6×)**| 1.47 s (35.6×)     |
+| 3 000 000 | 163 s     | 10.5 s (15.5×)    | 4.35 s (37.4×)     |
 
-Run-to-run spread on this (shared, virtualized) machine is ±5% — the large
-sizes have measured anywhere from 14.5× to 15.3× serial across runs — so read
-them as "about 15× serial", not as a sharp figure. The `n = 200` row sits just
-above the per-point fallback threshold: below it the cost model declines to
-batch at all.
+Run-to-run spread on this (shared, virtualized) machine is ±5%: across runs the
+million- and three-million-point rows have measured anywhere from 14.5× to 16.4×
+serial, so read them as "about 15× serial", not as a sharp figure. The
+`n = 200` row sits just above the per-point fallback threshold; below it the
+cost model declines to batch at all.
 
 For reference, the previous implementation of this same strategy measured
 4.7× serial at n = 100 000 on this machine (1.15 s), against 430 ms now.
 
-Chosen plans: 14 rounds of width 6/5 at n = 200, 13 rounds of width 7/6 at
-n = 6 000, 9 rounds of width 9 from n = 100 000 up.
+Chosen plans: 14 rounds of width 6/5 at n = 200, 16 rounds of width 6/5 at
+n = 1 000, 13 rounds of width 7/6 at n = 6 000, and 9 rounds of width 9 from
+n = 100 000 up — nine being the floor, since the slot budget caps the width at
+nine and `ceil(81/9) = 9`.
 
 Phase breakdown at n = 10⁶ (3.5 s total): 3.2 s in the nine rounds, 0.38 s
 converting the batch to affine, 0.04 s drawing coefficients. The conversion is

--- a/cryptography/BATCHED_SUBGROUP.md
+++ b/cryptography/BATCHED_SUBGROUP.md
@@ -36,16 +36,22 @@ below `2^-security`.
 
 ## The soundness building block (shared by A and C)
 
-A single combination `Q = Σ c_i·P_i` with `c_i` uniform iid over `{0,1,2}`:
-`h` is odd, so every nonzero cofactor part `T` has order ≥ 3, making `0·T`,
-`1·T`, `2·T` distinct. Fix any bad `P_j` and condition on all other
-coefficients: `c_j·T_j` must hit one fixed value, and it ranges over three
-distinct values — at most one works, so the combination vanishes with
-probability ≤ 1/3, for any number of bad points and any cofactor group
-structure. The bound is tight (a lone bad point escapes exactly when
-`c_j = 0`), so a *single* combination cannot beat `log₂3 ≈ 1.58` bits per
-evaluation; only more combinations can. `t = ⌈security/log₂3⌉ = 81`
-combinations give 128-bit soundness.
+A single combination `Q = Σ c_i·P_i` with `c_i` uniform iid over a three-element
+set — `{0,1,2}` as first implemented, `{-1,0,1}` as shipped: `h` is odd, so
+every nonzero cofactor part `T` has order ≥ 3 and never 2, so `c·T` takes three
+distinct values as `c` ranges over either set (two coinciding would need the
+order to divide a difference, and the differences are 1 and 2). Fix any bad
+`P_j` and condition on all other coefficients: `c_j·T_j` must hit one fixed
+value out of three, so the combination vanishes with probability ≤ 1/3, for any
+number of bad points and any cofactor group structure. The bound is tight (a
+lone bad point escapes exactly when `c_j = 0`), so a *single* combination cannot
+beat `log₂3 ≈ 1.58` bits per evaluation; only more combinations can.
+`t = ⌈security/log₂3⌉ = 81` combinations give 128-bit soundness.
+
+Three values is also the most a coefficient can be worth. Any coefficient acts
+on an order-3 component through its residue mod 3, so a larger alphabet buys no
+more than these three residues do — which is why signed trits, and not some
+wider digit, are what the shipped scheme draws.
 
 Verified footguns:
 
@@ -77,19 +83,26 @@ reference.
 
 ## Strategy C — m parallel combinations per round (shipping)
 
-Per round, draw for every point a coefficient *vector* in `{0,1,2}^m` (m iid
-trits = a base-3 bucket id in `[0, 3^m)`), and evaluate all m combinations
-`Q_j = Σ_i c_{j,i}·P_i` from one shared accumulation:
+Per round, draw for every point a coefficient *vector* in `{-1,0,1}^m` (m iid
+signed trits, read as a balanced-ternary value in `[-(3^m-1)/2, (3^m-1)/2]`),
+and evaluate all m combinations `Q_j = Σ_i c_{j,i}·P_i` from one shared
+accumulation:
 
-1. **Bucket by vector.** Points with the same coefficient vector are summed
-   together — `3^m` buckets, but still only `n` point additions total (each
-   point lands in exactly one bucket). This is the key: *one accumulation pass
-   serves m combinations.*
-2. **Combine deterministically.** `Q_j = Σ_{v_j=1} S_v + 2·Σ_{v_j=2} S_v`,
-   where `v_j` is the j-th base-3 digit of the bucket index. The weights are
-   deterministic digits — all randomness is in the vector assignment — so this
-   evaluates exactly the m combinations (it is *not* the unsound re-randomized
-   sum over bucket sums, which would collapse back to one combination).
+1. **Bucket by vector, folded onto its negation.** Points with the same
+   coefficient vector are summed together, and a vector shares a bucket with
+   its negation — negating an affine point is the sign of its `y`, so the point
+   is stored negated. That leaves `(3^m+1)/2` buckets, and still only `n` point
+   additions total (each point lands in exactly one bucket). This is the key:
+   *one accumulation pass serves m combinations.* The canonical bucket is the
+   absolute value of the balanced-ternary value, so it falls straight out of the
+   residue the sampler draws.
+2. **Combine deterministically.** `Q_j = Σ_{v_j=1} S_v - Σ_{v_j=-1} S_v`, where
+   `v_j` is the j-th balanced-ternary digit. The weights are deterministic
+   digits — all randomness is in the vector assignment — so this evaluates
+   exactly the m combinations (it is *not* the unsound re-randomized sum over
+   bucket sums, which would collapse back to one combination). Folding carries
+   the `-1` side across as it goes, so each `Q_j` ends up a plain sum with
+   nothing to negate or double.
 3. **Check the m outputs.** Soundness per round = `3^-m` (product of m
    independent 1/3 bounds); `r ≈ 81/m` rounds at 128-bit.
 
@@ -111,20 +124,26 @@ coefficient vector is the zero vector, which has probability `3^-m`. So the
 additions per point are
 
 ```
-adds/point ≈ (128 / log₂B) · (1 + B/n),     B = 3^m
+adds/point ≈ passes + Σ_rounds K_r/n,     K = (3^m+1)/2 buckets, passes = ⌈81/m⌉
 ```
 
-— one addition per point per pass for the accumulation, plus about two per
-occupied bucket for the combine. Minimizing over `B` gives ~10.8 additions per
-point at n = 100 000 and ~9.2 at n = 10⁶; the floor is 9 passes, because
-`⌈81/m⌉ = 9` for every width the cost model will accept. At six field
-multiplications per batch-affine addition, that is 55–65 multiplications per
-point against ~1200 for an exact check — a ceiling of 18–21×, which the
-implementation reaches to within about 15%.
+— one addition per point per pass for the accumulation, less one per bucket for
+the point that lands there first, plus about two per bucket for the combine.
+The two terms pull against each other: a wider round costs `3^m` in the combine
+to save one pass over `n`, so the width worth choosing rises with the batch and
+the cost model picks it per batch. At a hundred thousand points that is nine
+rounds of width nine (9.1 additions per point); at a million, eight rounds of
+width 11 and 10 (8.3); at three million, seven rounds of width 12 and 11 (7.4).
 
-This is why the speedup grows with the batch and then flattens: the `B/n` term
+Below about seven passes there is nothing left: six would need width 14, whose
+buckets alone outweigh three million points. At six field multiplications per
+batch-affine addition, seven passes is ~45 multiplications per point against
+~1200 for an exact check — a ceiling around 22×, which the implementation now
+reaches to within about 6%.
+
+This is why the speedup grows with the batch and then flattens: the `K/n` term
 and the fixed costs (converting to affine, drawing coefficients) amortize away,
-but nine passes do not.
+and the pass count steps down only twice more after nine.
 
 ## The engine
 
@@ -230,7 +249,8 @@ exactly linear:
 | 1 000     | 22.3 ms   | 6.81 ms (3.3×)  | 4.90 ms (4.6×)      |
 | 6 000     | 133 ms    | 24.0 ms (5.6×)  | 14.3 ms (9.3×)      |
 | 100 000   | 2.22 s    | 299 ms (7.5×)   | 141 ms (15.7×)      |
-| 1 000 000 | 22.1 s    | 3.19 s (7.0×)   | **1.17 s (18.9×)**  |
+| 1 000 000 | 21.3 s    | 3.19 s (7.0×)   | 1.13 s (18.8×)      |
+| 3 000 000 | 64.0 s    | —               | **3.08 s (20.8×)**  |
 
 "Previous engine" is the single-combination-per-round implementation this
 strategy replaced, measured on the same batches in the same session. Run-to-run
@@ -239,8 +259,8 @@ spread here is ±2%, tighter than the virtualized Xeon's ±5%.
 Every row is above the Xeon's, and the last two by more than the ratio of
 addition to check cost explains. Two of the choices above are worth more on a
 machine with this much cache: folding halves a round's slots, and the budget
-that bounds them is set here to admit width 11, which is the one step that buys
-a pass — eight rather than nine at a million points. On the Xeon both were left
+that bounds them is set here to admit widths 11 and 12, the two steps that buy
+a pass — eight rather than nine at a million points, seven at three million. On the Xeon both were left
 where its smaller L2 wants them. The shape is the same on both: flat below a
 thousand points, still climbing at a hundred thousand, flattening toward the
 pass floor after a million.
@@ -277,8 +297,9 @@ against per-point checking.
   the width stops being bounded by cache. It is a real fix for a real problem,
   but not one this machine has: raising the slot budget straight to 16 MiB —
   an 8.5 MB slot array, four times what the old budget allowed — costs nothing
-  measurable per addition and buys 9% at a million points, so cache was not
-  what bounded the width. What bounds it is the combine, which grows as `3^m`
+  measurable per addition and buys 9% at a million points; a 25 MB one at width
+  12 buys a further 8% at three million. Cache was not what bounded the
+  width. What bounds it is the combine, which grows as `3^m`
   and which partitioning does not touch. The premise is worth re-testing on a
   machine with a smaller last-level cache, where the Xeon's own numbers (8% per
   addition one step past its 2 MiB, 15% two steps) suggest it would bind.
@@ -336,7 +357,7 @@ round) reach the target. Points of comparison, from the paper itself:
 Strategy C therefore fills exactly the gap their cost model assumes away: it
 makes the no-prefilter multi-combination route cost `≈81/m` passes instead of
 81 MSMs, which is what turns batch SMT on **unmodified BLS12-381** from "slower
-than naive" (their result) into 8–15× serial and 19–37× parallel (ours, at a
+than naive" (their result) into 8–21× serial and 19–37× parallel (ours, at a
 stronger 2⁻¹²⁸ target). Their binary-coefficient variant also shows how C
 extends to even-cofactor curves (e.g. BLS12-377): use `{0,1}` coefficient
 vectors (2^m buckets, 1 bit per combination, 128 total) instead of trits.
@@ -344,7 +365,7 @@ vectors (2^m buckets, 1 bit per combination, 128 total) instead of trits.
 Note that a faster field multiplication would *lower* these ratios, not raise
 them: the exact check is almost pure multiplication while the batched path is
 part multiplication and part memory traffic. The multiplication-count ceiling
-above (18–21×) is the machine-independent statement.
+above (~22×) is the machine-independent statement.
 
 ## Status
 

--- a/cryptography/BATCHED_SUBGROUP.md
+++ b/cryptography/BATCHED_SUBGROUP.md
@@ -138,7 +138,10 @@ Three implementation choices carry most of the constant:
   uniform bucket ids only ~5% of points ever are. A point is therefore read
   once, added once, and never copied to a work list. Slots are touched in
   random order, so the accumulator prefetches the slot each point will land in
-  a couple of dozen iterations ahead.
+  a couple of dozen iterations ahead, and so does the completion walk, which
+  reopens those same slots in the same random order a chunk later — long after
+  the accumulator's read of them has been evicted. The hint is an intrinsic on
+  x86_64 and inline assembly on aarch64, where the intrinsic is still unstable.
 - **A shared collapse for the combine.** Recovering the `m` combinations one at
   a time touches `2·3^(m-1)` bucket sums each, which caps `m` where the combine
   costs more than the accumulation it saves. Summing away one digit at a time
@@ -152,7 +155,9 @@ Three implementation choices carry most of the constant:
   out-parameter cost more than the arithmetic), multiplications write into
   `MaybeUninit` rather than a zeroed temporary, and each addition consumes its
   inverse where the inversion's backward walk produces it, so no inverse is
-  ever written to memory.
+  ever written to memory. The running product that walk unwinds is extended as
+  each addition is queued, riding along with work already holding the
+  denominator, so the queue is written once and walked once instead of twice.
 
 A round's bucket slots are the accumulator's working set (and its collapse
 workspace is half as large again), so the cost model caps the width at what fits
@@ -195,6 +200,62 @@ Phase breakdown at n = 10⁶ (3.5 s total): 3.2 s in the nine rounds, 0.38 s
 converting the batch to affine, 0.04 s drawing coefficients. The conversion is
 7 field multiplications per point against 54 for the rounds, and it disappears
 entirely for callers whose points arrive already affine (as decoded points do).
+
+## On a second machine (Apple M5 Pro)
+
+The Xeon figures above are what the cost model was calibrated against. Repeating
+the measurement on an 18-core Apple M5 Pro (macOS, 6 performance cores) checks
+that the model travels: an exact check costs 22.5 µs there and a batch-affine
+addition ~145 ns, so a check is worth ~153 additions — within 2% of the Xeon's
+150, which is why no constant needed retuning.
+
+Single-threaded, on points in decoded (`z = 1`) form, best of several runs; the
+per-point column is measured on a 20 000-point prefix and scaled, since it is
+exactly linear:
+
+| n         | per-point | previous engine | C serial            |
+|-----------|-----------|-----------------|---------------------|
+| 1 000     | 22.5 ms   | 6.81 ms (3.3×)  | 5.28 ms (4.3×)      |
+| 6 000     | 135 ms    | 24.0 ms (5.6×)  | 15.6 ms (8.7×)      |
+| 100 000   | 2.26 s    | 299 ms (7.5×)   | 154 ms (14.7×)      |
+| 1 000 000 | 22.6 s    | 3.19 s (7.0×)   | **1.30 s (17.3×)**  |
+
+"Previous engine" is the single-combination-per-round implementation this
+strategy replaced, measured on the same batches in the same session. Run-to-run
+spread here is ±2%, tighter than the virtualized Xeon's ±5%.
+
+The million-point row is above the Xeon's ~15× because this machine's ratio of
+addition cost to check cost is slightly better and its cache holds a round's
+`3^9` slots more comfortably; the shape — flat below a thousand points, still
+climbing at a hundred thousand, flattening toward the nine-pass floor after a
+million — is the same on both.
+
+## What did not pay
+
+Recorded because each looked like it should, and the measurement is the only
+reason to believe otherwise. All figures are single-threaded on the M5 Pro,
+against per-point checking.
+
+- **Queueing the denominators instead of recomputing them.** A queued addition
+  stores its denominator and reads it back, 96 bytes of traffic that the
+  completing walk could avoid: it holds both operands already, so one
+  subtraction reproduces the value. It costs 3% (17.5× → 17.0× at a million
+  points). The stored denominator is a sequential load the hardware has
+  prefetched, while recomputing it puts the inversion chain's serial
+  multiplication — `running *= denominator` — behind the *random* slot load it
+  was previously independent of. The memory saved is not on the critical path;
+  the dependency added is.
+- **Resizing the inversion chunk.** 1024 additions per shared inversion holds
+  ~100 KB of denominators and prefix products, around this core's L1. Neither
+  direction moves it: 256 → 14.3×, 512 → 14.4×, 1024 → 14.7×, 2048 → 14.7× at a
+  hundred thousand points. An inversion is ~1.5 µs, so past a few hundred
+  additions its share is already under 2 ns each, and nothing else is
+  chunk-sensitive enough to show through the noise.
+- **Tiling the accumulation.** Worth it for an engine that materializes a work
+  list per pass; this one streams, so there is no per-tile buffer to keep
+  resident and the point array is read sequentially either way. Nine passes
+  over a million points is 864 MB of sequential reads against ~1.3 s of
+  arithmetic — under 2% of the time at this machine's bandwidth.
 
 ## Same-engine strategy comparison
 

--- a/cryptography/BATCHED_SUBGROUP.md
+++ b/cryptography/BATCHED_SUBGROUP.md
@@ -1,0 +1,149 @@
+# Batched G1 subgroup checks: strategy comparison
+
+Findings from implementing and measuring two randomized strategies for checking
+that a batch of BLS12-381 G1 points lies in the prime-order subgroup, to decide
+the approach forward. The shipping implementation is
+`bls12381::primitives::subgroup::batch_in_g1` (single-RLC, below); a naive
+bucketing prototype is preserved on `gv/subgroup-bucketed-prototype`.
+
+All timings in this document are from an 18-core Apple Silicon machine.
+
+## The problem
+
+A decoded curve point can lie outside the prime-order subgroup; using it in a
+pairing or scalar multiplication enables small-subgroup attacks. blst's exact
+per-point check (Scott, [2021/1130](https://eprint.iacr.org/2021/1130), the
+endomorphism test) costs **~22 µs per point**, so a 6000-point batch costs
+~133 ms checked one at a time.
+
+Every point splits as `P = G + T` with `G` in-subgroup and `T` a "cofactor
+part" in the group of order
+
+```
+h = 3 · (11 · 10177 · 859267 · 52437899)²   (odd; smallest prime factor 3)
+```
+
+`P ∈ G1` iff `T = 0`. Both strategies form random combinations of the points
+and check those; a combination is in G1 iff its combined cofactor parts cancel.
+Rounds are repeated until the cheating probability is below `2^-security`.
+
+## Strategy A — single random linear combination (shipping)
+
+Per round: draw `c_i ∈ {0,1,2}` uniformly per point, check the single point
+`Q = Σ c_i·P_i` (one 2-bit Pippenger MSM, one subgroup check).
+
+**Soundness (`1/3` per round).** `h` is odd, so every nonzero cofactor part `T`
+has order ≥ 3, making `0·T`, `1·T`, `2·T` distinct. Fix any bad `P_j` and
+condition on all other coefficients: `c_j·T_j` must hit one fixed value, and it
+ranges over three distinct values, so at most one choice of `c_j` works —
+probability ≤ 1/3, for any number of bad points and any cofactor group
+structure. The bound is tight (a lone bad point escapes exactly when `c_j = 0`),
+so larger coefficients cannot improve a single combination — only more
+combinations per round can (Strategy B).
+
+Two footguns verified during review:
+
+- **Round count.** 81 rounds = `81·log₂3 = 128.38` bits. 80 rounds = 126.8
+  bits — insufficient. The code divides by a strict lower bound on `log₂3` so
+  it never under-counts.
+- **Coefficient uniformity.** The margin is 0.38 bits. A biased `byte % 3`
+  (max probability 86/256) yields 127.5 bits — **below target**. The
+  implementation rejection-samples (bytes < 243 → five exact trits), which is
+  load-bearing, not pedantry.
+- **Odd cofactor required.** An order-2 part `T` has `2T = 0`: escape
+  probability 2/3 per round. BLS12-377 G1 (`2^92 | h`) cannot use this scheme
+  as-is.
+
+## Strategy B — random bucketing (celo/zexe PR #4)
+
+Per round: assign each point a uniform bucket in `{0,…,B−1}`, sum each bucket,
+subgroup-check **each** bucket sum.
+
+**Soundness (`1/B` per round).** A single bad point is always caught (nothing
+cancels it inside its bucket). The worst case is a cancelling pair (`T`, `−T`),
+which escapes only by colliding in the same bucket — probability `1/B`. So
+`rounds = ⌈security / log₂B⌉`: B=16 → 32 rounds, B=256 → 16 rounds.
+
+Bucketing *separates* a cancelling pair unless they collide, so each round
+extracts `log₂B` bits instead of `log₂3 ≈ 1.58`. Fewer rounds means fewer
+summation passes over the `n` points — the entire appeal.
+
+**There is no cheap hybrid.** Combining the `B` bucket sums into one RLC check
+per round re-merges the cancelling pair and collapses soundness back to 1/3.
+The `B` separate checks are load-bearing.
+
+## Cost accounting (128-bit security, B=16 for bucketing)
+
+The subgroup check (~22 µs) costs more than a summation pass, so totals are
+dominated by inversions + checks, not round count:
+
+| quantity          | A: single-RLC | B: naive buckets | B: shared-inversion buckets |
+|-------------------|:-------------:|:----------------:|:---------------------------:|
+| rounds            | 81            | 32               | 32                          |
+| field inversions  | ~81           | **512** (32×16)  | **~32**                     |
+| subgroup checks   | **81**        | 512 (32×16)      | 512 (32×16)                 |
+| summation passes  | 81            | 32               | 32                          |
+
+- **A** gets ~1 inversion/round free: Pippenger's bucket accumulation shares one
+  Montgomery batch inversion across its internal buckets.
+- **B (naive)** pays one inversion per bucket per round (`blst_p1s_add` per
+  bucket) — 512 total. The fewer-rounds saving is eaten by the extra inversions.
+- **B (shared-inversion)** — zexe's `batch_bucketed_add` — accumulates *all*
+  buckets through one batch inversion per addition pass, dropping inversions
+  below A while keeping the round advantage. This is the only variant that can
+  actually win.
+- Every B variant carries a fixed `rounds × B` **check floor**: 512 × 22 µs ≈
+  **11.3 ms serial**, independent of `n` (vs A's 1.8 ms). In parallel the floor
+  spreads across cores; serially it is a hard tax and pushes the per-point
+  fallback threshold up to `rounds × B` points.
+
+## Measured results
+
+Baseline (committed criterion bench, single-RLC vs per-point):
+
+| n    | per-point | A serial       | A parallel      |
+|------|-----------|----------------|-----------------|
+| 100  | 2.20 ms   | 2.18 ms        | 2.19 ms (auto-tuned serial) |
+| 1000 | 21.8 ms   | 12.1 ms (1.8×) | 1.59 ms (13.7×) |
+| 6000 | 132.7 ms  | 63.1 ms (2.1×) | 6.9 ms (19.2×)  |
+
+Naive bucketing prototype (best B per size, tuned over B ∈ {8…256}):
+
+| n    | mode     | A (shipping) | B naive (B=8) | outcome           |
+|------|----------|:------------:|:-------------:|-------------------|
+| 1000 | serial   | **12.1 ms**  | 15.9 ms       | B loses 1.3×      |
+| 1000 | parallel | **1.59 ms**  | 2.09 ms       | B loses 1.3×      |
+| 6000 | serial   | 63 ms        | **46 ms**     | B wins 1.37×      |
+| 6000 | parallel | 6.9 ms       | **5.17 ms**   | B wins 1.33×      |
+
+Larger B is strictly worse in the naive form (B=256 at n=6000: 111 ms serial —
+nearly per-point speed) because the check floor grows as `rounds × B`.
+
+External reference: zexe's own batched check (shared-inversion, arkworks field
+arithmetic, pre-2021 `[r]P` per-bucket check) measured on this machine at
+n=8192: 207 ms naive → 30.7 ms batched parallel. Our A beats it at every level
+via blst + the endomorphism check.
+
+## Decision
+
+**Current state: ship A (single-RLC).** Fewest inversions, fewest checks,
+simplest soundness argument, smallest review surface; already delivers 2×
+serial / 13–19× parallel over per-point.
+
+**Candidate follow-up: B with shared-inversion accumulation.** The cost table
+says it is the one variant with a real shot: ~32 inversions (vs A's 81) and 32
+summation passes (vs 81), against a 512-check floor that parallelizes well.
+Honest projection: **~1.5–3× over A at n=6000, roughly parity at n=1000** (the
+check floor dominates there). Costs to get it:
+
+- A hand-rolled unsafe batch-affine accumulator (blst does not expose bucket
+  sums — its Pippenger combines them internally), plus the required miri pass.
+- A higher per-point fallback threshold (`rounds × B` ≈ 512 points), so small
+  batches see no benefit at all.
+- The naive prototype's counting sort, `buckets_in_g1` shape, and large-batch
+  soundness tests carry over from `gv/subgroup-bucketed-prototype`.
+
+**The decision hinges on workload**: if typical batches are ≳ 4–6k points and
+the extra serial-path latency floor is acceptable, shared-inversion bucketing is
+worth building; if batches cluster near ~1k, A is already at the optimum and the
+added unsafe surface buys nothing.

--- a/cryptography/BATCHED_SUBGROUP.md
+++ b/cryptography/BATCHED_SUBGROUP.md
@@ -1,10 +1,10 @@
 # Batched G1 subgroup checks: strategy comparison
 
-Findings from implementing and measuring two randomized strategies for checking
-that a batch of BLS12-381 G1 points lies in the prime-order subgroup, to decide
-the approach forward. The shipping implementation is
-`bls12381::primitives::subgroup::batch_in_g1` (single-RLC, below); a naive
-bucketing prototype is preserved on `gv/subgroup-bucketed-prototype`.
+Findings from implementing and measuring three randomized strategies for
+checking that a batch of BLS12-381 G1 points lies in the prime-order subgroup.
+The shipping implementation is `bls12381::primitives::subgroup::batch_in_g1`
+(Strategy C below); a naive-bucketing prototype (Strategy B) is preserved on
+`gv/subgroup-bucketed-prototype`.
 
 All timings in this document are from an 18-core Apple Silicon machine.
 
@@ -14,7 +14,7 @@ A decoded curve point can lie outside the prime-order subgroup; using it in a
 pairing or scalar multiplication enables small-subgroup attacks. blst's exact
 per-point check (Scott, [2021/1130](https://eprint.iacr.org/2021/1130), the
 endomorphism test) costs **~22 µs per point**, so a 6000-point batch costs
-~133 ms checked one at a time.
+~127 ms checked one at a time.
 
 Every point splits as `P = G + T` with `G` in-subgroup and `T` a "cofactor
 part" in the group of order
@@ -23,127 +23,128 @@ part" in the group of order
 h = 3 · (11 · 10177 · 859267 · 52437899)²   (odd; smallest prime factor 3)
 ```
 
-`P ∈ G1` iff `T = 0`. Both strategies form random combinations of the points
-and check those; a combination is in G1 iff its combined cofactor parts cancel.
-Rounds are repeated until the cheating probability is below `2^-security`.
+`P ∈ G1` iff `T = 0`. Every strategy below forms random combinations of the
+points and applies the exact check to those; a combination is in G1 iff its
+combined cofactor parts cancel. Rounds repeat until the cheating probability is
+below `2^-security`.
 
-## Strategy A — single random linear combination (shipping)
+## The soundness building block (shared by A and C)
 
-Per round: draw `c_i ∈ {0,1,2}` uniformly per point, check the single point
-`Q = Σ c_i·P_i` (one 2-bit Pippenger MSM, one subgroup check).
-
-**Soundness (`1/3` per round).** `h` is odd, so every nonzero cofactor part `T`
-has order ≥ 3, making `0·T`, `1·T`, `2·T` distinct. Fix any bad `P_j` and
-condition on all other coefficients: `c_j·T_j` must hit one fixed value, and it
-ranges over three distinct values, so at most one choice of `c_j` works —
+A single combination `Q = Σ c_i·P_i` with `c_i` uniform iid over `{0,1,2}`:
+`h` is odd, so every nonzero cofactor part `T` has order ≥ 3, making `0·T`,
+`1·T`, `2·T` distinct. Fix any bad `P_j` and condition on all other
+coefficients: `c_j·T_j` must hit one fixed value, and it ranges over three
+distinct values — at most one works, so the combination vanishes with
 probability ≤ 1/3, for any number of bad points and any cofactor group
-structure. The bound is tight (a lone bad point escapes exactly when `c_j = 0`),
-so larger coefficients cannot improve a single combination — only more
-combinations per round can (Strategy B).
+structure. The bound is tight (a lone bad point escapes exactly when
+`c_j = 0`), so a *single* combination cannot beat `log₂3 ≈ 1.58` bits per
+evaluation; only more combinations can. `t = ⌈security/log₂3⌉ = 81`
+combinations give 128-bit soundness.
 
-Two footguns verified during review:
+Verified footguns:
 
-- **Round count.** 81 rounds = `81·log₂3 = 128.38` bits. 80 rounds = 126.8
-  bits — insufficient. The code divides by a strict lower bound on `log₂3` so
-  it never under-counts.
+- **Combination count.** 81 combinations = 128.38 bits; 80 = 126.8 —
+  insufficient. The code divides by a strict lower bound on `log₂3`.
 - **Coefficient uniformity.** The margin is 0.38 bits. A biased `byte % 3`
-  (max probability 86/256) yields 127.5 bits — **below target**. The
-  implementation rejection-samples (bytes < 243 → five exact trits), which is
-  load-bearing, not pedantry.
+  (max probability 86/256) yields 127.5 bits — below target. The implementation
+  rejection-samples (bytes < 243 → five exact trits); this is load-bearing.
 - **Odd cofactor required.** An order-2 part `T` has `2T = 0`: escape
-  probability 2/3 per round. BLS12-377 G1 (`2^92 | h`) cannot use this scheme
-  as-is.
+  probability 2/3 per combination. BLS12-377 G1 (`2^92 | h`) cannot use this
+  scheme as-is.
 
-## Strategy B — random bucketing (celo/zexe PR #4)
+## Strategy A — one combination per round (previous implementation)
+
+Per round: draw `c_i ∈ {0,1,2}` per point, evaluate `Q = Σ c_i·P_i` as one
+2-bit Pippenger MSM (blst), check `Q`. Needs 81 rounds — i.e. **81 full
+accumulation passes over the `n` points**, one check each.
+
+## Strategy B — random bucketing, per-bucket checks (celo/zexe PR #4)
 
 Per round: assign each point a uniform bucket in `{0,…,B−1}`, sum each bucket,
-subgroup-check **each** bucket sum.
+check **each** bucket sum. A cancelling pair escapes a round only by colliding
+in one bucket → `1/B` per round → `⌈security/log₂B⌉` rounds (32 at B=16).
 
-**Soundness (`1/B` per round).** A single bad point is always caught (nothing
-cancels it inside its bucket). The worst case is a cancelling pair (`T`, `−T`),
-which escapes only by colliding in the same bucket — probability `1/B`. So
-`rounds = ⌈security / log₂B⌉`: B=16 → 32 rounds, B=256 → 16 rounds.
+Fewer accumulation passes, but a fixed `rounds × B` check floor (512 × 22 µs ≈
+11.3 ms serial at B=16) plus — implemented naively with one `blst_p1s_add` per
+bucket — one field-inversion chain per bucket per round. **Measured: loses to A
+at n=1000 (15.9 vs 12.1 ms serial) and wins only ~1.35× at n=6000 (46 vs
+63 ms).** Rejected; prototype preserved for reference.
 
-Bucketing *separates* a cancelling pair unless they collide, so each round
-extracts `log₂B` bits instead of `log₂3 ≈ 1.58`. Fewer rounds means fewer
-summation passes over the `n` points — the entire appeal.
+## Strategy C — m parallel combinations per round (shipping)
 
-**There is no cheap hybrid.** Combining the `B` bucket sums into one RLC check
-per round re-merges the cancelling pair and collapses soundness back to 1/3.
-The `B` separate checks are load-bearing.
+Per round, draw for every point a coefficient *vector* in `{0,1,2}^m` (m iid
+trits = a base-3 bucket id in `[0, 3^m)`), and evaluate all m combinations
+`Q_j = Σ_i c_{j,i}·P_i` from one shared accumulation:
 
-## Cost accounting (128-bit security, B=16 for bucketing)
+1. **Bucket by vector.** Points with the same coefficient vector are summed
+   together — `3^m` buckets, but still only `n` point additions total (each
+   point lands in exactly one bucket). This is the key: *one accumulation pass
+   serves m combinations.*
+2. **Batch-affine accumulation (the inversion trick).** Each pass pairs up the
+   remaining points of every bucket and completes all pairs with a single
+   shared field inversion (Montgomery's trick): ~6 field multiplications per
+   addition instead of an inversion (~150 ns/point measured, flat in bucket
+   count). Hand-rolled over `blst_fp`; blst's Pippenger does not expose bucket
+   sums.
+3. **Combine deterministically.** `Q_j = Σ_{v_j=1} S_v + 2·Σ_{v_j=2} S_v`,
+   where `v_j` is the j-th base-3 digit of the bucket index. The weights are
+   deterministic digits — all randomness is in the vector assignment — so this
+   evaluates exactly the m combinations (it is *not* the unsound re-randomized
+   sum over bucket sums, which would collapse back to one combination).
+4. **Check the m outputs.** Soundness per round = `3^-m` (product of m
+   independent 1/3 bounds); `r = ⌈81/m⌉` rounds at 128-bit.
 
-The subgroup check (~22 µs) costs more than a summation pass, so totals are
-dominated by inversions + checks, not round count:
+`m` (and whether to batch at all) is chosen per batch by a cost model;
+soundness holds for every choice, so the model's constants only affect
+performance. In practice: n=1000 → m=3 (27 rounds), n=6000 → m=4 (21 rounds);
+n ≲ 120 falls back to per-point checks (run through the strategy, so they
+still parallelize).
 
-| quantity          | A: single-RLC | B: naive buckets | B: shared-inversion buckets |
-|-------------------|:-------------:|:----------------:|:---------------------------:|
-| rounds            | 81            | 32               | 32                          |
-| field inversions  | ~81           | **512** (32×16)  | **~32**                     |
-| subgroup checks   | **81**        | 512 (32×16)      | 512 (32×16)                 |
-| summation passes  | 81            | 32               | 32                          |
+### Why C dominates B
 
-- **A** gets ~1 inversion/round free: Pippenger's bucket accumulation shares one
-  Montgomery batch inversion across its internal buckets.
-- **B (naive)** pays one inversion per bucket per round (`blst_p1s_add` per
-  bucket) — 512 total. The fewer-rounds saving is eaten by the extra inversions.
-- **B (shared-inversion)** — zexe's `batch_bucketed_add` — accumulates *all*
-  buckets through one batch inversion per addition pass, dropping inversions
-  below A while keeping the round advantage. This is the only variant that can
-  actually win.
-- Every B variant carries a fixed `rounds × B` **check floor**: 512 × 22 µs ≈
-  **11.3 ms serial**, independent of `n` (vs A's 1.8 ms). In parallel the floor
-  spreads across cores; serially it is a hard tax and pushes the per-point
-  fallback threshold up to `rounds × B` points.
+At equal per-round soundness (`B = 3^m` buckets), B checks all `3^m` bucket
+sums where C checks only `m` combinations — C's total check count stays at
+`r·m ≈ 81–85` for any m (the same as A), while B's grows as `rounds × B`. And
+C's shared-inversion accumulation removes B's per-bucket inversion chains.
 
-## Measured results
+## Cost accounting (128-bit security)
 
-Baseline (committed criterion bench, single-RLC vs per-point):
+| quantity                    | A (one RLC) | B naive (B=16) | C (m=4, shipping) |
+|-----------------------------|:-----------:|:--------------:|:-----------------:|
+| accumulation passes over n  | 81          | 32             | **21**            |
+| subgroup checks             | 81          | **512**        | 84                |
+| shared-inversion adds       | yes (blst)  | no             | yes (hand-rolled) |
 
-| n    | per-point | A serial       | A parallel      |
-|------|-----------|----------------|-----------------|
-| 100  | 2.20 ms   | 2.18 ms        | 2.19 ms (auto-tuned serial) |
-| 1000 | 21.8 ms   | 12.1 ms (1.8×) | 1.59 ms (13.7×) |
-| 6000 | 132.7 ms  | 63.1 ms (2.1×) | 6.9 ms (19.2×)  |
+## Measured results (criterion medians, same machine)
 
-Naive bucketing prototype (best B per size, tuned over B ∈ {8…256}):
+| n    | per-point | A serial | A parallel | C serial          | C parallel         |
+|------|-----------|----------|------------|-------------------|--------------------|
+| 100  | 2.14 ms   | 2.18 ms* | 2.19 ms*   | 2.13 ms (fallback)| **0.31 ms (7×)**   |
+| 1000 | 21.4 ms   | 12.1 ms  | 1.59 ms    | **6.50 ms (3.3×)**| **1.16 ms (18.5×)**|
+| 6000 | 126.6 ms  | 63.1 ms  | 6.9 ms     | **22.6 ms (5.6×)**| **4.10 ms (30.9×)**|
 
-| n    | mode     | A (shipping) | B naive (B=8) | outcome           |
-|------|----------|:------------:|:-------------:|-------------------|
-| 1000 | serial   | **12.1 ms**  | 15.9 ms       | B loses 1.3×      |
-| 1000 | parallel | **1.59 ms**  | 2.09 ms       | B loses 1.3×      |
-| 6000 | serial   | 63 ms        | **46 ms**     | B wins 1.37×      |
-| 6000 | parallel | 6.9 ms       | **5.17 ms**   | B wins 1.33×      |
+Speedups in parentheses are vs per-point serial. (*) A's n=100 numbers predate
+routing the per-point fallback through the parallel strategy; C's 0.31 ms at
+n=100 comes from that routing, not from batching.
 
-Larger B is strictly worse in the naive form (B=256 at n=6000: 111 ms serial —
-nearly per-point speed) because the check floor grows as `rounds × B`.
+Isolated accumulator throughput: 146–178 ns/point, flat across 27–243 buckets
+(confirming accumulation cost is independent of bucket count).
 
-External reference: zexe's own batched check (shared-inversion, arkworks field
-arithmetic, pre-2021 `[r]P` per-bucket check) measured on this machine at
-n=8192: 207 ms naive → 30.7 ms batched parallel. Our A beats it at every level
-via blst + the endomorphism check.
+External reference: zexe's own batched check (Strategy B with shared
+inversions, arkworks field arithmetic, pre-2021 `[r]P` per-bucket check)
+measured on this machine at n=8192: 207 ms naive → 30.7 ms batched parallel.
 
-## Decision
+## Status
 
-**Current state: ship A (single-RLC).** Fewest inversions, fewest checks,
-simplest soundness argument, smallest review surface; already delivers 2×
-serial / 13–19× parallel over per-point.
+Strategy C is implemented in `subgroup::batch_in_g1` with:
 
-**Candidate follow-up: B with shared-inversion accumulation.** The cost table
-says it is the one variant with a real shot: ~32 inversions (vs A's 81) and 32
-summation passes (vs 81), against a 512-check floor that parallelizes well.
-Honest projection: **~1.5–3× over A at n=6000, roughly parity at n=1000** (the
-check floor dominates there). Costs to get it:
-
-- A hand-rolled unsafe batch-affine accumulator (blst does not expose bucket
-  sums — its Pippenger combines them internally), plus the required miri pass.
-- A higher per-point fallback threshold (`rounds × B` ≈ 512 points), so small
-  batches see no benefit at all.
-- The naive prototype's counting sort, `buckets_in_g1` shape, and large-batch
-  soundness tests carry over from `gv/subgroup-bucketed-prototype`.
-
-**The decision hinges on workload**: if typical batches are ≳ 4–6k points and
-the extra serial-path latency floor is acceptable, shared-inversion bucketing is
-worth building; if batches cluster near ~1k, A is already at the optimum and the
-added unsafe surface buys nothing.
+- soundness-bearing details in the module docs (odd-cofactor proof, exact-trit
+  requirement, deterministic-combine clarification);
+- an accumulator oracle test (fuzz vs naive G1 addition over mixed
+  good/bad/identity/negated/duplicated points) plus deterministic tests for
+  every special-case branch (cancelling pairs, doubling chains, identity
+  inputs, odd leftovers, empty buckets);
+- adversarial batch tests (cancelling bad pair, repeated bad point);
+- `cargo miri` cannot run the module (blst FFI is unsupported by miri); the
+  unsafe surface is thin per-call FFI wrappers, with all pass-scheduling logic
+  in safe Rust under the oracle tests.

--- a/cryptography/BATCHED_SUBGROUP.md
+++ b/cryptography/BATCHED_SUBGROUP.md
@@ -1,5 +1,11 @@
 # Batched G1 subgroup checks: strategy comparison
 
+This report describes the independent-combination strategies and historical
+measurements. Its pass-count limits apply to those constructions, not all
+subgroup-checking algorithms. The test-only [graph and recursive-certificate
+research](SUBGROUP_CASCADE.md) explores faster constructions; production
+verification is unchanged.
+
 Findings from implementing and measuring three randomized strategies for
 checking that a batch of BLS12-381 G1 points lies in the prime-order subgroup.
 The shipping implementation is `bls12381::primitives::subgroup::batch_in_g1`

--- a/cryptography/PAPER_EXPLAINER.html
+++ b/cryptography/PAPER_EXPLAINER.html
@@ -1,0 +1,661 @@
+<title>Batching the Subgroup Check</title>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=STIX+Two+Text:ital,wght@0,400..700;1,400..700&family=IBM+Plex+Mono:wght@400;500;600&display=swap">
+<style>
+  :root {
+    --bg: #F7F7F4;
+    --surface: #EFF0EA;
+    --surface-2: #E7E9E1;
+    --ink: #1C2420;
+    --muted: #5D6862;
+    --line: #D7DAD1;
+    --accent: #1E6B5A;
+    --accent-soft: #1E6B5A22;
+    --strat-a: #4A6B8A;
+    --strat-b: #96603F;
+    --warn-bg: #96603F14;
+    --warn-line: #96603F55;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root:not([data-theme="light"]) {
+      --bg: #141815;
+      --surface: #1C211D;
+      --surface-2: #232925;
+      --ink: #E1E6DF;
+      --muted: #97A29A;
+      --line: #333A34;
+      --accent: #5AB49A;
+      --accent-soft: #5AB49A26;
+      --strat-a: #86AACB;
+      --strat-b: #C6916D;
+      --warn-bg: #C6916D14;
+      --warn-line: #C6916D55;
+    }
+  }
+  :root[data-theme="dark"] {
+    --bg: #141815;
+    --surface: #1C211D;
+    --surface-2: #232925;
+    --ink: #E1E6DF;
+    --muted: #97A29A;
+    --line: #333A34;
+    --accent: #5AB49A;
+    --accent-soft: #5AB49A26;
+    --strat-a: #86AACB;
+    --strat-b: #C6916D;
+    --warn-bg: #C6916D14;
+    --warn-line: #C6916D55;
+  }
+
+  * { margin: 0; box-sizing: border-box; }
+  body {
+    background: var(--bg);
+    color: var(--ink);
+    font-family: "STIX Two Text", "Times New Roman", Georgia, serif;
+    font-size: 17px;
+    line-height: 1.68;
+    padding: 3.5rem 1.25rem 6rem;
+  }
+  .col { max-width: 46rem; margin: 0 auto; }
+  .wide { max-width: 56rem; margin: 2rem auto; }
+
+  .mono, .eyebrow, th, .tag, figcaption, .costnote {
+    font-family: "IBM Plex Mono", ui-monospace, "SF Mono", Menlo, monospace;
+  }
+
+  /* ---------- header ---------- */
+  header { max-width: 46rem; margin: 0 auto 3rem; }
+  .eyebrow {
+    font-size: 11px; letter-spacing: 0.14em; text-transform: uppercase;
+    color: var(--accent); margin-bottom: 1.1rem;
+  }
+  h1 {
+    font-size: clamp(30px, 5.5vw, 42px);
+    font-weight: 600; line-height: 1.12; text-wrap: balance;
+    margin-bottom: 0.9rem;
+  }
+  .standfirst {
+    font-size: 19px; font-style: italic; color: var(--muted);
+    line-height: 1.55; text-wrap: balance; margin-bottom: 1.4rem;
+  }
+  .meta {
+    font-family: "IBM Plex Mono", monospace; font-size: 12px; color: var(--muted);
+    display: flex; flex-wrap: wrap; gap: 0.4rem 1.6rem;
+    border-top: 1px solid var(--line); padding-top: 0.9rem;
+  }
+
+  /* ---------- prose ---------- */
+  h2 {
+    font-size: 24px; font-weight: 600; line-height: 1.25;
+    margin: 3rem 0 0.9rem; text-wrap: balance;
+  }
+  h3 { font-size: 18.5px; font-weight: 600; margin: 2rem 0 0.5rem; }
+  p { margin: 0 0 1rem; }
+  p:last-child { margin-bottom: 0; }
+  em, var { font-style: italic; font-family: inherit; }
+  strong { font-weight: 600; }
+  sub, sup { font-size: 0.72em; line-height: 0; }
+  a { color: var(--accent); text-decoration-thickness: 1px; text-underline-offset: 2px; }
+
+  .strathead {
+    display: flex; align-items: baseline; gap: 0.9rem;
+    margin: 3.2rem 0 0.9rem;
+  }
+  .stratletter {
+    font-size: 46px; font-weight: 700; line-height: 1;
+    font-style: italic;
+  }
+  .strathead h2 { margin: 0; }
+  .strathead .verdict {
+    font-family: "IBM Plex Mono", monospace; font-size: 11px;
+    letter-spacing: 0.1em; text-transform: uppercase; color: var(--muted);
+    margin-left: auto; white-space: nowrap;
+  }
+  .rule { height: 2px; border: 0; margin: 0 0 1.2rem; }
+  .strat-a .stratletter, .strat-a .verdict { color: var(--strat-a); }
+  .strat-a .rule { background: var(--strat-a); opacity: 0.5; }
+  .strat-b .stratletter, .strat-b .verdict { color: var(--strat-b); }
+  .strat-b .rule { background: var(--strat-b); opacity: 0.5; }
+  .strat-c .stratletter, .strat-c .verdict { color: var(--accent); }
+  .strat-c .rule { background: var(--accent); opacity: 0.55; }
+
+  /* ---------- math blocks ---------- */
+  .eq {
+    text-align: center; margin: 1.2rem 0; font-size: 18px;
+    overflow-x: auto; padding: 0.2rem 0;
+  }
+  .lemma {
+    background: var(--surface);
+    border: 1px solid var(--line);
+    padding: 1.1rem 1.3rem;
+    margin: 1.4rem 0;
+  }
+  .lemma .label {
+    font-variant: small-caps; letter-spacing: 0.04em; font-weight: 600;
+  }
+  .proof { margin: 0.9rem 0 1.4rem; padding-left: 1.3rem; }
+  .proof .label { font-style: italic; }
+  .qed { float: right; }
+  .remarks { margin: 1rem 0 1.4rem; padding-left: 1.3rem; }
+  .remarks li { margin-bottom: 0.55rem; }
+
+  .warn {
+    background: var(--warn-bg);
+    border: 1px solid var(--warn-line);
+    padding: 1rem 1.3rem;
+    margin: 1.4rem 0;
+  }
+  .warn .label {
+    font-family: "IBM Plex Mono", monospace; font-size: 11px;
+    letter-spacing: 0.12em; text-transform: uppercase; color: var(--strat-b);
+    display: block; margin-bottom: 0.4rem;
+  }
+
+  /* ---------- tables ---------- */
+  .tablewrap { overflow-x: auto; }
+  table {
+    border-collapse: collapse; width: 100%;
+    font-size: 15px; font-variant-numeric: tabular-nums;
+  }
+  caption {
+    text-align: left; font-family: "IBM Plex Mono", monospace;
+    font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase;
+    color: var(--muted); padding-bottom: 0.6rem;
+  }
+  th {
+    font-size: 11px; font-weight: 500; letter-spacing: 0.08em; text-transform: uppercase;
+    color: var(--muted); text-align: right; padding: 0.45rem 0.9rem;
+    border-bottom: 1px solid var(--ink);
+  }
+  th:first-child, td:first-child { text-align: left; padding-left: 0; }
+  th:last-child, td:last-child { padding-right: 0; }
+  td {
+    padding: 0.5rem 0.9rem; text-align: right;
+    border-bottom: 1px solid var(--line);
+    font-family: "IBM Plex Mono", monospace; font-size: 13.5px;
+  }
+  td:first-child { font-family: "STIX Two Text", serif; font-size: 15.5px; }
+  tr.hl td { background: var(--accent-soft); }
+  .best { color: var(--accent); font-weight: 600; }
+  .worst { color: var(--strat-b); }
+
+  /* ---------- figure ---------- */
+  figure { margin: 2rem 0; }
+  figure svg { max-width: 100%; height: auto; display: block; margin: 0 auto; }
+  figcaption {
+    font-size: 12.5px; color: var(--muted); line-height: 1.6;
+    max-width: 46rem; margin: 0.8rem auto 0;
+  }
+  .figwrap { overflow-x: auto; }
+
+  code {
+    font-family: "IBM Plex Mono", monospace; font-size: 0.82em;
+    background: var(--surface-2); padding: 0.08em 0.35em;
+  }
+
+  footer {
+    max-width: 46rem; margin: 4rem auto 0; padding-top: 1rem;
+    border-top: 1px solid var(--line);
+    font-family: "IBM Plex Mono", monospace; font-size: 12px; color: var(--muted);
+    line-height: 1.8;
+  }
+</style>
+
+<header>
+  <div class="eyebrow">Commonware · Cryptography Note</div>
+  <h1>Batching the Subgroup Check</h1>
+  <p class="standfirst">Three randomized strategies for verifying that a batch of untrusted
+  BLS12-381 points lies in the prime-order subgroup — what each buys per round, why one
+  third is the barrier for a single combination, and how to buy m combinations for the
+  price of one pass.</p>
+  <div class="meta">
+    <span>curve&nbsp;BLS12-381&nbsp;G1</span>
+    <span>target&nbsp;ε ≤ 2⁻¹²⁸</span>
+    <span>measurements: 18-core Apple&nbsp;Silicon</span>
+  </div>
+</header>
+
+<div class="col">
+
+<h2>1 · Setting</h2>
+
+<p>Let <var>E</var>/𝔽<sub>p</sub> be the BLS12-381 curve, with
+|<var>E</var>(𝔽<sub>p</sub>)| = <var>h</var>·<var>r</var> for a 255-bit prime <var>r</var> and cofactor</p>
+
+<div class="eq"><var>h</var> = 3 · (11 · 10177 · 859267 · 52437899)² ≈ 2¹²⁶.</div>
+
+<p>Since gcd(<var>h</var>, <var>r</var>) = 1, the curve group splits as
+<var>E</var>(𝔽<sub>p</sub>) ≅ <var>H</var> ⊕ 𝔾₁, where 𝔾₁ is the prime-order subgroup and
+<var>H</var> the subgroup of order <var>h</var>. Every on-curve point decomposes uniquely as
+<var>P</var> = <var>G</var> + <var>T</var> with <var>G</var> ∈ 𝔾₁, <var>T</var> ∈ <var>H</var>;
+write π(<var>P</var>) = <var>T</var> for the projection. π is a group homomorphism, and
+<var>P</var> ∈ 𝔾₁ ⟺ π(<var>P</var>) = 0.</p>
+
+<p>Decoding an untrusted point validates its encoding and the curve equation but says nothing
+about π(<var>P</var>); consuming a point with π(<var>P</var>) ≠ 0 in a pairing or scalar
+multiplication opens small-subgroup attacks. The exact membership test — Scott’s endomorphism
+check (<a href="https://eprint.iacr.org/2021/1130">eprint 2021/1130</a>, blst’s
+<code>blst_p1_in_g1</code>) — costs about <strong>22 µs</strong>; a batch-affine point addition
+costs about <strong>0.15 µs</strong>. This ≈150 : 1 exchange rate drives every design decision
+below: strategies are judged by how many exact checks and how many passes over the points they
+spend.</p>
+
+<p><strong>The verifier’s game.</strong> The adversary submits on-curve
+<var>P</var>₁, …, <var>P</var><sub>n</sub>. The verifier tosses private coins, forms a few
+combinations of the points, and exact-checks only those. The soundness error is</p>
+
+<div class="eq">ε &nbsp;=&nbsp; max<sub>∃i : π(P<sub>i</sub>) ≠ 0</sub>&nbsp; Pr[ verifier accepts ],</div>
+
+<p>with target ε ≤ 2⁻¹²⁸. Because π is linear,
+π(Σ <var>c</var><sub>i</sub><var>P</var><sub>i</sub>) = Σ <var>c</var><sub>i</sub><var>T</var><sub>i</sub>:
+every strategy is a question about when random combinations of the cofactor parts vanish
+in <var>H</var>.</p>
+
+<h2>2 · The one-third barrier</h2>
+
+<div class="lemma">
+  <span class="label">Lemma 1 (trit combination).</span>
+  Let <var>H</var> be a finite abelian group of odd order, let
+  <var>c</var>₁, …, <var>c</var><sub>n</sub> be i.i.d. uniform on {0, 1, 2} ⊂ ℤ, and let
+  <var>T</var>₁, …, <var>T</var><sub>n</sub> ∈ <var>H</var>, not all zero. Then
+  Pr[Σ<sub>i</sub> <var>c</var><sub>i</sub><var>T</var><sub>i</sub> = 0] ≤ 1/3.
+</div>
+
+<div class="proof">
+<p><span class="label">Proof.</span>
+Fix <var>j</var> with <var>T</var><sub>j</sub> ≠ 0 and define the <var>H</var>-valued random
+variable <var>U</var> = −Σ<sub>i≠j</sub> <var>c</var><sub>i</sub><var>T</var><sub>i</sub>.
+As a function of {<var>c</var><sub>i</sub>}<sub>i≠j</sub> alone, <var>U</var> is independent of
+<var>c</var><sub>j</sub>, and</p>
+
+<div class="eq">Σ<sub>i</sub> <var>c</var><sub>i</sub><var>T</var><sub>i</sub> = 0
+&nbsp;⟺&nbsp; <var>c</var><sub>j</sub><var>T</var><sub>j</sub> = <var>U</var>.</div>
+
+<p><em>Claim: the map</em> φ : {0, 1, 2} → <var>H</var>, φ(<var>a</var>) = <var>aT</var><sub>j</sub>,
+<em>is injective.</em> Let <var>d</var> = ord(<var>T</var><sub>j</sub>). By Lagrange’s theorem
+<var>d</var> divides |<var>H</var>|, and a divisor of an odd number is odd, so <var>d</var> is
+odd. <var>T</var><sub>j</sub> ≠ 0 means <var>T</var><sub>j</sub> is not the identity, so
+<var>d</var> ≠ 1. The only integer strictly between 1 and 3 is 2, which is even — excluded.
+Hence <var>d</var> ≥ 3. Now if φ(<var>a</var>) = φ(<var>b</var>) with
+<var>a</var> &gt; <var>b</var>, then (<var>a</var> − <var>b</var>)<var>T</var><sub>j</sub> = 0,
+so <var>d</var> | (<var>a</var> − <var>b</var>) — contradicting
+0 &lt; <var>a</var> − <var>b</var> ≤ 2 &lt; <var>d</var>. (This step is exactly where an even
+group order would break the lemma: it admits <var>d</var> = 2, and then
+φ(0) = φ(2) = 0 — only two distinct values, and the bound degrades to 2/3.)</p>
+
+<p>Injectivity gives |φ⁻¹(<var>u</var>)| ≤ 1 for every <var>u</var> ∈ <var>H</var>. Since
+<var>c</var><sub>j</sub> is uniform and independent of <var>U</var>, for every <var>u</var> in
+the support of <var>U</var>,</p>
+
+<div class="eq">Pr[ <var>c</var><sub>j</sub><var>T</var><sub>j</sub> = <var>U</var> | <var>U</var> = <var>u</var> ]
+&nbsp;=&nbsp; Pr[ <var>c</var><sub>j</sub> ∈ φ⁻¹(<var>u</var>) ]
+&nbsp;=&nbsp; |φ⁻¹(<var>u</var>)| / 3 &nbsp;≤&nbsp; 1/3,</div>
+
+<p>and averaging over the law of <var>U</var>,</p>
+
+<div class="eq">Pr[ Σ<sub>i</sub> <var>c</var><sub>i</sub><var>T</var><sub>i</sub> = 0 ]
+&nbsp;=&nbsp; 𝔼<sub>U</sub>&thinsp;Pr[ <var>c</var><sub>j</sub><var>T</var><sub>j</sub> = <var>U</var> | <var>U</var> ]
+&nbsp;≤&nbsp; 1/3. <span class="qed">∎</span></div>
+</div>
+
+<p>Five remarks a reviewer should check:</p>
+
+<ol class="remarks">
+  <li><strong>The barrier is real, not an artifact of trits.</strong> 3 | <var>h</var>, so
+  <var>H</var> contains <var>T</var> of order 3. Against the pair
+  (<var>T</var>, −<var>T</var>), a single combination with coefficients from <em>any</em>
+  distribution 𝒟 escapes iff <var>c</var>₁ ≡ <var>c</var>₂ (mod 3) — the mod-3 collision
+  probability of 𝒟, which is ≥ 1/3 for every distribution (Σ<var>p</var>² ≥ 1/3, equality iff
+  uniform). No single combination beats 1/3; larger coefficients only cost more.</li>
+  <li><strong>Budget.</strong> <var>t</var> independent combinations give ε ≤ 3⁻ᵗ.
+  3⁻⁸¹ = 2⁻¹²⁸·³⁸ meets the target; 3⁻⁸⁰ = 2⁻¹²⁶·⁸ does not. Every strategy below is a way
+  of purchasing <strong>81 combinations</strong>; they differ only in the price.</li>
+  <li><strong>Exact uniformity is load-bearing.</strong> The margin is 0.38 bits. Sampling a
+  trit as <code>byte % 3</code> puts mass 86/256 on one residue, and a lone planted bad point
+  then escapes each combination with probability 86/256, giving
+  (86/256)⁸¹ = 2⁻¹²⁷·⁵ — below target. The implementation rejection-samples bytes &lt; 3⁵ = 243,
+  each accepted byte yielding five exact trits.</li>
+  <li><strong>Coins are the verifier’s private randomness.</strong> As in batched signature
+  verification, the coefficients must be unpredictable to whoever chose the points; they are
+  drawn fresh per batch and never reused.</li>
+  <li><strong>Adversarially correlated points are priced in — quantifier order does the
+  work.</strong> The lemma reads ∀(<var>T</var>₁,…,<var>T</var><sub>n</sub>) fixed, then
+  probability over the coins alone: the adversary may choose <var>T</var><sub>j</sub> as any
+  function of the other <var>T</var><sub>i</sub> before the coins are sampled, and the proof
+  is insensitive to it — <var>U</var> is a function of the other <em>coins</em> and of
+  constants, and the conditional bound
+  Pr[<var>c</var><sub>j</sub><var>T</var><sub>j</sub> = <var>U</var> | <var>U</var> = <var>u</var>] ≤ 1/3
+  holds uniformly for <em>every</em> value <var>u</var>, whatever <var>U</var>’s distribution.
+  The natural objection — “with small weights, Σ<var>c</var><sub>i</sub><var>T</var><sub>i</sub>
+  is structured and not independent of the <var>T</var><sub>i</sub>” — is true and harmless:
+  no such independence is used. The worst case realizes it: <var>T</var>₂ = −<var>T</var>₁
+  escapes iff <var>c</var>₁ = <var>c</var>₂, exactly 1/3, meeting the bound with equality.
+  Nor would large weights help: by remark (i), even full-width coefficients act mod 3 in an
+  order-3 component and leave the pair a ≥ 1/3 escape. The model’s real requirements are the
+  ones in remark (iv): fresh, private, unpredictable coins — the bound does not survive coin
+  reuse or a predictable source.</li>
+</ol>
+
+</div><!-- /col -->
+
+<div class="col strat-a">
+  <div class="strathead">
+    <span class="stratletter">A</span>
+    <h2>One combination per round</h2>
+    <span class="verdict">previous implementation</span>
+  </div>
+  <hr class="rule">
+
+<p>The direct construction: 81 rounds, each drawing fresh trits and exact-checking
+<var>Q</var> = Σ <var>c</var><sub>i</sub><var>P</var><sub>i</sub>. The combination is a 2-bit
+multi-scalar multiplication, and Pippenger’s algorithm already evaluates it by grouping:
+skip the <var>c</var><sub>i</sub> = 0 points, sum the two coefficient classes
+<var>B</var>₁, <var>B</var>₂ with batch-affine additions, return
+<var>Q</var> = <var>B</var>₁ + 2<var>B</var>₂.</p>
+
+<p><strong>Price:</strong> soundness needs 81 combinations and A evaluates one per pass, so it
+pays <strong>81 full passes</strong> over the <var>n</var> points (≈126 ns/point in blst) and
+81 exact checks. At <var>n</var> = 6000 that is 63 ms serial — a 2× win over per-point
+checking, entirely from the exact-check count dropping from <var>n</var> to 81. The passes are
+now the bottleneck: each extracts only log₂3 ≈ 1.58 bits.</p>
+
+</div>
+
+<div class="col strat-b">
+  <div class="strathead">
+    <span class="stratletter">B</span>
+    <h2>Random bucketing</h2>
+    <span class="verdict">celo/zexe · rejected</span>
+  </div>
+  <hr class="rule">
+
+<p>The 2019 zexe construction (celo/zexe PR #4): draw a uniform bucket map
+β : [<var>n</var>] → [<var>B</var>], and exact-check <em>every</em> bucket sum
+<var>S</var><sub>b</sub> = Σ<sub>β(i)=b</sub> <var>P</var><sub>i</sub>.</p>
+
+<div class="lemma">
+  <span class="label">Lemma 2 (bucketing).</span>
+  If some <var>T</var><sub>j</sub> ≠ 0, then
+  Pr[∀<var>b</var> : π(<var>S</var><sub>b</sub>) = 0] ≤ 1/<var>B</var>.
+</div>
+
+<p class="proof"><span class="label">Proof.</span>
+Fix <var>j</var> with <var>T</var><sub>j</sub> ≠ 0 and condition on the buckets of all other
+points; let σ<sub>b</sub> be the torsion already in bucket <var>b</var>. If <var>j</var> lands
+in <var>b</var>, acceptance requires σ<sub>b</sub> + <var>T</var><sub>j</sub> = 0 <em>and</em>
+σ<sub>b′</sub> = 0 for all <var>b′</var> ≠ <var>b</var>. Were two buckets
+<var>b</var>₁ ≠ <var>b</var>₂ both admissible, the first condition at <var>b</var>₂ and the
+second at <var>b</var>₁ force −<var>T</var><sub>j</sub> = σ<sub>b₂</sub> = 0, a contradiction.
+So at most one admissible bucket exists, and β(<var>j</var>) is uniform over <var>B</var>.
+<span class="qed">∎</span></p>
+
+<p>The bound is exact for the cancelling pair (<var>T</var>, −<var>T</var>): same bucket
+⟺ everything cancels ⟺ escape, probability 1/<var>B</var>. So one pass now extracts
+log₂<var>B</var> bits — more than A’s 1.58 — because keeping <var>B</var> separate constraints
+refuses to collapse them into one combination. Rounds: ⌈128/log₂<var>B</var>⌉, e.g. 32 at
+<var>B</var> = 16.</p>
+
+<p><strong>Price:</strong> the constraints must each be <em>checked</em>. That is
+rounds × <var>B</var> exact checks — 512 at <var>B</var> = 16, an 11.3 ms serial floor
+independent of <var>n</var>, against A’s 1.8 ms. Implemented naively (one batch-add call per
+bucket) it also pays per-bucket inversion chains. Measured: <strong>slower than A at
+<var>n</var> = 1000</strong> (15.9 vs 12.1 ms serial) and only 1.35× ahead at
+<var>n</var> = 6000. The information per round went up; the price per round went up faster.</p>
+
+</div>
+
+<div class="col strat-c">
+  <div class="strathead">
+    <span class="stratletter">C</span>
+    <h2>m parallel combinations, one pass</h2>
+    <span class="verdict">shipping</span>
+  </div>
+  <hr class="rule">
+
+<p>Draw for each point a coefficient <em>vector</em>
+<var>v</var><sub>i</sub> = (<var>c</var><sub>1,i</sub>, …, <var>c</var><sub>m,i</sub>) uniform on
+{0, 1, 2}<sup>m</sup>, and exact-check the <var>m</var> combinations
+<var>Q</var><sub>j</sub> = Σ<sub>i</sub> <var>c</var><sub>j,i</sub><var>P</var><sub>i</sub>.</p>
+
+<div class="lemma">
+  <span class="label">Theorem (round soundness).</span>
+  If some <var>T</var><sub>i</sub> ≠ 0, then
+  Pr[<var>Q</var>₁, …, <var>Q</var><sub>m</sub> ∈ 𝔾₁] ≤ 3⁻ᵐ.
+</div>
+
+<p class="proof"><span class="label">Proof.</span>
+The event “π(<var>Q</var><sub>j</sub>) = 0” is a function of the <var>j</var>-th coordinates
+alone, and coordinates are disjoint fresh trits, so the <var>m</var> events are independent.
+Each has probability ≤ 1/3 by Lemma 1. <span class="qed">∎</span></p>
+
+<p>With <var>r</var> = ⌈81/<var>m</var>⌉ rounds, ε ≤ 3<sup>−rm</sup> ≤ 3⁻⁸¹. The worst case
+matches the bound: the pair (<var>T</var>, −<var>T</var>) escapes a round iff the two points
+drew <em>identical</em> vectors — coordinate differences lie in {−2, …, 2} and are annihilated
+only by 0 — probability exactly 3⁻ᵐ.</p>
+
+<h3>Evaluating m combinations for one pass</h3>
+
+<p>The construction is worthwhile only if <var>m</var> combinations cost roughly one. Three
+observations make that true:</p>
+
+<ol class="remarks">
+  <li><strong>Grouping is free.</strong> Read <var>v</var><sub>i</sub> as a base-3 index into
+  3<sup>m</sup> classes. Points sharing a vector contribute identical coefficients to every
+  combination, so first sum each class: still <var>n</var> additions total, independent of
+  3<sup>m</sup> — each point lands in exactly one class.</li>
+  <li><strong>The additions share their inversions.</strong> Affine addition needs
+  λ = Δ<var>y</var>/Δ<var>x</var>, an inversion each. Instead, a pass pairs up the remaining
+  points of <em>every</em> class and Montgomery-batches all denominators: prefix products, one
+  real inversion, back-substitution — 3 multiplications per inverse, ≈6 multiplications per
+  point addition, ⌈log₂(max class)⌉ passes. Measured 146–178 ns/point, flat from 27 to 243
+  classes. Adversarial edge cases are handled explicitly: planted (<var>P</var>, −<var>P</var>)
+  pairs collapse to the identity mid-tree; equal-<var>x</var> pairs are classified as
+  cancellation or doubling; and denominators never vanish because <var>h</var>·<var>r</var> is
+  odd — the curve has no 2-torsion, so <var>y</var> ≠ 0 on-curve.</li>
+  <li><strong>Recombination is deterministic.</strong> With
+  digit<sub>j</sub>(<var>v</var>) the <var>j</var>-th base-3 digit,
+  <div class="eq"><var>Q</var><sub>j</sub> = Σ<sub>digit<sub>j</sub>(v)=1</sub> <var>S</var><sub>v</sub>
+  &nbsp;+&nbsp; 2·Σ<sub>digit<sub>j</sub>(v)=2</sub> <var>S</var><sub>v</sub>,</div>
+  a combine over 2·3<sup>m−1</sup> class sums per output — trivial next to the pass.</li>
+</ol>
+
+<div class="warn">
+  <span class="label">The unsound shortcut</span>
+  Replacing the <var>m</var> checks by one re-randomized check
+  Σ<sub>v</sub> <var>r</var><sub>v</sub><var>S</var><sub>v</sub> collapses the round back to the
+  barrier: the pair placed in classes <var>v</var> ≠ <var>v′</var> escapes iff
+  <var>r</var><sub>v</sub> ≡ <var>r</var><sub>v′</sub>, a collision event of probability ≥ 1/3
+  by remark (i). The <var>m</var> separate checks with <em>deterministic digit weights</em> —
+  all randomness in the vector assignment — are precisely what preserve the product structure
+  3⁻ᵐ.
+</div>
+
+</div>
+
+<div class="wide figwrap">
+<figure>
+<svg viewBox="0 0 880 258" role="img" aria-label="One round of strategy C: n points are grouped by coefficient vector into 3^m class sums via shared-inversion passes, recombined by digit weights into m combinations, and each combination is exact-checked. One pass over the points serves all m combinations.">
+  <defs>
+    <marker id="arr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="currentColor"/>
+    </marker>
+    <marker id="arrAcc" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="var(--accent)"/>
+    </marker>
+  </defs>
+  <g fill="none" stroke="currentColor" stroke-width="1.2" color="var(--ink)">
+    <!-- box 1: points -->
+    <rect x="14" y="58" width="150" height="92"/>
+    <!-- box 2: class sums (the shared pass — accent) -->
+    <rect x="284" y="58" width="196" height="92" stroke="var(--accent)" stroke-width="1.8"/>
+    <!-- box 3: combinations -->
+    <rect x="596" y="58" width="128" height="92"/>
+    <!-- box 4: checks -->
+    <rect x="782" y="58" width="84" height="92"/>
+    <!-- arrows -->
+    <line x1="164" y1="104" x2="278" y2="104" marker-end="url(#arr)"/>
+    <line x1="480" y1="80"  x2="590" y2="80"  stroke="var(--accent)" marker-end="url(#arrAcc)"/>
+    <line x1="480" y1="104" x2="590" y2="104" stroke="var(--accent)" marker-end="url(#arrAcc)"/>
+    <line x1="480" y1="128" x2="590" y2="128" stroke="var(--accent)" marker-end="url(#arrAcc)"/>
+    <line x1="724" y1="104" x2="776" y2="104" marker-end="url(#arr)"/>
+  </g>
+  <g fill="var(--ink)" font-size="14" font-family="STIX Two Text, serif">
+    <text x="89"  y="92"  text-anchor="middle" font-style="italic">P₁ … Pₙ</text>
+    <text x="382" y="92"  text-anchor="middle" font-style="italic">S₀ … S₃ᵐ₋₁</text>
+    <text x="660" y="92"  text-anchor="middle" font-style="italic">Q₁ … Qₘ</text>
+    <text x="824" y="98"  text-anchor="middle" font-style="italic">∈ 𝔾₁ ?</text>
+  </g>
+  <g fill="var(--muted)" font-size="11.5" font-family="IBM Plex Mono, monospace">
+    <text x="89"  y="118" text-anchor="middle">n on-curve points</text>
+    <text x="89"  y="134" text-anchor="middle">vᵢ ∈ {0,1,2}ᵐ</text>
+    <text x="382" y="118" text-anchor="middle">3ᵐ class sums</text>
+    <text x="382" y="134" text-anchor="middle">n adds · 1 inv/pass</text>
+    <text x="660" y="118" text-anchor="middle">m combinations</text>
+    <text x="660" y="134" text-anchor="middle">2m·3ᵐ⁻¹ adds</text>
+    <text x="824" y="120" text-anchor="middle">m checks</text>
+    <text x="824" y="136" text-anchor="middle">22 µs each</text>
+    <!-- arrow labels -->
+    <text x="221" y="92"  text-anchor="middle">group by vᵢ</text>
+    <text x="221" y="122" text-anchor="middle">counting sort</text>
+    <text x="535" y="66"  text-anchor="middle" fill="var(--accent)">digit-j weights</text>
+    <text x="750" y="92"  text-anchor="middle">exact</text>
+  </g>
+  <g fill="var(--ink)" font-size="12.5" font-family="STIX Two Text, serif">
+    <text x="440" y="210" text-anchor="middle" font-style="italic">one pass over the points yields all m combinations — escape probability 3⁻ᵐ per round,</text>
+    <text x="440" y="230" text-anchor="middle" font-style="italic">repeated r = ⌈81/m⌉ times, so the exact-check total stays at r·m ≈ 81</text>
+  </g>
+</svg>
+<figcaption>One round of strategy C. The accented stage is the novelty: grouping by the joint
+coefficient vector lets a single shared-inversion accumulation pass serve every combination,
+where strategy A would spend one full pass per combination and strategy B would exact-check all
+3ᵐ class sums instead of the m recombinations.</figcaption>
+</figure>
+</div>
+
+<div class="col strat-c">
+
+<h3>Where C sits relative to A and B</h3>
+
+<p><strong>C generalizes A:</strong> at <var>m</var> = 1 the class sums are Pippenger’s
+coefficient buckets and the digit combine is <var>B</var>₁ + 2<var>B</var>₂ — strategy A
+exactly. <strong>C dominates B:</strong> set <var>B</var> = 3ᵐ and a B-round and a C-round
+have the same accumulation and the same escape bound 3⁻ᵐ, but B exact-checks 3ᵐ sums where C
+checks <var>m</var> recombinations. C’s check total stays at <var>r</var>·<var>m</var> ≈ 81 —
+the Lemma-1 budget, i.e. the minimum any strategy in this family pays — for every
+<var>m</var>.</p>
+
+<p>The combine grows as 3ᵐ, capping useful width: a cost model picks <var>m</var> per batch
+(<var>m</var> = 3 at <var>n</var> = 1000, <var>m</var> = 4 at <var>n</var> = 6000) and falls
+back to per-point checking below <var>n</var> ≈ 120. The model’s constants steer only speed —
+any (<var>m</var>, <var>r</var>) with <var>rm</var> ≥ 81 is sound.</p>
+
+</div>
+
+<div class="wide">
+<div class="tablewrap">
+<table>
+  <caption>Cost accounting · 128-bit target</caption>
+  <thead>
+    <tr><th>quantity</th><th>A — one RLC</th><th>B — buckets (B=16)</th><th>C — m=4</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>passes over the n points</td><td>81</td><td>32</td><td class="best">21</td></tr>
+    <tr><td>exact subgroup checks</td><td>81</td><td class="worst">512</td><td>84</td></tr>
+    <tr><td>bits per pass</td><td>1.58</td><td>4</td><td class="best">6.34</td></tr>
+    <tr><td>inversions amortized batch-wide</td><td>yes (blst)</td><td class="worst">no (per bucket)</td><td class="best">yes (hand-rolled)</td></tr>
+  </tbody>
+</table>
+</div>
+</div>
+
+<div class="wide">
+<div class="tablewrap">
+<table>
+  <caption>Measured · criterion medians · 18-core Apple Silicon</caption>
+  <thead>
+    <tr><th>n</th><th>per-point</th><th>A serial</th><th>A parallel</th><th>C serial</th><th>C parallel</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>100</td><td>2.14 ms</td><td>2.18 ms</td><td>2.19 ms</td><td>2.13 ms *</td><td class="best">0.31 ms</td></tr>
+    <tr><td>1 000</td><td>21.4 ms</td><td>12.1 ms</td><td>1.59 ms</td><td>6.50 ms</td><td class="best">1.16 ms</td></tr>
+    <tr class="hl"><td>6 000</td><td>126.6 ms</td><td>63.1 ms</td><td>6.9 ms</td><td>22.6 ms</td><td class="best">4.10 ms</td></tr>
+  </tbody>
+</table>
+</div>
+<p style="font-family:'IBM Plex Mono',monospace; font-size:12px; color:var(--muted); margin-top:0.7rem;">
+* n=100 takes the per-point fallback; its parallel win comes from routing fallback checks
+through the same adaptive strategy, not from batching. At n = 6 000, C parallel is
+30.9× per-point serial.</p>
+
+<div class="tablewrap" style="margin-top:2rem;">
+<table>
+  <caption>Same-engine strategy comparison · single-shot · serial / parallel</caption>
+  <thead>
+    <tr><th>n</th><th>per-point</th><th>A — 81 passes</th><th>B — best of {16, 64, 256}</th><th>C — shipping</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>1 000</td><td>21.4 ms</td><td>15.5 / 2.38 ms</td><td>15.9 / 2.40 ms (B=16)</td><td class="best">6.6 / 1.13 ms</td></tr>
+    <tr><td>6 000</td><td>126.5 ms</td><td>74.9 / 8.86 ms</td><td>40.1 / 4.49 ms (B=16)</td><td class="best">22.4 / 3.62 ms</td></tr>
+    <tr class="hl"><td>100 000</td><td>2 126 ms</td><td>1 249 / 138 ms</td><td>353 / 47.8 ms (B=256)</td><td class="best">298 / 49.6 ms</td></tr>
+  </tbody>
+</table>
+</div>
+<p style="font-family:'IBM Plex Mono',monospace; font-size:12px; color:var(--muted); margin-top:0.7rem;">
+All three strategies here run on the shipped batch-affine engine, so the comparison isolates
+the strategy (blst's MSM engine runs A's passes ~15% faster); B is steelmanned with shared
+inversions and swept over bucket counts. C wins serially at every size — 7.1× over per-point
+and 4.2× over A at n = 100 000 (42.8× parallel). One honest boundary: at n = 100 000
+parallel, B=256 ties C within noise — C's width cap (m ≤ 5, one-byte bucket ids) binds
+there, and the cost model puts m = 6 about 13% ahead as a follow-up.</p>
+</div>
+
+<div class="col">
+
+<h2>3 · Notes for review</h2>
+
+<ol class="remarks">
+  <li><strong>Odd cofactor is a precondition of the trit instantiation, not of the
+  construction.</strong> Lemma 1 needs ord(<var>T</var>) ≥ 3: an order-2 part has
+  2<var>T</var> = 0, so trit coefficients escape with probability 2/3 per combination, and
+  BLS12-377 𝔾₁ (2⁹² | <var>h</var>) cannot use the scheme as-is. Switching to {0, 1}
+  coefficient vectors restores it for even cofactors — <var>cT</var> ∈ {0, <var>T</var>} is
+  injective on {0, 1} for any <var>T</var> ≠ 0, giving ≤ 1/2 per combination, 2ᵐ buckets, and
+  128 combinations total instead of 81.</li>
+  <li><strong>Relation to the state of the art.</strong> The current literature reference is
+  Koshelev–El Housni–Fotiadis (<a href="https://eprint.iacr.org/2025/1311">eprint 2025/1311</a>):
+  a per-point Tate-pairing/power-residue prefilter removes the 3- and 11-torsion so that a few
+  rounds of 13-bit-coefficient MSMs suffice. They state the same 1/3 barrier and analyze the
+  same multi-round small-coefficient route, but their cost model charges one full MSM per
+  round — and by their own benchmarks the end-to-end method is <em>slower than naive per-point
+  checking on unmodified BLS12-381</em> (the prefilter dominates; their remedy is generating
+  new curves). They name batch-affine additions with Montgomery inversion as future work; the
+  cross-round vector-bucketing used here does not appear. The honest novelty claim is
+  therefore scoped: every ingredient is classical (small-exponent batch testing, multi-product
+  bucketing, Montgomery inversion), and what appears new is the composition for this problem —
+  one accumulation pass serving all <var>m</var> combinations, which removes exactly the cost
+  their model assumes and makes the no-prefilter route win on the unmodified curve at a
+  stronger 2⁻¹²⁸ target.</li>
+  <li><strong>The combine wiring is soundness-critical and invisible to black-box tests.</strong>
+  A bug that reuses one digit position for every output (a stuck divisor) silently degrades a
+  round from 3⁻ᵐ to 3⁻¹ — ε goes from 2⁻¹²⁸ to ≈2⁻⁴³ — while valid batches still verify and
+  bad batches still mostly reject. The test suite plants a single bad point at chosen class
+  indices: at <var>v</var> = 0 the round must accept (every digit 0); at <var>v</var> = 3ʲ and
+  <var>v</var> = 2·3ʲ combination <var>j</var> alone must reject, isolating each digit position
+  and weight deterministically.</li>
+  <li><strong>Assurance.</strong> The accumulator is differential-tested against naive group
+  addition over mixed valid / off-subgroup / identity / negated / duplicated inputs, with
+  deterministic tests for each special-case branch; adversarial batch tests cover the
+  cancelling pair and mass-duplicated bad points. The only new unsafe code is thin per-call
+  FFI wrappers over blst field ops; all pass scheduling is safe Rust.</li>
+  <li><strong>Provenance.</strong> Shipped as <code>bls12381::primitives::subgroup::batch_in_g1</code>
+  in <a href="https://github.com/commonwarexyz/monorepo/pull/4528">commonware PR #4528</a>,
+  ALPHA-gated pending review; the in-repo comparison lives at
+  <code>cryptography/BATCHED_SUBGROUP.md</code>. Strategy B reference: celo/zexe PR #4 (2019).</li>
+</ol>
+
+</div>
+
+<footer>
+  commonware · cryptography · 2026-08 &nbsp;—&nbsp; soundness claims: Lemmas 1–2 and the round
+  theorem above; performance claims: criterion medians on one machine, reproducible via the
+  <code>measure_scheme</code> and <code>measure_accumulator</code> harnesses in the module’s tests.
+</footer>

--- a/cryptography/PAPER_HANDOFF.md
+++ b/cryptography/PAPER_HANDOFF.md
@@ -4,6 +4,29 @@ Complete working notes for writing an ePrint note. Everything below is verified
 (proofs re-derived, measurements reproduced, prior art read first-hand) unless
 explicitly marked TODO. Written 2026-08-19.
 
+> **Stale as of 2026-08-24 — performance sections only.** The engine was
+> rebuilt after these notes were written: streaming accumulation into per-bucket
+> slots, a shared digit-collapse for the combine, per-round widths, and inlined
+> field arithmetic. Rounds went from seventeen of width five to **nine of width
+> nine**, which is the floor at this soundness target. What that invalidates
+> here: §2's construction parameters (the `m <= 5` cap and its `u8` bucket ids
+> are gone, `MAX_WIDTH` is now 11 with a cache budget binding first), §4's cost
+> model and its prediction-vs-measurement table, and §5's entire measurement
+> record — including the "possible follow-up" notes about `m = 6` and the
+> B-tie at 100k, both of which the rebuild settled. Single-threaded on an Apple
+> M5 Pro the check is now **17.3x** per-point checking at a million points and
+> 14.7x at a hundred thousand, against 7.0x and 7.5x for the engine these notes
+> describe.
+>
+> What is unaffected: §3 (soundness) in full — the bound, its tightness, the
+> any-distribution barrier, the uniformity margin and the even-cofactor
+> extension all concern the scheme, not the engine — along with §6 (prior art),
+> §7 (objections) and §8's checklist. §0's thesis holds and its headline
+> numbers are now conservative.
+>
+> `BATCHED_SUBGROUP.md` is the current source for the construction, the cost
+> analysis and every measurement; take numbers from there, not from below.
+
 ## 0. Thesis and framing
 
 **One-sentence claim:** batch subgroup membership testing on *unmodified*

--- a/cryptography/PAPER_HANDOFF.md
+++ b/cryptography/PAPER_HANDOFF.md
@@ -1,0 +1,412 @@
+# ePrint note handoff: batched subgroup membership testing on BLS12-381
+
+Complete working notes for writing an ePrint note. Everything below is verified
+(proofs re-derived, measurements reproduced, prior art read first-hand) unless
+explicitly marked TODO. Written 2026-08-19.
+
+## 0. Thesis and framing
+
+**One-sentence claim:** batch subgroup membership testing on *unmodified*
+BLS12-381 beats per-point checking after all — 7.1× single-threaded and 43×
+parallel at a 2⁻¹²⁸ soundness target — via m parallel small-coefficient
+combinations per round evaluated through one shared bucketed accumulation,
+directly contradicting the practical conclusion of the current state of the art
+(Koshelev–El Housni–Fotiadis, eprint 2025/1311), whose end-to-end method is
+slower than naive on this curve and whose proposed remedy is generating new
+curves.
+
+**Honest novelty scope (use this wording; it is defensible to the KEF authors):**
+every ingredient is classical — small-exponent batch testing (Bellare–Garay–
+Rabin '98), multiproduct/Pippenger bucketing (Henry's survey, cacr2010-26),
+Montgomery batch inversion — and the multi-round small-coefficient route with
+its 1/3-per-combination barrier is explicitly known (KEF25 §2.1 states
+ℙ ≤ 1/min{m,p} citing BGR Lemma 3.1 and a 2018 zcash issue). What appears new
+is the **composition for this problem**: grouping points by their joint
+coefficient vector so one accumulation pass serves all m combinations, which
+removes exactly the cost (one full MSM per round) that KEF's cost model
+`n(𝒫+ℬ𝒮)` charges and that led them to dismiss this route. Do NOT claim a new
+technique; claim the composition + analysis + measured result.
+
+**Suggested headline structures:**
+- "Batch subgroup membership testing on BLS12-381 without new curves"
+- "One pass, many combinations: batch subgroup checks for BLS12-381"
+
+## 1. Repository state (where everything lives)
+
+- Feature branch: `gv/batch-subgroup-check` → PR
+  https://github.com/commonwarexyz/monorepo/pull/4528 (7 commits at handoff;
+  head `e67f03bcb`).
+- Implementation: `cryptography/src/bls12381/primitives/subgroup.rs`
+  (module docs contain the soundness argument; ~975 lines incl. tests).
+  Supporting: `G1::in_subgroup`, `G1::read_unchecked` in
+  `cryptography/src/bls12381/primitives/group.rs` (all ALPHA-gated).
+- Design doc (good skeleton for the note's related-work + results sections):
+  `cryptography/BATCHED_SUBGROUP.md`.
+- Criterion bench: `cryptography/src/bls12381/benches/subgroup.rs`
+  (`cargo bench -p commonware-cryptography --features bls12381 --bench bls12381 -- subgroup`).
+- Manual harnesses (all `#[ignore]`d tests in subgroup.rs, run with
+  `RUSTUP_TOOLCHAIN=1.95.0 cargo test -p commonware-cryptography --release
+  --features bls12381 <name> -- --ignored --nocapture`):
+  - `measure_accumulator` — isolated ns/point of `sum_buckets`.
+  - `measure_scheme` — per-point vs batch, n ∈ {200, 1k, 6k, 100k}.
+  - `measure_strategies` — same-engine A/B/C comparison (A emulated as m=1
+    ×81 rounds; B emulated as `sum_buckets` + per-bucket `blst_p1_affine_in_g1`
+    checks, B ∈ {16, 64, 256}).
+- Rejected naive-bucketing prototype: local branch
+  `gv/subgroup-bucketed-prototype` (NOT pushed; counting sort + per-bucket
+  `blst_p1s_add`; measured numbers below).
+- Cryptographer-facing explainer artifact (private; has the formal Lemma 1
+  proof, the diagram, all tables):
+  https://claude.ai/code/artifact/ef1bf48b-e421-4c6f-8a0d-e09e528f551d
+- Toolchain: rustc 1.95.0, blst 0.3.16, commonware-parallel (adaptive Rayon
+  strategy). Machine: 18-core Apple Silicon, macOS (Darwin 25.6.0).
+
+## 2. The construction (strategy C, as shipped)
+
+Parameters: security µ (default 128); t = ⌈µ·1000/1584⌉ total combinations
+(1584 = strict lower bound on 1000·log₂3, so t is never under-counted; t = 81
+at µ=128); width m ∈ 1..=5 and rounds r = ⌈t/m⌉ chosen by a cost model
+(`plan()`), with per-point fallback when batching loses. Soundness holds for
+EVERY (m, r) with r·m ≥ t; the model affects speed only.
+
+Per round:
+1. **Coefficients.** Each point i gets m iid uniform trits c_{1..m,i} — its
+   coefficient vector — encoded as a base-3 bucket id v_i ∈ [0, 3^m). Trits
+   come from rejection sampling: each RNG byte < 243 = 3⁵ yields five exact
+   trits (`Trits` struct). Exactness is load-bearing (see §3, margins).
+2. **Accumulation (`sum_buckets`).** Counting-sort points into contiguous
+   per-bucket runs. Repeat until every bucket has ≤ 1 point: pair up the
+   remaining points of every bucket; classify each pair (identity operand →
+   copy; equal x with y₁+y₂=0 → identity; equal x otherwise → doubling with
+   denominator 2y; else chord addition with denominator x₂−x₁); collect ALL
+   arithmetic pairs' denominators across ALL buckets; ONE Montgomery batch
+   inversion (prefix products, 1 field inversion, 3 muls/element); complete
+   the affine formulas (λ; x₃ = λ²−x_a−x_b works for add and double since
+   b.x = a.x when doubling; y₃ = λ(x_a−x₃)−y_a). Operands are copied into the
+   op list before any write, so there are no aliasing hazards. Denominators
+   can never be zero: the curve group order h·r is odd ⇒ no 2-torsion ⇒
+   y ≠ 0 for non-identity on-curve points (G1 type invariant guarantees
+   on-curve).
+3. **Combine.** Q_j = Σ_{digit_j(v)=1} S_v + 2·Σ_{digit_j(v)=2} S_v, with
+   digit_j(v) = ⌊v/3^j⌋ mod 3. Weights are DETERMINISTIC digits; all
+   randomness is in the vector assignment. (Re-randomizing over bucket sums
+   instead collapses soundness to 1/3 — see §3.)
+4. **Check.** m exact checks (blst_p1_in_g1, Scott eprint 2021/1130
+   endomorphism test) on Q_1..Q_m. Total checks over the batch: r·m ∈
+   [t, t+m−1] ≤ 85 — invariant in m.
+
+Rounds are independent → parallelized via commonware-parallel Strategy
+(adaptive; fallback per-point checks also routed through the strategy).
+
+Implementation quirks worth fixing before/while writing the paper:
+- The all-zero-vector bucket (3⁻ᵐ of points) is summed but never used —
+  skippable (≤1.2% at m ≥ 4).
+- m is capped at 5 by u8 bucket ids. Lifting to u16 enables m=6 (729 buckets,
+  14 rounds), modeled ~13% faster at n=10⁵ — this is what closes the B-tie
+  (see §5).
+
+## 3. Soundness — complete proofs (all verified)
+
+Setting: |E(𝔽_p)| = h·r, r 255-bit prime,
+h = 3·(11·10177·859267·52437899)² = 76329603384216526031706109802092473003
+(odd; ≈2¹²⁶; smallest prime factor 3; the last factor 52437899 is prime — an
+earlier draft mistakenly wrote its square 2749733251534201 as prime).
+gcd(h,r)=1 ⇒ E(𝔽_p) ≅ H ⊕ 𝔾₁; π(P) = cofactor part; π linear; P ∈ 𝔾₁ ⟺
+π(P)=0. In KEF notation h = h₁ = 3e₁², e₁ = 11·p₁₄·p₂₀·p₂₆ with p₁₄ = 10177,
+p₂₀ = 859267, p₂₆ = 52437899.
+
+**Lemma 1 (trit combination).** H a finite abelian group of ODD order,
+c_i iid uniform on {0,1,2} ⊂ ℤ, T_i ∈ H not all zero. Then
+Pr[Σ c_iT_i = 0] ≤ 1/3.
+*Proof.* Fix j with T_j ≠ 0; U := −Σ_{i≠j} c_iT_i is independent of c_j.
+Event ⟺ c_jT_j = U. Claim φ(a) = aT_j injective on {0,1,2}: d = ord(T_j)
+divides |H| (Lagrange), divisor of odd is odd, T_j≠0 ⇒ d≠1, only integer in
+(1,3) is 2 (even, excluded) ⇒ d ≥ 3; a collision forces d | (a−b),
+0 < a−b ≤ 2 < d. So |φ⁻¹(u)| ≤ 1; conditioning on U=u gives ≤ 1/3; average. ∎
+
+**Tightness & barrier (important for the paper — reviewers will probe).**
+(i) 3 | h, so H has an order-3 element; a lone bad point escapes iff c_j = 0:
+exactly 1/3. (ii) NO single-combination coefficient distribution 𝒟 beats 1/3:
+against the pair (T, −T) with ord(T)=3, escape ⟺ c₁ ≡ c₂ (mod 3), the mod-3
+collision probability of 𝒟, which is Σp² ≥ 1/3 (Cauchy–Schwarz; equality iff
+uniform). Larger coefficients only cost more.
+
+**Round theorem (strategy C).** Coefficient vectors uniform on {0,1,2}^m,
+coordinates disjoint iid trits ⇒ the m events "combination j vanishes" are
+independent ⇒ Pr[all pass] ≤ 3⁻ᵐ. r rounds: 3^{−rm}. Worst case matches: the
+pair (T,−T) escapes a round iff the two vectors are identical (coordinate
+diffs ∈ {−2..2} annihilated only by 0), probability exactly 3⁻ᵐ.
+
+**Correctness of the bucket evaluation.** Q_j = Σ_v digit_j(v)·S_v =
+Σ_v digit_j(v)·Σ_{v_i=v} P_i = Σ_i c_{j,i}P_i — telescopes exactly; bucketing
+is pure evaluation strategy.
+
+**The unsound shortcut (must be warned against in the paper).** Checking one
+re-randomized combination Σ_v r_v·S_v of the bucket sums re-merges the
+cancelling pair: placed in buckets v ≠ v′, it escapes iff r_v ≡ r_{v′}
+(collision ≥ 1/3 by the barrier). The m separate checks with deterministic
+digit weights are what preserve the product structure.
+
+**Lemma 2 (bucketing, strategy B).** β:[n]→[B] uniform; some T_j ≠ 0. Then
+Pr[all bucket sums have zero cofactor part] ≤ 1/B.
+*Proof.* Condition on placements of all i ≠ j; σ_b = torsion already in b.
+If j→b, acceptance needs σ_b + T_j = 0 AND σ_{b′}=0 ∀b′≠b. Two admissible
+buckets b₁≠b₂ force −T_j = σ_{b₂} = 0, contradiction. ≤1 admissible bucket;
+β(j) uniform. ∎  Tight via (T,−T): escape ⟺ collision, exactly 1/B.
+
+**Margins & uniformity (numerically verified).**
+- t=81: 81·log₂3 = 128.382 bits ✓; t=80: 126.797 — insufficient.
+- byte%3 bias: max residue mass 86/256 ⇒ a lone planted bad point escapes each
+  combination w.p. 86/256 ⇒ (86/256)⁸¹ = 2⁻¹²⁷·⁵ — BELOW target. Rejection
+  sampling is load-bearing, not pedantry.
+- Coins are verifier-private, drawn fresh per batch, never reused (standard
+  batch-verification model; adversary fixes points before coins are drawn).
+
+**Even-cofactor extension (verified sound; not implemented).** With
+coefficients {0,1}: cT ∈ {0, T} distinct for ANY T ≠ 0 (no order assumption)
+⇒ ≤ 1/2 per combination ⇒ 2⁻ᵐ per round with m-bit vectors, 2^m buckets,
+⌈µ/m⌉ rounds, 128 combinations total. Combine simplifies: Q_j = Σ_{bit_j=1}S_v
+(no doubling, no weight-2 class). This restores BLS12-377 G1 (2⁹² | h; trits
+degrade to 2/3 there) and matches KEF's own m=2 handling. CAVEAT: our code is
+blst/BLS12-381-only; a 377 implementation needs another backend (arkworks or
+gnark-crypto) — either implement, or present theoretically with an estimate
+(combine threshold analog: n* ≈ w·m(m+1)·2^{m−1}).
+
+## 4. Cost analysis — derived expressions (validated to ~5%)
+
+Cost units: 1 a = one batch-affine addition = 2M+1S (chord) + 3M (Montgomery
+share) ≈ 6M ≈ 150 ns measured. Jacobian mixed add (combine) ≈ 11M ⇒ w ≈ 2
+(code uses conservative w=3). Exact check ρ = 22 µs/150 ns ≈ 147 a. Field
+inversion ≈ 60–100 M, shared once per pass.
+
+Tree lemma: k points → k−1 adds, ⌈log₂k⌉ passes; n points over K buckets →
+n − #nonempty ≈ n − K adds, ⌈log₂(n/K)⌉+O(1) passes, ONE inversion per pass
+shared across all buckets.
+
+Inversion accounting (the "inversion trick" quantified): plain affine = 1
+inversion per addition ⇒ r·n total (≈5 s at n=10⁵ — unusable); per-bucket
+batching (naive B) = r·B·log₂(n/B); global per-pass sharing = r·log₂(n/K)
+(C at n=10⁵, m=5: 17×9 = 153 total inversions).
+
+**A (one combination/round):** r_A = ⌈µ/log₂3⌉ = 81.
+Per round: 2-bit MSM skips the c=0 third ⇒ 2n/3 − 2 adds + (1 dbl + 1 add)
+combine + 1 check. Totals: adds 54n (blst engine) / 81n (our engine, which
+sums the zero bucket); checks 81; inversions 81·log₂(n/3).
+
+**B (bucketing, all buckets checked):** r_B = ⌈µ/log₂B⌉ (B=16→32, 64→22,
+256→16). Per round: n−B adds (no zero-skip — every point is in a checked
+bucket) + B checks. Totals: adds r_B(n−B); checks r_B·B (512 @ B=16,
+4096 @ B=256). Optimal B from dT/dB = 0 on T = (µ/log₂B)(n+ρB):
+**ρ·B(ln B − 1) = n** ⇒ B* ≈ 20 at n=6000 (use 16), ≈160 at n=10⁵ (use 256) —
+matches the sweep winners exactly.
+
+**C (m combinations, shared pass):** r_C = ⌈81/m⌉; checks r_C·m ∈ [81,85]
+invariant. Per round: n − 3^m accumulation adds + 2m·3^{m−1} mixed adds +
+m dbl (combine) + m checks. Totals: adds ⌈81/m⌉·n; combine ≈ 162·w·3^{m−1}
+(exponential in m — the cap); inversions ⌈81/m⌉·log₂(n/3^m).
+Optimal m from marginal balance 81n/(m(m+1)) = 324·w·3^{m−1}:
+**n* ≈ 4w·m(m+1)·3^{m−1}** ⇒ (w=3) m: 3→4 at n≈1300, 4→5 at n≈6500 — matches
+`plan()` (m=3 @1k, m=4 @6k, m=5 @100k). Fallback crossover (min_m T_C < ρn):
+n ≈ 140. Asymptotics: m* ≈ log₃n − O(1) ⇒ total adds → **µn/log₂n** — the same
+asymptotic as KEF's prefiltered large-coefficient MSM, without the prefilter.
+
+**Validation table (prediction vs measurement, same machine):**
+
+| config | formula | predicted | measured |
+|---|---|---|---|
+| A our-engine, n=6k | 81n + 81ρ = 498k a | 74.7 ms | 74.9 ms |
+| B=16, n=6k | 32·5984 + 512ρ = 266.8k a | 40.0 ms | 40.1 ms |
+| B=256, n=6k | 16·5744 + 4096ρ = 694k a | 104 ms | 100 ms |
+| B=256, n=100k | 16·99.7k + 4096ρ = 2.20M a | 330 ms | 353 ms |
+| C m=4, n=6k | 21·5919 + 21·216w + 84ρ = 145.7k a (w=2) | 21.9 ms | 22.4 ms |
+| C m=5, n=100k | 17·99.8k + 17·810w + 85ρ = 1.74M a | 260 ms (+~25 ms affine conv) | 298 ms |
+
+blst per-point-per-round sanity: 2/3 add × 6M × ~30ns ≈ 120 ns vs 126 ns
+measured. Our engine 154 ns/pt·round at m=1 (sums zero bucket): ratio checks.
+
+**The 100k parallel B-tie, explained analytically:** at optima the
+accumulation terms nearly match (B=256: 16n vs C m=5: 17n). Serially C wins by
+the check gap (602k vs 12.5k a). In parallel the 4096 checks spread over 18
+cores (~33k a effective) and the gap closes ⇒ measured 47.8 vs 49.6 ms tie.
+m=6 (u16 ids): 14n + 82k ≈ 1.49M a reopens a >30% serial gap.
+
+## 5. Measurements — full record
+
+Machine: 18-core Apple Silicon, macOS; blst 0.3.16; rustc 1.95.0; 2⁻¹²⁸ target.
+
+Criterion medians (`--bench bls12381 -- subgroup`, sample_size 10):
+
+| n | per-point | C serial | C parallel |
+|---|---|---|---|
+| 100 | 2.137 ms | 2.134 ms (fallback) | 0.305 ms |
+| 1000 | 21.39 ms | 6.500 ms | 1.159 ms |
+| 6000 | 126.6 ms | 22.58 ms | 4.099 ms |
+
+Historic criterion baselines on the same machine (useful for the paper's
+ablation): old strategy A via blst MSM: 12.1 / 63.1 ms serial, 1.59 / 6.9 ms
+parallel at n = 1k / 6k.
+
+Same-engine single-shot (`measure_strategies`, raw output preserved in the
+BATCHED_SUBGROUP.md table): serial/parallel —
+
+| n | per-point | A m=1 r=81 | B=16 r=32 | B=64 r=22 | B=256 r=16 | C (plan) |
+|---|---|---|---|---|---|---|
+| 1k | 22.8 ms | 15.5 / 2.38 | 15.9 / 2.40 | 32.9 / 4.44 | 86.4 / 12.1 | 6.62 / 1.13 (m=3, r=27) |
+| 6k | 126.5 ms | 74.9 / 8.86 | 40.1 / 4.49 | 49.5 / 6.49 | 100.4 / 12.7 | 22.4 / 3.62 (m=4, r=21) |
+| 100k | 2126 ms | 1249 / 138 | 538 / 65.8 | 393 / 57.9 | 353 / 47.8 | 298 / 49.6 (m=5, r=17) |
+
+Accumulator isolation (`measure_accumulator`): 146–178 ns/point, flat across
+27/81/243 buckets AND n ∈ {1k, 6k, 100k} (150–151 ns at 100k — no cache cliff;
+passes stream).
+
+Naive per-bucket prototype (branch `gv/subgroup-bucketed-prototype`,
+blst_p1s_add per bucket): n=1000 B=8: 15.9 ms serial / 2.09 ms parallel;
+n=6000 B=8: 46.2 / 5.17 — loses to old-A at 1k, only 1.37× at 6k. (This is
+what "naive bucketing" means throughout.)
+
+zexe (celo/zexe PR #4) measured on THIS machine (their Rust, arkworks-era,
+`RUSTFLAGS="--cap-lints allow"`, features
+`std bls12_381 curve verify batch_affine [parallel]`, test `test_sw_g1`,
+µ=128): serial run — n=1024: naive 55.5 ms, batched 47.6 ms; n=4096: 221.9 /
+116.7; n=8192: 443.8 / 207.5. Parallel run — n=1024 batched 4.97 ms; n=8192
+30.7 ms; n=16384 38.4 ms (naive est. 885 ms). Their per-bucket check is the
+slow pre-2021 [r]P order-mult; they also have recursive-bisection fast
+REJECTION (only helps the failure path).
+
+## 6. Prior art dossier (read first-hand unless marked TODO)
+
+**KEF25 — Koshelev, El Housni, Fotiadis, "Batch subgroup membership testing on
+pairing-friendly curves", eprint 2025/1311, CANS 2025.** THE reference. Read
+in full. Their Algorithm 1 (p.8): Step 1 per-point Koshelev/Tate prefilter
+checks P_i ∈ 𝔾₁′ = E(𝔽_q)[re′], removing small torsion (for BLS12-381:
+1 cubic-symbol t₃ pairing + 2 eleventh-symbol t₁₁ pairings per point,
+π′ = 3·11); Step 2: n rounds of RLC with c ∈ ℤ/m, m ≤ p = smallest remaining
+prime (BLS12-381: p₁₄ = 10177, m = 2¹³, n = 5 at their µ = 60), each round one
+full MSM + one Bowe–Scott check. Cost model (p.9): n(𝒫 + ℬ𝒮), 𝒫 = Pippenger.
+Key quotes (verify page refs against the PDF before citing):
+- p.6: "ℙ ≤ 1/min{m, p} and this upper bound does not seem to be
+  (significantly) improvable"; "The bound ℙ ≤ 1/3 ... is too big to rely on
+  such an ingenuous batch SMT."
+- p.16: "On BLS12-381 the full two-step method remains slower than the naive
+  method on valid inputs, because the first-stage Tate/residue checks still
+  dominate the total cost. By contrast, if the cost of Step 1 is disregarded,
+  Step 2 alone is between 9.59× and 47.02× faster."
+- p.17 (future work, old BLS12-377 = 60 rounds of {0,1} running-sum mixed
+  adds): "we might speed up the approach by using affine additions and
+  implementing Montgomery's batch inversion technique to invert all the
+  denominators at the cost of a single inversion."
+- pp.18–19 Note 2: for large N, {0,1} coefficients + many rounds beat
+  large-coefficient Pippenger "because point additions scale better ...
+  memory-wise" — they are optimizing inside exactly the regime our trick wins,
+  without the cross-round bucketing.
+Their benchmarks: AWS c7a.8xlarge (AMD EPYC 9R14), single-threaded, Go
+(gnark-crypto), N ∈ {2⁵..2²¹}, µ = 60. Speedups vs naive Bowe–Scott:
+BLS12-381 end-to-end < 1× (slower); old BLS12-377 ({0,1}×60 rounds):
+1.37–4.33×; new BLS12-377: 1.10–1.47×; BLS12-376: 1.18–1.54×. Remedy: two new
+curves (Table 3: BLS12-376, new BLS12-377 with e₁ = 2p prime-ish structure).
+Their Go repo: https://github.com/yelhousni/batch-subgroup-membership-testing.
+Acknowledgements: Antonio Sanso (problem), Gautam Botrel (software); Koshelev
+funded partly by Ethereum Foundation grant FY25-1896.
+
+**Internet-post prior art (KEF's [34], [77] — the "too short posts without
+clarifications"):**
+- [34] Gabizon, "Possible improvements in subgroup testing", 2018,
+  https://github.com/zcash/zcash/issues/3470 — TODO: read before submitting.
+- [77] Vlasov, EIP-2537 discussion thread, 2020,
+  https://ethereum-magicians.org/t/eip-2537-bls12-precompile-discussion-thread/4187
+  — TODO: read before submitting.
+- Also [3] Aumasson–Nguyen–Sanso, "Security of BLS batch verification",
+  ethresear.ch/t/10748 (2021) — adjacent, TODO skim.
+
+**zexe/celo PR #4 (2019)** — random bucketing (`rng.gen_range(0, num_buckets)`),
+`batch_bucketed_add` (shared-inversion batch-affine — they DID have the
+inversion trick for bucket sums), per-bucket check via [r]P order-mult
+(pre-Scott), recursive bisection on failure. `algebra-core/src/curves/
+batch_verify.rs`. Our Lemma 2 formalizes their soundness; measured numbers §5.
+
+**Per-point SMT line (cite, no overlap):** Bowe eprint 2019/814; Scott
+2021/1130 (the check blst implements; our ρ); Koshelev JCEN 2023 + correction
+(Tate-pairing test); Dai–He–Koshelev–Peng–Yang PKC 2026 (= eprint 2024/1790);
+Dai–Lin–Zhao–Zhou DCC 2023 (= 2022/348); El Housni–Guillevic–Piellard
+AFRICACRYPT 2022 (= 2022/352, cofactor clearing ≠ SMT); eprint 2026/749
+"Divide-and-Pair" (2026, Pornin/Koshelev hybrid, non-pairing curves,
+PER-POINT — confirmed no overlap via abstract).
+
+**Foundations:** Bellare–Garay–Rabin EUROCRYPT'98 (small exponents test);
+Boyd–Pavlovski ASIACRYPT'00 (attacking/repairing batch verification — check
+for the private-coin model); Henry cacr2010-26 (multiproduct/Pippenger);
+Freivalds-style random-matrix verification is the abstract frame (C = testing
+(T_i) against a random m×n trit matrix); Bernstein–Doumen–Lange–Oosterwijk
+INDOCRYPT'12 + Pastuszak et al. (bad-signature identification — relevant to
+the "which point failed" question KEF punt on in §5, and we punt on too).
+
+**Literature searches performed (2026-08-19):** "batch subgroup membership
+check ... eprint", "'batch' 'subgroup check' pairing curves bucketing ...",
+"batch subgroup membership testing 2026 eprint follow-up ..." — nothing beyond
+the above; 2025/1311 is the SOTA, 2026/749 the only 2026 item (per-point).
+
+## 7. Anticipated reviewer objections & answers
+
+1. *"Vector bucketing is just multiproduct Pippenger."* Yes — say so first
+   (cite Henry). The contribution is the composition + the observation that it
+   collapses KEF's per-round MSM cost, with proofs and measurements.
+2. *"Cross-machine comparison is unfair."* Fix before submission: run their Go
+   code on our machine (their repo is public), single-threaded, µ=60 AND
+   µ=128. Our serial numbers are the honest headline; parallel is a bonus.
+   Also note our naive baseline (blst 22 µs endomorphism check) is FASTER than
+   theirs (gnark Bowe–Scott ~2w·𝒜 + 128-bit double-add), so our speedup-vs-
+   naive ratios are conservative.
+3. *"B ties C at n=10⁵ parallel."* True; analytically explained (§4); m=6
+   (u16 ids) reopens the gap; serial C wins at every size regardless.
+4. *"Soundness model?"* Verifier-private fresh coins, adversary commits points
+   first — identical to KEF/BGR. Timing side-channels are moot (coins are
+   single-use). State it.
+5. *"µ=128 vs their µ=60."* We report both; at µ=60 C needs t=38 combinations
+   (r=⌈38/m⌉: m=4 → 10 rounds) — roughly halves our times; compute and report.
+6. *"Even cofactors?"* {0,1} variant (§3); implement on 377 if time permits,
+   else present with estimates.
+7. *"Bad-point identification?"* Out of scope, same as KEF §5; cite the
+   identification literature; note consensus use-case rejects whole batches.
+8. *Memory:* per round transiently ~224 bytes/point (buf 96 + copied op list
+   ~104 + denominators 24); at n=10⁵ with 17 concurrent rounds ≈ 380 MB worst
+   case. Fine on servers; mention.
+
+## 8. Pre-submission checklist (ordered)
+
+1. Same-machine benchmark of KEF's Go implementation (highest value; ~1 day).
+2. Read Gabizon zcash#3470 and the EIP-2537 thread; characterize first-hand.
+3. µ=60 numbers for C (change `security` param to 60; rerun harnesses).
+4. Optional: u16 ids → m ≤ 7; skip zero bucket; rerun 100k.
+5. Optional-strong: {0,1} variant on BLS12-377 (needs non-blst backend).
+6. Decide authorship/affiliation; consider contacting KEF authors (El Housni
+   = gnark-crypto lead; friendly "here's the missing piece" positioning —
+   they flagged half of it as their own future work). Check IACR ePrint
+   AI-assistance disclosure norms.
+7. Verify all KEF quotes/page numbers against the PDF (refetch
+   https://eprint.iacr.org/2025/1311.pdf).
+
+## 9. Suggested outline (with source mapping)
+
+1. Introduction — problem, KEF's negative result on BLS12-381, one-sentence
+   contribution. [thesis §0]
+2. Preliminaries — decomposition, π, exact-check costs, verifier game.
+   [artifact §1; BATCHED_SUBGROUP.md]
+3. The 1/3 barrier — Lemma 1 + tightness + any-distribution barrier + margins.
+   [§3 here; artifact §2 has the polished formal proof]
+4. Strategies — A (baseline), B (zexe, Lemma 2), C (construction §2 here,
+   round theorem, unsound-shortcut warning, {0,1} extension).
+5. Cost analysis — §4 here verbatim (derivations + optima + asymptotics +
+   validation table). This section is the note's distinctive artifact.
+6. Implementation & benchmarks — §5 here + KEF same-machine numbers (TODO 1).
+7. Related work — §6 here.
+8. Conclusion — batch SMT pays on deployed curves as-is; new curves optional.
+
+## 10. Numbers cheat-sheet (for quick reference while writing)
+
+t(µ=128)=81 (128.38 bits; 80→126.80); t(µ=60)=38. byte%3 → 127.5 bits (fails).
+ρ≈147 a; a≈150 ns ≈ 6M; w≈2 (code 3). plan: m=3@1k(r=27), m=4@6k(r=21),
+m=5@100k(r=17); fallback n≲140. B*: ρB(lnB−1)=n. m-threshold:
+n*≈4w·m(m+1)·3^{m−1}. C checks total ≤ 85. Headlines: 7.1× serial / 42.8×
+parallel @100k; 3.3×/18.5× @1k; 5.6×/30.9× @6k (criterion). KEF headline:
+<1× end-to-end on BLS12-381 (their words), Step-2-alone 9.59–47.02×, new
+curves 1.1–1.5×, all µ=60 single-thread AWS EPYC.

--- a/cryptography/PAPER_HANDOFF.md
+++ b/cryptography/PAPER_HANDOFF.md
@@ -55,8 +55,10 @@ technique; claim the composition + analysis + measured result.
 - Rejected naive-bucketing prototype: local branch
   `gv/subgroup-bucketed-prototype` (NOT pushed; counting sort + per-bucket
   `blst_p1s_add`; measured numbers below).
-- Cryptographer-facing explainer artifact (private; has the formal Lemma 1
-  proof, the diagram, all tables):
+- Cryptographer-facing explainer (formal Lemma 1 proof with all five remarks,
+  the round-pipeline diagram, all tables incl. the same-engine comparison and
+  the related-work positioning): source committed on this branch as
+  `cryptography/PAPER_EXPLAINER.html`; also published privately at
   https://claude.ai/code/artifact/ef1bf48b-e421-4c6f-8a0d-e09e528f551d
 - Toolchain: rustc 1.95.0, blst 0.3.16, commonware-parallel (adaptive Rayon
   strategy). Machine: 18-core Apple Silicon, macOS (Darwin 25.6.0).

--- a/cryptography/PAPER_HANDOFF.md
+++ b/cryptography/PAPER_HANDOFF.md
@@ -367,7 +367,25 @@ the above; 2025/1311 is the SOTA, 2026/749 the only 2026 item (per-point).
    else present with estimates.
 7. *"Bad-point identification?"* Out of scope, same as KEF §5; cite the
    identification literature; note consensus use-case rejects whole batches.
-8. *Memory:* per round transiently ~224 bytes/point (buf 96 + copied op list
+8. *"If T_j is chosen as a function of the other T_i, it is not independent
+   of Σc_iT_i — with small weights the sum's distribution is tied to the T_i."*
+   (Raised by Lucas, 2026-08-19; the classic objection — answer it in the
+   paper preemptively.) Quantifier order does the work: the lemma is
+   ∀(T_1..T_n) fixed, probability over coins alone; the adversary commits
+   points (arbitrarily correlated, T_j = f(T_1..T_n) included) BEFORE coins
+   are drawn. The proof's independence is between the COINS c_j and
+   U = −Σ_{i≠j}c_iT_i (a function of other coins and constants), and the
+   conditional bound Pr[c_jT_j = U | U = u] ≤ 1/3 is uniform in u, so U's
+   distribution — however structured or T_j-correlated — is irrelevant. No
+   independence of the sum from the points is ever used. Worst case realizes
+   the concern and meets the bound with equality: T_2 = −T_1 escapes iff
+   c_1 = c_2, exactly 1/3. Counterpoint to the "large weights would fix it"
+   premise: they would not — in an order-3 component any coefficient acts mod
+   3, so full-width weights leave the pair a ≥1/3 escape (the barrier lemma);
+   more combinations is the only lever. What the model genuinely requires:
+   fresh, verifier-private, unpredictable coins per batch — no reuse.
+   Documented in the module docs (commit 89ca68b44) and artifact remark (v).
+9. *Memory:* per round transiently ~224 bytes/point (buf 96 + copied op list
    ~104 + denominators 24); at n=10⁵ with 17 concurrent rounds ≈ 380 MB worst
    case. Fine on servers; mention.
 

--- a/cryptography/SUBGROUP_CASCADE.md
+++ b/cryptography/SUBGROUP_CASCADE.md
@@ -5,6 +5,10 @@ Research against `63a7a9bad`, 2026-09-08. All implementations are test-only in
 The derivations and implementations received skeptical agent review, not
 external cryptographic review or formal verification.
 
+For recurring 100,000-point batches, the subsequent
+[precomputation experiment](SUBGROUP_PRECOMPUTATION.md) separates advance setup
+from online verification and evaluates a fused graph accumulator.
+
 Soundness assumes inputs are already validated as on-curve and the batch is
 fixed before sampling fresh private randomness. This is a subgroup check,
 not a replacement for point decoding or on-curve validation.

--- a/cryptography/SUBGROUP_CASCADE.md
+++ b/cryptography/SUBGROUP_CASCADE.md
@@ -1,0 +1,374 @@
+# Certifying the whole subgroup-checking circuit
+
+Research against `63a7a9bad`, 2026-09-08. All implementations are test-only in
+`src/bls12381/primitives/subgroup/research/`. Production verification is unchanged.
+The derivations and implementations received skeptical agent review, not
+external cryptographic review or formal verification.
+
+Soundness assumes inputs are already validated as on-curve and the batch is
+fixed before sampling fresh private randomness. This is a subgroup check,
+not a replacement for point decoding or on-curve validation.
+
+## Result
+
+Recursive compression becomes substantially cheaper when its certificate
+examines the effective coefficients of the WHOLE inner circuit. It can then
+exclude all one- and two-input errors exactly, while preserving an ordinary
+probability bound for larger errors. This allows a much smaller recursive
+graph and less work in the final random combinations.
+
+Same-session end-to-end medians, in milliseconds:
+
+| Points | Original target128 | Previous two-pass | Plain q31 recursion | Certified q19 recursion | Truncated outer + certified q19 |
+| ---: | ---: | ---: | ---: | ---: | ---: |
+| 100,000 | 133.78 | 175.92 | 175.85 | 102.02 | 100.10 |
+| 1,000,000 | 1123.11 | 495.91 | 443.18 | 360.31 | 358.38 |
+| 3,000,000 | 3021.72 | 1046.62 | 990.26 | 907.71 | 904.47 |
+
+The final column takes 13.6% less time than the previous two-pass prototype at
+three million points, 27.7% less at one million, and 43.1% less at 100,000. It is
+3.34x, 3.13x, and 1.34x faster than the original checker at those respective
+sizes. Unlike the previous two-pass candidate, it beats the original at the
+measured 100,000-point size. Smaller crossover sizes have not been established.
+The same-session three-pass exact-exception median at three million points is
+1522.14 ms, so the new candidate takes 40.6% less time.
+
+Most of this gain comes from certifying the recursive circuit. The outer
+truncation improves the three-million-point median by only 3.24 ms, or 0.36%,
+relative to using the full q47 graph with the same certified recursion. Four
+manual samples do not establish a reliable gain that small; the full-graph
+variant is also a useful candidate with a simpler outer proof.
+
+At three million points, the truncated variant's median phase times are about
+14.6 ms affine conversion, 24.4 ms assignment/sign generation, 762.6 ms original
+input compression, and 102.6 ms complete inner verification. The previous
+two-pass checker spends about 245.6 ms in inner verification. The new inner
+time includes its own graph assignments, two recursive accumulations, full
+effective-column certificate, exact exceptions, and final random combinations.
+
+The final recursive graph outputs at most 13,718 points per outer side, or 27,436
+across both calls, rather than sending up to 207,646 outer bucket sums directly
+to the random-combination checker. This is a change to the computation and its
+soundness argument, not a change to the underlying curve arithmetic.
+
+## Measurement method and scope
+
+The ignored `measure_cascade` test uses four seeds, `TestRng::new(0..4)`, and
+reverses the complete algorithm order on alternate repetitions. Every algorithm
+starts from the same seed in a repetition. Inputs are distinct consecutive
+generator multiples normalized before timing; generation is excluded. Timings
+include conversion, allocation, all randomness, certificates, compression, and
+final checks. Runs are single-threaded on the same local Apple ARM machine in
+release mode with rustc 1.97.1. These are manual measurements, not Criterion
+confidence intervals or a claim about other platforms.
+
+The final truncated three-million-point samples are 903.448, 903.796, 905.134,
+and 907.129 ms. Corresponding full-graph certified samples are 904.605, 904.643,
+910.768, and 911.318 ms. The original's samples are 3014.352, 3020.684, 3022.748,
+and 3033.220 ms. Measurements from earlier reports were different sessions;
+the table above uses only this final same-session comparison.
+
+This comparison's algorithm IDs were 0=original, 1=three-pass exact exceptions,
+3=previous two-pass split111, 6=q31 recursion with split99, 7=truncated outer with
+ordinary pair-certified96, 8=full outer with effective-certified q19, and 9=the
+same effective-certified recursion under the truncated outer. Variant 7 has a
+three-million-point median of 1000.34 ms. Simpler variants retained in the source
+include the original joint129 check, q31 recursion with joint114, and a full
+outer graph with ordinary pair-certified96; these were exploratory comparisons.
+
+The `measure_cascade` driver selects `[0, 1, 3, 6, 7, 8, 9]`, reversing that
+order on odd repetitions. Separate drivers retain the original two-pass
+comparison and the [descent experiment](SUBGROUP_DESCENT.md), which includes an
+explicitly incomplete order-three-only filter.
+
+## First step: a stronger graph support bound
+
+Start with the [two-pass graph construction](SUBGROUP_TWO_PASS.md): a fixed
+simple girth-eight graph, a fresh private uniform injection of input indices
+into edges, and independent signs at the two endpoints of every input. A bad
+input means a point with a nonzero cofactor component. A support whose bucket
+sums can all vanish has minimum degree at least two.
+
+For such a support with k edges, v occupied vertices and bipartition sizes a,b,
+count nonbacktracking length-three paths oriented from left to right. Girth at
+least eight gives at most one path per endpoint pair; adjacent endpoints cannot
+have one, since that would make a four-cycle. Therefore
+
+```
+S = sum_edges (d_u-1)(d_v-1) <= a*b-k <= v^2/4-k.
+```
+
+Minimum degree two gives `(d_u-1)(d_v-1)>=d_u+d_v-3`. Cauchy-Schwarz then gives
+
+```
+S >= sum_vertices d_v^2-3k >= 4k^2/v-3k,
+v^3+8kv >= 16k^2.
+```
+
+Let f(k) be the smallest integer satisfying the last inequality. At k=12 this
+forces at least 11 occupied vertices, strengthening the previous eight-vertex
+bound by three bits. With c=floor(k/8), replace the previous intermediate bound
+by
+
+```
+c*choose(k-1,c-1)*M^c*L^(k-c)
+    / (2^max(8c,f(k))*choose(M,k)),   L=8(D-1).
+```
+
+This remains conservative for every component count j<=c: the additional
+factor `2^-max(f(k)-8c,0)` is justified by each support's vertex bound. The
+original connected-set counting and monotonicity arguments otherwise remain
+unchanged.
+
+This alone permits a q31 recursive graph, with 29,791 buckets per side. Its
+worst compression bound is 113.173282767731 bits at k=12. Adding a joint
+target114 check, which uses 72 trits, gives 112.569416957045 bits, stronger than
+the previous inner allowance `3^-71`. Separate target99 checks on its two sides
+give 112.747172349703 bits instead. `cascade_bound.py` verifies both complete
+outer compositions. This was the first measured improvement, before the
+effective-circuit certificate below.
+
+## Exact treatment of sparse inner errors
+
+An ordinary inner random-trit checker assigns each input a complete coefficient
+column in `{-1,0,1}^m`. Mark zero columns and EVERY copy of a column repeated up
+to one global sign, and subgroup-check every marked input exactly. Retain all
+original columns and inputs in the original random combinations.
+
+Acceptance is a subset of the unmodified checker's acceptance, so the error
+bound `3^-m` remains valid without conditioning or a retry penalty. Additionally,
+one- and two-input errors become impossible: an unmarked nonzero column cannot
+kill one nonzero odd-order cofactor element. For two elements to cancel in every
+row, their nonzero columns must agree up to the same global sign, which would
+have marked both copies. This is implemented in `pair.rs`.
+
+At the outer level, batches with at most two bad inputs now reject exactly.
+For every larger support a stronger marginal bound becomes available. For any
+three fixed nonzero elements of an odd-order abelian group, independently put
+each with a random sign into a uniform one of B>=2 buckets. Every output atom
+has probability at most `K3=3/(4B^2)`. Classify a target by its nonzero coordinates:
+
+- Zero: all three inputs must occupy one bucket; fixing two signs leaves at
+  most one valid remaining sign, for at most `1/(2B^2)`.
+- One: either all three occupy that bucket, or a singleton occupies it and a
+  pair cancels elsewhere. This gives at most
+  `1/(2B^3)+3(B-1)/(4B^3) <=3/(4B^2)`.
+- Two: at most six bucket assignments, each with sign probability at most 1/4,
+  give `3/(2B^3)<=3/(4B^2)`.
+- Three: at most six assignments, each with sign probability at most 1/8,
+  give `3/(4B^3)`. Larger target supports are impossible.
+
+For injective graph assignments with k>=3 bad inputs, condition only the other
+k-3 BAD inputs' edges and signs. Three independent draws from the FULL M-edge
+graph have uniform bucket marginals. Restricting these draws to distinct edges
+avoiding the conditioned bad edges multiplies a probability bound by at most
+`M^3/((M-k+3)(M-k+2)(M-k+1))`. Good-input placements remain unconditioned.
+
+For k>=34D, use the direct side-sign bound `2^-34` instead. Consequently
+
+```
+A3 = max(K3*M^3/((M-34D+4)(M-34D+3)(M-34D+2)), 2^-34)
+```
+
+bounds either side's zero probability uniformly for k>=3. At q47 it provides
+33.741155675819 bits. With fresh independent inner randomness and endpoint signs
+conditional on the injection, the composition bound is
+
+```
+P_accept <= P_compression + 2*epsilon*A3 + epsilon^2.
+```
+
+Taking `epsilon=3^-61`, ordinary pair-certified target96 gives 128.272229256651
+bits for the full outer graph. `triple_bound.py` also enumerates every mixed
+three-input multiset in Z3, Z5, Z9, and Z3 x Z3, with two through four buckets,
+checking every output atom. Those finite tests supplement, not replace, the
+general counting argument.
+
+## Breakthrough: certify the effective recursive circuit
+
+Compress an inner batch on another graph, then check the compressed sums using
+63 fresh random-trit combinations. For an ORIGINAL inner input P_i, the effective
+coefficient in final row j is
+
+```
+a_(j,i) = alpha_i*c_(j,L_i) + beta_i*c_(j,R_i), in {-2,-1,0,1,2}.
+```
+
+Here alpha,beta are its endpoint signs and c are the final coefficients on its
+two buckets. Compute the COMPLETE effective columns modulo three. Mark every
+zero column and every copy of a column repeated up to global sign. Exact-check
+those original inner inputs, keeping the whole sampled graph and final circuit
+unchanged. Two disjoint u64 bitplanes encode the 63 coefficients modulo three;
+F3 vector addition combines both endpoint columns without curve operations.
+
+The one- and two-error guarantee now relies on the specific BLS12-381 cofactor
+
+```
+h = 3*(11*10177*859267*52437899)^2
+  = 0x396c8c005555e1568c00aaab0000aaab.
+```
+
+One unmarked column has a coefficient of absolute value one or two, invertible
+on the cofactor group. Two unmarked columns are independent over F3, so some
+two-by-two INTEGER minor is nonzero modulo three. Its absolute value is at most
+eight. Every such determinant is coprime to h, because h has no factors two,
+five, or seven. Applying the adjugate to the two row equations forces both bad
+cofactor elements to zero. Cyclicity is not required. The proof would fail for
+arbitrary odd cofactors containing five or seven, or for an additional graph
+layer that increased the coefficient bound without a new argument.
+
+A bucket whose actual curve sum is the identity may be omitted and assigned a
+zero final coefficient column. This changes the effective matrix but leaves
+every final curve combination unchanged. The position map in `effective.rs`
+preserves original input indices and translates live buckets to final columns.
+Data-dependent omissions do not invalidate the subset-of-acceptance bound.
+
+If the final planner chooses exact checks instead of random combinations, the
+graph alone already guarantees exact rejection of one- and two-input errors.
+Both paths therefore satisfy the sparse-error requirement of the outer proof.
+
+## Making q19 sufficient: classify twelve-edge supports
+
+The recursive graph now has q19, 6,859 buckets per side and 130,321 edges. Its
+generic support bound was too loose at k=12. A twelve-edge stopping support must
+be either a twelve-cycle or three internally disjoint length-four paths between
+the same endpoints, denoted theta(4,4,4).
+
+Two edge-disjoint cycles need at least sixteen edges. Otherwise a non-cycle
+minimum-degree-two component contains a theta: three paths between two vertices.
+Each pair of paths forms a cycle of length at least eight. Summing the three
+cycle lengths shows the theta needs at least twelve edges, with equality only
+for lengths 4,4,4. No other edges remain. Disconnected stopping supports also
+need at least sixteen edges.
+
+Counting nonbacktracking length-eleven paths with a forced closing edge gives
+`C12<=M(D-1)^10/12`. For any pair of endpoints there are at most D distinct
+length-four paths. Write their count as m. Summing `choose(m,2)` over roots and
+endpoints counts each eight-cycle eight times; summing `choose(m,3)` counts each
+theta twice. Since `choose(m,3)=(m-2)*choose(m,2)/3`,
+
+```
+Theta444 <= 4*(D-2)*C8/3 <= M*(D-1)^4*(D-2)/6,
+P12 <= (C12/2^12 + Theta444/2^11) / choose(M,12).
+```
+
+`effective_bound.py` checks the remaining finite range with exact integers:
+
+| q19 support case | Derived bits |
+| --- | ---: |
+| k=8 | 97.962752377386 |
+| k=10 | 111.096359276141 |
+| k=12 | 131.958334296845 |
+| k=13 through 1253 | 97.324662163278, worst at 13 |
+| k>=1254 | at least 132 |
+| Compression plus 63-trit final check | 97.093989606749 |
+
+The last bound is stronger than `3^-61`, which is 96.682712543991 bits. Effective
+certification cannot increase this error and guarantees exact rejection of
+supports one and two. Thus this recursive checker can replace the ordinary
+pair-certified target96 checker in the outer composition.
+
+## Smaller outer graph and support-dependent composition
+
+Restrict the q47 graph's u and t coordinates to 0 through 42, keeping its other
+coordinates in F47. It has 94,987 vertices per side, degree 43 and 4,084,441 edges.
+It is a subgraph of the original graph, so retains simplicity and girth at
+least eight. Field arithmetic remains modulo 47, not 43; the edge code is
+`((u*47+v)*47+w)*43+t`.
+
+Its exact eight-cycle count is 1,263,308,051,793. Two independently structured
+integer enumerators in `cycles.rs` agree on this count and the full q3/q5 cases.
+The first histograms length-four path endpoints from roots `(u,0,0)`, pairs
+paths reaching the same endpoint, multiplies by 47^2 for translations, and
+divides by four left roots per cycle. The second enumerates the coordinate
+cycle equations `sum (u_(i+1)-u_i)*t_i=0` and
+`sum (u_(i+1)-u_i)*t_i^2=0`, then divides by eight starting-point/orientation
+choices. Four distinct t values give a nonsingular linear system; two distinct
+values must alternate; three distinct values are excluded by the Vandermonde
+argument. This finite count is security-critical, not a statistical estimate.
+
+The eight-input compression bound is 128.194096178451 bits. Every intermediate
+support from 12 through 2837 has at least 131.427809143352 bits, worst at 12; larger
+supports have at least 132 bits. An undifferentiated inner-error bound wastes
+too much margin here, but the original support size is fixed, so split cases.
+
+For k<=2 the complete checker rejects exactly. For 3<=k<=7, outer compression
+cannot vanish, giving `2*epsilon*A3+epsilon^2`. For k>=8, use the previously
+proved [sixth-moment atom bound](SUBGROUP_RESEARCH.md):
+
+```
+K6(B) = 15/(8B^3)-35/(16B^4)+21/(32B^5).
+```
+
+Condition all but six BAD inputs and transfer from independent full-graph draws
+as before. With `(x)_6` denoting six descending factors, a uniform side bound is
+
+```
+A6 = max(K6(B)*M^6/(M-49D+7)_6, 2^-49).
+```
+
+The direct sign bound supplies the second term for k>=49D. The complete error is
+
+```
+max(2*epsilon*A3+epsilon^2,
+    P_compression+2*epsilon*A6+epsilon^2).
+```
+
+The two cases are alternatives, not errors to sum. Using the conservative
+`epsilon=3^-61` gives 128.194076795566 bits for the symmetric truncated graph,
+verified by `truncated_bound.py`. This covers both ordinary pair-certified96
+and the stronger effective-certified q19 checker. The two sides' bucket
+placements are never assumed independent; only their endpoint signs and fresh
+inner randomness are independent after conditioning on the injection.
+
+## Validation, limits, and next work
+
+The new tests compare both cycle enumerators, exhaust every q19/q31/q47/q53
+edge's endpoint bounds and degrees, and check every truncated edge against the
+original endpoint map. A full curve-group oracle forces a genuinely cancelled
+bucket, cofactor pollution, signed endpoints, and two final rounds; it verifies
+the effective coefficients modulo three and exact integer curve combinations,
+including coefficients of magnitude two. Forced certificate regressions ensure
+that polluted duplicate copies and zero columns trigger exact checks of the
+ORIGINAL inputs. Adversarial end-to-end tests cover both full and truncated
+outer graphs and both recursive constructions.
+
+The skeptical reviewer checked the cofactor/minor argument, all probability
+compositions, finite parameter bounds, sampling, coefficient packing, identity
+maps, and the final oracle. A latent unsupported truncated joint129 configuration
+was guarded out. Production logic, public APIs, dependencies, encodings, and
+unsafe code are unchanged. The supplied proof scripts use floating point only
+to display approximate bit counts; security comparisons use exact arithmetic.
+
+All 68 focused subgroup tests passed in release mode with one test thread.
+Release Clippy passed, as did all four exact-arithmetic proof scripts below.
+
+Reproduce the checks and manual benchmark with:
+
+```sh
+just test -p commonware-cryptography --release --features bls12381 subgroup:: --test-threads 1
+just clippy -p commonware-cryptography --release --features bls12381
+python3 cryptography/src/bls12381/primitives/subgroup/research/cascade_bound.py
+python3 cryptography/src/bls12381/primitives/subgroup/research/triple_bound.py
+python3 cryptography/src/bls12381/primitives/subgroup/research/effective_bound.py
+python3 cryptography/src/bls12381/primitives/subgroup/research/truncated_bound.py
+just test -p commonware-cryptography --release --features bls12381 measure_cascade --run-ignored only --no-capture
+```
+
+q19 accepts at most 130,321 inner inputs, sufficient for either implemented q47
+outer graph but not a full q53 side. The full outer graph accepts at most 4,879,681
+original inputs; the truncated graph accepts 4,084,441. Fixed chunks with an
+all-chunks-accept predicate can preserve the per-chunk error bound for larger
+batches, but chunking is not implemented or benchmarked here.
+
+Parallel execution, other machines, arbitrary projective inputs, peak memory,
+and input-driven exception/tail-latency behavior remain unmeasured. In particular,
+exact-check exceptions can add work on unusual inputs; they are a correctness
+mechanism, not a worst-case latency guarantee. WASM validation remains blocked
+by the missing `wasm32-unknown-unknown` target. Independent cryptographic review
+and production-quality benchmarks are still required before integration.
+
+Original-input compression now dominates runtime. The next algorithmic target
+is that accumulation structure, not another small reduction in the final
+checker. Neither the two-pass count nor the current graph size is asserted to
+be a universal lower bound.

--- a/cryptography/SUBGROUP_DESCENT.md
+++ b/cryptography/SUBGROUP_DESCENT.md
@@ -1,0 +1,218 @@
+# Splitting off the order-three component
+
+Research against `63a7a9bad`, 2026-09-08. This experiment does NOT improve the
+complete G1 subgroup checker yet. Production verification is unchanged.
+The new test-only `research/primary.rs` checks just the order-three component;
+points with other cofactor components deliberately pass it.
+
+## Result and scope
+
+BLS12-381 admits a homomorphism that replaces curve additions with field
+multiplications when checking its order-three component. The prototype takes
+292.07 ms at three million points, versus 922.24 ms for the current complete
+graph/certificate checker in the same session. These implement DIFFERENT
+predicates, so this is not a 3.16x subgroup-checking speedup.
+
+The potential architecture is a cheap order-three check plus a different
+check for the remaining cofactor. A straightforward additive cost comparison
+leaves approximately 630 ms for that residual check at three million points.
+Shared preprocessing could change this estimate. No sufficiently cheap
+complete residual check has been derived or implemented here.
+
+The partial checker has a derived false-acceptance bound below `2^-128` only
+when some input has a nonzero order-three component. An explicit order-eleven
+fixture proves that this statement cannot be read as G1 subgroup soundness.
+Inputs must already be on-curve and fixed before fresh private verifier
+randomness is sampled.
+
+## The map
+
+For the curve `y^2=x^3+4`, let `T=(0,2)`, which has order three. Define alpha
+with values in the nonzero field elements modulo cubes:
+
+```
+alpha(O) = 1,
+alpha(T) = 1/4,
+alpha(x,y) = y-2 otherwise.
+```
+
+The general descent map appears in Definition 1.3 and Proposition 1.4 of
+[Cohen and Pazuki, Elementary 3-Descent with a 3-Isogeny](https://arxiv.org/html/0903.4963).
+The critical reviewer read that source in full. Its setting is elliptic curves
+over number fields and rank estimation, not BLS verification. The finite-field
+argument below is a direct derivation, not an application of its rank formulas.
+
+If three nonexceptional points lie on `y=m*x+c`, substituting the line into
+the curve yields the monic polynomial
+
+```
+x^3-m^2*x^2-2*m*c*x+4-c^2.
+```
+
+Evaluating at `(2-c)/m` shows that the product of their three `y-2` values is
+`(c-2)^3`; the horizontal case is immediate. Their curve sum is the identity,
+so this is the required multiplicative relation modulo cubes. For a vertical
+line, `alpha(P)*alpha(-P)=-x^3`, also a cube.
+
+For a line through T, write `y=m*x+2`. Its other two intersection coordinates
+satisfy `x_P*x_R=-4*m`, so their representatives multiply to `-4*m^3`.
+Multiplying by `alpha(T)=1/4` gives a cube. Tangencies are covered by repeated
+roots. The remaining exceptional relations follow from
+`(1/4)^2/(-4)=-1/64` and `(1/4)*(-4)=-1`. Thus alpha is a homomorphism.
+
+For ordinary points, `(y-2)(y+2)=x^3`, so `y+2` represents the inverse class
+without a field inversion. The vanishing representative at T, or the inverse
+representative at -T, must be replaced: 16 works because `16/(1/4)=4^3`.
+Using zero would be incorrect. Identity inputs are removed by the existing
+affine conversion before the prototype evaluates representatives.
+
+## Exactly which errors are visible
+
+With p the BLS base-field modulus, define
+
+```
+chi(P) = alpha(P)^((p-1)/3).
+```
+
+This maps into the three cube roots of unity. Exact arithmetic gives
+
+```
+chi(T) = 0x5f19672fdf76ce51ba69c6076a0f77eaddb3a93be6f89688de17d813620a00022e01fffffffefffe.
+```
+
+It is a nonidentity cube root, so chi is onto. The curve order is `r*h`, with
+`h=3*(11*10177*859267*52437899)^2` and exactly one factor of three. Therefore
+multiplication by three has a three-element kernel, its image has index three,
+and
+
+```
+ker(chi) = [3]E(Fp).
+```
+
+In other words, chi sees exactly the order-three component, while all other
+cofactor components are invisible. The remaining cofactor is
+`h/3=25443201128072175343902036600697491001`.
+
+The exact-arithmetic diagnostic constructs `Q=(4,sqrt(68))` and verifies that
+`P=[3]Q` has `chi(P)=1` but `[r]P!=O`. It also constructs a nonzero point of
+exact order eleven. The Rust fixture decodes that point and independently
+checks its order; adding it to subgroup points still passes the partial filter
+but fails the complete effective-certificate checker.
+
+## Multiplicative batching
+
+The partial checker uses the full q47 graph from the
+[two-pass construction](SUBGROUP_TWO_PASS.md): 4,879,681 possible edges,
+103,823 buckets per side, a fresh uniform injection, and two independent
+endpoint signs per input. A bucket now multiplies `y-2` or `y+2` representatives
+instead of adding signed curve points. Its character is exactly the character
+of the original signed curve sum.
+
+Each side is then checked with 71 fresh random-trit combinations, corresponding
+to inner target 111. The fixed width schedule is seven width-nine rounds and
+one width-eight round. The folded-ternary circuit also works multiplicatively:
+products replace sums, and squaring replaces negation MODULO CUBES. Squaring
+is not inversion in the full multiplicative field group. The circuit's
+intermediate field representatives need not equal a literal inverse-based
+calculation; their characters must agree.
+
+For example the collapse is
+
+```
+L[a] = S[a] * S[H+a] * S[H-a]^2 modulo cubes.
+```
+
+Each recovered combination gets one cube-character exponentiation. The
+ordinary inner bound is `3^-71`; the original full-graph split composition
+therefore applies unchanged to this order-three quotient. `two_bound.py`
+reproduces a total bound of 128.165118548981 bits. No assertion about the
+remaining cofactor follows from this bound.
+
+## Same-session measurements
+
+End-to-end medians in milliseconds, four seeds, on the same local Apple ARM
+machine with rustc 1.97.1, release mode, one thread:
+
+| Points | Original complete checker | Current complete graph checker | Order-three-only filter |
+| ---: | ---: | ---: | ---: |
+| 100,000 | 137.23 | 100.71 | 68.39 |
+| 1,000,000 | 1154.77 | 366.64 | 139.57 |
+| 3,000,000 | 3091.34 | 922.24 | 292.07 |
+
+The final column is intentionally incomplete. Its four three-million-point
+samples are 293.143, 291.093, 293.050, and 288.985 ms, in seed order. Approximate
+median phase times are 14.9 ms conversion, 26.4 ms assignment/sign generation,
+192.4 ms field-product compression, and 58.8 ms inner verification.
+
+The harness uses distinct consecutive generator multiples normalized before
+timing, excluding input generation. Conversion, allocations, all randomness,
+compression, and final checks are timed. Algorithm order is reversed on odd
+repetitions. These are manual measurements, not confidence intervals; timings
+from earlier reports belong to different sessions and are not compared here.
+The `measure_order_three` driver selects IDs `[0,9,20]`, with 20 explicitly
+labeled `component=order_three_only`. Complete-only comparisons have separate
+drivers, so the partial predicate cannot be mistaken for their replacement.
+
+## Why this is not yet a complete speedup
+
+A complete per-point criterion is `chi(P)=1` together with `[3]P` in G1.
+Tripling removes the order-three part and is invertible on the remaining
+cofactor. A residual batch verifier can triple only its final linear
+combinations, not every original point. But running the existing graph
+algorithm this way does not make its input accumulations cheaper.
+
+More decisively, the dominant eight-cycle cancellation is not peculiar to
+order three. Put eight identical nonzero order-eleven errors on a cycle.
+At each vertex the two signs must differ, giving exactly `2^-8` probability
+that all eight sums vanish. The diagnostic enumerates all 65,536 endpoint-sign
+assignments and finds 256 acceptances. Every input has trivial cubic character,
+so the partial filter cannot improve this residual failure probability.
+
+I also tested three accumulation reorganizations: whole-batch stable radix
+partitioning, 65,536-point windowed partitioning, and copy-free filtered scans.
+They preserve the signed sums, but none established a useful gain. At three
+million points the best whole-batch median was 918.43 ms versus its 891.27 ms
+baseline; the best windowed median was 913.88 ms versus 896.29 ms. Copy-free
+scanning ranged from 927.21 to 1319.53 ms versus 923.94 ms, with noticeable
+session drift and no convincing win. Each comparison used four seeds and
+reversed order. These timings come from separate sessions. The slower code
+was removed from the branch; a temporary archive retains the experiment.
+
+## Validation and next question
+
+All 73 focused subgroup tests passed in release mode with one test thread.
+Release Clippy and both exact-arithmetic diagnostics listed below passed.
+
+The critical agent reviewed the finite-field map, exceptional representatives,
+exponent constant, multiplicative collapse, randomness, and composition.
+Tests verify `3*CUBE_EXPONENT+1=p`, signed torsion and group-law cases, an
+independent coefficient oracle including actual widths eight/nine, malicious
+order-three batches, and deliberate order-eleven false positives. Additional
+regressions verify that both complete outer graph variants reject order-eleven
+pollution, including single and paired errors.
+
+The diagnostic exhausts all curve-point pairs for ten small primes and checks
+the BLS constants and counterexamples with exact arithmetic. It also exhibits
+other curves where the equality `ker(chi)=[3]E` fails, preventing an unwarranted
+generalization of the BLS-specific kernel argument.
+
+```sh
+just test -p commonware-cryptography --release --features bls12381 subgroup:: --test-threads 1
+just clippy -p commonware-cryptography --release --features bls12381
+python3 cryptography/src/bls12381/primitives/subgroup/research/descent_bound.py
+python3 cryptography/src/bls12381/primitives/subgroup/research/two_bound.py
+just test -p commonware-cryptography --release --features bls12381 measure_order_three --run-ignored only --no-capture
+```
+
+This remains agent-reviewed research, not external cryptographic review or
+formal verification. No public API, dependency, encoding, namespace, unsafe
+code, or production verifier was changed. WASM validation requires the missing
+`wasm32-unknown-unknown` target. Other platforms, arbitrary projective-input
+performance, and adversarial latency have not been measured.
+
+The next structural question is whether the residual cofactor can be checked
+substantially more cheaply than another pair of full curve accumulations.
+This work establishes a measured, correct partial building block, a concrete
+counterexample to treating it as a complete subgroup check, and an obstruction
+to shrinking the residual graph merely by removing order-three errors. It
+does not establish a new lower bound or a faster complete checker.

--- a/cryptography/SUBGROUP_PRECOMPUTATION.md
+++ b/cryptography/SUBGROUP_PRECOMPUTATION.md
@@ -1,0 +1,170 @@
+# Preparing recurring 100,000-point subgroup checks
+
+Test-only research against `f0c02cb92`, 2026-09-08. Production verification is
+unchanged. The workload is recurring batches of about 100,000 points, with
+input-independent work permitted before a batch arrives.
+
+## Result
+
+Precomputation reduces online latency, but the fused block accumulator does
+not improve this workload. The best measured candidate keeps the generic
+outer accumulator and prepares both recursive verification circuits in advance.
+
+Eight-sample medians in milliseconds, from one comparison session:
+
+| Variant | Preparation | Online | Total |
+| --- | ---: | ---: | ---: |
+| Current complete graph checker | 0 | 98.18 | 98.18 |
+| Fused blocks, outer preparation only | 1.90 | 99.64 | 101.57 |
+| Fused blocks, complete preparation | 18.36 | 83.92 | 102.40 |
+| Generic accumulator, complete preparation | 18.56 | 81.30 | 99.92 |
+
+The last row has 17.2% lower online latency, with slightly MORE total work.
+This is not a throughput improvement on one continuously busy core. It is
+useful when preparation fits before arrival, or can run on separate resources;
+concurrent preparation and verification have not been benchmarked.
+
+A second experiment actually prepares the circuit BEFORE constructing each
+new input batch. Its medians are 98.08 ms for the baseline and 81.31 ms online
+for the prepared checker, with 18.60 ms preparation and 99.90 ms total. Input
+generation is excluded from both timings. The first preparation in this run
+takes 33.71 ms; it is retained in the samples, not silently discarded.
+
+The second experiment's prepared online samples, in seed order, are 81.639,
+81.628, 81.519, 81.565, 81.110, 81.055, 80.658, and 80.910 ms. Baseline samples
+are 101.143, 98.259, 98.075, 98.025, 98.218, 98.081, 97.767, and 97.325 ms.
+
+## Fused block prototype
+
+The q47 graph maps `(u,v,w,t)` to the two vertices
+
+```
+left  = (u, v, w)
+right = (t, u*t-v, u*t*t-w), with field arithmetic modulo 47.
+```
+
+For fixed `(u,t)`, varying `(v,w)` visits each vertex of the two respective
+slabs exactly once. This is a matching: no two edges write the same output.
+Each slab contains 47^2 affine points, so the two slabs contain 424,128 bytes
+of point data. This count excludes inputs, schedules, and inversion buffers.
+
+There is also a direct coloring. For degree D, color a block by `(u+t) mod D`.
+Within one color, each u and each t occurs exactly once. All blocks of that
+color therefore have disjoint outputs on BOTH sides. The prototype groups
+indices by color and then u, sharing inversion batches across blocks and
+flushing at color boundaries. Flushing at every small block was slower.
+
+`two::blocks::Accumulator` updates both sides while visiting an input index.
+It reuses the existing field arithmetic and shared-inversion implementation,
+including doubling and cancellation handling, but needs no collision retry
+lists. It allocates exactly two graph-side slot arrays: 18.24 MB for the
+truncated graph, versus the generic outer round's 38.26 MB of affine slots.
+These are buffer-size calculations, not measured peak resident memory.
+
+The schedule is built AFTER the uniform injection and endpoint signs are
+drawn. It changes neither the assignment nor either sign. Reordering preserves
+each signed curve sum, including identities. Fusing execution still performs
+two algebraic accumulations; it does not halve the number of curve additions.
+
+Despite the smaller scratch and collision-free schedule, it loses at 100K.
+The current measurement does not isolate the contributions of scattered input
+reads, scheduling, and arithmetic. No larger-batch speedup is established here.
+The prototype remains as a reproducible comparison, not a replacement default.
+
+## What can be prepared
+
+The one-shot preparation contains the outer assignment and signs, both q19
+inner graph assignments, the final 63-trit coefficient matrices, exact-exception
+indices, and initially allocated scratch. Curve sums and actual subgroup tests
+cannot be evaluated until the points arrive.
+
+The key change is to give every possible inner output bucket a fixed position
+in the final coefficient matrix. An empty or cancelled bucket still has its
+sampled column; its POINT is the identity. This makes the complete effective
+matrix independent of point data, so its zero and duplicate-up-to-sign columns
+can be detected during preparation.
+
+Online execution compacts nonidentity inputs and graph outputs, retaining their
+original dense indices. It selects coefficients at those original indices;
+it does not renumber the prepared matrix. Original inputs marked by the
+certificate are checked exactly. Marked identity slots are already valid.
+The prepared path also passes affine outer slots directly to the inner checker,
+avoiding a projective wrapper followed by another affine copy.
+
+The generic control deliberately retains `Round` and its larger scratch. This
+separates the effect of preparing the circuit from the effect of changing the
+accumulator. Its remaining inner verification costs about 69.5 ms in the
+arrival experiment; outer accumulation costs about 11.5 ms.
+
+## Soundness and one-shot use
+
+Precomputation requires the batch to be independent of the prepared challenge.
+The assignment, coefficients, and all derived challenge information must remain
+private until the input batch is fixed. Sampling earlier is compatible with
+the probability argument only under that independence condition. This is NOT
+permission to publish challenges or reuse them for later adaptive batches.
+Each prototype's `check` consumes its preparation and draws no new randomness
+for the fully prepared path. Preparation types are private research types with
+no cloning API; this is not a production secret-storage or zeroization design.
+
+Preparing for n points and subsequently dropping identities uses the first m
+assigned edges for the m surviving points. Restricting a uniform injection to
+a fixed prefix is still uniform. The batch determines m independently of the
+private assignment. Both implementations enforce the prepared input length.
+
+Each inner graph is now sampled for all 94,987 outer bucket positions, even
+when some positions will hold identities. This is below the q19 capacity of
+130,321. The graph's stopping-support bounds concern nonzero cofactor inputs,
+so adding identity positions does not invalidate them. Keeping all final
+columns also leaves the final distribution at 63 independent random trits.
+
+The effective integer coefficients remain in [-2,2]. Therefore the same
+[BLS12-381 minor argument](SUBGROUP_CASCADE.md#breakthrough-certify-the-effective-recursive-circuit)
+excludes one- and two-input errors whenever exact exceptions pass. Identity
+compaction does not alter these integer coefficients: multiplying a retained
+coefficient by the identity contributes zero to the same full circuit.
+
+The unmodified q19 bound remains below `3^-61`, and the truncated outer
+composition retains its derived 128.194076795566-bit bound. No security
+parameter or graph size is reduced. The existing exact-arithmetic scripts
+reproduce these inequalities. This is an extension of the research argument,
+not independent cryptographic review or formal verification.
+
+## Validation and reproduction
+
+All 79 focused subgroup tests, release Clippy, and the two exact-arithmetic
+bound scripts below passed. WASM validation remains blocked by the missing
+`wasm32-unknown-unknown` target. No production logic, public API, dependency,
+encoding, or unsafe code was changed.
+
+New tests exhaust the block matching property for q19 and both q47 graphs,
+check schedule permutations and disjoint outputs, and compare fused sums with
+both direct group addition and the generic accumulator. Dense blocks exercise
+multiple full inversion queues, signs, repeated points, doubling, and complete
+cancellation. End-to-end tests include order-three and order-eleven pollution,
+single and paired errors, empty batches, and interleaved identities.
+
+The prepared-circuit oracle forces cancelled inner buckets and an absent
+original input, compares all dense graph sums, then compares every final curve
+combination against an independent ternary-digit calculation. Forced zero and
+duplicate columns verify exact checking of original dense input indices.
+
+The benchmarks use eight seeds, `TestRng::new(0..8)`, reversing algorithm order
+on alternate repetitions. Inputs are distinct consecutive generator multiples,
+normalized before verification. All preparation, allocation, verification,
+and destruction of the consumed preparation are included in their respective
+timed calls. Component medians need not add to the median total.
+
+Measurements are single-threaded release runs on the local Apple ARM machine,
+with rustc 1.97.1. These manual samples are not confidence intervals. They do
+not establish projective-input performance, adversarial tail latency, peak
+memory, other-platform performance, or concurrent pipeline throughput.
+
+```sh
+just test -p commonware-cryptography --release --features bls12381 subgroup:: --test-threads 1
+just clippy -p commonware-cryptography --release --features bls12381
+python3 cryptography/src/bls12381/primitives/subgroup/research/effective_bound.py
+python3 cryptography/src/bls12381/primitives/subgroup/research/truncated_bound.py
+just test -p commonware-cryptography --release --features bls12381 measure_blocks --run-ignored only --no-capture
+just test -p commonware-cryptography --release --features bls12381 measure_prepared_arrival --run-ignored only --no-capture
+```

--- a/cryptography/SUBGROUP_RESEARCH.md
+++ b/cryptography/SUBGROUP_RESEARCH.md
@@ -1,0 +1,522 @@
+# Beyond independent vector bucketing
+
+Research against `63a7a9bad`, 2026-09-08. The experiment is in
+`src/bls12381/primitives/subgroup/research.rs`, compiled only for tests.
+Production `batch_in_g1` is unchanged. A skeptical subagent reviewed the
+derivation and implementation and supplied independent finite checks. This
+is not external cryptographic review or a machine-checked proof.
+
+## Latest result: certified recursive compression
+
+The [effective-circuit certificate](SUBGROUP_CASCADE.md) makes a much smaller
+recursive graph sound by rejecting all one- and two-input errors exactly.
+In a new same-session comparison, the best prototype takes 904.47 ms at three
+million points, versus 1046.62 ms for the previous two-pass prototype and
+3021.72 ms for the original checker. It also beats the original at 100,000
+points. The report contains the new derivation, exact bound checks, critical
+review, and benchmark limitations. Everything remains test-only.
+
+## Previous result: two passes
+
+The [two-pass graph experiment](SUBGROUP_TWO_PASS.md) supersedes the three-pass
+result below for the measured large batches. A fixed girth-eight graph excludes
+the dangerous small cancellation patterns structurally; a fresh uniform input
+injection and independent endpoint signs preserve the adversarial-input bound.
+Separate inner checks at target 111 give a derived total false-acceptance bound
+below `2^-128`. This remains test-only, with production logic unchanged.
+
+In that earlier same-session comparison at three million points, median runtime
+is 1047.94 ms, versus 1527.10 ms for three-pass exact exceptions and 3028.37 ms
+for the original checker: 31.4% less time than three passes and 2.89x faster than
+the original. At one million points the respective times are 500.42, 560.75,
+and 1130.07 ms. At 100,000 points the original still wins. See the linked report
+for the construction, full derivation, exact finite bound checker, benchmark
+methodology, validation, and limitations. The rest of this document retains
+the earlier four- and three-pass research and measurements.
+
+## Three-pass result
+
+Remove the rare sparse cancellation patterns before relying on a stronger
+concentration bound. The first experiment does this by rejecting duplicate
+unsigned bucket signatures. The improved experiment finds a small set of
+inputs intersecting every dangerous assignment pattern and subgroup-checks
+those inputs exactly. Both use the current accumulator without changing the
+curve, encoding, or field arithmetic.
+
+The improved experiment needs only three compression passes. At three
+million inputs its bucket counts are `(131072, 16384, 16384)`, and each pass's
+sums are checked with inner target 100. Its derived overall soundness bound
+is at least 131.11 bits. Unlike assignment rejection, exact exceptions keep
+the original independent assignment distribution and require no retries.
+
+Earlier three-pass end-to-end medians, in milliseconds:
+
+| Points | Current, target 128 | Four passes | Three, rejection | Three, exact exceptions | Speedup over current |
+| ---: | ---: | ---: | ---: | ---: | ---: |
+| 1,000,000 | 1176.4 | 778.9 | 583.5 | 580.0 | 2.03x |
+| 3,000,000 | 3136.8 | 1904.7 | 1580.7 | 1582.5 | 1.98x |
+
+The exact-exception variant takes 25.5% and 16.9% less time than the
+four-pass experiment at these sizes. Both three-pass variants are similar
+on the sampled assignments: none required a retry or an exact exception.
+The retry elimination and expectation bound are structural/proof results,
+not measured tail-latency improvements in these samples.
+
+The updated manual harness uses four seeds, `TestRng::new(0..4)`, reversing
+algorithm order on alternate repetitions. Each algorithm starts from the
+same seed within a repetition, so the two three-pass variants see the
+same initial assignment. The input is distinct consecutive generator
+multiples normalized before timing, as in the original measurements.
+Times include conversion, all randomness, canonical sorting, graph checks,
+compression, and inner verification. Measurements are single-threaded on
+the same local Apple ARM machine with rustc 1.97.1 in release mode.
+
+For three-pass exact exceptions at three million inputs, the median phase
+times are about 15 ms conversion, 177 ms assignment/certificate, 1200 ms
+compression, and 190 ms inner verification. The zero-exception code path
+was measured; forced regression tests cover nonzero exceptions separately.
+These are four manual runs, not a Criterion confidence interval. Other
+platforms, parallel execution, small-batch crossover points for three
+passes, and peak memory remain unmeasured. The benchmark is retained as
+an ignored research test; a production benchmark should use Criterion and
+the contributor guide's benchmark registration convention.
+
+## Initial four-pass measurements
+
+With four passes, 65,536 buckets per pass, and an 80-bit invocation of the
+existing checker on each pass's sums, the derived overall soundness bound is
+at least 129.66 bits for batches of at most three million points. The 80-bit
+inner target is intentional; the proof concerns the composition of all four
+passes, including assignment rejection.
+
+Measured end to end, single-threaded on this checkout's local Apple ARM
+machine, medians of three runs:
+
+| Points | Current checker, 128-bit target | Four-pass experiment | Speedup |
+| ---: | ---: | ---: | ---: |
+| 100,000 | 136.1 ms | 224.4 ms | 0.61x |
+| 1,000,000 | 1,149.6 ms | 755.1 ms | 1.52x |
+| 3,000,000 | 3,058.1 ms | 1,843.8 ms | 1.66x |
+
+The input consists of distinct consecutive generator multiples, normalized
+before timing to match decoded points. Generation is excluded for both
+algorithms. Timings include conversion, randomness, sorting to check
+signature uniqueness, all accumulation, and verification of the compressed
+sums. They are manual harness measurements, not a Criterion study. Arbitrary
+projective inputs, other machines, and parallel execution were not measured.
+
+At three million points, approximately 1.54 s is compression, 238 ms is inner
+verification, 48 ms is assignment generation including duplicate detection,
+and 15 ms is affine conversion. The fixed compressed-batch cost makes this a
+large-batch technique; the existing checker wins at 100,000 points.
+
+## Construction
+
+Let `B = 2^16` and `d = 4`.
+
+1. Draw an independent uniform 64-bit value for every input. Its four 16-bit
+   limbs are the bucket indices for the four passes.
+2. Sort a copy. If any values coincide, discard the entire assignment and
+   draw again. Only unsigned bucket indices participate in this check.
+3. Draw an independent random sign for every point in every pass.
+4. In pass `j`, compute `S[j,b] = sum_{i: h[j,i]=b} sign[j,i] P[i]`.
+   Every input contributes exactly once, including bucket zero.
+5. Verify each pass's at most `B` sums using `batch_in_g1` with target 80
+   and fresh randomness. Accept only if all four calls accept.
+
+The prototype handles the same already-on-curve input as `batch_in_g1` and
+drops identity inputs before assigning signatures. Its entry points assert
+the three-million-point limit used below. It is not an API or an adaptive
+replacement for the shipping planner.
+
+## Why the old floor does not apply
+
+The cancelling-pair lower bound for a single pass remains true. What does
+not follow is a lower bound obtained by multiplying those probabilities
+across passes after conditioning their assignments on uniqueness.
+
+If only two points have nonzero cofactor parts, at least one pass puts them
+in distinct buckets. Both resulting singleton buckets remain bad, whatever
+their signs. Three bad points also cannot vanish in every pass: a pass can
+have no singleton only if all three land in one bucket, which in every pass
+would make their unsigned signatures identical.
+
+Thus one, two, and three bad points cannot disappear during compression.
+For four or more bad points, a stronger concentration bound applies. The
+scheme deliberately removes the worst sparse cases before using that bound.
+Ordinary independent bucketing does not have this property.
+
+This is also why merely forbidding the zero coefficient vector, increasing
+bucket widths, or rechecking a shared sum does not give the same result.
+
+## Four-input concentration lemma
+
+Work in the finite abelian cofactor group `H`, of odd order. For any nonzero
+`T` in `H`, let `mu_T` be the distribution in `H^B` obtained by putting `+T`
+or `-T` in one uniformly chosen bucket. Its `2B` outcomes are distinct and
+equiprobable.
+
+The probability that four independent samples from `mu_T` sum to zero is
+
+```
+K = (6 B + 24 choose(B,2)) / (2 B)^4
+  = 3/(4 B^2) - 3/(8 B^3).
+```
+
+The first term counts four entries in one bucket with two signs of each
+kind. The second counts two cancelling pairs in different buckets. Odd
+order excludes every other possibility: the nonzero even coefficients
+available here are only `+/-2` and `+/-4`.
+
+For four possibly different nonzero inputs, Fourier inversion and Holder's
+inequality bound every atom of their sum by `K`:
+
+```
+Pr[X1 + X2 + X3 + X4 = z]
+  <= product_i (average_chi |hat(mu_Ti)(chi)|^4)^(1/4)
+  = K.
+```
+
+The character average is normalized by `|H^B|`. Symmetry of `mu_T` makes
+each fourth character moment exactly the return probability above.
+Convolution with further independent inputs cannot increase the largest
+atom. Therefore, for any fixed batch containing at least four bad points,
+one unconditioned signed bucket pass produces entirely valid sums with
+probability at most `K`. This argument does not assume cyclic cofactor
+torsion or independent/adversary-random input points.
+
+Similarly, Cauchy-Schwarz bounds the largest atom after two inputs by
+`a = 1/(2B)`, since each input distribution has squared L2 norm `1/(2B)`.
+This remains an upper bound after adding a third input.
+
+## Soundness of the complete experiment
+
+Fix all adversarial inputs before drawing randomness. Let `G` be the event
+that the unsigned signatures are distinct. A union bound gives
+
+```
+Pr[G] >= g = 1 - n(n-1)/(2 B^4).
+```
+
+At `n = 3,000,000`, `g > 0.999999756`. Whole-assignment rejection samples
+exactly the independent assignment distribution conditioned on `G`.
+Consequently an unconditioned upper bound can be divided by `g`; independence
+between passes is used before conditioning, not asserted afterward.
+
+The inner target 80 requires at least 51 trit combinations, so use
+`epsilon = 3^-51` for each inner check. An exact-check fallback has zero
+error and also satisfies this bound.
+
+For at least four bad inputs, each unconditioned pass accepts with
+probability at most `K + epsilon`. The passes and their inner randomness
+are independent before conditioning, yielding
+
+```
+Pr[accept | G] <= (K + epsilon)^4 / g < 2^-129.66.
+```
+
+For two or three bad inputs, event `G` guarantees at least one nonzero
+compressed batch. Acceptance must therefore include at least one false
+acceptance by an inner check. Union over which pass supplies that false
+acceptance; each other unconditioned pass accepts with probability at most
+`a + epsilon`:
+
+```
+Pr[accept | G] <= 4 epsilon (a + epsilon)^3 / g < 2^-129.83.
+```
+
+One bad input leaves all four passes bad and has error at most
+`epsilon^4`. These cases exhaust all invalid batches. Their bounds are
+alternatives according to the number of bad inputs, not errors to add.
+
+The proof requires independent signs for each edge and fresh private
+randomness for each batch and inner check. Reusing public bucket signatures
+lets an attacker target the compression kernel and invalidates the argument.
+Checking only signed-signature uniqueness is insufficient: opposite signs
+can conceal equal unsigned signatures.
+
+## A simpler composition, and why it is slower
+
+An initial version concatenates all four bucket arrays and invokes the
+existing checker once with target 129 (at least 82 trit combinations).
+Its error bound is
+
+```
+K^4/g + 3^-82 < 2^-128.805
+```
+
+for the same size limit. Its measured median is 846 ms at one million and
+1,951 ms at three million. The per-pass composition above reduces the inner
+verification work and improves these to 755 ms and 1,844 ms. Both variants
+are retained in the experiment to make this distinction reproducible.
+
+## Three passes with a stronger assignment certificate
+
+The same reasoning suggests excluding every stopping set of size below six,
+using three signed bucket passes with `B = 2^15`. A stopping set here means
+a set of input columns that creates no singleton bucket in any pass. This
+is a property of bucket indices, independent of point values or signs.
+
+For three-part columns, distinctness excludes size two and three. Excluding
+size four also excludes size five: a size-five stopping set has at most two
+buckets per part, so its distinct columns are a five-element subset of the
+eight binary triples. Each such stopping set contains a size-four stopping
+set. The experiment exhaustively checks this finite combinatorial claim.
+
+The sixth-moment analogue of the lemma, maximized by order-three torsion, is
+
+```
+K6 = 15/(8 B^3) - 35/(16 B^4) + 21/(32 B^5).
+```
+
+It bounds every atom of six or more independently signed and bucketed bad
+inputs. The additional order-three contribution comes from bucket
+occupancies `3+3` and six equal-signed inputs in one bucket.
+
+Reject assignments with duplicate columns or size-four stopping sets. A
+union bound on their occurrence gives
+
+```
+g3 = 1 - choose(n,2)/B^3
+       - choose(n,4) (3/B^2 - 2/B^3)^3.
+```
+
+At three million inputs `g3 > 0.7984`. With inner target 100, hence
+`epsilon3 = 3^-64`, the analogous bounds are
+
+```
+small bad sets: 3 epsilon3 (1/(2B) + epsilon3)^2 / g3
+large bad sets: (K6 + epsilon3)^3 / g3.
+```
+
+Numerically these give at least 131.52 and 131.95 bits respectively for the
+same size limit. This three-pass verifier is implemented in
+`src/bls12381/primitives/subgroup/research/three.rs` alongside a stronger
+variant that handles exceptions exactly instead of rejecting assignments.
+
+For completeness, the favorable sixth-moment assignment count is
+
+```
+22B + 220B(B-1) + 120B(B-1)(B-2), divided by (2B)^6.
+```
+
+The terms count bucket occupancies 6, 4+2 and 3+3, and 2+2+2. For an
+order-three input, six signs in one bucket sum to zero in 22 ways; four
+signs return in 6 ways; three in 2 ways; and two in 2 ways. Larger odd
+orders cannot contribute additional returns. The Fourier/Holder argument
+then bounds every atom for six arbitrary nonzero cofactor inputs, not just
+six identical order-three inputs.
+
+The hard part is certifying the assignment cheaply. A straightforward exact
+certificate enumerates every pair of columns sharing their first bucket.
+It encodes the symmetric differences of their other two bucket coordinates
+as an exact 60-bit key and sorts those keys. Given distinct columns, a
+duplicate key identifies a size-four stopping set.
+
+The manual certificate benchmark measured:
+
+| Inputs | Pair keys | Key storage | Draw + build + sort |
+| ---: | ---: | ---: | ---: |
+| 1,000,000 | 15,257,200 | 122 MB | 191 ms |
+| 3,000,000 | 137,329,592 | 1,099 MB | 1,757 ms |
+
+Both sampled assignments passed, so these numbers exclude retries. At three
+million inputs, this certificate alone almost costs the whole four-pass
+verifier. The next two changes address that algorithmic obstacle.
+
+## Certify the graph without materializing all pair keys
+
+Write each unsigned column as `(a,b,c)`. Build an exact relation mapping
+`(b,c)` to its first coordinates `a`, then enumerate pairs sharing `a`.
+For a pair `(a,b,c),(a,b',c')`, a matching pair can use the original two
+`(b,c)` cells with a shared other first coordinate, or the crossed cells
+`(b,c'),(b',c)` with any shared first coordinate. These are exact queries
+against an open-addressing table containing full column values.
+
+This rule alone is WRONG when `b=b'` or `c=c'`. Equal coordinates disappear
+from the pair's incidence difference, so their values need not agree with
+those of a matching pair. Maintain two separate global lists instead:
+equal-b pairs are keyed only by their unordered c pair; equal-c pairs only
+by their unordered b pair. A repeated key in either list is a stopping
+set. The reviewer caught this omission in the initial join proposal with
+the four columns `(0,0,0),(0,0,1),(1,1,0),(1,1,1)`. The Rust exhaustive
+test failed before the repair and passes after it.
+
+Two conservative membership filters fold b and c to 13 bits each. They
+rule out most impossible joins before hash-table lookup. A filter can have
+false positives but no false negatives, and every positive candidate is
+confirmed exactly. Filters therefore do not change the certificate or its
+probability distribution. The implementation sorts a copy to identify
+duplicate columns before building the canonical relation.
+
+This replaces the large pair-key array and its sort with a relation of
+linear size plus two small expected-size degenerate-key lists. It still
+enumerates `choose(n,2)/B_first` pairs in expectation: at fixed bucket
+counts the pair-generation work is quadratic, not linear. The relation
+uses 64 MiB at three million inputs and the two filters use 16 MiB;
+canonical/grouped arrays, offsets, original assignments, and curve storage
+are additional. Peak process memory has not been measured.
+
+## Unequal bucket counts reduce certificate work
+
+The proof does not require equal bucket counts. For three passes with
+counts `B_j`, define `a_j=1/(2B_j)`, `K_j=K6(B_j)`, and `epsilon=3^-64`.
+Under whole-assignment rejection, the same bounds become
+
+```
+g = 1 - choose(n,2)/product_j B_j
+      - choose(n,4) product_j (3/B_j^2 - 2/B_j^3)
+small = sum_j epsilon product_{k != j}(a_k + epsilon) / g
+large = product_j(K_j + epsilon) / g.
+```
+
+Changing `(2^15,2^15,2^15)` to `(2^17,2^14,2^14)` preserves the product
+of bucket counts but divides first-coordinate pair enumeration by four:
+about 34.3 million instead of 137.3 million pairs at three million inputs.
+It increases the total number of bucket sums, so inner verification becomes
+more expensive. The measured tradeoff favors equal buckets at one million
+and unequal buckets at three million; this is a manual choice, not a
+finished planner. The larger first pass needs accumulator width 12 because
+131072 exceeds `folded(11)=88574`.
+
+At three million inputs, the unequal-shape rejection construction has
+`g >= 0.7984986732762581`, with small/large-support bounds of 130.7910 and
+131.9549 bits. The exact-exception variant below removes division by g.
+
+## Exact exceptions preserve independence and eliminate retries
+
+Draw all original unsigned columns independently ONCE. Mark every duplicate
+column value and find a hitting set of the four-column stopping sets among
+the distinct canonical columns: a hitting set contains at least one member
+of every such set. The join implementation marks both endpoints of every
+pair confirmed to participate in a stopping set. For degenerate-key
+collisions it marks the endpoints of all pairs carrying that key. It scans
+the full assignment, rather than stopping after the first match.
+
+Exactly subgroup-check EVERY original input carrying a marked column value,
+not just a representative of a duplicate column. Reject if any is invalid.
+Otherwise draw independent signs and compress ALL original inputs using
+their original columns, including the exact-checked inputs. Do not redraw
+columns, repair individual columns, or remove selected inputs from the
+compressed sums: the proof below uses those original independent sums.
+
+Fix an invalid input batch before drawing randomness, and let k be its
+number of nonzero cofactor parts. If all exact checks pass, every marked
+input has zero cofactor part. For k from two through five, the remaining
+bad columns are distinct and contain no four-column stopping set. They
+therefore cannot vanish in every pass. Acceptance must contain at least
+one inner false acceptance. Dropping the exact-check restrictions and
+union-bounding over which pass falsely accepts gives
+
+```
+small = sum_j epsilon product_{l != j}(a_l + epsilon).
+```
+
+Independence is applied to the original, unconditioned assignments; there
+is no conditioning denominator. With at least six bad original inputs,
+acceptance is a subset of all three original compression passes accepting,
+so `large = product_j(K_j + epsilon)`. With one bad input all three passes
+remain bad and the error is at most `epsilon^3`. Fresh signs and inner
+randomness can be regarded as sampled upfront even though the implementation
+draws them after exact checks succeed.
+
+| Shape | Small-support bound | Large-support bound |
+| --- | ---: | ---: |
+| `(2^15,2^15,2^15)` | 131.8526 bits | 132.2795 bits |
+| `(2^17,2^14,2^14)` | 131.1157 bits | 132.2795 bits |
+
+These alternative cases are not errors to add. The proof no longer depends
+on a batch-size limit, although the prototype retains its three-million
+input assertion for the measured allocation/performance scope. A union
+bound on the implemented number of exact-checked original inputs is
+
+```
+E[checks] <= 2 choose(n,2)/product_j B_j
+            + 4 choose(n,4) product_j (3/B_j^2 - 2/B_j^3).
+```
+
+This is below 0.551 at three million inputs for either shape. The first
+term includes ALL copies of a duplicated code. It is an expectation over
+the verifier's private random assignments, not a worst-case bound.
+
+## Skeptical review and regressions
+
+The independent subagent found no correctness blocker in the original
+four-pass construction. It recomputed the finite-size probability bounds
+using exact rational arithmetic, checked the rejection-conditioning and
+inner-check composition arguments, and inspected the production sampler
+and accumulator used by the prototype. It also caught the high-severity
+false-negative case in the subsequently proposed join shortcut described
+above. No defective certificate was wired into production.
+
+After repair, the reviewer independently compared the join rule with direct
+enumeration on all 17550 four-column and 80730 five-column subsets of the
+ternary cube, plus unequal-coordinate universes. Integrated Rust tests
+exhaust all ternary-cube four-sets and exercise hitting sets on seeded
+multisets, including duplicates and unequal coordinate widths. Separate
+tests force folded-filter collisions and demonstrate that candidates are
+still checked exactly.
+
+The reviewer added integer-convolution tests that enumerate every nonzero
+input multiset of sizes four and six in `Z3` and the noncyclic group
+`Z3 x Z3`. They check every output atom and attain the claimed two-bucket
+maxima, `36/256` and `484/4096`. The four tests cover 5, 7, 330, and 1716
+multisets. This supplements the original cyclic-group enumeration.
+
+Two forced-path regressions address cases ordinary random tests almost
+never reach. A valid canonical duplicate cannot conceal a later polluted
+copy: checking rejects at the second exact check. The degenerate four-point
+counterexample, polluted with `T,-T,-T,T` for an order-three point T, has
+valid unsigned bucket sums in every pass, yet exact exceptions reject it.
+Both tests verify rejection occurs before any signs are sampled. The
+reviewer inspected the final helper and reran both tests successfully.
+Another regression forces whole-vector rejection in the four-pass sampler.
+
+No remaining material correctness concern was found by this agent review.
+Finite tests cannot establish a cryptographic probability guarantee; the
+derivation still requires independent expert review before promotion.
+
+## Context and validation
+
+[Spielman's linear-time encodable codes](https://www.cs.yale.edu/homes/spielman/PAPERS/linearTimeIT.pdf)
+motivate looking outside independent combinations toward sparse encodings.
+The construction above uses a much weaker certificate than a full
+constant-distance code. A claim that a random code is typically good is
+insufficient here: its bad-code probability must fit the cryptographic error
+budget or be excluded by a checked certificate.
+
+[Koshelev, El Housni, and Fotiadis](https://eprint.iacr.org/2025/1311)
+study a different two-stage construction involving Tate tests and
+endomorphisms. These experiments establish neither publication novelty nor
+external cryptographic review of the proposed proof.
+
+Run the focused correctness checks and manual measurements with:
+
+```sh
+just test -p commonware-cryptography --release --features bls12381 research::
+just test -p commonware-cryptography --release --features bls12381 subgroup:: --test-threads 1
+just clippy -p commonware-cryptography --release --features bls12381
+just test -p commonware-cryptography --release --features bls12381 measure_sparse_compression --run-ignored only --no-capture
+just test -p commonware-cryptography --release --features bls12381 measure_small_stopping_certificate --run-ignored only --no-capture
+just test -p commonware-cryptography --release --features bls12381 measure_three_pass --run-ignored only --no-capture
+```
+
+Checks cover compression against direct group sums, cancellation and
+doubling, order-three pollution in otherwise valid batches, the five-column
+stopping-set lemma, and exhaustive four-input concentration in cyclic groups
+of orders 3, 5, 9, and 11 with two buckets. These finite checks support the
+derivation; they cannot empirically establish a 128-bit probability bound.
+
+Final validation: all 49 subgroup tests passed, including 15 research tests;
+release-mode crate Clippy passed; the final four-seed manual comparison
+completed. The parallel test run reported two passing tests as leaky; the
+complete serial rerun passed all 49 without that report. New research files
+pass rustfmt, and `git diff --check` passes. Formatting the parent
+`subgroup.rs` reports unrelated differences also present in HEAD; those were
+left untouched.
+
+The WASM build was attempted during the initial experiment but could not
+compile because `wasm32-unknown-unknown` is not installed locally. No public
+API, dependency, or unsafe code was added. Production subgroup-checking
+logic is unchanged; its documentation now scopes the pass-count discussion
+to independent combinations instead of claiming a universal nine-pass floor.

--- a/cryptography/SUBGROUP_TWO_PASS.md
+++ b/cryptography/SUBGROUP_TWO_PASS.md
@@ -1,0 +1,358 @@
+# Two-pass subgroup compression on a fixed girth-eight graph
+
+Research derivation, 2026-09-08. Implemented only in the test-only module
+`src/bls12381/primitives/subgroup/research/two.rs`.
+The argument and finite bounds were developed and independently checked by
+agents. It has not received external cryptographic review or formal verification.
+Production subgroup-checking logic is unchanged.
+
+Follow-up: [certifying the recursive circuit](SUBGROUP_CASCADE.md) reduces
+three-million-point runtime by another 13.6% in a new same-session comparison.
+The construction and baseline proof below remain relevant; the measurements
+here are historical and should not be mixed with the follow-up's timings.
+
+## Measured result
+
+The q=47 prototype replaces the three-pass experiment's assignment certificate
+and three input accumulations with a uniform injection into a fixed graph and
+two accumulations. Checking the two output arrays separately with inner target
+111 is slightly faster than checking their concatenation at target 129. Both
+compositions have a derived false-acceptance bound below `2^-128`.
+
+Same-session end-to-end medians in milliseconds:
+
+| Points | Original, target 128 | Three, exact exceptions | Two, joint 129 | Two, split 111 | Original / split |
+| ---: | ---: | ---: | ---: | ---: | ---: |
+| 100,000 | 133.11 | 148.01 | 183.40 | 173.32 | 0.77x |
+| 1,000,000 | 1130.07 | 560.75 | 520.28 | 500.42 | 2.26x |
+| 3,000,000 | 3028.37 | 1527.10 | 1069.46 | 1047.94 | 2.89x |
+
+At three million points, the split variant takes 31.4% less time than three
+passes and 2.0% less than the joint two-pass check. Its four samples range from
+1043.42 to 1052.59 ms. Median phase times are approximately 14.6 ms conversion,
+26.1 ms assignment/sign generation, 762.0 ms compression, and 244.9 ms inner
+verification. The important improvement is the outer construction; splitting
+the inner check is a smaller additional gain. At one million points, the split
+variant takes 10.8% less time than three passes. At 100,000 points the original
+checker still wins.
+
+The ignored `measure_two_pass` test uses four seeds, `TestRng::new(0..4)`, and
+reverses algorithm order on alternate repetitions. Each algorithm starts from
+the same seed within a repetition. Inputs are distinct consecutive generator
+multiples normalized before timing; generation is excluded. All conversion,
+allocation, randomness, accumulation, and inner verification are included.
+Measurements are single-threaded on the local Apple ARM machine with rustc
+1.97.1 in release mode. These are manual measurements, not Criterion confidence
+intervals; use the contributor guide's benchmark registration convention for
+a production benchmark.
+
+```sh
+just test -p commonware-cryptography --release --features bls12381 measure_two_pass --run-ignored only --no-capture
+```
+
+## Construction
+
+Fix an odd prime q and work in F_q. The bipartite graph has q^3 vertices on each
+side. Its edges are indexed by quadruples `(u,v,w,t)` and connect
+
+```
+(u,v,w)  --  (t, u*t-v, u*t*t-w), with arithmetic modulo q.
+```
+
+Thus the graph is simple, has M=q^4 edges, and is D=q regular. Each point has
+exactly one neighbor for each t; each line has exactly one neighbor for each u.
+This is the monomial graph G_q(xy,xy^2) described in Section 1 of
+[Kronenthal, Monomial Graphs and Generalized Quadrangles](https://faculty.kutztown.edu/kronenthal/Research/MGGQ.pdf).
+The elementary argument below supplies the girth property used here; no
+embedding into a full generalized quadrangle is required.
+
+For an input batch of n<=M already-on-curve points, sample a uniform injective
+assignment of input indices to graph edges. The graph may be public and fixed;
+the injection must be fresh private randomness. Draw TWO independent signs for
+each input, one at each endpoint. Add the signed input to its left bucket and
+its independently signed copy to its right bucket. This costs two point
+contributions per input. The initial variant checks the concatenation of both
+bucket arrays with the existing checker at target 129, using fresh randomness.
+The faster variant checks each side separately at target 111 with independent
+fresh inner randomness, accepting only if both checks pass. Its composition is
+proved below; it does not assume independent left and right bucket placements.
+
+Inputs are fixed adversarially before the injection is drawn. Their cofactor
+parts lie in the same odd-order finite abelian group as in the existing proofs.
+Removing identity inputs before sampling is harmless. Removing a subset chosen
+after inspecting random assignments would require rechecking the argument.
+
+## Why the graph has no four- or six-cycles
+
+Two distinct points sharing a line must have different u coordinates; if u were
+equal, the incidence equations force their other coordinates to agree. Dually,
+two distinct lines through a point have different t coordinates.
+
+In a four-cycle, subtracting the incidence equations gives
+`(u1-u2)*(t1-t2)=0`, contradicting both differences being nonzero.
+
+For a six-cycle, let the successive point first coordinates be u1,u2,u3 and
+the successive line first coordinates t1,t2,t3. All three t values are distinct.
+Set `delta_i=u_i-u_{i+1}`, cyclically. Summing the incidence equations around the
+cycle gives
+
+```
+sum delta_i = sum delta_i*t_i = sum delta_i*t_i^2 = 0.
+```
+
+The three-by-three Vandermonde matrix on the distinct t values is invertible,
+forcing every delta to zero, a contradiction. The graph is bipartite and simple,
+so it has girth at least eight, which is all this proof needs.
+
+## Fixed-support sign bound
+
+Let k be the fixed number of nonzero cofactor inputs. Their assigned edges form
+a uniform k-element subset of the M edges, independently of how many good input
+points were also assigned. Conditional on that subset and the assignment of
+cofactor values to its edges, a singleton occupied vertex cannot sum to zero.
+
+At any occupied vertex, condition on all but one incident endpoint sign. The
+remaining sign selects between two distinct values, since its cofactor input is
+nonzero and has odd order. The vertex sum vanishes with probability at most 1/2.
+Different vertices use disjoint endpoint-sign variables, giving conditional
+probability at most `2^-v` for all v occupied vertices to vanish simultaneously.
+This independence requires separate signs at BOTH endpoints of each edge.
+
+A support that can vanish must therefore have minimum degree at least two.
+Every connected component then contains a cycle, hence at least eight edges and
+eight occupied vertices. Also `v>=ceil(2k/D)`, by the degree bound.
+
+## Supports below twelve edges
+
+For k=1 through 7 there is no support of minimum degree two. For k=8 it must be
+an eight-cycle. For k=10 it must be a ten-cycle. The k=9 and k=11 cases are
+impossible.
+
+To justify the last assertions, two distinct cycles C1,C2 have at least eight
+edges each; their nonempty symmetric difference is an even-degree subgraph
+containing a cycle, hence also has at least eight edges. Therefore
+
+```
+|C1 union C2| = (|C1|+|C2|+|C1 symmetric_difference C2|)/2 >= 12.
+```
+
+A connected minimum-degree-two graph with at most eleven edges must consequently
+be a single cycle. Bipartiteness excludes odd cycles. Disconnected supports
+would require at least sixteen edges.
+
+For any simple D-regular girth-at-least-eight graph with M edges,
+
+```
+C8 <= M*(D-1)^4/8.
+```
+
+Proof: a fixed root has D*(D-1)^3 nonbacktracking length-four paths, all simple.
+For any endpoint there are at most D such paths, since fixing the first neighbor
+leaves at most one length-three continuation to the endpoint; two would create
+a cycle of length at most six. If m paths reach an endpoint, their unordered
+pairs number at most `(D-1)*m/2`. Distinct paths to that endpoint are internally
+disjoint, again by the girth bound, so each pair forms an eight-cycle. Sum over
+the 2M/D roots and divide by eight roots per cycle.
+
+A general simple-graph nonbacktracking path count also gives
+
+```
+C10 <= M*(D-1)^8/10.
+```
+
+There are at most `2M*(D-1)^8` oriented length-nine nonbacktracking paths. Their
+closing edge, if present, is forced. Each ten-cycle appears twenty times.
+
+The compression-failure bounds for these supports are therefore
+
+```
+P8  <= M*(D-1)^4 / (8*choose(M,8)*2^8)
+P10 <= M*(D-1)^8 / (10*choose(M,10)*2^10).
+```
+
+## Intermediate supports: elementary line-graph counting
+
+The line graph has M vertices and maximum degree Delta=2*(D-1). Let
+`L=4*Delta=8*(D-1)`. The number of connected sets of s graph edges is at most
+
+```
+M*L^(s-1).
+```
+
+To see this, encode a rooted plane spanning tree of the corresponding connected
+vertex set in the line graph. There are M root choices, at most `4^(s-1)` plane
+tree shapes, and at most `Delta^(s-1)` choices for its child-neighbor edges.
+Choose a deterministic spanning tree for each set; these encodings cover all
+sets, while noninjective embeddings and multiple roots only overcount.
+
+For a vanishing k-edge support with j components, every component has at least
+eight edges and eight vertices. Overcount its ordered component sizes by all
+positive compositions of k into j parts, of which there are `choose(k-1,j-1)`.
+Multiplying the connected-set bounds, ignoring disjointness and the possible
+division by j!, and applying the vertex-sign bound gives
+
+```
+P_k <= sum_{j=1}^{floor(k/8)}
+       choose(k-1,j-1)*M^j*L^(k-j) / (256^j*choose(M,k)).
+```
+
+Let `c=floor(k/8)`. For the parameters below, `M/(256L)>1`; both the geometric
+factor and `choose(k-1,j-1)` increase through j=c. Consequently the particularly
+simple bound checked by the companion script is
+
+```
+P_k <= c*choose(k-1,c-1)*M^c*L^(k-c) / (256^c*choose(M,k)).
+```
+
+These bounds are uniform over the adversarial cofactor values; they depend only
+on the number of bad inputs. The assignment of those values within the random
+edge set need not be analyzed further.
+
+## Exact finite verification and composition
+
+Run the standard-library-only companion check:
+
+```sh
+python3 cryptography/src/bls12381/primitives/subgroup/research/two_bound.py
+```
+
+It compares rational probabilities using exact integers; floating point is used
+only to print approximate bit counts. For each q it checks every integer k from
+12 through `66D-1`. For k>=66D, the conditional vertex-sign bound is at most
+`2^-132`, since at least 132 vertices are occupied.
+
+| Parameter/result | q=47 | q=53 |
+| --- | ---: | ---: |
+| Buckets per side | 103823 | 148877 |
+| M, maximum inputs | 4879681 | 7890481 |
+| D | 47 | 53 |
+| Eight-input bound, bits | 129.135023726055 | 133.280800717298 |
+| Ten-input bound, bits | 147.307556687691 | 152.132477371516 |
+| Intermediate range checked | 12 through 3101 | 12 through 3497 |
+| Weakest intermediate bound, bits | 129.807253209963 at k=12 | 135.488195799712 at k=12 |
+| Sign-only bound beyond that range | 132 bits | 132 bits |
+| Total after joint inner target 129, bits | 128.491824750398 | 129.651551568887 |
+
+The cases are alternatives according to k, not errors to sum. A single fresh
+inner target 129 uses at least 82 trits, with error `epsilon=3^-82` uniformly for
+every compressed batch. Total false acceptance is therefore bounded by
+
+```
+max(P8, P10, max_intermediate P_k, 2^-132) + 3^-82.
+```
+
+The script proves this is below `2^-128` by exact comparison for both parameters.
+At q=47 the derived bound is approximately 128.4918 bits. This establishes the
+mathematical bound for two original-input compression passes; the measurements
+and implementation checks are separate evidence.
+
+## Lower-cost composition: separate inner checks
+
+Conditional on the unsigned injection, let p_L and p_R be the probabilities,
+over their respective endpoint signs, that all cofactor sums on that side are
+zero. To bound their expectations, condition on the assigned edges and endpoint
+signs of every bad input except one. That last bad input is uniform over M-k+1
+remaining edges. At most D of them touch any specified bucket, and its two
+signed contributions are distinct because its cofactor part is nonzero and has
+odd order. Every possible contribution vector therefore has probability at most
+
+```
+D / (2*(M-k+1)).
+```
+
+This bounds either side's probability of canceling the fixed contributions of
+the other bad inputs. The conditioning is only on OTHER BAD INPUTS. Conditioning
+on all good-input assignments would incorrectly replace k by n; their zero
+cofactor contributions let their placements remain unconditioned.
+
+For large k, each side has at least `ceil(k/D)` occupied vertices, and independent
+endpoint signs give `p_side <= 2^-ceil(k/D)` for every injection. Split the cases
+at k=tD. For k<tD use the preceding concentration bound, and otherwise use the
+sign bound. A uniform upper bound for both E[p_L] and E[p_R] is
+
+```
+A = max(D/(2*(M-tD+2)), 2^-t).
+```
+
+Given the injection, left and right endpoint signs and the two fresh inner
+random streams are independent. If each inner invocation has error at most
+epsilon for every fixed invalid compressed batch, then
+
+```
+Pr[accept | injection] <= (p_L + epsilon)*(p_R + epsilon)
+Pr[accept] <= E[p_L*p_R] + epsilon*E[p_L+p_R] + epsilon^2
+           <= P_compression + 2*epsilon*A + epsilon^2.
+```
+
+The first term uses the joint graph compression bound already proved above,
+not a product of marginal placement probabilities. Sequential evaluation and
+early rejection preserve the argument: independent unused random streams can
+be coupled to an execution that evaluates both sides. The implementation draws
+the complete injection and both endpoint-sign arrays before invoking either
+inner check.
+
+Both target-111 calls use at least 71 trits each, so `epsilon=3^-71` suffices.
+The companion script verifies the complete expression using exact rational
+arithmetic, including every intermediate support size.
+
+| Parameter/result | q=47 | q=53 |
+| --- | ---: | ---: |
+| t | 18 | 19 |
+| Uniform one-side bound A | 47/9757674 | 53/15778952 |
+| Inner target on each side | 111 | 111 |
+| Derived total bound, bits | 128.165118548981 | 129.446504198433 |
+
+These are composition bounds, not permission to use a 111-bit checker as a
+standalone replacement for a 128-bit check.
+
+## Implementation, validation, and limitations
+
+The prototype uses exactly uniform partial Fisher-Yates sampling without
+replacement, separate endpoint signs, the stated graph coordinates, all original
+nonidentity inputs in both sums, and fresh inner randomness. Sampling independent
+edge IDs with replacement would invalidate the small-support proof unless
+collisions receive an additional sound treatment. The existing accumulator is
+reused without changing production field or group arithmetic.
+
+Eight new tests cover exact rejection sampling, all small partial-shuffle
+injections, independent endpoint sign bits, exhaustive small-graph girth, all
+edges' bounds/simplicity/regularity at q=47 and q=53, the exact `2^-8` cancellation
+probability on an eight-cycle, direct group-sum agreement, and end-to-end checks
+on adversarial order-three cofactor inputs. The last test exercises both graph
+parameters and both inner-check compositions, with identities and cancellation
+pairs included. Randomized regression tests do not establish a cryptographic
+failure probability; the derivation and exact finite inequalities supply that
+part of the evidence.
+
+A skeptical subagent independently checked the combinatorial bound, the split
+composition, and the implemented sampling and accumulation path. It found no
+remaining implementation/proof discrepancy. Validation passed:
+
+```sh
+just test -p commonware-cryptography --release --features bls12381 subgroup:: --test-threads 1
+just clippy -p commonware-cryptography --release --features bls12381
+python3 cryptography/src/bls12381/primitives/subgroup/research/two_bound.py
+```
+
+All 57 selected tests passed. WASM validation remains unavailable because the
+`wasm32-unknown-unknown` target is not installed. No public API, dependency,
+namespace, encoded format, or production verification path changed.
+
+The two passes output up to 207646 sums at q=47, so inner verification has more
+work than in the three-pass prototype. The shuffle allocates a full q^4-element
+u32 pool (about 19.5 MB at q=47), in addition to input, bucket, and ID storage;
+total peak memory is unmeasured. The q=47 implementation accepts at most 4879681
+input points, and q=53 at most 7890481. Larger batches can use another proved
+parameter set or fixed chunks at the same per-chunk security target, accepting
+only if every chunk accepts. Any invalid batch has a fixed invalid chunk, and
+accepting the whole batch implies falsely accepting that chunk, so this
+all-accept predicate needs no union-bound penalty. Chunking is not implemented
+or benchmarked here.
+
+Other platforms, parallel execution, arbitrary projective inputs, adversarial
+latency distributions, and crossover thresholds remain unmeasured. Production
+integration needs size-based selection retaining the original small-batch path,
+independent expert review, and broader performance validation. The next research
+targets are reducing the fixed inner-verification cost and the bucket working
+set, without weakening the outer compression bound. Neither two passes nor the
+current graph size is claimed as a universal lower bound.

--- a/cryptography/src/bls12381/benches/bench.rs
+++ b/cryptography/src/bls12381/benches/bench.rs
@@ -14,6 +14,7 @@ mod scheme_batch_verify_same_message;
 mod scheme_batch_verify_same_signer;
 mod signature_generation;
 mod signature_verification;
+mod subgroup;
 mod threshold_batch_verify_same_message;
 mod threshold_batch_verify_same_message_pre;
 mod threshold_batch_verify_same_signer;
@@ -41,6 +42,7 @@ criterion_main!(
     threshold_batch_verify_same_message::benches,
     threshold_batch_verify_same_message_pre::benches,
     threshold_batch_verify_same_signer::benches,
+    subgroup::benches,
     tle_encrypt::benches,
     tle_decrypt::benches,
 );

--- a/cryptography/src/bls12381/benches/subgroup.rs
+++ b/cryptography/src/bls12381/benches/subgroup.rs
@@ -5,7 +5,7 @@ use commonware_cryptography::bls12381::primitives::{
 use commonware_math::algebra::{CryptoGroup, Random};
 use commonware_parallel::{Rayon, Sequential};
 use commonware_utils::test_rng;
-use criterion::{BatchSize, Criterion, criterion_group};
+use criterion::{Criterion, criterion_group};
 use std::{hint::black_box, num::NonZeroUsize, thread::available_parallelism};
 
 /// Compare batched subgroup verification (serial and parallel) against
@@ -13,40 +13,28 @@ use std::{hint::black_box, num::NonZeroUsize, thread::available_parallelism};
 ///
 /// The batched check's advantage grows with the batch, so the sizes span from
 /// below the per-point fallback threshold to a batch large enough for the cost
-/// model to pick its widest round.
+/// model to pick its widest round. Every method reads the same batch and
+/// leaves it untouched, so it is built once per size rather than per iteration
+/// — at the largest size, building it costs more than checking it.
 fn bench_subgroup(c: &mut Criterion) {
     let threads = available_parallelism().unwrap_or(NonZeroUsize::new(1).unwrap());
     let rayon = Rayon::new(threads).unwrap();
     for n in [100usize, 1000, 6000, 100_000] {
-        let make = || {
-            let mut rng = test_rng();
-            (0..n)
-                .map(|_| G1::generator() * &Scalar::random(&mut rng))
-                .collect::<Vec<G1>>()
-        };
+        let mut rng = test_rng();
+        let points: Vec<G1> = (0..n)
+            .map(|_| G1::generator() * &Scalar::random(&mut rng))
+            .collect();
 
         c.bench_function(&format!("{}/method=per_point n={n}", module_path!()), |b| {
-            b.iter_batched(
-                make,
-                |points| black_box(points.iter().all(G1::in_subgroup)),
-                BatchSize::SmallInput,
-            );
+            b.iter(|| black_box(points.iter().all(G1::in_subgroup)));
         });
 
         c.bench_function(&format!("{}/method=serial n={n}", module_path!()), |b| {
-            b.iter_batched(
-                make,
-                |points| black_box(batch_in_g1(&points, 128, &Sequential, &mut test_rng())),
-                BatchSize::SmallInput,
-            );
+            b.iter(|| black_box(batch_in_g1(&points, 128, &Sequential, &mut test_rng())));
         });
 
         c.bench_function(&format!("{}/method=parallel n={n}", module_path!()), |b| {
-            b.iter_batched(
-                make,
-                |points| black_box(batch_in_g1(&points, 128, &rayon, &mut test_rng())),
-                BatchSize::SmallInput,
-            );
+            b.iter(|| black_box(batch_in_g1(&points, 128, &rayon, &mut test_rng())));
         });
     }
 }

--- a/cryptography/src/bls12381/benches/subgroup.rs
+++ b/cryptography/src/bls12381/benches/subgroup.rs
@@ -3,12 +3,16 @@ use commonware_cryptography::bls12381::primitives::{
     subgroup::batch_in_g1,
 };
 use commonware_math::algebra::{CryptoGroup, Random};
+use commonware_parallel::{Rayon, Sequential};
 use commonware_utils::test_rng;
 use criterion::{BatchSize, Criterion, criterion_group};
-use std::hint::black_box;
+use std::{hint::black_box, num::NonZeroUsize, thread::available_parallelism};
 
-/// Compare batched subgroup verification against per-point checking.
+/// Compare batched subgroup verification (serial and parallel) against
+/// per-point checking.
 fn bench_subgroup(c: &mut Criterion) {
+    let threads = available_parallelism().unwrap_or(NonZeroUsize::new(1).unwrap());
+    let rayon = Rayon::new(threads).unwrap();
     for n in [100usize, 1000, 6000] {
         let make = || {
             let mut rng = test_rng();
@@ -25,10 +29,18 @@ fn bench_subgroup(c: &mut Criterion) {
             );
         });
 
-        c.bench_function(&format!("{}/method=batched n={n}", module_path!()), |b| {
+        c.bench_function(&format!("{}/method=serial n={n}", module_path!()), |b| {
             b.iter_batched(
                 make,
-                |points| black_box(batch_in_g1(&points, 128, &mut test_rng())),
+                |points| black_box(batch_in_g1(&points, 128, &Sequential, &mut test_rng())),
+                BatchSize::SmallInput,
+            );
+        });
+
+        c.bench_function(&format!("{}/method=parallel n={n}", module_path!()), |b| {
+            b.iter_batched(
+                make,
+                |points| black_box(batch_in_g1(&points, 128, &rayon, &mut test_rng())),
                 BatchSize::SmallInput,
             );
         });

--- a/cryptography/src/bls12381/benches/subgroup.rs
+++ b/cryptography/src/bls12381/benches/subgroup.rs
@@ -1,0 +1,42 @@
+use commonware_cryptography::bls12381::primitives::{
+    group::{G1, Scalar},
+    subgroup::batch_in_g1,
+};
+use commonware_math::algebra::{CryptoGroup, Random};
+use commonware_utils::test_rng;
+use criterion::{BatchSize, Criterion, criterion_group};
+use std::hint::black_box;
+
+/// Compare batched subgroup verification against per-point checking.
+fn bench_subgroup(c: &mut Criterion) {
+    for n in [100usize, 1000, 6000] {
+        let make = || {
+            let mut rng = test_rng();
+            (0..n)
+                .map(|_| G1::generator() * &Scalar::random(&mut rng))
+                .collect::<Vec<G1>>()
+        };
+
+        c.bench_function(&format!("{}/method=per_point n={n}", module_path!()), |b| {
+            b.iter_batched(
+                make,
+                |points| black_box(points.iter().all(G1::in_subgroup)),
+                BatchSize::SmallInput,
+            );
+        });
+
+        c.bench_function(&format!("{}/method=batched n={n}", module_path!()), |b| {
+            b.iter_batched(
+                make,
+                |points| black_box(batch_in_g1(&points, 128, &mut test_rng())),
+                BatchSize::SmallInput,
+            );
+        });
+    }
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default().sample_size(10);
+    targets = bench_subgroup
+}

--- a/cryptography/src/bls12381/benches/subgroup.rs
+++ b/cryptography/src/bls12381/benches/subgroup.rs
@@ -10,10 +10,14 @@ use std::{hint::black_box, num::NonZeroUsize, thread::available_parallelism};
 
 /// Compare batched subgroup verification (serial and parallel) against
 /// per-point checking.
+///
+/// The batched check's advantage grows with the batch, so the sizes span from
+/// below the per-point fallback threshold to a batch large enough for the cost
+/// model to pick its widest round.
 fn bench_subgroup(c: &mut Criterion) {
     let threads = available_parallelism().unwrap_or(NonZeroUsize::new(1).unwrap());
     let rayon = Rayon::new(threads).unwrap();
-    for n in [100usize, 1000, 6000] {
+    for n in [100usize, 1000, 6000, 100_000] {
         let make = || {
             let mut rng = test_rng();
             (0..n)

--- a/cryptography/src/bls12381/primitives/group.rs
+++ b/cryptography/src/bls12381/primitives/group.rs
@@ -1098,22 +1098,6 @@ impl G1 {
         out
     }
 
-    /// Multi-scalar multiplication with tiny unsigned coefficients.
-    ///
-    /// Computes `sum_i coefficients[i] * affine[i]`, reading `bits` bits (at
-    /// most 8) of each one-byte coefficient. Uses blst's Pippenger routine,
-    /// whose bucket accumulation sums points batch-affine (one field inversion
-    /// per bucket), so this is far cheaper than a sequence of point additions.
-    #[commonware_macros::stability(ALPHA)]
-    pub(crate) fn small_msm(affine: &[blst_p1_affine], coefficients: &[u8], bits: usize) -> Self {
-        assert_eq!(affine.len(), coefficients.len());
-        assert!(bits <= 8);
-        if affine.is_empty() {
-            return Self::zero();
-        }
-        Self::msm_sequential(affine, coefficients, bits)
-    }
-
     /// Checks that `sum_i (p1[i] ⊙ p2[i]) + t1 ⊙ t2 == 0`.
     ///
     /// `p1` and `p2` MUST have the same length.

--- a/cryptography/src/bls12381/primitives/group.rs
+++ b/cryptography/src/bls12381/primitives/group.rs
@@ -1098,6 +1098,21 @@ impl G1 {
         out
     }
 
+    /// Multi-scalar multiplication with tiny unsigned coefficients.
+    ///
+    /// Computes `sum_i coefficients[i] * affine[i]`, reading `bits` bits (at
+    /// most 8) of each one-byte coefficient. Uses blst's Pippenger routine,
+    /// whose bucket accumulation sums points batch-affine (one field inversion
+    /// per bucket), so this is far cheaper than a sequence of point additions.
+    pub(crate) fn small_msm(affine: &[blst_p1_affine], coefficients: &[u8], bits: usize) -> Self {
+        assert_eq!(affine.len(), coefficients.len());
+        assert!(bits <= 8);
+        if affine.is_empty() {
+            return Self::zero();
+        }
+        Self::msm_sequential(affine, coefficients, bits)
+    }
+
     /// Checks that `sum_i (p1[i] ⊙ p2[i]) + t1 ⊙ t2 == 0`.
     ///
     /// `p1` and `p2` MUST have the same length.
@@ -1255,10 +1270,34 @@ impl Write for G1 {
     }
 }
 
-impl Read for G1 {
-    type Cfg = ();
+impl G1 {
+    /// Return whether this point lies in the prime-order subgroup G1.
+    ///
+    /// This is the exact per-point test (blst's endomorphism-based check). When
+    /// checking many points at once,
+    /// [`subgroup::batch_in_g1`](super::subgroup::batch_in_g1) is faster.
+    pub fn in_subgroup(&self) -> bool {
+        // SAFETY: self.0 is a valid blst_p1.
+        unsafe { blst_p1_in_g1(&self.0) }
+    }
 
-    fn read_cfg(buf: &mut impl Buf, _: &()) -> Result<Self, Error> {
+    /// Decode a point, verifying its encoding and that it is on the curve, but
+    /// *not* that it lies in the prime-order subgroup.
+    ///
+    /// # Warning
+    ///
+    /// The result may be a valid curve point outside G1. Using such a point in
+    /// a pairing or scalar multiplication without a subgroup check enables
+    /// small-subgroup attacks. Callers MUST establish subgroup membership —
+    /// via [`Self::in_subgroup`] or a batched
+    /// [`subgroup::batch_in_g1`](super::subgroup::batch_in_g1) — before relying
+    /// on it. This exists so that many points can be decoded cheaply and then
+    /// subgroup-checked together.
+    pub fn read_unchecked(buf: &mut impl Buf) -> Result<Self, Error> {
+        Self::read_point(buf, false)
+    }
+
+    fn read_point(buf: &mut impl Buf, subgroup: bool) -> Result<Self, Error> {
         let bytes = <[u8; Self::SIZE]>::read(buf)?;
         let mut ret = blst_p1::default();
         // SAFETY: bytes is a valid 48-byte array. blst_p1_uncompress validates encoding.
@@ -1283,11 +1322,19 @@ impl Read for G1 {
             }
 
             // Verify that the deserialized element is in G1
-            if !blst_p1_in_g1(&ret) {
+            if subgroup && !blst_p1_in_g1(&ret) {
                 return Err(Invalid("G1", "Outside G1"));
             }
         }
         Ok(Self(ret))
+    }
+}
+
+impl Read for G1 {
+    type Cfg = ();
+
+    fn read_cfg(buf: &mut impl Buf, _: &()) -> Result<Self, Error> {
+        Self::read_point(buf, true)
     }
 }
 

--- a/cryptography/src/bls12381/primitives/group.rs
+++ b/cryptography/src/bls12381/primitives/group.rs
@@ -1075,6 +1075,11 @@ impl G1 {
         Self(p)
     }
 
+    /// Borrows the underlying `blst_p1`.
+    pub(crate) const fn as_blst_p1(&self) -> &blst_p1 {
+        &self.0
+    }
+
     /// Batch converts projective G1 points to affine.
     ///
     /// This uses Montgomery's trick to reduce n field inversions to 1,

--- a/cryptography/src/bls12381/primitives/group.rs
+++ b/cryptography/src/bls12381/primitives/group.rs
@@ -1076,6 +1076,11 @@ impl G1 {
     }
 
     /// Borrows the underlying `blst_p1`.
+    ///
+    /// Only the batched subgroup check reads this, so it carries that module's
+    /// stability level and leaves with it; without the annotation a build above
+    /// ALPHA compiles the module out and fails on the dead method.
+    #[commonware_macros::stability(ALPHA)]
     pub(crate) const fn as_blst_p1(&self) -> &blst_p1 {
         &self.0
     }

--- a/cryptography/src/bls12381/primitives/group.rs
+++ b/cryptography/src/bls12381/primitives/group.rs
@@ -1104,6 +1104,7 @@ impl G1 {
     /// most 8) of each one-byte coefficient. Uses blst's Pippenger routine,
     /// whose bucket accumulation sums points batch-affine (one field inversion
     /// per bucket), so this is far cheaper than a sequence of point additions.
+    #[commonware_macros::stability(ALPHA)]
     pub(crate) fn small_msm(affine: &[blst_p1_affine], coefficients: &[u8], bits: usize) -> Self {
         assert_eq!(affine.len(), coefficients.len());
         assert!(bits <= 8);
@@ -1276,6 +1277,7 @@ impl G1 {
     /// This is the exact per-point test (blst's endomorphism-based check). When
     /// checking many points at once,
     /// [`subgroup::batch_in_g1`](super::subgroup::batch_in_g1) is faster.
+    #[commonware_macros::stability(ALPHA)]
     pub fn in_subgroup(&self) -> bool {
         // SAFETY: self.0 is a valid blst_p1.
         unsafe { blst_p1_in_g1(&self.0) }
@@ -1293,6 +1295,7 @@ impl G1 {
     /// [`subgroup::batch_in_g1`](super::subgroup::batch_in_g1) — before relying
     /// on it. This exists so that many points can be decoded cheaply and then
     /// subgroup-checked together.
+    #[commonware_macros::stability(ALPHA)]
     pub fn read_unchecked(buf: &mut impl Buf) -> Result<Self, Error> {
         Self::read_point(buf, false)
     }

--- a/cryptography/src/bls12381/primitives/mod.rs
+++ b/cryptography/src/bls12381/primitives/mod.rs
@@ -49,7 +49,8 @@
 pub mod group;
 pub mod ops;
 pub mod sharing;
-pub mod subgroup;
+// ALPHA until the batched subgroup check has had sufficient review.
+commonware_macros::stability_mod!(ALPHA, pub mod subgroup);
 pub mod variant;
 
 use thiserror::Error;

--- a/cryptography/src/bls12381/primitives/mod.rs
+++ b/cryptography/src/bls12381/primitives/mod.rs
@@ -49,6 +49,7 @@
 pub mod group;
 pub mod ops;
 pub mod sharing;
+pub mod subgroup;
 pub mod variant;
 
 use thiserror::Error;

--- a/cryptography/src/bls12381/primitives/subgroup.rs
+++ b/cryptography/src/bls12381/primitives/subgroup.rs
@@ -207,6 +207,18 @@ const CHECK_COST: usize = 150;
 /// multiplication per addition.
 const CHUNK: usize = 1024;
 
+/// Number of independent chains the shared inversion is split into, which is
+/// also how many additions are completed side by side.
+///
+/// A field multiplication's latency is well above its throughput, and both the
+/// running product of Montgomery's trick and the three multiplications of an
+/// addition are serial. Walking one chain would leave the core waiting on each
+/// result before it could start the next; interleaving this many independent
+/// chains keeps the multiplier busy. The chains cost a few extra
+/// multiplications per chunk to split one inversion between them. Measured
+/// flat from four upwards.
+const LANES: usize = 4;
+
 /// Flag stored in the high bit of a queued job's output slot, marking its
 /// operands equal (a doubling rather than a chord).
 const DOUBLE: u32 = 1 << 31;
@@ -751,27 +763,30 @@ fn absorb(
     state: &mut [u8],
     pending: &mut Pending,
 ) {
-    let Some(mut running) = pending.total_inverse() else {
+    let Some(mut running) = pending.chain_inverses() else {
         return;
     };
-    for index in (0..pending.jobs.len()).rev() {
+    let mut end = pending.jobs.len();
+    while end > 0 {
+        let start = end.saturating_sub(LANES);
         // The walk runs backwards, so the slot a job below will reopen is as
         // far off as the one the accumulation loop looks ahead for.
-        if let Some(&(ahead, _)) = pending.jobs.get(index.wrapping_sub(PREFETCH_DISTANCE)) {
-            prefetch(slots, (ahead & SLOT_MASK) as usize);
+        for index in start..end {
+            if let Some(&(ahead, _)) = pending.jobs.get(index.wrapping_sub(PREFETCH_DISTANCE)) {
+                prefetch(slots, (ahead & SLOT_MASK) as usize);
+            }
         }
-        let (slot, point) = pending.jobs[index];
-        let inverse = pending.unwind(index, &mut running);
-        let bucket = (slot & SLOT_MASK) as usize;
-        let sum = chord(
-            &slots[bucket],
-            &src[point as usize],
-            &inverse,
-            slot & DOUBLE != 0,
-            slot & OP_NEGATE != 0,
+        let inverses = pending.unwind(start, end, &mut running);
+        finish(
+            slots,
+            &pending.jobs[start..end],
+            &inverses[..end - start],
+            Seconds::Points(src),
         );
-        slots[bucket] = sum;
-        state[bucket] = FILLED;
+        for &(slot, _) in &pending.jobs[start..end] {
+            state[(slot & SLOT_MASK) as usize] = FILLED;
+        }
+        end = start;
     }
     pending.clear();
 }
@@ -841,24 +856,25 @@ fn queue_add(
 
 /// Finish the additions queued by [`queue_add`].
 fn complete(slots: &mut [blst_p1_affine], pending: &mut Pending) {
-    let Some(mut running) = pending.total_inverse() else {
+    let Some(mut running) = pending.chain_inverses() else {
         return;
     };
-    for index in (0..pending.jobs.len()).rev() {
-        if let Some(&(ahead, _)) = pending.jobs.get(index.wrapping_sub(PREFETCH_DISTANCE)) {
-            prefetch(slots, (ahead & SLOT_MASK) as usize);
+    let mut end = pending.jobs.len();
+    while end > 0 {
+        let start = end.saturating_sub(LANES);
+        for index in start..end {
+            if let Some(&(ahead, _)) = pending.jobs.get(index.wrapping_sub(PREFETCH_DISTANCE)) {
+                prefetch(slots, (ahead & SLOT_MASK) as usize);
+            }
         }
-        let (slot, second) = pending.jobs[index];
-        let inverse = pending.unwind(index, &mut running);
-        let out = (slot & SLOT_MASK) as usize;
-        let sum = chord(
-            &slots[out],
-            &slots[second as usize],
-            &inverse,
-            slot & DOUBLE != 0,
-            slot & OP_NEGATE != 0,
+        let inverses = pending.unwind(start, end, &mut running);
+        finish(
+            slots,
+            &pending.jobs[start..end],
+            &inverses[..end - start],
+            Seconds::Slots,
         );
-        slots[out] = sum;
+        end = start;
     }
     pending.clear();
 }
@@ -907,8 +923,9 @@ fn reduce(
 struct Pending {
     jobs: Vec<(u32, u32)>,
     denominators: Vec<blst_fp>,
-    /// Running products of the denominators, walked back down as each addition
-    /// takes its inverse.
+    /// Running products of the denominators along [`LANES`] interleaved
+    /// chains (entry `i` continues entry `i - LANES`), walked back down as each
+    /// addition takes its inverse.
     prefix: Vec<blst_fp>,
     /// How many additions to queue before sharing an inversion.
     limit: usize,
@@ -942,27 +959,51 @@ impl Pending {
     /// denominator.
     #[inline(always)]
     fn push(&mut self, slot: u32, second: u32, denominator: blst_fp) {
-        let product = self
-            .prefix
-            .last()
-            .map_or(denominator, |running| fp_mul(running, &denominator));
+        let product = match self.prefix.len().checked_sub(LANES) {
+            Some(previous) => fp_mul(&self.prefix[previous], &denominator),
+            None => denominator,
+        };
         self.prefix.push(product);
         self.jobs.push((slot, second));
         self.denominators.push(denominator);
     }
 
-    /// Invert the running product of every queued denominator, or `None` when
-    /// nothing is queued.
+    /// Invert every chain's running product, or `None` when nothing is queued.
+    ///
+    /// One field inversion serves all the chains: their totals are multiplied
+    /// together, the product inverted, and each chain's inverse recovered from
+    /// that by Montgomery's trick once more, over [`LANES`] values.
     ///
     /// Every denominator MUST be nonzero (`blst_fp_inverse(0) == 0` would
     /// silently poison the shared product); the callers' classification
     /// guarantees it.
-    fn total_inverse(&self) -> Option<blst_fp> {
-        let total = self.prefix.last()?;
-        let mut inverse = blst_fp::default();
+    fn chain_inverses(&self) -> Option<[blst_fp; LANES]> {
+        let len = self.prefix.len();
+        if len == 0 {
+            return None;
+        }
+        // Chain `c` holds the indices congruent to `c` modulo LANES, so its
+        // total is its last entry; chains past `len` are empty.
+        let chains = len.min(LANES);
+        let mut totals = [blst_fp::default(); LANES];
+        for (chain, total) in totals[..chains].iter_mut().enumerate() {
+            *total = self.prefix[len - 1 - (len - 1 - chain) % LANES];
+        }
+        let mut products = [blst_fp::default(); LANES];
+        products[0] = totals[0];
+        for chain in 1..chains {
+            products[chain] = fp_mul(&products[chain - 1], &totals[chain]);
+        }
+        let mut running = blst_fp::default();
         // SAFETY: both pointers reference valid blst_fp values.
-        unsafe { blst_fp_inverse(&mut inverse, total) };
-        Some(inverse)
+        unsafe { blst_fp_inverse(&mut running, &products[chains - 1]) };
+        let mut inverses = [blst_fp::default(); LANES];
+        for chain in (1..chains).rev() {
+            inverses[chain] = fp_mul(&running, &products[chain - 1]);
+            running = fp_mul(&running, &totals[chain]);
+        }
+        inverses[0] = running;
+        Some(inverses)
     }
 
     /// Whether the queue has grown to a full inversion's worth of work.
@@ -971,16 +1012,29 @@ impl Pending {
         self.jobs.len() >= self.limit
     }
 
-    /// Return the inverse of job `index`'s denominator, advancing `running` (the
-    /// inverse of the running product through `index`) to the next job down.
+    /// Return the inverses of the denominators of jobs `start..end` (at most
+    /// [`LANES`] consecutive jobs, so each on a different chain), advancing
+    /// each chain's `running` inverse to its next job down.
+    ///
+    /// The chains are independent, so the multiplications here overlap rather
+    /// than wait on one another.
     #[inline(always)]
-    fn unwind(&self, index: usize, running: &mut blst_fp) -> blst_fp {
-        if index == 0 {
-            return *running;
+    fn unwind(&self, start: usize, end: usize, running: &mut [blst_fp; LANES]) -> [blst_fp; LANES] {
+        debug_assert!(end - start <= LANES);
+        let mut inverses = [blst_fp::default(); LANES];
+        for (lane, index) in (start..end).enumerate() {
+            let running = &mut running[index % LANES];
+            inverses[lane] = index
+                .checked_sub(LANES)
+                .map_or(*running, |previous| fp_mul(running, &self.prefix[previous]));
         }
-        let inverse = fp_mul(running, &self.prefix[index - 1]);
-        *running = fp_mul(running, &self.denominators[index]);
-        inverse
+        for index in start..end {
+            if index >= LANES {
+                let running = &mut running[index % LANES];
+                *running = fp_mul(running, &self.denominators[index]);
+            }
+        }
+        inverses
     }
 
     fn clear(&mut self) {
@@ -990,13 +1044,88 @@ impl Pending {
     }
 }
 
-/// Complete one affine addition (or doubling) given the inverse of its
-/// denominator.
+/// Where a queued job's second operand lives.
+#[derive(Clone, Copy)]
+enum Seconds<'a> {
+    /// In the batch being accumulated, at the job's second index.
+    Points(&'a [blst_p1_affine]),
+    /// In the slot array itself, at the job's second index.
+    Slots,
+}
+
+/// Complete up to [`LANES`] queued additions (or doublings) side by side,
+/// given the inverses of their denominators, writing each result over the slot
+/// that held its first operand.
 ///
 /// Chord/tangent formulas for curve coefficient `a = 0`:
 /// `add: lambda = (y_b - y_a) / (x_b - x_a)`,
 /// `double: lambda = 3 x_a^2 / (2 y_a)`,
 /// `x_out = lambda^2 - x_a - x_b`, `y_out = lambda (x_a - x_out) - y_a`.
+///
+/// The three multiplications of one addition depend on each other; those of
+/// different additions do not. Each step is taken for every job before the
+/// next step for any, so consecutive multiplications are independent and the
+/// core can overlap them. Every operand is read before any result is written,
+/// which the callers' waves of disjoint outputs make sound.
+#[inline(always)]
+fn finish(
+    slots: &mut [blst_p1_affine],
+    jobs: &[(u32, u32)],
+    inverses: &[blst_fp],
+    seconds: Seconds<'_>,
+) {
+    let count = jobs.len();
+    debug_assert!((1..=LANES).contains(&count) && inverses.len() == count);
+    let mut results = [blst_p1_affine::default(); LANES];
+    {
+        let slots: &[blst_p1_affine] = slots;
+        let placeholder = &slots[0];
+        let mut firsts = [placeholder; LANES];
+        let mut others = [placeholder; LANES];
+        for (lane, &(slot, second)) in jobs.iter().enumerate() {
+            firsts[lane] = &slots[(slot & SLOT_MASK) as usize];
+            others[lane] = match seconds {
+                Seconds::Points(points) => &points[second as usize],
+                Seconds::Slots => &slots[second as usize],
+            };
+        }
+        let mut lambdas = [blst_fp::default(); LANES];
+        for (lane, &(slot, _)) in jobs.iter().enumerate() {
+            let (first, second) = (firsts[lane], others[lane]);
+            lambdas[lane] = if slot & DOUBLE != 0 {
+                let square = fp_sqr(&first.x);
+                fp_mul(&fp_add(&fp_add(&square, &square), &square), &inverses[lane])
+            } else if slot & OP_NEGATE != 0 {
+                // The second operand enters negated, which negates the
+                // numerator; the caller took its denominator the other way
+                // round, so the two signs cancel and the negation costs no
+                // arithmetic at all. Only x is read below, and negation leaves
+                // x alone.
+                fp_mul(&fp_add(&second.y, &first.y), &inverses[lane])
+            } else {
+                fp_mul(&fp_sub(&second.y, &first.y), &inverses[lane])
+            };
+        }
+        for lane in 0..count {
+            let (first, second) = (firsts[lane], others[lane]);
+            results[lane].x = fp_sub(&fp_sub(&fp_sqr(&lambdas[lane]), &first.x), &second.x);
+        }
+        for lane in 0..count {
+            let first = firsts[lane];
+            results[lane].y = fp_sub(
+                &fp_mul(&lambdas[lane], &fp_sub(&first.x, &results[lane].x)),
+                &first.y,
+            );
+        }
+    }
+    for (lane, &(slot, _)) in jobs.iter().enumerate() {
+        slots[(slot & SLOT_MASK) as usize] = results[lane];
+    }
+}
+
+/// Complete one affine addition (or doubling) given the inverse of its
+/// denominator; the single-job form of [`finish`], for the measurements.
+#[cfg(test)]
 #[inline(always)]
 fn chord(
     first: &blst_p1_affine,
@@ -2437,6 +2566,179 @@ mod tests {
                 all_valid
             );
         }
+    }
+
+    /// Latency vs throughput of the addition's pieces, and what interleaving
+    /// independent additions buys. Run with:
+    /// `cargo test -p commonware-cryptography --release --features bls12381 \
+    ///   subgroup::tests::measure_interleave -- --ignored --nocapture`
+    #[test]
+    #[ignore = "manual benchmark"]
+    fn measure_interleave() {
+        use std::time::Instant;
+        let mut rng = test_rng();
+        let n = 8192;
+        let points: Vec<G1> = (0..2 * n).map(|_| in_subgroup_point(&mut rng)).collect();
+        let affine = G1::batch_to_affine(&points);
+        let denominators: Vec<blst_fp> = (0..n)
+            .map(|i| fp_sub(&affine[2 * i + 1].x, &affine[2 * i].x))
+            .collect();
+
+        // Dependent chain: latency of one multiplication.
+        let reps = 2_000_000;
+        let mut x = affine[0].x;
+        let start = Instant::now();
+        for _ in 0..reps {
+            x = fp_mul(&x, &affine[1].x);
+        }
+        std::hint::black_box(&x);
+        println!(
+            "fp_mul dependent chain {:.1} ns",
+            start.elapsed().as_nanos() as f64 / reps as f64
+        );
+
+        // k independent chains interleaved: does the core overlap them?
+        for k in [1usize, 2, 4, 8] {
+            let mut xs: Vec<blst_fp> = affine[..k].iter().map(|p| p.x).collect();
+            let start = Instant::now();
+            for _ in 0..reps / k {
+                for chain in xs.iter_mut() {
+                    *chain = fp_mul(chain, &affine[1].x);
+                }
+            }
+            std::hint::black_box(&xs);
+            println!(
+                "fp_mul {k} interleaved chains {:.1} ns/mul",
+                start.elapsed().as_nanos() as f64 / reps as f64
+            );
+        }
+
+        let mut prefix = Vec::new();
+        let mut inverses = denominators.clone();
+        batch_invert(&mut inverses, &mut prefix);
+
+        // Chord: one at a time (as `complete` does), then k interleaved.
+        let reps = 200;
+        let mut out = vec![blst_p1_affine::default(); n];
+        let start = Instant::now();
+        for _ in 0..reps {
+            for i in 0..n {
+                out[i] = chord(&affine[2 * i], &affine[2 * i + 1], &inverses[i], false, false);
+            }
+            std::hint::black_box(&out);
+        }
+        println!(
+            "chord x1            {:.1} ns/addition",
+            start.elapsed().as_nanos() as f64 / (reps * n) as f64
+        );
+        let start = Instant::now();
+        for _ in 0..reps {
+            for i in (0..n).step_by(2) {
+                let (a, b) = (&affine[2 * i], &affine[2 * i + 1]);
+                let (c, d) = (&affine[2 * i + 2], &affine[2 * i + 3]);
+                let l0 = fp_mul(&fp_sub(&b.y, &a.y), &inverses[i]);
+                let l1 = fp_mul(&fp_sub(&d.y, &c.y), &inverses[i + 1]);
+                let x0 = fp_sub(&fp_sub(&fp_sqr(&l0), &a.x), &b.x);
+                let x1 = fp_sub(&fp_sub(&fp_sqr(&l1), &c.x), &d.x);
+                let y0 = fp_sub(&fp_mul(&l0, &fp_sub(&a.x, &x0)), &a.y);
+                let y1 = fp_sub(&fp_mul(&l1, &fp_sub(&c.x, &x1)), &c.y);
+                out[i] = blst_p1_affine { x: x0, y: y0 };
+                out[i + 1] = blst_p1_affine { x: x1, y: y1 };
+            }
+            std::hint::black_box(&out);
+        }
+        println!(
+            "chord x2 interleaved {:.1} ns/addition",
+            start.elapsed().as_nanos() as f64 / (reps * n) as f64
+        );
+        let start = Instant::now();
+        for _ in 0..reps {
+            for i in (0..n).step_by(4) {
+                let mut l = [blst_fp::default(); 4];
+                for j in 0..4 {
+                    let (a, b) = (&affine[2 * (i + j)], &affine[2 * (i + j) + 1]);
+                    l[j] = fp_mul(&fp_sub(&b.y, &a.y), &inverses[i + j]);
+                }
+                let mut xs = [blst_fp::default(); 4];
+                for j in 0..4 {
+                    let (a, b) = (&affine[2 * (i + j)], &affine[2 * (i + j) + 1]);
+                    xs[j] = fp_sub(&fp_sub(&fp_sqr(&l[j]), &a.x), &b.x);
+                }
+                for j in 0..4 {
+                    let a = &affine[2 * (i + j)];
+                    let y = fp_sub(&fp_mul(&l[j], &fp_sub(&a.x, &xs[j])), &a.y);
+                    out[i + j] = blst_p1_affine { x: xs[j], y };
+                }
+            }
+            std::hint::black_box(&out);
+        }
+        println!(
+            "chord x4 interleaved {:.1} ns/addition",
+            start.elapsed().as_nanos() as f64 / (reps * n) as f64
+        );
+
+        // Backward walk of the inversion: one serial chain vs four.
+        let reps = 400;
+        let start = Instant::now();
+        for _ in 0..reps {
+            let mut values = denominators.clone();
+            batch_invert(&mut values, &mut prefix);
+            std::hint::black_box(&values);
+        }
+        let clone_cost = {
+            let start = Instant::now();
+            for _ in 0..reps {
+                let values = denominators.clone();
+                std::hint::black_box(&values);
+            }
+            start.elapsed().as_nanos() as f64 / (reps * n) as f64
+        };
+        println!(
+            "batch_invert 1 chain {:.1} ns/element",
+            start.elapsed().as_nanos() as f64 / (reps * n) as f64 - clone_cost
+        );
+        let start = Instant::now();
+        for _ in 0..reps {
+            let values = denominators.clone();
+            // Forward: four interleaved prefix chains.
+            let mut pre = vec![blst_fp::default(); n];
+            pre[..4].copy_from_slice(&values[..4]);
+            for i in 4..n {
+                pre[i] = fp_mul(&pre[i - 4], &values[i]);
+            }
+            // One inversion of the product of the four totals, then split.
+            let t01 = fp_mul(&pre[n - 4], &pre[n - 3]);
+            let t23 = fp_mul(&pre[n - 2], &pre[n - 1]);
+            let total = fp_mul(&t01, &t23);
+            let mut inv = blst_fp::default();
+            // SAFETY: both pointers reference valid blst_fp values.
+            unsafe { blst_fp_inverse(&mut inv, &total) };
+            let inv01 = fp_mul(&inv, &t23);
+            let inv23 = fp_mul(&inv, &t01);
+            let mut running = [
+                fp_mul(&inv01, &pre[n - 3]),
+                fp_mul(&inv01, &pre[n - 4]),
+                fp_mul(&inv23, &pre[n - 1]),
+                fp_mul(&inv23, &pre[n - 2]),
+            ];
+            let mut out = vec![blst_fp::default(); n];
+            let mut i = n;
+            while i > 4 {
+                i -= 4;
+                for c in 0..4 {
+                    out[i + c] = fp_mul(&running[c], &pre[i + c - 4]);
+                }
+                for c in 0..4 {
+                    running[c] = fp_mul(&running[c], &values[i + c]);
+                }
+            }
+            out[..4].copy_from_slice(&running);
+            std::hint::black_box(&out);
+        }
+        println!(
+            "batch_invert 4 chains {:.1} ns/element (incl. alloc)",
+            start.elapsed().as_nanos() as f64 / (reps * n) as f64 - clone_cost
+        );
     }
 
     /// Cost of the pieces of one batch-affine addition. Run with:

--- a/cryptography/src/bls12381/primitives/subgroup.rs
+++ b/cryptography/src/bls12381/primitives/subgroup.rs
@@ -1,0 +1,260 @@
+//! Batched subgroup-membership checking for BLS12-381 G1.
+//!
+//! Verifying that a point lies in the prime-order subgroup G1 is a significant
+//! part of the cost of decoding an untrusted point (it dominates the field
+//! square root of decompression). When many points must be checked at once —
+//! for example every point in a block of transactions — checking them together
+//! is cheaper than checking each individually.
+//!
+//! # Method
+//!
+//! Given points `P_0, ..., P_{n-1}` (already verified to lie on the curve, e.g.
+//! via [`G1::read_unchecked`]), each round samples coefficients `c_i` uniformly
+//! from `{0, 1, 2}`, forms the combination `Q = sum_i c_i P_i`, and applies the
+//! exact per-point check [`G1::in_subgroup`] to the single point `Q`. If every
+//! round's combination is in G1, all points are accepted.
+//!
+//! The points are converted to affine once, and each round's combination is a
+//! two-bit multi-scalar multiplication: blst's Pippenger routine buckets the
+//! points by coefficient and sums each bucket with a single shared field
+//! inversion, which is much cheaper than adding the points one at a time.
+//!
+//! # Soundness
+//!
+//! Write each point as its in-subgroup part plus a "cofactor part" living in the
+//! group of order `h` (the G1 cofactor). `Q` lies in G1 exactly when the
+//! coefficient-weighted sum of the cofactor parts vanishes. If some `P_j` has a
+//! nonzero cofactor part, consider the smallest prime `p | h` where it is
+//! nonzero. Because the three coefficients `{0, 1, 2}` take three distinct
+//! values modulo any prime `p >= 3` (and are uniform modulo `3`), the weighted
+//! sum hits the single value `0` in that component with probability at most
+//! `1/3` per round. So `r` rounds accept a bad point with probability at most
+//! `3^{-r}`, independent of the cofactor's factorization.
+//!
+//! For BLS12-381 the G1 cofactor's smallest prime factor is `3`, so this `1/3`
+//! bound is tight and small coefficients are optimal: larger coefficients could
+//! not lower the per-round error, only make each round more expensive.
+
+use super::group::G1;
+#[cfg(not(feature = "std"))]
+use alloc::{vec, vec::Vec};
+use rand_core::CryptoRng;
+
+/// One thousand times a strict lower bound on `log2(3)`.
+///
+/// `log2(3) = 1.58496...`, and `1.584 < log2(3)`, so dividing by this bound
+/// never underestimates the number of rounds.
+const LOG2_3_SCALED_LOWER_BOUND: usize = 1584;
+
+/// Number of rounds needed for a soundness error of at most `2^-security`.
+///
+/// Each round has error at most `1/3`, so `r` rounds give `3^-r <= 2^-security`
+/// once `r >= security / log2(3)`.
+pub const fn rounds_for_security(security: usize) -> usize {
+    security
+        .saturating_mul(1000)
+        .div_ceil(LOG2_3_SCALED_LOWER_BOUND)
+}
+
+/// Verify that every point in `points` lies in the prime-order subgroup G1,
+/// with a soundness error of at most `2^-security`.
+///
+/// The points must already be valid curve points (for example decoded with
+/// [`G1::read_unchecked`]); this establishes only subgroup membership. An empty
+/// slice is accepted.
+///
+/// `rng` must be a cryptographically secure source the prover cannot predict:
+/// the coefficients are the verifier's private randomness, exactly as in a
+/// batched signature check.
+#[must_use]
+pub fn batch_in_g1(points: &[G1], security: usize, rng: &mut impl CryptoRng) -> bool {
+    let rounds = rounds_for_security(security);
+    // Batching pays a fixed cost of one subgroup check per round regardless of
+    // the input size, so for few points the exact per-point path is cheaper.
+    if points.len() <= 2 * rounds {
+        return points.iter().all(G1::in_subgroup);
+    }
+    // One shared inversion converts every point to affine; the per-round
+    // combinations then reuse them.
+    let affine = G1::batch_to_affine(points);
+    let mut coefficients = vec![0u8; points.len()];
+    let mut trits = Trits::new(rng);
+    for _ in 0..rounds {
+        for coefficient in &mut coefficients {
+            *coefficient = trits.next();
+        }
+        // Two-bit MSM: coefficients are 0, 1, or 2.
+        if !G1::small_msm(&affine, &coefficients, 2).in_subgroup() {
+            return false;
+        }
+    }
+    true
+}
+
+/// A stream of uniform trits over a cryptographic RNG.
+///
+/// Each accepted byte below `3^5 = 243` yields five independent uniform trits
+/// (its base-3 digits); bytes at or above 243 are rejected so the trits stay
+/// exactly uniform. Bytes are drawn in bulk to amortize RNG calls.
+struct Trits<'a, R: CryptoRng> {
+    rng: &'a mut R,
+    buffer: [u8; 256],
+    filled: usize,
+    position: usize,
+    current: u8,
+    remaining: u8,
+}
+
+impl<'a, R: CryptoRng> Trits<'a, R> {
+    const fn new(rng: &'a mut R) -> Self {
+        Self {
+            rng,
+            buffer: [0u8; 256],
+            filled: 0,
+            position: 0,
+            current: 0,
+            remaining: 0,
+        }
+    }
+
+    /// Return the next uniform value in `{0, 1, 2}`.
+    fn next(&mut self) -> u8 {
+        if self.remaining == 0 {
+            self.current = self.next_byte();
+            self.remaining = 5;
+        }
+        let trit = self.current % 3;
+        self.current /= 3;
+        self.remaining -= 1;
+        trit
+    }
+
+    /// Return the next byte strictly below 243, refilling the buffer as needed.
+    fn next_byte(&mut self) -> u8 {
+        loop {
+            if self.position == self.filled {
+                self.rng.fill_bytes(&mut self.buffer);
+                self.filled = self.buffer.len();
+                self.position = 0;
+            }
+            let byte = self.buffer[self.position];
+            self.position += 1;
+            if byte < 243 {
+                return byte;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::bls12381::primitives::group::{G1, Scalar};
+    use commonware_codec::FixedSize;
+    use commonware_math::algebra::{Additive, CryptoGroup, Random};
+    use commonware_utils::test_rng;
+
+    /// Standard soundness target for the tests.
+    const SECURITY: usize = 128;
+
+    fn in_subgroup_point(rng: &mut impl CryptoRng) -> G1 {
+        G1::generator() * &Scalar::random(rng)
+    }
+
+    /// Build a valid curve point that is (almost surely) outside G1.
+    ///
+    /// A uniformly random on-curve point lies in the prime-order subgroup with
+    /// probability `1/h` (negligible), so decoding random compressed bytes and
+    /// keeping the ones that are on-curve yields off-subgroup points.
+    fn off_subgroup_point(rng: &mut impl CryptoRng) -> G1 {
+        loop {
+            let mut bytes = [0u8; G1::SIZE];
+            rng.fill_bytes(&mut bytes);
+            // Compression flag set, infinity flag clear; keep a random y-sign.
+            bytes[0] = (bytes[0] & 0x3f) | 0x80;
+            if let Ok(point) = G1::read_unchecked(&mut &bytes[..])
+                && !point.in_subgroup()
+            {
+                return point;
+            }
+        }
+    }
+
+    #[test]
+    fn round_count_matches_security() {
+        assert_eq!(rounds_for_security(128), 81);
+        assert_eq!(rounds_for_security(0), 0);
+        // 3^r >= 2^security must hold at the returned r.
+        for security in [1usize, 40, 80, 100, 128, 200, 256] {
+            let rounds = rounds_for_security(security);
+            assert!(f64::from(rounds as u32) * 3f64.log2() >= security as f64);
+        }
+    }
+
+    #[test]
+    fn empty_batch_is_accepted() {
+        assert!(batch_in_g1(&[], SECURITY, &mut test_rng()));
+    }
+
+    #[test]
+    fn small_msm_matches_naive_combination() {
+        let mut rng = test_rng();
+        let points: Vec<G1> = (0..20).map(|_| in_subgroup_point(&mut rng)).collect();
+        let affine = G1::batch_to_affine(&points);
+        let coefficients: Vec<u8> = (0..points.len()).map(|i| (i % 3) as u8).collect();
+
+        let mut expected = G1::zero();
+        for (point, &c) in points.iter().zip(&coefficients) {
+            expected += &(*point * &Scalar::from(u64::from(c)));
+        }
+        assert_eq!(G1::small_msm(&affine, &coefficients, 2), expected);
+    }
+
+    #[test]
+    fn valid_points_are_accepted() {
+        let mut rng = test_rng();
+        let points: Vec<G1> = (0..64).map(|_| in_subgroup_point(&mut rng)).collect();
+        for point in &points {
+            assert!(point.in_subgroup());
+        }
+        assert!(batch_in_g1(&points, SECURITY, &mut rng));
+        // A single valid point, and the identity, are both accepted.
+        assert!(batch_in_g1(&points[..1], SECURITY, &mut rng));
+        assert!(batch_in_g1(&[G1::zero()], SECURITY, &mut rng));
+    }
+
+    #[test]
+    fn off_subgroup_point_is_rejected() {
+        let mut rng = test_rng();
+        let bad = off_subgroup_point(&mut rng);
+        assert!(!bad.in_subgroup());
+        // The exact and batched checks agree on the single bad point.
+        assert!(!batch_in_g1(&[bad], SECURITY, &mut rng));
+    }
+
+    #[test]
+    fn one_bad_point_in_a_batch_is_rejected() {
+        let mut rng = test_rng();
+        let mut points: Vec<G1> = (0..32).map(|_| in_subgroup_point(&mut rng)).collect();
+        points.insert(17, off_subgroup_point(&mut rng));
+        assert!(!batch_in_g1(&points, SECURITY, &mut rng));
+    }
+
+    #[test]
+    fn batch_agrees_with_per_point() {
+        let mut rng = test_rng();
+        for _ in 0..8 {
+            let points: Vec<G1> = (0..16)
+                .map(|i| {
+                    if i % 5 == 0 {
+                        off_subgroup_point(&mut rng)
+                    } else {
+                        in_subgroup_point(&mut rng)
+                    }
+                })
+                .collect();
+            let all_valid = points.iter().all(G1::in_subgroup);
+            assert_eq!(batch_in_g1(&points, SECURITY, &mut rng), all_valid);
+        }
+    }
+}

--- a/cryptography/src/bls12381/primitives/subgroup.rs
+++ b/cryptography/src/bls12381/primitives/subgroup.rs
@@ -157,9 +157,11 @@ const fn combinations_for_security(security: usize) -> usize {
 
 /// Largest supported number of parallel combinations per round.
 ///
-/// A round's collapse workspace holds about `1.5 * 3^m` points, so this bounds
-/// what a round can allocate; in practice [`SLOT_BUDGET`] binds first.
-const MAX_WIDTH: u32 = 11;
+/// Set to where the sampler runs out rather than to a performance judgement,
+/// so that [`SLOT_BUDGET`] is what decides the width: `3^13` is the largest
+/// power of three a drawn `u32` word can carry, and one id per word is the
+/// least the packing can do. [`SLOT_BUDGET`] binds well before this.
+const MAX_WIDTH: u32 = 13;
 
 /// Largest bucket-slot footprint a round should ask for, in bytes.
 ///
@@ -169,20 +171,26 @@ const MAX_WIDTH: u32 = 11;
 /// for a deeper level of the memory hierarchy on every point, and its workspace
 /// grows threefold per step, per thread.
 ///
-/// Sixteen MiB admits width 11, which is the one step that changes the round
-/// count at 128-bit security: `ceil(81/11) = 8` passes rather than the nine
-/// every narrower width needs. It is worth 9% at a million points here, and
-/// nothing at all below the size where the cost model stops choosing it — a
-/// hundred-thousand-point batch still plans nine rounds of width nine, because
-/// the combine a width-11 round pays for outgrows the pass it saves. Folding
-/// is what brings width 11 inside a budget this size at all: unfolded its slots
-/// would be 17 MB rather than 8.5 MB.
+/// Only two widths change the round count at 128-bit security, and this admits
+/// both: width 11 gives `ceil(81/11) = 8` passes rather than nine, and width 12
+/// gives seven. Measured here, the first is worth 9% at a million points and
+/// the second 8% at three million — 19.3x to 20.8x against per-point checking.
+/// Folding is what brings them inside a budget this size: width 12's slots are
+/// 25 MB folded against 51 MB unfolded.
+///
+/// A wider round is not free, which is why the budget is not simply the largest
+/// width the sampler supports. Each step triples the slot array the accumulator
+/// touches at random, and triples the per-thread workspace with it, while the
+/// combine it pays for grows as `3^m` against the single pass it saves. The
+/// cost model weighs that per batch, so a smaller batch declines the width a
+/// larger one takes: at a hundred thousand points it still plans nine rounds of
+/// width nine, and only past a million does width 12 start to pay.
 ///
 /// This is the constant most worth re-measuring on a new machine. It trades
 /// against the last level of cache that holds the slot array, so a machine with
 /// a smaller one wants it lower; the width it admits is a performance choice
 /// only, and every width is equally sound.
-const SLOT_BUDGET: usize = 16 << 20;
+const SLOT_BUDGET: usize = 32 << 20;
 
 /// Approximate cost of one [`G1::in_subgroup`] check, in units of one
 /// batch-affine point addition.
@@ -1351,6 +1359,8 @@ impl<'a, R: CryptoRng> Trits<'a, R> {
             9 => draw!(19683, 2),
             10 => draw!(59049, 2),
             11 => draw!(177147, 1),
+            12 => draw!(531441, 1),
+            13 => draw!(1594323, 1),
             _ => unreachable!("width is at most MAX_WIDTH"),
         }
         ids

--- a/cryptography/src/bls12381/primitives/subgroup.rs
+++ b/cryptography/src/bls12381/primitives/subgroup.rs
@@ -166,13 +166,23 @@ const MAX_WIDTH: u32 = 11;
 /// Points arrive in random bucket order, so the accumulator's working set is
 /// the whole slot array, and a round's collapse workspace is half as large
 /// again. A wider round needs fewer passes over the points, but its slots pay
-/// for a deeper level of the memory hierarchy on every point — measured here as
-/// 8% more per addition one step past the budget and 15% two steps past — and
-/// its workspace grows threefold per step, per thread. Two MiB holds `3^9`
-/// slots, which is where the two stop trading well: at a million points, the
-/// widest plan the next step up allows measures within noise of the one chosen
-/// here while asking for an order of magnitude more memory.
-const SLOT_BUDGET: usize = 2 << 20;
+/// for a deeper level of the memory hierarchy on every point, and its workspace
+/// grows threefold per step, per thread.
+///
+/// Sixteen MiB admits width 11, which is the one step that changes the round
+/// count at 128-bit security: `ceil(81/11) = 8` passes rather than the nine
+/// every narrower width needs. It is worth 9% at a million points here, and
+/// nothing at all below the size where the cost model stops choosing it — a
+/// hundred-thousand-point batch still plans nine rounds of width nine, because
+/// the combine a width-11 round pays for outgrows the pass it saves. Folding
+/// is what brings width 11 inside a budget this size at all: unfolded its slots
+/// would be 17 MB rather than 8.5 MB.
+///
+/// This is the constant most worth re-measuring on a new machine. It trades
+/// against the last level of cache that holds the slot array, so a machine with
+/// a smaller one wants it lower; the width it admits is a performance choice
+/// only, and every width is equally sound.
+const SLOT_BUDGET: usize = 16 << 20;
 
 /// Approximate cost of one [`G1::in_subgroup`] check, in units of one
 /// batch-affine point addition.
@@ -210,7 +220,7 @@ const ID_NEGATE: u32 = 1 << 31;
 /// together with its negation (see [`Trits`]), so the `3^m` vectors occupy
 /// `(3^m + 1) / 2` buckets: one per `{v, -v}` pair, plus the zero vector.
 const fn folded(m: u32) -> usize {
-    (3usize.pow(m) + 1) / 2
+    3usize.pow(m).div_ceil(2)
 }
 
 /// Bucket slot holding nothing, i.e. standing for the identity.
@@ -601,7 +611,7 @@ impl Round {
             let list = &mut self.marginals[j];
             list.clear();
             list.extend(
-                ((half + 1) / 2..=(3 * half - 1) / 2)
+                (half.div_ceil(2)..=(3 * half - 1) / 2)
                     .map(|b| (level + b) as u32)
                     .filter(|&index| self.live[index as usize]),
             );
@@ -1530,17 +1540,27 @@ mod tests {
         assert!(plan(6000, 81).is_some());
         // A zero soundness target needs no rounds at all.
         assert_eq!(plan(6000, 0), Some(Vec::new()));
-        // Wider rounds, and so fewer of them, pay off as the batch grows, until
-        // the slot budget stops the widening.
+        // Wider rounds, and so fewer of them, pay off as the batch grows: a
+        // wider round spends more on its combine and saves it on every point,
+        // so the crossover moves with n. Pinned as monotonicity rather than as
+        // particular widths, which move with the slot budget.
         let rounds = |n| plan(n, 81).map(|widths| widths.len());
         assert!(rounds(1000) > rounds(100_000));
-        assert_eq!(rounds(100_000), rounds(2_000_000));
+        assert!(rounds(100_000) >= rounds(2_000_000));
         let widest = |n| plan(n, 81).and_then(|widths| widths.into_iter().max());
         assert!(widest(1000) < widest(100_000));
-        assert_eq!(widest(2_000_000), widest(100_000));
+        assert!(widest(100_000) <= widest(2_000_000));
+        // Whatever the model picks, it stays inside the budget it is given, and
+        // the budget rather than the width cap is what stops the widening.
+        for n in [100_000usize, 2_000_000] {
+            let budgeted = widest(n).expect("batched");
+            assert!(folded(budgeted) * size_of::<blst_p1_affine>() <= SLOT_BUDGET);
+        }
         let budgeted = widest(2_000_000).expect("batched");
-        assert!(3usize.pow(budgeted) * size_of::<blst_p1_affine>() <= SLOT_BUDGET);
-        assert!(3usize.pow(budgeted + 1) * size_of::<blst_p1_affine>() > SLOT_BUDGET);
+        assert!(
+            budgeted == MAX_WIDTH
+                || folded(budgeted + 1) * size_of::<blst_p1_affine>() > SLOT_BUDGET
+        );
     }
 
     #[test]
@@ -2114,12 +2134,12 @@ mod tests {
                 // All points on one folded vector, half of them negated.
                 1 => (0..n)
                     .map(|i| {
-                        (seed as u32) % buckets | if i % 2 == 0 { ID_NEGATE } else { 0 }
+                        ((seed as u32) % buckets) | if i % 2 == 0 { ID_NEGATE } else { 0 }
                     })
                     .collect(),
                 // A tiny support, so collisions and cancellations dominate.
                 2 => (0..n)
-                    .map(|i| (i as u32) % buckets.min(3) | ((i as u32 & 1) << 31))
+                    .map(|i| ((i as u32) % buckets.min(3)) | ((i as u32 & 1) << 31))
                     .collect(),
                 _ => Trits::new(&mut rng).fill(m, n),
             };
@@ -2336,12 +2356,12 @@ mod tests {
         let mut rng = test_rng();
         let n = 100_000;
         let widths = plan(n, 81).expect("batched");
-        let widest = 3usize.pow(*widths.iter().max().expect("nonempty"))
-            * size_of::<blst_p1_affine>();
-        assert!(
-            widest * 3 > SLOT_BUDGET,
-            "expected the budget to bind, got {widths:?}"
-        );
+        let widest = *widths.iter().max().expect("nonempty");
+        // What matters here is that the plan is wide, so the collapse runs at
+        // full depth — not which of the two limits stopped the widening, since
+        // that moves with the slot budget.
+        assert!(widest >= 8, "expected a wide plan, got {widths:?}");
+        assert!(folded(widest) * size_of::<blst_p1_affine>() <= SLOT_BUDGET);
         let pool: Vec<G1> = (0..64).map(|_| in_subgroup_point(&mut rng)).collect();
         let mut points: Vec<G1> = (0..n).map(|i| pool[i % pool.len()]).collect();
         assert!(batch_in_g1(&points, SECURITY, &Sequential, &mut rng));

--- a/cryptography/src/bls12381/primitives/subgroup.rs
+++ b/cryptography/src/bls12381/primitives/subgroup.rs
@@ -28,13 +28,37 @@
 //!
 //! Summing `n` points into `3^m` buckets costs the same `n` point additions as
 //! summing them into one, so a single accumulation pass over the points serves
-//! all `m` combinations, and only `ceil(81/m)` passes are needed at 128-bit
-//! security instead of 81. The additions are batch-affine: each pass pairs up
-//! the remaining points of every bucket and completes all pairs with one shared
-//! field inversion (Montgomery's trick), about six field multiplications per
-//! addition. The per-batch choice of `m` (and of batching at all, versus
-//! checking each point individually) is a pure performance decision made by a
-//! cost model; soundness holds for every choice.
+//! all `m` combinations, and about `81/m` passes are needed at 128-bit security
+//! instead of 81. Four properties keep the constant small:
+//!
+//! - **Batch-affine additions.** Additions are queued rather than performed,
+//!   and a chunk of them shares one field inversion (Montgomery's trick) — six
+//!   field multiplications per addition instead of an inversion.
+//! - **Streaming accumulation.** A bucket's slot holds its running sum, so a
+//!   point is read once, added once, and never copied to a work list. A bucket
+//!   whose addition is still queued is closed until the chunk completes, and a
+//!   point that arrives meanwhile is carried to the next pass; with random
+//!   bucket ids only a few percent of points ever are.
+//! - **A shared collapse for the combine.** Recovering the `m` combinations one
+//!   at a time would touch `2 * 3^(m-1)` bucket sums each, which caps `m` where
+//!   the combine costs more than the accumulation it saves. Summing away one
+//!   digit at a time instead yields every digit's marginals for about two
+//!   additions per bucket in total, which is what makes wide rounds — and so
+//!   few passes — affordable.
+//! - **Widths chosen per round.** The plan spreads the required combinations
+//!   over its rounds as evenly as it can, so a round count that does not divide
+//!   them wastes at most one combination.
+//!
+//! The per-batch choice of widths (and of batching at all, versus checking each
+//! point individually) is a pure performance decision made by a cost model;
+//! soundness holds for every choice.
+//!
+//! What a batch cannot escape is one pass over the points per `log2(3^m)` bits
+//! of soundness (see below), so the cost per point falls only with the
+//! logarithm of the round width — and the width is bounded by what a round's
+//! bucket slots can hold in cache. That is why the speedup over per-point
+//! checking keeps growing with the batch: at `2^-128`, nine passes is the floor,
+//! and the fixed per-round overheads only amortize away as `n` grows.
 //!
 //! # Soundness
 //!
@@ -63,6 +87,13 @@
 //! residue mod 3, so even full-width random weights leave a cancelling pair a
 //! `1/3` escape.
 //!
+//! A round cannot do better than `3^-m` either, whatever it does with the
+//! bucket sums: a lone bad point escapes whenever its coefficient vector is the
+//! zero vector, which happens with probability `3^-m` however the `m`
+//! combinations are wired. A pass over the points is therefore worth at most
+//! `log2(3^m)` bits of soundness, and the accumulation cost is what decides how
+//! large `3^m` can usefully be.
+//!
 //! The bound requires an odd cofactor: an order-2 part `T` has `2*T = 0`, so
 //! `c * T` escapes with probability `2/3` per combination. A curve whose
 //! cofactor is even (e.g. BLS12-377 G1, with `2^92 | h`) cannot use this
@@ -76,11 +107,11 @@ use super::group::G1;
 #[cfg(not(feature = "std"))]
 use alloc::{vec, vec::Vec};
 use blst::{
-    blst_fp, blst_fp_add, blst_fp_inverse, blst_fp_mul, blst_fp_sqr, blst_fp_sub, blst_p1,
-    blst_p1_add_or_double, blst_p1_add_or_double_affine, blst_p1_affine, blst_p1_affine_is_inf,
-    blst_p1_double, blst_p1_in_g1,
+    blst_fp, blst_fp_inverse, blst_fp_mul, blst_fp_sqr, blst_p1, blst_p1_add_or_double_affine,
+    blst_p1_affine, blst_p1_double, blst_p1_from_affine, blst_p1_in_g1,
 };
 use commonware_parallel::Strategy;
+use core::mem::{MaybeUninit, size_of};
 use rand_core::CryptoRng;
 
 /// One thousand times a strict lower bound on `log2(3)`.
@@ -100,39 +131,124 @@ const fn combinations_for_security(security: usize) -> usize {
         .div_ceil(LOG2_3_SCALED_LOWER_BOUND)
 }
 
+/// Largest supported number of parallel combinations per round.
+///
+/// A round's collapse workspace holds about `1.5 * 3^m` points, so this bounds
+/// what a round can allocate; in practice [`SLOT_BUDGET`] binds first.
+const MAX_WIDTH: u32 = 11;
+
+/// Largest bucket-slot footprint a round should ask for, in bytes.
+///
+/// Points arrive in random bucket order, so the accumulator's working set is
+/// the whole slot array. A wider round needs fewer passes over the points, but
+/// once its slots outgrow the cache every point pays a miss that the saved
+/// passes do not repay — measured here as a 20-35% jump in cost per addition
+/// one step past the budget. Two MiB holds `3^9` slots.
+const SLOT_BUDGET: usize = 2 << 20;
+
 /// Approximate cost of one [`G1::in_subgroup`] check, in units of one
 /// batch-affine point addition.
 ///
-/// Machine-rough (measured ~22us per check against ~150ns per addition); it
-/// only steers the cost model's choice of `m` and the per-point fallback,
+/// Machine-rough (measured ~52us per check against ~350ns per addition); it
+/// only steers the cost model's choice of widths and the per-point fallback,
 /// never soundness.
 const CHECK_COST: usize = 150;
 
-/// Approximate cost of one Jacobian mixed addition (used by the bucket
-/// combine), in units of one batch-affine point addition.
-const MIXED_ADD_COST: usize = 3;
-
-/// Pick the number of parallel combinations per round, or `None` if checking
-/// each point individually is cheaper.
+/// Number of point additions completed per shared field inversion.
 ///
-/// Returns `(m, rounds)` minimizing the modeled cost
-/// `rounds * (n additions + combine + m checks)` subject to
-/// `rounds * m >= combinations`; soundness holds for every choice, so the
-/// constants above only affect performance.
-fn plan(n: usize, combinations: usize) -> Option<(u32, usize)> {
+/// Sized so that a chunk's denominators, prefix products and freshly written
+/// results stay in cache while the inversion amortizes to well under one field
+/// multiplication per addition.
+const CHUNK: usize = 1024;
+
+/// Flag stored in the high bit of a queued job's output slot, marking its
+/// operands equal (a doubling rather than a chord).
+const DOUBLE: u32 = 1 << 31;
+
+/// Bucket slot holding nothing, i.e. standing for the identity.
+const EMPTY: u8 = 0;
+
+/// Bucket slot holding a running sum that further points can be added to.
+const FILLED: u8 = 1;
+
+/// Bucket slot closed by an addition that is queued but not yet completed.
+const BUSY: u8 = 2;
+
+/// How far ahead the accumulator prefetches the slot a point will land in.
+///
+/// The loop body is short, so this needs to cover an L2 or L3 miss; overshooting
+/// only costs a cache line that would have been fetched anyway.
+const PREFETCH_DISTANCE: usize = 24;
+
+/// Expected number of occupied buckets when `n` points fall uniformly into `b`
+/// of them: `b * (1 - e^(-n/b))`, with a cheap rational stand-in for the
+/// exponential (the cost model only needs the shape).
+fn expected_occupied(n: usize, b: usize) -> usize {
+    let x = n as f64 / b as f64;
+    if x > 32.0 {
+        return b.min(n);
+    }
+    let series = 1.0 + x + x * x / 2.0 + x * x * x / 6.0;
+    ((b as f64 * (1.0 - 1.0 / series)) as usize).min(n)
+}
+
+/// Modeled cost of one round at width `m`, in units of one batch-affine point
+/// addition.
+///
+/// Summing `n` points into `3^m` buckets takes one addition per point that is
+/// not the last one left in its bucket, and recovering the `m` combinations
+/// takes about two additions per occupied bucket (one for the collapse chain,
+/// one for the marginals it feeds). The `m` exact checks are charged too, since
+/// they are what makes narrow rounds expensive on small batches.
+fn round_cost(n: usize, m: u32) -> usize {
+    let buckets = 3usize.pow(m);
+    let occupied = expected_occupied(n, buckets);
+    (n - occupied) + 2 * occupied + (m as usize) * CHECK_COST
+}
+
+/// Plan the rounds: one width per round, summing to at least `combinations`.
+///
+/// Returns `None` if checking each point individually is cheaper. The widths of
+/// a plan differ by at most one, so a round count that does not divide
+/// `combinations` wastes no more than one combination — which matters, since
+/// the round count is what the batch pays for.
+///
+/// Soundness holds for every plan (a round of width `m` has error `3^-m`, and
+/// the widths sum to at least `combinations`), so the cost model's constants
+/// only affect performance.
+fn plan(n: usize, combinations: usize) -> Option<Vec<u32>> {
+    if combinations == 0 {
+        return Some(Vec::new());
+    }
+    // A width is only usable if its buckets are neither hopelessly sparse nor
+    // too many to keep close to the CPU.
+    let mut widest = 0u32;
+    while widest < MAX_WIDTH
+        && 3usize.pow(widest + 1) <= 4 * n.max(1)
+        && 3usize.pow(widest + 1) * size_of::<blst_p1_affine>() <= SLOT_BUDGET
+    {
+        widest += 1;
+    }
+    if widest == 0 {
+        return None;
+    }
     let mut best_cost = n.saturating_mul(CHECK_COST);
     let mut best = None;
-    let mut pow3 = 1usize;
-    for m in 1..=5u32 {
-        pow3 *= 3;
-        let rounds = combinations.div_ceil(m as usize);
-        // Combining bucket sums into output j touches the 2*3^(m-1) buckets
-        // whose j-th digit is nonzero, for each of the m outputs.
-        let combine = MIXED_ADD_COST * 2 * (m as usize) * (pow3 / 3);
-        let cost = rounds.saturating_mul(n + combine + (m as usize) * CHECK_COST);
+    for rounds in combinations.div_ceil(widest as usize)..=combinations {
+        let width = (combinations / rounds) as u32;
+        let wide = combinations % rounds;
+        // Spreading combinations evenly cannot push a round past `widest`: a
+        // round count that leaves a remainder also leaves `width < widest`.
+        debug_assert!(width < widest || wide == 0);
+        let cost = wide.saturating_mul(round_cost(n, width + 1))
+            + (rounds - wide).saturating_mul(round_cost(n, width));
         if cost < best_cost {
             best_cost = cost;
-            best = Some((m, rounds));
+            best = Some(
+                (0..rounds)
+                    .map(|round| if round < wide { width + 1 } else { width })
+                    .collect(),
+            );
         }
     }
     best
@@ -161,263 +277,799 @@ pub fn batch_in_g1(
     rng: &mut impl CryptoRng,
 ) -> bool {
     let combinations = combinations_for_security(security);
-    // Whether to batch at all, and at what width, is an algorithmic choice the
+    // Whether to batch at all, and at what widths, is an algorithmic choice the
     // cost model makes; it cannot be delegated to `strategy` (which only
     // chooses serial vs parallel execution of a single algorithm). Either
     // path's independent units still run through `strategy`.
-    let Some((m, rounds)) = plan(points.len(), combinations) else {
+    let Some(widths) = plan(points.len(), combinations) else {
         return strategy
             .map_collect_vec_with_multiplier(points.iter(), 1, |point| point.in_subgroup())
             .into_iter()
             .all(|in_subgroup| in_subgroup);
     };
+    let Some(&widest) = widths.iter().max() else {
+        return true;
+    };
     // One shared inversion converts every point to affine; the per-round
     // accumulations then reuse them.
-    let affine = G1::batch_to_affine(points);
+    let affine = to_affine(points);
+
     // The RNG is sequential, so draw every round's coefficient vectors (as
     // base-3 bucket ids) up front; the rounds themselves are independent and
     // run through the strategy, weighted by the per-round accumulation size.
     let mut trits = Trits::new(rng);
-    let id_sets: Vec<Vec<u8>> = (0..rounds)
-        .map(|_| (0..points.len()).map(|_| trits.bucket(m)).collect())
+    let id_sets: Vec<(u32, Vec<u32>)> = widths
+        .iter()
+        .map(|&m| (m, trits.fill(m, affine.len())))
         .collect();
     strategy
-        .map_collect_vec_with_multiplier(id_sets.iter(), points.len(), |ids| {
-            round_in_g1(&affine, ids, m)
-        })
+        .map_init_collect_vec_with_multiplier(
+            id_sets.iter(),
+            affine.len(),
+            || Round::new(widest),
+            |round, (m, ids)| round.run(&affine, ids, *m),
+        )
         .into_iter()
         .all(|in_subgroup| in_subgroup)
 }
 
-/// Run one round: sum the points into `3^m` buckets keyed by coefficient
-/// vector, recover the `m` combinations from the bucket sums, and check each.
-fn round_in_g1(affine: &[blst_p1_affine], ids: &[u8], m: u32) -> bool {
-    let sums = sum_buckets(affine, ids, 3usize.pow(m));
-    for j in 0..m {
-        let divisor = 3usize.pow(j);
-        // Output j is (sum of buckets with digit_j = 1) + 2 * (digit_j = 2).
-        let mut ones = blst_p1::default();
-        let mut twos = blst_p1::default();
-        for (v, sum) in sums.iter().enumerate() {
-            if affine_is_inf(sum) {
+/// Convert `points` to affine, dropping the identities among them.
+///
+/// One shared inversion serves a chunk of the batch (Montgomery's trick), so a
+/// point costs about seven field multiplications. The chunking keeps the
+/// inversion's running products in cache, which on a large batch matters more
+/// than the handful of extra inversions it costs. The identity contributes
+/// nothing to any combination, so dropping it here spares the accumulator a
+/// test for it on every pass.
+fn to_affine(points: &[G1]) -> Vec<blst_p1_affine> {
+    let mut affine = Vec::with_capacity(points.len());
+    let mut inverses = Vec::with_capacity(CHUNK);
+    let mut prefix = Vec::with_capacity(CHUNK);
+    for chunk in points.chunks(CHUNK) {
+        inverses.clear();
+        inverses.extend(
+            chunk
+                .iter()
+                .map(G1::as_blst_p1)
+                .map(|point| point.z)
+                .filter(|z| !fp_is_zero(z) && !fp_is_one(z)),
+        );
+        batch_invert(&mut inverses, &mut prefix);
+        let mut inverses = inverses.iter();
+        for point in chunk.iter().map(G1::as_blst_p1) {
+            if fp_is_zero(&point.z) {
                 continue;
             }
-            let acc = match (v / divisor) % 3 {
-                1 => &mut ones,
-                2 => &mut twos,
-                _ => continue,
-            };
-            // SAFETY: acc and sum are valid points; blst_p1_add_or_double_affine
-            // handles identity and equal operands, and permits out == a.
-            unsafe { blst_p1_add_or_double_affine(acc, acc, sum) };
+            // A point decoded from the wire is already normalized, which is the
+            // common case for a batch of untrusted points.
+            if fp_is_one(&point.z) {
+                affine.push(blst_p1_affine {
+                    x: point.x,
+                    y: point.y,
+                });
+                continue;
+            }
+            let inverse = inverses.next().expect("one inverse per surviving point");
+            let squared = fp_sqr(inverse);
+            let cubed = fp_mul(&squared, inverse);
+            affine.push(blst_p1_affine {
+                x: fp_mul(&point.x, &squared),
+                y: fp_mul(&point.y, &cubed),
+            });
         }
-        let mut combination = blst_p1::default();
-        // SAFETY: all operands are valid blst_p1 values (identity included).
-        unsafe {
-            blst_p1_double(&mut combination, &twos);
-            blst_p1_add_or_double(&mut combination, &combination, &ones);
-            if !blst_p1_in_g1(&combination) {
+    }
+    affine
+}
+
+/// Working state for one round, reused across the round's passes — and, under a
+/// sequential strategy, across every round.
+struct Round {
+    /// Number of parallel combinations of the round being run, i.e. base-3
+    /// digits per bucket id.
+    m: u32,
+    /// Start of each collapse level within [`Self::sums`]. Level `j` holds
+    /// `3^(m-j)` entries: level 0 is the bucket sums themselves (and doubles as
+    /// the accumulator's per-bucket slots), and level `j+1` is level `j` with
+    /// its lowest remaining digit summed away.
+    levels: Vec<usize>,
+    /// The concatenated collapse levels.
+    sums: Vec<blst_p1_affine>,
+    /// Whether the matching entry of [`Self::sums`] holds a point; an entry
+    /// that does not stands for the identity.
+    live: Vec<bool>,
+    /// Per-bucket accumulator state over level 0 of [`Self::sums`]: empty,
+    /// holding a running sum, or closed by an addition awaiting its inversion.
+    state: Vec<u8>,
+    /// Ping-pong lists of points still to be paired, with their bucket ids.
+    lists: [Vec<blst_p1_affine>; 2],
+    ids: [Vec<u32>; 2],
+    /// Additions queued for the next shared inversion.
+    pending: Pending,
+    /// Entries still to be summed for each of the `2m` marginals.
+    marginals: Vec<Vec<u32>>,
+}
+
+impl Round {
+    /// Allocate state able to run any round up to width `widest`.
+    fn new(widest: u32) -> Self {
+        debug_assert!((1..=MAX_WIDTH).contains(&widest));
+        let total = (3usize.pow(widest + 1) - 3) / 2;
+        Self {
+            m: 0,
+            levels: Vec::with_capacity(widest as usize),
+            sums: vec![blst_p1_affine::default(); total],
+            live: vec![false; total],
+            state: vec![EMPTY; 3usize.pow(widest)],
+            lists: [Vec::new(), Vec::new()],
+            ids: [Vec::new(), Vec::new()],
+            pending: Pending::new(),
+            marginals: (0..2 * widest as usize).map(|_| Vec::new()).collect(),
+        }
+    }
+
+    /// Lay out the collapse levels for a round of width `m`.
+    fn widen(&mut self, m: u32) {
+        debug_assert!((1..=MAX_WIDTH).contains(&m));
+        debug_assert!(3usize.pow(m) <= self.state.len());
+        if self.m == m {
+            return;
+        }
+        self.m = m;
+        self.pending.bound(3usize.pow(m));
+        self.levels.clear();
+        let mut total = 0usize;
+        for j in 0..m {
+            self.levels.push(total);
+            total += 3usize.pow(m - j);
+        }
+    }
+
+    /// Sum `points` into the `3^m` buckets named by `ids`, leaving each bucket's
+    /// sum in its slot at level 0 of [`Self::sums`].
+    fn accumulate(&mut self, points: &[blst_p1_affine], ids: &[u32]) {
+        self.state[..3usize.pow(self.m)].fill(EMPTY);
+        accumulate_pass(
+            points,
+            ids,
+            &mut self.lists[0],
+            &mut self.ids[0],
+            &mut self.sums,
+            &mut self.state,
+            &mut self.pending,
+        );
+        while !self.lists[0].is_empty() {
+            let ([front, back], [front_ids, back_ids]) = (&mut self.lists, &mut self.ids);
+            accumulate_pass(
+                front,
+                front_ids,
+                back,
+                back_ids,
+                &mut self.sums,
+                &mut self.state,
+                &mut self.pending,
+            );
+            self.lists.swap(0, 1);
+            self.ids.swap(0, 1);
+        }
+        // The collapse works off the shared liveness flags; level 0's come from
+        // the accumulator's per-bucket state.
+        let buckets = 3usize.pow(self.m);
+        for (live, &state) in self.live[..buckets].iter_mut().zip(&self.state[..buckets]) {
+            *live = state != EMPTY;
+        }
+    }
+
+    /// Run one round: sum the points into `3^m` buckets keyed by coefficient
+    /// vector, recover the `m` combinations from the bucket sums, and check
+    /// each.
+    fn run(&mut self, points: &[blst_p1_affine], ids: &[u32], m: u32) -> bool {
+        self.widen(m);
+        self.accumulate(points, ids);
+
+        // Collapse chain: level `j+1` sums away level `j`'s lowest digit, so
+        // every digit position's marginals come out of one shared walk over the
+        // bucket sums rather than one walk per combination.
+        for j in 0..(self.m as usize).saturating_sub(1) {
+            let (source, target) = (self.levels[j], self.levels[j + 1]);
+            let width = 3usize.pow(self.m - j as u32 - 1);
+            for digit in [1usize, 2] {
+                for k in 0..width {
+                    let out = (target + k) as u32;
+                    let first = if digit == 1 {
+                        (source + 3 * k) as u32
+                    } else {
+                        out
+                    };
+                    queue_add(
+                        &mut self.sums,
+                        &mut self.live,
+                        &mut self.pending,
+                        out,
+                        first,
+                        (source + 3 * k + digit) as u32,
+                    );
+                }
+                complete(&mut self.sums, &mut self.pending);
+            }
+        }
+
+        // Combination `j` is the sum of the buckets whose `j`-th digit is 1 plus
+        // twice the sum of those whose digit is 2, and level `j` has every other
+        // digit already summed away.
+        for j in 0..self.m as usize {
+            let level = self.levels[j];
+            let width = 3usize.pow(self.m - j as u32 - 1);
+            for digit in [1usize, 2] {
+                let list = &mut self.marginals[2 * j + digit - 1];
+                list.clear();
+                list.extend(
+                    (0..width)
+                        .map(|k| (level + digit + 3 * k) as u32)
+                        .filter(|&index| self.live[index as usize]),
+                );
+            }
+        }
+        reduce(
+            &mut self.sums,
+            &mut self.live,
+            &mut self.marginals,
+            &mut self.pending,
+        );
+
+        for j in 0..self.m as usize {
+            let mut combination = blst_p1::default();
+            if let Some(&twos) = self.marginals[2 * j + 1].first() {
+                let mut point = blst_p1::default();
+                // SAFETY: the index names a live affine point, and blst_p1
+                // defaults to the identity.
+                unsafe {
+                    blst_p1_from_affine(&mut point, &self.sums[twos as usize]);
+                    blst_p1_double(&mut combination, &point);
+                }
+            }
+            if let Some(&ones) = self.marginals[2 * j].first() {
+                // SAFETY: both operands are valid; the routine handles the
+                // identity and equal operands, and permits out == a.
+                unsafe {
+                    blst_p1_add_or_double_affine(
+                        &mut combination,
+                        &combination,
+                        &self.sums[ones as usize],
+                    );
+                }
+            }
+            // SAFETY: combination is a valid blst_p1 (identity included).
+            if !unsafe { blst_p1_in_g1(&combination) } {
                 return false;
             }
         }
+        true
     }
-    true
 }
 
-/// A pending affine addition or doubling. Operands are copied out when the
-/// pass is scheduled so results can be written back without aliasing hazards.
-struct Arith {
-    a: blst_p1_affine,
-    b: blst_p1_affine,
-    out: usize,
-    double: bool,
-}
-
-/// Sum `points` into `num_buckets` buckets given by `ids` (each id less than
-/// `num_buckets`), returning one affine sum per bucket (the identity for empty
-/// buckets).
+/// Add each point of `src` into its bucket's running sum.
 ///
-/// Each pass pairs up the remaining points within every bucket and completes
-/// all pairs with a single shared field inversion (Montgomery's trick), so an
-/// addition costs about six field multiplications instead of an inversion.
-fn sum_buckets(points: &[blst_p1_affine], ids: &[u8], num_buckets: usize) -> Vec<blst_p1_affine> {
-    debug_assert_eq!(points.len(), ids.len());
-    // Counting sort the points into contiguous per-bucket runs.
-    let mut lens = vec![0usize; num_buckets];
-    for &id in ids {
-        lens[id as usize] += 1;
-    }
-    let mut starts = vec![0usize; num_buckets];
-    let mut acc = 0;
-    for (start, len) in starts.iter_mut().zip(&lens) {
-        *start = acc;
-        acc += len;
-    }
-    let mut buf = vec![blst_p1_affine::default(); points.len()];
-    let mut cursor = starts.clone();
-    for (point, &id) in points.iter().zip(ids) {
-        buf[cursor[id as usize]] = *point;
-        cursor[id as usize] += 1;
-    }
-
-    // Halve every bucket per pass until each holds at most one point. Copies
-    // (identity-involved pairs and odd leftovers) are deferred alongside the
-    // arithmetic so all reads complete before any write.
-    let mut arith: Vec<Arith> = Vec::new();
-    let mut denominators: Vec<blst_fp> = Vec::new();
-    let mut copies: Vec<(usize, blst_p1_affine)> = Vec::new();
-    loop {
-        arith.clear();
-        denominators.clear();
-        copies.clear();
-        for b in 0..num_buckets {
-            let (start, len) = (starts[b], lens[b]);
-            if len < 2 {
+/// The sum stays in the bucket's slot, so a point is read once and written once
+/// rather than travelling down a pairing tree. An addition is only queued, not
+/// completed, until its chunk shares an inversion, so a bucket with an
+/// outstanding addition is closed and any further point for it moves to
+/// `carry`, to be retried on the next pass. The pass returns with `carry` empty
+/// exactly when every point has been absorbed.
+fn accumulate_pass(
+    src: &[blst_p1_affine],
+    src_ids: &[u32],
+    carry: &mut Vec<blst_p1_affine>,
+    carry_ids: &mut Vec<u32>,
+    slots: &mut [blst_p1_affine],
+    state: &mut [u8],
+    pending: &mut Pending,
+) {
+    debug_assert_eq!(src.len(), src_ids.len());
+    carry.clear();
+    carry_ids.clear();
+    let mut deferred = 0usize;
+    for (index, (point, &id)) in src.iter().zip(src_ids).enumerate() {
+        // Bucket ids are uniform, so the slot a point lands in is a cache miss
+        // the loop can see coming a long way off.
+        if let Some(&ahead) = src_ids.get(index + PREFETCH_DISTANCE) {
+            prefetch(slots, ahead as usize);
+        }
+        let bucket = id as usize;
+        match state[bucket] {
+            EMPTY => {
+                state[bucket] = FILLED;
+                slots[bucket] = *point;
                 continue;
             }
-            for k in 0..len / 2 {
-                let a = buf[start + 2 * k];
-                let c = buf[start + 2 * k + 1];
-                let out = start + k;
-                if affine_is_inf(&a) {
-                    copies.push((out, c));
-                } else if affine_is_inf(&c) {
-                    copies.push((out, a));
-                } else if a.x.l == c.x.l {
-                    // Same x: on the curve y is determined up to sign, so this
-                    // is either P + (-P) = identity or a doubling.
-                    let two_y = fp_add(&a.y, &c.y);
-                    if two_y.l == [0u64; 6] {
-                        copies.push((out, blst_p1_affine::default()));
-                    } else {
-                        // y_a == y_c != 0, so two_y = 2*y_a is the doubling
-                        // denominator. (y == 0 cannot occur: the group order
-                        // h * r is odd, so the curve has no 2-torsion.)
-                        denominators.push(two_y);
-                        arith.push(Arith {
-                            a,
-                            b: c,
-                            out,
-                            double: true,
-                        });
-                    }
-                } else {
-                    denominators.push(fp_sub(&c.x, &a.x));
-                    arith.push(Arith {
-                        a,
-                        b: c,
-                        out,
-                        double: false,
-                    });
+            BUSY => {
+                carry.push(*point);
+                carry_ids.push(id);
+                // Bound the share of a pass that defers, so a batch whose ids
+                // collide constantly still converges in a few passes.
+                deferred += 1;
+                if deferred > pending.jobs.len() {
+                    absorb(src, slots, state, pending);
+                    deferred = 0;
+                }
+                continue;
+            }
+            _ => {}
+        }
+        // Only the x coordinates decide which formula applies, so the running
+        // sum is read a field element at a time rather than copied whole.
+        let held = &slots[bucket];
+        if fp_eq(&held.x, &point.x) {
+            // Same x: on the curve y is determined up to sign, so this is
+            // either P + (-P) = identity or a doubling.
+            let two_y = fp_add(&held.y, &point.y);
+            if fp_is_zero(&two_y) {
+                // The sum cancels, and an empty slot is the identity.
+                state[bucket] = EMPTY;
+                continue;
+            }
+            // y_held == y_point != 0, so two_y = 2*y_held is the doubling
+            // denominator. (y == 0 cannot occur: the group order h * r is odd,
+            // so the curve has no 2-torsion.)
+            pending.push(bucket as u32 | DOUBLE, index as u32, two_y);
+        } else {
+            pending.push(bucket as u32, index as u32, fp_sub(&point.x, &held.x));
+        }
+        state[bucket] = BUSY;
+        if pending.is_full() {
+            absorb(src, slots, state, pending);
+            deferred = 0;
+        }
+    }
+    absorb(src, slots, state, pending);
+}
+
+/// Finish the additions queued by [`accumulate_pass`] and reopen their buckets.
+///
+/// The shared inversion's backward walk hands each addition its inverse just as
+/// the addition needs it, so no inverse is ever written to memory.
+fn absorb(
+    src: &[blst_p1_affine],
+    slots: &mut [blst_p1_affine],
+    state: &mut [u8],
+    pending: &mut Pending,
+) {
+    let Some(mut running) = prefix_inverse(&pending.denominators, &mut pending.prefix) else {
+        return;
+    };
+    for index in (0..pending.jobs.len()).rev() {
+        let (slot, point) = pending.jobs[index];
+        let inverse = pending.unwind(index, &mut running);
+        let bucket = (slot & !DOUBLE) as usize;
+        let sum = chord(
+            &slots[bucket],
+            &src[point as usize],
+            &inverse,
+            slot & DOUBLE != 0,
+        );
+        slots[bucket] = sum;
+        state[bucket] = FILLED;
+    }
+    pending.clear();
+}
+
+/// Queue `slots[out] = slots[first] + slots[second]`.
+///
+/// The first operand is moved into the output slot immediately, so a completed
+/// job needs only the output and the second operand. Queued jobs must never
+/// read a slot another queued job writes; every caller below queues a wave of
+/// disjoint outputs and completes it before starting the next.
+fn queue_add(
+    slots: &mut [blst_p1_affine],
+    live: &mut [bool],
+    pending: &mut Pending,
+    out: u32,
+    first: u32,
+    second: u32,
+) {
+    let (out_index, first_index, second_index) = (out as usize, first as usize, second as usize);
+    if !live[second_index] {
+        if live[first_index] && out != first {
+            slots[out_index] = slots[first_index];
+        }
+        live[out_index] = live[first_index];
+        return;
+    }
+    if !live[first_index] {
+        slots[out_index] = slots[second_index];
+        live[out_index] = true;
+        return;
+    }
+    if out != first {
+        slots[out_index] = slots[first_index];
+    }
+    live[out_index] = true;
+    let (held, point) = (&slots[out_index], &slots[second_index]);
+    if fp_eq(&held.x, &point.x) {
+        let two_y = fp_add(&held.y, &point.y);
+        if fp_is_zero(&two_y) {
+            live[out_index] = false;
+            return;
+        }
+        pending.push(out | DOUBLE, second, two_y);
+    } else {
+        pending.push(out, second, fp_sub(&point.x, &held.x));
+    }
+    if pending.is_full() {
+        complete(slots, pending);
+    }
+}
+
+/// Finish the additions queued by [`queue_add`].
+fn complete(slots: &mut [blst_p1_affine], pending: &mut Pending) {
+    let Some(mut running) = prefix_inverse(&pending.denominators, &mut pending.prefix) else {
+        return;
+    };
+    for index in (0..pending.jobs.len()).rev() {
+        let (slot, second) = pending.jobs[index];
+        let inverse = pending.unwind(index, &mut running);
+        let out = (slot & !DOUBLE) as usize;
+        let sum = chord(
+            &slots[out],
+            &slots[second as usize],
+            &inverse,
+            slot & DOUBLE != 0,
+        );
+        slots[out] = sum;
+    }
+    pending.clear();
+}
+
+/// Sum each list of slot indices down to a single entry, in place.
+///
+/// Every list halves on each wave and all lists share the wave's inversion, so
+/// the whole combine costs a handful of inversions rather than one per list.
+fn reduce(
+    slots: &mut [blst_p1_affine],
+    live: &mut [bool],
+    lists: &mut [Vec<u32>],
+    pending: &mut Pending,
+) {
+    while lists.iter().any(|list| list.len() > 1) {
+        for list in lists.iter() {
+            for pair in list.chunks_exact(2) {
+                queue_add(slots, live, pending, pair[0], pair[0], pair[1]);
+            }
+        }
+        complete(slots, pending);
+        for list in lists.iter_mut() {
+            let len = list.len();
+            let mut kept = 0;
+            for index in 0..len / 2 {
+                let slot = list[2 * index];
+                if live[slot as usize] {
+                    list[kept] = slot;
+                    kept += 1;
                 }
             }
             if len % 2 == 1 {
-                copies.push((start + len / 2, buf[start + len - 1]));
+                list[kept] = list[len - 1];
+                kept += 1;
             }
-            lens[b] = len.div_ceil(2);
+            list.truncate(kept);
         }
-        if arith.is_empty() && copies.is_empty() {
-            break;
-        }
-        batch_invert(&mut denominators);
-        for (op, inverse) in arith.iter().zip(&denominators) {
-            // Affine chord/tangent formulas (curve coefficient a = 0):
-            //   add:    lambda = (y_b - y_a) / (x_b - x_a)
-            //   double: lambda = 3 * x_a^2 / (2 * y_a)
-            //   x_out = lambda^2 - x_a - x_b;  y_out = lambda*(x_a - x_out) - y_a
-            let lambda = if op.double {
-                let x_sq = fp_sqr(&op.a.x);
-                fp_mul(&fp_add(&fp_add(&x_sq, &x_sq), &x_sq), inverse)
-            } else {
-                fp_mul(&fp_sub(&op.b.y, &op.a.y), inverse)
-            };
-            let x_out = fp_sub(&fp_sub(&fp_sqr(&lambda), &op.a.x), &op.b.x);
-            let y_out = fp_sub(&fp_mul(&lambda, &fp_sub(&op.a.x, &x_out)), &op.a.y);
-            buf[op.out] = blst_p1_affine { x: x_out, y: y_out };
-        }
-        for &(out, value) in &copies {
-            buf[out] = value;
+    }
+}
+
+/// Additions queued for the next shared field inversion.
+///
+/// A queued job names the slot its result belongs in (with [`DOUBLE`] set when
+/// its operands are equal) and the second operand; the first operand is
+/// wherever the completing routine knows to find it.
+struct Pending {
+    jobs: Vec<(u32, u32)>,
+    denominators: Vec<blst_fp>,
+    /// Running products of the denominators, walked back down as each addition
+    /// takes its inverse.
+    prefix: Vec<blst_fp>,
+    /// How many additions to queue before sharing an inversion.
+    limit: usize,
+}
+
+impl Pending {
+    fn new() -> Self {
+        Self {
+            jobs: Vec::with_capacity(CHUNK),
+            denominators: Vec::with_capacity(CHUNK),
+            prefix: vec![blst_fp::default(); CHUNK],
+            limit: CHUNK,
         }
     }
 
-    (0..num_buckets)
-        .map(|b| {
-            if lens[b] == 0 {
-                blst_p1_affine::default()
-            } else {
-                buf[starts[b]]
-            }
-        })
-        .collect()
+    /// Bound the chunk so a round with few buckets does not spend most of a
+    /// chunk unable to touch any of them.
+    ///
+    /// An accumulating bucket is closed until its addition completes, so at
+    /// most one addition per bucket can be in flight; queueing past that only
+    /// defers points to another pass.
+    fn bound(&mut self, buckets: usize) {
+        self.limit = CHUNK.min(buckets);
+    }
+
+    /// Queue one addition.
+    #[inline(always)]
+    fn push(&mut self, slot: u32, second: u32, denominator: blst_fp) {
+        self.jobs.push((slot, second));
+        self.denominators.push(denominator);
+    }
+
+    /// Whether the queue has grown to a full inversion's worth of work.
+    #[inline(always)]
+    const fn is_full(&self) -> bool {
+        self.jobs.len() >= self.limit
+    }
+
+    /// Return the inverse of job `index`'s denominator, advancing `running` (the
+    /// inverse of the running product through `index`) to the next job down.
+    #[inline(always)]
+    fn unwind(&self, index: usize, running: &mut blst_fp) -> blst_fp {
+        if index == 0 {
+            return *running;
+        }
+        let inverse = fp_mul(running, &self.prefix[index - 1]);
+        *running = fp_mul(running, &self.denominators[index]);
+        inverse
+    }
+
+    fn clear(&mut self) {
+        self.jobs.clear();
+        self.denominators.clear();
+    }
 }
 
-/// Replace every element with its inverse using Montgomery's trick: one field
-/// inversion plus three multiplications per element.
+/// Complete one affine addition (or doubling) given the inverse of its
+/// denominator.
+///
+/// Chord/tangent formulas for curve coefficient `a = 0`:
+/// `add: lambda = (y_b - y_a) / (x_b - x_a)`,
+/// `double: lambda = 3 x_a^2 / (2 y_a)`,
+/// `x_out = lambda^2 - x_a - x_b`, `y_out = lambda (x_a - x_out) - y_a`.
+#[inline(always)]
+fn chord(
+    first: &blst_p1_affine,
+    second: &blst_p1_affine,
+    inverse: &blst_fp,
+    double: bool,
+) -> blst_p1_affine {
+    let lambda = if double {
+        let square = fp_sqr(&first.x);
+        fp_mul(&fp_add(&fp_add(&square, &square), &square), inverse)
+    } else {
+        fp_mul(&fp_sub(&second.y, &first.y), inverse)
+    };
+    let x = fp_sub(&fp_sub(&fp_sqr(&lambda), &first.x), &second.x);
+    let y = fp_sub(&fp_mul(&lambda, &fp_sub(&first.x, &x)), &first.y);
+    blst_p1_affine { x, y }
+}
+
+/// Fill `prefix` with the running products of `values` and return the inverse
+/// of their total, or `None` when there is nothing to invert.
+///
+/// This is the forward half of Montgomery's trick; each caller walks back down
+/// the prefix products itself so that an element's inverse is consumed where it
+/// is produced. Together the two halves cost one field inversion plus three
+/// multiplications per element.
 ///
 /// Every element MUST be nonzero (`blst_fp_inverse(0) == 0` would silently
-/// poison the shared product); [`sum_buckets`]'s classification guarantees it.
-fn batch_invert(values: &mut [blst_fp]) {
-    if values.is_empty() {
-        return;
+/// poison the shared product); the callers' classification guarantees it.
+fn prefix_inverse(values: &[blst_fp], prefix: &mut Vec<blst_fp>) -> Option<blst_fp> {
+    let (first, rest) = values.split_first()?;
+    if prefix.len() < values.len() {
+        prefix.resize(values.len(), blst_fp::default());
     }
-    // prefix[i] = values[0] * ... * values[i]
-    let mut prefix = Vec::with_capacity(values.len());
-    let mut acc = values[0];
-    prefix.push(acc);
-    for value in &values[1..] {
-        acc = fp_mul(&acc, value);
-        prefix.push(acc);
+    let mut running = *first;
+    prefix[0] = running;
+    for (value, slot) in rest.iter().zip(prefix[1..].iter_mut()) {
+        running = fp_mul(&running, value);
+        *slot = running;
     }
-    // inverse = (values[0] * ... * values[i])^-1, walking i down from the end.
     let mut inverse = blst_fp::default();
     // SAFETY: both pointers reference valid blst_fp values.
-    unsafe { blst_fp_inverse(&mut inverse, &acc) };
-    for i in (1..values.len()).rev() {
-        let value_inverse = fp_mul(&inverse, &prefix[i - 1]);
-        inverse = fp_mul(&inverse, &values[i]);
-        values[i] = value_inverse;
-    }
-    values[0] = inverse;
+    unsafe { blst_fp_inverse(&mut inverse, &running) };
+    Some(inverse)
 }
 
-fn affine_is_inf(p: &blst_p1_affine) -> bool {
-    // SAFETY: p is a valid blst_p1_affine.
-    unsafe { blst_p1_affine_is_inf(p) }
-}
-
-fn fp_add(a: &blst_fp, b: &blst_fp) -> blst_fp {
-    let mut out = blst_fp::default();
-    // SAFETY: all pointers reference valid blst_fp values.
-    unsafe { blst_fp_add(&mut out, a, b) };
-    out
-}
-
-fn fp_sub(a: &blst_fp, b: &blst_fp) -> blst_fp {
-    let mut out = blst_fp::default();
-    // SAFETY: all pointers reference valid blst_fp values.
-    unsafe { blst_fp_sub(&mut out, a, b) };
-    out
-}
-
-fn fp_mul(a: &blst_fp, b: &blst_fp) -> blst_fp {
-    let mut out = blst_fp::default();
-    // SAFETY: all pointers reference valid blst_fp values.
-    unsafe { blst_fp_mul(&mut out, a, b) };
-    out
-}
-
-fn fp_sqr(a: &blst_fp) -> blst_fp {
-    let mut out = blst_fp::default();
-    // SAFETY: all pointers reference valid blst_fp values.
-    unsafe { blst_fp_sqr(&mut out, a) };
-    out
-}
-
-/// A stream of uniform trits over a cryptographic RNG.
+/// Hint that `slots[index]` will be read soon.
 ///
-/// Each accepted byte below `3^5 = 243` yields five independent uniform trits
-/// (its base-3 digits); bytes at or above 243 are rejected so the trits stay
-/// exactly uniform. Bytes are drawn in bulk to amortize RNG calls.
+/// A point spans two cache lines, and the caller reads both.
+#[inline(always)]
+fn prefetch(slots: &[blst_p1_affine], index: usize) {
+    let _ = (slots, index);
+    #[cfg(target_arch = "x86_64")]
+    {
+        use core::arch::x86_64::{_MM_HINT_T0, _mm_prefetch};
+        let base = slots.as_ptr().wrapping_add(index).cast::<i8>();
+        // SAFETY: _mm_prefetch never dereferences its argument, so any address
+        // is allowed; the index is in range for the slice regardless.
+        unsafe {
+            _mm_prefetch(base, _MM_HINT_T0);
+            _mm_prefetch(base.wrapping_add(64), _MM_HINT_T0);
+        }
+    }
+    #[cfg(target_arch = "aarch64")]
+    {
+        use core::arch::aarch64::{_PREFETCH_LOCALITY3, _PREFETCH_READ, _prefetch};
+        let base = slots.as_ptr().wrapping_add(index).cast::<i8>();
+        // SAFETY: _prefetch never dereferences its argument.
+        unsafe {
+            _prefetch::<_PREFETCH_READ, _PREFETCH_LOCALITY3>(base);
+            _prefetch::<_PREFETCH_READ, _PREFETCH_LOCALITY3>(base.wrapping_add(64));
+        }
+    }
+}
+
+/// Replace every element with its inverse, using one shared field inversion.
+fn batch_invert(values: &mut [blst_fp], prefix: &mut Vec<blst_fp>) {
+    let Some(mut running) = prefix_inverse(values, prefix) else {
+        return;
+    };
+    for index in (1..values.len()).rev() {
+        let inverse = fp_mul(&running, &prefix[index - 1]);
+        running = fp_mul(&running, &values[index]);
+        values[index] = inverse;
+    }
+    values[0] = running;
+}
+
+/// The BLS12-381 base field modulus, as little-endian 64-bit limbs.
+///
+/// `2 * MODULUS < 2^384`, so adding two reduced elements never carries out of
+/// the top limb.
+const MODULUS: [u64; 6] = [
+    0xb9fe_ffff_ffff_aaab,
+    0x1eab_fffe_b153_ffff,
+    0x6730_d2a0_f6b0_f624,
+    0x6477_4b84_f385_12bf,
+    0x4b1b_a7b6_434b_acd7,
+    0x1a01_11ea_397f_e69a,
+];
+
+/// Whether two field elements are equal.
+///
+/// Written as a short-circuiting limb comparison: the accumulator's hot path
+/// asks this of two unrelated points, which almost always differ in the first
+/// limb.
+#[inline(always)]
+const fn fp_eq(a: &blst_fp, b: &blst_fp) -> bool {
+    a.l[0] == b.l[0]
+        && a.l[1] == b.l[1]
+        && a.l[2] == b.l[2]
+        && a.l[3] == b.l[3]
+        && a.l[4] == b.l[4]
+        && a.l[5] == b.l[5]
+}
+
+/// Whether a field element is zero.
+#[inline(always)]
+const fn fp_is_zero(a: &blst_fp) -> bool {
+    (a.l[0] | a.l[1] | a.l[2] | a.l[3] | a.l[4] | a.l[5]) == 0
+}
+
+/// One in the field's Montgomery form, `R mod MODULUS` for `R = 2^384`.
+///
+/// A point decoded from the wire carries this as its `z`.
+const MONTGOMERY_ONE: blst_fp = blst_fp {
+    l: [
+        0x7609_0000_0002_fffd,
+        0xebf4_000b_c40c_0002,
+        0x5f48_9857_53c7_58ba,
+        0x77ce_5853_7052_5745,
+        0x5c07_1a97_a256_ec6d,
+        0x15f6_5ec3_fa80_e493,
+    ],
+};
+
+/// Whether a field element is one, i.e. whether a point is already normalized.
+#[inline(always)]
+const fn fp_is_one(a: &blst_fp) -> bool {
+    fp_eq(a, &MONTGOMERY_ONE)
+}
+
+/// Add two reduced field elements.
+///
+/// Inlined rather than delegated to `blst_fp_add`: the batch-affine addition
+/// spends several of these per point addition, where the call and the mandatory
+/// zeroing of the out-parameter cost more than the arithmetic itself. The
+/// carry chains are written in the form that lowers to `adc`/`sbb`.
+#[inline(always)]
+fn fp_add(a: &blst_fp, b: &blst_fp) -> blst_fp {
+    let mut sum = [0u64; 6];
+    let mut carry = false;
+    for (out, (left, right)) in sum.iter_mut().zip(a.l.iter().zip(&b.l)) {
+        let (limb, first) = left.overflowing_add(*right);
+        let (limb, second) = limb.overflowing_add(carry as u64);
+        *out = limb;
+        carry = first | second;
+    }
+    debug_assert!(!carry, "2 * MODULUS fits in 384 bits");
+    subtract_modulus(sum)
+}
+
+/// Subtract one reduced field element from another.
+#[inline(always)]
+fn fp_sub(a: &blst_fp, b: &blst_fp) -> blst_fp {
+    let mut difference = [0u64; 6];
+    let mut borrow = false;
+    for (out, (left, right)) in difference.iter_mut().zip(a.l.iter().zip(&b.l)) {
+        let (limb, first) = left.overflowing_sub(*right);
+        let (limb, second) = limb.overflowing_sub(borrow as u64);
+        *out = limb;
+        borrow = first | second;
+    }
+    // The subtraction underflowed exactly when a < b; add the modulus back.
+    let mask = 0u64.wrapping_sub(borrow as u64);
+    let mut sum = [0u64; 6];
+    let mut carry = false;
+    for (out, (limb, modulus)) in sum.iter_mut().zip(difference.iter().zip(&MODULUS)) {
+        let (limb, first) = limb.overflowing_add(modulus & mask);
+        let (limb, second) = limb.overflowing_add(carry as u64);
+        *out = limb;
+        carry = first | second;
+    }
+    blst_fp { l: sum }
+}
+
+/// Reduce a value known to be below `2 * MODULUS`.
+#[inline(always)]
+fn subtract_modulus(value: [u64; 6]) -> blst_fp {
+    let mut reduced = [0u64; 6];
+    let mut borrow = false;
+    for (out, (limb, modulus)) in reduced.iter_mut().zip(value.iter().zip(&MODULUS)) {
+        let (limb, first) = limb.overflowing_sub(*modulus);
+        let (limb, second) = limb.overflowing_sub(borrow as u64);
+        *out = limb;
+        borrow = first | second;
+    }
+    // Keep the reduced value unless subtracting the modulus underflowed.
+    let mask = 0u64.wrapping_sub(borrow as u64);
+    let mut out = [0u64; 6];
+    for (out, (value, reduced)) in out.iter_mut().zip(value.iter().zip(&reduced)) {
+        *out = (value & mask) | (reduced & !mask);
+    }
+    blst_fp { l: out }
+}
+
+#[inline(always)]
+fn fp_mul(a: &blst_fp, b: &blst_fp) -> blst_fp {
+    let mut out = MaybeUninit::<blst_fp>::uninit();
+    // SAFETY: the operands are valid blst_fp values and blst_fp_mul writes the
+    // whole result before returning.
+    unsafe {
+        blst_fp_mul(out.as_mut_ptr(), a, b);
+        out.assume_init()
+    }
+}
+
+#[inline(always)]
+fn fp_sqr(a: &blst_fp) -> blst_fp {
+    let mut out = MaybeUninit::<blst_fp>::uninit();
+    // SAFETY: the operand is a valid blst_fp value and blst_fp_sqr writes the
+    // whole result before returning.
+    unsafe {
+        blst_fp_sqr(out.as_mut_ptr(), a);
+        out.assume_init()
+    }
+}
+
+/// Number of exactly uniform trits carried by one accepted word.
+///
+/// `3^20 < 2^32 <= 3^21`, so twenty is the most a `u32` can hold.
+const TRITS_PER_WORD: u32 = 20;
+
+/// `3^TRITS_PER_WORD`: the rejection bound for one drawn word.
+const TRIT_WORD_BOUND: u32 = 3u32.pow(TRITS_PER_WORD);
+
+/// A stream of uniform coefficient vectors over a cryptographic RNG.
+///
+/// Each accepted word below `3^20` yields twenty independent uniform trits (its
+/// base-3 digits); words at or above the bound are rejected so the trits stay
+/// exactly uniform. A vector of `m` trits is the word's residue modulo `3^m`,
+/// and the quotient stays uniform over the remaining digits, so one word serves
+/// `floor(20 / m)` vectors. Words are drawn in bulk to amortize RNG calls.
 ///
 /// Exact uniformity is load-bearing: the soundness bound leaves a fraction of
 /// a bit of margin over the security target, and the bias of a `byte % 3`
@@ -425,62 +1077,78 @@ fn fp_sqr(a: &blst_fp) -> blst_fp {
 /// dropping the total below it.
 struct Trits<'a, R: CryptoRng> {
     rng: &'a mut R,
-    buffer: [u8; 256],
+    buffer: [u8; 1024],
     filled: usize,
     position: usize,
-    current: u8,
-    remaining: u8,
 }
 
 impl<'a, R: CryptoRng> Trits<'a, R> {
     const fn new(rng: &'a mut R) -> Self {
         Self {
             rng,
-            buffer: [0u8; 256],
+            buffer: [0u8; 1024],
             filled: 0,
             position: 0,
-            current: 0,
-            remaining: 0,
         }
     }
 
-    /// Return the next uniform value in `{0, 1, 2}`.
-    fn next(&mut self) -> u8 {
-        if self.remaining == 0 {
-            self.current = self.next_byte();
-            self.remaining = 5;
+    /// Draw `count` uniform bucket ids in `[0, 3^m)`.
+    ///
+    /// The width is dispatched once for the whole run rather than per id, so
+    /// the inner loop divides by a literal and the compiler turns each division
+    /// into a multiply and a shift. Trits left over from a word are dropped
+    /// when the run ends; they are only ever a fraction of one draw.
+    fn fill(&mut self, m: u32, count: usize) -> Vec<u32> {
+        debug_assert!((1..=MAX_WIDTH).contains(&m));
+        let mut ids = Vec::with_capacity(count);
+        macro_rules! draw {
+            ($modulus:literal, $per_word:literal) => {{
+                while ids.len() < count {
+                    let mut word = self.next_word();
+                    for _ in 0..$per_word {
+                        if ids.len() == count {
+                            break;
+                        }
+                        ids.push(word % $modulus);
+                        word /= $modulus;
+                    }
+                }
+            }};
         }
-        let trit = self.current % 3;
-        self.current /= 3;
-        self.remaining -= 1;
-        trit
+        match m {
+            1 => draw!(3, 20),
+            2 => draw!(9, 10),
+            3 => draw!(27, 6),
+            4 => draw!(81, 5),
+            5 => draw!(243, 4),
+            6 => draw!(729, 3),
+            7 => draw!(2187, 2),
+            8 => draw!(6561, 2),
+            9 => draw!(19683, 2),
+            10 => draw!(59049, 2),
+            11 => draw!(177147, 1),
+            _ => unreachable!("width is at most MAX_WIDTH"),
+        }
+        ids
     }
 
-    /// Return a uniform bucket id in `[0, 3^m)` — the next `m` trits as base-3
-    /// digits. `m` must be at most 5.
-    fn bucket(&mut self, m: u32) -> u8 {
-        debug_assert!((1..=5).contains(&m));
-        let mut id = 0u8;
-        let mut weight = 1u8;
-        for _ in 0..m {
-            id += weight * self.next();
-            weight = weight.wrapping_mul(3);
-        }
-        id
-    }
-
-    /// Return the next byte strictly below 243, refilling the buffer as needed.
-    fn next_byte(&mut self) -> u8 {
+    /// Return the next word strictly below `3^20`, refilling the buffer as
+    /// needed.
+    fn next_word(&mut self) -> u32 {
         loop {
             if self.position == self.filled {
                 self.rng.fill_bytes(&mut self.buffer);
                 self.filled = self.buffer.len();
                 self.position = 0;
             }
-            let byte = self.buffer[self.position];
-            self.position += 1;
-            if byte < 243 {
-                return byte;
+            let word = u32::from_le_bytes(
+                self.buffer[self.position..self.position + 4]
+                    .try_into()
+                    .expect("four bytes"),
+            );
+            self.position += 4;
+            if word < TRIT_WORD_BOUND {
+                return word;
             }
         }
     }
@@ -490,11 +1158,10 @@ impl<'a, R: CryptoRng> Trits<'a, R> {
 mod tests {
     use super::*;
     use crate::bls12381::primitives::group::{G1, Scalar};
-    use commonware_codec::FixedSize;
+    use commonware_codec::{Encode, FixedSize};
     use commonware_math::algebra::{Additive, CryptoGroup, Random};
     use commonware_parallel::Sequential;
     use commonware_utils::test_rng;
-    use rand_core::Rng;
 
     /// Standard soundness target for the tests.
     const SECURITY: usize = 128;
@@ -502,6 +1169,12 @@ mod tests {
     /// A batch size comfortably above the per-point fallback threshold, so the
     /// batched path is exercised.
     const LARGE: usize = 1000;
+
+    /// Whether an affine point is the point at infinity.
+    fn affine_is_inf(p: &blst_p1_affine) -> bool {
+        // SAFETY: p is a valid blst_p1_affine.
+        unsafe { blst::blst_p1_affine_is_inf(p) }
+    }
 
     fn in_subgroup_point(rng: &mut impl CryptoRng) -> G1 {
         G1::generator() * &Scalar::random(rng)
@@ -526,27 +1199,50 @@ mod tests {
         }
     }
 
-    /// Assert that [`sum_buckets`] agrees with naive per-bucket G1 addition.
-    fn assert_sums_match(points: &[G1], ids: &[u8], num_buckets: usize) {
-        let affine = G1::batch_to_affine(points);
-        let sums = sum_buckets(&affine, ids, num_buckets);
-        assert_eq!(sums.len(), num_buckets);
-        for (b, got) in sums.iter().enumerate() {
+    /// Drop identity points exactly as [`batch_in_g1`] does, keeping the ids
+    /// aligned with the points that survive.
+    fn affine_with_ids(points: &[G1], ids: &[u32]) -> (Vec<blst_p1_affine>, Vec<u32>) {
+        let kept: Vec<u32> = points
+            .iter()
+            .zip(ids)
+            .filter(|(point, _)| !fp_is_zero(&point.as_blst_p1().z))
+            .map(|(_, &id)| id)
+            .collect();
+        (to_affine(points), kept)
+    }
+
+    /// Run the accumulator and return each bucket's sum, with `None` for the
+    /// buckets that sum to the identity.
+    fn bucket_sums(points: &[G1], ids: &[u32], m: u32) -> Vec<Option<blst_p1_affine>> {
+        let (affine, affine_ids) = affine_with_ids(points, ids);
+        let mut round = Round::new(m);
+        round.widen(m);
+        round.accumulate(&affine, &affine_ids);
+        (0..3usize.pow(m))
+            .map(|bucket| round.live[bucket].then_some(round.sums[bucket]))
+            .collect()
+    }
+
+    /// Assert that the accumulator agrees with naive per-bucket G1 addition.
+    fn assert_sums_match(points: &[G1], ids: &[u32], m: u32) {
+        let sums = bucket_sums(points, ids, m);
+        assert_eq!(sums.len(), 3usize.pow(m));
+        for (bucket, got) in sums.iter().enumerate() {
             let mut expected = G1::zero();
             for (point, &id) in points.iter().zip(ids) {
-                if id as usize == b {
+                if id as usize == bucket {
                     expected += point;
                 }
             }
             let expected = G1::batch_to_affine(&[expected]);
-            assert_eq!(
-                affine_is_inf(got),
-                affine_is_inf(&expected[0]),
-                "bucket {b} identity mismatch"
-            );
-            if !affine_is_inf(got) {
-                assert_eq!(got.x.l, expected[0].x.l, "bucket {b} x mismatch");
-                assert_eq!(got.y.l, expected[0].y.l, "bucket {b} y mismatch");
+            let expected = (!affine_is_inf(&expected[0])).then_some(expected[0]);
+            match (got, expected) {
+                (None, None) => {}
+                (Some(got), Some(expected)) => {
+                    assert_eq!(got.x.l, expected.x.l, "bucket {bucket} x mismatch");
+                    assert_eq!(got.y.l, expected.y.l, "bucket {bucket} y mismatch");
+                }
+                _ => panic!("bucket {bucket} identity mismatch"),
             }
         }
     }
@@ -560,27 +1256,50 @@ mod tests {
             // 3^t >= 2^security must hold at the returned t.
             assert!(f64::from(combinations as u32) * 3f64.log2() >= security as f64);
             // Every plan must cover the required number of combinations.
-            for n in [0usize, 1, 50, 130, 200, 1000, 6000, 100_000] {
-                if let Some((m, rounds)) = plan(n, combinations) {
-                    assert!((1..=5).contains(&m));
-                    assert!(rounds * m as usize >= combinations, "n={n} s={security}");
+            for n in [0usize, 1, 50, 130, 200, 1000, 6000, 100_000, 2_000_000] {
+                let Some(widths) = plan(n, combinations) else {
+                    continue;
+                };
+                for &m in &widths {
+                    assert!((1..=MAX_WIDTH).contains(&m));
+                    assert!(3usize.pow(m) <= 4 * n.max(1));
+                    assert!(3usize.pow(m) * size_of::<blst_p1_affine>() <= SLOT_BUDGET);
                 }
+                // Every plan must cover the required number of combinations,
+                // and must not waste more than one on rounding.
+                let total: usize = widths.iter().map(|&m| m as usize).sum();
+                assert!(total >= combinations, "n={n} s={security}");
+                assert!(
+                    total < combinations + widths.len(),
+                    "n={n} s={security} wastes combinations"
+                );
             }
         }
         // Small batches fall back to per-point checking; large ones batch.
         assert!(plan(1, 81).is_none());
         assert!(plan(50, 81).is_none());
         assert!(plan(6000, 81).is_some());
+        // A zero soundness target needs no rounds at all.
+        assert_eq!(plan(6000, 0), Some(Vec::new()));
+        // Wider rounds, and so fewer of them, pay off as the batch grows, until
+        // the slot budget stops the widening.
+        let rounds = |n| plan(n, 81).map(|widths| widths.len());
+        assert!(rounds(1000) > rounds(100_000));
+        assert_eq!(rounds(100_000), rounds(2_000_000));
+        let widest = |n| plan(n, 81).and_then(|widths| widths.into_iter().max());
+        assert!(widest(1000) < widest(100_000));
+        assert_eq!(widest(2_000_000), widest(100_000));
+        let budgeted = widest(2_000_000).expect("batched");
+        assert!(3usize.pow(budgeted) * size_of::<blst_p1_affine>() <= SLOT_BUDGET);
+        assert!(3usize.pow(budgeted + 1) * size_of::<blst_p1_affine>() > SLOT_BUDGET);
     }
 
     #[test]
     fn bucket_ids_are_in_range() {
         let mut rng = test_rng();
         let mut trits = Trits::new(&mut rng);
-        for m in 1..=5u32 {
-            for _ in 0..1000 {
-                assert!((trits.bucket(m) as usize) < 3usize.pow(m));
-            }
+        for m in 1..=MAX_WIDTH {
+            assert!(trits.fill(m, 1000).into_iter().all(|id| id < 3u32.pow(m)));
         }
     }
 
@@ -589,8 +1308,8 @@ mod tests {
         let mut rng = test_rng();
         let mut trits = Trits::new(&mut rng);
         let mut counts = [0usize; 9];
-        for _ in 0..9000 {
-            counts[trits.bucket(2) as usize] += 1;
+        for id in trits.fill(2, 9000) {
+            counts[id as usize] += 1;
         }
         // Expected 1000 per id; the window is ~6.7 standard deviations wide.
         for &count in &counts {
@@ -611,24 +1330,98 @@ mod tests {
         let mut points: Vec<G1> = (0..300).map(|_| in_subgroup_point(&mut rng)).collect();
         let bad_index = points.len();
         points.push(off_subgroup_point(&mut rng));
-        let affine = G1::batch_to_affine(&points);
         // Good points are spread arbitrarily; their in-subgroup parts cannot
         // mask a cofactor part in any combination.
-        let mut ids: Vec<u8> = (0..points.len()).map(|i| (i % 243) as u8).collect();
+        let mut ids: Vec<u32> = (0..points.len()).map(|i| (i % 243) as u32).collect();
+        let mut round = Round::new(M);
         // Vector 0 assigns the bad point coefficient 0 in every combination,
         // so the round must accept.
         ids[bad_index] = 0;
-        assert!(round_in_g1(&affine, &ids, M));
+        let (affine, affine_ids) = affine_with_ids(&points, &ids);
+        assert!(round.run(&affine, &affine_ids, M));
         // Any nonzero vector leaves a nonzero digit in some combination, which
         // must reject: 3^j isolates digit j with value 1; 2 and 162 = 2 * 3^4
         // cover value 2 at the lowest and highest positions.
-        for v in [1u8, 2, 3, 9, 27, 81, 162] {
+        for v in [1u32, 2, 3, 9, 27, 81, 162] {
             ids[bad_index] = v;
+            let (affine, affine_ids) = affine_with_ids(&points, &ids);
             assert!(
-                !round_in_g1(&affine, &ids, M),
+                !round.run(&affine, &affine_ids, M),
                 "bad point at bucket {v} escaped"
             );
         }
+    }
+
+    #[test]
+    fn field_helpers_match_blst() {
+        use blst::{blst_fp_add, blst_fp_sub};
+        let mut rng = test_rng();
+        // Coordinates of random curve points are reduced field elements
+        // covering the whole range, and the modulus-boundary cases are added
+        // explicitly.
+        let points: Vec<G1> = (0..64).map(|_| in_subgroup_point(&mut rng)).collect();
+        let affine = G1::batch_to_affine(&points);
+        let mut values: Vec<blst_fp> = affine.iter().flat_map(|p| [p.x, p.y]).collect();
+        values.push(blst_fp { l: [0u64; 6] });
+        let mut largest = MODULUS;
+        largest[0] -= 1;
+        values.push(blst_fp { l: largest });
+        values.push(blst_fp {
+            l: [1, 0, 0, 0, 0, 0],
+        });
+        for a in &values {
+            for b in &values {
+                let mut expected = blst_fp::default();
+                // SAFETY: all pointers reference valid blst_fp values.
+                unsafe { blst_fp_add(&mut expected, a, b) };
+                assert_eq!(fp_add(a, b).l, expected.l, "add");
+                // SAFETY: all pointers reference valid blst_fp values.
+                unsafe { blst_fp_sub(&mut expected, a, b) };
+                assert_eq!(fp_sub(a, b).l, expected.l, "sub");
+                assert_eq!(fp_eq(a, b), a.l == b.l, "eq");
+            }
+            assert_eq!(fp_is_zero(a), a.l == [0u64; 6], "zero");
+        }
+    }
+
+    #[test]
+    fn montgomery_one_is_one() {
+        use blst::blst_fp_from_uint64;
+        let mut one = blst_fp::default();
+        // SAFETY: both pointers reference valid, correctly sized values.
+        unsafe { blst_fp_from_uint64(&mut one, [1u64, 0, 0, 0, 0, 0].as_ptr()) };
+        assert_eq!(one.l, MONTGOMERY_ONE.l);
+        assert!(fp_is_one(&one));
+        assert!(!fp_is_one(&blst_fp::default()));
+        // A decoded point is normalized, so the conversion's fast path applies.
+        let mut rng = test_rng();
+        let point = in_subgroup_point(&mut rng);
+        let bytes = point.encode();
+        let decoded = G1::read_unchecked(&mut bytes.as_ref()).expect("decodes");
+        assert!(fp_is_one(&decoded.as_blst_p1().z));
+    }
+
+    #[test]
+    fn to_affine_matches_blst() {
+        let mut rng = test_rng();
+        let mut points: Vec<G1> = (0..33).map(|_| in_subgroup_point(&mut rng)).collect();
+        // Identities are dropped, wherever they sit.
+        points[0] = G1::zero();
+        points[17] = G1::zero();
+        points.push(G1::zero());
+        let expected: Vec<blst_p1_affine> = G1::batch_to_affine(&points)
+            .into_iter()
+            .filter(|point| !affine_is_inf(point))
+            .collect();
+        let got = to_affine(&points);
+        assert_eq!(got.len(), expected.len());
+        for (got, expected) in got.iter().zip(&expected) {
+            assert_eq!(got.x.l, expected.x.l);
+            assert_eq!(got.y.l, expected.y.l);
+        }
+        // An all-identity batch converts to nothing.
+        assert!(to_affine(&[G1::zero()]).is_empty());
+        assert!(to_affine(&[]).is_empty());
     }
 
     #[test]
@@ -636,10 +1429,11 @@ mod tests {
         let mut rng = test_rng();
         let points: Vec<G1> = (0..17).map(|_| in_subgroup_point(&mut rng)).collect();
         let affine = G1::batch_to_affine(&points);
+        let mut prefix = Vec::new();
         for take in [0usize, 1, 2, 17] {
             let original: Vec<blst_fp> = affine.iter().take(take).map(|p| p.x).collect();
             let mut inverted = original.clone();
-            batch_invert(&mut inverted);
+            batch_invert(&mut inverted, &mut prefix);
             // value * inverse must be the same element (one) for every entry,
             // and multiplying by it must be the identity map.
             if take == 0 {
@@ -654,11 +1448,11 @@ mod tests {
     }
 
     #[test]
-    fn sum_buckets_handles_special_pairs() {
+    fn accumulator_handles_special_pairs() {
         let mut rng = test_rng();
         let p = in_subgroup_point(&mut rng);
         let q = off_subgroup_point(&mut rng);
-        let cases: Vec<(Vec<G1>, Vec<u8>, usize)> = vec![
+        let cases: Vec<(Vec<G1>, Vec<u32>, u32)> = vec![
             // Cancelling pair produces the identity.
             (vec![p, -p], vec![0, 0], 1),
             // Duplicates force the doubling path.
@@ -672,19 +1466,21 @@ mod tests {
             // Odd leftovers and cancellation combined.
             (vec![p, -p, p], vec![0, 0, 0], 1),
             // Singleton with empty buckets around it.
-            (vec![p], vec![1], 3),
+            (vec![p], vec![1], 1),
+            // A doubling chain that spans several passes.
+            (vec![p; 9], vec![2; 9], 2),
         ];
-        for (points, ids, num_buckets) in cases {
-            assert_sums_match(&points, &ids, num_buckets);
+        for (points, ids, m) in cases {
+            assert_sums_match(&points, &ids, m);
         }
     }
 
     #[test]
-    fn sum_buckets_matches_naive() {
+    fn accumulator_matches_naive() {
         let mut rng = test_rng();
-        for round in 0..20usize {
+        for round in 0..24usize {
             let n = 1 + (round * 37) % 150;
-            let num_buckets = [1usize, 2, 3, 9, 27, 243][round % 6];
+            let m = 1 + (round % 5) as u32;
             let mut points: Vec<G1> = Vec::with_capacity(n);
             for i in 0..n {
                 let point = match i % 7 {
@@ -696,13 +1492,8 @@ mod tests {
                 };
                 points.push(point);
             }
-            let mut id_bytes = vec![0u8; n];
-            rng.fill_bytes(&mut id_bytes);
-            let ids: Vec<u8> = id_bytes
-                .iter()
-                .map(|&b| (b as usize % num_buckets) as u8)
-                .collect();
-            assert_sums_match(&points, &ids, num_buckets);
+            let ids = Trits::new(&mut rng).fill(m, n);
+            assert_sums_match(&points, &ids, m);
         }
     }
 
@@ -726,6 +1517,14 @@ mod tests {
     fn all_identity_batch_is_accepted() {
         let points = vec![G1::zero(); LARGE];
         assert!(batch_in_g1(&points, SECURITY, &Sequential, &mut test_rng()));
+    }
+
+    #[test]
+    fn identity_padding_does_not_hide_a_bad_point() {
+        let mut rng = test_rng();
+        let mut points = vec![G1::zero(); LARGE];
+        points[LARGE / 2] = off_subgroup_point(&mut rng);
+        assert!(!batch_in_g1(&points, SECURITY, &Sequential, &mut rng));
     }
 
     #[test]
@@ -763,6 +1562,20 @@ mod tests {
         let bad = off_subgroup_point(&mut rng);
         // Many duplicates of one bad point stress same-bucket doubling chains.
         let points = vec![bad; LARGE];
+        assert!(!batch_in_g1(&points, SECURITY, &Sequential, &mut rng));
+    }
+
+    #[test]
+    fn wide_rounds_agree_with_per_point() {
+        // A batch large enough for the cost model to pick a wide round, so the
+        // collapse chain runs at full depth.
+        let mut rng = test_rng();
+        let n = 20_000;
+        let widths = plan(n, 81).expect("batched");
+        assert!(widths[0] >= 7, "expected a wide plan, got {widths:?}");
+        let mut points: Vec<G1> = (0..n).map(|_| in_subgroup_point(&mut rng)).collect();
+        assert!(batch_in_g1(&points, SECURITY, &Sequential, &mut rng));
+        points[n - 1] = off_subgroup_point(&mut rng);
         assert!(!batch_in_g1(&points, SECURITY, &Sequential, &mut rng));
     }
 
@@ -809,6 +1622,117 @@ mod tests {
         }
     }
 
+    /// Cost of the pieces of one batch-affine addition. Run with:
+    /// `cargo test -p commonware-cryptography --release --features bls12381 \
+    ///   subgroup::tests::measure_addition -- --ignored --nocapture`
+    #[test]
+    #[ignore = "manual benchmark"]
+    fn measure_addition() {
+        use std::time::Instant;
+        let mut rng = test_rng();
+        let n = 8192;
+        let points: Vec<G1> = (0..2 * n).map(|_| in_subgroup_point(&mut rng)).collect();
+        let affine = G1::batch_to_affine(&points);
+        let originals: Vec<blst_fp> = (0..n)
+            .map(|i| fp_sub(&affine[2 * i + 1].x, &affine[2 * i].x))
+            .collect();
+        let mut prefix = Vec::new();
+
+        // Raw field-op throughput, over arrays rather than a dependency chain.
+        let mut out = vec![blst_fp::default(); n];
+        let reps = 200;
+        let start = Instant::now();
+        for _ in 0..reps {
+            for i in 0..n {
+                out[i] = fp_mul(&affine[i].x, &affine[i].y);
+            }
+            std::hint::black_box(&out);
+        }
+        println!(
+            "fp_mul  array {:.1} ns",
+            start.elapsed().as_nanos() as f64 / (reps * n) as f64
+        );
+        let start = Instant::now();
+        for _ in 0..reps {
+            for i in 0..n {
+                out[i] = fp_sub(&affine[i].x, &affine[i].y);
+            }
+            std::hint::black_box(&out);
+        }
+        println!(
+            "fp_sub  array {:.1} ns",
+            start.elapsed().as_nanos() as f64 / (reps * n) as f64
+        );
+
+        for size in [128usize, 256, 512, 1024, 2048, 8192] {
+            let mut values = originals[..size].to_vec();
+            let reps = 400_000 / size;
+            let start = Instant::now();
+            for _ in 0..reps {
+                values.copy_from_slice(&originals[..size]);
+                batch_invert(&mut values, &mut prefix);
+                std::hint::black_box(&values);
+            }
+            let invert = start.elapsed().as_nanos() as f64 / (reps * size) as f64;
+            println!("batch_invert size={size:>5} {invert:.1} ns/element");
+        }
+
+        let mut values = originals;
+        batch_invert(&mut values, &mut prefix);
+        let mut out = vec![blst_p1_affine::default(); n];
+        let reps = 200;
+        let start = Instant::now();
+        for _ in 0..reps {
+            for i in 0..n {
+                out[i] = chord(&affine[2 * i], &affine[2 * i + 1], &values[i], false);
+            }
+            std::hint::black_box(&out);
+        }
+        let chord_cost = start.elapsed().as_nanos() as f64 / (reps * n) as f64;
+        println!("chord         {chord_cost:.1} ns/addition");
+    }
+
+    /// Where a large batch's time goes, phase by phase. Run with:
+    /// `cargo test -p commonware-cryptography --release --features bls12381 \
+    ///   subgroup::tests::measure_phases -- --ignored --nocapture`
+    #[test]
+    #[ignore = "manual benchmark"]
+    fn measure_phases() {
+        use std::time::Instant;
+        let mut rng = test_rng();
+        let n = 1_000_000usize;
+        let points: Vec<G1> = (0..n).map(|_| in_subgroup_point(&mut rng)).collect();
+        for pass in 0..2 {
+            let total = Instant::now();
+            let start = Instant::now();
+            let affine = to_affine(&points);
+            let converted = start.elapsed();
+            let start = Instant::now();
+            std::hint::black_box(G1::batch_to_affine(&points));
+            let blst_converted = start.elapsed();
+            let start = Instant::now();
+            let widths = plan(n, 81).expect("batched");
+            let mut trits = Trits::new(&mut rng);
+            let id_sets: Vec<(u32, Vec<u32>)> = widths
+                .iter()
+                .map(|&m| (m, trits.fill(m, affine.len())))
+                .collect();
+            let sampled = start.elapsed();
+            let start = Instant::now();
+            let mut round = Round::new(*widths.iter().max().expect("nonempty"));
+            let allocated = start.elapsed();
+            let start = Instant::now();
+            let ok = id_sets.iter().all(|(m, ids)| round.run(&affine, ids, *m));
+            let rounds = start.elapsed();
+            assert!(ok);
+            println!(
+                "pass={pass} to_affine={converted:?} (blst {blst_converted:?}) \
+                 sampling={sampled:?} alloc={allocated:?} rounds={rounds:?} total={:?}",
+                total.elapsed()
+            );
+        }
+    }
+
     /// Stage gate: isolated accumulator throughput. Run with:
     /// `cargo test -p commonware-cryptography --release --features bls12381 \
     ///   subgroup::tests::measure_accumulator -- --ignored --nocapture`
@@ -817,22 +1741,40 @@ mod tests {
     fn measure_accumulator() {
         use std::time::Instant;
         let mut rng = test_rng();
-        for n in [1000usize, 6000, 100_000] {
+        for n in [1000usize, 6000, 100_000, 1_000_000] {
             let points: Vec<G1> = (0..n).map(|_| in_subgroup_point(&mut rng)).collect();
+            let passes = if n > 500_000 { 3 } else { 20 };
+            let start = Instant::now();
+            for _ in 0..passes {
+                std::hint::black_box(G1::batch_to_affine(&points));
+            }
+            println!(
+                "n={n} batch_to_affine={:.0} ns/point",
+                start.elapsed().as_nanos() as f64 / (passes * n) as f64
+            );
             let affine = G1::batch_to_affine(&points);
-            let mut ids = vec![0u8; n];
-            rng.fill_bytes(&mut ids);
-            for num_buckets in [27usize, 81, 243] {
-                for id in &mut ids {
-                    *id %= num_buckets as u8;
+            for m in [6u32, 7, 8, 9] {
+                let ids = Trits::new(&mut rng).fill(m, n);
+                if 3usize.pow(m) > 4 * n {
+                    continue;
                 }
-                let reps = 50;
+                let mut round = Round::new(m);
+                round.widen(m);
+                let reps = if n > 500_000 { 3 } else { 20 };
                 let start = Instant::now();
                 for _ in 0..reps {
-                    std::hint::black_box(sum_buckets(&affine, &ids, num_buckets));
+                    round.accumulate(&affine, &ids);
+                    std::hint::black_box(&round.sums[0]);
                 }
-                let per_point = start.elapsed().as_nanos() as f64 / (reps * n) as f64;
-                println!("n={n} buckets={num_buckets} {per_point:.0} ns/point");
+                let accumulate = start.elapsed().as_nanos() as f64 / (reps * n) as f64;
+                let start = Instant::now();
+                for _ in 0..reps {
+                    std::hint::black_box(round.run(&affine, &ids, m));
+                }
+                let full = start.elapsed().as_nanos() as f64 / (reps * n) as f64;
+                println!(
+                    "n={n} m={m} accumulate={accumulate:.0} ns/point round={full:.0} ns/point"
+                );
             }
         }
     }
@@ -844,32 +1786,62 @@ mod tests {
     #[ignore = "manual benchmark"]
     fn measure_scheme() {
         use commonware_parallel::Rayon;
-        use std::{thread::available_parallelism, time::Instant};
+        use std::{thread::available_parallelism, time::Duration, time::Instant};
+
+        /// Best of three, which on a shared machine is the estimate least
+        /// contaminated by whatever else is running.
+        fn best(mut run: impl FnMut() -> Duration) -> Duration {
+            (0..3).map(|_| run()).min().expect("three runs")
+        }
+
         let threads = available_parallelism().unwrap();
         let rayon = Rayon::new(threads).unwrap();
         println!("threads = {threads}");
-        for n in [200usize, 1000, 6000, 100_000] {
+        for n in [200usize, 1000, 6000, 100_000, 300_000, 1_000_000, 3_000_000] {
             let mut rng = test_rng();
             let points: Vec<G1> = (0..n).map(|_| in_subgroup_point(&mut rng)).collect();
-            println!("n={n} plan={:?}", plan(n, combinations_for_security(128)));
-            let start = Instant::now();
-            assert!(points.iter().all(G1::in_subgroup));
-            println!("n={n} per_point_serial = {:?}", start.elapsed());
-            let start = Instant::now();
-            assert!(batch_in_g1(&points, 128, &Sequential, &mut test_rng()));
-            println!("n={n} batch_serial    = {:?}", start.elapsed());
-            let start = Instant::now();
-            assert!(batch_in_g1(&points, 128, &rayon, &mut test_rng()));
-            println!("n={n} batch_parallel  = {:?}", start.elapsed());
+            let widths = plan(n, combinations_for_security(128)).unwrap_or_default();
+            let mut distinct = widths.clone();
+            distinct.dedup();
+            println!("n={n} rounds={} widths={distinct:?}", widths.len());
+
+            // The per-point cost is exactly linear in n, so a bounded prefix
+            // measures it without spending a minute on the baseline alone.
+            let sample = n.min(20_000);
+            let per_point = best(|| {
+                let start = Instant::now();
+                assert!(points[..sample].iter().all(G1::in_subgroup));
+                start.elapsed()
+            })
+            .mul_f64(n as f64 / sample as f64);
+            println!("n={n} per_point_serial = {per_point:?}");
+            let serial = best(|| {
+                let start = Instant::now();
+                assert!(batch_in_g1(&points, 128, &Sequential, &mut test_rng()));
+                start.elapsed()
+            });
+            println!(
+                "n={n} batch_serial    = {serial:?} ({:.1}x)",
+                per_point.as_secs_f64() / serial.as_secs_f64()
+            );
+            let parallel = best(|| {
+                let start = Instant::now();
+                assert!(batch_in_g1(&points, 128, &rayon, &mut test_rng()));
+                start.elapsed()
+            });
+            println!(
+                "n={n} batch_parallel  = {parallel:?} ({:.1}x)",
+                per_point.as_secs_f64() / parallel.as_secs_f64()
+            );
         }
     }
 
     /// Compare the shipping scheme (C) against the two alternatives from
     /// `cryptography/BATCHED_SUBGROUP.md`, all on the same accumulation engine:
     /// A is one combination per round (m = 1, 81 rounds); B is random bucketing
-    /// with every bucket sum exact-checked (shared-inversion steelman). Run with:
-    /// `cargo test -p commonware-cryptography --release --features bls12381 \
-    ///   subgroup::tests::measure_strategies -- --ignored --nocapture`
+    /// with every bucket sum exact-checked (shared-inversion steelman). Run
+    /// with: `cargo test -p commonware-cryptography --release --features
+    /// bls12381 subgroup::tests::measure_strategies -- --ignored --nocapture`
     #[test]
     #[ignore = "manual benchmark"]
     fn measure_strategies() {
@@ -878,6 +1850,12 @@ mod tests {
         use std::{thread::available_parallelism, time::Instant};
 
         /// Strategy A/C with a forced width and round count.
+        ///
+        /// At `m = 1` this is not a fair rendering of A: three buckets leave at
+        /// most three additions in flight, so the shared inversion has nothing
+        /// to amortize over and the engine is the wrong one for the strategy. A
+        /// real A would accumulate in Jacobian coordinates (as blst's MSM
+        /// does); its cost is 81 passes over the points either way.
         fn forced(
             points: &[G1],
             m: u32,
@@ -887,44 +1865,49 @@ mod tests {
         ) -> bool {
             let affine = G1::batch_to_affine(points);
             let mut trits = Trits::new(rng);
-            let id_sets: Vec<Vec<u8>> = (0..rounds)
-                .map(|_| (0..points.len()).map(|_| trits.bucket(m)).collect())
+            let id_sets: Vec<Vec<u32>> = (0..rounds)
+                .map(|_| trits.fill(m, affine.len()))
                 .collect();
             strategy
-                .map_collect_vec_with_multiplier(id_sets.iter(), points.len(), |ids| {
-                    round_in_g1(&affine, ids, m)
-                })
+                .map_init_collect_vec_with_multiplier(
+                    id_sets.iter(),
+                    affine.len(),
+                    || Round::new(m),
+                    |round, ids| round.run(&affine, ids, m),
+                )
                 .into_iter()
                 .all(|in_subgroup| in_subgroup)
         }
 
-        /// Strategy B: `num_buckets` a power of two, every bucket sum checked.
+        /// Strategy B: `3^m` buckets, every bucket sum exact-checked.
         fn bucketed(
             points: &[G1],
-            num_buckets: usize,
+            m: u32,
             rounds: usize,
             strategy: &impl Strategy,
             rng: &mut impl CryptoRng,
         ) -> bool {
             let affine = G1::batch_to_affine(points);
-            let mask = (num_buckets - 1) as u8;
-            let id_sets: Vec<Vec<u8>> = (0..rounds)
-                .map(|_| {
-                    let mut ids = vec![0u8; points.len()];
-                    rng.fill_bytes(&mut ids);
-                    for id in &mut ids {
-                        *id &= mask;
-                    }
-                    ids
-                })
+            let mut trits = Trits::new(rng);
+            let id_sets: Vec<Vec<u32>> = (0..rounds)
+                .map(|_| trits.fill(m, affine.len()))
                 .collect();
             strategy
-                .map_collect_vec_with_multiplier(id_sets.iter(), points.len(), |ids| {
-                    sum_buckets(&affine, ids, num_buckets).iter().all(|sum| {
-                        // SAFETY: sum is a valid blst_p1_affine.
-                        affine_is_inf(sum) || unsafe { blst_p1_affine_in_g1(sum) }
-                    })
-                })
+                .map_init_collect_vec_with_multiplier(
+                    id_sets.iter(),
+                    affine.len(),
+                    || Round::new(m),
+                    |round, ids| {
+                        round.widen(m);
+                        round.accumulate(&affine, ids);
+                        (0..3usize.pow(m)).all(|bucket| {
+                            // SAFETY: the slot holds a valid affine point.
+                            !round.live[bucket] || unsafe {
+                                blst_p1_affine_in_g1(&round.sums[bucket])
+                            }
+                        })
+                    },
+                )
                 .into_iter()
                 .all(|in_subgroup| in_subgroup)
         }
@@ -945,30 +1928,21 @@ mod tests {
             let start = Instant::now();
             assert!(forced(&points, 1, 81, &rayon, &mut test_rng()));
             println!("n={n} A m=1 r=81 parallel = {:?}", start.elapsed());
-            // B: buckets with per-bucket checks, rounds = ceil(128 / log2 B).
-            for (num_buckets, rounds) in [(16usize, 32usize), (64, 22), (256, 16)] {
+            // B: buckets with per-bucket checks, rounds = ceil(81 / m).
+            for m in [2u32, 4, 6] {
+                let rounds = 81usize.div_ceil(m as usize);
                 let start = Instant::now();
-                assert!(bucketed(
-                    &points,
-                    num_buckets,
-                    rounds,
-                    &Sequential,
-                    &mut test_rng()
-                ));
+                assert!(bucketed(&points, m, rounds, &Sequential, &mut test_rng()));
                 println!(
-                    "n={n} B B={num_buckets:>3} r={rounds}   serial = {:?}",
+                    "n={n} B B={:>5} r={rounds}   serial = {:?}",
+                    3usize.pow(m),
                     start.elapsed()
                 );
                 let start = Instant::now();
-                assert!(bucketed(
-                    &points,
-                    num_buckets,
-                    rounds,
-                    &rayon,
-                    &mut test_rng()
-                ));
+                assert!(bucketed(&points, m, rounds, &rayon, &mut test_rng()));
                 println!(
-                    "n={n} B B={num_buckets:>3} r={rounds} parallel = {:?}",
+                    "n={n} B B={:>5} r={rounds} parallel = {:?}",
+                    3usize.pow(m),
                     start.elapsed()
                 );
             }

--- a/cryptography/src/bls12381/primitives/subgroup.rs
+++ b/cryptography/src/bls12381/primitives/subgroup.rs
@@ -683,10 +683,15 @@ fn absorb(
     state: &mut [u8],
     pending: &mut Pending,
 ) {
-    let Some(mut running) = prefix_inverse(&pending.denominators, &mut pending.prefix) else {
+    let Some(mut running) = pending.total_inverse() else {
         return;
     };
     for index in (0..pending.jobs.len()).rev() {
+        // The walk runs backwards, so the slot a job below will reopen is as
+        // far off as the one the accumulation loop looks ahead for.
+        if let Some(&(ahead, _)) = pending.jobs.get(index.wrapping_sub(PREFETCH_DISTANCE)) {
+            prefetch(slots, (ahead & !DOUBLE) as usize);
+        }
         let (slot, point) = pending.jobs[index];
         let inverse = pending.unwind(index, &mut running);
         let bucket = (slot & !DOUBLE) as usize;
@@ -751,10 +756,13 @@ fn queue_add(
 
 /// Finish the additions queued by [`queue_add`].
 fn complete(slots: &mut [blst_p1_affine], pending: &mut Pending) {
-    let Some(mut running) = prefix_inverse(&pending.denominators, &mut pending.prefix) else {
+    let Some(mut running) = pending.total_inverse() else {
         return;
     };
     for index in (0..pending.jobs.len()).rev() {
+        if let Some(&(ahead, _)) = pending.jobs.get(index.wrapping_sub(PREFETCH_DISTANCE)) {
+            prefetch(slots, (ahead & !DOUBLE) as usize);
+        }
         let (slot, second) = pending.jobs[index];
         let inverse = pending.unwind(index, &mut running);
         let out = (slot & !DOUBLE) as usize;
@@ -825,7 +833,7 @@ impl Pending {
         Self {
             jobs: Vec::with_capacity(CHUNK),
             denominators: Vec::with_capacity(CHUNK),
-            prefix: vec![blst_fp::default(); CHUNK],
+            prefix: Vec::with_capacity(CHUNK),
             limit: CHUNK,
         }
     }
@@ -841,10 +849,34 @@ impl Pending {
     }
 
     /// Queue one addition.
+    ///
+    /// The running product the shared inversion needs is extended here rather
+    /// than in a pass of its own, so the queue is written once and walked once:
+    /// the multiplication rides along with work that is already touching the
+    /// denominator.
     #[inline(always)]
     fn push(&mut self, slot: u32, second: u32, denominator: blst_fp) {
+        let product = match self.prefix.last() {
+            Some(running) => fp_mul(running, &denominator),
+            None => denominator,
+        };
+        self.prefix.push(product);
         self.jobs.push((slot, second));
         self.denominators.push(denominator);
+    }
+
+    /// Invert the running product of every queued denominator, or `None` when
+    /// nothing is queued.
+    ///
+    /// Every denominator MUST be nonzero (`blst_fp_inverse(0) == 0` would
+    /// silently poison the shared product); the callers' classification
+    /// guarantees it.
+    fn total_inverse(&self) -> Option<blst_fp> {
+        let total = self.prefix.last()?;
+        let mut inverse = blst_fp::default();
+        // SAFETY: both pointers reference valid blst_fp values.
+        unsafe { blst_fp_inverse(&mut inverse, total) };
+        Some(inverse)
     }
 
     /// Whether the queue has grown to a full inversion's worth of work.
@@ -868,6 +900,7 @@ impl Pending {
     fn clear(&mut self) {
         self.jobs.clear();
         self.denominators.clear();
+        self.prefix.clear();
     }
 }
 
@@ -899,10 +932,12 @@ fn chord(
 /// Fill `prefix` with the running products of `values` and return the inverse
 /// of their total, or `None` when there is nothing to invert.
 ///
-/// This is the forward half of Montgomery's trick; each caller walks back down
-/// the prefix products itself so that an element's inverse is consumed where it
-/// is produced. Together the two halves cost one field inversion plus three
-/// multiplications per element.
+/// This is the forward half of Montgomery's trick, for a caller holding its
+/// values before it needs any inverse; [`Pending`] instead extends the same
+/// running product as it queues, which is cheaper when the two coincide.
+/// Either way the caller walks back down the prefix products itself, so that an
+/// element's inverse is consumed where it is produced, and the two halves
+/// together cost one field inversion plus three multiplications per element.
 ///
 /// Every element MUST be nonzero (`blst_fp_inverse(0) == 0` would silently
 /// poison the shared product); the callers' classification guarantees it.
@@ -926,8 +961,7 @@ fn prefix_inverse(values: &[blst_fp], prefix: &mut Vec<blst_fp>) -> Option<blst_
 /// Hint that `slots[index]` will be read soon.
 ///
 /// A point spans two cache lines, and the caller reads both. This is only a
-/// hint, so a target without one is slower here, never wrong; aarch64's
-/// prefetch intrinsics are still unstable, so it goes without.
+/// hint, so a target without one is slower here, never wrong.
 #[inline(always)]
 fn prefetch(slots: &[blst_p1_affine], index: usize) {
     let _ = (slots, index);
@@ -940,6 +974,25 @@ fn prefetch(slots: &[blst_p1_affine], index: usize) {
         unsafe {
             _mm_prefetch(base, _MM_HINT_T0);
             _mm_prefetch(base.wrapping_add(64), _MM_HINT_T0);
+        }
+    }
+    #[cfg(target_arch = "aarch64")]
+    {
+        let base = slots.as_ptr().wrapping_add(index);
+        // SAFETY: `prfm` is architecturally a hint. It takes its address as an
+        // addressing mode rather than dereferencing it, cannot fault whatever
+        // the address, and changes nothing a program can observe apart from
+        // the cache; the index is in range for the slice regardless. The
+        // intrinsic wrapping this instruction is still unstable, so it is
+        // written out — `readonly` matches the memory clobber the x86 arm's
+        // intrinsic carries.
+        unsafe {
+            core::arch::asm!(
+                "prfm pldl1keep, [{base}]",
+                "prfm pldl1keep, [{base}, #64]",
+                base = in(reg) base,
+                options(nostack, preserves_flags, readonly),
+            );
         }
     }
 }

--- a/cryptography/src/bls12381/primitives/subgroup.rs
+++ b/cryptography/src/bls12381/primitives/subgroup.rs
@@ -140,10 +140,14 @@ const MAX_WIDTH: u32 = 11;
 /// Largest bucket-slot footprint a round should ask for, in bytes.
 ///
 /// Points arrive in random bucket order, so the accumulator's working set is
-/// the whole slot array. A wider round needs fewer passes over the points, but
-/// once its slots outgrow the cache every point pays a miss that the saved
-/// passes do not repay — measured here as a 20-35% jump in cost per addition
-/// one step past the budget. Two MiB holds `3^9` slots.
+/// the whole slot array, and a round's collapse workspace is half as large
+/// again. A wider round needs fewer passes over the points, but its slots pay
+/// for a deeper level of the memory hierarchy on every point — measured here as
+/// 8% more per addition one step past the budget and 15% two steps past — and
+/// its workspace grows threefold per step, per thread. Two MiB holds `3^9`
+/// slots, which is where the two stop trading well: at a million points, the
+/// widest plan the next step up allows measures within noise of the one chosen
+/// here while asking for an order of magnitude more memory.
 const SLOT_BUDGET: usize = 2 << 20;
 
 /// Approximate cost of one [`G1::in_subgroup`] check, in units of one
@@ -206,16 +210,26 @@ fn round_cost(n: usize, m: u32) -> usize {
     (n - occupied) + 2 * occupied + (m as usize) * CHECK_COST
 }
 
-/// Plan the rounds: one width per round, summing to at least `combinations`.
+/// Plan the rounds: one width per round, together covering `combinations`.
 ///
-/// Returns `None` if checking each point individually is cheaper. The widths of
-/// a plan differ by at most one, so a round count that does not divide
-/// `combinations` wastes no more than one combination — which matters, since
-/// the round count is what the batch pays for.
+/// Returns `None` if checking each point individually is cheaper.
 ///
 /// Soundness holds for every plan (a round of width `m` has error `3^-m`, and
 /// the widths sum to at least `combinations`), so the cost model's constants
 /// only affect performance.
+/// Spread `combinations` over `rounds` rounds as evenly as possible.
+///
+/// The widths differ by at most one, so a round count that does not divide the
+/// combinations wastes none of them — which matters, since the round count is
+/// what the batch pays for.
+fn spread(combinations: usize, rounds: usize) -> Vec<u32> {
+    let width = (combinations / rounds) as u32;
+    let wide = combinations % rounds;
+    (0..rounds)
+        .map(|round| if round < wide { width + 1 } else { width })
+        .collect()
+}
+
 fn plan(n: usize, combinations: usize) -> Option<Vec<u32>> {
     if combinations == 0 {
         return Some(Vec::new());
@@ -235,20 +249,17 @@ fn plan(n: usize, combinations: usize) -> Option<Vec<u32>> {
     let mut best_cost = n.saturating_mul(CHECK_COST);
     let mut best = None;
     for rounds in combinations.div_ceil(widest as usize)..=combinations {
-        let width = (combinations / rounds) as u32;
-        let wide = combinations % rounds;
-        // Spreading combinations evenly cannot push a round past `widest`: a
-        // round count that leaves a remainder also leaves `width < widest`.
-        debug_assert!(width < widest || wide == 0);
-        let cost = wide.saturating_mul(round_cost(n, width + 1))
-            + (rounds - wide).saturating_mul(round_cost(n, width));
+        let widths = spread(combinations, rounds);
+        // Spreading evenly cannot push a round past `widest`: a round count that
+        // leaves a remainder also leaves the base width below it.
+        debug_assert!(widths.iter().all(|&m| m <= widest));
+        let cost = widths
+            .iter()
+            .map(|&m| round_cost(n, m))
+            .fold(0usize, |total, cost| total.saturating_add(cost));
         if cost < best_cost {
             best_cost = cost;
-            best = Some(
-                (0..rounds)
-                    .map(|round| if round < wide { width + 1 } else { width })
-                    .collect(),
-            );
+            best = Some(widths);
         }
     }
     best
@@ -1295,6 +1306,28 @@ mod tests {
     }
 
     #[test]
+    fn spread_is_even_and_complete() {
+        for combinations in [1usize, 2, 7, 81, 128, 255] {
+            for rounds in 1..=combinations {
+                let widths = spread(combinations, rounds);
+                assert_eq!(widths.len(), rounds);
+                // Every combination is placed, and none is wasted.
+                assert_eq!(
+                    widths.iter().map(|&m| m as usize).sum::<usize>(),
+                    combinations
+                );
+                // Widths differ by at most one, widest first.
+                let (&first, &last) = (
+                    widths.first().expect("nonempty"),
+                    widths.last().expect("nonempty"),
+                );
+                assert!(first - last <= 1);
+                assert!(widths.windows(2).all(|pair| pair[0] >= pair[1]));
+            }
+        }
+    }
+
+    #[test]
     fn bucket_ids_are_in_range() {
         let mut rng = test_rng();
         let mut trits = Trits::new(&mut rng);
@@ -1540,6 +1573,286 @@ mod tests {
         }
     }
 
+
+    /// Stress the accumulator where collisions dominate: few buckets, many
+    /// points, and heavy duplication/cancellation.
+    #[test]
+    fn accumulator_stress_collisions() {
+        let mut rng = test_rng();
+        for &(n, m) in &[
+            (3000usize, 1u32),
+            (3000, 2),
+            (5000, 3),
+            (4000, 5),
+            (1, 1),
+            (2, 1),
+        ] {
+            // Pool of distinct points, reused heavily so doublings abound.
+            let pool: Vec<G1> = (0..8).map(|_| in_subgroup_point(&mut rng)).collect();
+            let bad: Vec<G1> = (0..3).map(|_| off_subgroup_point(&mut rng)).collect();
+            let mut points: Vec<G1> = Vec::with_capacity(n);
+            for i in 0..n {
+                let point = match i % 11 {
+                    0 => G1::zero(),
+                    1 => pool[i % pool.len()],
+                    2 => -pool[i % pool.len()],
+                    3 => bad[i % bad.len()],
+                    4 => -bad[i % bad.len()],
+                    5 => pool[0],
+                    6 => -pool[0],
+                    _ => in_subgroup_point(&mut rng),
+                };
+                points.push(point);
+            }
+            let ids = Trits::new(&mut rng).fill(m, n);
+            assert_sums_match(&points, &ids, m);
+        }
+    }
+
+    /// All points land in one bucket, so every pass but the first is pure
+    /// carry: the worst case for termination and for the doubling chain.
+    #[test]
+    fn accumulator_single_bucket() {
+        let mut rng = test_rng();
+        for &n in &[1usize, 2, 3, 7, 64, 1000, 3000] {
+            for m in [1u32, 2, 5] {
+                let p = in_subgroup_point(&mut rng);
+                // Same point repeated: every addition after the first is a
+                // doubling or a chord against a running multiple.
+                let points = vec![p; n];
+                let ids = vec![1u32; n];
+                assert_sums_match(&points, &ids, m);
+            }
+        }
+    }
+
+    /// A wide round with enough points to fill whole inversion chunks, so the
+    /// `is_full` flush path and the collapse chain both run at scale.
+    #[test]
+    fn accumulator_wide_round_chunks() {
+        let mut rng = test_rng();
+        for m in [4u32, 6, 7] {
+            let n = 6 * 3usize.pow(m);
+            let base: Vec<G1> = (0..64).map(|_| in_subgroup_point(&mut rng)).collect();
+            let points: Vec<G1> = (0..n)
+                .map(|i| match i % 5 {
+                    0 => base[i % base.len()],
+                    1 => -base[i % base.len()],
+                    2 => G1::zero(),
+                    _ => in_subgroup_point(&mut rng),
+                })
+                .collect();
+            let ids = Trits::new(&mut rng).fill(m, n);
+            assert_sums_match(&points, &ids, m);
+        }
+    }
+
+    /// Reuse one `Round` across widths, as the strategy does, and check the
+    /// combines still agree with a direct computation of each combination.
+    #[test]
+    fn combinations_match_direct() {
+        let mut rng = test_rng();
+        let widest = 4u32;
+        let mut round = Round::new(widest);
+        for m in [1u32, 3, 4, 2, 4, 1] {
+            let n = 400usize;
+            let points: Vec<G1> = (0..n)
+                .map(|i| match i % 6 {
+                    0 => G1::zero(),
+                    1 => off_subgroup_point(&mut rng),
+                    _ => in_subgroup_point(&mut rng),
+                })
+                .collect();
+            let ids = Trits::new(&mut rng).fill(m, n);
+            let (affine, affine_ids) = affine_with_ids(&points, &ids);
+            // Direct per-combination computation over the surviving points.
+            let mut expected_ok = true;
+            for j in 0..m {
+                let mut acc = G1::zero();
+                for (point, &id) in points.iter().zip(&ids) {
+                    let digit = (id / 3u32.pow(j)) % 3;
+                    for _ in 0..digit {
+                        acc += point;
+                    }
+                }
+                if !acc.in_subgroup() {
+                    expected_ok = false;
+                }
+            }
+            assert_eq!(
+                round.run(&affine, &affine_ids, m),
+                expected_ok,
+                "m={m} mismatch"
+            );
+        }
+    }
+
+
+    /// Randomized differential fuzz: every combination's exact value against a
+    /// direct computation, over adversarial id and point distributions.
+    #[test]
+    fn round_fuzz_against_direct() {
+        use commonware_utils::TestRng;
+        let mut round: Option<(u32, Round)> = None;
+        for seed in 0..400u64 {
+            let mut rng = TestRng::new(seed);
+            let m = 1 + (seed % 9) as u32;
+            let widest = 9u32;
+            let n = match seed % 7 {
+                0 => 1,
+                1 => 2,
+                2 => 17,
+                3 => 300,
+                4 => 3000,
+                5 => 9000,
+                _ => 1 + (seed as usize * 137) % 4000,
+            };
+            let pool: Vec<G1> = (0..4).map(|_| in_subgroup_point(&mut rng)).collect();
+            let points: Vec<G1> = (0..n)
+                .map(|i| match (i as u64 + seed) % 8 {
+                    0 => G1::zero(),
+                    1 => pool[i % pool.len()],
+                    2 => -pool[i % pool.len()],
+                    3 => pool[0],
+                    4 => -pool[0],
+                    _ => in_subgroup_point(&mut rng),
+                })
+                .collect();
+            // Id distributions: uniform, all-equal, and a tiny support.
+            let ids: Vec<u32> = match seed % 4 {
+                0 => Trits::new(&mut rng).fill(m, n),
+                1 => vec![(seed as u32) % 3u32.pow(m); n],
+                2 => (0..n).map(|i| (i as u32) % 3u32.min(3u32.pow(m))).collect(),
+                _ => Trits::new(&mut rng).fill(m, n),
+            };
+            let (affine, affine_ids) = affine_with_ids(&points, &ids);
+            let round = &mut round.get_or_insert_with(|| (widest, Round::new(widest))).1;
+            assert!(round.run(&affine, &affine_ids, m), "seed={seed} rejected");
+            let kept: Vec<G1> = points.iter().copied().filter(|p| p != &G1::zero()).collect();
+            assert_eq!(kept.len(), affine_ids.len());
+            for j in 0..m {
+                let mut expected = G1::zero();
+                for (point, &id) in kept.iter().zip(&affine_ids) {
+                    let digit = (id / 3u32.pow(j)) % 3;
+                    for _ in 0..digit {
+                        expected += point;
+                    }
+                }
+                let mut got = blst_p1::default();
+                if let Some(&twos) = round.marginals[2 * j as usize + 1].first() {
+                    let mut point = blst_p1::default();
+                    unsafe {
+                        blst_p1_from_affine(&mut point, &round.sums[twos as usize]);
+                        blst_p1_double(&mut got, &point);
+                    }
+                }
+                if let Some(&ones) = round.marginals[2 * j as usize].first() {
+                    unsafe {
+                        blst_p1_add_or_double_affine(&mut got, &got, &round.sums[ones as usize]);
+                    }
+                }
+                let mut got_affine = blst_p1_affine::default();
+                unsafe { blst::blst_p1_to_affine(&mut got_affine, &got) };
+                let expected_affine = G1::batch_to_affine(&[expected])[0];
+                assert_eq!(
+                    affine_is_inf(&got_affine),
+                    affine_is_inf(&expected_affine),
+                    "seed={seed} m={m} n={n} j={j} identity mismatch"
+                );
+                if !affine_is_inf(&got_affine) {
+                    assert_eq!(got_affine.x.l, expected_affine.x.l, "seed={seed} m={m} j={j}");
+                    assert_eq!(got_affine.y.l, expected_affine.y.l, "seed={seed} m={m} j={j}");
+                }
+            }
+        }
+    }
+
+    /// Chi-square-ish uniformity of drawn ids, per width and per position in
+    /// the word that produced them.
+    #[test]
+    fn trit_ids_are_uniform_per_position() {
+        let mut rng = test_rng();
+        for m in 1..=MAX_WIDTH {
+            let buckets = 3usize.pow(m) as usize;
+            if buckets > 6561 {
+                continue;
+            }
+            let per_word = (20 / m) as usize;
+            let target = 400usize;
+            let count = buckets * target;
+            let ids = Trits::new(&mut rng).fill(m, count);
+            let mut counts = vec![0usize; buckets];
+            let mut per_pos = vec![vec![0usize; buckets]; per_word];
+            for (i, &id) in ids.iter().enumerate() {
+                counts[id as usize] += 1;
+                per_pos[i % per_word][id as usize] += 1;
+            }
+            let chi: f64 = counts
+                .iter()
+                .map(|&c| {
+                    let d = c as f64 - target as f64;
+                    d * d / target as f64
+                })
+                .sum();
+            let df = (buckets - 1) as f64;
+            assert!(chi < df + 8.0 * (2.0 * df).sqrt(), "m={m} chi={chi} df={df}");
+            for (pos, counts) in per_pos.iter().enumerate() {
+                let expect = count as f64 / per_word as f64 / buckets as f64;
+                let chi: f64 = counts
+                    .iter()
+                    .map(|&c| {
+                        let d = c as f64 - expect;
+                        d * d / expect
+                    })
+                    .sum();
+                assert!(
+                    chi < df + 8.0 * (2.0 * df).sqrt(),
+                    "m={m} pos={pos} chi={chi} df={df}"
+                );
+            }
+        }
+    }
+
+
+    #[test]
+    fn accumulate_large_widths_match_naive() {
+        for seed in 0..3u64 {
+            let mut rng = commonware_utils::TestRng::new(seed);
+            for m in [8u32, 9] {
+                let n = 5 * 3usize.pow(m);
+                let pool: Vec<G1> = (0..16).map(|_| in_subgroup_point(&mut rng)).collect();
+                let points: Vec<G1> = (0..n)
+                    .map(|i| match i % 7 {
+                        0 => G1::zero(),
+                        1 => pool[i % pool.len()],
+                        2 => -pool[i % pool.len()],
+                        3 => pool[0],
+                        _ => in_subgroup_point(&mut rng),
+                    })
+                    .collect();
+                let ids = Trits::new(&mut rng).fill(m, n);
+                // Naive: one running G1 sum per bucket.
+                let mut expected = vec![G1::zero(); 3usize.pow(m)];
+                for (point, &id) in points.iter().zip(&ids) {
+                    expected[id as usize] += point;
+                }
+                let expected = G1::batch_to_affine(&expected);
+                let (affine, affine_ids) = affine_with_ids(&points, &ids);
+                let mut round = Round::new(m);
+                round.widen(m);
+                round.accumulate(&affine, &affine_ids);
+                for bucket in 0..3usize.pow(m) {
+                    let want_inf = affine_is_inf(&expected[bucket]);
+                    assert_eq!(round.live[bucket], !want_inf, "seed {seed} m {m} bucket {bucket} liveness");
+                    if !want_inf {
+                        assert_eq!(round.sums[bucket].x.l, expected[bucket].x.l, "seed {seed} m {m} bucket {bucket} x");
+                        assert_eq!(round.sums[bucket].y.l, expected[bucket].y.l, "seed {seed} m {m} bucket {bucket} y");
+                    }
+                }
+            }
+        }
+    }
+
     #[test]
     fn empty_batch_is_accepted() {
         assert!(batch_in_g1(&[], SECURITY, &Sequential, &mut test_rng()));
@@ -1735,6 +2048,58 @@ mod tests {
         println!("chord         {chord_cost:.1} ns/addition");
     }
 
+    /// Whether the cost model picks the cheapest plan. Run with:
+    /// `cargo test -p commonware-cryptography --release --features bls12381 \
+    ///   subgroup::tests::measure_plans -- --ignored --nocapture`
+    #[test]
+    #[ignore = "manual benchmark"]
+    fn measure_plans() {
+        use std::time::Instant;
+
+        /// Time the rounds of a forced plan, best of three.
+        fn timed(affine: &[blst_p1_affine], widths: &[u32], rng: &mut impl CryptoRng) -> f64 {
+            let widest = *widths.iter().max().expect("nonempty");
+            let mut round = Round::new(widest);
+            let best = (0..3)
+                .map(|_| {
+                    let mut trits = Trits::new(rng);
+                    let id_sets: Vec<(u32, Vec<u32>)> = widths
+                        .iter()
+                        .map(|&m| (m, trits.fill(m, affine.len())))
+                        .collect();
+                    let start = Instant::now();
+                    let ok = id_sets.iter().all(|(m, ids)| round.run(affine, ids, *m));
+                    assert!(ok);
+                    start.elapsed().as_micros()
+                })
+                .min()
+                .expect("three runs");
+            best as f64 / 1000.0
+        }
+
+        let mut rng = test_rng();
+        for n in [100_000usize, 1_000_000] {
+            let points: Vec<G1> = (0..n).map(|_| in_subgroup_point(&mut rng)).collect();
+            let affine = to_affine(&points);
+            let chosen = plan(n, 81).expect("batched");
+            // Compare the model's choice against its neighbours: the same
+            // combinations spread over one fewer and a few more rounds.
+            for rounds in chosen.len().saturating_sub(1)..=chosen.len() + 3 {
+                let widths = spread(81, rounds);
+                if widths.iter().any(|&m| m > MAX_WIDTH) {
+                    continue;
+                }
+                let mut distinct = widths.clone();
+                distinct.dedup();
+                println!(
+                    "n={n} rounds={rounds} widths={distinct:?} rounds_time={:.1} ms{}",
+                    timed(&affine, &widths, &mut rng),
+                    if widths == chosen { "  <- chosen by the model" } else { "" }
+                );
+            }
+        }
+    }
+
     /// Where a large batch's time goes, phase by phase. Run with:
     /// `cargo test -p commonware-cryptography --release --features bls12381 \
     ///   subgroup::tests::measure_phases -- --ignored --nocapture`
@@ -1796,7 +2161,7 @@ mod tests {
                 start.elapsed().as_nanos() as f64 / (passes * n) as f64
             );
             let affine = G1::batch_to_affine(&points);
-            for m in [6u32, 7, 8, 9] {
+            for m in [8u32, 9, 10, 11] {
                 let ids = Trits::new(&mut rng).fill(m, n);
                 if 3usize.pow(m) > 4 * n {
                     continue;

--- a/cryptography/src/bls12381/primitives/subgroup.rs
+++ b/cryptography/src/bls12381/primitives/subgroup.rs
@@ -11,22 +11,33 @@
 //! Given points `P_0, ..., P_{n-1}` (already verified to lie on the curve, e.g.
 //! via [`G1::read_unchecked`]), the check runs `r` rounds of `m` parallel
 //! random linear combinations. Each round draws an independent uniform
-//! coefficient `c_{j,i}` in `{0, 1, 2}` for every combination `j < m` and every
-//! point `i`, and applies the exact per-point test [`G1::in_subgroup`] to the
-//! `m` points `Q_j = sum_i c_{j,i} P_i`. The batch is accepted if every
+//! coefficient `c_{j,i}` in `{-1, 0, 1}` for every combination `j < m` and
+//! every point `i`, and applies the exact per-point test [`G1::in_subgroup`] to
+//! the `m` points `Q_j = sum_i c_{j,i} P_i`. The batch is accepted if every
 //! combination in every round lies in G1.
 //!
 //! Rather than computing each `Q_j` separately, a round groups the points by
-//! their coefficient *vector* `(c_{0,i}, ..., c_{m-1,i})` — one of `3^m`
-//! buckets — sums each bucket once, and recovers every combination from the
-//! bucket sums: `Q_j = sum_{v: v_j=1} S_v + 2 * sum_{v: v_j=2} S_v`, where
-//! `v_j` is the `j`-th base-3 digit of bucket index `v`. The combine weights
-//! are the *deterministic* digits of the bucket index — all randomness lives in
-//! the vector assignment — so this evaluates exactly the `m` combinations
-//! above. (It is not the unsound shortcut of re-randomizing over bucket sums,
-//! which would collapse the `m` combinations back into one.)
+//! their coefficient *vector* `(c_{0,i}, ..., c_{m-1,i})`, sums each group
+//! once, and recovers every combination from the group sums:
+//! `Q_j = sum_{v: v_j=1} S_v - sum_{v: v_j=-1} S_v`, where `v_j` is the `j`-th
+//! balanced-ternary digit of the vector `v`. The combine weights are the
+//! *deterministic* digits of the vector — all randomness lives in the vector
+//! assignment — so this evaluates exactly the `m` combinations above. (It is
+//! not the unsound shortcut of re-randomizing over bucket sums, which would
+//! collapse the `m` combinations back into one.)
 //!
-//! Summing `n` points into `3^m` buckets costs the same `n` point additions as
+//! A vector and its negation are stored together: negating an affine point
+//! costs nothing but the sign of its `y`, so a point whose vector is `-v` is
+//! stored negated in `v`'s bucket, leaving `(3^m + 1) / 2` buckets rather than
+//! `3^m`. Reading a bucket's index as a balanced-ternary *value* makes the
+//! canonical vectors exactly the non-negative values, so the bucket is the
+//! value's absolute value and the sign says whether the point enters negated.
+//! Halving the buckets halves both the combine and the cache footprint of a
+//! round, and the sign costs no arithmetic even in the accumulator: negating an
+//! addition's second operand negates the chord's numerator, so taking its
+//! denominator the other way round cancels the sign back out.
+//!
+//! Summing `n` points into many buckets costs the same `n` point additions as
 //! summing them into one, so a single accumulation pass over the points serves
 //! all `m` combinations, and about `81/m` passes are needed at 128-bit security
 //! instead of 81. Four properties keep the constant small:
@@ -40,9 +51,9 @@
 //!   point that arrives meanwhile is carried to the next pass; with random
 //!   bucket ids only a few percent of points ever are.
 //! - **A shared collapse for the combine.** Recovering the `m` combinations one
-//!   at a time would touch `2 * 3^(m-1)` bucket sums each, which caps `m` where
-//!   the combine costs more than the accumulation it saves. Summing away one
-//!   digit at a time instead yields every digit's marginals for about two
+//!   at a time would touch most of the bucket sums each, which caps `m` where
+//!   the combine costs more than the accumulation it saves. Folding away one
+//!   digit at a time instead yields every digit's marginal for about two
 //!   additions per bucket in total, which is what makes wide rounds — and so
 //!   few passes — affordable.
 //! - **Widths chosen per round.** The plan spreads the required combinations
@@ -66,11 +77,13 @@
 //! the group of order `h` (the G1 cofactor). A combination `Q_j` lies in G1
 //! exactly when its coefficient-weighted sum of cofactor parts vanishes. The
 //! G1 cofactor `h = 3 * (11 * 10177 * 859267 * 52437899)^2` is odd, so every
-//! nonzero cofactor part `T` has order at least 3, making `0*T`, `1*T`, and
-//! `2*T` three distinct group elements. Pick any bad point (nonzero `T_i`) and
-//! condition on every other coefficient of combination `j`: the combination
-//! vanishes only if `c_{j,i} * T_i` hits one fixed value, and it takes three
-//! distinct values as `c_{j,i}` ranges over `{0, 1, 2}`, so at most one works —
+//! nonzero cofactor part `T` has order at least 3 — and odd, so never 2 —
+//! making `-1*T`, `0*T` and `1*T` three distinct group elements: two of them
+//! coinciding would need the order to divide their difference, one of `1` or
+//! `2`. Pick any bad point (nonzero `T_i`) and condition on every other
+//! coefficient of combination `j`: the combination vanishes only if
+//! `c_{j,i} * T_i` hits one fixed value, and it takes three distinct values as
+//! `c_{j,i}` ranges over `{-1, 0, 1}`, so at most one works —
 //! probability at most `1/3`, for any number of bad points and any structure of
 //! the cofactor group. The `m` combinations of a round use disjoint independent
 //! coefficients, so a round accepts a bad batch with probability at most
@@ -85,7 +98,10 @@
 //! the point-chooser can predict. Larger coefficients would not strengthen a
 //! combination: in a component of order 3 a coefficient acts through its
 //! residue mod 3, so even full-width random weights leave a cancelling pair a
-//! `1/3` escape.
+//! `1/3` escape. Nor does folding weaken it — folding is a change of storage,
+//! not of the coefficients drawn: a point stored negated in `v`'s bucket
+//! contributes `d_j(v) * (-P)`, which is the `d_j(-v) * P` its own vector
+//! calls for.
 //!
 //! A round cannot do better than `3^-m` either, whatever it does with the
 //! bucket sums: a lone bad point escapes whenever its coefficient vector is the
@@ -107,8 +123,8 @@ use super::group::G1;
 #[cfg(not(feature = "std"))]
 use alloc::{vec, vec::Vec};
 use blst::{
-    blst_fp, blst_fp_inverse, blst_fp_mul, blst_fp_sqr, blst_p1, blst_p1_add_or_double_affine,
-    blst_p1_affine, blst_p1_double, blst_p1_from_affine, blst_p1_in_g1,
+    blst_fp, blst_fp_inverse, blst_fp_mul, blst_fp_sqr, blst_p1, blst_p1_affine,
+    blst_p1_from_affine, blst_p1_in_g1,
 };
 use commonware_parallel::Strategy;
 use core::mem::{MaybeUninit, size_of};
@@ -177,6 +193,26 @@ const CHUNK: usize = 1024;
 /// operands equal (a doubling rather than a chord).
 const DOUBLE: u32 = 1 << 31;
 
+/// Flag stored in a queued job's output slot, marking its second operand
+/// subtracted rather than added.
+const OP_NEGATE: u32 = 1 << 30;
+
+/// The slot index of a queued job, with [`DOUBLE`] and [`OP_NEGATE`] masked off.
+const SLOT_MASK: u32 = !(DOUBLE | OP_NEGATE);
+
+/// Flag stored in the high bit of a drawn bucket id, marking the point stored
+/// negated because its coefficient vector was folded onto the vector's negation.
+const ID_NEGATE: u32 = 1 << 31;
+
+/// Number of canonical buckets at width `m`.
+///
+/// Coefficient vectors are drawn from `{-1,0,1}^m` and a vector is stored
+/// together with its negation (see [`Trits`]), so the `3^m` vectors occupy
+/// `(3^m + 1) / 2` buckets: one per `{v, -v}` pair, plus the zero vector.
+const fn folded(m: u32) -> usize {
+    (3usize.pow(m) + 1) / 2
+}
+
 /// Bucket slot holding nothing, i.e. standing for the identity.
 const EMPTY: u8 = 0;
 
@@ -207,13 +243,14 @@ fn expected_occupied(n: usize, b: usize) -> usize {
 /// Modeled cost of one round at width `m`, in units of one batch-affine point
 /// addition.
 ///
-/// Summing `n` points into `3^m` buckets takes one addition per point that is
-/// not the last one left in its bucket, and recovering the `m` combinations
-/// takes about two additions per occupied bucket (one for the collapse chain,
-/// one for the marginals it feeds). The `m` exact checks are charged too, since
-/// they are what makes narrow rounds expensive on small batches.
+/// Summing `n` points into the round's buckets takes one addition per point
+/// that is not the last one left in its bucket, and recovering the `m`
+/// combinations takes about two additions per occupied bucket (one for the
+/// collapse chain, one for the marginals it feeds). The `m` exact checks are
+/// charged too, since they are what makes narrow rounds expensive on small
+/// batches.
 fn round_cost(n: usize, m: u32) -> usize {
-    let buckets = 3usize.pow(m);
+    let buckets = folded(m);
     let occupied = expected_occupied(n, buckets);
     (n - occupied) + 2 * occupied + (m as usize) * CHECK_COST
 }
@@ -271,8 +308,8 @@ fn plan(n: usize, combinations: usize) -> Option<Vec<u32>> {
     // too many to keep close to the CPU.
     let mut widest = 0u32;
     while widest < MAX_WIDTH
-        && 3usize.pow(widest + 1) <= 4 * n.max(1)
-        && 3usize.pow(widest + 1) * size_of::<blst_p1_affine>() <= SLOT_BUDGET
+        && folded(widest + 1) <= 4 * n.max(1)
+        && folded(widest + 1) * size_of::<blst_p1_affine>() <= SLOT_BUDGET
     {
         widest += 1;
     }
@@ -415,9 +452,9 @@ struct Round {
     /// digits per bucket id.
     m: u32,
     /// Start of each collapse level within [`Self::sums`]. Level `j` holds
-    /// `3^(m-j)` entries: level 0 is the bucket sums themselves (and doubles as
-    /// the accumulator's per-bucket slots), and level `j+1` is level `j` with
-    /// its lowest remaining digit summed away.
+    /// `folded(m-j)` entries: level 0 is the bucket sums themselves (and
+    /// doubles as the accumulator's per-bucket slots), and level `j+1` is level
+    /// `j` with its top remaining digit folded away.
     levels: Vec<usize>,
     /// The concatenated collapse levels.
     sums: Vec<blst_p1_affine>,
@@ -432,7 +469,7 @@ struct Round {
     ids: [Vec<u32>; 2],
     /// Additions queued for the next shared inversion.
     pending: Pending,
-    /// Entries still to be summed for each of the `2m` marginals.
+    /// Entries still to be summed for each of the `m` marginals.
     marginals: Vec<Vec<u32>>,
 }
 
@@ -440,41 +477,41 @@ impl Round {
     /// Allocate state able to run any round up to width `widest`.
     fn new(widest: u32) -> Self {
         debug_assert!((1..=MAX_WIDTH).contains(&widest));
-        let total = (3usize.pow(widest + 1) - 3) / 2;
+        let total: usize = (1..=widest).map(folded).sum();
         Self {
             m: 0,
             levels: Vec::with_capacity(widest as usize),
             sums: vec![blst_p1_affine::default(); total],
             live: vec![false; total],
-            state: vec![EMPTY; 3usize.pow(widest)],
+            state: vec![EMPTY; folded(widest)],
             lists: [Vec::new(), Vec::new()],
             ids: [Vec::new(), Vec::new()],
             pending: Pending::new(),
-            marginals: (0..2 * widest as usize).map(|_| Vec::new()).collect(),
+            marginals: (0..widest as usize).map(|_| Vec::new()).collect(),
         }
     }
 
     /// Lay out the collapse levels for a round of width `m`.
     fn widen(&mut self, m: u32) {
         debug_assert!((1..=MAX_WIDTH).contains(&m));
-        debug_assert!(3usize.pow(m) <= self.state.len());
+        debug_assert!(folded(m) <= self.state.len());
         if self.m == m {
             return;
         }
         self.m = m;
-        self.pending.bound(3usize.pow(m));
+        self.pending.bound(folded(m));
         self.levels.clear();
         let mut total = 0usize;
         for j in 0..m {
             self.levels.push(total);
-            total += 3usize.pow(m - j);
+            total += folded(m - j);
         }
     }
 
-    /// Sum `points` into the `3^m` buckets named by `ids`, leaving each bucket's
-    /// sum in its slot at level 0 of [`Self::sums`].
+    /// Sum `points` into the canonical buckets named by `ids`, leaving each
+    /// bucket's sum in its slot at level 0 of [`Self::sums`].
     fn accumulate(&mut self, points: &[blst_p1_affine], ids: &[u32]) {
-        self.state[..3usize.pow(self.m)].fill(EMPTY);
+        self.state[..folded(self.m)].fill(EMPTY);
         accumulate_pass(
             points,
             ids,
@@ -500,32 +537,44 @@ impl Round {
         }
         // The collapse works off the shared liveness flags; level 0's come from
         // the accumulator's per-bucket state.
-        let buckets = 3usize.pow(self.m);
+        let buckets = folded(self.m);
         for (live, &state) in self.live[..buckets].iter_mut().zip(&self.state[..buckets]) {
             *live = state != EMPTY;
         }
     }
 
-    /// Run one round: sum the points into `3^m` buckets keyed by coefficient
-    /// vector, recover the `m` combinations from the bucket sums, and check
-    /// each.
+    /// Run one round: sum the points into the canonical buckets keyed by
+    /// coefficient vector, recover the `m` combinations from the bucket sums,
+    /// and check each.
     fn run(&mut self, points: &[blst_p1_affine], ids: &[u32], m: u32) -> bool {
         self.widen(m);
         self.accumulate(points, ids);
 
-        // Collapse chain: level `j+1` sums away level `j`'s lowest digit, so
-        // every digit position's marginals come out of one shared walk over the
+        // Collapse chain: level `j+1` folds away level `j`'s top digit, so
+        // every digit position's marginal comes out of one shared walk over the
         // bucket sums rather than one walk per combination.
+        //
+        // A canonical vector splits as `[d, u]` with `d` its top digit, which
+        // is `0` or `+1` — never `-1`, since a leading `-1` is exactly what
+        // folding negates away. Writing `S` for a level indexed by balanced
+        // ternary value and `H = 3^(level digits - 1)`, the `d = +1` half
+        // covers the full cube in `u`, so pairing `u` with `-u` there gives
+        //
+        //     L[a] = S[a] + S[H + a] - S[H - a]
+        //
+        // whose three terms are the canonical values of `[0, u]`, `[1, u]` and
+        // `[1, -u]`. Index 0 is the all-zero vector: no marginal reads it, so
+        // it is neither folded nor summed.
         for j in 0..(self.m as usize).saturating_sub(1) {
             let (source, target) = (self.levels[j], self.levels[j + 1]);
-            let width = 3usize.pow(self.m - j as u32 - 1);
-            for digit in [1usize, 2] {
-                for k in 0..width {
-                    let out = (target + k) as u32;
-                    let first = if digit == 1 {
-                        (source + 3 * k) as u32
+            let half = 3usize.pow(self.m - j as u32 - 1);
+            for subtract in [false, true] {
+                for a in 1..=(half - 1) / 2 {
+                    let out = (target + a) as u32;
+                    let (first, second) = if subtract {
+                        (out, (source + half - a) as u32)
                     } else {
-                        out
+                        ((source + a) as u32, (source + half + a) as u32)
                     };
                     queue_add(
                         &mut self.sums,
@@ -533,60 +582,43 @@ impl Round {
                         &mut self.pending,
                         out,
                         first,
-                        (source + 3 * k + digit) as u32,
+                        second,
+                        subtract,
                     );
                 }
                 complete(&mut self.sums, &mut self.pending);
             }
         }
 
-        // Combination `j` is the sum of the buckets whose `j`-th digit is 1 plus
-        // twice the sum of those whose digit is 2, and level `j` has every other
-        // digit already summed away.
+        // Combination `j` is the sum of the canonical buckets whose digit `j`
+        // is `+1`, taken at the level where `j` is the top digit — the folding
+        // already carried the `-1` side across, so there is nothing to subtract
+        // and no weight-2 class to double. Those buckets are the values of
+        // `[1, u]`, a contiguous range.
         for j in 0..self.m as usize {
-            let level = self.levels[j];
-            let width = 3usize.pow(self.m - j as u32 - 1);
-            for digit in [1usize, 2] {
-                let list = &mut self.marginals[2 * j + digit - 1];
-                list.clear();
-                list.extend(
-                    (0..width)
-                        .map(|k| (level + digit + 3 * k) as u32)
-                        .filter(|&index| self.live[index as usize]),
-                );
-            }
+            let level = self.levels[self.m as usize - 1 - j];
+            let half = 3usize.pow(j as u32);
+            let list = &mut self.marginals[j];
+            list.clear();
+            list.extend(
+                ((half + 1) / 2..=(3 * half - 1) / 2)
+                    .map(|b| (level + b) as u32)
+                    .filter(|&index| self.live[index as usize]),
+            );
         }
         reduce(
             &mut self.sums,
             &mut self.live,
-            &mut self.marginals,
+            &mut self.marginals[..self.m as usize],
             &mut self.pending,
         );
 
         for j in 0..self.m as usize {
             let mut combination = blst_p1::default();
-            if let Some(&twos) = self.marginals[2 * j + 1].first() {
-                let mut point = blst_p1::default();
+            if let Some(&marginal) = self.marginals[j].first() {
                 // SAFETY: the index names a live affine point, and blst_p1
                 // defaults to the identity.
-                unsafe {
-                    blst_p1_from_affine(&mut point, &self.sums[twos as usize]);
-                    blst_p1_double(&mut combination, &point);
-                }
-            }
-            if let Some(&ones) = self.marginals[2 * j].first() {
-                // Copied rather than passed twice: handing the same local out
-                // as both `&mut` and `&` would alias.
-                let twos = combination;
-                // SAFETY: all operands are valid blst values, the identity
-                // included, and the routine handles equal operands.
-                unsafe {
-                    blst_p1_add_or_double_affine(
-                        &mut combination,
-                        &twos,
-                        &self.sums[ones as usize],
-                    );
-                }
+                unsafe { blst_p1_from_affine(&mut combination, &self.sums[marginal as usize]) };
             }
             // SAFETY: combination is a valid blst_p1 (identity included).
             if !unsafe { blst_p1_in_g1(&combination) } {
@@ -622,13 +654,18 @@ fn accumulate_pass(
         // Bucket ids are uniform, so the slot a point lands in is a cache miss
         // the loop can see coming a long way off.
         if let Some(&ahead) = src_ids.get(index + PREFETCH_DISTANCE) {
-            prefetch(slots, ahead as usize);
+            prefetch(slots, (ahead & !ID_NEGATE) as usize);
         }
-        let bucket = id as usize;
+        // A point whose vector folded onto its negation enters negated. The
+        // negation is free everywhere but here: an affine point negates in its
+        // y alone, and the addition formulas below absorb the sign by choosing
+        // which way round to subtract.
+        let negate = id & ID_NEGATE != 0;
+        let bucket = (id & !ID_NEGATE) as usize;
         match state[bucket] {
             EMPTY => {
                 state[bucket] = FILLED;
-                slots[bucket] = *point;
+                slots[bucket] = if negate { neg_affine(point) } else { *point };
                 continue;
             }
             BUSY => {
@@ -648,21 +685,34 @@ fn accumulate_pass(
         // Only the x coordinates decide which formula applies, so the running
         // sum is read a field element at a time rather than copied whole.
         let held = &slots[bucket];
+        let flag = if negate { OP_NEGATE } else { 0 };
         if fp_eq(&held.x, &point.x) {
             // Same x: on the curve y is determined up to sign, so this is
             // either P + (-P) = identity or a doubling.
-            let two_y = fp_add(&held.y, &point.y);
+            let two_y = if negate {
+                fp_sub(&held.y, &point.y)
+            } else {
+                fp_add(&held.y, &point.y)
+            };
             if fp_is_zero(&two_y) {
                 // The sum cancels, and an empty slot is the identity.
                 state[bucket] = EMPTY;
                 continue;
             }
-            // y_held == y_point != 0, so two_y = 2*y_held is the doubling
+            // The operands are equal, so two_y = 2*y_held is the doubling
             // denominator. (y == 0 cannot occur: the group order h * r is odd,
             // so the curve has no 2-torsion.)
-            pending.push(bucket as u32 | DOUBLE, index as u32, two_y);
+            pending.push(bucket as u32 | DOUBLE | flag, index as u32, two_y);
         } else {
-            pending.push(bucket as u32, index as u32, fp_sub(&point.x, &held.x));
+            // Negating the operand negates the chord's numerator, so taking the
+            // denominator the other way round cancels it back out and the sign
+            // costs no arithmetic at all.
+            let denominator = if negate {
+                fp_sub(&held.x, &point.x)
+            } else {
+                fp_sub(&point.x, &held.x)
+            };
+            pending.push(bucket as u32 | flag, index as u32, denominator);
         }
         state[bucket] = BUSY;
         if pending.is_full() {
@@ -690,16 +740,17 @@ fn absorb(
         // The walk runs backwards, so the slot a job below will reopen is as
         // far off as the one the accumulation loop looks ahead for.
         if let Some(&(ahead, _)) = pending.jobs.get(index.wrapping_sub(PREFETCH_DISTANCE)) {
-            prefetch(slots, (ahead & !DOUBLE) as usize);
+            prefetch(slots, (ahead & SLOT_MASK) as usize);
         }
         let (slot, point) = pending.jobs[index];
         let inverse = pending.unwind(index, &mut running);
-        let bucket = (slot & !DOUBLE) as usize;
+        let bucket = (slot & SLOT_MASK) as usize;
         let sum = chord(
             &slots[bucket],
             &src[point as usize],
             &inverse,
             slot & DOUBLE != 0,
+            slot & OP_NEGATE != 0,
         );
         slots[bucket] = sum;
         state[bucket] = FILLED;
@@ -707,7 +758,8 @@ fn absorb(
     pending.clear();
 }
 
-/// Queue `slots[out] = slots[first] + slots[second]`.
+/// Queue `slots[out] = slots[first] +/- slots[second]`, subtracting when
+/// `subtract` is set.
 ///
 /// The first operand is moved into the output slot immediately, so a completed
 /// job needs only the output and the second operand. Queued jobs must never
@@ -720,6 +772,7 @@ fn queue_add(
     out: u32,
     first: u32,
     second: u32,
+    subtract: bool,
 ) {
     let (out_index, first_index, second_index) = (out as usize, first as usize, second as usize);
     if !live[second_index] {
@@ -730,7 +783,11 @@ fn queue_add(
         return;
     }
     if !live[first_index] {
-        slots[out_index] = slots[second_index];
+        slots[out_index] = if subtract {
+            neg_affine(&slots[second_index])
+        } else {
+            slots[second_index]
+        };
         live[out_index] = true;
         return;
     }
@@ -738,16 +795,26 @@ fn queue_add(
         slots[out_index] = slots[first_index];
     }
     live[out_index] = true;
+    let flag = if subtract { OP_NEGATE } else { 0 };
     let (held, point) = (&slots[out_index], &slots[second_index]);
     if fp_eq(&held.x, &point.x) {
-        let two_y = fp_add(&held.y, &point.y);
+        let two_y = if subtract {
+            fp_sub(&held.y, &point.y)
+        } else {
+            fp_add(&held.y, &point.y)
+        };
         if fp_is_zero(&two_y) {
             live[out_index] = false;
             return;
         }
-        pending.push(out | DOUBLE, second, two_y);
+        pending.push(out | DOUBLE | flag, second, two_y);
     } else {
-        pending.push(out, second, fp_sub(&point.x, &held.x));
+        let denominator = if subtract {
+            fp_sub(&held.x, &point.x)
+        } else {
+            fp_sub(&point.x, &held.x)
+        };
+        pending.push(out | flag, second, denominator);
     }
     if pending.is_full() {
         complete(slots, pending);
@@ -761,16 +828,17 @@ fn complete(slots: &mut [blst_p1_affine], pending: &mut Pending) {
     };
     for index in (0..pending.jobs.len()).rev() {
         if let Some(&(ahead, _)) = pending.jobs.get(index.wrapping_sub(PREFETCH_DISTANCE)) {
-            prefetch(slots, (ahead & !DOUBLE) as usize);
+            prefetch(slots, (ahead & SLOT_MASK) as usize);
         }
         let (slot, second) = pending.jobs[index];
         let inverse = pending.unwind(index, &mut running);
-        let out = (slot & !DOUBLE) as usize;
+        let out = (slot & SLOT_MASK) as usize;
         let sum = chord(
             &slots[out],
             &slots[second as usize],
             &inverse,
             slot & DOUBLE != 0,
+            slot & OP_NEGATE != 0,
         );
         slots[out] = sum;
     }
@@ -790,7 +858,7 @@ fn reduce(
     while lists.iter().any(|list| list.len() > 1) {
         for list in lists.iter() {
             for pair in list.chunks_exact(2) {
-                queue_add(slots, live, pending, pair[0], pair[0], pair[1]);
+                queue_add(slots, live, pending, pair[0], pair[0], pair[1], false);
             }
         }
         complete(slots, pending);
@@ -917,16 +985,53 @@ fn chord(
     second: &blst_p1_affine,
     inverse: &blst_fp,
     double: bool,
+    negate: bool,
 ) -> blst_p1_affine {
     let lambda = if double {
         let square = fp_sqr(&first.x);
         fp_mul(&fp_add(&fp_add(&square, &square), &square), inverse)
+    } else if negate {
+        // The second operand enters negated, which negates the numerator; the
+        // caller took its denominator the other way round, so the two signs
+        // cancel and the negation costs no arithmetic. Only x is read below,
+        // and negation leaves x alone.
+        fp_mul(&fp_add(&second.y, &first.y), inverse)
     } else {
         fp_mul(&fp_sub(&second.y, &first.y), inverse)
     };
     let x = fp_sub(&fp_sub(&fp_sqr(&lambda), &first.x), &second.x);
     let y = fp_sub(&fp_mul(&lambda, &fp_sub(&first.x, &x)), &first.y);
     blst_p1_affine { x, y }
+}
+
+/// Negate an affine point, which negates its `y` alone.
+#[inline(always)]
+fn neg_affine(point: &blst_p1_affine) -> blst_p1_affine {
+    blst_p1_affine {
+        x: point.x,
+        y: fp_neg(&point.y),
+    }
+}
+
+/// Negate a field element.
+///
+/// Zero is its own negation; every other value is `MODULUS - value`, which is
+/// already reduced.
+#[inline(always)]
+fn fp_neg(a: &blst_fp) -> blst_fp {
+    if fp_is_zero(a) {
+        return *a;
+    }
+    let mut difference = [0u64; 6];
+    let mut borrow = false;
+    for (out, (modulus, limb)) in difference.iter_mut().zip(MODULUS.iter().zip(&a.l)) {
+        let (value, first) = modulus.overflowing_sub(*limb);
+        let (value, second) = value.overflowing_sub(borrow as u64);
+        *out = value;
+        borrow = first | second;
+    }
+    debug_assert!(!borrow, "a reduced element is at most MODULUS");
+    blst_fp { l: difference }
 }
 
 /// Fill `prefix` with the running products of `values` and return the inverse
@@ -1187,7 +1292,15 @@ impl<'a, R: CryptoRng> Trits<'a, R> {
         }
     }
 
-    /// Draw `count` uniform bucket ids in `[0, 3^m)`.
+    /// Draw `count` uniform canonical bucket ids in `[0, (3^m+1)/2)`, each with
+    /// [`ID_NEGATE`] set when its coefficient vector was folded onto its
+    /// negation.
+    ///
+    /// A uniform residue in `[0, 3^m)` is a uniform balanced-ternary *value*
+    /// once centred, and centring is the whole of the fold: a vector's value is
+    /// positive exactly when its top nonzero digit is `+1`, so the canonical
+    /// bucket is the absolute value and the sign says whether the point enters
+    /// negated. The draw itself is unchanged, and so is its exact uniformity.
     ///
     /// The width is dispatched once for the whole run rather than per id, so
     /// the inner loop divides by a literal and the compiler turns each division
@@ -1198,14 +1311,20 @@ impl<'a, R: CryptoRng> Trits<'a, R> {
         let mut ids = Vec::with_capacity(count);
         macro_rules! draw {
             ($modulus:literal, $per_word:literal) => {{
+                const HALF: u32 = ($modulus - 1) / 2;
                 while ids.len() < count {
                     let mut word = self.next_word();
                     for _ in 0..$per_word {
                         if ids.len() == count {
                             break;
                         }
-                        ids.push(word % $modulus);
+                        let residue = word % $modulus;
                         word /= $modulus;
+                        ids.push(if residue >= HALF {
+                            residue - HALF
+                        } else {
+                            (HALF - residue) | ID_NEGATE
+                        });
                     }
                 }
             }};
@@ -1306,6 +1425,41 @@ mod tests {
         (to_affine(points), kept)
     }
 
+    /// The `m` balanced-ternary digits of the coefficient vector a drawn id
+    /// stands for, lowest digit first.
+    ///
+    /// An id is the absolute value of the vector's balanced-ternary value, with
+    /// [`ID_NEGATE`] recording that the vector was folded onto its negation.
+    fn signed_digits(id: u32, m: u32) -> Vec<i64> {
+        let mut value = signed_value(id);
+        (0..m)
+            .map(|_| {
+                let digit = match value.rem_euclid(3) {
+                    2 => -1,
+                    other => other,
+                };
+                value = (value - digit) / 3;
+                digit
+            })
+            .collect()
+    }
+
+    /// The balanced-ternary value a drawn id stands for, sign included.
+    fn signed_value(id: u32) -> i64 {
+        let magnitude = i64::from(id & !ID_NEGATE);
+        if id & ID_NEGATE != 0 {
+            -magnitude
+        } else {
+            magnitude
+        }
+    }
+
+    /// The point an id contributes to its bucket, negated when the id's vector
+    /// was folded.
+    fn folded_point(point: &G1, id: u32) -> G1 {
+        if id & ID_NEGATE != 0 { -*point } else { *point }
+    }
+
     /// Run the accumulator and return each bucket's sum, with `None` for the
     /// buckets that sum to the identity.
     fn bucket_sums(points: &[G1], ids: &[u32], m: u32) -> Vec<Option<blst_p1_affine>> {
@@ -1313,7 +1467,7 @@ mod tests {
         let mut round = Round::new(m);
         round.widen(m);
         round.accumulate(&affine, &affine_ids);
-        (0..3usize.pow(m))
+        (0..folded(m))
             .map(|bucket| round.live[bucket].then_some(round.sums[bucket]))
             .collect()
     }
@@ -1321,12 +1475,12 @@ mod tests {
     /// Assert that the accumulator agrees with naive per-bucket G1 addition.
     fn assert_sums_match(points: &[G1], ids: &[u32], m: u32) {
         let sums = bucket_sums(points, ids, m);
-        assert_eq!(sums.len(), 3usize.pow(m));
+        assert_eq!(sums.len(), folded(m));
         for (bucket, got) in sums.iter().enumerate() {
             let mut expected = G1::zero();
             for (point, &id) in points.iter().zip(ids) {
-                if id as usize == bucket {
-                    expected += point;
+                if (id & !ID_NEGATE) as usize == bucket {
+                    expected += &folded_point(point, id);
                 }
             }
             let expected = G1::batch_to_affine(&[expected]);
@@ -1357,8 +1511,8 @@ mod tests {
                 };
                 for &m in &widths {
                     assert!((1..=MAX_WIDTH).contains(&m));
-                    assert!(3usize.pow(m) <= 4 * n.max(1));
-                    assert!(3usize.pow(m) * size_of::<blst_p1_affine>() <= SLOT_BUDGET);
+                    assert!(folded(m) <= 4 * n.max(1));
+                    assert!(folded(m) * size_of::<blst_p1_affine>() <= SLOT_BUDGET);
                 }
                 // Every plan must cover the required number of combinations,
                 // and must not waste more than one on rounding.
@@ -1398,8 +1552,8 @@ mod tests {
             for n in [0usize, 1, 7, 130, 200, 999, 1000, 6000, 20_000, 100_000, 400_000] {
                 let mut widest = 0u32;
                 while widest < MAX_WIDTH
-                    && 3usize.pow(widest + 1) <= 4 * n.max(1)
-                    && 3usize.pow(widest + 1) * size_of::<blst_p1_affine>() <= SLOT_BUDGET
+                    && folded(widest + 1) <= 4 * n.max(1)
+                    && folded(widest + 1) * size_of::<blst_p1_affine>() <= SLOT_BUDGET
                 {
                     widest += 1;
                 }
@@ -1484,7 +1638,12 @@ mod tests {
         let mut rng = test_rng();
         let mut trits = Trits::new(&mut rng);
         for m in 1..=MAX_WIDTH {
-            assert!(trits.fill(m, 1000).into_iter().all(|id| id < 3u32.pow(m)));
+            assert!(
+                trits
+                    .fill(m, 1000)
+                    .into_iter()
+                    .all(|id| ((id & !ID_NEGATE) as usize) < folded(m))
+            );
         }
     }
 
@@ -1492,9 +1651,11 @@ mod tests {
     fn bucket_ids_are_roughly_uniform() {
         let mut rng = test_rng();
         let mut trits = Trits::new(&mut rng);
+        // Folding is a bijection onto the signed values, so uniformity of the
+        // ids is uniformity over the nine vectors of width two.
         let mut counts = [0usize; 9];
         for id in trits.fill(2, 9000) {
-            counts[id as usize] += 1;
+            counts[(signed_value(id) + 4) as usize] += 1;
         }
         // Expected 1000 per id; the window is ~6.7 standard deviations wide.
         for &count in &counts {
@@ -1522,12 +1683,17 @@ mod tests {
                 let mut digits = vec![[0usize; 3]; m as usize];
                 let mut pairs = vec![[0usize; 9]; m as usize - 1];
                 for id in ids {
-                    assert!(id < 3u32.pow(m));
-                    let mut value = id;
+                    assert!(((id & !ID_NEGATE) as usize) < folded(m));
+                    let mut value = signed_value(id);
                     let mut previous = None;
                     for (position, counts) in digits.iter_mut().enumerate() {
-                        let digit = (value % 3) as usize;
-                        value /= 3;
+                        // Balanced-ternary digits, shifted to index {0,1,2}.
+                        let signed = match value.rem_euclid(3) {
+                            2 => -1,
+                            other => other,
+                        };
+                        value = (value - signed) / 3;
+                        let digit = (signed + 1) as usize;
                         counts[digit] += 1;
                         if let Some(previous) = previous {
                             pairs[position - 1][previous * 3 + digit] += 1;
@@ -1575,7 +1741,9 @@ mod tests {
         points.push(off_subgroup_point(&mut rng));
         // Good points are spread arbitrarily; their in-subgroup parts cannot
         // mask a cofactor part in any combination.
-        let mut ids: Vec<u32> = (0..points.len()).map(|i| (i % 243) as u32).collect();
+        let mut ids: Vec<u32> = (0..points.len())
+            .map(|i| (i % folded(M)) as u32)
+            .collect();
         let mut round = Round::new(M);
         // Vector 0 assigns the bad point coefficient 0 in every combination,
         // so the round must accept.
@@ -1583,9 +1751,20 @@ mod tests {
         let (affine, affine_ids) = affine_with_ids(&points, &ids);
         assert!(round.run(&affine, &affine_ids, M));
         // Any nonzero vector leaves a nonzero digit in some combination, which
-        // must reject: 3^j isolates digit j with value 1; 2 and 162 = 2 * 3^4
-        // cover value 2 at the lowest and highest positions.
-        for v in [1u32, 2, 3, 9, 27, 81, 162] {
+        // must reject. A value of 3^j isolates digit j at +1, and the same
+        // value folded isolates it at -1, so these cover both signs at the
+        // lowest and highest positions as well as a two-digit vector.
+        for v in [
+            1u32,
+            3,
+            9,
+            27,
+            81,
+            1 | ID_NEGATE,
+            81 | ID_NEGATE,
+            4,
+            82 | ID_NEGATE,
+        ] {
             ids[bad_index] = v;
             let (affine, affine_ids) = affine_with_ids(&points, &ids);
             assert!(
@@ -1880,9 +2059,10 @@ mod tests {
             for j in 0..m {
                 let mut acc = G1::zero();
                 for (point, &id) in points.iter().zip(&ids) {
-                    let digit = (id / 3u32.pow(j)) % 3;
-                    for _ in 0..digit {
-                        acc += point;
+                    match signed_digits(id, m)[j as usize] {
+                        1 => acc += point,
+                        -1 => acc += &-*point,
+                        _ => {}
                     }
                 }
                 if !acc.in_subgroup() {
@@ -1928,10 +2108,19 @@ mod tests {
                 })
                 .collect();
             // Id distributions: uniform, all-equal, and a tiny support.
+            let buckets = folded(m) as u32;
             let ids: Vec<u32> = match seed % 4 {
                 0 => Trits::new(&mut rng).fill(m, n),
-                1 => vec![(seed as u32) % 3u32.pow(m); n],
-                2 => (0..n).map(|i| (i as u32) % 3u32.min(3u32.pow(m))).collect(),
+                // All points on one folded vector, half of them negated.
+                1 => (0..n)
+                    .map(|i| {
+                        (seed as u32) % buckets | if i % 2 == 0 { ID_NEGATE } else { 0 }
+                    })
+                    .collect(),
+                // A tiny support, so collisions and cancellations dominate.
+                2 => (0..n)
+                    .map(|i| (i as u32) % buckets.min(3) | ((i as u32 & 1) << 31))
+                    .collect(),
                 _ => Trits::new(&mut rng).fill(m, n),
             };
             let (affine, affine_ids) = affine_with_ids(&points, &ids);
@@ -1942,34 +2131,19 @@ mod tests {
             for j in 0..m {
                 let mut expected = G1::zero();
                 for (point, &id) in kept.iter().zip(&affine_ids) {
-                    let digit = (id / 3u32.pow(j)) % 3;
-                    for _ in 0..digit {
-                        expected += point;
+                    match signed_digits(id, m)[j as usize] {
+                        1 => expected += point,
+                        -1 => expected += &-*point,
+                        _ => {}
                     }
                 }
                 // Rebuild the combination from the round's marginals exactly
                 // as `run` does, so a wiring bug shows up as a value mismatch.
                 let mut got = blst_p1::default();
-                if let Some(&twos) = round.marginals[2 * j as usize + 1].first() {
-                    let mut point = blst_p1::default();
+                if let Some(&marginal) = round.marginals[j as usize].first() {
                     // SAFETY: the index names a live affine point, and blst_p1
                     // defaults to the identity.
-                    unsafe {
-                        blst_p1_from_affine(&mut point, &round.sums[twos as usize]);
-                        blst_p1_double(&mut got, &point);
-                    }
-                }
-                if let Some(&ones) = round.marginals[2 * j as usize].first() {
-                    let doubled = got;
-                    // SAFETY: all operands are valid blst values, the identity
-                    // included, and the routine handles equal operands.
-                    unsafe {
-                        blst_p1_add_or_double_affine(
-                            &mut got,
-                            &doubled,
-                            &round.sums[ones as usize],
-                        );
-                    }
+                    unsafe { blst_p1_from_affine(&mut got, &round.sums[marginal as usize]) };
                 }
                 let mut got_affine = blst_p1_affine::default();
                 // SAFETY: both pointers reference valid blst values.
@@ -2004,9 +2178,14 @@ mod tests {
             let ids = Trits::new(&mut rng).fill(m, count);
             let mut counts = vec![0usize; buckets];
             let mut per_pos = vec![vec![0usize; buckets]; per_word];
+            // Uniformity is a property of the vector drawn, not of the bucket
+            // it folds onto: two vectors share a bucket, so counting buckets
+            // would pass even if the sign were biased.
+            let centre = (buckets as i64 - 1) / 2;
             for (i, &id) in ids.iter().enumerate() {
-                counts[id as usize] += 1;
-                per_pos[i % per_word][id as usize] += 1;
+                let vector = (signed_value(id) + centre) as usize;
+                counts[vector] += 1;
+                per_pos[i % per_word][vector] += 1;
             }
             let chi: f64 = counts
                 .iter()
@@ -2053,10 +2232,11 @@ mod tests {
                     })
                     .collect();
                 let ids = Trits::new(&mut rng).fill(m, n);
-                // Naive: one running G1 sum per bucket.
-                let mut expected = vec![G1::zero(); 3usize.pow(m)];
+                // Naive: one running G1 sum per bucket, each point entering
+                // negated when its vector folded onto its negation.
+                let mut expected = vec![G1::zero(); folded(m)];
                 for (point, &id) in points.iter().zip(&ids) {
-                    expected[id as usize] += point;
+                    expected[(id & !ID_NEGATE) as usize] += &folded_point(point, id);
                 }
                 let expected = G1::batch_to_affine(&expected);
                 let (affine, affine_ids) = affine_with_ids(&points, &ids);
@@ -2291,7 +2471,7 @@ mod tests {
         let start = Instant::now();
         for _ in 0..reps {
             for i in 0..n {
-                out[i] = chord(&affine[2 * i], &affine[2 * i + 1], &values[i], false);
+                out[i] = chord(&affine[2 * i], &affine[2 * i + 1], &values[i], false, false);
             }
             std::hint::black_box(&out);
         }

--- a/cryptography/src/bls12381/primitives/subgroup.rs
+++ b/cryptography/src/bls12381/primitives/subgroup.rs
@@ -31,9 +31,15 @@
 //! `1/3` per round. So `r` rounds accept a bad point with probability at most
 //! `3^{-r}`, independent of the cofactor's factorization.
 //!
-//! For BLS12-381 the G1 cofactor's smallest prime factor is `3`, so this `1/3`
-//! bound is tight and small coefficients are optimal: larger coefficients could
-//! not lower the per-round error, only make each round more expensive.
+//! For BLS12-381 the G1 cofactor's smallest prime factor is `3`, so for a
+//! single combination per round this `1/3` bound is tight: larger coefficients
+//! cannot lower a round's error, only make it more expensive. This is not the
+//! only design point, though. Partitioning the points into `B` buckets and
+//! checking each bucket sum separately lowers the per-round error to `1/B`
+//! (needing fewer rounds), at the cost of `B` subgroup checks per round instead
+//! of one; which is faster depends on the relative cost of a subgroup check and
+//! a point summation. This module takes the single-combination approach, whose
+//! one fast check per round pairs well with blst's endomorphism-based test.
 
 use super::group::G1;
 #[cfg(not(feature = "std"))]
@@ -82,8 +88,15 @@ pub fn batch_in_g1(
     let rounds = rounds_for_security(security);
     // Batching pays a fixed cost of one subgroup check per round regardless of
     // the input size, so for few points the exact per-point path is cheaper.
+    // This crossover is algorithmic and cannot be delegated to `strategy`
+    // (which only chooses serial vs parallel execution of a single algorithm),
+    // but the per-point checks still run through `strategy` so a parallel one
+    // spreads them across threads just as it does the batched rounds.
     if points.len() <= 2 * rounds {
-        return points.iter().all(G1::in_subgroup);
+        return strategy
+            .map_collect_vec_with_multiplier(points.iter(), 1, |point| point.in_subgroup())
+            .into_iter()
+            .all(|in_subgroup| in_subgroup);
     }
     // One shared inversion converts every point to affine; the per-round
     // combinations then reuse them.
@@ -269,6 +282,13 @@ mod tests {
         points[123] = off_subgroup_point(&mut rng);
         assert!(!batch_in_g1(&points, SECURITY, &rayon, &mut rng));
         assert!(!batch_in_g1(&points, SECURITY, &Sequential, &mut rng));
+
+        // Small batches take the per-point fallback, which also runs through the
+        // strategy; a parallel strategy must handle it correctly too.
+        let mut small: Vec<G1> = (0..50).map(|_| in_subgroup_point(&mut rng)).collect();
+        assert!(batch_in_g1(&small, SECURITY, &rayon, &mut rng));
+        small[7] = off_subgroup_point(&mut rng);
+        assert!(!batch_in_g1(&small, SECURITY, &rayon, &mut rng));
     }
 
     #[test]

--- a/cryptography/src/bls12381/primitives/subgroup.rs
+++ b/cryptography/src/bls12381/primitives/subgroup.rs
@@ -125,10 +125,18 @@ const LOG2_3_SCALED_LOWER_BOUND: usize = 1584;
 ///
 /// Each combination has error at most `1/3`, so `t` of them give
 /// `3^-t <= 2^-security` once `t >= security / log2(3)` (81 at 128-bit).
+///
+/// The scaling is done in `u128` and saturates upward, so an absurd target asks
+/// for more combinations than any batch can afford — which falls back to
+/// per-point checking — rather than silently asking for fewer.
 const fn combinations_for_security(security: usize) -> usize {
-    security
-        .saturating_mul(1000)
-        .div_ceil(LOG2_3_SCALED_LOWER_BOUND)
+    let scaled = (security as u128) * 1000;
+    let combinations = scaled.div_ceil(LOG2_3_SCALED_LOWER_BOUND as u128);
+    if combinations > usize::MAX as u128 {
+        usize::MAX
+    } else {
+        combinations as usize
+    }
 }
 
 /// Largest supported number of parallel combinations per round.
@@ -210,13 +218,6 @@ fn round_cost(n: usize, m: u32) -> usize {
     (n - occupied) + 2 * occupied + (m as usize) * CHECK_COST
 }
 
-/// Plan the rounds: one width per round, together covering `combinations`.
-///
-/// Returns `None` if checking each point individually is cheaper.
-///
-/// Soundness holds for every plan (a round of width `m` has error `3^-m`, and
-/// the widths sum to at least `combinations`), so the cost model's constants
-/// only affect performance.
 /// Spread `combinations` over `rounds` rounds as evenly as possible.
 ///
 /// The widths differ by at most one, so a round count that does not divide the
@@ -230,6 +231,34 @@ fn spread(combinations: usize, rounds: usize) -> Vec<u32> {
         .collect()
 }
 
+/// Modeled cost of the plan that spreads `combinations` over `rounds` rounds,
+/// or `None` if that spread needs a round wider than `widest`.
+fn plan_cost(n: usize, combinations: usize, rounds: usize, widest: u32) -> Option<usize> {
+    let width = (combinations / rounds) as u32;
+    let wide = combinations % rounds;
+    if width + u32::from(wide > 0) > widest {
+        return None;
+    }
+    Some(
+        wide.saturating_mul(round_cost(n, width + 1))
+            .saturating_add((rounds - wide).saturating_mul(round_cost(n, width))),
+    )
+}
+
+/// Plan the rounds: one width per round, together covering `combinations`.
+///
+/// Returns `None` if checking each point individually is cheaper.
+///
+/// Only a couple of round counts per width can be worth considering. Round
+/// counts sharing a base width form a contiguous band, and within a band the
+/// modeled cost is linear in the round count, so an optimum always sits at a
+/// band's edge — which keeps the search proportional to the widths available
+/// rather than to the combinations required, and so bounded whatever soundness
+/// target a caller asks for.
+///
+/// Soundness holds for every plan (a round of width `m` has error `3^-m`, and
+/// the widths sum to `combinations`), so the cost model's constants only affect
+/// performance.
 fn plan(n: usize, combinations: usize) -> Option<Vec<u32>> {
     if combinations == 0 {
         return Some(Vec::new());
@@ -243,26 +272,26 @@ fn plan(n: usize, combinations: usize) -> Option<Vec<u32>> {
     {
         widest += 1;
     }
-    if widest == 0 {
-        return None;
-    }
     let mut best_cost = n.saturating_mul(CHECK_COST);
     let mut best = None;
-    for rounds in combinations.div_ceil(widest as usize)..=combinations {
-        let widths = spread(combinations, rounds);
-        // Spreading evenly cannot push a round past `widest`: a round count that
-        // leaves a remainder also leaves the base width below it.
-        debug_assert!(widths.iter().all(|&m| m <= widest));
-        let cost = widths
-            .iter()
-            .map(|&m| round_cost(n, m))
-            .fold(0usize, |total, cost| total.saturating_add(cost));
-        if cost < best_cost {
-            best_cost = cost;
-            best = Some(widths);
+    for width in 1..=widest as usize {
+        // The round counts whose spread has base width `width`, which is where
+        // the modeled cost is linear.
+        let band = [combinations / (width + 1) + 1, combinations / width];
+        for rounds in band {
+            if rounds == 0 || rounds > combinations {
+                continue;
+            }
+            let Some(cost) = plan_cost(n, combinations, rounds, widest) else {
+                continue;
+            };
+            if cost < best_cost {
+                best_cost = cost;
+                best = Some(rounds);
+            }
         }
     }
-    best
+    best.map(|rounds| spread(combinations, rounds))
 }
 
 /// Verify that every point in `points` lies in the prime-order subgroup G1,
@@ -539,12 +568,15 @@ impl Round {
                 }
             }
             if let Some(&ones) = self.marginals[2 * j].first() {
-                // SAFETY: both operands are valid; the routine handles the
-                // identity and equal operands, and permits out == a.
+                // Copied rather than passed twice: handing the same local out
+                // as both `&mut` and `&` would alias.
+                let twos = combination;
+                // SAFETY: all operands are valid blst values, the identity
+                // included, and the routine handles equal operands.
                 unsafe {
                     blst_p1_add_or_double_affine(
                         &mut combination,
-                        &combination,
+                        &twos,
                         &self.sums[ones as usize],
                     );
                 }
@@ -886,7 +918,9 @@ fn prefix_inverse(values: &[blst_fp], prefix: &mut Vec<blst_fp>) -> Option<blst_
 
 /// Hint that `slots[index]` will be read soon.
 ///
-/// A point spans two cache lines, and the caller reads both.
+/// A point spans two cache lines, and the caller reads both. This is only a
+/// hint, so a target without one is slower here, never wrong; aarch64's
+/// prefetch intrinsics are still unstable, so it goes without.
 #[inline(always)]
 fn prefetch(slots: &[blst_p1_affine], index: usize) {
     let _ = (slots, index);
@@ -899,16 +933,6 @@ fn prefetch(slots: &[blst_p1_affine], index: usize) {
         unsafe {
             _mm_prefetch(base, _MM_HINT_T0);
             _mm_prefetch(base.wrapping_add(64), _MM_HINT_T0);
-        }
-    }
-    #[cfg(target_arch = "aarch64")]
-    {
-        use core::arch::aarch64::{_PREFETCH_LOCALITY3, _PREFETCH_READ, _prefetch};
-        let base = slots.as_ptr().wrapping_add(index).cast::<i8>();
-        // SAFETY: _prefetch never dereferences its argument.
-        unsafe {
-            _prefetch::<_PREFETCH_READ, _PREFETCH_LOCALITY3>(base);
-            _prefetch::<_PREFETCH_READ, _PREFETCH_LOCALITY3>(base.wrapping_add(64));
         }
     }
 }
@@ -1306,6 +1330,69 @@ mod tests {
     }
 
     #[test]
+    fn plan_matches_exhaustive_search() {
+        // The search only visits the edges of each base-width band, on the
+        // argument that the modeled cost is linear inside one. Check that
+        // against the exhaustive search it replaces.
+        for combinations in [1usize, 2, 5, 37, 81, 128, 200] {
+            for n in [0usize, 1, 7, 130, 200, 999, 1000, 6000, 20_000, 100_000, 400_000] {
+                let mut widest = 0u32;
+                while widest < MAX_WIDTH
+                    && 3usize.pow(widest + 1) <= 4 * n.max(1)
+                    && 3usize.pow(widest + 1) * size_of::<blst_p1_affine>() <= SLOT_BUDGET
+                {
+                    widest += 1;
+                }
+                let mut best = (n.saturating_mul(CHECK_COST), None);
+                for rounds in 1..=combinations {
+                    let Some(cost) = plan_cost(n, combinations, rounds, widest) else {
+                        continue;
+                    };
+                    if cost < best.0 {
+                        best = (cost, Some(rounds));
+                    }
+                }
+                let exhaustive = best.1.map(|rounds| spread(combinations, rounds));
+                let got = plan(n, combinations);
+                // Equal cost is enough; ties may be broken differently.
+                match (&got, &exhaustive) {
+                    (None, None) => {}
+                    (Some(got), Some(exhaustive)) => {
+                        let cost = |widths: &[u32]| {
+                            widths.iter().map(|&m| round_cost(n, m)).sum::<usize>()
+                        };
+                        assert_eq!(
+                            cost(got),
+                            cost(exhaustive),
+                            "n={n} c={combinations}: {got:?} vs {exhaustive:?}"
+                        );
+                    }
+                    _ => panic!("n={n} c={combinations}: {got:?} vs {exhaustive:?}"),
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn plan_is_bounded_for_absurd_targets() {
+        // `security` is a caller-supplied parameter with no upper bound, so the
+        // search must not grow with it. These return promptly, and ask for
+        // per-point checking rather than a plan that is short of the target.
+        for security in [1_000_000usize, usize::MAX / 2, usize::MAX] {
+            let combinations = combinations_for_security(security);
+            assert!(combinations >= security / 2, "saturated downward");
+            for n in [1000usize, 100_000] {
+                assert_eq!(plan(n, combinations), None);
+            }
+        }
+        // The scaling never rounds down below the target either.
+        for security in [1usize, 40, 128, 1000, 100_000] {
+            let combinations = combinations_for_security(security);
+            assert!((combinations as f64) * 3f64.log2() >= security as f64);
+        }
+    }
+
+    #[test]
     fn spread_is_even_and_complete() {
         for combinations in [1usize, 2, 7, 81, 128, 255] {
             for rounds in 1..=combinations {
@@ -1347,6 +1434,64 @@ mod tests {
         // Expected 1000 per id; the window is ~6.7 standard deviations wide.
         for &count in &counts {
             assert!((800..1200).contains(&count), "{counts:?}");
+        }
+    }
+
+    #[test]
+    fn coefficients_are_uniform_and_independent() {
+        // Exact uniformity of every coefficient is soundness-bearing, and the
+        // sampler packs several ids into one drawn word, so a skew could hide in
+        // one digit position or in the correlation between two of them rather
+        // than in the ids overall. Windows below are ~6 standard deviations.
+        const DRAWS: usize = 90_000;
+        let mut rng = test_rng();
+        for m in [5u32, 9, 10] {
+            // Drawing in one call and in many small ones exercise different
+            // word-boundary behaviour; both must be unbiased.
+            for batch in [DRAWS, 7] {
+                let mut trits = Trits::new(&mut rng);
+                let mut ids = Vec::with_capacity(DRAWS);
+                while ids.len() < DRAWS {
+                    ids.extend(trits.fill(m, batch.min(DRAWS - ids.len())));
+                }
+                let mut digits = vec![[0usize; 3]; m as usize];
+                let mut pairs = vec![[0usize; 9]; m as usize - 1];
+                for id in ids {
+                    assert!(id < 3u32.pow(m));
+                    let mut value = id;
+                    let mut previous = None;
+                    for (position, counts) in digits.iter_mut().enumerate() {
+                        let digit = (value % 3) as usize;
+                        value /= 3;
+                        counts[digit] += 1;
+                        if let Some(previous) = previous {
+                            pairs[position - 1][previous * 3 + digit] += 1;
+                        }
+                        previous = Some(digit);
+                    }
+                }
+                for (position, counts) in digits.iter().enumerate() {
+                    let expected = DRAWS / 3;
+                    let window = 6 * ((DRAWS * 2 / 9) as f64).sqrt() as usize;
+                    for &count in counts {
+                        assert!(
+                            count.abs_diff(expected) < window,
+                            "m={m} batch={batch} digit {position} skewed: {counts:?}"
+                        );
+                    }
+                }
+                for (position, counts) in pairs.iter().enumerate() {
+                    let expected = DRAWS / 9;
+                    let window = 6 * ((DRAWS * 8 / 81) as f64).sqrt() as usize;
+                    for &count in counts {
+                        assert!(
+                            count.abs_diff(expected) < window,
+                            "m={m} batch={batch} digits {position},{} correlated: {counts:?}",
+                            position + 1
+                        );
+                    }
+                }
+            }
         }
     }
 
@@ -1687,7 +1832,6 @@ mod tests {
         }
     }
 
-
     /// Randomized differential fuzz: every combination's exact value against a
     /// direct computation, over adversarial id and point distributions.
     #[test]
@@ -1738,20 +1882,32 @@ mod tests {
                         expected += point;
                     }
                 }
+                // Rebuild the combination from the round's marginals exactly
+                // as `run` does, so a wiring bug shows up as a value mismatch.
                 let mut got = blst_p1::default();
                 if let Some(&twos) = round.marginals[2 * j as usize + 1].first() {
                     let mut point = blst_p1::default();
+                    // SAFETY: the index names a live affine point, and blst_p1
+                    // defaults to the identity.
                     unsafe {
                         blst_p1_from_affine(&mut point, &round.sums[twos as usize]);
                         blst_p1_double(&mut got, &point);
                     }
                 }
                 if let Some(&ones) = round.marginals[2 * j as usize].first() {
+                    let doubled = got;
+                    // SAFETY: all operands are valid blst values, the identity
+                    // included, and the routine handles equal operands.
                     unsafe {
-                        blst_p1_add_or_double_affine(&mut got, &got, &round.sums[ones as usize]);
+                        blst_p1_add_or_double_affine(
+                            &mut got,
+                            &doubled,
+                            &round.sums[ones as usize],
+                        );
                     }
                 }
                 let mut got_affine = blst_p1_affine::default();
+                // SAFETY: both pointers reference valid blst values.
                 unsafe { blst::blst_p1_to_affine(&mut got_affine, &got) };
                 let expected_affine = G1::batch_to_affine(&[expected])[0];
                 assert_eq!(
@@ -1773,7 +1929,7 @@ mod tests {
     fn trit_ids_are_uniform_per_position() {
         let mut rng = test_rng();
         for m in 1..=MAX_WIDTH {
-            let buckets = 3usize.pow(m) as usize;
+            let buckets = 3usize.pow(m);
             if buckets > 6561 {
                 continue;
             }
@@ -1813,7 +1969,8 @@ mod tests {
         }
     }
 
-
+    /// The widest plans the cost model can pick, checked bucket by bucket
+    /// against a naive running sum.
     #[test]
     fn accumulate_large_widths_match_naive() {
         for seed in 0..3u64 {
@@ -1841,12 +1998,16 @@ mod tests {
                 let mut round = Round::new(m);
                 round.widen(m);
                 round.accumulate(&affine, &affine_ids);
-                for bucket in 0..3usize.pow(m) {
-                    let want_inf = affine_is_inf(&expected[bucket]);
-                    assert_eq!(round.live[bucket], !want_inf, "seed {seed} m {m} bucket {bucket} liveness");
-                    if !want_inf {
-                        assert_eq!(round.sums[bucket].x.l, expected[bucket].x.l, "seed {seed} m {m} bucket {bucket} x");
-                        assert_eq!(round.sums[bucket].y.l, expected[bucket].y.l, "seed {seed} m {m} bucket {bucket} y");
+                for (bucket, expected) in expected.iter().enumerate() {
+                    let empty = affine_is_inf(expected);
+                    assert_eq!(
+                        round.live[bucket], !empty,
+                        "seed={seed} m={m} bucket {bucket} liveness"
+                    );
+                    if !empty {
+                        let got = round.sums[bucket];
+                        assert_eq!(got.x.l, expected.x.l, "seed={seed} m={m} bucket {bucket} x");
+                        assert_eq!(got.y.l, expected.y.l, "seed={seed} m={m} bucket {bucket} y");
                     }
                 }
             }

--- a/cryptography/src/bls12381/primitives/subgroup.rs
+++ b/cryptography/src/bls12381/primitives/subgroup.rs
@@ -807,7 +807,7 @@ mod tests {
     fn measure_accumulator() {
         use std::time::Instant;
         let mut rng = test_rng();
-        for n in [1000usize, 6000] {
+        for n in [1000usize, 6000, 100_000] {
             let points: Vec<G1> = (0..n).map(|_| in_subgroup_point(&mut rng)).collect();
             let affine = G1::batch_to_affine(&points);
             let mut ids = vec![0u8; n];
@@ -838,7 +838,7 @@ mod tests {
         let threads = available_parallelism().unwrap();
         let rayon = Rayon::new(threads).unwrap();
         println!("threads = {threads}");
-        for n in [200usize, 1000, 6000] {
+        for n in [200usize, 1000, 6000, 100_000] {
             let mut rng = test_rng();
             let points: Vec<G1> = (0..n).map(|_| in_subgroup_point(&mut rng)).collect();
             println!("n={n} plan={:?}", plan(n, combinations_for_security(128)));
@@ -851,6 +851,132 @@ mod tests {
             let start = Instant::now();
             assert!(batch_in_g1(&points, 128, &rayon, &mut test_rng()));
             println!("n={n} batch_parallel  = {:?}", start.elapsed());
+        }
+    }
+
+    /// Compare the shipping scheme (C) against the two alternatives from
+    /// `cryptography/BATCHED_SUBGROUP.md`, all on the same accumulation engine:
+    /// A is one combination per round (m = 1, 81 rounds); B is random bucketing
+    /// with every bucket sum exact-checked (shared-inversion steelman). Run with:
+    /// `cargo test -p commonware-cryptography --release --features bls12381 \
+    ///   subgroup::tests::measure_strategies -- --ignored --nocapture`
+    #[test]
+    #[ignore = "manual benchmark"]
+    fn measure_strategies() {
+        use blst::blst_p1_affine_in_g1;
+        use commonware_parallel::Rayon;
+        use std::{thread::available_parallelism, time::Instant};
+
+        /// Strategy A/C with a forced width and round count.
+        fn forced(
+            points: &[G1],
+            m: u32,
+            rounds: usize,
+            strategy: &impl Strategy,
+            rng: &mut impl CryptoRng,
+        ) -> bool {
+            let affine = G1::batch_to_affine(points);
+            let mut trits = Trits::new(rng);
+            let id_sets: Vec<Vec<u8>> = (0..rounds)
+                .map(|_| (0..points.len()).map(|_| trits.bucket(m)).collect())
+                .collect();
+            strategy
+                .map_collect_vec_with_multiplier(id_sets.iter(), points.len(), |ids| {
+                    round_in_g1(&affine, ids, m)
+                })
+                .into_iter()
+                .all(|in_subgroup| in_subgroup)
+        }
+
+        /// Strategy B: `num_buckets` a power of two, every bucket sum checked.
+        fn bucketed(
+            points: &[G1],
+            num_buckets: usize,
+            rounds: usize,
+            strategy: &impl Strategy,
+            rng: &mut impl CryptoRng,
+        ) -> bool {
+            let affine = G1::batch_to_affine(points);
+            let mask = (num_buckets - 1) as u8;
+            let id_sets: Vec<Vec<u8>> = (0..rounds)
+                .map(|_| {
+                    let mut ids = vec![0u8; points.len()];
+                    rng.fill_bytes(&mut ids);
+                    for id in &mut ids {
+                        *id &= mask;
+                    }
+                    ids
+                })
+                .collect();
+            strategy
+                .map_collect_vec_with_multiplier(id_sets.iter(), points.len(), |ids| {
+                    sum_buckets(&affine, ids, num_buckets).iter().all(|sum| {
+                        // SAFETY: sum is a valid blst_p1_affine.
+                        affine_is_inf(sum) || unsafe { blst_p1_affine_in_g1(sum) }
+                    })
+                })
+                .into_iter()
+                .all(|in_subgroup| in_subgroup)
+        }
+
+        let threads = available_parallelism().unwrap();
+        let rayon = Rayon::new(threads).unwrap();
+        println!("threads = {threads}");
+        for n in [1000usize, 6000, 100_000] {
+            let mut rng = test_rng();
+            let points: Vec<G1> = (0..n).map(|_| in_subgroup_point(&mut rng)).collect();
+            let start = Instant::now();
+            assert!(points.iter().all(G1::in_subgroup));
+            println!("n={n} per_point serial = {:?}", start.elapsed());
+            // A: one combination per round, 81 rounds.
+            let start = Instant::now();
+            assert!(forced(&points, 1, 81, &Sequential, &mut test_rng()));
+            println!("n={n} A m=1 r=81   serial = {:?}", start.elapsed());
+            let start = Instant::now();
+            assert!(forced(&points, 1, 81, &rayon, &mut test_rng()));
+            println!("n={n} A m=1 r=81 parallel = {:?}", start.elapsed());
+            // B: buckets with per-bucket checks, rounds = ceil(128 / log2 B).
+            for (num_buckets, rounds) in [(16usize, 32usize), (64, 22), (256, 16)] {
+                let start = Instant::now();
+                assert!(bucketed(
+                    &points,
+                    num_buckets,
+                    rounds,
+                    &Sequential,
+                    &mut test_rng()
+                ));
+                println!(
+                    "n={n} B B={num_buckets:>3} r={rounds}   serial = {:?}",
+                    start.elapsed()
+                );
+                let start = Instant::now();
+                assert!(bucketed(
+                    &points,
+                    num_buckets,
+                    rounds,
+                    &rayon,
+                    &mut test_rng()
+                ));
+                println!(
+                    "n={n} B B={num_buckets:>3} r={rounds} parallel = {:?}",
+                    start.elapsed()
+                );
+            }
+            // C: the shipping scheme.
+            let start = Instant::now();
+            assert!(batch_in_g1(&points, 128, &Sequential, &mut test_rng()));
+            println!(
+                "n={n} C plan={:?} serial = {:?}",
+                plan(n, 81),
+                start.elapsed()
+            );
+            let start = Instant::now();
+            assert!(batch_in_g1(&points, 128, &rayon, &mut test_rng()));
+            println!(
+                "n={n} C plan={:?} parallel = {:?}",
+                plan(n, 81),
+                start.elapsed()
+            );
         }
     }
 }

--- a/cryptography/src/bls12381/primitives/subgroup.rs
+++ b/cryptography/src/bls12381/primitives/subgroup.rs
@@ -224,6 +224,7 @@ fn round_cost(n: usize, m: u32) -> usize {
 /// combinations wastes none of them — which matters, since the round count is
 /// what the batch pays for.
 fn spread(combinations: usize, rounds: usize) -> Vec<u32> {
+    debug_assert!(combinations / rounds <= MAX_WIDTH as usize);
     let width = (combinations / rounds) as u32;
     let wide = combinations % rounds;
     (0..rounds)
@@ -234,11 +235,14 @@ fn spread(combinations: usize, rounds: usize) -> Vec<u32> {
 /// Modeled cost of the plan that spreads `combinations` over `rounds` rounds,
 /// or `None` if that spread needs a round wider than `widest`.
 fn plan_cost(n: usize, combinations: usize, rounds: usize, widest: u32) -> Option<usize> {
-    let width = (combinations / rounds) as u32;
+    // Compared before narrowing, so a round count far too small to be usable is
+    // rejected rather than wrapping into a plausible-looking width.
+    let width = combinations / rounds;
     let wide = combinations % rounds;
-    if width + u32::from(wide > 0) > widest {
+    if width + usize::from(wide > 0) > widest as usize {
         return None;
     }
+    let width = width as u32;
     Some(
         wide.saturating_mul(round_cost(n, width + 1))
             .saturating_add((rounds - wide).saturating_mul(round_cost(n, width))),
@@ -300,6 +304,9 @@ fn plan(n: usize, combinations: usize) -> Option<Vec<u32>> {
 /// The points must already be valid curve points (for example decoded with
 /// [`G1::read_unchecked`]); this establishes only subgroup membership. An empty
 /// slice is accepted.
+///
+/// A `security` of zero asks for no soundness at all — an error of `2^0` — and
+/// accepts without examining the points; every positive target examines them.
 ///
 /// `rng` must be a cryptographically secure source the prover cannot predict:
 /// the coefficients are the verifier's private randomness, exactly as in a
@@ -2084,16 +2091,41 @@ mod tests {
 
     #[test]
     fn wide_rounds_agree_with_per_point() {
-        // A batch large enough for the cost model to pick a wide round, so the
-        // collapse chain runs at full depth.
+        // A batch large enough for the cost model to pick its widest round, so
+        // the collapse chain runs at full depth end to end. The points are
+        // drawn from a small pool and cycled, both to keep the batch cheap to
+        // build and because the duplicates stress the doubling path.
         let mut rng = test_rng();
-        let n = 20_000;
+        let n = 100_000;
         let widths = plan(n, 81).expect("batched");
-        assert!(widths[0] >= 7, "expected a wide plan, got {widths:?}");
-        let mut points: Vec<G1> = (0..n).map(|_| in_subgroup_point(&mut rng)).collect();
+        let widest = 3usize.pow(*widths.iter().max().expect("nonempty"))
+            * size_of::<blst_p1_affine>();
+        assert!(
+            widest * 3 > SLOT_BUDGET,
+            "expected the budget to bind, got {widths:?}"
+        );
+        let pool: Vec<G1> = (0..64).map(|_| in_subgroup_point(&mut rng)).collect();
+        let mut points: Vec<G1> = (0..n).map(|i| pool[i % pool.len()]).collect();
         assert!(batch_in_g1(&points, SECURITY, &Sequential, &mut rng));
         points[n - 1] = off_subgroup_point(&mut rng);
         assert!(!batch_in_g1(&points, SECURITY, &Sequential, &mut rng));
+    }
+
+    #[test]
+    fn zero_security_accepts_without_checking() {
+        // An error bound of 2^0 is no bound, so the check is entitled to accept
+        // anything. Pin it, so the boundary is a decision rather than an
+        // accident, and pin that the very next target does examine the points.
+        let mut rng = test_rng();
+        let bad: Vec<G1> = (0..LARGE).map(|_| off_subgroup_point(&mut rng)).collect();
+        assert_eq!(combinations_for_security(0), 0);
+        assert_eq!(plan(bad.len(), 0), Some(Vec::new()));
+        assert!(batch_in_g1(&bad, 0, &Sequential, &mut rng));
+        // One bit of soundness is still one round: rejection is then only
+        // probable, so the certain part is that a round runs at all.
+        assert_eq!(combinations_for_security(1), 1);
+        assert_eq!(plan(bad.len(), 1).map(|widths| widths.len()), Some(1));
+        assert!(!batch_in_g1(&bad, SECURITY, &Sequential, &mut rng));
     }
 
     #[test]

--- a/cryptography/src/bls12381/primitives/subgroup.rs
+++ b/cryptography/src/bls12381/primitives/subgroup.rs
@@ -1455,8 +1455,13 @@ mod tests {
     #[test]
     fn spread_is_even_and_complete() {
         for combinations in [1usize, 2, 7, 81, 128, 255] {
-            for rounds in 1..=combinations {
+            // Too few rounds to carry the combinations at all is not a spread
+            // this has to be even about: it is the precondition `spread`
+            // asserts and `plan_cost` rejects before ever calling it.
+            let fewest = combinations.div_ceil(MAX_WIDTH as usize).max(1);
+            for rounds in fewest..=combinations {
                 let widths = spread(combinations, rounds);
+                assert!(widths.iter().all(|&m| m <= MAX_WIDTH));
                 assert_eq!(widths.len(), rounds);
                 // Every combination is placed, and none is wasted.
                 assert_eq!(

--- a/cryptography/src/bls12381/primitives/subgroup.rs
+++ b/cryptography/src/bls12381/primitives/subgroup.rs
@@ -9,67 +9,123 @@
 //! # Method
 //!
 //! Given points `P_0, ..., P_{n-1}` (already verified to lie on the curve, e.g.
-//! via [`G1::read_unchecked`]), each round samples coefficients `c_i` uniformly
-//! from `{0, 1, 2}`, forms the combination `Q = sum_i c_i P_i`, and applies the
-//! exact per-point check [`G1::in_subgroup`] to the single point `Q`. If every
-//! round's combination is in G1, all points are accepted.
+//! via [`G1::read_unchecked`]), the check runs `r` rounds of `m` parallel
+//! random linear combinations. Each round draws an independent uniform
+//! coefficient `c_{j,i}` in `{0, 1, 2}` for every combination `j < m` and every
+//! point `i`, and applies the exact per-point test [`G1::in_subgroup`] to the
+//! `m` points `Q_j = sum_i c_{j,i} P_i`. The batch is accepted if every
+//! combination in every round lies in G1.
 //!
-//! The points are converted to affine once, and each round's combination is a
-//! two-bit multi-scalar multiplication: blst's Pippenger routine buckets the
-//! points by coefficient and sums each bucket with a single shared field
-//! inversion, which is much cheaper than adding the points one at a time.
+//! Rather than computing each `Q_j` separately, a round groups the points by
+//! their coefficient *vector* `(c_{0,i}, ..., c_{m-1,i})` — one of `3^m`
+//! buckets — sums each bucket once, and recovers every combination from the
+//! bucket sums: `Q_j = sum_{v: v_j=1} S_v + 2 * sum_{v: v_j=2} S_v`, where
+//! `v_j` is the `j`-th base-3 digit of bucket index `v`. The combine weights
+//! are the *deterministic* digits of the bucket index — all randomness lives in
+//! the vector assignment — so this evaluates exactly the `m` combinations
+//! above. (It is not the unsound shortcut of re-randomizing over bucket sums,
+//! which would collapse the `m` combinations back into one.)
+//!
+//! Summing `n` points into `3^m` buckets costs the same `n` point additions as
+//! summing them into one, so a single accumulation pass over the points serves
+//! all `m` combinations, and only `ceil(81/m)` passes are needed at 128-bit
+//! security instead of 81. The additions are batch-affine: each pass pairs up
+//! the remaining points of every bucket and completes all pairs with one shared
+//! field inversion (Montgomery's trick), about six field multiplications per
+//! addition. The per-batch choice of `m` (and of batching at all, versus
+//! checking each point individually) is a pure performance decision made by a
+//! cost model; soundness holds for every choice.
 //!
 //! # Soundness
 //!
-//! Write each point as its in-subgroup part plus a "cofactor part" living in the
-//! group of order `h` (the G1 cofactor). `Q` lies in G1 exactly when the
-//! coefficient-weighted sum of the cofactor parts vanishes. The G1 cofactor
-//! `h = 3 * (11 * 10177 * 859267 * 52437899)^2` is odd, so every nonzero
-//! cofactor part `T` has order at least 3, making `0*T`, `1*T`, and `2*T` three
-//! distinct group elements. Pick any bad point `P_j` (nonzero `T_j`) and
-//! condition on every other coefficient: the round accepts only if `c_j * T_j`
-//! hits the single fixed value `-sum_{i != j} c_i T_i`, and as `c_j` ranges
-//! uniformly over `{0, 1, 2}` it takes three distinct values, so at most one
-//! works — probability at most `1/3`, for any number of bad points and any
-//! structure of the cofactor group. `r` rounds accept with probability at most
-//! `3^{-r}`.
+//! Write each point as its in-subgroup part plus a "cofactor part" living in
+//! the group of order `h` (the G1 cofactor). A combination `Q_j` lies in G1
+//! exactly when its coefficient-weighted sum of cofactor parts vanishes. The
+//! G1 cofactor `h = 3 * (11 * 10177 * 859267 * 52437899)^2` is odd, so every
+//! nonzero cofactor part `T` has order at least 3, making `0*T`, `1*T`, and
+//! `2*T` three distinct group elements. Pick any bad point (nonzero `T_i`) and
+//! condition on every other coefficient of combination `j`: the combination
+//! vanishes only if `c_{j,i} * T_i` hits one fixed value, and it takes three
+//! distinct values as `c_{j,i}` ranges over `{0, 1, 2}`, so at most one works —
+//! probability at most `1/3`, for any number of bad points and any structure of
+//! the cofactor group. The `m` combinations of a round use disjoint independent
+//! coefficients, so a round accepts a bad batch with probability at most
+//! `3^-m`, and `r` rounds with probability at most `3^{-rm}`. The check uses
+//! `r*m >= ceil(security / log2(3))` total combinations (81 at 128-bit).
 //!
 //! The bound requires an odd cofactor: an order-2 part `T` has `2*T = 0`, so
-//! `c * T` escapes with probability `2/3` per round. A curve whose cofactor is
-//! even (e.g. BLS12-377 G1, with `2^92 | h`) cannot use this scheme as-is.
+//! `c * T` escapes with probability `2/3` per combination. A curve whose
+//! cofactor is even (e.g. BLS12-377 G1, with `2^92 | h`) cannot use this
+//! scheme as-is.
 //!
-//! For BLS12-381 the `1/3` bound is also tight (a lone bad point escapes a
-//! round exactly when `c_j = 0`, and `3 | h`), so for a single combination per
-//! round larger coefficients cannot lower the error, only make each round more
-//! expensive. This is not the only design point, though. Partitioning the
-//! points into `B` buckets and checking each bucket sum separately lowers the
-//! per-round error to `1/B` (needing fewer rounds), at the cost of `B` subgroup
-//! checks per round instead of one; which is faster depends on the relative
-//! cost of a subgroup check and a point summation. This module takes the
-//! single-combination approach, whose one fast check per round pairs well with
-//! blst's endomorphism-based test. See `cryptography/BATCHED_SUBGROUP.md` for
-//! the full comparison.
+//! See `cryptography/BATCHED_SUBGROUP.md` for the comparison against the
+//! alternatives (per-point checking, one combination per round, and random
+//! bucketing with per-bucket checks) and measured results.
 
 use super::group::G1;
 #[cfg(not(feature = "std"))]
 use alloc::{vec, vec::Vec};
+use blst::{
+    blst_fp, blst_fp_add, blst_fp_inverse, blst_fp_mul, blst_fp_sqr, blst_fp_sub, blst_p1,
+    blst_p1_add_or_double, blst_p1_add_or_double_affine, blst_p1_affine, blst_p1_affine_is_inf,
+    blst_p1_double, blst_p1_in_g1,
+};
 use commonware_parallel::Strategy;
 use rand_core::CryptoRng;
 
 /// One thousand times a strict lower bound on `log2(3)`.
 ///
 /// `log2(3) = 1.58496...`, and `1.584 < log2(3)`, so dividing by this bound
-/// never underestimates the number of rounds.
+/// never underestimates the number of combinations.
 const LOG2_3_SCALED_LOWER_BOUND: usize = 1584;
 
-/// Number of rounds needed for a soundness error of at most `2^-security`.
+/// Total number of `{0,1,2}`-coefficient combinations needed for a soundness
+/// error of at most `2^-security`.
 ///
-/// Each round has error at most `1/3`, so `r` rounds give `3^-r <= 2^-security`
-/// once `r >= security / log2(3)`.
-pub const fn rounds_for_security(security: usize) -> usize {
+/// Each combination has error at most `1/3`, so `t` of them give
+/// `3^-t <= 2^-security` once `t >= security / log2(3)` (81 at 128-bit).
+const fn combinations_for_security(security: usize) -> usize {
     security
         .saturating_mul(1000)
         .div_ceil(LOG2_3_SCALED_LOWER_BOUND)
+}
+
+/// Approximate cost of one [`G1::in_subgroup`] check, in units of one
+/// batch-affine point addition.
+///
+/// Machine-rough (measured ~22us per check against ~150ns per addition); it
+/// only steers the cost model's choice of `m` and the per-point fallback,
+/// never soundness.
+const CHECK_COST: usize = 150;
+
+/// Approximate cost of one Jacobian mixed addition (used by the bucket
+/// combine), in units of one batch-affine point addition.
+const MIXED_ADD_COST: usize = 3;
+
+/// Pick the number of parallel combinations per round, or `None` if checking
+/// each point individually is cheaper.
+///
+/// Returns `(m, rounds)` minimizing the modeled cost
+/// `rounds * (n additions + combine + m checks)` subject to
+/// `rounds * m >= combinations`; soundness holds for every choice, so the
+/// constants above only affect performance.
+fn plan(n: usize, combinations: usize) -> Option<(u32, usize)> {
+    let mut best_cost = n.saturating_mul(CHECK_COST);
+    let mut best = None;
+    let mut pow3 = 1usize;
+    for m in 1..=5u32 {
+        pow3 *= 3;
+        let rounds = combinations.div_ceil(m as usize);
+        // Combining bucket sums into output j touches the 2*3^(m-1) buckets
+        // whose j-th digit is nonzero, for each of the m outputs.
+        let combine = MIXED_ADD_COST * 2 * (m as usize) * (pow3 / 3);
+        let cost = rounds.saturating_mul(n + combine + (m as usize) * CHECK_COST);
+        if cost < best_cost {
+            best_cost = cost;
+            best = Some((m, rounds));
+        }
+    }
+    best
 }
 
 /// Verify that every point in `points` lies in the prime-order subgroup G1,
@@ -94,36 +150,257 @@ pub fn batch_in_g1(
     strategy: &impl Strategy,
     rng: &mut impl CryptoRng,
 ) -> bool {
-    let rounds = rounds_for_security(security);
-    // Batching pays a fixed cost of one subgroup check per round regardless of
-    // the input size, so for few points the exact per-point path is cheaper.
-    // This crossover is algorithmic and cannot be delegated to `strategy`
-    // (which only chooses serial vs parallel execution of a single algorithm),
-    // but the per-point checks still run through `strategy` so a parallel one
-    // spreads them across threads just as it does the batched rounds.
-    if points.len() <= 2 * rounds {
+    let combinations = combinations_for_security(security);
+    // Whether to batch at all, and at what width, is an algorithmic choice the
+    // cost model makes; it cannot be delegated to `strategy` (which only
+    // chooses serial vs parallel execution of a single algorithm). Either
+    // path's independent units still run through `strategy`.
+    let Some((m, rounds)) = plan(points.len(), combinations) else {
         return strategy
             .map_collect_vec_with_multiplier(points.iter(), 1, |point| point.in_subgroup())
             .into_iter()
             .all(|in_subgroup| in_subgroup);
-    }
+    };
     // One shared inversion converts every point to affine; the per-round
-    // combinations then reuse them.
+    // accumulations then reuse them.
     let affine = G1::batch_to_affine(points);
-    // The RNG is sequential, so draw every round's coefficients up front; the
-    // rounds themselves are independent and run through the strategy.
+    // The RNG is sequential, so draw every round's coefficient vectors (as
+    // base-3 bucket ids) up front; the rounds themselves are independent and
+    // run through the strategy, weighted by the per-round accumulation size.
     let mut trits = Trits::new(rng);
-    let coefficient_sets: Vec<Vec<u8>> = (0..rounds)
-        .map(|_| (0..points.len()).map(|_| trits.next()).collect())
+    let id_sets: Vec<Vec<u8>> = (0..rounds)
+        .map(|_| (0..points.len()).map(|_| trits.bucket(m)).collect())
         .collect();
-    // Each round is a two-bit MSM over `points.len()` points, so weight the
-    // per-round cost by that size for the adaptive serial/parallel choice.
     strategy
-        .map_collect_vec_with_multiplier(coefficient_sets.iter(), points.len(), |coefficients| {
-            G1::small_msm(&affine, coefficients, 2).in_subgroup()
+        .map_collect_vec_with_multiplier(id_sets.iter(), points.len(), |ids| {
+            round_in_g1(&affine, ids, m)
         })
         .into_iter()
         .all(|in_subgroup| in_subgroup)
+}
+
+/// Run one round: sum the points into `3^m` buckets keyed by coefficient
+/// vector, recover the `m` combinations from the bucket sums, and check each.
+fn round_in_g1(affine: &[blst_p1_affine], ids: &[u8], m: u32) -> bool {
+    let sums = sum_buckets(affine, ids, 3usize.pow(m));
+    for j in 0..m {
+        let divisor = 3usize.pow(j);
+        // Output j is (sum of buckets with digit_j = 1) + 2 * (digit_j = 2).
+        let mut ones = blst_p1::default();
+        let mut twos = blst_p1::default();
+        for (v, sum) in sums.iter().enumerate() {
+            if affine_is_inf(sum) {
+                continue;
+            }
+            let acc = match (v / divisor) % 3 {
+                1 => &mut ones,
+                2 => &mut twos,
+                _ => continue,
+            };
+            // SAFETY: acc and sum are valid points; blst_p1_add_or_double_affine
+            // handles identity and equal operands, and permits out == a.
+            unsafe { blst_p1_add_or_double_affine(acc, acc, sum) };
+        }
+        let mut combination = blst_p1::default();
+        // SAFETY: all operands are valid blst_p1 values (identity included).
+        unsafe {
+            blst_p1_double(&mut combination, &twos);
+            blst_p1_add_or_double(&mut combination, &combination, &ones);
+            if !blst_p1_in_g1(&combination) {
+                return false;
+            }
+        }
+    }
+    true
+}
+
+/// A pending affine addition or doubling. Operands are copied out when the
+/// pass is scheduled so results can be written back without aliasing hazards.
+struct Arith {
+    a: blst_p1_affine,
+    b: blst_p1_affine,
+    out: usize,
+    double: bool,
+}
+
+/// Sum `points` into `num_buckets` buckets given by `ids` (each id less than
+/// `num_buckets`), returning one affine sum per bucket (the identity for empty
+/// buckets).
+///
+/// Each pass pairs up the remaining points within every bucket and completes
+/// all pairs with a single shared field inversion (Montgomery's trick), so an
+/// addition costs about six field multiplications instead of an inversion.
+fn sum_buckets(points: &[blst_p1_affine], ids: &[u8], num_buckets: usize) -> Vec<blst_p1_affine> {
+    debug_assert_eq!(points.len(), ids.len());
+    // Counting sort the points into contiguous per-bucket runs.
+    let mut lens = vec![0usize; num_buckets];
+    for &id in ids {
+        lens[id as usize] += 1;
+    }
+    let mut starts = vec![0usize; num_buckets];
+    let mut acc = 0;
+    for (start, len) in starts.iter_mut().zip(&lens) {
+        *start = acc;
+        acc += len;
+    }
+    let mut buf = vec![blst_p1_affine::default(); points.len()];
+    let mut cursor = starts.clone();
+    for (point, &id) in points.iter().zip(ids) {
+        buf[cursor[id as usize]] = *point;
+        cursor[id as usize] += 1;
+    }
+
+    // Halve every bucket per pass until each holds at most one point. Copies
+    // (identity-involved pairs and odd leftovers) are deferred alongside the
+    // arithmetic so all reads complete before any write.
+    let mut arith: Vec<Arith> = Vec::new();
+    let mut denominators: Vec<blst_fp> = Vec::new();
+    let mut copies: Vec<(usize, blst_p1_affine)> = Vec::new();
+    loop {
+        arith.clear();
+        denominators.clear();
+        copies.clear();
+        for b in 0..num_buckets {
+            let (start, len) = (starts[b], lens[b]);
+            if len < 2 {
+                continue;
+            }
+            for k in 0..len / 2 {
+                let a = buf[start + 2 * k];
+                let c = buf[start + 2 * k + 1];
+                let out = start + k;
+                if affine_is_inf(&a) {
+                    copies.push((out, c));
+                } else if affine_is_inf(&c) {
+                    copies.push((out, a));
+                } else if a.x.l == c.x.l {
+                    // Same x: on the curve y is determined up to sign, so this
+                    // is either P + (-P) = identity or a doubling.
+                    let two_y = fp_add(&a.y, &c.y);
+                    if two_y.l == [0u64; 6] {
+                        copies.push((out, blst_p1_affine::default()));
+                    } else {
+                        // y_a == y_c != 0, so two_y = 2*y_a is the doubling
+                        // denominator. (y == 0 cannot occur: the group order
+                        // h * r is odd, so the curve has no 2-torsion.)
+                        denominators.push(two_y);
+                        arith.push(Arith {
+                            a,
+                            b: c,
+                            out,
+                            double: true,
+                        });
+                    }
+                } else {
+                    denominators.push(fp_sub(&c.x, &a.x));
+                    arith.push(Arith {
+                        a,
+                        b: c,
+                        out,
+                        double: false,
+                    });
+                }
+            }
+            if len % 2 == 1 {
+                copies.push((start + len / 2, buf[start + len - 1]));
+            }
+            lens[b] = len.div_ceil(2);
+        }
+        if arith.is_empty() && copies.is_empty() {
+            break;
+        }
+        batch_invert(&mut denominators);
+        for (op, inverse) in arith.iter().zip(&denominators) {
+            // Affine chord/tangent formulas (curve coefficient a = 0):
+            //   add:    lambda = (y_b - y_a) / (x_b - x_a)
+            //   double: lambda = 3 * x_a^2 / (2 * y_a)
+            //   x_out = lambda^2 - x_a - x_b;  y_out = lambda*(x_a - x_out) - y_a
+            let lambda = if op.double {
+                let x_sq = fp_sqr(&op.a.x);
+                fp_mul(&fp_add(&fp_add(&x_sq, &x_sq), &x_sq), inverse)
+            } else {
+                fp_mul(&fp_sub(&op.b.y, &op.a.y), inverse)
+            };
+            let x_out = fp_sub(&fp_sub(&fp_sqr(&lambda), &op.a.x), &op.b.x);
+            let y_out = fp_sub(&fp_mul(&lambda, &fp_sub(&op.a.x, &x_out)), &op.a.y);
+            buf[op.out] = blst_p1_affine { x: x_out, y: y_out };
+        }
+        for &(out, value) in &copies {
+            buf[out] = value;
+        }
+    }
+
+    (0..num_buckets)
+        .map(|b| {
+            if lens[b] == 0 {
+                blst_p1_affine::default()
+            } else {
+                buf[starts[b]]
+            }
+        })
+        .collect()
+}
+
+/// Replace every element with its inverse using Montgomery's trick: one field
+/// inversion plus three multiplications per element.
+///
+/// Every element MUST be nonzero (`blst_fp_inverse(0) == 0` would silently
+/// poison the shared product); [`sum_buckets`]'s classification guarantees it.
+fn batch_invert(values: &mut [blst_fp]) {
+    if values.is_empty() {
+        return;
+    }
+    // prefix[i] = values[0] * ... * values[i]
+    let mut prefix = Vec::with_capacity(values.len());
+    let mut acc = values[0];
+    prefix.push(acc);
+    for value in &values[1..] {
+        acc = fp_mul(&acc, value);
+        prefix.push(acc);
+    }
+    // inverse = (values[0] * ... * values[i])^-1, walking i down from the end.
+    let mut inverse = blst_fp::default();
+    // SAFETY: both pointers reference valid blst_fp values.
+    unsafe { blst_fp_inverse(&mut inverse, &acc) };
+    for i in (1..values.len()).rev() {
+        let value_inverse = fp_mul(&inverse, &prefix[i - 1]);
+        inverse = fp_mul(&inverse, &values[i]);
+        values[i] = value_inverse;
+    }
+    values[0] = inverse;
+}
+
+fn affine_is_inf(p: &blst_p1_affine) -> bool {
+    // SAFETY: p is a valid blst_p1_affine.
+    unsafe { blst_p1_affine_is_inf(p) }
+}
+
+fn fp_add(a: &blst_fp, b: &blst_fp) -> blst_fp {
+    let mut out = blst_fp::default();
+    // SAFETY: all pointers reference valid blst_fp values.
+    unsafe { blst_fp_add(&mut out, a, b) };
+    out
+}
+
+fn fp_sub(a: &blst_fp, b: &blst_fp) -> blst_fp {
+    let mut out = blst_fp::default();
+    // SAFETY: all pointers reference valid blst_fp values.
+    unsafe { blst_fp_sub(&mut out, a, b) };
+    out
+}
+
+fn fp_mul(a: &blst_fp, b: &blst_fp) -> blst_fp {
+    let mut out = blst_fp::default();
+    // SAFETY: all pointers reference valid blst_fp values.
+    unsafe { blst_fp_mul(&mut out, a, b) };
+    out
+}
+
+fn fp_sqr(a: &blst_fp) -> blst_fp {
+    let mut out = blst_fp::default();
+    // SAFETY: all pointers reference valid blst_fp values.
+    unsafe { blst_fp_sqr(&mut out, a) };
+    out
 }
 
 /// A stream of uniform trits over a cryptographic RNG.
@@ -132,9 +409,10 @@ pub fn batch_in_g1(
 /// (its base-3 digits); bytes at or above 243 are rejected so the trits stay
 /// exactly uniform. Bytes are drawn in bulk to amortize RNG calls.
 ///
-/// Exact uniformity is load-bearing: at 81 rounds the margin over `2^-128` is
-/// only `0.38` bits, and the bias of a `byte % 3` shortcut (max probability
-/// `86/256`) would drop the total to `127.5` bits, below the target.
+/// Exact uniformity is load-bearing: the soundness bound leaves a fraction of
+/// a bit of margin over the security target, and the bias of a `byte % 3`
+/// shortcut (max probability `86/256`) compounds across every coefficient,
+/// dropping the total below it.
 struct Trits<'a, R: CryptoRng> {
     rng: &'a mut R,
     buffer: [u8; 256],
@@ -168,6 +446,19 @@ impl<'a, R: CryptoRng> Trits<'a, R> {
         trit
     }
 
+    /// Return a uniform bucket id in `[0, 3^m)` — the next `m` trits as base-3
+    /// digits. `m` must be at most 5.
+    fn bucket(&mut self, m: u32) -> u8 {
+        debug_assert!((1..=5).contains(&m));
+        let mut id = 0u8;
+        let mut weight = 1u8;
+        for _ in 0..m {
+            id += weight * self.next();
+            weight = weight.wrapping_mul(3);
+        }
+        id
+    }
+
     /// Return the next byte strictly below 243, refilling the buffer as needed.
     fn next_byte(&mut self) -> u8 {
         loop {
@@ -193,9 +484,14 @@ mod tests {
     use commonware_math::algebra::{Additive, CryptoGroup, Random};
     use commonware_parallel::Sequential;
     use commonware_utils::test_rng;
+    use rand_core::Rng;
 
     /// Standard soundness target for the tests.
     const SECURITY: usize = 128;
+
+    /// A batch size comfortably above the per-point fallback threshold, so the
+    /// batched path is exercised.
+    const LARGE: usize = 1000;
 
     fn in_subgroup_point(rng: &mut impl CryptoRng) -> G1 {
         G1::generator() * &Scalar::random(rng)
@@ -220,14 +516,183 @@ mod tests {
         }
     }
 
+    /// Assert that [`sum_buckets`] agrees with naive per-bucket G1 addition.
+    fn assert_sums_match(points: &[G1], ids: &[u8], num_buckets: usize) {
+        let affine = G1::batch_to_affine(points);
+        let sums = sum_buckets(&affine, ids, num_buckets);
+        assert_eq!(sums.len(), num_buckets);
+        for (b, got) in sums.iter().enumerate() {
+            let mut expected = G1::zero();
+            for (point, &id) in points.iter().zip(ids) {
+                if id as usize == b {
+                    expected += point;
+                }
+            }
+            let expected = G1::batch_to_affine(&[expected]);
+            assert_eq!(
+                affine_is_inf(got),
+                affine_is_inf(&expected[0]),
+                "bucket {b} identity mismatch"
+            );
+            if !affine_is_inf(got) {
+                assert_eq!(got.x.l, expected[0].x.l, "bucket {b} x mismatch");
+                assert_eq!(got.y.l, expected[0].y.l, "bucket {b} y mismatch");
+            }
+        }
+    }
+
     #[test]
-    fn round_count_matches_security() {
-        assert_eq!(rounds_for_security(128), 81);
-        assert_eq!(rounds_for_security(0), 0);
-        // 3^r >= 2^security must hold at the returned r.
-        for security in [1usize, 40, 80, 100, 128, 200, 256] {
-            let rounds = rounds_for_security(security);
-            assert!(f64::from(rounds as u32) * 3f64.log2() >= security as f64);
+    fn plan_meets_security() {
+        assert_eq!(combinations_for_security(128), 81);
+        assert_eq!(combinations_for_security(0), 0);
+        for security in [1usize, 40, 80, 100, 128, 256] {
+            let combinations = combinations_for_security(security);
+            // 3^t >= 2^security must hold at the returned t.
+            assert!(f64::from(combinations as u32) * 3f64.log2() >= security as f64);
+            // Every plan must cover the required number of combinations.
+            for n in [0usize, 1, 50, 130, 200, 1000, 6000, 100_000] {
+                if let Some((m, rounds)) = plan(n, combinations) {
+                    assert!((1..=5).contains(&m));
+                    assert!(rounds * m as usize >= combinations, "n={n} s={security}");
+                }
+            }
+        }
+        // Small batches fall back to per-point checking; large ones batch.
+        assert!(plan(1, 81).is_none());
+        assert!(plan(50, 81).is_none());
+        assert!(plan(6000, 81).is_some());
+    }
+
+    #[test]
+    fn bucket_ids_are_in_range() {
+        let mut rng = test_rng();
+        let mut trits = Trits::new(&mut rng);
+        for m in 1..=5u32 {
+            for _ in 0..1000 {
+                assert!((trits.bucket(m) as usize) < 3usize.pow(m));
+            }
+        }
+    }
+
+    #[test]
+    fn bucket_ids_are_roughly_uniform() {
+        let mut rng = test_rng();
+        let mut trits = Trits::new(&mut rng);
+        let mut counts = [0usize; 9];
+        for _ in 0..9000 {
+            counts[trits.bucket(2) as usize] += 1;
+        }
+        // Expected 1000 per id; the window is ~6.7 standard deviations wide.
+        for &count in &counts {
+            assert!((800..1200).contains(&count), "{counts:?}");
+        }
+    }
+
+    #[test]
+    fn round_isolates_each_combination() {
+        // A round's soundness multiplies across its m combinations only if the
+        // combine actually wires digit j of the bucket index to combination j.
+        // Placing a single bad point at a chosen bucket makes combination j's
+        // cofactor part exactly digit_j(bucket) * T, so each bucket id below
+        // deterministically isolates one digit position and value; a wiring
+        // bug (a stuck or truncated digit) accepts one of the rejecting cases.
+        let mut rng = test_rng();
+        const M: u32 = 5;
+        let mut points: Vec<G1> = (0..300).map(|_| in_subgroup_point(&mut rng)).collect();
+        let bad_index = points.len();
+        points.push(off_subgroup_point(&mut rng));
+        let affine = G1::batch_to_affine(&points);
+        // Good points are spread arbitrarily; their in-subgroup parts cannot
+        // mask a cofactor part in any combination.
+        let mut ids: Vec<u8> = (0..points.len()).map(|i| (i % 243) as u8).collect();
+        // Vector 0 assigns the bad point coefficient 0 in every combination,
+        // so the round must accept.
+        ids[bad_index] = 0;
+        assert!(round_in_g1(&affine, &ids, M));
+        // Any nonzero vector leaves a nonzero digit in some combination, which
+        // must reject: 3^j isolates digit j with value 1; 2 and 162 = 2 * 3^4
+        // cover value 2 at the lowest and highest positions.
+        for v in [1u8, 2, 3, 9, 27, 81, 162] {
+            ids[bad_index] = v;
+            assert!(
+                !round_in_g1(&affine, &ids, M),
+                "bad point at bucket {v} escaped"
+            );
+        }
+    }
+
+    #[test]
+    fn batch_invert_matches_single() {
+        let mut rng = test_rng();
+        let points: Vec<G1> = (0..17).map(|_| in_subgroup_point(&mut rng)).collect();
+        let affine = G1::batch_to_affine(&points);
+        for take in [0usize, 1, 2, 17] {
+            let original: Vec<blst_fp> = affine.iter().take(take).map(|p| p.x).collect();
+            let mut inverted = original.clone();
+            batch_invert(&mut inverted);
+            // value * inverse must be the same element (one) for every entry,
+            // and multiplying by it must be the identity map.
+            if take == 0 {
+                continue;
+            }
+            let one = fp_mul(&original[0], &inverted[0]);
+            for (value, inverse) in original.iter().zip(&inverted) {
+                assert_eq!(fp_mul(value, inverse).l, one.l);
+                assert_eq!(fp_mul(&one, value).l, value.l);
+            }
+        }
+    }
+
+    #[test]
+    fn sum_buckets_handles_special_pairs() {
+        let mut rng = test_rng();
+        let p = in_subgroup_point(&mut rng);
+        let q = off_subgroup_point(&mut rng);
+        let cases: Vec<(Vec<G1>, Vec<u8>, usize)> = vec![
+            // Cancelling pair produces the identity.
+            (vec![p, -p], vec![0, 0], 1),
+            // Duplicates force the doubling path.
+            (vec![p, p], vec![0, 0], 1),
+            (vec![q, q, q], vec![0, 0, 0], 1),
+            // Identity inputs and identity-only buckets.
+            (vec![p, G1::zero()], vec![0, 0], 1),
+            (vec![G1::zero(), G1::zero()], vec![0, 0], 1),
+            // Cancellation in a later pass: (p+q) + -(p+q).
+            (vec![p, q, -p, -q], vec![0, 0, 0, 0], 1),
+            // Odd leftovers and cancellation combined.
+            (vec![p, -p, p], vec![0, 0, 0], 1),
+            // Singleton with empty buckets around it.
+            (vec![p], vec![1], 3),
+        ];
+        for (points, ids, num_buckets) in cases {
+            assert_sums_match(&points, &ids, num_buckets);
+        }
+    }
+
+    #[test]
+    fn sum_buckets_matches_naive() {
+        let mut rng = test_rng();
+        for round in 0..20usize {
+            let n = 1 + (round * 37) % 150;
+            let num_buckets = [1usize, 2, 3, 9, 27, 243][round % 6];
+            let mut points: Vec<G1> = Vec::with_capacity(n);
+            for i in 0..n {
+                let point = match i % 7 {
+                    0 => G1::zero(),
+                    1 | 2 => off_subgroup_point(&mut rng),
+                    3 if i > 0 => -points[i - 1],
+                    4 if i > 1 => points[i - 2],
+                    _ => in_subgroup_point(&mut rng),
+                };
+                points.push(point);
+            }
+            let mut id_bytes = vec![0u8; n];
+            rng.fill_bytes(&mut id_bytes);
+            let ids: Vec<u8> = id_bytes
+                .iter()
+                .map(|&b| (b as usize % num_buckets) as u8)
+                .collect();
+            assert_sums_match(&points, &ids, num_buckets);
         }
     }
 
@@ -237,30 +702,20 @@ mod tests {
     }
 
     #[test]
-    fn small_msm_matches_naive_combination() {
+    fn valid_points_are_accepted() {
         let mut rng = test_rng();
-        let points: Vec<G1> = (0..20).map(|_| in_subgroup_point(&mut rng)).collect();
-        let affine = G1::batch_to_affine(&points);
-        let coefficients: Vec<u8> = (0..points.len()).map(|i| (i % 3) as u8).collect();
-
-        let mut expected = G1::zero();
-        for (point, &c) in points.iter().zip(&coefficients) {
-            expected += &(*point * &Scalar::from(u64::from(c)));
-        }
-        assert_eq!(G1::small_msm(&affine, &coefficients, 2), expected);
+        // A large batch exercises the bucketed path; small ones the fallback.
+        let points: Vec<G1> = (0..LARGE).map(|_| in_subgroup_point(&mut rng)).collect();
+        assert!(batch_in_g1(&points, SECURITY, &Sequential, &mut rng));
+        assert!(batch_in_g1(&points[..64], SECURITY, &Sequential, &mut rng));
+        assert!(batch_in_g1(&points[..1], SECURITY, &Sequential, &mut rng));
+        assert!(batch_in_g1(&[G1::zero()], SECURITY, &Sequential, &mut rng));
     }
 
     #[test]
-    fn valid_points_are_accepted() {
-        let mut rng = test_rng();
-        let points: Vec<G1> = (0..64).map(|_| in_subgroup_point(&mut rng)).collect();
-        for point in &points {
-            assert!(point.in_subgroup());
-        }
-        assert!(batch_in_g1(&points, SECURITY, &Sequential, &mut rng));
-        // A single valid point, and the identity, are both accepted.
-        assert!(batch_in_g1(&points[..1], SECURITY, &Sequential, &mut rng));
-        assert!(batch_in_g1(&[G1::zero()], SECURITY, &Sequential, &mut rng));
+    fn all_identity_batch_is_accepted() {
+        let points = vec![G1::zero(); LARGE];
+        assert!(batch_in_g1(&points, SECURITY, &Sequential, &mut test_rng()));
     }
 
     #[test]
@@ -273,10 +728,31 @@ mod tests {
     }
 
     #[test]
-    fn one_bad_point_in_a_batch_is_rejected() {
+    fn one_bad_point_in_a_large_batch_is_rejected() {
         let mut rng = test_rng();
-        let mut points: Vec<G1> = (0..32).map(|_| in_subgroup_point(&mut rng)).collect();
-        points.insert(17, off_subgroup_point(&mut rng));
+        let mut points: Vec<G1> = (0..LARGE).map(|_| in_subgroup_point(&mut rng)).collect();
+        points[LARGE / 2] = off_subgroup_point(&mut rng);
+        assert!(!batch_in_g1(&points, SECURITY, &Sequential, &mut rng));
+    }
+
+    #[test]
+    fn cancelling_bad_pair_is_rejected() {
+        let mut rng = test_rng();
+        // Two bad points whose cofactor parts cancel: they escape a round only
+        // by drawing identical coefficient vectors.
+        let mut points: Vec<G1> = (0..LARGE).map(|_| in_subgroup_point(&mut rng)).collect();
+        let bad = off_subgroup_point(&mut rng);
+        points[100] = bad;
+        points[200] = -bad;
+        assert!(!batch_in_g1(&points, SECURITY, &Sequential, &mut rng));
+    }
+
+    #[test]
+    fn repeated_bad_point_is_rejected() {
+        let mut rng = test_rng();
+        let bad = off_subgroup_point(&mut rng);
+        // Many duplicates of one bad point stress same-bucket doubling chains.
+        let points = vec![bad; LARGE];
         assert!(!batch_in_g1(&points, SECURITY, &Sequential, &mut rng));
     }
 
@@ -285,19 +761,17 @@ mod tests {
         use commonware_parallel::Rayon;
         use core::num::NonZeroUsize;
         let mut rng = test_rng();
-        // Large enough to exceed the per-point fallback and exercise the
-        // adaptive strategy's parallel path.
-        let mut points: Vec<G1> = (0..400).map(|_| in_subgroup_point(&mut rng)).collect();
         let rayon = Rayon::new(NonZeroUsize::new(4).unwrap()).unwrap();
+
+        // Large batch: the batched path, serial and parallel, must agree.
+        let mut points: Vec<G1> = (0..LARGE).map(|_| in_subgroup_point(&mut rng)).collect();
         assert!(batch_in_g1(&points, SECURITY, &rayon, &mut rng));
         assert!(batch_in_g1(&points, SECURITY, &Sequential, &mut rng));
-
-        points[123] = off_subgroup_point(&mut rng);
+        points[LARGE / 3] = off_subgroup_point(&mut rng);
         assert!(!batch_in_g1(&points, SECURITY, &rayon, &mut rng));
         assert!(!batch_in_g1(&points, SECURITY, &Sequential, &mut rng));
 
-        // Small batches take the per-point fallback, which also runs through the
-        // strategy; a parallel strategy must handle it correctly too.
+        // Small batch: the per-point fallback also runs through the strategy.
         let mut small: Vec<G1> = (0..50).map(|_| in_subgroup_point(&mut rng)).collect();
         assert!(batch_in_g1(&small, SECURITY, &rayon, &mut rng));
         small[7] = off_subgroup_point(&mut rng);
@@ -322,6 +796,61 @@ mod tests {
                 batch_in_g1(&points, SECURITY, &Sequential, &mut rng),
                 all_valid
             );
+        }
+    }
+
+    /// Stage gate: isolated accumulator throughput. Run with:
+    /// `cargo test -p commonware-cryptography --release --features bls12381 \
+    ///   subgroup::tests::measure_accumulator -- --ignored --nocapture`
+    #[test]
+    #[ignore = "manual benchmark"]
+    fn measure_accumulator() {
+        use std::time::Instant;
+        let mut rng = test_rng();
+        for n in [1000usize, 6000] {
+            let points: Vec<G1> = (0..n).map(|_| in_subgroup_point(&mut rng)).collect();
+            let affine = G1::batch_to_affine(&points);
+            let mut ids = vec![0u8; n];
+            rng.fill_bytes(&mut ids);
+            for num_buckets in [27usize, 81, 243] {
+                for id in &mut ids {
+                    *id %= num_buckets as u8;
+                }
+                let reps = 50;
+                let start = Instant::now();
+                for _ in 0..reps {
+                    std::hint::black_box(sum_buckets(&affine, &ids, num_buckets));
+                }
+                let per_point = start.elapsed().as_nanos() as f64 / (reps * n) as f64;
+                println!("n={n} buckets={num_buckets} {per_point:.0} ns/point");
+            }
+        }
+    }
+
+    /// End-to-end timing across sizes. Run with:
+    /// `cargo test -p commonware-cryptography --release --features bls12381 \
+    ///   subgroup::tests::measure_scheme -- --ignored --nocapture`
+    #[test]
+    #[ignore = "manual benchmark"]
+    fn measure_scheme() {
+        use commonware_parallel::Rayon;
+        use std::{thread::available_parallelism, time::Instant};
+        let threads = available_parallelism().unwrap();
+        let rayon = Rayon::new(threads).unwrap();
+        println!("threads = {threads}");
+        for n in [200usize, 1000, 6000] {
+            let mut rng = test_rng();
+            let points: Vec<G1> = (0..n).map(|_| in_subgroup_point(&mut rng)).collect();
+            println!("n={n} plan={:?}", plan(n, combinations_for_security(128)));
+            let start = Instant::now();
+            assert!(points.iter().all(G1::in_subgroup));
+            println!("n={n} per_point_serial = {:?}", start.elapsed());
+            let start = Instant::now();
+            assert!(batch_in_g1(&points, 128, &Sequential, &mut test_rng()));
+            println!("n={n} batch_serial    = {:?}", start.elapsed());
+            let start = Instant::now();
+            assert!(batch_in_g1(&points, 128, &rayon, &mut test_rng()));
+            println!("n={n} batch_parallel  = {:?}", start.elapsed());
         }
     }
 }

--- a/cryptography/src/bls12381/primitives/subgroup.rs
+++ b/cryptography/src/bls12381/primitives/subgroup.rs
@@ -38,6 +38,7 @@
 use super::group::G1;
 #[cfg(not(feature = "std"))]
 use alloc::{vec, vec::Vec};
+use commonware_parallel::Strategy;
 use rand_core::CryptoRng;
 
 /// One thousand times a strict lower bound on `log2(3)`.
@@ -66,8 +67,18 @@ pub const fn rounds_for_security(security: usize) -> usize {
 /// `rng` must be a cryptographically secure source the prover cannot predict:
 /// the coefficients are the verifier's private randomness, exactly as in a
 /// batched signature check.
+///
+/// The independent rounds are run through `strategy`; an adaptive strategy such
+/// as [`commonware_parallel::Rayon`] runs them serially for small inputs and
+/// across threads once the work is large enough. Pass
+/// [`commonware_parallel::Sequential`] to stay single-threaded.
 #[must_use]
-pub fn batch_in_g1(points: &[G1], security: usize, rng: &mut impl CryptoRng) -> bool {
+pub fn batch_in_g1(
+    points: &[G1],
+    security: usize,
+    strategy: &impl Strategy,
+    rng: &mut impl CryptoRng,
+) -> bool {
     let rounds = rounds_for_security(security);
     // Batching pays a fixed cost of one subgroup check per round regardless of
     // the input size, so for few points the exact per-point path is cheaper.
@@ -77,18 +88,20 @@ pub fn batch_in_g1(points: &[G1], security: usize, rng: &mut impl CryptoRng) -> 
     // One shared inversion converts every point to affine; the per-round
     // combinations then reuse them.
     let affine = G1::batch_to_affine(points);
-    let mut coefficients = vec![0u8; points.len()];
+    // The RNG is sequential, so draw every round's coefficients up front; the
+    // rounds themselves are independent and run through the strategy.
     let mut trits = Trits::new(rng);
-    for _ in 0..rounds {
-        for coefficient in &mut coefficients {
-            *coefficient = trits.next();
-        }
-        // Two-bit MSM: coefficients are 0, 1, or 2.
-        if !G1::small_msm(&affine, &coefficients, 2).in_subgroup() {
-            return false;
-        }
-    }
-    true
+    let coefficient_sets: Vec<Vec<u8>> = (0..rounds)
+        .map(|_| (0..points.len()).map(|_| trits.next()).collect())
+        .collect();
+    // Each round is a two-bit MSM over `points.len()` points, so weight the
+    // per-round cost by that size for the adaptive serial/parallel choice.
+    strategy
+        .map_collect_vec_with_multiplier(coefficient_sets.iter(), points.len(), |coefficients| {
+            G1::small_msm(&affine, coefficients, 2).in_subgroup()
+        })
+        .into_iter()
+        .all(|in_subgroup| in_subgroup)
 }
 
 /// A stream of uniform trits over a cryptographic RNG.
@@ -152,6 +165,7 @@ mod tests {
     use crate::bls12381::primitives::group::{G1, Scalar};
     use commonware_codec::FixedSize;
     use commonware_math::algebra::{Additive, CryptoGroup, Random};
+    use commonware_parallel::Sequential;
     use commonware_utils::test_rng;
 
     /// Standard soundness target for the tests.
@@ -193,7 +207,7 @@ mod tests {
 
     #[test]
     fn empty_batch_is_accepted() {
-        assert!(batch_in_g1(&[], SECURITY, &mut test_rng()));
+        assert!(batch_in_g1(&[], SECURITY, &Sequential, &mut test_rng()));
     }
 
     #[test]
@@ -217,10 +231,10 @@ mod tests {
         for point in &points {
             assert!(point.in_subgroup());
         }
-        assert!(batch_in_g1(&points, SECURITY, &mut rng));
+        assert!(batch_in_g1(&points, SECURITY, &Sequential, &mut rng));
         // A single valid point, and the identity, are both accepted.
-        assert!(batch_in_g1(&points[..1], SECURITY, &mut rng));
-        assert!(batch_in_g1(&[G1::zero()], SECURITY, &mut rng));
+        assert!(batch_in_g1(&points[..1], SECURITY, &Sequential, &mut rng));
+        assert!(batch_in_g1(&[G1::zero()], SECURITY, &Sequential, &mut rng));
     }
 
     #[test]
@@ -229,7 +243,7 @@ mod tests {
         let bad = off_subgroup_point(&mut rng);
         assert!(!bad.in_subgroup());
         // The exact and batched checks agree on the single bad point.
-        assert!(!batch_in_g1(&[bad], SECURITY, &mut rng));
+        assert!(!batch_in_g1(&[bad], SECURITY, &Sequential, &mut rng));
     }
 
     #[test]
@@ -237,7 +251,24 @@ mod tests {
         let mut rng = test_rng();
         let mut points: Vec<G1> = (0..32).map(|_| in_subgroup_point(&mut rng)).collect();
         points.insert(17, off_subgroup_point(&mut rng));
-        assert!(!batch_in_g1(&points, SECURITY, &mut rng));
+        assert!(!batch_in_g1(&points, SECURITY, &Sequential, &mut rng));
+    }
+
+    #[test]
+    fn parallel_strategy_agrees_with_serial() {
+        use commonware_parallel::Rayon;
+        use core::num::NonZeroUsize;
+        let mut rng = test_rng();
+        // Large enough to exceed the per-point fallback and exercise the
+        // adaptive strategy's parallel path.
+        let mut points: Vec<G1> = (0..400).map(|_| in_subgroup_point(&mut rng)).collect();
+        let rayon = Rayon::new(NonZeroUsize::new(4).unwrap()).unwrap();
+        assert!(batch_in_g1(&points, SECURITY, &rayon, &mut rng));
+        assert!(batch_in_g1(&points, SECURITY, &Sequential, &mut rng));
+
+        points[123] = off_subgroup_point(&mut rng);
+        assert!(!batch_in_g1(&points, SECURITY, &rayon, &mut rng));
+        assert!(!batch_in_g1(&points, SECURITY, &Sequential, &mut rng));
     }
 
     #[test]
@@ -254,7 +285,10 @@ mod tests {
                 })
                 .collect();
             let all_valid = points.iter().all(G1::in_subgroup);
-            assert_eq!(batch_in_g1(&points, SECURITY, &mut rng), all_valid);
+            assert_eq!(
+                batch_in_g1(&points, SECURITY, &Sequential, &mut rng),
+                all_valid
+            );
         }
     }
 }

--- a/cryptography/src/bls12381/primitives/subgroup.rs
+++ b/cryptography/src/bls12381/primitives/subgroup.rs
@@ -984,7 +984,7 @@ fn prefetch(slots: &[blst_p1_affine], index: usize) {
         // the address, and changes nothing a program can observe apart from
         // the cache; the index is in range for the slice regardless. The
         // intrinsic wrapping this instruction is still unstable, so it is
-        // written out — `readonly` matches the memory clobber the x86 arm's
+        // written out; `readonly` matches the memory clobber the x86 arm's
         // intrinsic carries.
         unsafe {
             core::arch::asm!(

--- a/cryptography/src/bls12381/primitives/subgroup.rs
+++ b/cryptography/src/bls12381/primitives/subgroup.rs
@@ -23,23 +23,32 @@
 //!
 //! Write each point as its in-subgroup part plus a "cofactor part" living in the
 //! group of order `h` (the G1 cofactor). `Q` lies in G1 exactly when the
-//! coefficient-weighted sum of the cofactor parts vanishes. If some `P_j` has a
-//! nonzero cofactor part, consider the smallest prime `p | h` where it is
-//! nonzero. Because the three coefficients `{0, 1, 2}` take three distinct
-//! values modulo any prime `p >= 3` (and are uniform modulo `3`), the weighted
-//! sum hits the single value `0` in that component with probability at most
-//! `1/3` per round. So `r` rounds accept a bad point with probability at most
-//! `3^{-r}`, independent of the cofactor's factorization.
+//! coefficient-weighted sum of the cofactor parts vanishes. The G1 cofactor
+//! `h = 3 * (11 * 10177 * 859267 * 52437899)^2` is odd, so every nonzero
+//! cofactor part `T` has order at least 3, making `0*T`, `1*T`, and `2*T` three
+//! distinct group elements. Pick any bad point `P_j` (nonzero `T_j`) and
+//! condition on every other coefficient: the round accepts only if `c_j * T_j`
+//! hits the single fixed value `-sum_{i != j} c_i T_i`, and as `c_j` ranges
+//! uniformly over `{0, 1, 2}` it takes three distinct values, so at most one
+//! works — probability at most `1/3`, for any number of bad points and any
+//! structure of the cofactor group. `r` rounds accept with probability at most
+//! `3^{-r}`.
 //!
-//! For BLS12-381 the G1 cofactor's smallest prime factor is `3`, so for a
-//! single combination per round this `1/3` bound is tight: larger coefficients
-//! cannot lower a round's error, only make it more expensive. This is not the
-//! only design point, though. Partitioning the points into `B` buckets and
-//! checking each bucket sum separately lowers the per-round error to `1/B`
-//! (needing fewer rounds), at the cost of `B` subgroup checks per round instead
-//! of one; which is faster depends on the relative cost of a subgroup check and
-//! a point summation. This module takes the single-combination approach, whose
-//! one fast check per round pairs well with blst's endomorphism-based test.
+//! The bound requires an odd cofactor: an order-2 part `T` has `2*T = 0`, so
+//! `c * T` escapes with probability `2/3` per round. A curve whose cofactor is
+//! even (e.g. BLS12-377 G1, with `2^92 | h`) cannot use this scheme as-is.
+//!
+//! For BLS12-381 the `1/3` bound is also tight (a lone bad point escapes a
+//! round exactly when `c_j = 0`, and `3 | h`), so for a single combination per
+//! round larger coefficients cannot lower the error, only make each round more
+//! expensive. This is not the only design point, though. Partitioning the
+//! points into `B` buckets and checking each bucket sum separately lowers the
+//! per-round error to `1/B` (needing fewer rounds), at the cost of `B` subgroup
+//! checks per round instead of one; which is faster depends on the relative
+//! cost of a subgroup check and a point summation. This module takes the
+//! single-combination approach, whose one fast check per round pairs well with
+//! blst's endomorphism-based test. See `cryptography/BATCHED_SUBGROUP.md` for
+//! the full comparison.
 
 use super::group::G1;
 #[cfg(not(feature = "std"))]
@@ -122,6 +131,10 @@ pub fn batch_in_g1(
 /// Each accepted byte below `3^5 = 243` yields five independent uniform trits
 /// (its base-3 digits); bytes at or above 243 are rejected so the trits stay
 /// exactly uniform. Bytes are drawn in bulk to amortize RNG calls.
+///
+/// Exact uniformity is load-bearing: at 81 rounds the margin over `2^-128` is
+/// only `0.38` bits, and the bias of a `byte % 3` shortcut (max probability
+/// `86/256`) would drop the total to `127.5` bits, below the target.
 struct Trits<'a, R: CryptoRng> {
     rng: &'a mut R,
     buffer: [u8; 256],

--- a/cryptography/src/bls12381/primitives/subgroup.rs
+++ b/cryptography/src/bls12381/primitives/subgroup.rs
@@ -856,10 +856,10 @@ impl Pending {
     /// denominator.
     #[inline(always)]
     fn push(&mut self, slot: u32, second: u32, denominator: blst_fp) {
-        let product = match self.prefix.last() {
-            Some(running) => fp_mul(running, &denominator),
-            None => denominator,
-        };
+        let product = self
+            .prefix
+            .last()
+            .map_or(denominator, |running| fp_mul(running, &denominator));
         self.prefix.push(product);
         self.jobs.push((slot, second));
         self.denominators.push(denominator);

--- a/cryptography/src/bls12381/primitives/subgroup.rs
+++ b/cryptography/src/bls12381/primitives/subgroup.rs
@@ -1422,6 +1422,49 @@ mod tests {
         // An all-identity batch converts to nothing.
         assert!(to_affine(&[G1::zero()]).is_empty());
         assert!(to_affine(&[]).is_empty());
+
+        // Decoded points are already normalized and take the fast path; mixing
+        // them with projective ones must keep the shared inversion in step.
+        let mixed: Vec<G1> = points
+            .iter()
+            .enumerate()
+            .map(|(index, point)| {
+                // The wire format has no infinity that decodes back, so the
+                // identities in the batch stay as they are.
+                if index % 3 == 0 && point != &G1::zero() {
+                    G1::read_unchecked(&mut point.encode().as_ref()).expect("decodes")
+                } else {
+                    *point
+                }
+            })
+            .collect();
+        let expected: Vec<blst_p1_affine> = G1::batch_to_affine(&mixed)
+            .into_iter()
+            .filter(|point| !affine_is_inf(point))
+            .collect();
+        let got = to_affine(&mixed);
+        assert_eq!(got.len(), expected.len());
+        for (got, expected) in got.iter().zip(&expected) {
+            assert_eq!(got.x.l, expected.x.l);
+            assert_eq!(got.y.l, expected.y.l);
+        }
+    }
+
+    #[test]
+    fn decoded_points_are_accepted() {
+        // The batch a caller actually has: points decoded from the wire, which
+        // arrive normalized and so skip the affine conversion's inversion.
+        let mut rng = test_rng();
+        let mut points: Vec<G1> = (0..LARGE)
+            .map(|_| {
+                let point = in_subgroup_point(&mut rng);
+                G1::read_unchecked(&mut point.encode().as_ref()).expect("decodes")
+            })
+            .collect();
+        assert!(points.iter().all(|point| fp_is_one(&point.as_blst_p1().z)));
+        assert!(batch_in_g1(&points, SECURITY, &Sequential, &mut rng));
+        points[LARGE / 4] = off_subgroup_point(&mut rng);
+        assert!(!batch_in_g1(&points, SECURITY, &Sequential, &mut rng));
     }
 
     #[test]

--- a/cryptography/src/bls12381/primitives/subgroup.rs
+++ b/cryptography/src/bls12381/primitives/subgroup.rs
@@ -53,6 +53,16 @@
 //! `3^-m`, and `r` rounds with probability at most `3^{-rm}`. The check uses
 //! `r*m >= ceil(security / log2(3))` total combinations (81 at 128-bit).
 //!
+//! The bound needs no independence between the combinations and the points:
+//! the points are fixed — arbitrarily and adversarially correlated — before
+//! the coefficients are drawn, and the conditioning argument is uniform over
+//! that choice (a cancelling pair achieves exactly `1/3`, never more). What it
+//! does not survive is coefficient reuse across batches or a randomness source
+//! the point-chooser can predict. Larger coefficients would not strengthen a
+//! combination: in a component of order 3 a coefficient acts through its
+//! residue mod 3, so even full-width random weights leave a cancelling pair a
+//! `1/3` escape.
+//!
 //! The bound requires an odd cofactor: an order-2 part `T` has `2*T = 0`, so
 //! `c * T` escapes with probability `2/3` per combination. A curve whose
 //! cofactor is even (e.g. BLS12-377 G1, with `2^92 | h`) cannot use this

--- a/cryptography/src/bls12381/primitives/subgroup.rs
+++ b/cryptography/src/bls12381/primitives/subgroup.rs
@@ -64,12 +64,10 @@
 //! point individually) is a pure performance decision made by a cost model;
 //! soundness holds for every choice.
 //!
-//! What a batch cannot escape is one pass over the points per `log2(3^m)` bits
-//! of soundness (see below), so the cost per point falls only with the
-//! logarithm of the round width — and the width is bounded by what a round's
-//! bucket slots can hold in cache. That is why the speedup over per-point
-//! checking keeps growing with the batch: at `2^-128`, nine passes is the floor,
-//! and the fixed per-round overheads only amortize away as `n` grows.
+//! In this independent-combination construction, one pass buys `log2(3^m)`
+//! bits of soundness (see below). Wider rounds reduce the pass count while
+//! increasing the bucket workspace and combine cost. The planner balances
+//! those costs for each batch; fixed per-round overheads amortize as it grows.
 //!
 //! # Soundness
 //!
@@ -129,6 +127,10 @@ use blst::{
 use commonware_parallel::Strategy;
 use core::mem::{MaybeUninit, size_of};
 use rand_core::CryptoRng;
+
+#[cfg(test)]
+#[path = "subgroup/research.rs"]
+mod research;
 
 /// One thousand times a strict lower bound on `log2(3)`.
 ///

--- a/cryptography/src/bls12381/primitives/subgroup/research.rs
+++ b/cryptography/src/bls12381/primitives/subgroup/research.rs
@@ -1,0 +1,387 @@
+//! Experimental sparse compression. No production caller uses this module.
+//!
+//! See `cryptography/SUBGROUP_RESEARCH.md` for the soundness argument and scope.
+
+use super::*;
+use commonware_math::algebra::{Additive, CryptoGroup};
+use commonware_parallel::Sequential;
+use commonware_utils::test_rng;
+use rand_core::Rng;
+use std::time::{Duration, Instant};
+
+#[path = "research/cycles.rs"]
+mod cycles;
+#[path = "research/effective.rs"]
+mod effective;
+#[path = "research/moments.rs"]
+mod moments;
+#[path = "research/pair.rs"]
+mod pair;
+#[path = "research/primary.rs"]
+mod primary;
+#[path = "research/three.rs"]
+mod three;
+#[path = "research/two.rs"]
+mod two;
+
+const BUCKETS: usize = 1 << 16;
+const PASSES: usize = 4;
+
+fn order_three() -> G1 {
+    let one = G1::generator().as_blst_p1().z;
+    G1::from_blst_p1(blst_p1 {
+        x: blst_fp::default(),
+        y: fp_add(&one, &one),
+        z: one,
+    })
+}
+
+// An on-curve order-eleven fixture, independently checked by descent_bound.py
+// and the partial-filter regression.
+fn order_eleven() -> G1 {
+    let x = [
+        0x19b3e2c8c6bbf59du64,
+        0x3c326b531fc1e639,
+        0xd29200c28624ac60,
+        0x4f251a12908c9b7f,
+        0x735318617f625954,
+        0xcc71cdf03229b1ef,
+    ];
+    let mut encoded = [0u8; 48];
+    for (word, bytes) in x.iter().zip(encoded.chunks_exact_mut(8)) {
+        bytes.copy_from_slice(&word.to_be_bytes());
+    }
+    encoded[0] |= 0x80;
+    G1::read_unchecked(&mut encoded.as_slice()).expect("on-curve order-eleven fixture")
+}
+
+fn benchmark_points(n: usize) -> Vec<G1> {
+    let generator = G1::generator();
+    let one = generator.as_blst_p1().z;
+    let mut point = generator;
+    let projective: Vec<_> = (0..n)
+        .map(|_| {
+            point += &generator;
+            point
+        })
+        .collect();
+    to_affine(&projective)
+        .into_iter()
+        .map(|p| {
+            G1::from_blst_p1(blst_p1 {
+                x: p.x,
+                y: p.y,
+                z: one,
+            })
+        })
+        .collect()
+}
+
+fn draw_distinct_codes(n: usize, mut draw: impl FnMut() -> u64) -> Vec<u64> {
+    // Reject the entire assignment if any two unsigned columns coincide.
+    let mut codes = vec![0u64; n];
+    let mut sorted = vec![0u64; n];
+    loop {
+        for code in &mut codes {
+            *code = draw();
+        }
+        sorted.copy_from_slice(&codes);
+        sorted.sort_unstable();
+        if sorted.windows(2).all(|pair| pair[0] != pair[1]) {
+            return codes;
+        }
+    }
+}
+
+fn draw_ids(n: usize, rng: &mut impl CryptoRng) -> [Vec<u32>; PASSES] {
+    let codes = draw_distinct_codes(n, || rng.next_u64());
+    let mut ids: [Vec<u32>; PASSES] = core::array::from_fn(|_| Vec::with_capacity(n));
+    for code in codes {
+        let signs = rng.next_u32();
+        for (pass, ids) in ids.iter_mut().enumerate() {
+            let bucket = ((code >> (16 * pass)) & 0xffff) as u32;
+            ids.push(bucket | (((signs >> pass) & 1) * ID_NEGATE));
+        }
+    }
+    ids
+}
+
+#[test]
+fn duplicate_signature_redraws_entire_assignment() {
+    let mut words = [7, 7, 99, 2, 3, 4].into_iter();
+    let codes = draw_distinct_codes(3, || words.next().expect("scripted assignment"));
+    assert_eq!(codes, [2, 3, 4]);
+    assert!(words.next().is_none());
+}
+
+fn compress(affine: &[blst_p1_affine], ids: &[Vec<u32>; PASSES]) -> Vec<G1> {
+    let mut round = Round::new(11);
+    round.widen(11);
+    let mut sums = Vec::with_capacity(PASSES * BUCKETS);
+    for ids in ids {
+        sums.extend(compress_round(&mut round, affine, ids));
+    }
+    sums
+}
+
+fn compress_round(round: &mut Round, affine: &[blst_p1_affine], ids: &[u32]) -> Vec<G1> {
+    compress_round_with_buckets(round, affine, ids, BUCKETS)
+}
+
+fn compress_round_with_buckets(
+    round: &mut Round,
+    affine: &[blst_p1_affine],
+    ids: &[u32],
+    buckets: usize,
+) -> Vec<G1> {
+    let mut sums = Vec::with_capacity(buckets);
+    let one = G1::generator().as_blst_p1().z;
+    round.accumulate(affine, ids);
+    for (point, &live) in round.sums[..buckets].iter().zip(&round.live) {
+        if live {
+            sums.push(G1::from_blst_p1(blst_p1 {
+                x: point.x,
+                y: point.y,
+                z: one,
+            }));
+        }
+    }
+    sums
+}
+
+fn sparse_check(points: &[G1], rng: &mut impl CryptoRng) -> (bool, [Duration; 4]) {
+    assert!(points.len() <= 3_000_000);
+    let start = Instant::now();
+    let affine = to_affine(points);
+    let normalized = start.elapsed();
+    let start = Instant::now();
+    let ids = draw_ids(affine.len(), rng);
+    let sampled = start.elapsed();
+    let start = Instant::now();
+    let sums = compress(&affine, &ids);
+    let compressed = start.elapsed();
+    let start = Instant::now();
+    let valid = batch_in_g1(&sums, 129, &Sequential, rng);
+    (valid, [normalized, sampled, compressed, start.elapsed()])
+}
+
+fn sparse_check_separate(points: &[G1], rng: &mut impl CryptoRng) -> (bool, [Duration; 4]) {
+    assert!(points.len() <= 3_000_000);
+    let start = Instant::now();
+    let affine = to_affine(points);
+    let normalized = start.elapsed();
+    let start = Instant::now();
+    let ids = draw_ids(affine.len(), rng);
+    let sampled = start.elapsed();
+    let mut round = Round::new(11);
+    round.widen(11);
+    let mut compressed = Duration::ZERO;
+    let mut checked = Duration::ZERO;
+    for ids in ids {
+        let start = Instant::now();
+        let sums = compress_round(&mut round, &affine, &ids);
+        compressed += start.elapsed();
+        let start = Instant::now();
+        let valid = batch_in_g1(&sums, 80, &Sequential, rng);
+        checked += start.elapsed();
+        if !valid {
+            return (false, [normalized, sampled, compressed, checked]);
+        }
+    }
+    (true, [normalized, sampled, compressed, checked])
+}
+
+#[test]
+fn compression_matches_direct_sums() {
+    let mut rng = test_rng();
+    let generator = G1::generator();
+    let bad = order_three();
+    assert!(!bad.in_subgroup());
+    assert_eq!(bad + &bad + &bad, G1::zero());
+    let points: Vec<G1> = (0..96)
+        .map(|i| match i % 5 {
+            0 => G1::zero(),
+            1 => generator,
+            2 => bad,
+            3 => -bad,
+            _ => -generator,
+        })
+        .collect();
+    let points: Vec<_> = points.into_iter().filter(|p| *p != G1::zero()).collect();
+    let mut ids = draw_ids(points.len(), &mut rng);
+    // Deliberate contention covers cancellations and doubling as well as signs.
+    for ids in &mut ids {
+        for id in ids {
+            *id = (*id & ID_NEGATE) | (*id % 8);
+        }
+    }
+    let mut expected = Vec::new();
+    for ids in &ids {
+        let mut sums = [G1::zero(); 8];
+        for (point, &id) in points.iter().zip(ids) {
+            let bucket = (id & !ID_NEGATE) as usize;
+            if id & ID_NEGATE != 0 {
+                sums[bucket] -= point;
+            } else {
+                sums[bucket] += point;
+            }
+        }
+        expected.extend(sums.into_iter().filter(|p| *p != G1::zero()));
+    }
+    assert_eq!(compress(&to_affine(&points), &ids), expected);
+}
+
+#[test]
+fn four_input_concentration_small_groups() {
+    // Enumerate every nonzero input quadruple and every signed assignment to
+    // two buckets. The maximum atom is 3/(4*2^2) - 3/(8*2^3) = 36/256.
+    for order in [3usize, 5, 9, 11] {
+        let mut worst = 0;
+        for mut inputs in 0..(order - 1).pow(4) {
+            let mut values = [0; 4];
+            for value in &mut values {
+                *value = inputs % (order - 1) + 1;
+                inputs /= order - 1;
+            }
+            let mut counts = vec![0; order * order];
+            for mut assignment in 0usize..256 {
+                let mut sum = [0; 2];
+                for value in values {
+                    let bucket = assignment & 1;
+                    let signed = if assignment & 2 == 0 {
+                        value
+                    } else {
+                        order - value
+                    };
+                    sum[bucket] = (sum[bucket] + signed) % order;
+                    assignment >>= 2;
+                }
+                counts[sum[0] + order * sum[1]] += 1;
+            }
+            worst = worst.max(*counts.iter().max().unwrap());
+        }
+        assert_eq!(worst, 36);
+    }
+}
+
+#[test]
+fn sparse_check_adversarial_batches() {
+    let generator = G1::generator();
+    let bad = order_three();
+    for count in [0, 1, 2, 3, 4, 6, 32] {
+        let mut points = vec![generator; 1000];
+        for (i, point) in points.iter_mut().take(count).enumerate() {
+            *point += &if i % 2 == 0 { bad } else { -bad };
+        }
+        points.extend([G1::zero(); 16]);
+        assert_eq!(
+            sparse_check_separate(&points, &mut test_rng()).0,
+            count == 0
+        );
+    }
+}
+
+#[test]
+fn five_column_stopping_sets_contain_four() {
+    // Five distinct columns of a three-part stopping set occupy at most two
+    // buckets per part. Relabel those buckets 0/1 and enumerate the 8 columns.
+    for mask in 0u32..256 {
+        if mask.count_ones() != 5 {
+            continue;
+        }
+        let stopping = |set: u32, size: u32| {
+            (0..3).all(|part| {
+                let ones = (0..8)
+                    .filter(|&column| set & (1 << column) != 0 && column & (1 << part) != 0)
+                    .count() as u32;
+                ones != 1 && ones != size - 1
+            })
+        };
+        if stopping(mask, 5) {
+            assert!(
+                (0..8).any(|column| mask & (1 << column) != 0 && stopping(mask ^ (1 << column), 4))
+            );
+        }
+    }
+}
+
+#[test]
+#[ignore = "manual research benchmark"]
+fn measure_small_stopping_certificate() {
+    const MASK: u64 = (1 << 15) - 1;
+    for n in [1_000_000usize, 3_000_000] {
+        let mut rng = test_rng();
+        let start = Instant::now();
+        let mut codes: Vec<_> = (0..n).map(|_| rng.next_u64() & ((1 << 45) - 1)).collect();
+        codes.sort_unstable();
+        let duplicates = codes.windows(2).any(|pair| pair[0] == pair[1]);
+        let drawn = start.elapsed();
+        let start = Instant::now();
+        let mut pairs = Vec::with_capacity(n * n / (2 * (1 << 15)) + n);
+        let mut first = 0;
+        while first < codes.len() {
+            let end =
+                first + codes[first..].partition_point(|code| code >> 30 == codes[first] >> 30);
+            for i in first..end {
+                for j in i + 1..end {
+                    let mut key = 0;
+                    for shift in [15, 0] {
+                        let a = (codes[i] >> shift) & MASK;
+                        let b = (codes[j] >> shift) & MASK;
+                        let component = if a == b {
+                            0
+                        } else {
+                            (a.min(b) << 15) | a.max(b)
+                        };
+                        key = (key << 30) | component;
+                    }
+                    pairs.push(key);
+                }
+            }
+            first = end;
+        }
+        let built = start.elapsed();
+        let start = Instant::now();
+        pairs.sort_unstable();
+        let stopping_four = pairs.windows(2).any(|pair| pair[0] == pair[1]);
+        let sorted = start.elapsed();
+        eprintln!(
+            "{}::measure_small_stopping_certificate/n={n} pairs={} bytes={} draw={drawn:?} build={built:?} sort={sorted:?} duplicates={duplicates} stopping_four={stopping_four}",
+            module_path!(),
+            pairs.len(),
+            pairs.len() * size_of::<u64>()
+        );
+    }
+}
+
+#[test]
+#[ignore = "manual research benchmark"]
+fn measure_sparse_compression() {
+    let points = benchmark_points(3_000_000);
+    for n in [100_000, 1_000_000, 3_000_000] {
+        for repeat in 0..3 {
+            let mut rng = test_rng();
+            let start = Instant::now();
+            assert!(batch_in_g1(&points[..n], 128, &Sequential, &mut rng));
+            let baseline = start.elapsed();
+            let start = Instant::now();
+            let (valid, phases) = sparse_check(&points[..n], &mut rng);
+            assert!(valid);
+            let sparse = start.elapsed();
+            eprintln!(
+                "{}::measure_sparse_compression/n={n} repeat={repeat} variant=joint baseline={baseline:?} sparse={sparse:?} speedup={:.3} phases={phases:?}",
+                module_path!(),
+                baseline.as_secs_f64() / sparse.as_secs_f64()
+            );
+            let start = Instant::now();
+            let (valid, phases) = sparse_check_separate(&points[..n], &mut rng);
+            assert!(valid);
+            let separate = start.elapsed();
+            eprintln!(
+                "{}::measure_sparse_compression/n={n} repeat={repeat} variant=separate separate={separate:?} speedup={:.3} phases={phases:?}",
+                module_path!(),
+                baseline.as_secs_f64() / separate.as_secs_f64()
+            );
+        }
+    }
+}

--- a/cryptography/src/bls12381/primitives/subgroup/research/blocks.rs
+++ b/cryptography/src/bls12381/primitives/subgroup/research/blocks.rs
@@ -1,0 +1,581 @@
+//! Fuse the two graph accumulations in collision-free (u,t) blocks.
+//!
+//! Scheduling preserves the sampled input-to-edge map and both endpoint signs.
+//! Blocks of the same color (u+t) mod D have distinct outputs on both sides,
+//! so they share inversion batches without retry lists or per-block flushes.
+//! See `cryptography/SUBGROUP_PRECOMPUTATION.md` for measurements and scope.
+
+use super::*;
+
+struct Schedule {
+    offsets: Vec<usize>,
+    indices: Vec<u32>,
+}
+
+impl Schedule {
+    fn new<const Q: u32, const D: u32>(edges: &[u32]) -> Self {
+        let block = |edge: u32| {
+            let u = edge / (D * Q * Q);
+            let t = edge % D;
+            (((u + t) % D) * D + u) as usize
+        };
+        let mut offsets = vec![0; D.pow(2) as usize + 1];
+        for &edge in edges {
+            offsets[block(edge) + 1] += 1;
+        }
+        for i in 1..offsets.len() {
+            offsets[i] += offsets[i - 1];
+        }
+        let mut cursors = offsets.clone();
+        let mut indices = vec![0; edges.len()];
+        for (index, &edge) in edges.iter().enumerate() {
+            let cursor = &mut cursors[block(edge)];
+            indices[*cursor] = index as u32;
+            *cursor += 1;
+        }
+        // Preserve block locality inside each color, but flush only between
+        // colors: all blocks of one color write disjoint left AND right slabs.
+        let offsets = offsets.into_iter().step_by(D as usize).collect();
+        Self { offsets, indices }
+    }
+}
+
+struct Accumulator {
+    buckets: usize,
+    sums: Vec<blst_p1_affine>,
+    state: Vec<u8>,
+    pending: Pending,
+}
+
+impl Accumulator {
+    fn new(buckets: usize) -> Self {
+        Self {
+            buckets,
+            sums: vec![blst_p1_affine::default(); 2 * buckets],
+            state: vec![EMPTY; 2 * buckets],
+            pending: Pending::new(),
+        }
+    }
+
+    fn queue(&mut self, points: &[blst_p1_affine], index: u32, bucket: usize, negate: bool) {
+        let point = &points[index as usize];
+        debug_assert_ne!(self.state[bucket], BUSY, "color outputs must be distinct");
+        if self.state[bucket] == EMPTY {
+            self.sums[bucket] = if negate { neg_affine(point) } else { *point };
+            self.state[bucket] = FILLED;
+            return;
+        }
+        let held = &self.sums[bucket];
+        let mut flags = if negate { OP_NEGATE } else { 0 };
+        let denominator = if fp_eq(&held.x, &point.x) {
+            let two_y = if negate {
+                fp_sub(&held.y, &point.y)
+            } else {
+                fp_add(&held.y, &point.y)
+            };
+            if fp_is_zero(&two_y) {
+                self.state[bucket] = EMPTY;
+                return;
+            }
+            flags |= DOUBLE;
+            two_y
+        } else if negate {
+            fp_sub(&held.x, &point.x)
+        } else {
+            fp_sub(&point.x, &held.x)
+        };
+        self.pending.push(bucket as u32 | flags, index, denominator);
+        self.state[bucket] = BUSY;
+        if self.pending.is_full() {
+            self.flush(points);
+        }
+    }
+
+    fn flush(&mut self, points: &[blst_p1_affine]) {
+        absorb(points, &mut self.sums, &mut self.state, &mut self.pending);
+    }
+
+    fn accumulate(&mut self, points: &[blst_p1_affine], ids: &[Vec<u32>; 2], schedule: &Schedule) {
+        assert!(points.len() <= ids[0].len());
+        assert_eq!(ids[0].len(), ids[1].len());
+        self.state.fill(EMPTY);
+        for range in schedule.offsets.windows(2) {
+            let block = &schedule.indices[range[0]..range[1]];
+            for (position, &index) in block.iter().enumerate() {
+                if let Some(&ahead) = block.get(position + PREFETCH_DISTANCE)
+                    && (ahead as usize) < points.len()
+                {
+                    prefetch(points, ahead as usize);
+                }
+                // Restricting a uniform injection to a prefix is still uniform.
+                // This permits identity removal after one-shot preparation.
+                if index as usize >= points.len() {
+                    continue;
+                }
+                for (pass, ids) in ids.iter().enumerate() {
+                    let id = ids[index as usize];
+                    let bucket = pass * self.buckets + (id & !ID_NEGATE) as usize;
+                    self.queue(points, index, bucket, id & ID_NEGATE != 0);
+                }
+            }
+            // A later color may revisit either side's outputs.
+            self.flush(points);
+        }
+    }
+
+    fn points(&self, pass: usize) -> Vec<G1> {
+        let start = pass * self.buckets;
+        self.sums[start..start + self.buckets]
+            .iter()
+            .zip(&self.state[start..start + self.buckets])
+            .filter(|&(_, &state)| state != EMPTY)
+            .map(|(point, _)| {
+                G1::from_blst_p1(blst_p1 {
+                    x: point.x,
+                    y: point.y,
+                    z: MONTGOMERY_ONE,
+                })
+            })
+            .collect()
+    }
+}
+
+// Consume a preparation exactly once. Its randomness must remain private until
+// the corresponding batch is fixed; preparations must never be reused.
+struct Prepared {
+    n: usize,
+    ids: [Vec<u32>; 2],
+    schedule: Schedule,
+    accumulator: Accumulator,
+}
+
+impl Prepared {
+    fn new<const D: u32>(n: usize, rng: &mut impl CryptoRng) -> Self {
+        assert!(matches!(D, 43 | 47));
+        let edges = sample_edges(47 * 47 * D * D, n, |bound| {
+            uniform_below(bound, || rng.next_u64())
+        });
+        let ids = signed_ids_with::<47, D>(&edges, rng);
+        let schedule = Schedule::new::<47, D>(&edges);
+        drop(edges);
+        Self {
+            n,
+            ids,
+            schedule,
+            accumulator: Accumulator::new((47 * 47 * D) as usize),
+        }
+    }
+
+    fn check(mut self, points: &[G1], rng: &mut impl CryptoRng) -> (bool, [Duration; 4]) {
+        assert_eq!(points.len(), self.n);
+        let start = Instant::now();
+        let affine = to_affine(points);
+        let normalized = start.elapsed();
+        let start = Instant::now();
+        self.accumulator
+            .accumulate(&affine, &self.ids, &self.schedule);
+        let mut compressed = start.elapsed();
+        let mut checked = Duration::ZERO;
+        for pass in 0..2 {
+            let start = Instant::now();
+            let sums = self.accumulator.points(pass);
+            compressed += start.elapsed();
+            let start = Instant::now();
+            let valid = super::super::effective::check(&sums, rng);
+            checked += start.elapsed();
+            if !valid {
+                return (false, [normalized, Duration::ZERO, compressed, checked]);
+            }
+        }
+        (true, [normalized, Duration::ZERO, compressed, checked])
+    }
+}
+
+struct PreparedBatch {
+    outer: Prepared,
+    inner: [super::super::effective::Prepared; 2],
+}
+
+impl PreparedBatch {
+    fn new(n: usize, rng: &mut impl CryptoRng) -> Self {
+        let outer = Prepared::new::<43>(n, rng);
+        let inner = core::array::from_fn(|_| {
+            super::super::effective::Prepared::new(outer.accumulator.buckets, rng)
+        });
+        Self { outer, inner }
+    }
+
+    fn check(self, points: &[G1]) -> (bool, [Duration; 4]) {
+        let Self { mut outer, inner } = self;
+        assert_eq!(points.len(), outer.n);
+        let start = Instant::now();
+        let affine = to_affine(points);
+        let normalized = start.elapsed();
+        let start = Instant::now();
+        outer
+            .accumulator
+            .accumulate(&affine, &outer.ids, &outer.schedule);
+        let compressed = start.elapsed();
+        let start = Instant::now();
+        let buckets = outer.accumulator.buckets;
+        for (pass, inner) in inner.into_iter().enumerate() {
+            let range = pass * buckets..(pass + 1) * buckets;
+            if !inner.check(
+                &outer.accumulator.sums[range.clone()],
+                &outer.accumulator.state[range],
+            ) {
+                return (
+                    false,
+                    [normalized, Duration::ZERO, compressed, start.elapsed()],
+                );
+            }
+        }
+        (
+            true,
+            [normalized, Duration::ZERO, compressed, start.elapsed()],
+        )
+    }
+}
+
+// Control for separating the benefit of preparation from block scheduling.
+// Keep the generic outer accumulator, but feed affine slots to prepared inners.
+struct PreparedGenericBatch {
+    n: usize,
+    ids: [Vec<u32>; 2],
+    round: Round,
+    inner: [super::super::effective::Prepared; 2],
+}
+
+impl PreparedGenericBatch {
+    fn new(n: usize, rng: &mut impl CryptoRng) -> Self {
+        let edges = sample_edges(47 * 47 * 43 * 43, n, |bound| {
+            uniform_below(bound, || rng.next_u64())
+        });
+        let ids = signed_ids_with::<47, 43>(&edges, rng);
+        drop(edges);
+        let inner =
+            core::array::from_fn(|_| super::super::effective::Prepared::new(47 * 47 * 43, rng));
+        let mut round = Round::new(12);
+        round.widen(12);
+        Self {
+            n,
+            ids,
+            round,
+            inner,
+        }
+    }
+
+    fn check(self, points: &[G1]) -> (bool, [Duration; 4]) {
+        let Self {
+            n,
+            ids,
+            mut round,
+            inner,
+        } = self;
+        assert_eq!(points.len(), n);
+        let start = Instant::now();
+        let affine = to_affine(points);
+        let normalized = start.elapsed();
+        let mut compressed = Duration::ZERO;
+        let mut checked = Duration::ZERO;
+        for (ids, inner) in ids.iter().zip(inner) {
+            let start = Instant::now();
+            round.accumulate(&affine, &ids[..affine.len()]);
+            compressed += start.elapsed();
+            let start = Instant::now();
+            let valid = inner.check(&round.sums[..47 * 47 * 43], &round.state[..47 * 47 * 43]);
+            checked += start.elapsed();
+            if !valid {
+                return (false, [normalized, Duration::ZERO, compressed, checked]);
+            }
+        }
+        (true, [normalized, Duration::ZERO, compressed, checked])
+    }
+}
+
+#[test]
+fn blocks_are_matchings_on_both_sides() {
+    fn verify<const Q: u32, const D: u32>() {
+        let side = (Q * Q) as usize;
+        for u in 0..D {
+            for t in 0..D {
+                let mut seen = vec![false; side];
+                for v in 0..Q {
+                    for w in 0..Q {
+                        let edge = ((u * Q + v) * Q + w) * D + t;
+                        let [left, right] = truncated_endpoints::<Q, D>(edge);
+                        assert_eq!(left, (u * Q + v) * Q + w);
+                        assert_eq!(right / (Q * Q), t);
+                        let right = right as usize % side;
+                        assert!(!seen[right]);
+                        seen[right] = true;
+                    }
+                }
+                assert!(seen.into_iter().all(|seen| seen));
+            }
+        }
+    }
+    verify::<3, 3>();
+    verify::<19, 19>();
+    verify::<47, 47>();
+    verify::<47, 43>();
+}
+
+fn compare<const Q: u32, const D: u32>(points: &[G1], edges: &[u32], rng: &mut impl CryptoRng) {
+    let affine = to_affine(points);
+    assert_eq!(affine.len(), edges.len());
+    let ids = signed_ids_with::<Q, D>(edges, rng);
+    let schedule = Schedule::new::<Q, D>(edges);
+    let mut permutation = schedule.indices.clone();
+    permutation.sort_unstable();
+    assert_eq!(permutation, (0..edges.len() as u32).collect::<Vec<_>>());
+    let buckets = (Q * Q * D) as usize;
+    for range in schedule.offsets.windows(2) {
+        let mut seen = vec![false; 2 * buckets];
+        for &index in &schedule.indices[range[0]..range[1]] {
+            for (pass, ids) in ids.iter().enumerate() {
+                let bucket = pass * buckets + (ids[index as usize] & !ID_NEGATE) as usize;
+                assert!(!seen[bucket]);
+                seen[bucket] = true;
+            }
+        }
+    }
+    let mut accumulator = Accumulator::new(buckets);
+    let width = (1..=MAX_WIDTH).find(|&m| folded(m) >= buckets).unwrap();
+    let mut round = Round::new(width);
+    round.widen(width);
+    // Reuse the buffers to check that cancelled and previously live slots reset.
+    for _ in 0..2 {
+        accumulator.accumulate(&affine, &ids, &schedule);
+        assert!(!accumulator.state.contains(&BUSY));
+        for (pass, ids) in ids.iter().enumerate() {
+            let mut direct = vec![G1::zero(); buckets];
+            for (point, &id) in points.iter().zip(ids) {
+                let bucket = (id & !ID_NEGATE) as usize;
+                if id & ID_NEGATE == 0 {
+                    direct[bucket] += point;
+                } else {
+                    direct[bucket] -= point;
+                }
+            }
+            let direct: Vec<_> = direct.into_iter().filter(|p| *p != G1::zero()).collect();
+            assert_eq!(accumulator.points(pass), direct);
+            assert_eq!(
+                compress_round_with_buckets(&mut round, &affine, ids, buckets),
+                direct
+            );
+        }
+    }
+}
+
+#[test]
+fn fused_blocks_match_direct_and_generic_sums() {
+    let generator = G1::generator();
+    let three = order_three();
+    let eleven = order_eleven();
+    for seed in 0..4 {
+        let mut rng = TestRng::new(seed);
+        for n in [0, 1, 2, 40, 81] {
+            let edges = sample_edges(81, n, |bound| uniform_below(bound, || rng.next_u64()));
+            let points: Vec<_> = (0..n)
+                .map(|i| match i % 6 {
+                    0 => generator,
+                    1 => -generator,
+                    2 => three,
+                    3 => -three,
+                    4 => eleven,
+                    _ => generator + &eleven,
+                })
+                .collect();
+            compare::<3, 3>(&points, &edges, &mut rng);
+        }
+    }
+    // Entire blocks exercise multiple full shared-inversion queues, repeated
+    // points, doublings, and cancellations across block boundaries.
+    let edges: Vec<_> = (0..47 * 47)
+        .flat_map(|vw| (0..4).map(move |t| vw * 43 + t))
+        .collect();
+    let points: Vec<_> = (0..edges.len())
+        .map(|i| match i % 4 {
+            0 | 1 => generator,
+            2 => three,
+            _ => -generator,
+        })
+        .collect();
+    compare::<47, 43>(&points, &edges, &mut test_rng());
+    let torsion = vec![three; 81];
+    compare::<3, 3>(
+        &torsion,
+        &(0..81).collect::<Vec<_>>(),
+        &mut ScriptedRng::new([0; 81]),
+    );
+}
+
+#[test]
+fn fused_check_rejects_adversarial_batches() {
+    for bad in [order_three(), order_eleven()] {
+        for count in [0, 1, 2, 8, 31] {
+            let mut points = vec![G1::generator(); 4096];
+            for (i, point) in points.iter_mut().take(count).enumerate() {
+                *point += &if i % 2 == 0 { bad } else { -bad };
+            }
+            let mut original_rng = TestRng::new(13);
+            let mut blocked_rng = TestRng::new(13);
+            let original = graph_check_with::<47, 43, true, _>(
+                &points,
+                &mut original_rng,
+                super::super::effective::check,
+            )
+            .0;
+            let blocked = Prepared::new::<43>(points.len(), &mut blocked_rng)
+                .check(&points, &mut blocked_rng)
+                .0;
+            assert_eq!(original, count == 0);
+            assert_eq!(blocked, original);
+            assert_eq!(original_rng.next_u64(), blocked_rng.next_u64());
+            points.extend([G1::zero(); 16]);
+            assert_eq!(
+                Prepared::new::<47>(points.len(), &mut test_rng())
+                    .check(&points, &mut test_rng())
+                    .0,
+                count == 0
+            );
+        }
+    }
+    for points in [vec![], vec![G1::zero(); 16]] {
+        assert!(
+            Prepared::new::<43>(points.len(), &mut test_rng())
+                .check(&points, &mut test_rng())
+                .0
+        );
+    }
+}
+
+#[test]
+fn prepared_batch_rejects_adversarial_inputs_and_identity_padding() {
+    for bad in [order_three(), order_eleven()] {
+        for count in [0, 1, 2, 8, 31] {
+            // Prepare before constructing the points, including identities
+            // interleaved with live inputs rather than only appended.
+            let prepared = PreparedBatch::new(4096, &mut test_rng());
+            let generic = PreparedGenericBatch::new(4096, &mut test_rng());
+            let mut points = vec![G1::generator(); 4096];
+            for (i, point) in points.iter_mut().enumerate() {
+                if i % 4 == 0 {
+                    *point = G1::zero();
+                }
+            }
+            for i in 0..count {
+                points[4 * i + 1] += &if i % 2 == 0 { bad } else { -bad };
+            }
+            assert_eq!(prepared.check(&points).0, count == 0);
+            assert_eq!(generic.check(&points).0, count == 0);
+        }
+    }
+    for points in [vec![], vec![G1::zero(); 16], vec![G1::generator()]] {
+        assert!(
+            PreparedBatch::new(points.len(), &mut test_rng())
+                .check(&points)
+                .0
+        );
+        assert!(
+            PreparedGenericBatch::new(points.len(), &mut test_rng())
+                .check(&points)
+                .0
+        );
+    }
+}
+
+#[test]
+#[ignore = "manual research benchmark"]
+fn measure_blocks() {
+    let points = benchmark_points(100_000);
+    for repeat in 0..8 {
+        for index in 0..4 {
+            let variant = if repeat % 2 == 0 { index } else { 3 - index };
+            let mut rng = TestRng::new(repeat);
+            let start = Instant::now();
+            let (valid, phases, prepared, online) = if variant == 3 {
+                let prepared = PreparedGenericBatch::new(points.len(), &mut rng);
+                let preparation = start.elapsed();
+                let online = Instant::now();
+                let (valid, phases) = prepared.check(&points);
+                (valid, phases, preparation, online.elapsed())
+            } else if variant == 2 {
+                let prepared = PreparedBatch::new(points.len(), &mut rng);
+                let preparation = start.elapsed();
+                let online = Instant::now();
+                let (valid, phases) = prepared.check(&points);
+                (valid, phases, preparation, online.elapsed())
+            } else if variant == 1 {
+                let prepared = Prepared::new::<43>(points.len(), &mut rng);
+                let preparation = start.elapsed();
+                let online = Instant::now();
+                let (valid, phases) = prepared.check(&points, &mut rng);
+                (valid, phases, preparation, online.elapsed())
+            } else {
+                let (valid, phases) = graph_check_with::<47, 43, true, _>(
+                    &points,
+                    &mut rng,
+                    super::super::effective::check,
+                );
+                (valid, phases, Duration::ZERO, start.elapsed())
+            };
+            assert!(valid);
+            let variant = ["baseline", "blocks", "prepared_blocks", "prepared_generic"][variant];
+            eprintln!(
+                "{}::measure_blocks/n={} repeat={repeat} variant={variant} total={:?} preparation={prepared:?} online={online:?} phases={phases:?}",
+                module_path!(),
+                points.len(),
+                start.elapsed()
+            );
+        }
+    }
+}
+
+#[test]
+#[ignore = "manual research benchmark; prepare before constructing each batch"]
+fn measure_prepared_arrival() {
+    const N: usize = 100_000;
+    for repeat in 0..8 {
+        let start = Instant::now();
+        let mut prepared = Some(PreparedGenericBatch::new(N, &mut TestRng::new(repeat)));
+        let preparation = start.elapsed();
+        // Point generation is excluded. It occurs after preparation, touching
+        // fresh input memory instead of executing immediately on warm scratch.
+        let points = benchmark_points(N);
+        for index in 0..2 {
+            let use_prepared = (index + repeat) % 2 != 0;
+            let start = Instant::now();
+            let (valid, phases) = if use_prepared {
+                prepared
+                    .take()
+                    .expect("one use per challenge")
+                    .check(&points)
+            } else {
+                graph_check_with::<47, 43, true, _>(
+                    &points,
+                    &mut TestRng::new(repeat),
+                    super::super::effective::check,
+                )
+            };
+            let online = start.elapsed();
+            let setup = if use_prepared {
+                preparation
+            } else {
+                Duration::ZERO
+            };
+            let variant = if use_prepared {
+                "prepared_generic"
+            } else {
+                "baseline"
+            };
+            assert!(valid);
+            eprintln!(
+                "{}::measure_prepared_arrival/n={N} repeat={repeat} variant={variant} total={:?} preparation={setup:?} online={online:?} phases={phases:?}",
+                module_path!(),
+                setup + online
+            );
+        }
+    }
+}

--- a/cryptography/src/bls12381/primitives/subgroup/research/cascade_bound.py
+++ b/cryptography/src/bls12381/primitives/subgroup/research/cascade_bound.py
@@ -1,0 +1,75 @@
+"""Exact bounds for recursive graph compression and pair-certified inner checks."""
+
+from fractions import Fraction
+from math import comb, log2
+
+
+def vertex_bound(k):
+    v = 8
+    while v**3 + 8*k*v < 16*k*k:
+        v += 1
+    return v
+
+
+def compression_bound(q, degree=None, cycle_count=None):
+    degree = q if degree is None else degree
+    edges = q*q*degree*degree
+    tree = 8*(degree-1)
+    assert edges > 256*tree
+    if cycle_count is None:
+        cycle_count = Fraction(edges*(degree-1)**4, 8)
+    cycle8 = cycle_count / (comb(edges, 8)*256)
+    cycle10 = Fraction(edges*(degree-1)**8, 10*comb(edges, 10)*1024)
+    worst, worst_k = Fraction(0), None
+    choose = 1
+    for k in range(1, 66*degree):
+        choose = choose*(edges-k+1)//k
+        if k < 12:
+            continue
+        components = k//8
+        vertices = max(8*components, vertex_bound(k))
+        probability = Fraction(
+            components*comb(k-1, components-1)*edges**components*tree**(k-components),
+            2**vertices*choose,
+        )
+        if probability > worst:
+            worst, worst_k = probability, k
+    result = max(cycle8, cycle10, worst, Fraction(1, 2**132))
+    print(f"q={q}, d={degree}: intermediate {-log2(worst):.12f} bits at k={worst_k}; compression {-log2(result):.12f}")
+    return result
+
+
+def side_bound(q, degree=None, certified=False):
+    degree = q if degree is None else degree
+    buckets = q*q*degree
+    edges = buckets*degree
+    if certified:
+        t = 34
+        remaining = edges-t*degree+4
+        bound = Fraction(3*edges**3, 4*buckets*buckets*remaining*(remaining-1)*(remaining-2))
+    else:
+        t = (2*buckets-1).bit_length()
+        bound = Fraction(degree, 2*(edges-t*degree+2))
+    return max(bound, Fraction(1, 2**t))
+
+
+def verify():
+    assert vertex_bound(12) == 11
+    outer = compression_bound(47)
+    inner = compression_bound(31)
+    reference = Fraction(1, 3**71)
+    recursive_joint = inner + Fraction(1, 3**72)
+    recursive_split = inner + 2*Fraction(1, 3**63)*side_bound(31) + Fraction(1, 3**126)
+    for label, error in (("recursive joint114", recursive_joint), ("recursive split99", recursive_split)):
+        assert error < reference
+        total = outer + 2*error*side_bound(47) + error**2
+        assert total < Fraction(1, 2**128)
+        print(f"{label}: inner {-log2(error):.12f} bits; total {-log2(total):.12f} bits")
+    epsilon = Fraction(1, 3**61)
+    certified = outer + 2*epsilon*side_bound(47, certified=True) + epsilon**2
+    assert certified < Fraction(1, 2**128)
+    print(f"pair-certified inner96: {-log2(certified):.12f} bits")
+
+
+if __name__ == "__main__":
+    verify()

--- a/cryptography/src/bls12381/primitives/subgroup/research/cycles.rs
+++ b/cryptography/src/bls12381/primitives/subgroup/research/cycles.rs
@@ -1,0 +1,122 @@
+//! Independent exact eight-cycle counts for the truncated graph.
+
+// An independent enumeration solves the two cycle equations for four u values.
+// Adjacent t values are different. Four distinct t values give a unique pair
+// of ratios, three distinct ones are impossible, and two must alternate.
+fn cycles_algebraic<const Q: usize>(us: &[usize], ts: &[usize]) -> u64 {
+    let mut inverse = vec![0; Q];
+    for (x, inverse) in inverse.iter_mut().enumerate().skip(1) {
+        *inverse = (1..Q).find(|&y| x * y % Q == 1).unwrap();
+    }
+    let mut allowed = vec![0u64; Q * Q];
+    let mut alternating = 0u64;
+    for &u0 in us {
+        for &u1 in us {
+            if u0 == u1 {
+                continue;
+            }
+            let scale = inverse[(u1 + Q - u0) % Q];
+            for &u2 in us {
+                if u2 == u1 {
+                    continue;
+                }
+                let u3 = (u0 + Q + u2 - u1) % Q;
+                if us.contains(&u3) {
+                    alternating += 1;
+                }
+                for &u3 in us {
+                    if u3 == u2 || u3 == u0 {
+                        continue;
+                    }
+                    let r = (u2 + Q - u0) * scale % Q;
+                    let s = (u3 + Q - u0) * scale % Q;
+                    allowed[r * Q + s] += 1;
+                }
+            }
+        }
+    }
+    let mut ordered = alternating * (ts.len() * (ts.len() - 1)) as u64;
+    for &t0 in ts {
+        for &t1 in ts {
+            if t1 == t0 {
+                continue;
+            }
+            for &t2 in ts {
+                if t2 == t0 || t2 == t1 {
+                    continue;
+                }
+                for &t3 in ts {
+                    if t3 == t0 || t3 == t1 || t3 == t2 {
+                        continue;
+                    }
+                    let a = (t1 + Q - t2) % Q;
+                    let b = (t2 + Q - t3) % Q;
+                    let c = (t1 + Q - t0) % Q;
+                    let inv = inverse[a * b * (t3 + Q - t1) % Q];
+                    let r = c * b * (t2 + t3 + 2 * Q - t1 - t0) * inv % Q;
+                    let s = a * c * (t0 + Q - t2) * inv % Q;
+                    ordered += allowed[r * Q + s];
+                }
+            }
+        }
+    }
+    assert_eq!(ordered * (Q * Q) as u64 % 8, 0);
+    ordered * (Q * Q) as u64 / 8
+}
+
+fn cycles<const Q: usize>(us: &[usize], ts: &[usize]) -> u64 {
+    let mut uv = vec![vec![0; us.len()]; ts.len()];
+    let mut uw = uv.clone();
+    for (ti, &t) in ts.iter().enumerate() {
+        for (ui, &u) in us.iter().enumerate() {
+            uv[ti][ui] = u * t % Q;
+            uw[ti][ui] = u * t * t % Q;
+        }
+    }
+    let mut counts = vec![0u16; us.len() * Q * Q];
+    let mut pairs = 0u64;
+    for u0 in 0..us.len() {
+        counts.fill(0);
+        for u1 in 0..us.len() {
+            if u1 == u0 {
+                continue;
+            }
+            for t1 in 0..ts.len() {
+                for t2 in 0..ts.len() {
+                    if t2 == t1 {
+                        continue;
+                    }
+                    let v = (uv[t1][u1] + 2 * Q - uv[t1][u0] - uv[t2][u1]) % Q;
+                    let w = (uw[t1][u1] + 2 * Q - uw[t1][u0] - uw[t2][u1]) % Q;
+                    for u2 in 0..us.len() {
+                        if u2 == u1 {
+                            continue;
+                        }
+                        let vv = (v + uv[t2][u2]) % Q;
+                        let ww = (w + uw[t2][u2]) % Q;
+                        let index = (u2 * Q + vv) * Q + ww;
+                        pairs += u64::from(counts[index]);
+                        counts[index] += 1;
+                    }
+                }
+            }
+        }
+    }
+    let rooted = pairs * (Q * Q) as u64;
+    assert_eq!(rooted % 4, 0);
+    rooted / 4
+}
+
+#[test]
+fn eight_cycle_counts_agree() {
+    let q3: Vec<_> = (0..3).collect();
+    assert_eq!(cycles::<3>(&q3, &q3), 81);
+    assert_eq!(cycles_algebraic::<3>(&q3, &q3), 81);
+    let q5: Vec<_> = (0..5).collect();
+    assert_eq!(cycles::<5>(&q5, &q5), 12500);
+    assert_eq!(cycles_algebraic::<5>(&q5, &q5), 12500);
+    let symbols: Vec<_> = (0..43).collect();
+    let expected = 1_263_308_051_793;
+    assert_eq!(cycles::<47>(&symbols, &symbols), expected);
+    assert_eq!(cycles_algebraic::<47>(&symbols, &symbols), expected);
+}

--- a/cryptography/src/bls12381/primitives/subgroup/research/descent_bound.py
+++ b/cryptography/src/bls12381/primitives/subgroup/research/descent_bound.py
@@ -1,0 +1,118 @@
+"""Arithmetic diagnostics for the rational 3-torsion descent map; not a verifier."""
+
+from math import gcd
+
+
+def add(p, left, right):
+    if left is None:
+        return right
+    if right is None:
+        return left
+    x, y = left
+    xx, yy = right
+    if x == xx and (y+yy) % p == 0:
+        return None
+    if x == xx:
+        slope = 3*x*x*pow(2*y, -1, p) % p
+    else:
+        slope = (yy-y)*pow(xx-x, -1, p) % p
+    xxx = (slope*slope-x-xx) % p
+    return xxx, (slope*(x-xxx)-y) % p
+
+
+def mul(p, n, point):
+    answer = None
+    while n:
+        if n & 1:
+            answer = add(p, answer, point)
+        point = add(p, point, point)
+        n >>= 1
+    return answer
+
+
+def representative(p, point):
+    if point is None:
+        return 1
+    _, y = point
+    # 16 and 1/4 are identical modulo cubes, because their quotient is 4^3.
+    return 16 % p if y == 2 else (y-2) % p
+
+
+def character(p, point):
+    return pow(representative(p, point), (p-1)//3, p)
+
+
+def verify():
+    for p in (7, 13, 19, 31, 37, 43, 61, 67, 73, 97):
+        points = [None]+[(x, y) for x in range(p) for y in range(p)
+                         if (y*y-x*x*x-4) % p == 0]
+        for left in points:
+            for right in points:
+                assert character(p, add(p, left, right)) == character(p, left)*character(p, right) % p
+        values = {character(p, point) for point in points}
+        kernel = {point for point in points if character(p, point) == 1}
+        triples = {mul(p, 3, point) for point in points}
+        assert triples <= kernel
+        if len(points) % 9:
+            assert triples == kernel
+        print(f"p={p} #E={len(points)} image={len(values)} kernel={len(kernel)} [3]E={len(triples)}")
+
+    x = -0xd201000000010000
+    r = x**4-x*x+1
+    h = (x-1)**2//3
+    p = (x-1)**2*r//3+x
+    assert p == int('1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab', 16)
+    assert h == 3*(11*10177*859267*52437899)**2
+    assert (r*h) % 3 == 0 and (r*h) % 9 != 0
+    assert p % 3 == 1
+    torsion = (0, 2)
+    assert mul(p, 3, torsion) is None
+    zeta = character(p, torsion)
+    assert zeta != 1 and pow(zeta, 3, p) == 1
+    print(f"BLS p mod9={p%9}; chi(T)={zeta:#x}")
+    print(f"remaining cofactor h/3={h//3}; gcd(h/3,p-1)={gcd(h//3,p-1)}")
+    print(f"cofactor factors modp-1: {[(ell, (p-1)%ell) for ell in (11,10177,859267,52437899)]}")
+
+    # Explicit residual-cofactor counterexample: [3]Q has trivial cubic character
+    # but remains outside G1. The square root exists because p is 3 modulo 4.
+    for xx in range(1, 100):
+        yy = pow((xx**3+4)%p, (p+1)//4, p)
+        if yy*yy % p != (xx**3+4)%p:
+            continue
+        point = (xx, yy)
+        residual = mul(p, 3, point)
+        if mul(p, r, residual) is not None:
+            assert character(p, residual) == 1
+            assert mul(p, r*h, point) is None
+            for a in range(6):
+                for b in range(6):
+                    left, right = mul(p, a, point), mul(p, b, torsion)
+                    assert character(p, add(p, left, right)) == character(p, left)*character(p, right)%p
+            print(f"residual counterexample = [3]({xx}, sqrt({xx**3+4})); x={residual[0]:#x}; y={residual[1]:#x}")
+            eleven = mul(p, r*h//(11*11), point)
+            if mul(p, 11, eleven) is not None:
+                eleven = mul(p, 11, eleven)
+            assert eleven is not None and mul(p, 11, eleven) is None
+            assert character(p, eleven) == 1
+            assert mul(p, r, eleven) is not None
+            print(f"order11 counterexample: x={eleven[0]:#x}; y={eleven[1]:#x}")
+            break
+    else:
+        raise AssertionError("residual counterexample not found")
+
+    # Eight equal order11 points on an eight-cycle. Each edge has an independent
+    # sign at each endpoint, hence 16 sign bits; degree-two vertices force opposite
+    # signs. Arithmetic mod11 exactly models their cyclic subgroup.
+    accepted = 0
+    for signs in range(1 << 16):
+        sums = [0]*8
+        for edge in range(8):
+            for endpoint, vertex in enumerate((edge, (edge+1)%8)):
+                sums[vertex] += 1 if signs & (1 << (2*edge+endpoint)) else -1
+        accepted += all(value % 11 == 0 for value in sums)
+    assert accepted == 256
+    print(f"order11 eight-cycle accepts {accepted}/65536 endpoint-sign assignments; exactly 1/256")
+
+
+if __name__ == "__main__":
+    verify()

--- a/cryptography/src/bls12381/primitives/subgroup/research/effective.rs
+++ b/cryptography/src/bls12381/primitives/subgroup/research/effective.rs
@@ -152,6 +152,229 @@ pub(super) fn check(points: &[G1], rng: &mut impl CryptoRng) -> bool {
         .all(|(&width, pass)| final_round.run(&compressed, pass, width))
 }
 
+// A one-shot, input-independent circuit. All graph buckets retain their final
+// coefficient columns, including buckets whose eventual curve sum is zero.
+// Thus exact exceptions can be certified before any input point is available.
+pub(super) struct Prepared {
+    graph_ids: [Vec<u32>; 2],
+    widths: Vec<u32>,
+    ids: Vec<Vec<u32>>,
+    exceptions: Vec<usize>,
+    graph_round: Round,
+    final_round: Round,
+    affine: Vec<blst_p1_affine>,
+    inputs: Vec<usize>,
+    compressed: Vec<blst_p1_affine>,
+    outputs: Vec<usize>,
+    filtered: Vec<u32>,
+}
+
+impl Prepared {
+    pub(super) fn new(n: usize, rng: &mut impl CryptoRng) -> Self {
+        assert!(n <= Q.pow(4) as usize);
+        let graph_ids = super::two::draw_ids::<Q>(n, rng);
+        let widths = plan(2 * BUCKETS, combinations_for_security(99)).expect("batched final stage");
+        let mut trits = Trits::new(rng);
+        let ids: Vec<_> = widths
+            .iter()
+            .map(|&width| trits.fill(width, 2 * BUCKETS))
+            .collect();
+        let positions: Vec<_> = (0..2 * BUCKETS).collect();
+        let effective = effective_columns(&graph_ids, &positions, &columns(&widths, &ids), BUCKETS);
+        let exceptions =
+            super::pair::exception_indices(effective.into_iter().map(Column::canonical));
+        let mut graph_round = Round::new(9);
+        graph_round.widen(9);
+        let final_round = Round::new(*widths.iter().max().expect("positive target"));
+        Self {
+            graph_ids,
+            widths,
+            ids,
+            exceptions,
+            graph_round,
+            final_round,
+            affine: Vec::with_capacity(n),
+            inputs: Vec::with_capacity(n),
+            compressed: Vec::with_capacity(2 * BUCKETS),
+            outputs: Vec::with_capacity(2 * BUCKETS),
+            filtered: Vec::with_capacity(n.max(2 * BUCKETS)),
+        }
+    }
+
+    fn compress(&mut self, points: &[blst_p1_affine], state: &[u8]) {
+        for (index, (&point, &state)) in points.iter().zip(state).enumerate() {
+            if state != EMPTY {
+                self.affine.push(point);
+                self.inputs.push(index);
+            }
+        }
+        for (pass, ids) in self.graph_ids.iter().enumerate() {
+            self.filtered.clear();
+            self.filtered
+                .extend(self.inputs.iter().map(|&index| ids[index]));
+            self.graph_round.accumulate(&self.affine, &self.filtered);
+            for bucket in 0..BUCKETS {
+                if self.graph_round.live[bucket] {
+                    self.compressed.push(self.graph_round.sums[bucket]);
+                    self.outputs.push(pass * BUCKETS + bucket);
+                }
+            }
+        }
+    }
+
+    pub(super) fn check(mut self, points: &[blst_p1_affine], state: &[u8]) -> bool {
+        assert_eq!(points.len(), self.graph_ids[0].len());
+        assert_eq!(points.len(), state.len());
+        assert!(!state.contains(&BUSY));
+        if !self
+            .exceptions
+            .iter()
+            .all(|&index| state[index] == EMPTY || in_subgroup(points[index]))
+        {
+            return false;
+        }
+        self.compress(points, state);
+        for (&width, ids) in self.widths.iter().zip(&self.ids) {
+            self.filtered.clear();
+            self.filtered
+                .extend(self.outputs.iter().map(|&index| ids[index]));
+            if !self
+                .final_round
+                .run(&self.compressed, &self.filtered, width)
+            {
+                return false;
+            }
+        }
+        true
+    }
+}
+
+#[test]
+fn prepared_circuit_preserves_identity_positions_and_final_coefficients() {
+    let generator = G1::generator();
+    let three = order_three();
+    let eleven = order_eleven();
+    let points = [
+        generator,
+        -generator,
+        G1::zero(),
+        three,
+        -three,
+        eleven,
+        generator + &eleven,
+        -generator,
+    ];
+    let affine: Vec<_> = points
+        .iter()
+        .map(|point| {
+            if *point == G1::zero() {
+                blst_p1_affine::default()
+            } else {
+                to_affine(&[*point])[0]
+            }
+        })
+        .collect();
+    let state: Vec<_> = points
+        .iter()
+        .map(|point| if *point == G1::zero() { EMPTY } else { FILLED })
+        .collect();
+    let mut prepared = Prepared::new(points.len(), &mut test_rng());
+    assert_eq!(prepared.widths.iter().sum::<u32>(), 63);
+    // Force cancellations in two graph buckets, plus an absent original input.
+    prepared.graph_ids = [
+        vec![0, 0, 1, 2, 2, 3, 3, 4],
+        vec![0, 1, 2, 3, 4, 5, 5, 6 | ID_NEGATE],
+    ];
+    let mut expected = vec![G1::zero(); 2 * BUCKETS];
+    for (pass, ids) in prepared.graph_ids.iter().enumerate() {
+        for (point, &id) in points.iter().zip(ids) {
+            let out = &mut expected[pass * BUCKETS + (id & !ID_NEGATE) as usize];
+            if id & ID_NEGATE == 0 {
+                *out += point;
+            } else {
+                *out -= point;
+            }
+        }
+    }
+    prepared.compress(&affine, &state);
+    assert!(!prepared.inputs.contains(&2));
+    assert!(!prepared.outputs.contains(&0));
+    assert!(!prepared.outputs.contains(&2));
+    let mut actual = vec![G1::zero(); 2 * BUCKETS];
+    for (&index, &point) in prepared.outputs.iter().zip(&prepared.compressed) {
+        actual[index] = G1::from_blst_p1(blst_p1 {
+            x: point.x,
+            y: point.y,
+            z: MONTGOMERY_ONE,
+        });
+    }
+    assert_eq!(actual, expected);
+    let expected: Vec<_> = expected
+        .into_iter()
+        .enumerate()
+        .filter(|(_, point)| *point != G1::zero())
+        .collect();
+    for (&width, ids) in prepared.widths.iter().zip(&prepared.ids) {
+        let filtered: Vec<_> = prepared.outputs.iter().map(|&index| ids[index]).collect();
+        let _ = prepared
+            .final_round
+            .run(&prepared.compressed, &filtered, width);
+        for row in 0..width {
+            let mut direct = G1::zero();
+            for &(index, point) in &expected {
+                let id = ids[index];
+                let value = (id & !ID_NEGATE) as i32 * if id & ID_NEGATE == 0 { 1 } else { -1 };
+                let digit = ((value + (3i32.pow(width) - 1) / 2) / 3i32.pow(row)) % 3 - 1;
+                match digit {
+                    1 => direct += &point,
+                    -1 => direct -= &point,
+                    _ => {}
+                }
+            }
+            let actual =
+                prepared.final_round.marginals[row as usize]
+                    .first()
+                    .map_or(G1::zero(), |&slot| {
+                        let point = prepared.final_round.sums[slot as usize];
+                        G1::from_blst_p1(blst_p1 {
+                            x: point.x,
+                            y: point.y,
+                            z: MONTGOMERY_ONE,
+                        })
+                    });
+            assert_eq!(actual, direct);
+        }
+    }
+}
+
+#[test]
+fn prepared_certificate_checks_original_dense_input_indices() {
+    for bad in [order_three(), order_eleven()] {
+        for value in [0, 1] {
+            let mut prepared = Prepared::new(3, &mut test_rng());
+            prepared.graph_ids = [vec![0, 1, 2], vec![0, 1, 2]];
+            for pass in &mut prepared.ids {
+                pass.fill(value);
+            }
+            let positions: Vec<_> = (0..2 * BUCKETS).collect();
+            let effective = effective_columns(
+                &prepared.graph_ids,
+                &positions,
+                &columns(&prepared.widths, &prepared.ids),
+                BUCKETS,
+            );
+            prepared.exceptions =
+                super::pair::exception_indices(effective.into_iter().map(Column::canonical));
+            let mut marked = prepared.exceptions.clone();
+            marked.sort_unstable();
+            assert_eq!(marked, [0, 1, 2]);
+            let mut affine = vec![blst_p1_affine::default()];
+            affine.extend(to_affine(&[G1::generator(), G1::generator() + &bad]));
+            assert!(!prepared.check(&affine, &[EMPTY, FILLED, FILLED]));
+        }
+    }
+}
+
 #[test]
 fn bit_planes_match_ternary_arithmetic() {
     let from_digit = |digit| Column {

--- a/cryptography/src/bls12381/primitives/subgroup/research/effective.rs
+++ b/cryptography/src/bls12381/primitives/subgroup/research/effective.rs
@@ -1,0 +1,330 @@
+//! Certify sparse kernels of the complete recursive linear circuit.
+//!
+//! The effective integer coefficients lie in [-2,2]. Modulo-three independence
+//! certifies two-column independence for the BLS12-381 cofactor, which has no
+//! factors two, five, or seven. This is not a generic odd-cofactor argument.
+
+use super::*;
+
+const Q: u32 = 19;
+const BUCKETS: usize = Q.pow(3) as usize;
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+struct Column {
+    positive: u64,
+    negative: u64,
+}
+
+impl Column {
+    fn signed(self, negate: bool) -> Self {
+        if negate {
+            Self {
+                positive: self.negative,
+                negative: self.positive,
+            }
+        } else {
+            self
+        }
+    }
+
+    fn plus(self, other: Self) -> Self {
+        let zero = !(self.positive | self.negative);
+        let other_zero = !(other.positive | other.negative);
+        Self {
+            positive: (zero & other.positive)
+                | (self.positive & other_zero)
+                | (self.negative & other.negative),
+            negative: (zero & other.negative)
+                | (self.negative & other_zero)
+                | (self.positive & other.positive),
+        }
+    }
+
+    fn canonical(self) -> u128 {
+        let forward = (u128::from(self.positive) << 64) | u128::from(self.negative);
+        let backward = (u128::from(self.negative) << 64) | u128::from(self.positive);
+        forward.min(backward)
+    }
+}
+
+fn columns(widths: &[u32], ids: &[Vec<u32>]) -> Vec<Column> {
+    assert_eq!(widths.len(), ids.len());
+    assert!(widths.iter().sum::<u32>() <= 64);
+    let mut columns = vec![Column::default(); ids.first().map_or(0, Vec::len)];
+    let mut offset = 0;
+    for (&width, pass) in widths.iter().zip(ids) {
+        assert_eq!(pass.len(), columns.len());
+        for (&id, column) in pass.iter().zip(&mut columns) {
+            let mut value = (id & !ID_NEGATE) as i32;
+            if id & ID_NEGATE != 0 {
+                value = -value;
+            }
+            for bit in offset..offset + width {
+                let digit = value.rem_euclid(3);
+                match digit {
+                    1 => column.positive |= 1 << bit,
+                    2 => column.negative |= 1 << bit,
+                    _ => {}
+                }
+                value = (value - if digit == 2 { -1 } else { digit }) / 3;
+            }
+            assert_eq!(value, 0);
+        }
+        offset += width;
+    }
+    columns
+}
+
+fn effective_columns(
+    graph_ids: &[Vec<u32>; 2],
+    positions: &[usize],
+    columns: &[Column],
+    buckets: usize,
+) -> Vec<Column> {
+    assert_eq!(positions.len(), 2 * buckets);
+    assert_eq!(graph_ids[0].len(), graph_ids[1].len());
+    graph_ids[0]
+        .iter()
+        .zip(&graph_ids[1])
+        .map(|(&left, &right)| {
+            let mut sum = Column::default();
+            for (pass, id) in [left, right].into_iter().enumerate() {
+                let position = positions[pass * buckets + (id & !ID_NEGATE) as usize];
+                if position != usize::MAX {
+                    sum = sum.plus(columns[position].signed(id & ID_NEGATE != 0));
+                }
+            }
+            sum
+        })
+        .collect()
+}
+
+fn in_subgroup(point: blst_p1_affine) -> bool {
+    G1::from_blst_p1(blst_p1 {
+        x: point.x,
+        y: point.y,
+        z: G1::generator().as_blst_p1().z,
+    })
+    .in_subgroup()
+}
+
+fn checked_effective(affine: &[blst_p1_affine], columns: Vec<Column>) -> bool {
+    super::pair::exception_indices(columns.into_iter().map(Column::canonical))
+        .into_iter()
+        .all(|index| in_subgroup(affine[index]))
+}
+
+pub(super) fn check(points: &[G1], rng: &mut impl CryptoRng) -> bool {
+    assert!(points.len() <= Q.pow(4) as usize);
+    let affine = to_affine(points);
+    let graph_ids = super::two::draw_ids::<Q>(affine.len(), rng);
+    let mut round = Round::new(9);
+    round.widen(9);
+    let mut compressed = Vec::with_capacity(2 * BUCKETS);
+    let mut positions = vec![usize::MAX; 2 * BUCKETS];
+    for (pass, ids) in graph_ids.iter().enumerate() {
+        round.accumulate(&affine, ids);
+        for bucket in 0..BUCKETS {
+            if round.live[bucket] {
+                positions[pass * BUCKETS + bucket] = compressed.len();
+                compressed.push(round.sums[bucket]);
+            }
+        }
+    }
+    let Some(widths) = plan(compressed.len(), combinations_for_security(99)) else {
+        return compressed.into_iter().all(in_subgroup);
+    };
+    let mut trits = Trits::new(rng);
+    let ids: Vec<_> = widths
+        .iter()
+        .map(|&width| trits.fill(width, compressed.len()))
+        .collect();
+    let columns = columns(&widths, &ids);
+    let effective = effective_columns(&graph_ids, &positions, &columns, BUCKETS);
+    if !checked_effective(&affine, effective) {
+        return false;
+    }
+    // Exact checks only restrict acceptance; preserve the entire sampled circuit.
+    let mut final_round = Round::new(*widths.iter().max().expect("positive target"));
+    widths
+        .iter()
+        .zip(&ids)
+        .all(|(&width, pass)| final_round.run(&compressed, pass, width))
+}
+
+#[test]
+fn bit_planes_match_ternary_arithmetic() {
+    let from_digit = |digit| Column {
+        positive: u64::from(digit == 1),
+        negative: u64::from(digit == 2),
+    };
+    for a in 0..3 {
+        for b in 0..3 {
+            assert_eq!(from_digit(a).plus(from_digit(b)), from_digit((a + b) % 3));
+        }
+        assert_eq!(from_digit(a).signed(true), from_digit((3 - a) % 3));
+    }
+    let mut ids = vec![Vec::new()];
+    for value in -40i32..=40 {
+        ids[0].push(value.unsigned_abs() | if value < 0 { ID_NEGATE } else { 0 });
+    }
+    for (index, column) in columns(&[4], &ids).into_iter().enumerate() {
+        assert_eq!(column.positive & column.negative, 0);
+        let recovered: i32 = (0..4)
+            .map(|bit| {
+                (((column.positive >> bit) & 1) as i32 - ((column.negative >> bit) & 1) as i32)
+                    * 3i32.pow(bit)
+            })
+            .sum();
+        assert_eq!(recovered, index as i32 - 40);
+    }
+}
+
+#[test]
+fn effective_certificate_marks_original_copies_and_omissions() {
+    let one = Column {
+        positive: 1,
+        negative: 0,
+    };
+    let two = one.signed(true);
+    let graph_ids = [vec![0, 0, 0], vec![0, ID_NEGATE, 1]];
+    let effective = effective_columns(&graph_ids, &[0, usize::MAX, 1, usize::MAX], &[one, two], 2);
+    let effective: Vec<_> = effective.into_iter().map(Column::canonical).collect();
+    assert_eq!(effective[0], 0);
+    assert_eq!(effective[1], one.canonical());
+    assert_eq!(effective[2], one.canonical());
+    assert_eq!(super::pair::exception_indices(effective), [0, 1, 2]);
+}
+
+#[test]
+fn recursive_effective_check_rejects_adversarial_inputs() {
+    let generator = G1::generator();
+    let bad = order_three();
+    assert!(check(&[], &mut test_rng()));
+    assert!(check(&[G1::zero(); 16], &mut test_rng()));
+    for count in [0, 1, 2, 3, 4, 8, 12, 13, 32, 1254] {
+        let mut points = vec![generator; 4096];
+        for (i, point) in points.iter_mut().take(count).enumerate() {
+            *point += &if i % 2 == 0 { bad } else { -bad };
+        }
+        points.extend([G1::zero(); 16]);
+        assert_eq!(check(&points, &mut test_rng()), count == 0);
+    }
+}
+
+#[test]
+fn effective_columns_match_the_complete_group_circuit() {
+    let generator = G1::generator();
+    let one = generator.as_blst_p1().z;
+    let bad = order_three();
+    let mut rng = test_rng();
+    let graph_ids = super::two::draw_ids::<3>(81, &mut rng);
+    let mut point = generator;
+    let mut points: Vec<_> = (0..81)
+        .map(|i| {
+            point += &generator;
+            if i % 3 == 0 { point + &bad } else { point }
+        })
+        .collect();
+    let mut replacements = [generator, generator, -(generator + &generator)].into_iter();
+    for (point, &id) in points.iter_mut().zip(&graph_ids[0]) {
+        if id & !ID_NEGATE == 0 {
+            let replacement = replacements.next().unwrap();
+            *point = if id & ID_NEGATE == 0 {
+                replacement
+            } else {
+                -replacement
+            };
+        }
+    }
+    assert!(replacements.next().is_none());
+    let affine = to_affine(&points);
+    assert_eq!(affine.len(), points.len());
+    let mut round = Round::new(4);
+    round.widen(4);
+    let mut positions = vec![usize::MAX; 54];
+    let mut compressed = Vec::new();
+    for (pass, ids) in graph_ids.iter().enumerate() {
+        round.accumulate(&affine, ids);
+        for bucket in 0..27 {
+            if round.live[bucket] {
+                positions[pass * 27 + bucket] = compressed.len();
+                let point = round.sums[bucket];
+                compressed.push(G1::from_blst_p1(blst_p1 {
+                    x: point.x,
+                    y: point.y,
+                    z: one,
+                }));
+            }
+        }
+    }
+    assert_eq!(positions[0], usize::MAX);
+    let widths = [2, 3];
+    let mut trits = Trits::new(&mut rng);
+    let ids: Vec<_> = widths
+        .iter()
+        .map(|&width| trits.fill(width, compressed.len()))
+        .collect();
+    let effective = effective_columns(&graph_ids, &positions, &columns(&widths, &ids), 27);
+    let mut digits = vec![Vec::new(); compressed.len()];
+    for (&width, pass) in widths.iter().zip(&ids) {
+        let half = (3i32.pow(width) - 1) / 2;
+        for (digits, &id) in digits.iter_mut().zip(pass) {
+            let value = (id & !ID_NEGATE) as i32 * if id & ID_NEGATE == 0 { 1 } else { -1 };
+            for bit in 0..width {
+                digits.push((((value + half) / 3i32.pow(bit)) % 3 - 1) as i8);
+            }
+        }
+    }
+    let mut saw_double = false;
+    for row in 0..5 {
+        let mut direct = G1::zero();
+        for (point, digits) in compressed.iter().zip(&digits) {
+            if digits[row] == 1 {
+                direct += point;
+            }
+            if digits[row] == -1 {
+                direct -= point;
+            }
+        }
+        let mut composed = G1::zero();
+        for (index, point) in points.iter().enumerate() {
+            let mut coefficient = 0i8;
+            for (pass, ids) in graph_ids.iter().enumerate() {
+                let id = ids[index];
+                let position = positions[pass * 27 + (id & !ID_NEGATE) as usize];
+                if position != usize::MAX {
+                    coefficient += digits[position][row] * if id & ID_NEGATE == 0 { 1 } else { -1 };
+                }
+            }
+            saw_double |= coefficient.abs() == 2;
+            assert_eq!(
+                (effective[index].positive >> row) & 1,
+                u64::from(coefficient.rem_euclid(3) == 1)
+            );
+            assert_eq!(
+                (effective[index].negative >> row) & 1,
+                u64::from(coefficient.rem_euclid(3) == 2)
+            );
+            for _ in 0..coefficient.unsigned_abs() {
+                if coefficient > 0 {
+                    composed += point;
+                } else {
+                    composed -= point;
+                }
+            }
+        }
+        assert_eq!(direct, composed);
+    }
+    assert!(saw_double);
+    let polluted = to_affine(&[generator, generator + &bad]);
+    let column = Column {
+        positive: 1,
+        negative: 0,
+    };
+    assert!(!checked_effective(&polluted, vec![column, column]));
+    assert!(!checked_effective(
+        &polluted,
+        vec![column, Column::default()]
+    ));
+}

--- a/cryptography/src/bls12381/primitives/subgroup/research/effective_bound.py
+++ b/cryptography/src/bls12381/primitives/subgroup/research/effective_bound.py
@@ -1,0 +1,51 @@
+"""Exact cofactor and support bounds for the effective-circuit certificate."""
+
+from fractions import Fraction
+from math import comb, gcd, log2
+
+
+def verify_cofactor():
+    h = int('396c8c005555e1568c00aaab0000aaab', 16)
+    assert h == 3*(11*10177*859267*52437899)**2
+    assert h % 3 == 0
+    assert gcd(h, 2*5*7) == 1
+    for minor in range(-8, 9):
+        if minor % 3:
+            assert gcd(minor, h) == 1
+
+
+def verify(q):
+    m = q**4
+    l = 8*(q-1)
+    c8 = Fraction(m*(q-1)**4, 8)
+    cycle8 = c8/(256*comb(m, 8))
+    cycle10 = Fraction(m*(q-1)**8, 10*1024*comb(m, 10))
+    c12 = Fraction(m*(q-1)**10, 12)
+    theta444 = Fraction(4*(q-2), 3)*c8
+    support12 = (c12/4096+theta444/2048)/comb(m, 12)
+    worst = Fraction(0)
+    worst_k = 0
+    choose = 1
+    vertices = 0
+    for k in range(1, 66*q):
+        choose = choose*(m-k+1)//k
+        if k < (13 if q == 19 else 12):
+            continue
+        while vertices**3+8*k*vertices < 16*k*k:
+            vertices += 1
+        c = k//8
+        probability = Fraction(c*comb(k-1,c-1)*m**c*l**(k-c),
+                               2**max(8*c, vertices)*choose)
+        if probability > worst:
+            worst, worst_k = probability, k
+    compression = max(cycle8, cycle10, support12, worst, Fraction(1, 2**132))
+    total = compression+Fraction(1, 3**63)
+    assert total < Fraction(1, 3**61)
+    print(f"q{q} C8={-log2(cycle8):.12f}, C10={-log2(cycle10):.12f}, support12={-log2(support12):.12f}, intermediate={-log2(worst):.12f} at k={worst_k}")
+    print(f"compression={-log2(compression):.12f}, with joint63trits={-log2(total):.12f}; required={61*log2(3):.12f}")
+
+
+if __name__ == "__main__":
+    verify_cofactor()
+    verify(23)
+    verify(19)

--- a/cryptography/src/bls12381/primitives/subgroup/research/moments.rs
+++ b/cryptography/src/bls12381/primitives/subgroup/research/moments.rs
@@ -1,0 +1,78 @@
+//! Exact concentration checks in cyclic and noncyclic groups of exponent three.
+
+fn add(mut first: usize, mut second: usize, rank: u32) -> usize {
+    let mut result = 0;
+    let mut place = 1;
+    for _ in 0..rank {
+        result += ((first % 3 + second % 3) % 3) * place;
+        first /= 3;
+        second /= 3;
+        place *= 3;
+    }
+    result
+}
+
+fn check_moment(rank: u32, moment: usize, bound: u64) -> usize {
+    let order = 3usize.pow(rank);
+    let addition: Vec<Vec<_>> = (0..order)
+        .map(|first| (0..order).map(|second| add(first, second, rank)).collect())
+        .collect();
+    let mut values = vec![1; moment];
+    let mut tested = 0;
+    let mut worst = 0;
+    loop {
+        // Counts enumerate all four choices: either sign in either bucket.
+        let mut distribution = vec![0u64; order * order];
+        distribution[0] = 1;
+        for &value in &values {
+            let mut next = vec![0u64; order * order];
+            // In a group of exponent three, the negative of T is 2*T.
+            let negative = addition[value][value];
+            for (index, &count) in distribution.iter().enumerate() {
+                let (first, second) = (index / order, index % order);
+                for signed in [value, negative] {
+                    next[addition[first][signed] * order + second] += count;
+                    next[first * order + addition[second][signed]] += count;
+                }
+            }
+            distribution = next;
+        }
+        assert_eq!(distribution.iter().sum::<u64>(), 4u64.pow(moment as u32));
+        let largest = *distribution.iter().max().unwrap();
+        assert!(largest <= bound, "rank={rank} inputs={values:?}");
+        worst = worst.max(largest);
+        tested += 1;
+
+        // Input permutations have the same distribution, so enumerate every
+        // nonzero multiset, including mixed values and repeated inputs.
+        let Some(index) = values.iter().rposition(|&value| value < order - 1) else {
+            break;
+        };
+        let next = values[index] + 1;
+        values[index..].fill(next);
+    }
+    assert_eq!(worst, bound);
+    tested
+}
+
+#[test]
+fn fourth_moment_order_three() {
+    // At B=2, the fourth-moment bound is 36/4^4.
+    assert_eq!(check_moment(1, 4, 36), 5);
+}
+
+#[test]
+fn sixth_moment_order_three() {
+    // At B=2, the sixth-moment bound is 484/4^6, including order-three returns.
+    assert_eq!(check_moment(1, 6, 484), 7);
+}
+
+#[test]
+fn fourth_moment_noncyclic_order_nine() {
+    assert_eq!(check_moment(2, 4, 36), 330);
+}
+
+#[test]
+fn sixth_moment_noncyclic_order_nine() {
+    assert_eq!(check_moment(2, 6, 484), 1716);
+}

--- a/cryptography/src/bls12381/primitives/subgroup/research/pair.rs
+++ b/cryptography/src/bls12381/primitives/subgroup/research/pair.rs
@@ -1,0 +1,128 @@
+//! An inner check with exact treatment of one- and two-input kernels.
+
+use super::*;
+
+fn exceptions(widths: &[u32], ids: &[Vec<u32>]) -> Vec<usize> {
+    assert_eq!(widths.len(), ids.len());
+    assert!(widths.iter().sum::<u32>() <= 79);
+    let n = ids.first().map_or(0, Vec::len);
+    let mut columns = vec![0i128; n];
+    let mut factor = 1i128;
+    for (&width, pass) in widths.iter().zip(ids) {
+        assert_eq!(pass.len(), n);
+        for (column, &id) in columns.iter_mut().zip(pass) {
+            let value = i128::from(id & !ID_NEGATE);
+            *column += factor * if id & ID_NEGATE == 0 { value } else { -value };
+        }
+        factor *= 3i128.pow(width);
+    }
+    exception_indices(columns.into_iter().map(i128::unsigned_abs))
+}
+
+pub(super) fn exception_indices(values: impl IntoIterator<Item = u128>) -> Vec<usize> {
+    let mut columns: Vec<_> = values
+        .into_iter()
+        .enumerate()
+        .map(|(index, value)| (value, index))
+        .collect();
+    columns.sort_unstable();
+    let mut marked = Vec::new();
+    let mut start = 0;
+    while start < columns.len() {
+        let mut end = start + 1;
+        while end < columns.len() && columns[end].0 == columns[start].0 {
+            end += 1;
+        }
+        if columns[start].0 == 0 || end - start > 1 {
+            marked.extend(columns[start..end].iter().map(|&(_, index)| index));
+        }
+        start = end;
+    }
+    marked
+}
+
+fn checked_columns(affine: &[blst_p1_affine], widths: &[u32], ids: &[Vec<u32>]) -> bool {
+    let one = G1::generator().as_blst_p1().z;
+    exceptions(widths, ids).into_iter().all(|index| {
+        let point = affine[index];
+        G1::from_blst_p1(blst_p1 {
+            x: point.x,
+            y: point.y,
+            z: one,
+        })
+        .in_subgroup()
+    })
+}
+
+pub(super) fn check<const SECURITY: usize>(points: &[G1], rng: &mut impl CryptoRng) -> bool {
+    assert!(matches!(SECURITY, 96 | 99));
+    let Some(widths) = plan(points.len(), combinations_for_security(SECURITY)) else {
+        return points.iter().all(G1::in_subgroup);
+    };
+    let affine = to_affine(points);
+    let mut trits = Trits::new(rng);
+    let ids: Vec<_> = widths
+        .iter()
+        .map(|&m| trits.fill(m, affine.len()))
+        .collect();
+    if !checked_columns(&affine, &widths, &ids) {
+        return false;
+    }
+    // Keep all inputs and their iid columns after exact-checking exceptions.
+    let mut round = Round::new(*widths.iter().max().expect("positive target"));
+    widths
+        .iter()
+        .zip(&ids)
+        .all(|(&width, pass)| round.run(&affine, pass, width))
+}
+
+#[test]
+fn packed_columns_preserve_global_sign() {
+    let mut ids = vec![Vec::new(), Vec::new()];
+    for value in -121i32..=121 {
+        let low = (value + 4).rem_euclid(9) - 4;
+        let high = (value - low) / 9;
+        for (pass, part) in [low, high].into_iter().enumerate() {
+            ids[pass].push(part.unsigned_abs() | if part < 0 { ID_NEGATE } else { 0 });
+        }
+    }
+    let mut marked = exceptions(&[2, 3], &ids);
+    marked.sort_unstable();
+    assert_eq!(marked, (0..243).collect::<Vec<_>>());
+    let positive: Vec<Vec<_>> = ids.iter().map(|pass| pass[122..].to_vec()).collect();
+    assert!(exceptions(&[2, 3], &positive).is_empty());
+    let mixed = [vec![1, 1], vec![1, 1 | ID_NEGATE]];
+    assert!(exceptions(&[1, 1], &mixed).is_empty());
+}
+
+#[test]
+fn exact_exceptions_check_polluted_duplicate_copies() {
+    let generator = G1::generator();
+    let bad = order_three();
+    let points = [generator, generator + &bad];
+    for ids in [vec![1, 1], vec![1, 1 | ID_NEGATE], vec![1, 0]] {
+        assert!(!checked_columns(&to_affine(&points), &[1], &[ids]));
+    }
+    assert!(checked_columns(
+        &to_affine(&[generator; 3]),
+        &[1],
+        &[vec![0, 1, 1 | ID_NEGATE]],
+    ));
+}
+
+#[test]
+fn certified_inner_rejects_adversarial_batches() {
+    assert_eq!(combinations_for_security(96), 61);
+    let generator = G1::generator();
+    let bad = order_three();
+    assert!(check::<96>(&[], &mut test_rng()));
+    assert!(check::<96>(&[G1::zero(); 16], &mut test_rng()));
+    for count in [0, 1, 2, 3, 4, 8, 12, 32, 1598] {
+        let mut points = vec![generator; 4096];
+        for (i, point) in points.iter_mut().take(count).enumerate() {
+            *point += &if i % 2 == 0 { bad } else { -bad };
+        }
+        assert_eq!(check::<96>(&points, &mut test_rng()), count == 0);
+        assert_eq!(check::<99>(&points, &mut test_rng()), count == 0);
+    }
+}

--- a/cryptography/src/bls12381/primitives/subgroup/research/primary.rs
+++ b/cryptography/src/bls12381/primitives/subgroup/research/primary.rs
@@ -1,0 +1,270 @@
+//! The order-three component only. This is NOT a G1 subgroup verifier.
+//!
+//! Descent maps curve addition to multiplication modulo cubes. The remaining
+//! cofactor is invisible to this map and needs a separate, complete check.
+//! See `cryptography/SUBGROUP_DESCENT.md` for the derivation and limitations.
+
+use super::*;
+
+const Q: u32 = 47;
+const BUCKETS: usize = Q.pow(3) as usize;
+
+const CUBE_EXPONENT: [u64; 6] = [
+    0x9354ffffffffe38e,
+    0x0a395554e5c6aaaa,
+    0xcd104635a790520c,
+    0xcc27c3d6fbd7063f,
+    0x190937e76bc3e447,
+    0x08ab05f8bdd54cde,
+];
+
+fn character(value: &blst_fp) -> blst_fp {
+    let mut result = G1::generator().as_blst_p1().z;
+    for word in CUBE_EXPONENT.iter().rev() {
+        for bit in (0..64).rev() {
+            result = fp_sqr(&result);
+            if word & (1 << bit) != 0 {
+                result = fp_mul(&result, value);
+            }
+        }
+    }
+    result
+}
+
+fn representative(point: &blst_p1_affine, negate: bool) -> blst_fp {
+    let one = G1::generator().as_blst_p1().z;
+    let two = fp_add(&one, &one);
+    let value = if negate {
+        fp_add(&point.y, &two)
+    } else {
+        fp_sub(&point.y, &two)
+    };
+    if fp_is_zero(&value) {
+        // At (0,2), 16 represents 1/4 modulo cubes. It also represents the
+        // inverse class at (0,-2), where the negative representative vanishes.
+        fp_sqr(&fp_sqr(&two))
+    } else {
+        value
+    }
+}
+
+fn combinations(values: &[blst_fp], ids: &[u32], width: u32) -> Vec<blst_fp> {
+    assert_eq!(values.len(), ids.len());
+    assert!((1..=MAX_WIDTH).contains(&width));
+    let one = G1::generator().as_blst_p1().z;
+    let mut slots = vec![one; folded(width)];
+    for (value, &id) in values.iter().zip(ids) {
+        let bucket = (id & !ID_NEGATE) as usize;
+        if bucket != 0 {
+            // Squaring is inversion in the quotient by cubes, not in Fp*.
+            let value = if id & ID_NEGATE == 0 {
+                *value
+            } else {
+                fp_sqr(value)
+            };
+            slots[bucket] = fp_mul(&slots[bucket], &value);
+        }
+    }
+    let mut result = Vec::with_capacity(width as usize);
+    for remaining in (1..=width).rev() {
+        let half = 3usize.pow(remaining - 1);
+        let mut product = one;
+        for value in &slots[half.div_ceil(2)..=(3 * half - 1) / 2] {
+            product = fp_mul(&product, value);
+        }
+        result.push(product);
+        if remaining > 1 {
+            let mut next = vec![one; folded(remaining - 1)];
+            for a in 1..=(half - 1) / 2 {
+                next[a] = fp_mul(
+                    &fp_mul(&slots[a], &slots[half + a]),
+                    &fp_sqr(&slots[half - a]),
+                );
+            }
+            slots = next;
+        }
+    }
+    result
+}
+
+fn inner(values: &[blst_fp], rng: &mut impl CryptoRng) -> bool {
+    let widths = spread(combinations_for_security(111), 8);
+    let mut trits = Trits::new(rng);
+    widths.into_iter().all(|width| {
+        let ids = trits.fill(width, values.len());
+        combinations(values, &ids, width)
+            .iter()
+            .all(|value| fp_is_one(&character(value)))
+    })
+}
+
+/// Test only the order-three component with error below 2^-128.
+///
+/// Inputs must already be on-curve and fixed before fresh private randomness
+/// is drawn. Passing this filter does not establish G1 membership.
+pub(super) fn check_order_three(points: &[G1], rng: &mut impl CryptoRng) -> (bool, [Duration; 4]) {
+    assert!(points.len() <= Q.pow(4) as usize);
+    let start = Instant::now();
+    let affine = to_affine(points);
+    let normalized = start.elapsed();
+    if affine.is_empty() {
+        return (
+            true,
+            [normalized, Duration::ZERO, Duration::ZERO, Duration::ZERO],
+        );
+    }
+    let start = Instant::now();
+    let ids = super::two::draw_ids::<Q>(affine.len(), rng);
+    let sampled = start.elapsed();
+    let one = G1::generator().as_blst_p1().z;
+    let mut compressed = Duration::ZERO;
+    let mut checked = Duration::ZERO;
+    for pass in &ids {
+        let start = Instant::now();
+        let mut products = vec![one; BUCKETS];
+        for (point, &id) in affine.iter().zip(pass) {
+            let bucket = (id & !ID_NEGATE) as usize;
+            products[bucket] = fp_mul(
+                &products[bucket],
+                &representative(point, id & ID_NEGATE != 0),
+            );
+        }
+        compressed += start.elapsed();
+        let start = Instant::now();
+        let valid = inner(&products, rng);
+        checked += start.elapsed();
+        if !valid {
+            return (false, [normalized, sampled, compressed, checked]);
+        }
+    }
+    (true, [normalized, sampled, compressed, checked])
+}
+
+#[test]
+fn descent_handles_torsion_signs_and_group_addition() {
+    let mut carry = 1u128;
+    for (&word, &modulus) in CUBE_EXPONENT.iter().zip(&MODULUS) {
+        let product = u128::from(word) * 3 + carry;
+        assert_eq!(product as u64, modulus);
+        carry = product >> 64;
+    }
+    assert_eq!(carry, 0);
+    let generator = G1::generator();
+    let one = generator.as_blst_p1().z;
+    let torsion = order_three();
+    let chi = |point: G1| {
+        if point == G1::zero() {
+            one
+        } else {
+            character(&representative(&to_affine(&[point])[0], false))
+        }
+    };
+    assert!(fp_is_one(&chi(generator)));
+    assert!(!fp_is_one(&chi(torsion)));
+    let mut point = generator;
+    for _ in 0..12 {
+        for other in [
+            G1::zero(),
+            generator,
+            torsion,
+            -torsion,
+            generator + &torsion,
+        ] {
+            assert!(fp_eq(
+                &chi(point + &other),
+                &fp_mul(&chi(point), &chi(other))
+            ));
+        }
+        let affine = to_affine(&[point])[0];
+        assert!(fp_is_one(&character(&fp_mul(
+            &representative(&affine, false),
+            &representative(&affine, true)
+        ))));
+        point += &generator;
+        point += &torsion;
+    }
+    for point in [torsion, -torsion] {
+        let affine = to_affine(&[point])[0];
+        assert!(!fp_is_zero(&representative(&affine, false)));
+        assert!(!fp_is_zero(&representative(&affine, true)));
+        assert!(fp_eq(
+            &character(&representative(&affine, true)),
+            &chi(-point)
+        ));
+    }
+}
+
+#[test]
+fn multiplicative_collapse_matches_independent_digit_oracle() {
+    let one = G1::generator().as_blst_p1().z;
+    let two = fp_add(&one, &one);
+    let mut rng = test_rng();
+    for width in [1, 2, 3, 4, 5, 8, 9] {
+        let ids = Trits::new(&mut rng).fill(width, 250);
+        let mut power = one;
+        let values: Vec<_> = (0..ids.len())
+            .map(|_| {
+                power = fp_mul(&power, &two);
+                power
+            })
+            .collect();
+        let actual = combinations(&values, &ids, width);
+        for row in 0..width {
+            let mut direct = one;
+            let offset = (3i32.pow(width) - 1) / 2;
+            for (value, &id) in values.iter().zip(&ids) {
+                let unsigned = (id & !ID_NEGATE) as i32;
+                let signed = if id & ID_NEGATE == 0 {
+                    unsigned
+                } else {
+                    -unsigned
+                };
+                let digit = ((signed + offset) / 3i32.pow(row)) % 3 - 1;
+                let factor = match digit {
+                    -1 => fp_sqr(value),
+                    0 => one,
+                    1 => *value,
+                    _ => unreachable!(),
+                };
+                direct = fp_mul(&direct, &factor);
+            }
+            assert!(fp_eq(
+                &character(&actual[(width - 1 - row) as usize]),
+                &character(&direct)
+            ));
+        }
+    }
+}
+
+#[test]
+fn order_three_filter_is_deliberately_not_a_subgroup_check() {
+    let bad = order_eleven();
+    assert_ne!(bad, G1::zero());
+    assert!(!bad.in_subgroup());
+    let mut sum = G1::zero();
+    for _ in 0..11 {
+        sum += &bad;
+    }
+    assert_eq!(sum, G1::zero());
+    let points = vec![G1::generator() + &bad; 4096];
+    assert!(check_order_three(&points, &mut test_rng()).0);
+    assert!(!super::effective::check(&points, &mut test_rng()));
+}
+
+#[test]
+fn order_three_filter_rejects_polluted_batches() {
+    let generator = G1::generator();
+    let bad = order_three();
+    assert!(check_order_three(&[], &mut test_rng()).0);
+    assert!(check_order_three(&[G1::zero(); 16], &mut test_rng()).0);
+    for count in [0, 1, 2, 3, 8, 12, 32] {
+        let mut points = vec![generator; 4096];
+        for (i, point) in points.iter_mut().take(count).enumerate() {
+            *point += &if i % 2 == 0 { bad } else { -bad };
+        }
+        points.extend([G1::zero(); 16]);
+        assert_eq!(check_order_three(&points, &mut test_rng()).0, count == 0);
+    }
+    assert!(!check_order_three(&[bad], &mut test_rng()).0);
+    assert!(!check_order_three(&[-bad], &mut test_rng()).0);
+}

--- a/cryptography/src/bls12381/primitives/subgroup/research/three.rs
+++ b/cryptography/src/bls12381/primitives/subgroup/research/three.rs
@@ -1,0 +1,598 @@
+//! Exact stopping-set certification by joining projected bucket coordinates.
+
+use super::*;
+use commonware_utils::TestRng;
+
+const BITS: u32 = 15;
+const EMPTY_CELL: u64 = u64::MAX;
+const REPEATED: u64 = 1 << 63;
+const MIX: u64 = 0x9e3779b97f4a7c15;
+
+struct Relation {
+    cells: Vec<u64>,
+    shift: u32,
+    first_bits: u32,
+    mask: u64,
+    code_mask: u64,
+}
+
+impl Relation {
+    fn new(codes: &[u64], first_bits: u32, bits: u32) -> Option<Self> {
+        let size = (codes.len().max(1) * 2).next_power_of_two();
+        let mut result = Self {
+            cells: vec![EMPTY_CELL; size],
+            shift: 64 - size.ilog2(),
+            first_bits,
+            mask: (1 << first_bits) - 1,
+            code_mask: (1 << (first_bits + 2 * bits)) - 1,
+        };
+        for &code in codes {
+            let key = code >> first_bits;
+            let mut slot = result.index(key);
+            let mut repeated = false;
+            loop {
+                let cell = &mut result.cells[slot];
+                if *cell == EMPTY_CELL {
+                    *cell = code | if repeated { REPEATED } else { 0 };
+                    break;
+                }
+                if *cell & result.code_mask == code {
+                    return None;
+                }
+                if (*cell & result.code_mask) >> first_bits == key {
+                    *cell |= REPEATED;
+                    repeated = true;
+                }
+                slot = (slot + 1) & (size - 1);
+            }
+        }
+        Some(result)
+    }
+
+    fn index(&self, key: u64) -> usize {
+        (key.wrapping_mul(MIX) >> self.shift) as usize
+    }
+
+    fn contains(&self, key: u64, a: u64) -> bool {
+        let target = (key << self.first_bits) | a;
+        let mut slot = self.index(key);
+        loop {
+            let cell = self.cells[slot];
+            if cell == EMPTY_CELL {
+                return false;
+            }
+            if cell & self.code_mask == target {
+                return true;
+            }
+            slot = (slot + 1) & (self.cells.len() - 1);
+        }
+    }
+
+    fn common_first(&self, first: u64, second: u64, excluded: Option<u64>) -> bool {
+        let mut slot = self.index(first);
+        loop {
+            let cell = self.cells[slot];
+            if cell == EMPTY_CELL {
+                return false;
+            }
+            let a = cell & self.mask;
+            if (cell & self.code_mask) >> self.first_bits == first
+                && excluded != Some(a)
+                && self.contains(second, a)
+            {
+                return true;
+            }
+            slot = (slot + 1) & (self.cells.len() - 1);
+        }
+    }
+}
+
+fn certificate(codes: &[u64], bits: u32) -> bool {
+    certificate_shaped(codes, bits, bits)
+}
+
+fn certificate_shaped(codes: &[u64], first_bits: u32, bits: u32) -> bool {
+    exception_codes(codes, first_bits, bits).is_empty()
+}
+
+fn exception_codes(codes: &[u64], first_bits: u32, bits: u32) -> Vec<u64> {
+    let mut canonical = codes.to_vec();
+    canonical.sort_unstable();
+    let mut marked: Vec<_> = canonical
+        .windows(2)
+        .filter(|pair| pair[0] == pair[1])
+        .map(|pair| pair[0])
+        .collect();
+    canonical.dedup();
+    let codes = canonical.as_slice();
+    let relation = Relation::new(codes, first_bits, bits).expect("canonical columns are distinct");
+    let first_buckets = 1usize << first_bits;
+    let first_mask = (first_buckets - 1) as u64;
+    let mask = (1u64 << bits) - 1;
+    // Folding coordinates creates false positives only. Exact joins decide
+    // acceptance, so this filter changes neither the certificate nor its law.
+    let filter_bits = bits.min(13);
+    let filter_mask = (1u64 << filter_bits) - 1;
+    let filter_index =
+        |key: u64| (((key >> bits) & filter_mask) << filter_bits | (key & filter_mask)) as usize;
+    let words = ((1usize << (2 * filter_bits)) / 64).max(1);
+    let mut present = vec![0u64; words];
+    let mut repeated = vec![0u64; words];
+    for &cell in &relation.cells {
+        if cell == EMPTY_CELL {
+            continue;
+        }
+        let index = filter_index((cell & relation.code_mask) >> first_bits);
+        present[index / 64] |= 1 << (index % 64);
+        if cell & REPEATED != 0 {
+            repeated[index / 64] |= 1 << (index % 64);
+        }
+    }
+    let mut offsets = vec![0usize; first_buckets + 1];
+    for &code in codes {
+        offsets[(code & first_mask) as usize + 1] += 1;
+    }
+    for i in 1..offsets.len() {
+        offsets[i] += offsets[i - 1];
+    }
+    let mut cursors = offsets[..first_buckets].to_vec();
+    let mut grouped = vec![0u64; codes.len()];
+    for &code in codes {
+        let index = filter_index(code >> first_bits);
+        let flagged = code
+            | if repeated[index / 64] & (1 << (index % 64)) != 0 {
+                REPEATED
+            } else {
+                0
+            };
+        let cursor = &mut cursors[(code & first_mask) as usize];
+        grouped[*cursor] = flagged;
+        *cursor += 1;
+    }
+    let mut same_b = Vec::new();
+    let mut same_c = Vec::new();
+    for a in 0..first_buckets {
+        let group = &grouped[offsets[a]..offsets[a + 1]];
+        for (i, &first) in group.iter().enumerate() {
+            let bc1 = (first & relation.code_mask) >> first_bits;
+            let (b1, c1) = (bc1 >> bits, bc1 & mask);
+            for &second in &group[i + 1..] {
+                let bc2 = (second & relation.code_mask) >> first_bits;
+                if first & second & REPEATED != 0 && relation.common_first(bc1, bc2, Some(a as u64))
+                {
+                    marked.extend([first & relation.code_mask, second & relation.code_mask]);
+                    continue;
+                }
+                let (b2, c2) = (bc2 >> bits, bc2 & mask);
+                // An equal coordinate cancels from the pair's incidence
+                // vector, so its value may differ in the matching pair.
+                if b1 == b2 {
+                    same_b.push((
+                        (c1.min(c2) << bits) | c1.max(c2),
+                        first & relation.code_mask,
+                        second & relation.code_mask,
+                    ));
+                    continue;
+                }
+                if c1 == c2 {
+                    same_c.push((
+                        (b1.min(b2) << bits) | b1.max(b2),
+                        first & relation.code_mask,
+                        second & relation.code_mask,
+                    ));
+                    continue;
+                }
+                let crossed1 = (b1 << bits) | c2;
+                let crossed2 = (b2 << bits) | c1;
+                let index1 = filter_index(crossed1);
+                if present[index1 / 64] & (1 << (index1 % 64)) == 0 {
+                    continue;
+                }
+                let index2 = filter_index(crossed2);
+                if present[index2 / 64] & (1 << (index2 % 64)) != 0
+                    && relation.common_first(crossed1, crossed2, None)
+                {
+                    marked.extend([first & relation.code_mask, second & relation.code_mask]);
+                }
+            }
+        }
+    }
+    for mut pairs in [same_b, same_c] {
+        pairs.sort_unstable();
+        let mut start = 0;
+        while start < pairs.len() {
+            let end = start + pairs[start..].partition_point(|pair| pair.0 == pairs[start].0);
+            if end - start > 1 {
+                for &(_, first, second) in &pairs[start..end] {
+                    marked.extend([first, second]);
+                }
+            }
+            start = end;
+        }
+    }
+    marked.sort_unstable();
+    marked.dedup();
+    marked
+}
+
+fn draw_three_ids(
+    n: usize,
+    first_bits: u32,
+    bits: u32,
+    rng: &mut impl CryptoRng,
+) -> ([Vec<u32>; 3], usize) {
+    let code_mask = (1u64 << (first_bits + 2 * bits)) - 1;
+    let mut codes = vec![0u64; n];
+    let mut attempts = 0;
+    loop {
+        attempts += 1;
+        for code in &mut codes {
+            *code = rng.next_u64() & code_mask;
+        }
+        if certificate_shaped(&codes, first_bits, bits) {
+            break;
+        }
+    }
+    (codes_to_ids(&codes, first_bits, bits, rng), attempts)
+}
+
+fn codes_to_ids(
+    codes: &[u64],
+    first_bits: u32,
+    bits: u32,
+    rng: &mut impl CryptoRng,
+) -> [Vec<u32>; 3] {
+    let mut ids: [Vec<u32>; 3] = core::array::from_fn(|_| Vec::with_capacity(codes.len()));
+    for &code in codes {
+        let mut code = code;
+        let signs = rng.next_u32();
+        for (pass, ids) in ids.iter_mut().enumerate() {
+            let width = if pass == 0 { first_bits } else { bits };
+            let bucket = (code & ((1 << width) - 1)) as u32;
+            code >>= width;
+            ids.push(bucket | (((signs >> pass) & 1) * ID_NEGATE));
+        }
+    }
+    ids
+}
+
+fn three_pass_check(
+    points: &[G1],
+    first_bits: u32,
+    bits: u32,
+    rng: &mut impl CryptoRng,
+) -> (bool, [Duration; 4], usize) {
+    assert!(points.len() <= 3_000_000);
+    assert!(matches!((first_bits, bits), (15, 15) | (17, 14)));
+    let start = Instant::now();
+    let affine = to_affine(points);
+    let normalized = start.elapsed();
+    let start = Instant::now();
+    let (ids, attempts) = draw_three_ids(affine.len(), first_bits, bits, rng);
+    let sampled = start.elapsed();
+    let width = if first_bits > 16 { 12 } else { 11 };
+    let mut round = Round::new(width);
+    round.widen(width);
+    let mut compressed = Duration::ZERO;
+    let mut checked = Duration::ZERO;
+    for (pass, ids) in ids.into_iter().enumerate() {
+        let start = Instant::now();
+        let buckets = 1 << if pass == 0 { first_bits } else { bits };
+        let sums = compress_round_with_buckets(&mut round, &affine, &ids, buckets);
+        compressed += start.elapsed();
+        let start = Instant::now();
+        let valid = batch_in_g1(&sums, 100, &Sequential, rng);
+        checked += start.elapsed();
+        if !valid {
+            return (false, [normalized, sampled, compressed, checked], attempts);
+        }
+    }
+    (true, [normalized, sampled, compressed, checked], attempts)
+}
+
+pub(super) fn three_pass_exceptions(
+    points: &[G1],
+    first_bits: u32,
+    bits: u32,
+    rng: &mut impl CryptoRng,
+) -> (bool, [Duration; 4], usize) {
+    assert!(points.len() <= 3_000_000);
+    assert!(matches!((first_bits, bits), (15, 15) | (17, 14)));
+    let start = Instant::now();
+    let affine = to_affine(points);
+    let normalized = start.elapsed();
+    let start = Instant::now();
+    let code_mask = (1u64 << (first_bits + 2 * bits)) - 1;
+    let codes: Vec<_> = (0..affine.len())
+        .map(|_| rng.next_u64() & code_mask)
+        .collect();
+    let (ids, exceptions) = match checked_ids(&affine, &codes, first_bits, bits, rng) {
+        Ok(result) => result,
+        Err(exceptions) => {
+            return (
+                false,
+                [normalized, start.elapsed(), Duration::ZERO, Duration::ZERO],
+                exceptions,
+            );
+        }
+    };
+    let sampled = start.elapsed();
+    let width = if first_bits > 16 { 12 } else { 11 };
+    let mut round = Round::new(width);
+    round.widen(width);
+    let mut compressed = Duration::ZERO;
+    let mut checked = Duration::ZERO;
+    for (pass, ids) in ids.into_iter().enumerate() {
+        let start = Instant::now();
+        let buckets = 1 << if pass == 0 { first_bits } else { bits };
+        let sums = compress_round_with_buckets(&mut round, &affine, &ids, buckets);
+        compressed += start.elapsed();
+        let start = Instant::now();
+        let valid = batch_in_g1(&sums, 100, &Sequential, rng);
+        checked += start.elapsed();
+        if !valid {
+            return (
+                false,
+                [normalized, sampled, compressed, checked],
+                exceptions,
+            );
+        }
+    }
+    (true, [normalized, sampled, compressed, checked], exceptions)
+}
+
+fn checked_ids(
+    affine: &[blst_p1_affine],
+    codes: &[u64],
+    first_bits: u32,
+    bits: u32,
+    rng: &mut impl CryptoRng,
+) -> Result<([Vec<u32>; 3], usize), usize> {
+    assert_eq!(affine.len(), codes.len());
+    let marked = exception_codes(codes, first_bits, bits);
+    let mut exceptions = 0;
+    let one = G1::generator().as_blst_p1().z;
+    for (point, code) in affine.iter().zip(codes) {
+        if marked.binary_search(code).is_ok() {
+            exceptions += 1;
+            if !G1::from_blst_p1(blst_p1 {
+                x: point.x,
+                y: point.y,
+                z: one,
+            })
+            .in_subgroup()
+            {
+                return Err(exceptions);
+            }
+        }
+    }
+    // Retain every input and its original iid column, including exact-checked
+    // points. The proof uses the unconditioned distribution of these sums.
+    Ok((codes_to_ids(codes, first_bits, bits, rng), exceptions))
+}
+
+#[test]
+fn exact_exceptions_check_every_duplicate_copy() {
+    let generator = G1::generator();
+    let bad = order_three();
+    let points = [G1::zero(), generator, generator + &bad, generator - &bad];
+    let affine = to_affine(&points);
+    let mut rng = test_rng();
+    assert_eq!(checked_ids(&affine, &[0, 0, 0], 15, 15, &mut rng), Err(2));
+    assert_eq!(
+        rng.next_u64(),
+        test_rng().next_u64(),
+        "failure precedes sign sampling"
+    );
+    let affine = to_affine(&[generator; 3]);
+    let (ids, checked) = checked_ids(&affine, &[0, 0, 0], 15, 15, &mut rng).unwrap();
+    assert_eq!(checked, 3);
+    assert!(
+        ids.iter()
+            .all(|pass| pass.len() == 3 && pass.iter().all(|id| id & !ID_NEGATE == 0))
+    );
+}
+
+#[test]
+fn exact_exceptions_reject_degenerate_cancellation() {
+    let generator = G1::generator();
+    let bad = order_three();
+    let points = [
+        generator + &bad,
+        generator - &bad,
+        generator - &bad,
+        generator + &bad,
+    ];
+    let codes = [0, 4, 17, 21];
+    for pass in 0..3 {
+        let mut sums = [G1::zero(); 4];
+        for (&code, point) in codes.iter().zip(&points) {
+            sums[((code >> (2 * pass)) & 3) as usize] += point;
+        }
+        assert!(sums.iter().all(G1::in_subgroup));
+    }
+    let mut rng = test_rng();
+    assert_eq!(
+        checked_ids(&to_affine(&points), &codes, 2, 2, &mut rng),
+        Err(1)
+    );
+    assert_eq!(rng.next_u64(), test_rng().next_u64());
+}
+
+#[test]
+fn join_certificate_matches_small_stopping_sets() {
+    let codes: Vec<_> = (0u64..64)
+        .filter(|code| (0..3).all(|part| ((code >> (2 * part)) & 3) < 3))
+        .collect();
+    assert!(!certificate(&[0, 0], 2));
+    for a in 0..codes.len() {
+        for b in a + 1..codes.len() {
+            for c in b + 1..codes.len() {
+                for d in c + 1..codes.len() {
+                    let set = [codes[a], codes[b], codes[c], codes[d]];
+                    let stopping = (0..3).all(|part| {
+                        (0..3).all(|bucket| {
+                            set.iter()
+                                .filter(|&&code| ((code >> (2 * part)) & 3) == bucket)
+                                .count()
+                                != 1
+                        })
+                    });
+                    assert_eq!(certificate(&set, 2), !stopping, "{set:?}");
+                }
+            }
+        }
+    }
+}
+
+fn stopping_set(codes: &[u64], first_bits: u32, bits: u32) -> bool {
+    let widths = [first_bits, bits, bits];
+    let mut shift = 0;
+    for width in widths {
+        let mask = (1u64 << width) - 1;
+        for &code in codes {
+            let bucket = (code >> shift) & mask;
+            if codes
+                .iter()
+                .filter(|&&other| (other >> shift) & mask == bucket)
+                .count()
+                == 1
+            {
+                return false;
+            }
+        }
+        shift += width;
+    }
+    true
+}
+
+#[test]
+fn exceptions_hit_every_small_stopping_set() {
+    let mut rng = test_rng();
+    for (first_bits, bits) in [(1, 1), (3, 1), (2, 2), (3, 2)] {
+        let mask = (1u64 << (first_bits + 2 * bits)) - 1;
+        for _ in 0..128 {
+            let n = (rng.next_u32() as usize % 13) + 1;
+            let codes: Vec<_> = (0..n).map(|_| rng.next_u64() & mask).collect();
+            let marked = exception_codes(&codes, first_bits, bits);
+            assert!(marked.iter().all(|code| codes.contains(code)));
+            let mut canonical = codes.clone();
+            canonical.sort_unstable();
+            let mut needs_exception = false;
+            for pair in canonical.windows(2).filter(|pair| pair[0] == pair[1]) {
+                assert!(marked.contains(&pair[0]));
+                needs_exception = true;
+            }
+            canonical.dedup();
+            for i in 0..canonical.len() {
+                for j in i + 1..canonical.len() {
+                    for k in j + 1..canonical.len() {
+                        for l in k + 1..canonical.len() {
+                            let set = [canonical[i], canonical[j], canonical[k], canonical[l]];
+                            if stopping_set(&set, first_bits, bits) {
+                                needs_exception = true;
+                                assert!(
+                                    set.iter().any(|code| marked.contains(code)),
+                                    "unhit {set:?} in {codes:?}"
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+            assert_eq!(!marked.is_empty(), needs_exception);
+        }
+    }
+}
+
+#[test]
+fn projected_filter_false_positives_are_checked_exactly() {
+    let encode = |a: u64, b: u64, c: u64| (((b << 14) | c) << 3) | a;
+    let mut codes = vec![encode(0, 0, 0), encode(0, 8192, 8192), encode(1, 0, 8192)];
+    assert!(exception_codes(&codes, 3, 14).is_empty());
+    codes.push(encode(1, 8192, 0));
+    assert!(!exception_codes(&codes, 3, 14).is_empty());
+    // Equal-coordinate pairs match even when their erased values differ.
+    assert!(!exception_codes(&[0, 4, 17, 21], 2, 2).is_empty());
+}
+
+#[test]
+fn three_pass_checks_adversarial_inputs() {
+    let generator = G1::generator();
+    let bad = order_three();
+    for count in [0, 1, 2, 3, 4, 5, 6, 32] {
+        let mut points = vec![generator; 1000];
+        for (i, point) in points.iter_mut().take(count).enumerate() {
+            *point += &if i % 2 == 0 { bad } else { -bad };
+        }
+        points.extend([G1::zero(); 16]);
+        for (first_bits, bits) in [(15, 15), (17, 14)] {
+            assert_eq!(
+                three_pass_check(&points, first_bits, bits, &mut test_rng()).0,
+                count == 0
+            );
+            assert_eq!(
+                three_pass_exceptions(&points, first_bits, bits, &mut test_rng()).0,
+                count == 0
+            );
+        }
+    }
+}
+
+#[test]
+#[ignore = "manual research benchmark"]
+fn measure_join_certificate() {
+    for n in [1_000_000, 3_000_000] {
+        let mut rng = test_rng();
+        let codes: Vec<_> = (0..n).map(|_| rng.next_u64() & ((1 << 45) - 1)).collect();
+        let start = Instant::now();
+        let good = certificate(&codes, BITS);
+        eprintln!(
+            "{}::measure_join_certificate/n={n} elapsed={:?} good={good}",
+            module_path!(),
+            start.elapsed()
+        );
+    }
+}
+
+#[test]
+#[ignore = "manual research benchmark"]
+fn measure_three_pass() {
+    let points = benchmark_points(3_000_000);
+    for n in [1_000_000, 3_000_000] {
+        for repeat in 0..4 {
+            for algorithm in if repeat % 2 == 0 {
+                [0, 1, 2, 3]
+            } else {
+                [3, 2, 1, 0]
+            } {
+                // Independent seeds across repetitions, with identical initial
+                // streams for the two three-pass constructions within a pair.
+                let mut rng = TestRng::new(repeat);
+                let start = Instant::now();
+                let shape = if n == 1_000_000 { (15, 15) } else { (17, 14) };
+                let (valid, phases, count) = match algorithm {
+                    0 => (
+                        batch_in_g1(&points[..n], 128, &Sequential, &mut rng),
+                        [Duration::ZERO; 4],
+                        0,
+                    ),
+                    1 => {
+                        let (valid, phases) = sparse_check_separate(&points[..n], &mut rng);
+                        (valid, phases, 1)
+                    }
+                    2 => three_pass_check(&points[..n], shape.0, shape.1, &mut rng),
+                    _ => three_pass_exceptions(&points[..n], shape.0, shape.1, &mut rng),
+                };
+                assert!(valid);
+                eprintln!(
+                    "{}::measure_three_pass/n={n} repeat={repeat} algorithm={algorithm} first_bits={} bits={} elapsed={:?} phases={phases:?} attempts_or_exceptions={count}",
+                    module_path!(),
+                    shape.0,
+                    shape.1,
+                    start.elapsed()
+                );
+            }
+        }
+    }
+}

--- a/cryptography/src/bls12381/primitives/subgroup/research/triple_bound.py
+++ b/cryptography/src/bls12381/primitives/subgroup/research/triple_bound.py
@@ -1,0 +1,59 @@
+"""Exact three-input atom checks and pair-certified outer composition."""
+
+from collections import Counter
+from fractions import Fraction
+from itertools import combinations_with_replacement, product
+from math import comb, log2
+
+
+def check_atoms(moduli, buckets):
+    elements = list(product(*(range(m) for m in moduli)))
+    index = {value: i for i, value in enumerate(elements)}
+    addition = [[index[tuple((a+b) % m for a, b, m in zip(x, y, moduli))] for y in elements] for x in elements]
+    negative = [index[tuple(-a % m for a, m in zip(x, moduli))] for x in elements]
+    worst = 0
+    tested = 0
+    for values in combinations_with_replacement(range(1, len(elements)), 3):
+        counts = {(0,)*buckets: 1}
+        for value in values:
+            next_counts = Counter()
+            for state, count in counts.items():
+                for bucket in range(buckets):
+                    for signed in (value, negative[value]):
+                        updated = list(state)
+                        updated[bucket] = addition[updated[bucket]][signed]
+                        next_counts[tuple(updated)] += count
+            counts = next_counts
+        largest = max(counts.values())
+        assert largest*4*buckets**2 <= 3*(2*buckets)**3, (moduli, buckets, values)
+        assert sum(counts.values()) == (2*buckets)**3
+        worst = max(worst, largest)
+        tested += 1
+    print(f"H={moduli}, B={buckets}: {tested} multisets, max atom={Fraction(worst, (2*buckets)**3)}, bound={Fraction(3,4*buckets*buckets)}")
+
+
+def verify():
+    for moduli in ((3,), (5,), (9,), (3, 3)):
+        for buckets in (2, 3, 4):
+            check_atoms(moduli, buckets)
+
+    q = 47
+    d = q
+    m = q**4
+    b = q**3
+    t = 34
+    threshold = t*d
+    remaining = m-threshold+4
+    atom = Fraction(3, 4*b*b)
+    side = max(atom*m**3/(remaining*(remaining-1)*(remaining-2)), Fraction(1, 2**t))
+    compression = Fraction(m*(d-1)**4, 8*comb(m, 8)*256)
+    trits = (96*1000+1583)//1584
+    assert trits == 61
+    epsilon = Fraction(1, 3**trits)
+    total = compression+2*epsilon*side+epsilon**2
+    assert total < Fraction(1, 2**128)
+    print(f"q47 certified inner96: marginal bits={-log2(side):.12f}, total bits={-log2(total):.12f}")
+
+
+if __name__ == "__main__":
+    verify()

--- a/cryptography/src/bls12381/primitives/subgroup/research/truncated_bound.py
+++ b/cryptography/src/bls12381/primitives/subgroup/research/truncated_bound.py
@@ -1,0 +1,66 @@
+"""Exact inequalities for contiguous-symbol truncated Gamma_3(47)."""
+
+from fractions import Fraction
+from math import comb, log2
+
+
+def verify(q, a, b, cycles, trits):
+    buckets = min(a, b)*q*q
+    edges = a*b*q*q
+    degree = max(a, b)
+    trees = 4*(a+b-2)
+    cutoff = 66*degree
+    assert edges > 256*trees
+    cycle8 = Fraction(cycles, 256*comb(edges, 8))
+    cycle10 = Fraction(edges*(degree-1)**8, 10*1024*comb(edges, 10))
+    choose = 1
+    worst = Fraction(0)
+    worst_k = None
+    vertices = 0
+    for k in range(1, cutoff):
+        choose = choose*(edges-k+1)//k
+        if k < 12:
+            continue
+        while vertices**3+8*k*vertices < 16*k*k:
+            vertices += 1
+        assert vertices**3+8*k*vertices >= 16*k*k
+        assert (vertices-1)**3+8*k*(vertices-1) < 16*k*k
+        components = k//8
+        numerator = (components*comb(k-1, components-1)
+                     *edges**components*trees**(k-components))
+        denominator = 2**max(8*components, vertices)*choose
+        probability = Fraction(numerator, denominator)
+        assert probability < Fraction(1, 2**128), (q, a, b, k)
+        if probability > worst:
+            worst = probability
+            worst_k = k
+    compression = max(cycle8, cycle10, worst, Fraction(1, 2**132))
+    side = max(
+        Fraction(3*edges**3, 4*buckets*buckets*(edges-34*degree+4)
+                 *(edges-34*degree+3)*(edges-34*degree+2)),
+        Fraction(1, 2**34),
+    )
+    epsilon = Fraction(1, 3**trits)
+    moment6 = (Fraction(15, 8*buckets**3)-Fraction(35, 16*buckets**4)
+               +Fraction(21, 32*buckets**5))
+    remaining = edges-49*degree+7
+    falling = 1
+    for offset in range(6):
+        falling *= remaining-offset
+    side6 = max(moment6*edges**6/falling, Fraction(1, 2**49))
+    small = 2*epsilon*side+epsilon**2
+    large = compression+2*epsilon*side6+epsilon**2
+    overall = max(small, large)
+    assert overall < Fraction(1, 2**128), (q, a, b, trits)
+    print(f"q={q} a={a} b={b} M={edges} Bmin={buckets} C8={cycles} trits={trits}")
+    print(f"cycle8={-log2(cycle8):.12f} cycle10={-log2(cycle10):.12f}")
+    print(f"intermediate={-log2(worst):.12f} at k={worst_k}; large>=132")
+    print(f"compression={-log2(compression):.12f}; side={-log2(side):.12f}; total={-log2(overall):.12f}")
+    print(f"side6={-log2(side6):.12f}; small-support={-log2(small):.12f}; large-support={-log2(large):.12f}")
+
+
+if __name__ == "__main__":
+    verify(47, 43, 43, 1263308051793, 61)
+    # Additional shapes are bound-only experiments, not Rust implementations.
+    verify(47, 42, 43, 1147259175618, 61)
+    verify(53, 33, 34, 163687581714, 61)

--- a/cryptography/src/bls12381/primitives/subgroup/research/two.rs
+++ b/cryptography/src/bls12381/primitives/subgroup/research/two.rs
@@ -1,0 +1,559 @@
+//! Two-pass compression on a fixed algebraic graph of girth eight.
+//!
+//! The graph is public; its injective input assignment and endpoint signs are
+//! freshly randomized. See `cryptography/SUBGROUP_TWO_PASS.md` for the proof.
+
+use super::*;
+use commonware_utils::{ScriptedRng, TestRng};
+
+fn uniform_below(bound: u32, mut draw: impl FnMut() -> u64) -> u32 {
+    assert!(bound > 0);
+    let bound = u64::from(bound);
+    let limit = u64::MAX - u64::MAX % bound;
+    loop {
+        let word = draw();
+        if word < limit {
+            return (word % bound) as u32;
+        }
+    }
+}
+
+fn sample_edges(universe: u32, n: usize, mut choose: impl FnMut(u32) -> u32) -> Vec<u32> {
+    assert!(n <= universe as usize);
+    if n == 0 {
+        return Vec::new();
+    }
+    let mut edges: Vec<_> = (0..universe).collect();
+    for i in 0..n {
+        let remaining = universe - i as u32;
+        let offset = choose(remaining);
+        assert!(offset < remaining);
+        edges.swap(i, i + offset as usize);
+    }
+    edges.truncate(n);
+    edges
+}
+
+fn endpoints<const Q: u32>(edge: u32) -> [u32; 2] {
+    truncated_endpoints::<Q, Q>(edge)
+}
+
+fn truncated_endpoints<const Q: u32, const D: u32>(edge: u32) -> [u32; 2] {
+    let left = edge / D;
+    let (u, v, w, t) = (left / (Q * Q), left / Q % Q, left % Q, edge % D);
+    let right = (t * Q + (u * t + Q - v) % Q) * Q + (u * t * t + Q - w) % Q;
+    [left, right]
+}
+
+fn signed_ids<const Q: u32>(edges: &[u32], rng: &mut impl CryptoRng) -> [Vec<u32>; 2] {
+    signed_ids_with::<Q, Q>(edges, rng)
+}
+
+fn signed_ids_with<const Q: u32, const D: u32>(
+    edges: &[u32],
+    rng: &mut impl CryptoRng,
+) -> [Vec<u32>; 2] {
+    let mut ids = [
+        Vec::with_capacity(edges.len()),
+        Vec::with_capacity(edges.len()),
+    ];
+    for &edge in edges {
+        let buckets = truncated_endpoints::<Q, D>(edge);
+        let signs = rng.next_u32();
+        for pass in 0..2 {
+            ids[pass].push(buckets[pass] | (((signs >> pass) & 1) * ID_NEGATE));
+        }
+    }
+    ids
+}
+
+pub(super) fn draw_ids<const Q: u32>(n: usize, rng: &mut impl CryptoRng) -> [Vec<u32>; 2] {
+    let edges = sample_edges(Q.pow(4), n, |bound| uniform_below(bound, || rng.next_u64()));
+    signed_ids::<Q>(&edges, rng)
+}
+
+fn two_pass_check<const Q: u32, const SPLIT: bool>(
+    points: &[G1],
+    rng: &mut impl CryptoRng,
+) -> (bool, [Duration; 4]) {
+    two_pass_check_with::<Q, SPLIT, _>(points, rng, |points, rng| {
+        batch_in_g1(points, 111, &Sequential, rng)
+    })
+}
+
+fn recursive_inner<const SPLIT: bool>(points: &[G1], rng: &mut impl CryptoRng) -> bool {
+    assert!(points.len() <= 31u32.pow(4) as usize);
+    let affine = to_affine(points);
+    let ids = draw_ids::<31>(affine.len(), rng);
+    let mut round = Round::new(11);
+    round.widen(11);
+    let mut sums = Vec::with_capacity(2 * 31usize.pow(3));
+    for pass in &ids {
+        let compressed = compress_round_with_buckets(&mut round, &affine, pass, 31usize.pow(3));
+        if SPLIT {
+            if !batch_in_g1(&compressed, 99, &Sequential, rng) {
+                return false;
+            }
+        } else {
+            sums.extend(compressed);
+        }
+    }
+    SPLIT || batch_in_g1(&sums, 114, &Sequential, rng)
+}
+
+fn two_pass_check_with<const Q: u32, const SPLIT: bool, R: CryptoRng>(
+    points: &[G1],
+    rng: &mut R,
+    check: impl FnMut(&[G1], &mut R) -> bool,
+) -> (bool, [Duration; 4]) {
+    graph_check_with::<Q, Q, SPLIT, _>(points, rng, check)
+}
+
+fn graph_check_with<const Q: u32, const D: u32, const SPLIT: bool, R: CryptoRng>(
+    points: &[G1],
+    rng: &mut R,
+    mut check: impl FnMut(&[G1], &mut R) -> bool,
+) -> (bool, [Duration; 4]) {
+    assert!(matches!((Q, D), (47, 47) | (53, 53) | (47, 43)));
+    assert!(
+        D == Q || SPLIT,
+        "truncated graph requires split composition"
+    );
+    let universe = Q * Q * D * D;
+    assert!(points.len() <= universe as usize);
+    let start = Instant::now();
+    let affine = to_affine(points);
+    let normalized = start.elapsed();
+    let start = Instant::now();
+    let edges = sample_edges(universe, affine.len(), |bound| {
+        uniform_below(bound, || rng.next_u64())
+    });
+    let ids = signed_ids_with::<Q, D>(&edges, rng);
+    drop(edges);
+    let sampled = start.elapsed();
+    let start = Instant::now();
+    let buckets = (Q * Q * D) as usize;
+    let mut round = Round::new(12);
+    round.widen(12);
+    let mut sums = Vec::with_capacity(if SPLIT { 0 } else { 2 * buckets });
+    let mut compressed = start.elapsed();
+    let mut checked = Duration::ZERO;
+    for pass in &ids {
+        let start = Instant::now();
+        let pass_sums = compress_round_with_buckets(&mut round, &affine, pass, buckets);
+        if SPLIT {
+            compressed += start.elapsed();
+            let start = Instant::now();
+            let valid = check(&pass_sums, rng);
+            checked += start.elapsed();
+            if !valid {
+                return (false, [normalized, sampled, compressed, checked]);
+            }
+        } else {
+            sums.extend(pass_sums);
+            compressed += start.elapsed();
+        }
+    }
+    let start = Instant::now();
+    let valid = SPLIT || batch_in_g1(&sums, 129, &Sequential, rng);
+    checked += start.elapsed();
+    (valid, [normalized, sampled, compressed, checked])
+}
+
+#[test]
+fn uniform_sampler_rejects_incomplete_residue_class() {
+    let bound = 7;
+    let limit = u64::MAX - u64::MAX % u64::from(bound);
+    let mut words = [u64::MAX, limit, limit - 1].into_iter();
+    assert_eq!(uniform_below(bound, || words.next().unwrap()), bound - 1);
+    assert!(words.next().is_none());
+    assert_eq!(uniform_below(1, || 17), 0);
+    for residue in 0..bound {
+        assert_eq!(uniform_below(bound, || u64::from(residue)), residue);
+    }
+}
+
+#[test]
+fn partial_shuffle_enumerates_every_injection_once() {
+    let mut injections = std::collections::BTreeSet::new();
+    for a in 0..4 {
+        for b in 0..3 {
+            for c in 0..2 {
+                let mut offsets = [a, b, c].into_iter();
+                let edges = sample_edges(4, 3, |_| offsets.next().unwrap());
+                assert!(injections.insert(edges));
+            }
+        }
+    }
+    assert_eq!(injections.len(), 24);
+    assert!(sample_edges(4, 0, |_| panic!("empty injection draws nothing")).is_empty());
+    assert_eq!(sample_edges(4, 4, |_| 0), [0, 1, 2, 3]);
+    let mut rng = test_rng();
+    let mut edges = sample_edges(1000, 1000, |bound| uniform_below(bound, || rng.next_u64()));
+    edges.sort_unstable();
+    assert_eq!(edges, (0..1000).collect::<Vec<_>>());
+}
+
+#[test]
+fn endpoint_signs_use_separate_bits() {
+    let mut rng = ScriptedRng::new([0, 1, 2, 3]);
+    let ids = signed_ids::<3>(&[0; 4], &mut rng);
+    assert_eq!(ids[0], [0, ID_NEGATE, 0, ID_NEGATE]);
+    assert_eq!(ids[1], [0, 0, ID_NEGATE, ID_NEGATE]);
+}
+
+fn graph<const Q: u32>() -> Vec<Vec<usize>> {
+    let buckets = Q.pow(3) as usize;
+    let mut graph = vec![Vec::new(); 2 * buckets];
+    for edge in 0..Q.pow(4) {
+        let [left, right] = endpoints::<Q>(edge);
+        let (left, right) = (left as usize, right as usize + buckets);
+        graph[left].push(right);
+        graph[right].push(left);
+    }
+    graph
+}
+
+fn check_graph<const Q: u32>() {
+    let graph = graph::<Q>();
+    for neighbors in &graph {
+        let mut distinct = neighbors.clone();
+        distinct.sort_unstable();
+        distinct.dedup();
+        assert_eq!(distinct.len(), Q as usize);
+    }
+    let mut girth = usize::MAX;
+    for root in 0..graph.len() {
+        let mut distance = vec![usize::MAX; graph.len()];
+        let mut parent = vec![usize::MAX; graph.len()];
+        let mut queue = vec![root];
+        distance[root] = 0;
+        let mut index = 0;
+        while index < queue.len() {
+            let vertex = queue[index];
+            index += 1;
+            if distance[vertex] == 4 {
+                continue;
+            }
+            for &neighbor in &graph[vertex] {
+                if distance[neighbor] == usize::MAX {
+                    distance[neighbor] = distance[vertex] + 1;
+                    parent[neighbor] = vertex;
+                    queue.push(neighbor);
+                } else if parent[vertex] != neighbor {
+                    girth = girth.min(distance[vertex] + distance[neighbor] + 1);
+                }
+            }
+        }
+    }
+    assert_eq!(girth, 8);
+}
+
+#[test]
+fn algebraic_graph_is_regular_and_has_girth_eight() {
+    check_graph::<3>();
+    check_graph::<5>();
+    check_graph::<7>();
+}
+
+fn check_full_parameters<const Q: u32>() {
+    let buckets = Q.pow(3) as usize;
+    let mut degree = [vec![0u32; buckets], vec![0u32; buckets]];
+    for edge in 0..Q.pow(4) {
+        let [left, right] = endpoints::<Q>(edge);
+        assert!(left < buckets as u32 && right < buckets as u32);
+        assert_eq!(left, edge / Q);
+        // The right first coordinate distinguishes all neighbors of a left
+        // vertex, so no two edge codes describe the same endpoint pair.
+        assert_eq!(right / (Q * Q), edge % Q);
+        degree[0][left as usize] += 1;
+        degree[1][right as usize] += 1;
+    }
+    assert!(degree.iter().flatten().all(|&count| count == Q));
+}
+
+#[test]
+fn full_parameter_graphs_are_simple_bounded_and_regular() {
+    check_full_parameters::<19>();
+    check_full_parameters::<31>();
+    check_full_parameters::<47>();
+    check_full_parameters::<53>();
+}
+
+#[test]
+fn truncated_graph_is_a_regular_subgraph() {
+    let buckets = 47 * 47 * 43;
+    let mut degree = [vec![0u32; buckets], vec![0u32; buckets]];
+    for edge in 0..47 * 47 * 43 * 43 {
+        let actual = truncated_endpoints::<47, 43>(edge);
+        assert_eq!(actual, endpoints::<47>((edge / 43) * 47 + edge % 43));
+        assert_eq!(actual[0], edge / 43);
+        assert_eq!(actual[1] / (47 * 47), edge % 43);
+        for pass in 0..2 {
+            assert!((actual[pass] as usize) < buckets);
+            degree[pass][actual[pass] as usize] += 1;
+        }
+    }
+    assert!(degree.iter().flatten().all(|&count| count == 43));
+}
+
+#[test]
+fn recursive_check_rejects_adversarial_inputs() {
+    assert_eq!(combinations_for_security(114), 72);
+    assert_eq!(combinations_for_security(99), 63);
+    let generator = G1::generator();
+    let bad = order_three();
+    for count in [0, 1, 2, 3, 4, 6, 8, 10, 12, 16, 32, 2046] {
+        let mut points = vec![generator; 4096];
+        for (i, point) in points.iter_mut().take(count).enumerate() {
+            *point += &if i % 2 == 0 { bad } else { -bad };
+        }
+        points.extend([G1::zero(); 16]);
+        assert_eq!(
+            recursive_inner::<false>(&points, &mut test_rng()),
+            count == 0
+        );
+        assert_eq!(
+            recursive_inner::<true>(&points, &mut test_rng()),
+            count == 0
+        );
+        assert_eq!(
+            two_pass_check_with::<47, true, _>(&points, &mut test_rng(), recursive_inner::<false>)
+                .0,
+            count == 0
+        );
+        assert_eq!(
+            two_pass_check_with::<47, true, _>(&points, &mut test_rng(), recursive_inner::<true>).0,
+            count == 0
+        );
+        assert_eq!(
+            two_pass_check_with::<47, true, _>(&points, &mut test_rng(), super::pair::check::<96>)
+                .0,
+            count == 0
+        );
+        assert_eq!(
+            graph_check_with::<47, 43, true, _>(&points, &mut test_rng(), super::pair::check::<99>)
+                .0,
+            count == 0
+        );
+    }
+    assert!(recursive_inner::<false>(&[], &mut test_rng()));
+    assert!(recursive_inner::<false>(&[G1::zero(); 8], &mut test_rng()));
+    assert!(recursive_inner::<true>(&[], &mut test_rng()));
+    assert!(recursive_inner::<true>(&[G1::zero(); 8], &mut test_rng()));
+}
+
+#[test]
+fn effective_outer_check_rejects_adversarial_inputs() {
+    let generator = G1::generator();
+    let bad = order_three();
+    for count in [0, 1, 2, 3, 7, 8, 12, 32, 3102] {
+        let mut points = vec![generator; 4096];
+        for (i, point) in points.iter_mut().take(count).enumerate() {
+            *point += &if i % 2 == 0 { bad } else { -bad };
+        }
+        points.extend([G1::zero(); 16]);
+        assert_eq!(
+            two_pass_check_with::<47, true, _>(&points, &mut test_rng(), super::effective::check).0,
+            count == 0
+        );
+        assert_eq!(
+            graph_check_with::<47, 43, true, _>(&points, &mut test_rng(), super::effective::check)
+                .0,
+            count == 0
+        );
+    }
+}
+
+#[test]
+fn eight_cycle_has_exact_endpoint_sign_probability() {
+    let cycle = [0, 27, 28, 25, 24, 78, 79, 1];
+    let mut vanished = 0;
+    for signs in 0u32..1 << 16 {
+        let mut sums = [[0u8; 27]; 2];
+        for (i, edge) in cycle.into_iter().enumerate() {
+            for (pass, bucket) in endpoints::<3>(edge).into_iter().enumerate() {
+                // Either sign of a fixed order-three element.
+                let value = 1 + ((signs >> (2 * i + pass)) & 1) as u8;
+                sums[pass][bucket as usize] = (sums[pass][bucket as usize] + value) % 3;
+            }
+        }
+        vanished += usize::from(sums.iter().flatten().all(|&sum| sum == 0));
+    }
+    assert_eq!(vanished, 256);
+}
+
+#[test]
+fn graph_compression_matches_direct_group_sums() {
+    let generator = G1::generator();
+    let bad = order_three();
+    let points: Vec<_> = (0..81)
+        .map(|i| match i % 4 {
+            0 => generator,
+            1 => -generator,
+            2 => bad,
+            _ => generator + &bad,
+        })
+        .collect();
+    let affine = to_affine(&points);
+    let ids = draw_ids::<3>(points.len(), &mut test_rng());
+    let mut round = Round::new(4);
+    round.widen(4);
+    for pass in &ids {
+        let mut expected = [G1::zero(); 27];
+        for (point, &id) in points.iter().zip(pass) {
+            let bucket = (id & !ID_NEGATE) as usize;
+            if id & ID_NEGATE == 0 {
+                expected[bucket] += point;
+            } else {
+                expected[bucket] -= point;
+            }
+        }
+        let expected: Vec<_> = expected.into_iter().filter(|p| *p != G1::zero()).collect();
+        assert_eq!(
+            compress_round_with_buckets(&mut round, &affine, pass, 27),
+            expected
+        );
+    }
+}
+
+#[test]
+fn two_pass_checks_adversarial_inputs() {
+    let generator = G1::generator();
+    let bad = order_three();
+    assert!(!bad.in_subgroup());
+    assert_eq!(bad + &bad + &bad, G1::zero());
+    for points in [vec![], vec![G1::zero(); 16], vec![generator]] {
+        assert!(two_pass_check::<47, false>(&points, &mut test_rng()).0);
+        assert!(two_pass_check::<53, false>(&points, &mut test_rng()).0);
+        assert!(two_pass_check::<47, true>(&points, &mut test_rng()).0);
+        assert!(two_pass_check::<53, true>(&points, &mut test_rng()).0);
+    }
+    for count in [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 32, 3102] {
+        let mut points = vec![generator; 4096];
+        for (i, point) in points.iter_mut().take(count).enumerate() {
+            *point += &if i % 2 == 0 { bad } else { -bad };
+        }
+        points.extend([G1::zero(); 16]);
+        assert_eq!(
+            two_pass_check::<47, false>(&points, &mut test_rng()).0,
+            count == 0
+        );
+        assert_eq!(
+            two_pass_check::<53, false>(&points, &mut test_rng()).0,
+            count == 0
+        );
+        assert_eq!(
+            two_pass_check::<47, true>(&points, &mut test_rng()).0,
+            count == 0
+        );
+        assert_eq!(
+            two_pass_check::<53, true>(&points, &mut test_rng()).0,
+            count == 0
+        );
+    }
+}
+
+#[test]
+fn effective_outer_check_rejects_order_eleven_inputs() {
+    let bad = order_eleven();
+    for count in [1, 2, 8] {
+        let mut points = vec![G1::generator(); 4096];
+        for (i, point) in points.iter_mut().take(count).enumerate() {
+            *point += &if i % 2 == 0 { bad } else { -bad };
+        }
+        let (full, _) =
+            graph_check_with::<47, 47, true, _>(&points, &mut test_rng(), super::effective::check);
+        let (truncated, _) =
+            graph_check_with::<47, 43, true, _>(&points, &mut test_rng(), super::effective::check);
+        assert!(!full);
+        assert!(!truncated);
+    }
+}
+
+#[test]
+#[ignore = "manual research benchmark"]
+fn measure_two_pass() {
+    measure_algorithms("measure_two_pass", &[0, 1, 2, 3]);
+}
+
+#[test]
+#[ignore = "manual research benchmark"]
+fn measure_cascade() {
+    measure_algorithms("measure_cascade", &[0, 1, 3, 6, 7, 8, 9]);
+}
+
+#[test]
+#[ignore = "manual research benchmark; the order-three filter is incomplete"]
+fn measure_order_three() {
+    measure_algorithms("measure_order_three", &[0, 9, 20]);
+}
+
+fn measure_algorithms(operation: &str, algorithms: &[u32]) {
+    let points = benchmark_points(3_000_000);
+    for n in [100_000, 1_000_000, 3_000_000] {
+        for repeat in 0..4 {
+            for index in 0..algorithms.len() {
+                let index = if repeat % 2 == 0 {
+                    index
+                } else {
+                    algorithms.len() - 1 - index
+                };
+                let algorithm = algorithms[index];
+                let mut rng = TestRng::new(repeat);
+                let start = Instant::now();
+                let (valid, phases) = match algorithm {
+                    0 => (
+                        batch_in_g1(&points[..n], 128, &Sequential, &mut rng),
+                        [Duration::ZERO; 4],
+                    ),
+                    1 => {
+                        let shape = if n < 3_000_000 { (15, 15) } else { (17, 14) };
+                        let (valid, phases, _) = super::three::three_pass_exceptions(
+                            &points[..n],
+                            shape.0,
+                            shape.1,
+                            &mut rng,
+                        );
+                        (valid, phases)
+                    }
+                    2 => two_pass_check::<47, false>(&points[..n], &mut rng),
+                    3 => two_pass_check::<47, true>(&points[..n], &mut rng),
+                    6 => two_pass_check_with::<47, true, _>(
+                        &points[..n],
+                        &mut rng,
+                        recursive_inner::<true>,
+                    ),
+                    7 => graph_check_with::<47, 43, true, _>(
+                        &points[..n],
+                        &mut rng,
+                        super::pair::check::<96>,
+                    ),
+                    8 => two_pass_check_with::<47, true, _>(
+                        &points[..n],
+                        &mut rng,
+                        super::effective::check,
+                    ),
+                    9 => graph_check_with::<47, 43, true, _>(
+                        &points[..n],
+                        &mut rng,
+                        super::effective::check,
+                    ),
+                    20 => super::primary::check_order_three(&points[..n], &mut rng),
+                    _ => unreachable!(),
+                };
+                assert!(valid);
+                let component = if algorithm == 20 {
+                    "order_three_only"
+                } else {
+                    "complete"
+                };
+                eprintln!(
+                    "{}::{operation}/n={n} repeat={repeat} algorithm={algorithm} component={component} elapsed={:?} phases={phases:?}",
+                    module_path!(),
+                    start.elapsed()
+                );
+            }
+        }
+    }
+}

--- a/cryptography/src/bls12381/primitives/subgroup/research/two.rs
+++ b/cryptography/src/bls12381/primitives/subgroup/research/two.rs
@@ -6,6 +6,9 @@
 use super::*;
 use commonware_utils::{ScriptedRng, TestRng};
 
+#[path = "blocks.rs"]
+mod blocks;
+
 fn uniform_below(bound: u32, mut draw: impl FnMut() -> u64) -> u32 {
     assert!(bound > 0);
     let bound = u64::from(bound);

--- a/cryptography/src/bls12381/primitives/subgroup/research/two_bound.py
+++ b/cryptography/src/bls12381/primitives/subgroup/research/two_bound.py
@@ -1,0 +1,69 @@
+"""Exact finite inequalities for the derivation in SUBGROUP_TWO_PASS.md.
+
+The graph and probability arguments are proved in that report; this script
+checks the remaining finite parameter ranges without rounding the bounds.
+"""
+
+from fractions import Fraction
+from math import comb, log2
+
+
+def verify(q):
+    buckets = q**3
+    edges = q**4
+    degree = q
+    line_degree = 2*(degree-1)
+    tree_bound = 4*line_degree
+    cutoff = 66*degree
+    assert edges > 256*tree_bound
+
+    cycle8 = Fraction(edges*(degree-1)**4, 8*comb(edges, 8)*256)
+    cycle10 = Fraction(edges*(degree-1)**8, 10*comb(edges, 10)*1024)
+    assert cycle8 < Fraction(1, 2**129)
+    assert cycle10 < Fraction(1, 2**140)
+
+    choose = 1
+    worst = Fraction(0)
+    worst_k = None
+    for k in range(1, cutoff):
+        choose = choose*(edges-k+1)//k
+        if k < 12:
+            continue
+        components = k//8
+        numerator = (
+            components*comb(k-1, components-1)
+            *edges**components*tree_bound**(k-components)
+        )
+        denominator = 256**components*choose
+        # Exact integer inequality, not a floating point security assertion.
+        assert numerator*2**129 < denominator, (q, k)
+        if numerator*worst.denominator > worst.numerator*denominator:
+            worst = Fraction(numerator, denominator)
+            worst_k = k
+
+    sign_only = Fraction(1, 2**132)
+    compression = max(cycle8, cycle10, worst, sign_only)
+    inner = Fraction(1, 3**82)
+    overall = compression + inner
+    assert overall < Fraction(1, 2**128)
+
+    side_bits = (2*buckets-1).bit_length()
+    side = max(
+        Fraction(degree, 2*(edges-side_bits*degree+2)),
+        Fraction(1, 2**side_bits),
+    )
+    split_inner = Fraction(1, 3**71)
+    split_total = compression + 2*split_inner*side + split_inner**2
+    assert split_total < Fraction(1, 2**128)
+    print(f"q={q} B={buckets} M={edges} D={degree}")
+    print(f"k=8 bound: {-log2(cycle8):.12f} bits")
+    print(f"k=10 bound: {-log2(cycle10):.12f} bits")
+    print(f"k=12..{cutoff-1}: worst {-log2(worst):.12f} bits at k={worst_k}")
+    print(f"k>={cutoff}: >=132 bits from signs")
+    print(f"compression: {-log2(compression):.12f}; with joint inner129: {-log2(overall):.12f} bits")
+    print(f"separate inner111: {-log2(split_total):.12f} bits; side-zero bound={side}")
+
+
+if __name__ == "__main__":
+    verify(47)
+    verify(53)

--- a/docs/serve.py
+++ b/docs/serve.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+
+"""Serve the docs site with live reload.
+
+Rebuilds markdown when a source file changes, then refreshes the browser.
+"""
+
+from __future__ import annotations
+
+import argparse
+import http.server
+import os
+import subprocess
+import threading
+import time
+from pathlib import Path
+from urllib.parse import unquote, urlparse
+
+
+DOCS_ROOT = Path(__file__).resolve().parent
+SKIP_DIRS = {".venv", "code", ".git"}
+REBUILD_SUFFIXES = {".md"}
+REBUILD_NAMES = {"template.html"}
+WATCH_SUFFIXES = {".md", ".html", ".css", ".js"}
+POLL_SECONDS = 0.4
+INJECT = b"""<script>
+(function () {
+  let version = null;
+  setInterval(async () => {
+    try {
+      const next = await (await fetch("/__livereload")).text();
+      if (version === null) version = next;
+      else if (next !== version) location.reload();
+    } catch (e) {}
+  }, 400);
+})();
+</script>
+"""
+
+
+def collect_mtimes() -> dict[Path, float]:
+    mtimes = {}
+    for path in DOCS_ROOT.rglob("*"):
+        if not path.is_file() or SKIP_DIRS.intersection(path.parts):
+            continue
+        if path.suffix in WATCH_SUFFIXES or path.name in REBUILD_NAMES:
+            mtimes[path] = path.stat().st_mtime
+    return mtimes
+
+
+def rebuild() -> None:
+    print("Rebuilding markdown...")
+    subprocess.run(["make", "markdown"], cwd=DOCS_ROOT, check=False)
+
+
+class State:
+    def __init__(self) -> None:
+        self.version = 0
+        self.lock = threading.Lock()
+
+    def bump(self) -> None:
+        with self.lock:
+            self.version += 1
+
+    def current(self) -> int:
+        with self.lock:
+            return self.version
+
+
+def watch(state: State) -> None:
+    previous = collect_mtimes()
+    while True:
+        time.sleep(POLL_SECONDS)
+        current = collect_mtimes()
+        changed = [path for path, mtime in current.items() if previous.get(path) != mtime]
+        if not changed:
+            previous = current
+            continue
+        if any(path.suffix in REBUILD_SUFFIXES or path.name in REBUILD_NAMES for path in changed):
+            rebuild()
+            current = collect_mtimes()
+        state.bump()
+        print("Reload: " + ", ".join(str(path.relative_to(DOCS_ROOT)) for path in changed))
+        previous = current
+
+
+class Handler(http.server.SimpleHTTPRequestHandler):
+    def __init__(self, *args, state: State, **kwargs):
+        self.state = state
+        super().__init__(*args, directory=str(DOCS_ROOT), **kwargs)
+
+    def do_GET(self) -> None:
+        if self.path == "/__livereload":
+            body = str(self.state.current()).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain")
+            self.send_header("Cache-Control", "no-store")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            return
+
+        parsed = urlparse(self.path)
+        rel = unquote(parsed.path).lstrip("/")
+        path = (DOCS_ROOT / rel).resolve()
+        if path.is_dir():
+            path = path / "index.html"
+        if path.suffix == ".html" and path.is_file() and path.is_relative_to(DOCS_ROOT):
+            data = path.read_bytes()
+            if b"</body>" in data:
+                data = data.replace(b"</body>", INJECT + b"</body>", 1)
+            else:
+                data += INJECT
+            self.send_response(200)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.send_header("Cache-Control", "no-store")
+            self.send_header("Content-Length", str(len(data)))
+            self.end_headers()
+            self.wfile.write(data)
+            return
+
+        super().do_GET()
+
+    def log_message(self, format: str, *args) -> None:
+        if args and str(args[0]).startswith("GET /__livereload"):
+            return
+        super().log_message(format, *args)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--port", type=int, default=8000)
+    args = parser.parse_args()
+
+    os.chdir(DOCS_ROOT)
+    rebuild()
+
+    state = State()
+    threading.Thread(target=watch, args=(state,), daemon=True).start()
+
+    def handler(*handler_args, **handler_kwargs):
+        return Handler(*handler_args, state=state, **handler_kwargs)
+
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", args.port), handler)
+    print(f"Serving docs at http://127.0.0.1:{args.port}/")
+    print("Saving a .md, .css, or .js file rebuilds and refreshes the browser.")
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds `bls12381::primitives::subgroup::batch_in_g1`: a randomized batched subgroup-membership check for G1 that verifies `n` untrusted (on-curve) points with far fewer exact per-point checks, plus `G1::in_subgroup` and `G1::read_unchecked` so many points can be decoded cheaply and subgroup-checked together. All new surface is gated at **ALPHA** (the rest of `bls12381` is BETA) pending review.

## Scheme

Each round draws every point an independent uniform coefficient vector in `{0,1,2}^m` and exact-checks the `m` combinations `Q_j = Σ c_{j,i} P_i`:

- Points are bucketed by coefficient vector (`3^m` buckets — one uniform trit per combination), so **one accumulation pass over the points serves all `m` combinations**.
- Buckets are summed with hand-rolled **batch-affine additions**: each pass pairs the remaining points of every bucket and completes all pairs with a single shared field inversion (Montgomery's trick), ~6 field muls per addition (measured 146–178 ns/point, flat across bucket counts).
- Each combination is recovered from the bucket sums by its **deterministic** base-3 digits (all randomness is in the vector assignment) and checked with blst's endomorphism test.

**Soundness:** the G1 cofactor is odd, so any nonzero cofactor part has order ≥ 3 and a single `{0,1,2}` combination cancels it with probability ≤ 1/3 (tight, and independent of the cofactor's structure); the `m` combinations of a round use disjoint coefficients, so a round passes a bad batch with probability ≤ `3^-m`, and the check uses `r·m ≥ ⌈security/log₂3⌉` total combinations (81 at 128-bit). Full argument in the module docs; footguns (0.38-bit margin, exact-uniform trits, odd-cofactor precondition) are documented and tested. `cryptography/BATCHED_SUBGROUP.md` records the strategy comparison (per-point, one-combination-per-round, zexe-style per-bucket checks) and measured results.

A cost model picks `m` per batch and falls back to per-point checks for small batches; every choice is sound. Both paths run through a `commonware-parallel` `Strategy`, so an adaptive strategy parallelizes rounds (or fallback checks) and stays serial when that's faster.

## Measured (criterion medians, 18-core Apple Silicon, 128-bit)

| n | per-point | batched serial | batched parallel |
|---|---|---|---|
| 100 | 2.14 ms | 2.13 ms (fallback) | 0.31 ms (7×) |
| 1000 | 21.4 ms | 6.50 ms (3.3×) | 1.16 ms (18.5×) |
| 6000 | 126.6 ms | 22.6 ms (5.6×) | 4.10 ms (30.9×) |

## Testing

- Accumulator oracle fuzz vs naive G1 addition (mixed valid/off-subgroup/identity/negated/duplicated points) plus deterministic tests for every special-case branch (cancelling pairs → identity mid-tree, doubling chains, identity inputs, odd leftovers, empty buckets).
- Adversarial batches: cancelling bad pair, repeated bad point, one bad point in a large batch.
- `round_isolates_each_combination`: plants a bad point at chosen bucket ids to deterministically verify each digit position wires to its own combination (a wiring bug would silently degrade per-round soundness from `3^-m` to `1/3` while accept/reject tests still pass).
- Serial/parallel agreement above and below the fallback threshold; trit-stream range and uniformity smoke tests.
- `just pre-pr` green. `cargo miri` cannot execute the module (blst FFI: `extern static BLS12_381_G1` unsupported); the unsafe surface is thin per-call FFI wrappers with `// SAFETY:` comments, and all pass-scheduling logic is safe Rust under the oracle tests. The cryptography WASM cdylib build was not runnable locally (macOS clang lacks the wasm32 backend; pre-existing, covered by CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)