### PR TITLE
[codec] Reject incomparable values in RangeCfg::contains

### DIFF
--- a/codec/src/config.rs
+++ b/codec/src/config.rs
@@ -1,6 +1,7 @@
 //! Types for use as [crate::Read::Cfg].
 
 use core::{
+    cmp::Ordering,
     num::{NonZeroU8, NonZeroU16, NonZeroU32, NonZeroU64, NonZeroUsize},
     ops::{Bound, RangeBounds},
 };
@@ -193,22 +194,39 @@ impl<T: Copy + PartialOrd> RangeCfg<T> {
     }
 
     /// Returns true if the value is within this range.
+    ///
+    /// Bounds are checked with inclusion tests rather than exclusion tests so
+    /// that values incomparable to a bound (such as `f64::NAN`) are rejected,
+    /// matching [`RangeBounds::contains`].
     pub fn contains(&self, value: &T) -> bool {
-        // Exclude by start bound
+        // Include by start bound. `partial_cmp` returns `None` for values
+        // incomparable to the bound, which is treated as out of range.
         match &self.start {
-            Bound::Included(s) if value < s => return false,
-            Bound::Excluded(s) if value <= s => return false,
-            _ => {}
+            Bound::Included(s) => match s.partial_cmp(value) {
+                Some(Ordering::Less | Ordering::Equal) => {}
+                _ => return false,
+            },
+            Bound::Excluded(s) => match s.partial_cmp(value) {
+                Some(Ordering::Less) => {}
+                _ => return false,
+            },
+            Bound::Unbounded => {}
         }
 
-        // Exclude by end bound
+        // Include by end bound
         match &self.end {
-            Bound::Included(e) if value > e => return false,
-            Bound::Excluded(e) if value >= e => return false,
-            _ => {}
+            Bound::Included(e) => match value.partial_cmp(e) {
+                Some(Ordering::Less | Ordering::Equal) => {}
+                _ => return false,
+            },
+            Bound::Excluded(e) => match value.partial_cmp(e) {
+                Some(Ordering::Less) => {}
+                _ => return false,
+            },
+            Bound::Unbounded => {}
         }
 
-        // If not excluded by either bound, the value is within the range
+        // Within both bounds
         true
     }
 }
@@ -446,5 +464,15 @@ mod tests {
         // Type inference when assigning to typed variable
         let cfg: RangeCfg<u32> = RangeCfg::new(0..1000);
         assert!(cfg.contains(&500));
+    }
+
+    #[test]
+    fn test_range_cfg_partial_ord_nan() {
+        // NaN is unordered: it is neither less than, greater than, nor equal
+        // to any bound. `RangeCfg::contains` must reject it, matching
+        // `RangeBounds::contains` from core.
+        let cfg = RangeCfg::new(0.0f64..=1.0f64);
+        assert!(!RangeBounds::contains(&cfg, &f64::NAN));
+        assert!(!cfg.contains(&f64::NAN));
     }
 }


### PR DESCRIPTION
The inherent `RangeCfg::contains` is written as a pair of exclusion tests (`value < s`, `value > e`). Under a partial order the negation of "is less than" is not "is greater or equal", so a value incomparable to both bounds escapes every arm and is reported as contained.

Since the inherent method shadows the one from the `RangeBounds` impl, the same `RangeCfg` gives two different answers for the same value:

```rust
let cfg = RangeCfg::new(0.0f64..=1.0f64);
cfg.contains(&f64::NAN);                // true
RangeBounds::contains(&cfg, &f64::NAN); // false
```

`core`s `RangeBounds::contains` uses inclusion tests, which is why it gets this right.

The bound on `RangeCfg` is `Copy + PartialOrd`, so `RangeCfg<f64>` compiles today. I grepped the workspace and every current instantiation is an integer or `NonZero` type, where the two definitions coincide, so this is latent rather than live. Filing it because the divergence is silently wrong for any future `PartialOrd`-only type, and because the fix costs nothing for existing users.

**Fix:** use `partial_cmp` and treat `None` as out of range. This is also what `clippy::neg_cmp_op_on_partial_ord` recommends; the naive rewrite to `!(s <= value)` trips that lint, which exists for exactly this class of bug.

Behavior is unchanged for totally ordered types. No wire format change.

Added `test_range_cfg_partial_ord_nan`, which fails on `main` and passes here. `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt`, and `cargo check --no-default-features` are all clean for `commonware-codec`.