### PR TITLE
[glue] Release Canceled Verification Ancestry During Startup

### DIFF
--- a/cryptography/curve25519/src/curve.rs
+++ b/cryptography/curve25519/src/curve.rs
@@ -141,8 +141,8 @@ impl F {
         }
 
         let mut out = [0u8; 32];
-        for (chunk, word) in out.chunks_exact_mut(8).zip(words) {
-            chunk.copy_from_slice(&word.to_le_bytes());
+        for (chunk, word) in out.as_chunks_mut::<8>().0.iter_mut().zip(words) {
+            *chunk = word.to_le_bytes();
         }
         out
     }

--- a/cryptography/curve25519/src/signing/core/scalar.rs
+++ b/cryptography/curve25519/src/signing/core/scalar.rs
@@ -208,8 +208,8 @@ impl Scalar {
     /// Returns the canonical little-endian encoding of this scalar.
     pub fn to_bytes(self) -> [u8; 32] {
         let mut bytes = [0u8; 32];
-        for (chunk, limb) in bytes.chunks_exact_mut(8).zip(self.0) {
-            chunk.copy_from_slice(&limb.to_le_bytes());
+        for (chunk, limb) in bytes.as_chunks_mut::<8>().0.iter_mut().zip(self.0) {
+            *chunk = limb.to_le_bytes();
         }
         bytes
     }

--- a/cryptography/src/lthash/mod.rs
+++ b/cryptography/src/lthash/mod.rs
@@ -139,8 +139,8 @@ impl LtHash {
     /// Return the [Digest] of the current state.
     pub fn checksum(&self) -> Digest {
         let mut bytes = [0u8; LTHASH_SIZE];
-        for (chunk, val) in bytes.chunks_exact_mut(2).zip(&self.state) {
-            chunk.copy_from_slice(&val.to_le_bytes());
+        for (chunk, val) in bytes.as_chunks_mut::<2>().0.iter_mut().zip(&self.state) {
+            *chunk = val.to_le_bytes();
         }
         Blake3::hash(&[&bytes])
     }

--- a/cryptography/src/sha256/mod.rs
+++ b/cryptography/src/sha256/mod.rs
@@ -64,8 +64,8 @@ const IV: [u32; 8] = [
 #[inline]
 fn digest_from_state(state: [u32; 8]) -> [u8; DIGEST_LENGTH] {
     let mut out = [0u8; DIGEST_LENGTH];
-    for (chunk, word) in out.chunks_exact_mut(4).zip(state) {
-        chunk.copy_from_slice(&word.to_be_bytes());
+    for (chunk, word) in out.as_chunks_mut::<4>().0.iter_mut().zip(state) {
+        *chunk = word.to_be_bytes();
     }
     out
 }

--- a/cryptography/src/zk/bulletproofs/benches/ipa.rs
+++ b/cryptography/src/zk/bulletproofs/benches/ipa.rs
@@ -17,7 +17,9 @@ fn make_setup(len: usize) -> Setup<G1> {
     Setup::new(
         generators[0],
         generators[1..]
-            .chunks_exact(2)
+            .as_chunks::<2>()
+            .0
+            .iter()
             .map(|chunk| (chunk[0], chunk[1])),
     )
 }

--- a/cryptography/src/zk/bulletproofs/circuit.rs
+++ b/cryptography/src/zk/bulletproofs/circuit.rs
@@ -1904,7 +1904,9 @@ pub mod fuzz {
                 ipa::Setup::new(
                     gens[2 * TEST_SETUP_PAIRS],
                     gens[..2 * TEST_SETUP_PAIRS]
-                        .chunks_exact(2)
+                        .as_chunks::<2>()
+                        .0
+                        .iter()
                         .map(|c| (c[0], c[1])),
                 ),
                 gens[2 * TEST_SETUP_PAIRS + 1],

--- a/cryptography/src/zk/bulletproofs/ipa.rs
+++ b/cryptography/src/zk/bulletproofs/ipa.rs
@@ -87,7 +87,9 @@
 //! let setup = Setup::new(
 //!     GENERATORS[0].clone(),
 //!     GENERATORS[1..]
-//!         .chunks_exact(2)
+//!         .as_chunks::<2>()
+//!         .0
+//!         .iter()
 //!         .map(|chunk| (chunk[0].clone(), chunk[1].clone())),
 //! );
 //!
@@ -865,7 +867,9 @@ pub mod fuzz {
             Setup::new(
                 generators[0],
                 generators[1..]
-                    .chunks_exact(2)
+                    .as_chunks::<2>()
+                    .0
+                    .iter()
                     .map(|chunk| (chunk[0], chunk[1])),
             )
         })

--- a/glue/src/stateful/actor/core/mailbox.rs
+++ b/glue/src/stateful/actor/core/mailbox.rs
@@ -26,14 +26,15 @@ use std::{
 };
 use tracing::{Span, info_span};
 
-/// Re-enqueues verification requests invalidated by finalization or pruning.
+/// Re-enqueues live verification requests after finalization or pruning stops
+/// their active attempt.
 type RetryMailbox<E, A> = Arc<dyn Fn(Message<E, A>) + Send + Sync>;
 
 /// A non-owning reference to ancestry owned by the verification caller.
 ///
-/// Queued, deferred, and retry requests carry this handle so caller cancellation
+/// Queued and deferred requests carry this handle so caller cancellation
 /// releases the ancestry's backing blocks. Each active attempt clones an
-/// independent cursor while the caller remains live.
+/// independent cursor from the same caller-owned ancestry.
 pub(in crate::stateful::actor) struct VerificationAncestry<B: Block>(Weak<Mutex<BoxedAncestry<B>>>);
 
 impl<B: Block> VerificationAncestry<B> {

--- a/glue/src/stateful/actor/core/mailbox.rs
+++ b/glue/src/stateful/actor/core/mailbox.rs
@@ -6,7 +6,7 @@ use commonware_actor::{
     mailbox::{Overflow, Policy, Sender},
 };
 use commonware_consensus::{
-    Application as ConsensusApplication, CertifiableBlock, Epochable, Reporter, Viewable,
+    Application as ConsensusApplication, Block, CertifiableBlock, Epochable, Reporter, Viewable,
     marshal::{
         Update,
         ancestry::{Ancestry, BoxedAncestry},
@@ -17,12 +17,31 @@ use commonware_runtime::{Clock, Metrics, Spawner, telemetry::traces::TracedExt a
 use commonware_utils::{
     acknowledgement::Exact,
     channel::{fallible::OneshotExt, oneshot},
+    sync::Mutex,
 };
 use rand_core::Rng;
-use std::{collections::VecDeque, sync::Arc};
+use std::{
+    collections::VecDeque,
+    sync::{Arc, Weak},
+};
 use tracing::{Span, info_span};
 
 type RetryMailbox<E, A> = Arc<dyn Fn(Message<E, A>) + Send + Sync>;
+
+/// Non-owning access to verification ancestry whose lifetime is scoped to its caller.
+pub(in crate::stateful::actor) struct VerificationAncestry<B: Block>(Weak<Mutex<BoxedAncestry<B>>>);
+
+impl<B: Block> VerificationAncestry<B> {
+    fn new(ancestry: impl Ancestry<B>) -> (Arc<Mutex<BoxedAncestry<B>>>, Self) {
+        let owner = Arc::new(Mutex::new(BoxedAncestry::new(ancestry)));
+        let reference = Self(Arc::downgrade(&owner));
+        (owner, reference)
+    }
+
+    pub(in crate::stateful::actor) fn clone_cursor(&self) -> Option<BoxedAncestry<B>> {
+        self.0.upgrade().map(|ancestry| ancestry.lock().clone())
+    }
+}
 
 /// A verification is scoped to its caller.
 pub(in crate::stateful::actor) struct Verification {
@@ -62,7 +81,7 @@ where
     Verify {
         span: Span,
         context: (E, A::Context),
-        ancestry: BoxedAncestry<A::Block>,
+        ancestry: VerificationAncestry<A::Block>,
         verification: Verification,
     },
 
@@ -267,6 +286,7 @@ where
     ) -> bool {
         // Actor availability cannot override the application's decision.
         let (response, receiver) = oneshot::channel();
+        let (ancestry_owner, ancestry) = VerificationAncestry::new(ancestry);
         let span = info_span!(
             "stateful.mailbox.verify",
             epoch = context.1.epoch().traced(),
@@ -275,12 +295,14 @@ where
         let _ = self.sender.enqueue(Message::Verify {
             span,
             context,
-            ancestry: BoxedAncestry::new(ancestry),
+            ancestry,
             verification: Verification { response },
         });
-        receiver
+        let result = receiver
             .await
-            .expect("stateful actor dropped during verify")
+            .expect("stateful actor dropped during verify");
+        drop(ancestry_owner);
+        result
     }
 }
 

--- a/glue/src/stateful/actor/core/mailbox.rs
+++ b/glue/src/stateful/actor/core/mailbox.rs
@@ -35,9 +35,9 @@ type RetryMailbox<E, A> = Arc<dyn Fn(Message<E, A>) + Send + Sync>;
 /// Queued and deferred requests carry this handle so caller cancellation
 /// releases the ancestry's backing blocks. Each active attempt clones an
 /// independent cursor from the same caller-owned ancestry.
-pub(in crate::stateful::actor) struct VerificationAncestry<B: Block>(Weak<Mutex<BoxedAncestry<B>>>);
+pub(in crate::stateful::actor) struct WeakAncestry<B: Block>(Weak<Mutex<BoxedAncestry<B>>>);
 
-impl<B: Block> VerificationAncestry<B> {
+impl<B: Block> WeakAncestry<B> {
     /// Returns the caller-owned ancestry and a non-owning request handle.
     fn new(ancestry: impl Ancestry<B>) -> (Arc<Mutex<BoxedAncestry<B>>>, Self) {
         let owner = Arc::new(Mutex::new(BoxedAncestry::new(ancestry)));
@@ -91,7 +91,7 @@ where
     Verify {
         span: Span,
         context: (E, A::Context),
-        ancestry: VerificationAncestry<A::Block>,
+        ancestry: WeakAncestry<A::Block>,
         verification: Verification,
     },
 
@@ -300,7 +300,7 @@ where
         // Scope the strong ancestry owner to this caller. Queued work receives only a weak
         // handle, so cancellation releases backing blocks before the actor drains the request.
         let (response, receiver) = oneshot::channel();
-        let (ancestry_owner, ancestry) = VerificationAncestry::new(ancestry);
+        let (ancestry_owner, ancestry) = WeakAncestry::new(ancestry);
         let span = info_span!(
             "stateful.mailbox.verify",
             epoch = context.1.epoch().traced(),

--- a/glue/src/stateful/actor/core/mailbox.rs
+++ b/glue/src/stateful/actor/core/mailbox.rs
@@ -45,10 +45,10 @@ impl<B: Block> WeakAncestry<B> {
         (owner, reference)
     }
 
-    /// Acquires an independent cursor while the caller still owns the ancestry.
+    /// Upgrades to an independent cursor while the caller still owns the ancestry.
     ///
     /// Returns `None` once caller cancellation releases the strong owner.
-    pub(in crate::stateful::actor) fn acquire(&self) -> Option<BoxedAncestry<B>> {
+    pub(in crate::stateful::actor) fn upgrade(&self) -> Option<BoxedAncestry<B>> {
         self.0.upgrade().map(|ancestry| ancestry.lock().clone())
     }
 }

--- a/glue/src/stateful/actor/core/mailbox.rs
+++ b/glue/src/stateful/actor/core/mailbox.rs
@@ -45,10 +45,10 @@ impl<B: Block> VerificationAncestry<B> {
         (owner, reference)
     }
 
-    /// Clones an independent cursor while the caller still owns the ancestry.
+    /// Acquires an independent cursor while the caller still owns the ancestry.
     ///
     /// Returns `None` once caller cancellation releases the strong owner.
-    pub(in crate::stateful::actor) fn clone_cursor(&self) -> Option<BoxedAncestry<B>> {
+    pub(in crate::stateful::actor) fn acquire(&self) -> Option<BoxedAncestry<B>> {
         self.0.upgrade().map(|ancestry| ancestry.lock().clone())
     }
 }

--- a/glue/src/stateful/actor/core/mailbox.rs
+++ b/glue/src/stateful/actor/core/mailbox.rs
@@ -26,18 +26,27 @@ use std::{
 };
 use tracing::{Span, info_span};
 
+/// Re-enqueues verification requests invalidated by finalization or pruning.
 type RetryMailbox<E, A> = Arc<dyn Fn(Message<E, A>) + Send + Sync>;
 
-/// Non-owning access to verification ancestry whose lifetime is scoped to its caller.
+/// A non-owning reference to ancestry owned by the verification caller.
+///
+/// Queued, deferred, and retry requests carry this handle so caller cancellation
+/// releases the ancestry's backing blocks. Each active attempt clones an
+/// independent cursor while the caller remains live.
 pub(in crate::stateful::actor) struct VerificationAncestry<B: Block>(Weak<Mutex<BoxedAncestry<B>>>);
 
 impl<B: Block> VerificationAncestry<B> {
+    /// Returns the caller-owned ancestry and a non-owning request handle.
     fn new(ancestry: impl Ancestry<B>) -> (Arc<Mutex<BoxedAncestry<B>>>, Self) {
         let owner = Arc::new(Mutex::new(BoxedAncestry::new(ancestry)));
         let reference = Self(Arc::downgrade(&owner));
         (owner, reference)
     }
 
+    /// Clones an independent cursor while the caller still owns the ancestry.
+    ///
+    /// Returns `None` once caller cancellation releases the strong owner.
     pub(in crate::stateful::actor) fn clone_cursor(&self) -> Option<BoxedAncestry<B>> {
         self.0.upgrade().map(|ancestry| ancestry.lock().clone())
     }
@@ -117,6 +126,9 @@ where
     }
 }
 
+/// FIFO overflow for reliable messages that do not fit in the bounded mailbox.
+///
+/// Caller-scoped requests are discarded after their response channel closes.
 pub(super) struct Pending<E, A>(VecDeque<Message<E, A>>)
 where
     E: Rng + Spawner + Metrics + Clock,
@@ -284,7 +296,8 @@ where
         context: (E, Self::Context),
         ancestry: impl Ancestry<Self::Block>,
     ) -> bool {
-        // Actor availability cannot override the application's decision.
+        // Scope the strong ancestry owner to this caller. Queued work receives only a weak
+        // handle, so cancellation releases backing blocks before the actor drains the request.
         let (response, receiver) = oneshot::channel();
         let (ancestry_owner, ancestry) = VerificationAncestry::new(ancestry);
         let span = info_span!(
@@ -298,6 +311,8 @@ where
             ancestry,
             verification: Verification { response },
         });
+
+        // Retain ancestry through the application verdict. Actor shutdown remains an error.
         let result = receiver
             .await
             .expect("stateful actor dropped during verify");

--- a/glue/src/stateful/actor/core/mod.rs
+++ b/glue/src/stateful/actor/core/mod.rs
@@ -303,20 +303,63 @@ mod tests {
         },
     };
     use commonware_consensus::{
-        Application as _, CertifiableBlock as _, marshal::ancestry,
+        Application as _, CertifiableBlock as _, Reporter as _,
+        marshal::{Update, ancestry},
         simplex::mocks::scheme as scheme_mocks,
     };
     use commonware_cryptography::sha256::Digest as Sha256Digest;
     use commonware_macros::select;
     use commonware_runtime::{Clock as _, Runner as _, Supervisor as _, deterministic};
-    use commonware_utils::{NZU64, NZUsize, channel::mpsc};
-    use std::{convert::Infallible, time::Duration};
+    use commonware_utils::{
+        Acknowledgement as _, NZU64, NZUsize,
+        acknowledgement::Exact,
+        channel::{mpsc, oneshot},
+        sync::Mutex,
+    };
+    use futures::poll;
+    use std::{convert::Infallible, sync::Arc, time::Duration};
 
-    #[derive(Clone)]
-    struct NoopResolver;
+    struct StartupGate {
+        started: oneshot::Sender<()>,
+        release: oneshot::Receiver<()>,
+    }
+
+    #[derive(Clone, Default)]
+    struct NoopResolver {
+        startup_gate: Arc<Mutex<Option<StartupGate>>>,
+    }
+
+    impl NoopResolver {
+        fn gated() -> (Self, oneshot::Receiver<()>, oneshot::Sender<()>) {
+            let (started, started_rx) = oneshot::channel();
+            let (release, release_rx) = oneshot::channel();
+            (
+                Self {
+                    startup_gate: Arc::new(Mutex::new(Some(StartupGate {
+                        started,
+                        release: release_rx,
+                    }))),
+                },
+                started_rx,
+                release,
+            )
+        }
+    }
 
     impl AttachableResolver<TestDb> for NoopResolver {
-        async fn attach_database(&self, _db: Shared<TestDb>) {}
+        async fn attach_database(&self, _db: Shared<TestDb>) {
+            let Some(StartupGate {
+                started,
+                mut release,
+            }) = self.startup_gate.lock().take()
+            else {
+                return;
+            };
+            started
+                .send(())
+                .expect("test should await the startup gate");
+            let _ = (&mut release).await;
+        }
     }
 
     impl StateSyncDb<deterministic::Context, NoopResolver> for TestDb {
@@ -362,7 +405,7 @@ mod tests {
                     marshal: (marshal.mailbox, marshal.floor),
                     mailbox_size: NZUsize!(8),
                     plan: plan.with_floor(finalization),
-                    resolvers: NoopResolver,
+                    resolvers: NoopResolver::default(),
                     sync_config: SyncEngineConfig {
                         fetch_batch_size: NZU64!(1),
                         apply_batch_size: NZU64!(1),
@@ -389,6 +432,112 @@ mod tests {
             }
 
             handle.abort();
+        });
+    }
+
+    #[test]
+    fn startup_recovery_releases_cancelled_verify_ancestries() {
+        deterministic::Runner::timed(Duration::from_secs(5)).start(|mut context| async move {
+            let prefix = "startup-recovery-cancelled-verifications";
+            let scheme = scheme_mocks::fixture(&mut context, prefix.as_bytes(), 1);
+            let genesis = TestBlock::new(0, 0);
+            let finalized = TestBlock::child(&genesis, 1);
+            let marshal = fixtures::marshal_fixture(
+                context.child("marshal"),
+                prefix,
+                scheme.schemes[0].clone(),
+                None,
+                NZUsize!(8),
+                true,
+            )
+            .await;
+
+            let (resolver, startup_started, startup_release) = NoopResolver::gated();
+            let plan = SyncPlan::init(&context, format!("{prefix}-stateful")).await;
+            let (stateful, mut mailbox) = Stateful::init(
+                context.child("stateful"),
+                Config {
+                    application: TestApp,
+                    db_config: (),
+                    provider: (),
+                    marshal: (marshal.mailbox.clone(), marshal.floor),
+                    mailbox_size: NZUsize!(1),
+                    plan,
+                    resolvers: resolver,
+                    sync_config: SyncEngineConfig {
+                        fetch_batch_size: NZU64!(1),
+                        apply_batch_size: NZU64!(1),
+                        max_outstanding_requests: 1,
+                        update_channel_size: NZUsize!(1),
+                        max_retained_roots: 1,
+                    },
+                    prune_config: None,
+                },
+            );
+            let actor = stateful.start();
+            startup_started
+                .await
+                .expect("startup should reach resolver attachment before processing");
+
+            let owners = [
+                Arc::new(TestBlock::new(2, 2)),
+                Arc::new(TestBlock::new(3, 3)),
+                Arc::new(TestBlock::new(4, 4)),
+            ];
+            let weak_owners = owners.iter().map(Arc::downgrade).collect::<Vec<_>>();
+
+            let mut first_mailbox = mailbox.clone();
+            let mut first = Box::pin(first_mailbox.verify(
+                (context.child("verify_first"), owners[0].context()),
+                ancestry::from_iter([Arc::clone(&owners[0])]),
+            ));
+            assert!(poll!(&mut first).is_pending());
+
+            let mut second_mailbox = mailbox.clone();
+            let mut second = Box::pin(second_mailbox.verify(
+                (context.child("verify_second"), owners[1].context()),
+                ancestry::from_iter([Arc::clone(&owners[1])]),
+            ));
+            assert!(poll!(&mut second).is_pending());
+
+            let mut third_mailbox = mailbox.clone();
+            let mut third = Box::pin(third_mailbox.verify(
+                (context.child("verify_third"), owners[2].context()),
+                ancestry::from_iter([Arc::clone(&owners[2])]),
+            ));
+            assert!(poll!(&mut third).is_pending());
+
+            let (acknowledgement, mut acknowledgement_waiter) = Exact::handle();
+            let _ = mailbox.report(Update::Block(Arc::new(finalized), acknowledgement));
+
+            drop(first);
+            drop(second);
+            drop(third);
+            drop(owners);
+            context.sleep(Duration::from_millis(10)).await;
+
+            assert!(poll!(&mut acknowledgement_waiter).is_pending());
+            for (index, owner) in weak_owners.iter().enumerate() {
+                assert!(
+                    owner.upgrade().is_none(),
+                    "cancelled startup verification {index} retained its ancestry owner",
+                );
+            }
+
+            startup_release
+                .send(())
+                .expect("startup should remain gated");
+            select! {
+                result = acknowledgement_waiter => {
+                    result.expect("finalized block should be acknowledged after startup");
+                },
+                _ = context.sleep(Duration::from_millis(100)) => {
+                    panic!("finalized acknowledgement stalled after startup");
+                },
+            }
+
+            actor.abort();
+            drop(marshal.guards);
         });
     }
 }

--- a/glue/src/stateful/actor/core/mod.rs
+++ b/glue/src/stateful/actor/core/mod.rs
@@ -319,17 +319,20 @@ mod tests {
     use futures::poll;
     use std::{convert::Infallible, sync::Arc, time::Duration};
 
+    /// Blocks startup before the actor begins polling its mailbox.
     struct StartupGate {
         started: oneshot::Sender<()>,
         release: oneshot::Receiver<()>,
     }
 
+    /// Resolver that can pause database attachment during startup.
     #[derive(Clone, Default)]
     struct NoopResolver {
         startup_gate: Arc<Mutex<Option<StartupGate>>>,
     }
 
     impl NoopResolver {
+        /// Creates a resolver with handles to observe and release its next database attachment.
         fn gated() -> (Self, oneshot::Receiver<()>, oneshot::Sender<()>) {
             let (started, started_rx) = oneshot::channel();
             let (release, release_rx) = oneshot::channel();
@@ -348,6 +351,7 @@ mod tests {
 
     impl AttachableResolver<TestDb> for NoopResolver {
         async fn attach_database(&self, _db: Shared<TestDb>) {
+            // Consume the single-use gate before waiting so the wait does not hold the gate lock.
             let Some(StartupGate {
                 started,
                 mut release,
@@ -438,6 +442,7 @@ mod tests {
     #[test]
     fn startup_recovery_releases_cancelled_verify_ancestries() {
         deterministic::Runner::timed(Duration::from_secs(5)).start(|mut context| async move {
+            // Hold startup after database recovery but before processing polls the mailbox.
             let prefix = "startup-recovery-cancelled-verifications";
             let scheme = scheme_mocks::fixture(&mut context, prefix.as_bytes(), 1);
             let genesis = TestBlock::new(0, 0);
@@ -479,6 +484,7 @@ mod tests {
                 .await
                 .expect("startup should reach resolver attachment before processing");
 
+            // Fill the single ready slot and reliable overflow with independently owned ancestries.
             let owners = [
                 Arc::new(TestBlock::new(2, 2)),
                 Arc::new(TestBlock::new(3, 3)),
@@ -507,6 +513,7 @@ mod tests {
             ));
             assert!(poll!(&mut third).is_pending());
 
+            // Queue a finalization behind the verifications, then cancel every caller.
             let (acknowledgement, mut acknowledgement_waiter) = Exact::handle();
             let _ = mailbox.report(Update::Block(Arc::new(finalized), acknowledgement));
 
@@ -516,6 +523,7 @@ mod tests {
             drop(owners);
             context.sleep(Duration::from_millis(10)).await;
 
+            // Startup remains blocked while cancellation releases every ancestry block.
             assert!(poll!(&mut acknowledgement_waiter).is_pending());
             for (index, owner) in weak_owners.iter().enumerate() {
                 assert!(
@@ -524,6 +532,7 @@ mod tests {
                 );
             }
 
+            // Resuming startup drains the queue and acknowledges the later finalization.
             startup_release
                 .send(())
                 .expect("startup should remain gated");

--- a/glue/src/stateful/actor/core/processing.rs
+++ b/glue/src/stateful/actor/core/processing.rs
@@ -52,8 +52,8 @@ fn requeue_verifications<E, A>(
     E: Rng + Spawner + Metrics + Clock,
     A: Application<E>,
 {
-    // FIFO puts each retry behind work accepted while the mutation ran and
-    // ahead of later arrivals, without waiting for the mailbox to become idle.
+    // Re-enter each live request through FIFO. Work accepted during the mutation
+    // precedes its next attempt, while later arrivals remain behind it.
     for VerificationRequest {
         span,
         context,

--- a/glue/src/stateful/actor/core/verifications.rs
+++ b/glue/src/stateful/actor/core/verifications.rs
@@ -18,7 +18,9 @@ use rand_core::Rng;
 use std::{collections::BTreeMap, future::Future};
 use tracing::{Instrument as _, Span, info_span};
 
-/// A verification request that can be deferred or retried.
+/// A caller-scoped verification request that can be deferred or retried.
+///
+/// The request remains non-owning while each active attempt uses an independent cursor.
 pub(super) struct Request<E, A>
 where
     E: Rng + Spawner + Metrics + Clock,
@@ -95,9 +97,13 @@ where
     }
 
     pub(super) fn schedule(&mut self, mut verifier: Verifier<E, A>, mut request: Request<E, A>) {
+        // Give the active attempt an independent cursor. Requests whose callers already canceled
+        // cannot provide one, while deferred and retryable requests remain non-owning.
         let Some(ancestry) = request.ancestry.clone_cursor() else {
             return;
         };
+
+        // Register the attempt before polling it so invalidation and progress share one lifecycle.
         let id = self.next_id;
         self.next_id = self
             .next_id
@@ -117,6 +123,8 @@ where
                 .is_none()
         );
 
+        // Move only the independent cursor into active work. The original request returns with
+        // its weak ancestry handle intact for completion or retry.
         let marshal = self.marshal.clone();
         let process = info_span!(parent: &request.span, "stateful.actor.verify");
         self.jobs.push(

--- a/glue/src/stateful/actor/core/verifications.rs
+++ b/glue/src/stateful/actor/core/verifications.rs
@@ -98,9 +98,9 @@ where
     }
 
     pub(super) fn schedule(&mut self, mut verifier: Verifier<E, A>, mut request: Request<E, A>) {
-        // Acquire an independent cursor for this active attempt. Canceled callers cannot provide
+        // Upgrade to an independent cursor for this active attempt. Canceled callers cannot provide
         // one, while queued requests remain non-owning.
-        let Some(ancestry) = request.ancestry.acquire() else {
+        let Some(ancestry) = request.ancestry.upgrade() else {
             return;
         };
 

--- a/glue/src/stateful/actor/core/verifications.rs
+++ b/glue/src/stateful/actor/core/verifications.rs
@@ -1,12 +1,12 @@
 use crate::stateful::{
     Application,
     actor::{
-        core::mailbox::Verification,
+        core::mailbox::{Verification, VerificationAncestry},
         processor::{Disposition, PendingDigest, VerificationProgress, Verifier},
     },
 };
 use commonware_consensus::marshal::{
-    ancestry::{BlockProvider, BoxedAncestry},
+    ancestry::BlockProvider,
     core::{Mailbox as MarshalMailbox, Variant},
 };
 use commonware_cryptography::certificate::Scheme;
@@ -26,7 +26,7 @@ where
 {
     pub(super) span: Span,
     pub(super) context: (E, A::Context),
-    pub(super) ancestry: BoxedAncestry<A::Block>,
+    pub(super) ancestry: VerificationAncestry<A::Block>,
     pub(super) verification: Verification,
 }
 
@@ -95,6 +95,9 @@ where
     }
 
     pub(super) fn schedule(&mut self, mut verifier: Verifier<E, A>, mut request: Request<E, A>) {
+        let Some(ancestry) = request.ancestry.clone_cursor() else {
+            return;
+        };
         let id = self.next_id;
         self.next_id = self
             .next_id
@@ -118,7 +121,6 @@ where
         let process = info_span!(parent: &request.span, "stateful.actor.verify");
         self.jobs.push(
             async move {
-                let ancestry = request.ancestry.clone();
                 select! {
                     _ = invalidated => JobResult::Invalidated { id, request },
                     valid = verifier.run(

--- a/glue/src/stateful/actor/core/verifications.rs
+++ b/glue/src/stateful/actor/core/verifications.rs
@@ -1,7 +1,7 @@
 use crate::stateful::{
     Application,
     actor::{
-        core::mailbox::{Verification, VerificationAncestry},
+        core::mailbox::{Verification, WeakAncestry},
         processor::{Disposition, PendingDigest, VerificationProgress, Verifier},
     },
 };
@@ -29,7 +29,7 @@ where
 {
     pub(super) span: Span,
     pub(super) context: (E, A::Context),
-    pub(super) ancestry: VerificationAncestry<A::Block>,
+    pub(super) ancestry: WeakAncestry<A::Block>,
     pub(super) verification: Verification,
 }
 

--- a/glue/src/stateful/actor/core/verifications.rs
+++ b/glue/src/stateful/actor/core/verifications.rs
@@ -98,9 +98,9 @@ where
     }
 
     pub(super) fn schedule(&mut self, mut verifier: Verifier<E, A>, mut request: Request<E, A>) {
-        // Clone the caller's ancestry for this active attempt. Canceled callers cannot provide a
-        // cursor, while queued requests remain non-owning.
-        let Some(ancestry) = request.ancestry.clone_cursor() else {
+        // Acquire an independent cursor for this active attempt. Canceled callers cannot provide
+        // one, while queued requests remain non-owning.
+        let Some(ancestry) = request.ancestry.acquire() else {
             return;
         };
 

--- a/glue/src/stateful/actor/core/verifications.rs
+++ b/glue/src/stateful/actor/core/verifications.rs
@@ -18,9 +18,10 @@ use rand_core::Rng;
 use std::{collections::BTreeMap, future::Future};
 use tracing::{Instrument as _, Span, info_span};
 
-/// A caller-scoped verification request that can be deferred or retried.
+/// A caller-scoped verification request that can be deferred or restarted.
 ///
-/// The request remains non-owning while each active attempt uses an independent cursor.
+/// The request retains the same non-owning ancestry handle while each active
+/// attempt uses an independent cursor.
 pub(super) struct Request<E, A>
 where
     E: Rng + Spawner + Metrics + Clock,
@@ -97,13 +98,14 @@ where
     }
 
     pub(super) fn schedule(&mut self, mut verifier: Verifier<E, A>, mut request: Request<E, A>) {
-        // Give the active attempt an independent cursor. Requests whose callers already canceled
-        // cannot provide one, while deferred and retryable requests remain non-owning.
+        // Clone the caller's ancestry for this active attempt. Canceled callers cannot provide a
+        // cursor, while queued requests remain non-owning.
         let Some(ancestry) = request.ancestry.clone_cursor() else {
             return;
         };
 
-        // Register the attempt before polling it so invalidation and progress share one lifecycle.
+        // Register the attempt before polling it so actor invalidation and progress share one
+        // lifecycle.
         let id = self.next_id;
         self.next_id = self
             .next_id
@@ -124,7 +126,7 @@ where
         );
 
         // Move only the independent cursor into active work. The original request returns with
-        // its weak ancestry handle intact for completion or retry.
+        // its weak ancestry handle intact for completion or another attempt.
         let marshal = self.marshal.clone();
         let process = info_span!(parent: &request.span, "stateful.actor.verify");
         self.jobs.push(
@@ -169,7 +171,8 @@ where
     /// Cancels every active attempt and waits for verification work to stop.
     ///
     /// Pruning uses this full barrier because it can remove history needed by
-    /// every branch. Live requests are returned for rescheduling afterward.
+    /// every branch. Live requests retain their ancestry and are returned for
+    /// a new attempt.
     pub(super) async fn quiesce(&mut self) -> Vec<Request<E, A>> {
         let (retry, reject) = self.quiesce_where(|_| Disposition::Retry).await;
         assert!(reject.is_empty());

--- a/glue/src/stateful/actor/processor/mod.rs
+++ b/glue/src/stateful/actor/processor/mod.rs
@@ -92,14 +92,15 @@ enum VerificationPhase<D> {
 pub(super) enum Disposition {
     /// Continue polling work proven to descend from the finalized block.
     Retain,
-    /// Re-evaluate work whose branch is unknown or whose active phase cannot cross finalization.
+    /// Restart the same request when its branch is unknown or its active phase
+    /// cannot cross finalization.
     Retry,
     /// Return false for work already proven to use an incompatible parent.
     Reject,
 }
 
-/// Progress needed to decide whether an active verification remains valid
-/// across an incoming finalization.
+/// Progress used to classify an active verification attempt across an incoming
+/// finalization.
 #[derive(Clone)]
 pub(super) struct VerificationProgress<D: Copy>(Arc<Mutex<VerificationPhase<D>>>);
 

--- a/glue/src/stateful/db/mod.rs
+++ b/glue/src/stateful/db/mod.rs
@@ -1576,9 +1576,7 @@ impl<D: Digest, T: Clone> CoordinatorState<D, T> {
                 if let Some((anchor, targets)) = self.latest_tip.take() {
                     let generation = self.current_generation + 1;
                     self.current_generation = generation;
-                    for db in &mut self.dbs {
-                        *db = DbSyncState::Seeking { generation };
-                    }
+                    self.dbs.fill(DbSyncState::Seeking { generation });
                     self.generation_state
                         .insert(generation, (anchor, targets.clone()));
                     self.last_dispatched_anchor = anchor;

--- a/runtime/src/iouring/mod.rs
+++ b/runtime/src/iouring/mod.rs
@@ -312,7 +312,9 @@ impl Handle {
     /// Enqueue a request for the io_uring loop.
     ///
     /// On success, this publishes one submission and conditionally wakes the
-    /// loop if a futex or eventfd wait target is currently armed.
+    /// loop if a futex or eventfd wait target is currently armed. On failure,
+    /// it returns the unsent request so callers can recover its owned resources.
+    #[allow(clippy::result_large_err)]
     async fn enqueue(&self, request: Request) -> Result<(), mpsc::error::SendError<Request>> {
         self.inner
             .sender

--- a/runtime/src/network/tokio.rs
+++ b/runtime/src/network/tokio.rs
@@ -1,5 +1,5 @@
 use crate::{BufferPool, Error, IoBufs};
-use std::{convert::identity, net::SocketAddr, time::Duration};
+use std::{net::SocketAddr, time::Duration};
 use tokio::{
     io::{AsyncReadExt as _, AsyncWriteExt as _, BufReader},
     net::{
@@ -78,7 +78,7 @@ impl crate::Sink for Sink {
         // Time out if we take too long to write
         let result = timeout(write_timeout, send)
             .await
-            .map_or(Err(Error::Timeout), identity);
+            .unwrap_or(Err(Error::Timeout));
 
         // A failed send leaves the write-half unusable.
         if result.is_err() {
@@ -126,7 +126,7 @@ impl crate::Stream for Stream {
         // Time out if we take too long to read
         let result = timeout(self.read_timeout, recv)
             .await
-            .map_or(Err(Error::Timeout), identity);
+            .unwrap_or(Err(Error::Timeout));
 
         // Unpoison on success.
         if result.is_ok() {

--- a/storage/src/bmt/mod.rs
+++ b/storage/src/bmt/mod.rs
@@ -578,8 +578,8 @@ impl<D: Digest> Proof<D> {
             }
         }
         let mut sorted: Vec<(u32, D)> = Vec::with_capacity(elements.len());
-        let mut leaf_chunks = elements.chunks_exact(2);
-        for chunk in &mut leaf_chunks {
+        let (leaf_chunks, leaf_remainder) = elements.as_chunks::<2>();
+        for chunk in leaf_chunks {
             let (leaf_a, pos_a) = &chunk[0];
             let (leaf_b, pos_b) = &chunk[1];
             let (digest_a, digest_b) = H::hash_pair(
@@ -589,7 +589,7 @@ impl<D: Digest> Proof<D> {
             sorted.push((*pos_a, digest_a));
             sorted.push((*pos_b, digest_b));
         }
-        for (leaf, position) in leaf_chunks.remainder() {
+        for (leaf, position) in leaf_remainder {
             let digest = H::hash(&[&position.to_be_bytes(), leaf.as_ref()]);
             sorted.push((*position, digest));
         }
@@ -649,8 +649,8 @@ impl<D: Digest> Proof<D> {
             }
 
             // Second pass: hash independent parent digests two at a time via `hash_pair`.
-            let mut parent_chunks = parents.chunks_exact(2);
-            for chunk in &mut parent_chunks {
+            let (parent_chunks, parent_remainder) = parents.as_chunks::<2>();
+            for chunk in parent_chunks {
                 let (pos_a, left_a, right_a) = chunk[0];
                 let (pos_b, left_b, right_b) = chunk[1];
                 let (digest_a, digest_b) = H::hash_pair(
@@ -660,7 +660,7 @@ impl<D: Digest> Proof<D> {
                 next_level.push((pos_a, digest_a));
                 next_level.push((pos_b, digest_b));
             }
-            for &(pos, left, right) in parent_chunks.remainder() {
+            for &(pos, left, right) in parent_remainder {
                 next_level.push((pos, H::hash(&[left.as_ref(), right.as_ref()])));
             }
             parents.clear();

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -1464,12 +1464,7 @@ impl<E: Context, A: CodecFixedShared> Reader<'_, E, A> {
             .map(|group_hits| group_hits as u64)
             .sum();
 
-        #[allow(unknown_lints)]
-        #[allow(
-            clippy::chunks_exact_to_as_chunks,
-            reason = "generic associated sizes are not accepted as const-generic arguments"
-        )]
-        for slice in reusable_buf.chunks_exact(A::SIZE) {
+        for slice in reusable_buf.chunks(A::SIZE) {
             result.push(A::decode(slice).map_err(Error::Codec)?);
         }
 
@@ -1543,12 +1538,7 @@ impl<E: Context, A: CodecFixedShared> Reader<'_, E, A> {
             let misses =
                 blob.try_read_many_sync_into(buf, &blob_offsets, Inner::<E, A>::CHUNK_SIZE);
             let mut misses = misses.into_iter().peekable();
-            #[allow(unknown_lints)]
-            #[allow(
-                clippy::chunks_exact_to_as_chunks,
-                reason = "generic associated sizes are not accepted as const-generic arguments"
-            )]
-            for (idx, slice) in buf.chunks_exact(A::SIZE).enumerate() {
+            for (idx, slice) in buf.chunks(A::SIZE).enumerate() {
                 if misses.peek() == Some(&idx) {
                     misses.next();
                     continue;

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -1464,7 +1464,8 @@ impl<E: Context, A: CodecFixedShared> Reader<'_, E, A> {
             .map(|group_hits| group_hits as u64)
             .sum();
 
-        for slice in reusable_buf.chunks(A::SIZE) {
+        #[allow(unknown_lints, clippy::chunks_exact_to_as_chunks)]
+        for slice in reusable_buf.chunks_exact(A::SIZE) {
             result.push(A::decode(slice).map_err(Error::Codec)?);
         }
 
@@ -1538,7 +1539,8 @@ impl<E: Context, A: CodecFixedShared> Reader<'_, E, A> {
             let misses =
                 blob.try_read_many_sync_into(buf, &blob_offsets, Inner::<E, A>::CHUNK_SIZE);
             let mut misses = misses.into_iter().peekable();
-            for (idx, slice) in buf.chunks(A::SIZE).enumerate() {
+            #[allow(unknown_lints, clippy::chunks_exact_to_as_chunks)]
+            for (idx, slice) in buf.chunks_exact(A::SIZE).enumerate() {
                 if misses.peek() == Some(&idx) {
                     misses.next();
                     continue;

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -1464,6 +1464,11 @@ impl<E: Context, A: CodecFixedShared> Reader<'_, E, A> {
             .map(|group_hits| group_hits as u64)
             .sum();
 
+        #[allow(unknown_lints)]
+        #[allow(
+            clippy::chunks_exact_to_as_chunks,
+            reason = "generic associated sizes are not accepted as const-generic arguments"
+        )]
         for slice in reusable_buf.chunks_exact(A::SIZE) {
             result.push(A::decode(slice).map_err(Error::Codec)?);
         }
@@ -1538,6 +1543,11 @@ impl<E: Context, A: CodecFixedShared> Reader<'_, E, A> {
             let misses =
                 blob.try_read_many_sync_into(buf, &blob_offsets, Inner::<E, A>::CHUNK_SIZE);
             let mut misses = misses.into_iter().peekable();
+            #[allow(unknown_lints)]
+            #[allow(
+                clippy::chunks_exact_to_as_chunks,
+                reason = "generic associated sizes are not accepted as const-generic arguments"
+            )]
             for (idx, slice) in buf.chunks_exact(A::SIZE).enumerate() {
                 if misses.peek() == Some(&idx) {
                     misses.next();

--- a/storage/src/merkle/batch.rs
+++ b/storage/src/merkle/batch.rs
@@ -423,8 +423,8 @@ impl<F: Family, D: Digest, S: Strategy> UnmerkleizedBatch<F, D, S> {
         height: u32,
         output: &mut Vec<(Position<F>, D)>,
     ) {
-        let mut pairs = positions.chunks_exact(2);
-        for pair in &mut pairs {
+        let (pairs, remainder) = positions.as_chunks::<2>();
+        for pair in pairs {
             let (left, right) = (pair[0], pair[1]);
             let (ll, lr) = self.child_digests(base, left, height);
             let (rl, rr) = self.child_digests(base, right, height);
@@ -433,7 +433,7 @@ impl<F: Family, D: Digest, S: Strategy> UnmerkleizedBatch<F, D, S> {
             output.push((left, left_digest));
             output.push((right, right_digest));
         }
-        if let [pos] = pairs.remainder() {
+        if let [pos] = remainder {
             let (left, right) = self.child_digests(base, *pos, height);
             output.push((*pos, hasher.node_digest(*pos, &left, &right)));
         }

--- a/utils/src/bitmap/mod.rs
+++ b/utils/src/bitmap/mod.rs
@@ -527,11 +527,11 @@ impl<const N: usize> BitMap<N> {
     #[inline]
     fn count_ones_in_chunk_slice(chunks: &[[u8; N]]) -> u64 {
         let mut total = 0u64;
-        let mut words = chunks.as_flattened().chunks_exact(8);
-        for word in &mut words {
-            total += u64::from_le_bytes(word.try_into().unwrap()).count_ones() as u64;
+        let (words, remainder) = chunks.as_flattened().as_chunks::<8>();
+        for word in words {
+            total += u64::from_le_bytes(*word).count_ones() as u64;
         }
-        for byte in words.remainder() {
+        for byte in remainder {
             total += byte.count_ones() as u64;
         }
         total

--- a/utils/src/bitmap/roaring/container/bitmap.rs
+++ b/utils/src/bitmap/roaring/container/bitmap.rs
@@ -456,7 +456,12 @@ impl Write for Bitmap {
         // Preserve the codec's big-endian word order while collapsing 1024 small
         // `put_slice` calls into one bulk write.
         let mut bytes = [0u8; ENCODED_BYTES];
-        for (dst, &word) in bytes.as_chunks_mut::<8>().0.iter_mut().zip(self.words.iter()) {
+        for (dst, &word) in bytes
+            .as_chunks_mut::<8>()
+            .0
+            .iter_mut()
+            .zip(self.words.iter())
+        {
             dst.copy_from_slice(&word.to_be_bytes());
         }
         buf.put_slice(&bytes);

--- a/utils/src/bitmap/roaring/container/bitmap.rs
+++ b/utils/src/bitmap/roaring/container/bitmap.rs
@@ -456,7 +456,7 @@ impl Write for Bitmap {
         // Preserve the codec's big-endian word order while collapsing 1024 small
         // `put_slice` calls into one bulk write.
         let mut bytes = [0u8; ENCODED_BYTES];
-        for (dst, &word) in bytes.chunks_exact_mut(8).zip(self.words.iter()) {
+        for (dst, &word) in bytes.as_chunks_mut::<8>().0.iter_mut().zip(self.words.iter()) {
             dst.copy_from_slice(&word.to_be_bytes());
         }
         buf.put_slice(&bytes);
@@ -476,7 +476,7 @@ impl Read for Bitmap {
         let bytes = <[u8; ENCODED_BYTES]>::read(buf)?;
 
         let mut words = [0u64; WORDS];
-        for (word, chunk) in words.iter_mut().zip(bytes.chunks_exact(8)) {
+        for (word, chunk) in words.iter_mut().zip(bytes.as_chunks::<8>().0.iter()) {
             let mut word_bytes = [0u8; 8];
             word_bytes.copy_from_slice(chunk);
             *word = u64::from_be_bytes(word_bytes);


### PR DESCRIPTION
Stateful does not poll its mailbox while startup initializes databases and attaches resolvers. Canceled `Verify` requests queued during that window still strongly owned `BoxedAncestry`, retaining entire decoded blocks in the ready queue and reliable overflow.

Make the caller future the sole strong ancestry owner. Queued, state-sync-deferred, and retry requests now carry `Weak`; each live attempt upgrades it and clones an independent cursor. This releases canceled blocks immediately without changing startup, mailbox FIFO, retry, or verdict semantics.

The deterministic regression blocks startup before processing, queues one ready verification plus two overflow verifications, cancels all three, and proves their block owners are released. It then resumes startup and confirms a finalization queued behind them is acknowledged.

Validated with `just test -p commonware-glue`, `just clippy -p commonware-glue`, and `just check-fmt`.