### PR TITLE
[storage] Parallelize replay decode in QMDB parallel init

### DIFF
--- a/runtime/src/tokio/runtime.rs
+++ b/runtime/src/tokio/runtime.rs
@@ -932,8 +932,8 @@ impl crate::BufferPooler for Context {
 mod tests {
     use super::*;
     use crate::{
-        Blob as _, Metrics, Network, Resolver, Runner as _, Sink, Spawner as _, Storage as _,
-        Strategizer as _, Stream, Supervisor as _, telemetry::metrics::raw::Counter,
+        AbortOnDrop, Blob as _, Metrics, Network, Resolver, Runner as _, Sink, Spawner as _,
+        Storage as _, Strategizer as _, Stream, Supervisor as _, telemetry::metrics::raw::Counter,
         tokio::telemetry,
     };
     use bytes::Bytes;
@@ -963,6 +963,13 @@ mod tests {
         Return,
         FuturePanic,
         ConstructorPanic,
+    }
+
+    #[derive(Clone, Copy, Debug)]
+    enum JoinRelease {
+        Task,
+        Completion,
+        Output,
     }
 
     fn spawn_drop_gated_task(
@@ -1200,6 +1207,98 @@ mod tests {
                 assert_runner_drains_spawned_task(execution, root_exit);
             }
         }
+    }
+
+    fn assert_join_all_releases_pending_work(release_owner: JoinRelease) {
+        let cfg = Config::new();
+        let storage_directory = cfg.storage_directory().clone();
+        let (started, started_rx) = commonware_utils::channel::oneshot::channel();
+        let (release, release_rx) = std::sync::mpsc::channel();
+        let (joining, joining_rx) = std::sync::mpsc::channel();
+        let (done, done_rx) = std::sync::mpsc::channel();
+        let (exited, exited_rx) = std::sync::mpsc::channel();
+        let (drop_release, drop_release_rx) = std::sync::mpsc::channel();
+        drop(drop_release);
+        let release_on_drop = TaskDropGate {
+            entered: release.clone(),
+            release: drop_release_rx,
+        };
+
+        let runner = std::thread::spawn(move || {
+            Runner::new(cfg).start(move |context| async move {
+                let blocked = context
+                    .child("blocked")
+                    .dedicated()
+                    .spawn(move |_| async move {
+                        started.send(()).unwrap();
+                        release_rx.recv().unwrap();
+                        exited.send(()).unwrap();
+                        Ok::<_, Error>(None::<TaskDropGate>)
+                    })
+                    .abort_on_drop();
+                let failed = Handle::ready(Ok(Err(Error::Closed))).abort_on_drop();
+                let mut guards = vec![failed, blocked];
+                if matches!(release_owner, JoinRelease::Output) {
+                    guards.insert(
+                        0,
+                        Handle::ready(Ok(Ok(Some(release_on_drop)))).abort_on_drop(),
+                    );
+                } else {
+                    let pending = async move {
+                        let _release_on_drop = release_on_drop;
+                        futures::future::pending::<Result<Option<TaskDropGate>, Error>>().await
+                    };
+                    let pending = if matches!(release_owner, JoinRelease::Task) {
+                        context.child("pending").spawn(move |_| pending)
+                    } else {
+                        Handle::from_future(async move { Ok(pending.await) })
+                    };
+                    guards.push(pending.abort_on_drop());
+                }
+
+                started_rx.await.unwrap();
+                joining.send(()).unwrap();
+                let result = AbortOnDrop::join_all::<Error>(guards).await;
+                assert!(done.send((result, exited_rx.try_recv().is_ok())).is_ok());
+            });
+        });
+
+        joining_rx
+            .recv_timeout(Duration::from_secs(5))
+            .expect("blocking task did not start");
+        let early = done_rx.recv_timeout(Duration::from_secs(5));
+        let completed = early.is_ok();
+
+        // Release the blocking poll even when cancellation stalls, so the runner can shut down.
+        let _ = release.send(());
+        let (result, exited) = early.unwrap_or_else(|_| {
+            done_rx
+                .recv_timeout(Duration::from_secs(5))
+                .expect("joining did not finish after releasing the blocking task")
+        });
+        runner.join().unwrap();
+        let _ = std::fs::remove_dir_all(storage_directory);
+        assert!(
+            completed,
+            "joining stalled with release owned by {release_owner:?}"
+        );
+        assert!(exited, "joining returned before the blocking task exited");
+        assert!(matches!(result, Err(Error::Closed)));
+    }
+
+    #[test]
+    fn test_join_all_aborts_all_tasks_before_waiting() {
+        assert_join_all_releases_pending_work(JoinRelease::Task);
+    }
+
+    #[test]
+    fn test_join_all_drains_completions_concurrently() {
+        assert_join_all_releases_pending_work(JoinRelease::Completion);
+    }
+
+    #[test]
+    fn test_join_all_drops_outputs_before_waiting() {
+        assert_join_all_releases_pending_work(JoinRelease::Output);
     }
 
     #[test]

--- a/runtime/src/utils/handle.rs
+++ b/runtime/src/utils/handle.rs
@@ -279,6 +279,52 @@ where
             HandleState::Completion { .. } => None,
         }
     }
+
+    /// Wrap this handle so the task is aborted if the wrapper is dropped before being
+    /// joined.
+    #[commonware_macros::stability(ALPHA)]
+    pub const fn abort_on_drop(self) -> AbortOnDrop<T> {
+        AbortOnDrop(Some(self))
+    }
+}
+
+/// Aborts a task if dropped before being joined.
+///
+/// Supervision ties spawned tasks to their spawning task's lifetime, but work spawned from
+/// a plain future outlives that future's drop. Wrapping the handle (see
+/// [`Handle::abort_on_drop`]) ties the task to the guard instead, so cancelling the future
+/// holding it cannot leave the task running. Dropping the guard only signals the abort;
+/// use [`AbortOnDrop::abort`] to also await the task's exit.
+#[commonware_macros::stability(ALPHA)]
+pub struct AbortOnDrop<T: Send + 'static>(Option<Handle<T>>);
+
+#[commonware_macros::stability(ALPHA)]
+impl<T: Send + 'static> AbortOnDrop<T> {
+    /// Abort the task, then join it.
+    pub async fn abort(mut self) {
+        let handle = self.0.take().expect("handle joined once");
+        handle.abort();
+        let _ = handle.await;
+    }
+
+    /// Join the task.
+    pub async fn join(mut self) -> Result<T, Error> {
+        // Poll the handle by reference: the guard must keep owning it so dropping this
+        // future mid-join still aborts the task.
+        let handle = self.0.as_mut().expect("handle joined once");
+        let result = handle.await;
+        self.0 = None;
+        result
+    }
+}
+
+#[commonware_macros::stability(ALPHA)]
+impl<T: Send + 'static> Drop for AbortOnDrop<T> {
+    fn drop(&mut self) {
+        if let Some(handle) = &self.0 {
+            handle.abort();
+        }
+    }
 }
 
 impl<T> Future for Handle<T>

--- a/runtime/src/utils/handle.rs
+++ b/runtime/src/utils/handle.rs
@@ -317,6 +317,7 @@ impl<T: Send + 'static> AbortOnDrop<T> {
     }
 }
 
+#[commonware_macros::stability(ALPHA)]
 impl<T, E1> AbortOnDrop<Result<T, E1>>
 where
     T: Send + 'static,
@@ -326,7 +327,6 @@ where
     /// error or a failed join), abort and join every remaining guard before surfacing it,
     /// so no task outlives the failure (dropping a guard only signals the abort without
     /// awaiting it). Joining in order makes the surfaced failure deterministic.
-    #[commonware_macros::stability(ALPHA)]
     pub async fn join_all<E2>(guards: Vec<Self>) -> Result<Vec<T>, E2>
     where
         E2: From<E1> + From<Error>,

--- a/runtime/src/utils/handle.rs
+++ b/runtime/src/utils/handle.rs
@@ -280,8 +280,7 @@ where
         }
     }
 
-    /// Wrap this handle so the task is aborted if the wrapper is dropped before being
-    /// joined.
+    /// Wrap this handle so the task is aborted if the wrapper is dropped before being joined.
     #[commonware_macros::stability(ALPHA)]
     pub const fn abort_on_drop(self) -> AbortOnDrop<T> {
         AbortOnDrop(Some(self))
@@ -290,11 +289,11 @@ where
 
 /// Aborts a task if dropped before being joined.
 ///
-/// Supervision ties spawned tasks to their spawning task's lifetime, but work spawned from
-/// a plain future outlives that future's drop. Wrapping the handle (see
-/// [`Handle::abort_on_drop`]) ties the task to the guard instead, so cancelling the future
-/// holding it cannot leave the task running. Dropping the guard only signals the abort;
-/// use [`AbortOnDrop::abort`] to also await the task's exit.
+/// Supervision ties spawned tasks to their spawning task's lifetime, but work spawned from a plain
+/// future outlives that future's drop. Wrapping the handle (see [`Handle::abort_on_drop`]) ties the
+/// task to the guard instead, so cancelling the future holding it cannot leave the task running.
+/// Dropping the guard only signals the abort; use [`AbortOnDrop::abort`] to also await the task's
+/// exit.
 #[commonware_macros::stability(ALPHA)]
 pub struct AbortOnDrop<T: Send + 'static>(Option<Handle<T>>);
 
@@ -309,12 +308,43 @@ impl<T: Send + 'static> AbortOnDrop<T> {
 
     /// Join the task.
     pub async fn join(mut self) -> Result<T, Error> {
-        // Poll the handle by reference: the guard must keep owning it so dropping this
-        // future mid-join still aborts the task.
+        // Poll the handle by reference: the guard must keep owning it so dropping this future
+        // mid-join still aborts the task.
         let handle = self.0.as_mut().expect("handle joined once");
         let result = handle.await;
         self.0 = None;
         result
+    }
+}
+
+impl<T, E1> AbortOnDrop<Result<T, E1>>
+where
+    T: Send + 'static,
+    E1: Send + 'static,
+{
+    /// Join `guards` in order, collecting each task's output. On the first failure (a task
+    /// error or a failed join), abort and join every remaining guard before surfacing it,
+    /// so no task outlives the failure (dropping a guard only signals the abort without
+    /// awaiting it). Joining in order makes the surfaced failure deterministic.
+    #[commonware_macros::stability(ALPHA)]
+    pub async fn join_all<E2>(guards: Vec<Self>) -> Result<Vec<T>, E2>
+    where
+        E2: From<E1> + From<Error>,
+    {
+        let mut joined = Vec::with_capacity(guards.len());
+        let mut failure: Option<E2> = None;
+        for guard in guards {
+            if failure.is_some() {
+                guard.abort().await;
+                continue;
+            }
+            match guard.join().await {
+                Ok(Ok(output)) => joined.push(output),
+                Ok(Err(err)) => failure = Some(err.into()),
+                Err(err) => failure = Some(err.into()),
+            }
+        }
+        failure.map_or_else(|| Ok(joined), Err)
     }
 }
 

--- a/runtime/src/utils/handle.rs
+++ b/runtime/src/utils/handle.rs
@@ -292,8 +292,8 @@ where
 /// Supervision ties spawned tasks to their spawning task's lifetime, but work spawned from a plain
 /// future outlives that future's drop. Wrapping the handle (see [`Handle::abort_on_drop`]) ties the
 /// task to the guard instead, so cancelling the future holding it cannot leave the task running.
-/// Dropping the guard only signals the abort; use [`AbortOnDrop::abort`] to also await the task's
-/// exit.
+/// Dropping the guard only signals the abort. Use [`AbortOnDrop::abort`] to also await the
+/// task's exit.
 #[commonware_macros::stability(ALPHA)]
 pub struct AbortOnDrop<T: Send + 'static>(Option<Handle<T>>);
 

--- a/runtime/src/utils/handle.rs
+++ b/runtime/src/utils/handle.rs
@@ -20,6 +20,7 @@ use std::{
     pin::Pin,
     sync::Arc,
     task::{Context, Poll},
+    vec::IntoIter,
 };
 use tracing::error;
 
@@ -51,20 +52,26 @@ where
     },
 }
 
-/// Signals all aborts before dropping any handle, whose result or completion future may wake
-/// other tasks in the group during destruction.
-struct HandleGroup<T>(Vec<Handle<T>>)
+/// Signals all aborts before dropping any handle, whose result or completion future may depend
+/// on another task in the group during destruction.
+struct HandleGroup<T>(IntoIter<AbortOnDrop<T>>)
 where
     T: Send + 'static;
+
+impl<T: Send + 'static> HandleGroup<T> {
+    fn abort(&self) {
+        for guard in self.0.as_slice() {
+            guard.0.abort();
+        }
+    }
+}
 
 impl<T> Drop for HandleGroup<T>
 where
     T: Send + 'static,
 {
     fn drop(&mut self) {
-        for handle in &self.0 {
-            handle.abort();
-        }
+        self.abort();
     }
 }
 
@@ -218,16 +225,22 @@ where
     ) -> impl Future<Output = Result<T, Error>> + Send + 'static {
         // Construct the guard before returning so dropping the future without polling still aborts
         // every handle.
-        let mut handles = HandleGroup(handles.into_iter().collect::<Vec<_>>());
+        let mut handles = HandleGroup(
+            handles
+                .into_iter()
+                .map(Self::abort_on_drop)
+                .collect::<Vec<_>>()
+                .into_iter(),
+        );
 
         async move {
-            if handles.0.is_empty() {
+            if handles.0.as_slice().is_empty() {
                 return Err(Error::Closed);
             }
 
             poll_fn(move |cx| {
-                for handle in &mut handles.0 {
-                    if let Poll::Ready(result) = Pin::new(handle).poll(cx) {
+                for guard in handles.0.as_mut_slice() {
+                    if let Poll::Ready(result) = Pin::new(&mut guard.0).poll(cx) {
                         return Poll::Ready(result);
                     }
                 }
@@ -324,31 +337,41 @@ where
     ///
     /// Spawned tasks are cancelled and joined. Completion handles only stop waiting for their
     /// underlying work.
-    pub async fn join_all<E2>(guards: Vec<Self>) -> Result<Vec<T>, E2>
+    ///
+    /// Dropping the returned future signals every cancellation before destroying any owned
+    /// outputs or completion futures.
+    pub fn join_all<E2>(guards: Vec<Self>) -> impl Future<Output = Result<Vec<T>, E2>>
     where
         E2: From<E1> + From<Error>,
     {
-        let mut joined = Vec::with_capacity(guards.len());
-        let mut guards = guards.into_iter();
-        while let Some(guard) = guards.next() {
-            let error = match guard.join().await {
-                Ok(Ok(output)) => {
-                    joined.push(output);
-                    continue;
+        let guards = HandleGroup(guards.into_iter());
+        async move {
+            // Cancellation must drop the group before destroying collected outputs.
+            let mut joined = Vec::with_capacity(guards.0.len());
+            let mut guards = guards;
+            while let Some(guard) = guards.0.as_mut_slice().first_mut() {
+                // Error conversion may destroy resources, so signal all cancellations first.
+                let result = (&mut guard.0).await;
+                if !matches!(result, Ok(Ok(_))) {
+                    guards.abort();
                 }
-                Ok(Err(err)) => err.into(),
-                Err(err) => err.into(),
-            };
-
-            // Signal every cancellation before destroying outputs that may depend on other tasks.
-            for guard in guards.as_slice() {
-                guard.0.abort();
+                match result
+                    .map_err(E2::from)
+                    .and_then(|result| result.map_err(E2::from))
+                {
+                    Ok(output) => joined.push(output),
+                    Err(error) => {
+                        // Release collected outputs before waiting on dependent tasks.
+                        drop(joined);
+                        drop(guards.0.next());
+                        futures::future::join_all(guards.0.by_ref().map(Self::abort)).await;
+                        return Err(error);
+                    }
+                }
+                drop(guards.0.next());
             }
-            drop(joined);
-            futures::future::join_all(guards.map(Self::abort)).await;
-            return Err(error);
+            Ok(joined)
         }
-        Ok(joined)
     }
 }
 
@@ -516,8 +539,10 @@ impl Aborter {
 mod tests {
     use super::{AbortOnDrop, Handle};
     use crate::{Error, Metrics as _, Runner, Spawner, Supervisor as _, deterministic};
-    use commonware_utils::channel::oneshot;
-    use futures::{FutureExt as _, future, poll};
+    use commonware_utils::{channel::oneshot, sync::Mutex};
+    use futures::{FutureExt as _, future, poll, stream::AbortHandle};
+    use rstest::rstest;
+    use std::sync::Arc;
 
     const METRIC_PREFIX: &str = "runtime_tasks_running{";
 
@@ -720,6 +745,78 @@ mod tests {
                     .expect("task still owns sender")
                     .is_err()
             );
+        });
+    }
+
+    struct AbortObservation {
+        abort_handle: AbortHandle,
+        observed: Arc<Mutex<Option<bool>>>,
+    }
+
+    impl Drop for AbortObservation {
+        fn drop(&mut self) {
+            *self.observed.lock() = Some(self.abort_handle.is_aborted());
+        }
+    }
+
+    impl From<AbortObservation> for Error {
+        fn from(_error: AbortObservation) -> Self {
+            Self::Closed
+        }
+    }
+
+    #[derive(Debug)]
+    enum JoinCleanup {
+        Unpolled,
+        CollectedOutput,
+        RemainingOutput,
+        PendingCompletion,
+        ErrorConversion,
+    }
+
+    #[rstest]
+    #[case::unpolled(JoinCleanup::Unpolled)]
+    #[case::collected_output(JoinCleanup::CollectedOutput)]
+    #[case::remaining_output(JoinCleanup::RemainingOutput)]
+    #[case::pending_completion(JoinCleanup::PendingCompletion)]
+    #[case::error_conversion(JoinCleanup::ErrorConversion)]
+    fn join_all_aborts_before_destruction(#[case] cleanup: JoinCleanup) {
+        deterministic::Runner::default().start(|context| async move {
+            let pending = context
+                .child("pending")
+                .spawn(|_| future::pending::<Result<Option<AbortObservation>, AbortObservation>>());
+            let abort_handle = pending.aborter().unwrap().inner;
+            assert!(!abort_handle.is_aborted());
+            let observed = Arc::new(Mutex::new(None));
+            let resource = AbortObservation {
+                abort_handle,
+                observed: observed.clone(),
+            };
+            let first = match cleanup {
+                JoinCleanup::PendingCompletion => Handle::from_future(async move {
+                    let _resource = resource;
+                    future::pending().await
+                }),
+                JoinCleanup::ErrorConversion => Handle::ready(Ok(Err(resource))),
+                _ => Handle::ready(Ok(Ok(Some(resource)))),
+            };
+            let mut handles = vec![first, pending];
+            if matches!(cleanup, JoinCleanup::RemainingOutput) {
+                handles.insert(0, Handle::from_future(future::pending()));
+                handles.insert(0, Handle::ready(Ok(Ok(None))));
+            }
+            let mut joining = Box::pin(AbortOnDrop::join_all::<Error>(
+                handles.into_iter().map(Handle::abort_on_drop).collect(),
+            ));
+            if matches!(cleanup, JoinCleanup::ErrorConversion) {
+                assert!(matches!(joining.await, Err(Error::Closed)));
+            } else {
+                if !matches!(cleanup, JoinCleanup::Unpolled) {
+                    assert!(poll!(&mut joining).is_pending());
+                }
+                drop(joining);
+            }
+            assert_eq!(*observed.lock(), Some(true));
         });
     }
 

--- a/runtime/src/utils/handle.rs
+++ b/runtime/src/utils/handle.rs
@@ -291,9 +291,9 @@ where
 ///
 /// Supervision ties spawned tasks to their spawning task's lifetime, but work spawned from a plain
 /// future outlives that future's drop. Wrapping the handle (see [`Handle::abort_on_drop`]) ties the
-/// task's cancellation to the guard instead. Dropping the guard signals cancellation; use
-/// [`AbortOnDrop::abort`] to also join the handle. Completion handles only stop waiting and do
-/// not cancel the underlying work (see [`Handle`]).
+/// task's cancellation to the guard instead. Dropping the guard signals cancellation. Use
+/// [`AbortOnDrop::abort`] to also join the handle. Completion handles only stop waiting and
+/// do not cancel the underlying work (see [`Handle`]).
 pub struct AbortOnDrop<T: Send + 'static>(Handle<T>);
 
 impl<T: Send + 'static> AbortOnDrop<T> {
@@ -316,28 +316,39 @@ where
     T: Send + 'static,
     E1: Send + 'static,
 {
-    /// Join `guards` in order, collecting each task's output. On the first failure (a task
-    /// error or a failed join), abort and join every remaining guard before surfacing it.
-    /// Spawned tasks are cancelled and joined; completion handles only stop waiting for their
-    /// underlying work. Joining in order makes the surfaced failure deterministic.
+    /// Join `guards` in order, collecting each task's output.
+    ///
+    /// On the first failure (a task error or a failed join), abort every remaining guard, discard
+    /// collected outputs, and drain the remaining guards concurrently before surfacing the error.
+    /// Joining in order makes the surfaced failure deterministic.
+    ///
+    /// Spawned tasks are cancelled and joined. Completion handles only stop waiting for their
+    /// underlying work.
     pub async fn join_all<E2>(guards: Vec<Self>) -> Result<Vec<T>, E2>
     where
         E2: From<E1> + From<Error>,
     {
         let mut joined = Vec::with_capacity(guards.len());
-        let mut failure: Option<E2> = None;
-        for guard in guards {
-            if failure.is_some() {
-                guard.abort().await;
-                continue;
+        let mut guards = guards.into_iter();
+        while let Some(guard) = guards.next() {
+            let error = match guard.join().await {
+                Ok(Ok(output)) => {
+                    joined.push(output);
+                    continue;
+                }
+                Ok(Err(err)) => err.into(),
+                Err(err) => err.into(),
+            };
+
+            // Signal every cancellation before destroying outputs that may depend on other tasks.
+            for guard in guards.as_slice() {
+                guard.0.abort();
             }
-            match guard.join().await {
-                Ok(Ok(output)) => joined.push(output),
-                Ok(Err(err)) => failure = Some(err.into()),
-                Err(err) => failure = Some(err.into()),
-            }
+            drop(joined);
+            futures::future::join_all(guards.map(Self::abort)).await;
+            return Err(error);
         }
-        failure.map_or_else(|| Ok(joined), Err)
+        Ok(joined)
     }
 }
 

--- a/runtime/src/utils/handle.rs
+++ b/runtime/src/utils/handle.rs
@@ -51,7 +51,8 @@ where
     },
 }
 
-/// Aborts every owned handle when a group is no longer supervised.
+/// Signals all aborts before dropping any handle, whose result or completion future may wake
+/// other tasks in the group during destruction.
 struct HandleGroup<T>(Vec<Handle<T>>)
 where
     T: Send + 'static;
@@ -280,53 +281,45 @@ where
         }
     }
 
-    /// Wrap this handle so the task is aborted if the wrapper is dropped before being joined.
-    #[commonware_macros::stability(ALPHA)]
+    /// Wrap this handle so dropping the wrapper calls [`Handle::abort`].
     pub const fn abort_on_drop(self) -> AbortOnDrop<T> {
-        AbortOnDrop(Some(self))
+        AbortOnDrop(self)
     }
 }
 
-/// Aborts a task if dropped before being joined.
+/// Calls [`Handle::abort`] when dropped.
 ///
 /// Supervision ties spawned tasks to their spawning task's lifetime, but work spawned from a plain
 /// future outlives that future's drop. Wrapping the handle (see [`Handle::abort_on_drop`]) ties the
-/// task to the guard instead, so cancelling the future holding it cannot leave the task running.
-/// Dropping the guard only signals the abort. Use [`AbortOnDrop::abort`] to also await the
-/// task's exit.
-#[commonware_macros::stability(ALPHA)]
-pub struct AbortOnDrop<T: Send + 'static>(Option<Handle<T>>);
+/// task's cancellation to the guard instead. Dropping the guard signals cancellation; use
+/// [`AbortOnDrop::abort`] to also join the handle. Completion handles only stop waiting and do
+/// not cancel the underlying work (see [`Handle`]).
+pub struct AbortOnDrop<T: Send + 'static>(Handle<T>);
 
-#[commonware_macros::stability(ALPHA)]
 impl<T: Send + 'static> AbortOnDrop<T> {
-    /// Abort the task, then join it.
+    /// Abort and join the handle. Completion handles only stop waiting for the underlying work.
     pub async fn abort(mut self) {
-        let handle = self.0.take().expect("handle joined once");
-        handle.abort();
-        let _ = handle.await;
+        self.0.abort();
+        let _ = (&mut self.0).await;
     }
 
-    /// Join the task.
+    /// Join the handle.
     pub async fn join(mut self) -> Result<T, Error> {
         // Poll the handle by reference: the guard must keep owning it so dropping this future
         // mid-join still aborts the task.
-        let handle = self.0.as_mut().expect("handle joined once");
-        let result = handle.await;
-        self.0 = None;
-        result
+        (&mut self.0).await
     }
 }
 
-#[commonware_macros::stability(ALPHA)]
 impl<T, E1> AbortOnDrop<Result<T, E1>>
 where
     T: Send + 'static,
     E1: Send + 'static,
 {
     /// Join `guards` in order, collecting each task's output. On the first failure (a task
-    /// error or a failed join), abort and join every remaining guard before surfacing it,
-    /// so no task outlives the failure (dropping a guard only signals the abort without
-    /// awaiting it). Joining in order makes the surfaced failure deterministic.
+    /// error or a failed join), abort and join every remaining guard before surfacing it.
+    /// Spawned tasks are cancelled and joined; completion handles only stop waiting for their
+    /// underlying work. Joining in order makes the surfaced failure deterministic.
     pub async fn join_all<E2>(guards: Vec<Self>) -> Result<Vec<T>, E2>
     where
         E2: From<E1> + From<Error>,
@@ -348,12 +341,9 @@ where
     }
 }
 
-#[commonware_macros::stability(ALPHA)]
 impl<T: Send + 'static> Drop for AbortOnDrop<T> {
     fn drop(&mut self) {
-        if let Some(handle) = &self.0 {
-            handle.abort();
-        }
+        self.0.abort();
     }
 }
 
@@ -513,10 +503,10 @@ impl Aborter {
 
 #[cfg(test)]
 mod tests {
-    use super::Handle;
+    use super::{AbortOnDrop, Handle};
     use crate::{Error, Metrics as _, Runner, Spawner, Supervisor as _, deterministic};
     use commonware_utils::channel::oneshot;
-    use futures::future;
+    use futures::{FutureExt as _, future, poll};
 
     const METRIC_PREFIX: &str = "runtime_tasks_running{";
 
@@ -674,6 +664,71 @@ mod tests {
 
             assert!(sender.send(Ok(())).is_ok());
             assert!(matches!(handle.await, Err(Error::Aborted)));
+        });
+    }
+
+    #[test]
+    fn abort_on_drop_cancels_pending_join() {
+        for poll_join in [false, true] {
+            deterministic::Runner::default().start(|context| async move {
+                let (held, released) = oneshot::channel::<()>();
+                let guard = context
+                    .child("guarded")
+                    .spawn(move |_| async move {
+                        let _held = held;
+                        future::pending::<()>().await;
+                    })
+                    .abort_on_drop();
+                let mut join = Box::pin(guard.join());
+                if poll_join {
+                    assert!(poll!(&mut join).is_pending());
+                }
+                drop(join);
+                assert!(released.await.is_err());
+            });
+        }
+    }
+
+    #[test]
+    fn abort_on_drop_join_all_drains_pending_task() {
+        deterministic::Runner::default().start(|context| async move {
+            let (held, released) = oneshot::channel::<()>();
+            let pending = context
+                .child("pending")
+                .spawn(move |_| async move {
+                    let _held = held;
+                    future::pending::<Result<(), Error>>().await
+                })
+                .abort_on_drop();
+            let failed = Handle::ready(Ok(Err(Error::Closed))).abort_on_drop();
+            let result = AbortOnDrop::join_all::<Error>(vec![failed, pending]).await;
+            assert!(matches!(result, Err(Error::Closed)));
+            assert!(
+                released
+                    .now_or_never()
+                    .expect("task still owns sender")
+                    .is_err()
+            );
+        });
+    }
+
+    #[test]
+    fn abort_on_drop_completion_leaves_producer_running() {
+        deterministic::Runner::default().start(|context| async move {
+            let (release, wait) = oneshot::channel::<()>();
+            let (sender, receiver) = oneshot::channel();
+            let mut producer = context.child("producer").spawn(move |_| async move {
+                wait.await.unwrap();
+                let _ = sender.send(Ok(()));
+            });
+
+            Handle::from_receiver(receiver)
+                .abort_on_drop()
+                .abort()
+                .await;
+            assert!(poll!(&mut producer).is_pending());
+            release.send(()).unwrap();
+            producer.await.unwrap();
         });
     }
 

--- a/runtime/src/utils/mod.rs
+++ b/runtime/src/utils/mod.rs
@@ -16,6 +16,8 @@ pub mod signal;
 pub(crate) mod thread;
 
 mod handle;
+#[commonware_macros::stability(ALPHA)]
+pub use handle::AbortOnDrop;
 pub use handle::Handle;
 #[commonware_macros::stability(ALPHA)]
 pub(crate) use handle::Panicked;

--- a/runtime/src/utils/mod.rs
+++ b/runtime/src/utils/mod.rs
@@ -17,10 +17,8 @@ pub(crate) mod thread;
 
 mod handle;
 #[commonware_macros::stability(ALPHA)]
-pub use handle::AbortOnDrop;
-pub use handle::Handle;
-#[commonware_macros::stability(ALPHA)]
 pub(crate) use handle::Panicked;
+pub use handle::{AbortOnDrop, Handle};
 pub(crate) use handle::{Aborter, MetricHandle, Panicker};
 
 mod cell;

--- a/storage/src/journal/authenticated.rs
+++ b/storage/src/journal/authenticated.rs
@@ -972,13 +972,13 @@ where
         self.journal.try_read_many_sync(positions)
     }
 
-    async fn replay(
+    async fn replay_range(
         &self,
-        start_pos: u64,
+        range: Range<u64>,
         buffer: NonZeroUsize,
         read_options: ReadOptions,
     ) -> Result<impl Stream<Item = Result<(u64, C::Item), JournalError>> + Send, JournalError> {
-        self.journal.replay(start_pos, buffer, read_options).await
+        self.journal.replay_range(range, buffer, read_options).await
     }
 }
 

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -191,22 +191,27 @@ fn replay_stream<'a, B: RBlob, A: CodecFixedShared>(
     blobs: &Blobs<'a, B>,
     bounds: Range<u64>,
     items_per_blob: NonZeroU64,
-    start_pos: u64,
+    range: Range<u64>,
     buffer: NonZeroUsize,
     read_options: ReadOptions,
 ) -> Result<impl Stream<Item = Result<(u64, A), Error>> + Send + use<'a, B, A>, Error> {
-    if start_pos > bounds.end {
-        return Err(Error::ItemOutOfRange(start_pos));
+    if range.start > range.end || range.end > bounds.end {
+        return Err(Error::ItemOutOfRange(if range.start > range.end {
+            range.start
+        } else {
+            range.end
+        }));
     }
-    if start_pos < bounds.start {
-        return Err(Error::ItemPruned(start_pos));
+    if range.start < bounds.start {
+        return Err(Error::ItemPruned(range.start));
     }
 
     let mut states = Vec::new();
-    if start_pos < bounds.end {
+    if range.start < range.end {
         let items_per_blob = items_per_blob.get();
+        let start_pos = range.start;
         let start_blob = super::position_to_blob(start_pos, items_per_blob);
-        let end_blob = super::position_to_blob(bounds.end - 1, items_per_blob);
+        let end_blob = super::position_to_blob(range.end - 1, items_per_blob);
         let items_per_batch = (buffer.get() / A::SIZE).max(1);
 
         for blob in start_blob..=end_blob {
@@ -218,7 +223,7 @@ fn replay_stream<'a, B: RBlob, A: CodecFixedShared>(
             } else {
                 blob_first
             };
-            let blob_end = super::blob_end_position(blob, items_per_blob, bounds.end);
+            let blob_end = super::blob_end_position(blob, items_per_blob, range.end);
             let offset = (first_pos - blob_first)
                 .checked_mul(A::SIZE as u64)
                 .ok_or(Error::OffsetOverflow)?;
@@ -1616,9 +1621,9 @@ impl<E: Context, A: CodecFixedShared> super::Contiguous for Reader<'_, E, A> {
         self.probe_items(positions)
     }
 
-    async fn replay(
+    async fn replay_range(
         &self,
-        start_pos: u64,
+        range: Range<u64>,
         buffer: NonZeroUsize,
         read_options: ReadOptions,
     ) -> Result<impl Stream<Item = Result<(u64, A), Error>> + Send, Error> {
@@ -1626,7 +1631,7 @@ impl<E: Context, A: CodecFixedShared> super::Contiguous for Reader<'_, E, A> {
             &self.blobs,
             self.bounds.clone(),
             self.items_per_blob,
-            start_pos,
+            range,
             buffer,
             read_options,
         )
@@ -1656,9 +1661,9 @@ impl<E: Context, A: CodecFixedShared> super::Contiguous for Inner<E, A> {
         self.reader().probe_items(positions)
     }
 
-    async fn replay(
+    async fn replay_range(
         &self,
-        start_pos: u64,
+        range: Range<u64>,
         buffer: NonZeroUsize,
         read_options: ReadOptions,
     ) -> Result<impl Stream<Item = Result<(u64, A), Error>> + Send, Error> {
@@ -1667,7 +1672,7 @@ impl<E: Context, A: CodecFixedShared> super::Contiguous for Inner<E, A> {
             &blobs,
             self.bounds.clone(),
             self.items_per_blob,
-            start_pos,
+            range,
             buffer,
             read_options,
         )
@@ -1697,13 +1702,13 @@ impl<E: Context, A: CodecFixedShared> super::Contiguous for Journal<E, A> {
         super::Contiguous::try_read_many_sync(&*self.0, positions)
     }
 
-    async fn replay(
+    async fn replay_range(
         &self,
-        start_pos: u64,
+        range: Range<u64>,
         buffer: NonZeroUsize,
         read_options: ReadOptions,
     ) -> Result<impl Stream<Item = Result<(u64, A), Error>> + Send, Error> {
-        super::Contiguous::replay(&*self.0, start_pos, buffer, read_options).await
+        super::Contiguous::replay_range(&*self.0, range, buffer, read_options).await
     }
 }
 
@@ -2909,6 +2914,74 @@ mod tests {
                     assert_eq!(i as u64, *pos - START_POS);
                 }
             }
+
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    /// `replay_range` yields exactly the requested positions, spanning blob boundaries, and
+    /// validates the range against `bounds()`.
+    #[test_traced]
+    fn test_fixed_journal_replay_range() {
+        const ITEMS_PER_BLOB: NonZeroU64 = NZU64!(7);
+
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = test_cfg(&context, ITEMS_PER_BLOB);
+            let mut journal = Journal::init(context.child("storage"), cfg.clone())
+                .await
+                .expect("failed to initialize journal");
+
+            // Fill ten blobs and part of the eleventh.
+            let total = ITEMS_PER_BLOB.get() * 10 + 3;
+            for i in 0u64..total {
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
+            }
+
+            // A mid-journal range crossing several blob boundaries yields exactly [start, end).
+            let (start, end) = (12u64, 40u64);
+            {
+                let stream = journal
+                    .replay_range(start..end, NZUsize!(1024), ReadOptions::default())
+                    .await
+                    .expect("failed to replay range");
+                pin_mut!(stream);
+                let mut next = start;
+                while let Some(result) = stream.next().await {
+                    let (pos, item) = result.expect("failed to read item");
+                    assert_eq!(pos, next);
+                    assert_eq!(item, test_digest(pos));
+                    next += 1;
+                }
+                assert_eq!(next, end);
+            }
+
+            // An empty range yields an empty stream.
+            {
+                let stream = journal
+                    .replay_range(5..5, NZUsize!(1024), ReadOptions::default())
+                    .await
+                    .expect("failed to replay empty range");
+                pin_mut!(stream);
+                assert!(stream.next().await.is_none());
+            }
+
+            // A range past the journal's end is rejected.
+            let err = journal
+                .replay_range(0..total + 1, NZUsize!(1024), ReadOptions::default())
+                .await
+                .map(|_| ())
+                .unwrap_err();
+            assert!(matches!(err, Error::ItemOutOfRange(pos) if pos == total + 1));
+
+            // An inverted range is rejected.
+            #[allow(clippy::reversed_empty_ranges)]
+            let err = journal
+                .replay_range(10..5, NZUsize!(1024), ReadOptions::default())
+                .await
+                .map(|_| ())
+                .unwrap_err();
+            assert!(matches!(err, Error::ItemOutOfRange(10)));
 
             journal.destroy().await.unwrap();
         });

--- a/storage/src/journal/contiguous/mod.rs
+++ b/storage/src/journal/contiguous/mod.rs
@@ -190,11 +190,8 @@ pub trait Contiguous: Send + Sync {
     /// async read paths are the sole error authority for declined positions.
     fn try_read_many_sync(&self, positions: &[u64]) -> Vec<Option<Self::Item>>;
 
-    /// Return a stream of the items in `range`, which must fall within `bounds()`.
-    ///
-    /// Replay state is constructed only for the blobs `range` touches, so a caller consuming a
-    /// small slice of a large journal should bound the range rather than dropping an unbounded
-    /// stream early. An empty range within `bounds()` yields an empty stream.
+    /// Return a stream of the items in `range`, in position order. `range` must fall within
+    /// `bounds()`; an empty range within `bounds()` yields an empty stream.
     ///
     /// `buffer` controls the replay byte budget for each chunk. Every backing blob read from
     /// sealed history uses `read_options`. Backing reads from the live writable tip instead use

--- a/storage/src/journal/contiguous/mod.rs
+++ b/storage/src/journal/contiguous/mod.rs
@@ -191,7 +191,7 @@ pub trait Contiguous: Send + Sync {
     fn try_read_many_sync(&self, positions: &[u64]) -> Vec<Option<Self::Item>>;
 
     /// Return a stream of the items in `range`, in position order. `range` must fall within
-    /// `bounds()`; an empty range within `bounds()` yields an empty stream.
+    /// `bounds()`. An empty range within `bounds()` yields an empty stream.
     ///
     /// `buffer` controls the replay byte budget for each chunk. Every backing blob read from
     /// sealed history uses `read_options`. Backing reads from the live writable tip instead use

--- a/storage/src/journal/contiguous/mod.rs
+++ b/storage/src/journal/contiguous/mod.rs
@@ -194,11 +194,17 @@ pub trait Contiguous: Send + Sync {
     ///
     /// Replay state is constructed only for the blobs `range` touches, so a caller consuming a
     /// small slice of a large journal should bound the range rather than dropping an unbounded
-    /// stream early. An empty range yields an empty stream.
+    /// stream early. An empty range within `bounds()` yields an empty stream.
     ///
     /// `buffer` controls the replay byte budget for each chunk. Every backing blob read from
     /// sealed history uses `read_options`. Backing reads from the live writable tip instead use
     /// [ReadOptions::DONT_CACHE] on page-cache misses because the cache retains the fetched pages.
+    ///
+    /// # Errors
+    ///
+    /// Returns [Error::ItemPruned] if `range.start` precedes `bounds().start`, or
+    /// [Error::ItemOutOfRange] if `range.end` exceeds `bounds().end` or the range is inverted
+    /// (`start > end`).
     fn replay_range(
         &self,
         range: Range<u64>,

--- a/storage/src/journal/contiguous/mod.rs
+++ b/storage/src/journal/contiguous/mod.rs
@@ -190,11 +190,27 @@ pub trait Contiguous: Send + Sync {
     /// async read paths are the sole error authority for declined positions.
     fn try_read_many_sync(&self, positions: &[u64]) -> Vec<Option<Self::Item>>;
 
-    /// Return a stream of all items starting from `start_pos`, bounded by `bounds()`.
+    /// Return a stream of the items in `range`, which must fall within `bounds()`.
+    ///
+    /// Replay state is constructed only for the blobs `range` touches, so a caller consuming a
+    /// small slice of a large journal should bound the range rather than dropping an unbounded
+    /// stream early. An empty range yields an empty stream.
     ///
     /// `buffer` controls the replay byte budget for each chunk. Every backing blob read from
     /// sealed history uses `read_options`. Backing reads from the live writable tip instead use
     /// [ReadOptions::DONT_CACHE] on page-cache misses because the cache retains the fetched pages.
+    fn replay_range(
+        &self,
+        range: Range<u64>,
+        buffer: NonZeroUsize,
+        read_options: ReadOptions,
+    ) -> impl Future<
+        Output = Result<impl Stream<Item = Result<(u64, Self::Item), Error>> + Send, Error>,
+    > + Send;
+
+    /// Return a stream of all items starting from `start_pos`, bounded by `bounds()`.
+    ///
+    /// See [`replay_range`](Self::replay_range) for the `buffer` and `read_options` contract.
     fn replay(
         &self,
         start_pos: u64,
@@ -202,7 +218,12 @@ pub trait Contiguous: Send + Sync {
         read_options: ReadOptions,
     ) -> impl Future<
         Output = Result<impl Stream<Item = Result<(u64, Self::Item), Error>> + Send, Error>,
-    > + Send;
+    > + Send {
+        async move {
+            self.replay_range(start_pos..self.bounds().end, buffer, read_options)
+                .await
+        }
+    }
 }
 
 /// Items to append via [`Mutable::append_many`].

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -606,28 +606,33 @@ impl<'a, E: Context, V: CodecShared> Reader<'a, E, V> {
         })
     }
 
-    /// Build one replay state for each data blob touched by `[start_pos, bounds.end)`.
+    /// Build one replay state for each data blob touched by `range`.
     async fn replay_states(
         &self,
-        start_pos: u64,
+        range: core::ops::Range<u64>,
         buffer: NonZeroUsize,
         read_options: ReadOptions,
     ) -> Result<Vec<ReplayState<'a, E::Blob, V>>, Error> {
         let bounds = self.bounds();
-        if start_pos > bounds.end {
-            return Err(Error::ItemOutOfRange(start_pos));
+        if range.start > range.end || range.end > bounds.end {
+            return Err(Error::ItemOutOfRange(if range.start > range.end {
+                range.start
+            } else {
+                range.end
+            }));
         }
-        if start_pos < bounds.start {
-            return Err(Error::ItemPruned(start_pos));
+        if range.start < bounds.start {
+            return Err(Error::ItemPruned(range.start));
         }
 
         let mut states = Vec::new();
-        if start_pos < bounds.end {
+        if range.start < range.end {
             // The first blob may start at a nonzero data offset; subsequent blob states always
             // start at byte offset 0.
             let items_per_blob = self.items_per_blob.get();
+            let start_pos = range.start;
             let start_blob = position_to_blob(start_pos, items_per_blob);
-            let end_blob = position_to_blob(bounds.end - 1, items_per_blob);
+            let end_blob = position_to_blob(range.end - 1, items_per_blob);
             let start_offset = self.offsets.read(start_pos).await?;
 
             for blob in start_blob..=end_blob {
@@ -642,7 +647,7 @@ impl<'a, E: Context, V: CodecShared> Reader<'a, E, V> {
                 } else {
                     blob_first_position(blob, items_per_blob)?
                 };
-                let end_pos = super::blob_end_position(blob, items_per_blob, bounds.end);
+                let end_pos = super::blob_end_position(blob, items_per_blob, range.end);
 
                 // Store codec settings in the state because the stream owns states across await
                 // points and cannot borrow `self`.
@@ -1037,13 +1042,13 @@ impl<E: Context, V: CodecShared> super::Contiguous for Reader<'_, E, V> {
         items
     }
 
-    async fn replay(
+    async fn replay_range(
         &self,
-        start_pos: u64,
+        range: core::ops::Range<u64>,
         buffer: NonZeroUsize,
         read_options: ReadOptions,
     ) -> Result<impl Stream<Item = Result<(u64, V), Error>> + Send, Error> {
-        let states = self.replay_states(start_pos, buffer, read_options).await?;
+        let states = self.replay_states(range, buffer, read_options).await?;
 
         Ok(super::replay_stream_from_states(states))
     }
@@ -2396,16 +2401,14 @@ impl<E: Context, V: CodecShared> Contiguous for Inner<E, V> {
         self.reader().try_read_many_sync(positions)
     }
 
-    async fn replay(
+    async fn replay_range(
         &self,
-        start_pos: u64,
+        range: Range<u64>,
         buffer: NonZeroUsize,
         read_options: ReadOptions,
     ) -> Result<impl Stream<Item = Result<(u64, V), Error>> + Send, Error> {
         let reader = self.reader();
-        let states = reader
-            .replay_states(start_pos, buffer, read_options)
-            .await?;
+        let states = reader.replay_states(range, buffer, read_options).await?;
 
         Ok(super::replay_stream_from_states(states))
     }
@@ -2434,13 +2437,13 @@ impl<E: Context, V: CodecShared> Contiguous for Journal<E, V> {
         Contiguous::try_read_many_sync(&*self.0, positions)
     }
 
-    async fn replay(
+    async fn replay_range(
         &self,
-        start_pos: u64,
+        range: Range<u64>,
         buffer: NonZeroUsize,
         read_options: ReadOptions,
     ) -> Result<impl Stream<Item = Result<(u64, V), Error>> + Send, Error> {
-        Contiguous::replay(&*self.0, start_pos, buffer, read_options).await
+        Contiguous::replay_range(&*self.0, range, buffer, read_options).await
     }
 }
 
@@ -3789,6 +3792,77 @@ mod tests {
             (journal, pos) = journal.append(&999).await.unwrap();
             assert_eq!(pos, 20);
             assert_eq!(journal.read(20).await.unwrap(), 999);
+
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    /// `replay_range` yields exactly the requested positions, spanning blob boundaries, and
+    /// validates the range against `bounds()`.
+    #[test_traced]
+    fn test_variable_replay_range() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "replay-range".into(),
+                items_per_section: NZU64!(10),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, LARGE_PAGE_SIZE, NZUsize!(10)),
+                write_buffer: NZUsize!(1024),
+            };
+            let mut journal = Journal::<_, u64>::init(context, cfg).await.unwrap();
+
+            // Append 40 items across 4 blobs.
+            for i in 0..40u64 {
+                (journal, _) = journal.append(&(i * 100)).await.unwrap();
+            }
+
+            // A mid-journal range crossing blob boundaries yields exactly [start, end).
+            {
+                let stream = journal
+                    .replay_range(7..25, NZUsize!(20), ReadOptions::default())
+                    .await
+                    .unwrap();
+                futures::pin_mut!(stream);
+                for i in 7..25u64 {
+                    let (pos, item) = stream.next().await.unwrap().unwrap();
+                    assert_eq!(pos, i);
+                    assert_eq!(item, i * 100);
+                }
+                assert!(stream.next().await.is_none());
+            }
+
+            // An empty range yields an empty stream.
+            {
+                let stream = journal
+                    .replay_range(5..5, NZUsize!(20), ReadOptions::default())
+                    .await
+                    .unwrap();
+                futures::pin_mut!(stream);
+                assert!(stream.next().await.is_none());
+            }
+
+            // A range past the journal's end is rejected.
+            let res = journal
+                .replay_range(0..41, NZUsize!(20), ReadOptions::default())
+                .await
+                .map(|_| ());
+            assert!(matches!(
+                res,
+                Err(crate::journal::Error::ItemOutOfRange(41))
+            ));
+
+            // An inverted range is rejected.
+            #[allow(clippy::reversed_empty_ranges)]
+            let res = journal
+                .replay_range(10..5, NZUsize!(20), ReadOptions::default())
+                .await
+                .map(|_| ());
+            assert!(matches!(
+                res,
+                Err(crate::journal::Error::ItemOutOfRange(10))
+            ));
 
             journal.destroy().await.unwrap();
         });

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -609,7 +609,7 @@ impl<'a, E: Context, V: CodecShared> Reader<'a, E, V> {
     /// Build one replay state for each data blob touched by `range`.
     async fn replay_states(
         &self,
-        range: core::ops::Range<u64>,
+        range: Range<u64>,
         buffer: NonZeroUsize,
         read_options: ReadOptions,
     ) -> Result<Vec<ReplayState<'a, E::Blob, V>>, Error> {
@@ -1044,7 +1044,7 @@ impl<E: Context, V: CodecShared> super::Contiguous for Reader<'_, E, V> {
 
     async fn replay_range(
         &self,
-        range: core::ops::Range<u64>,
+        range: Range<u64>,
         buffer: NonZeroUsize,
         read_options: ReadOptions,
     ) -> Result<impl Stream<Item = Result<(u64, V), Error>> + Send, Error> {
@@ -2228,7 +2228,7 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
     pub(crate) async fn init_sync(
         context: E,
         cfg: Config<V::Cfg>,
-        range: core::ops::Range<u64>,
+        range: Range<u64>,
     ) -> Result<Self, Error> {
         Ok(Self(Inner::init_sync(context, cfg, range).await?))
     }

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -3810,6 +3810,7 @@ mod tests {
                 codec_config: (),
                 page_cache: CacheRef::from_pooler(&context, LARGE_PAGE_SIZE, NZUsize!(10)),
                 write_buffer: NZUsize!(1024),
+                replay_buffer: NZUsize!(1024),
             };
             let mut journal = Journal::<_, u64>::init(context, cfg).await.unwrap();
 

--- a/storage/src/qmdb/any/mod.rs
+++ b/storage/src/qmdb/any/mod.rs
@@ -138,9 +138,9 @@ pub struct Config<T: Translator, J, S: Strategy, B = ()> {
 
     /// The index's snapshot-build concurrency (see [crate::qmdb::SnapshotBuild::Concurrency]): `()`
     /// for index types that build serially, and the number of build tasks for index types that
-    /// build in parallel. A value of `1` builds the index entirely on the init task. A value of
-    /// `2` decodes on the init task and inserts on one worker. Larger values split between decode
-    /// and insert tasks while the init task merely forwards batches.
+    /// build in parallel. A value of `1` builds the index entirely on the init task. Values of
+    /// `2` and `3` decode on the init task and insert on one or two workers. Larger values split
+    /// between spawned decode and insert tasks while the init task merely forwards batches.
     pub init_concurrency: B,
 }
 

--- a/storage/src/qmdb/any/mod.rs
+++ b/storage/src/qmdb/any/mod.rs
@@ -136,10 +136,9 @@ pub struct Config<T: Translator, J, S: Strategy, B = ()> {
     /// Size (in bytes) of the read buffer used to replay the log during init.
     pub init_buffer: NonZeroUsize,
 
-    /// The index's snapshot-build concurrency (see [crate::qmdb::SnapshotBuild::Concurrency]):
-    /// `()` for index types that build serially, and the number of build tasks for index types
-    /// that build in parallel: the init task plus the decode and insert tasks it coordinates
-    /// (`1` builds entirely on the init task).
+    /// The index's snapshot-build concurrency (see [crate::qmdb::SnapshotBuild::Concurrency]): `()`
+    /// for index types that build serially, and the number of build tasks for index types that
+    /// build in parallel. A value of `1` builds the index entirely on the init task.
     pub init_concurrency: B,
 }
 

--- a/storage/src/qmdb/any/mod.rs
+++ b/storage/src/qmdb/any/mod.rs
@@ -138,7 +138,9 @@ pub struct Config<T: Translator, J, S: Strategy, B = ()> {
 
     /// The index's snapshot-build concurrency (see [crate::qmdb::SnapshotBuild::Concurrency]): `()`
     /// for index types that build serially, and the number of build tasks for index types that
-    /// build in parallel. A value of `1` builds the index entirely on the init task.
+    /// build in parallel. A value of `1` builds the index entirely on the init task; a value of
+    /// `2` decodes on the init task and inserts on one worker. Larger values split between decode
+    /// and insert tasks while the init task merely forwards batches.
     pub init_concurrency: B,
 }
 

--- a/storage/src/qmdb/any/mod.rs
+++ b/storage/src/qmdb/any/mod.rs
@@ -138,7 +138,7 @@ pub struct Config<T: Translator, J, S: Strategy, B = ()> {
 
     /// The index's snapshot-build concurrency (see [crate::qmdb::SnapshotBuild::Concurrency]): `()`
     /// for index types that build serially, and the number of build tasks for index types that
-    /// build in parallel. A value of `1` builds the index entirely on the init task; a value of
+    /// build in parallel. A value of `1` builds the index entirely on the init task. A value of
     /// `2` decodes on the init task and inserts on one worker. Larger values split between decode
     /// and insert tasks while the init task merely forwards batches.
     pub init_concurrency: B,
@@ -1695,7 +1695,7 @@ pub(crate) mod test {
                 assert!(spawned, "build tasks never spawned");
             }
 
-            // Leaving the scope dropped the init future; give the runtime a beat to reap
+            // Leaving the scope dropped the init future. Give the runtime a beat to reap
             // the aborted tasks.
             context.sleep(Duration::from_millis(10)).await;
             let metrics = context.encode();

--- a/storage/src/qmdb/any/mod.rs
+++ b/storage/src/qmdb/any/mod.rs
@@ -1676,9 +1676,7 @@ pub(crate) mod test {
             drop(db);
 
             {
-                // Poll the reopen just enough for the build's tasks to spawn. Workers and
-                // decoders only progress while the coordinator (inside this future) is
-                // polled, so pausing here holds the build mid-flight.
+                // Poll until snapshot tasks own the pending build, then cancel before init returns.
                 let init = UnorderedFixedP1::init(ctx.child("storage"), cfg());
                 pin_mut!(init);
                 let mut spawned = false;

--- a/storage/src/qmdb/any/mod.rs
+++ b/storage/src/qmdb/any/mod.rs
@@ -137,9 +137,9 @@ pub struct Config<T: Translator, J, S: Strategy, B = ()> {
     pub init_buffer: NonZeroUsize,
 
     /// The index's snapshot-build concurrency (see [crate::qmdb::SnapshotBuild::Concurrency]):
-    /// `()` for index types that build serially, and the number of build tasks (including the
-    /// init task itself, which replays and routes the log, so `1` builds entirely on the init
-    /// task) for index types that build in parallel.
+    /// `()` for index types that build serially, and the number of build tasks for index types
+    /// that build in parallel: the init task plus the decode and insert tasks it coordinates
+    /// (`1` builds entirely on the init task).
     pub init_concurrency: B,
 }
 
@@ -1316,7 +1316,9 @@ pub(crate) mod test {
     };
     use commonware_macros::{test_group, test_traced};
     use commonware_parallel::{Sequential, Strategy};
-    use commonware_runtime::{Runner as _, deterministic};
+    use commonware_runtime::{Clock as _, Metrics as _, Runner as _, deterministic};
+    use core::time::Duration;
+    use futures::{pin_mut, poll};
 
     // Type aliases for all 12 MMR variants (all use OneCap for collision coverage).
     type UnorderedFixed =
@@ -1633,6 +1635,71 @@ pub(crate) mod test {
         let (db, range) = db.apply_batch(merkleized).await.unwrap();
         let db = db.commit().await.unwrap();
         (db, range)
+    }
+
+    /// Dropping an in-flight parallel init (e.g. losing a select against a timeout) aborts
+    /// its snapshot workers and decoders rather than leaving them running until they happen
+    /// to observe a closed channel.
+    #[test_traced("INFO")]
+    fn test_parallel_init_aborted_on_cancel() {
+        /// Sum of the runtime's running-task gauges for snapshot build tasks.
+        fn running_build_tasks(metrics: &str) -> u64 {
+            metrics
+                .lines()
+                .filter(|line| {
+                    line.starts_with("runtime_tasks_running{")
+                        && (line.contains("snapshot_worker") || line.contains("snapshot_decoder"))
+                })
+                .filter_map(|line| line.rsplit_once(' ')?.1.trim().parse::<u64>().ok())
+                .sum()
+        }
+
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let ctx = context.child("db");
+            let cfg =
+                || fixed_db_config_full::<OneCap, _, _>("cancel", &ctx, Sequential, NZUsize!(4));
+
+            // Persist enough operations that the reopen's build spans many decode chunks.
+            let db: UnorderedFixedP1 = UnorderedFixedP1::init(ctx.child("storage"), cfg())
+                .await
+                .unwrap();
+            let mut batch = db.new_batch();
+            for i in 0..2_000u64 {
+                batch = batch.write(key(i), Some(key(i)));
+            }
+            let merkleized = batch.merkleize(&db, None).await.unwrap();
+            let (db, _) = db.apply_batch(merkleized).await.unwrap();
+            let db = db.commit().await.unwrap();
+            let db = db.sync().await.unwrap();
+            drop(db);
+
+            {
+                // Poll the reopen just enough for the build's tasks to spawn. Workers and
+                // decoders only progress while the coordinator (inside this future) is
+                // polled, so pausing here holds the build mid-flight.
+                let init = UnorderedFixedP1::init(ctx.child("storage"), cfg());
+                pin_mut!(init);
+                let mut spawned = false;
+                for _ in 0..10_000 {
+                    if poll!(&mut init).is_ready() {
+                        panic!("init completed before it could be cancelled");
+                    }
+                    context.sleep(Duration::from_millis(1)).await;
+                    if running_build_tasks(&context.encode()) > 0 {
+                        spawned = true;
+                        break;
+                    }
+                }
+                assert!(spawned, "build tasks never spawned");
+            }
+
+            // Leaving the scope dropped the init future; give the runtime a beat to reap
+            // the aborted tasks.
+            context.sleep(Duration::from_millis(10)).await;
+            let metrics = context.encode();
+            assert_eq!(running_build_tasks(&metrics), 0, "{metrics}");
+        });
     }
 
     /// An empty batch (no mutations) still produces a valid commit.

--- a/storage/src/qmdb/any/ordered/fixed.rs
+++ b/storage/src/qmdb/any/ordered/fixed.rs
@@ -785,11 +785,8 @@ pub(crate) mod test {
                 OneCap,
             );
 
-            // Every read now fails, and the failure necessarily surfaces through the replay
-            // stream: the reopened journal's page cache is fresh (only the buffer pool is shared
-            // across configs, never cached pages), so replay's first item forces a storage read,
-            // and with far fewer ops than the routing batch size no batch reaches a worker, so
-            // workers never read the log themselves.
+            // The reopened journal has a fresh page cache, so replay's first item requires a read.
+            // Failing that read leaves workers idle because no batches have been routed.
             context.storage_fault_config().write().read_rate = Some(probability!(1.0));
             let result = index
                 .build_snapshot(

--- a/storage/src/qmdb/any/unordered/fixed.rs
+++ b/storage/src/qmdb/any/unordered/fixed.rs
@@ -162,7 +162,7 @@ pub(crate) mod test {
         reschedule,
     };
     use commonware_utils::{NZU16, NZU64, NZUsize, TestRng, probability};
-    use core::num::NonZeroUsize;
+    use core::{num::NonZeroUsize, ops::Range};
     use futures::{FutureExt as _, Stream};
     use rand::Rng;
     use std::{
@@ -621,7 +621,7 @@ pub(crate) mod test {
         db: AnyTestGeneric<F>,
         writes: impl IntoIterator<Item = (Digest, Option<Digest>)>,
         metadata: Option<Digest>,
-    ) -> (AnyTestGeneric<F>, std::ops::Range<GenericLocation<F>>) {
+    ) -> (AnyTestGeneric<F>, Range<GenericLocation<F>>) {
         let mut batch = db.new_batch();
         for (k, v) in writes {
             batch = batch.write(k, v);
@@ -933,7 +933,7 @@ pub(crate) mod test {
     impl<C: Contiguous<Item: Sync>> Contiguous for FailingReads<C> {
         type Item = C::Item;
 
-        fn bounds(&self) -> std::ops::Range<u64> {
+        fn bounds(&self) -> Range<u64> {
             self.0.bounds()
         }
 
@@ -963,7 +963,7 @@ pub(crate) mod test {
 
         fn replay_range(
             &self,
-            range: std::ops::Range<u64>,
+            range: Range<u64>,
             buffer: NonZeroUsize,
             read_options: ReadOptions,
         ) -> impl Future<

--- a/storage/src/qmdb/any/unordered/fixed.rs
+++ b/storage/src/qmdb/any/unordered/fixed.rs
@@ -966,9 +966,9 @@ pub(crate) mod test {
             positions.iter().map(|_| None).collect()
         }
 
-        fn replay(
+        fn replay_range(
             &self,
-            start_pos: u64,
+            range: std::ops::Range<u64>,
             buffer: NonZeroUsize,
             read_options: ReadOptions,
         ) -> impl Future<
@@ -977,7 +977,7 @@ pub(crate) mod test {
                 JournalError,
             >,
         > + Send {
-            self.0.replay(start_pos, buffer, read_options)
+            self.0.replay_range(range, buffer, read_options)
         }
     }
 

--- a/storage/src/qmdb/any/unordered/fixed.rs
+++ b/storage/src/qmdb/any/unordered/fixed.rs
@@ -824,13 +824,11 @@ pub(crate) mod test {
     #[test_traced("WARN")]
     fn test_unordered_partitioned_p1_parallel_init_equivalence() {
         deterministic::Runner::default().start(|context| async move {
-            // Concurrency 201 (200 workers) rounds down to 128 equal two-partition ranges for
-            // P=1 (count=256) and 301 exceeds the partition count and clamps. Both must
-            // reconstruct the same root without panicking.
+            // Cover partition-range rounding and budgets beyond the partition and chunk counts.
             check_parallel_init_equivalence::<1>(
                 context,
                 "unordered_parallel_equiv_p1",
-                &[1, 2, 3, 5, 9, 201, 301],
+                &[1, 2, 3, 5, 9, 201, 301, usize::MAX],
             )
             .await;
         });
@@ -1053,7 +1051,7 @@ pub(crate) mod test {
     fn test_unordered_partitioned_parallel_init_empty_log() {
         deterministic::Runner::default().start(|context| async move {
             let mut results = Vec::new();
-            for concurrency in [1usize, 4] {
+            for concurrency in [1usize, 4, usize::MAX / 2, usize::MAX] {
                 let cfg =
                     fixed_db_config_partitioned::<OneCap>("unordered_parallel_empty", &context);
                 let log = Journal::<Context, Operation<mmr::Family, Digest, Digest>>::init(
@@ -1088,7 +1086,7 @@ pub(crate) mod test {
                 assert_eq!(result.0, 0);
                 results.push(result);
             }
-            assert_eq!(results[0], results[1]);
+            assert!(results.windows(2).all(|pair| pair[0] == pair[1]));
         });
     }
 

--- a/storage/src/qmdb/any/unordered/fixed.rs
+++ b/storage/src/qmdb/any/unordered/fixed.rs
@@ -903,11 +903,8 @@ pub(crate) mod test {
                 OneCap,
             );
 
-            // Every read now fails, and the failure necessarily surfaces through the replay
-            // stream: the reopened journal's page cache is fresh (only the buffer pool is shared
-            // across configs, never cached pages), so replay's first item forces a storage read,
-            // and with far fewer ops than the routing batch size no batch reaches a worker, so
-            // workers never read the log themselves.
+            // The reopened journal has a fresh page cache, so replay's first item requires a read.
+            // Failing that read leaves workers idle because no batches have been routed.
             context.storage_fault_config().write().read_rate = Some(probability!(1.0));
             let result = index
                 .build_snapshot(

--- a/storage/src/qmdb/benches/scale.rs
+++ b/storage/src/qmdb/benches/scale.rs
@@ -30,8 +30,8 @@
 //! reporting the total build time.
 //!
 //! `init` reopens it (read-only) and times one `init` at the given init cache size (`cache` entries,
-//! `0` = off) and `concurrency` (`1` = serial, `N` = N total build tasks, so N-1 workers alongside
-//! the init task). It reports the replay-region size `R` (so a full-coverage cache is `cache = R`)
+//! `0` = off) and `concurrency` (`1` = serial, `2` adds one insert worker, and larger values
+//! split between decode and insert tasks while the init task merely forwards). It reports the replay-region size `R` (so a full-coverage cache is `cache = R`)
 //! and the elapsed time. Sweep cache/concurrency by driving the command from a shell loop.
 //!
 //! `get` times random point reads through the full stack (index lookup, page cache, blob read): it

--- a/storage/src/qmdb/benches/scale.rs
+++ b/storage/src/qmdb/benches/scale.rs
@@ -30,9 +30,11 @@
 //! reporting the total build time.
 //!
 //! `init` reopens it (read-only) and times one `init` at the given init cache size (`cache` entries,
-//! `0` = off) and `concurrency` (`1` = serial, `2` adds one insert worker, and larger values
-//! split between decode and insert tasks while the init task merely forwards). It reports the replay-region size `R` (so a full-coverage cache is `cache = R`)
-//! and the elapsed time. Sweep cache/concurrency by driving the command from a shell loop.
+//! `0` = off) and `concurrency` (`1` = serial, `2` and `3` decode on the init task with one or
+//! two insert workers, and larger values split between spawned decode and insert tasks while the
+//! init task merely forwards). It reports the replay-region size `R` (so a full-coverage cache is
+//! `cache = R`) and the elapsed time. Sweep cache/concurrency by driving the command from a shell
+//! loop.
 //!
 //! `get` times random point reads through the full stack (index lookup, page cache, blob read): it
 //! opens the database (untimed), then for each entry in the comma-separated concurrency list drops
@@ -133,7 +135,8 @@ impl IndexKind {
 }
 
 /// Parse a `concurrency` CLI argument into a snapshot-build concurrency (`1` = serial on the
-/// init task, `n` = `n - 1` worker tasks in addition to it). `None` is a parse failure.
+/// init task, larger values follow the decode/insert split in the module docs). `None` is a
+/// parse failure.
 fn parse_concurrency(arg: &str) -> Option<NonZeroUsize> {
     arg.parse::<usize>().ok().and_then(NonZeroUsize::new)
 }

--- a/storage/src/qmdb/benches/scale.rs
+++ b/storage/src/qmdb/benches/scale.rs
@@ -33,8 +33,7 @@
 //! `0` = off) and `concurrency` (`1` = serial, `2` and `3` decode on the init task with one or
 //! two insert workers, and larger values split between spawned decode and insert tasks while the
 //! init task merely forwards). It reports the replay-region size `R` (so a full-coverage cache is
-//! `cache = R`) and the elapsed time. Sweep cache/concurrency by driving the command from a shell
-//! loop.
+//! `cache = R`) and the elapsed time.
 //!
 //! `get` times random point reads through the full stack (index lookup, page cache, blob read): it
 //! opens the database (untimed), then for each entry in the comma-separated concurrency list drops

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -385,7 +385,7 @@ pub struct Config<T: Translator, J, S: Strategy, B = ()> {
 
     /// The index's snapshot-build concurrency (see [crate::qmdb::SnapshotBuild::Concurrency]): `()`
     /// for index types that build serially, and the number of build tasks for index types that
-    /// build in parallel. A value of `1` builds the index entirely on the init task; a value of
+    /// build in parallel. A value of `1` builds the index entirely on the init task. A value of
     /// `2` decodes on the init task and inserts on one worker. Larger values split between decode
     /// and insert tasks while the init task merely forwards batches.
     pub init_concurrency: B,

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -384,9 +384,9 @@ pub struct Config<T: Translator, J, S: Strategy, B = ()> {
     pub init_buffer: NonZeroUsize,
 
     /// The index's snapshot-build concurrency (see [crate::qmdb::SnapshotBuild::Concurrency]):
-    /// `()` for index types that build serially, and the number of build tasks (including the
-    /// init task itself, which replays and routes the log, so `1` builds entirely on the init
-    /// task) for index types that build in parallel.
+    /// `()` for index types that build serially, and the number of build tasks for index types
+    /// that build in parallel: the init task plus the decode and insert tasks it coordinates
+    /// (`1` builds entirely on the init task).
     pub init_concurrency: B,
 }
 

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -385,9 +385,9 @@ pub struct Config<T: Translator, J, S: Strategy, B = ()> {
 
     /// The index's snapshot-build concurrency (see [crate::qmdb::SnapshotBuild::Concurrency]): `()`
     /// for index types that build serially, and the number of build tasks for index types that
-    /// build in parallel. A value of `1` builds the index entirely on the init task. A value of
-    /// `2` decodes on the init task and inserts on one worker. Larger values split between decode
-    /// and insert tasks while the init task merely forwards batches.
+    /// build in parallel. A value of `1` builds the index entirely on the init task. Values of
+    /// `2` and `3` decode on the init task and insert on one or two workers. Larger values split
+    /// between spawned decode and insert tasks while the init task merely forwards batches.
     pub init_concurrency: B,
 }
 

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -385,7 +385,9 @@ pub struct Config<T: Translator, J, S: Strategy, B = ()> {
 
     /// The index's snapshot-build concurrency (see [crate::qmdb::SnapshotBuild::Concurrency]): `()`
     /// for index types that build serially, and the number of build tasks for index types that
-    /// build in parallel. A value of `1` builds the index entirely on the init task.
+    /// build in parallel. A value of `1` builds the index entirely on the init task; a value of
+    /// `2` decodes on the init task and inserts on one worker. Larger values split between decode
+    /// and insert tasks while the init task merely forwards batches.
     pub init_concurrency: B,
 }
 

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -383,10 +383,9 @@ pub struct Config<T: Translator, J, S: Strategy, B = ()> {
     /// Size (in bytes) of the read buffer used to replay the log during init.
     pub init_buffer: NonZeroUsize,
 
-    /// The index's snapshot-build concurrency (see [crate::qmdb::SnapshotBuild::Concurrency]):
-    /// `()` for index types that build serially, and the number of build tasks for index types
-    /// that build in parallel: the init task plus the decode and insert tasks it coordinates
-    /// (`1` builds entirely on the init task).
+    /// The index's snapshot-build concurrency (see [crate::qmdb::SnapshotBuild::Concurrency]): `()`
+    /// for index types that build serially, and the number of build tasks for index types that
+    /// build in parallel. A value of `1` builds the index entirely on the init task.
     pub init_concurrency: B,
 }
 

--- a/storage/src/qmdb/mod.rs
+++ b/storage/src/qmdb/mod.rs
@@ -657,9 +657,10 @@ where
     Ok((active_keys, activity))
 }
 
-/// Build a snapshot by splitting the log replay across parallel workers, each owning a contiguous
-/// range of the index's partitions (see [Partitioned]). Returns the number of active keys and
-/// the activity bitmap (see [SnapshotBuild::build_snapshot]).
+/// Build a snapshot by decoding the log replay in contiguous chunks on concurrent decode tasks
+/// and routing each keyed operation to the parallel insert worker owning its partition range
+/// (see [Partitioned]). Returns the number of active keys and the activity bitmap (see
+/// [SnapshotBuild::build_snapshot]).
 async fn build_snapshot_parallel<F, E, C, I>(
     snapshot: &mut I,
     context: E,
@@ -705,9 +706,9 @@ where
     let floor = *inactivity_floor_loc;
     let range_size = count.div_ceil(workers);
 
-    // `range_size` rounds up, so `range_size * workers` can exceed `count`, leaving trailing
-    // ranges empty (and a naive `count - lo` would underflow). Reduce to the number of
-    // non-empty ranges so routing (`p / range_size`) stays in `[0, workers)`.
+    // `range_size` rounds up, so the last ranges could start at or past `count`. Reduce
+    // `workers` to the number of non-empty ranges: every spawned worker then owns at least one
+    // partition and routing (`partition / range_size`) stays in `[0, workers)`.
     let workers = count.div_ceil(range_size);
     let per_worker_cache = cache_size.and_then(|n| NonZeroUsize::new(n.get() / workers));
     let end = log.bounds().end;

--- a/storage/src/qmdb/mod.rs
+++ b/storage/src/qmdb/mod.rs
@@ -70,7 +70,7 @@ use crate::{
 };
 use commonware_codec::Encode;
 use commonware_cryptography::Hasher;
-use commonware_runtime::{Handle, ReadOptions, Spawner};
+use commonware_runtime::{AbortOnDrop, ReadOptions, Spawner};
 use commonware_utils::{
     bitmap::{Atomic, BitMap},
     cache::Clock,
@@ -471,42 +471,6 @@ where
     Ok(None)
 }
 
-/// Aborts a spawned init task if dropped before being joined, so cancelling an init future
-/// (e.g. via a timeout) cannot leave the task running (with its log clone) until it happens
-/// to observe a closed channel.
-pub(crate) struct AbortOnDrop<T: Send + 'static>(Option<Handle<T>>);
-
-impl<T: Send + 'static> AbortOnDrop<T> {
-    pub(crate) const fn new(handle: Handle<T>) -> Self {
-        Self(Some(handle))
-    }
-
-    /// Abort the task, then join it.
-    pub(crate) async fn abort(mut self) {
-        let handle = self.0.take().expect("handle joined once");
-        handle.abort();
-        let _ = handle.await;
-    }
-
-    /// Join the task.
-    pub(crate) async fn join(mut self) -> Result<T, commonware_runtime::Error> {
-        // Poll the handle by reference: the guard must keep owning it so dropping this
-        // future mid-join still aborts the task.
-        let handle = self.0.as_mut().expect("handle joined once");
-        let result = handle.await;
-        self.0 = None;
-        result
-    }
-}
-
-impl<T: Send + 'static> Drop for AbortOnDrop<T> {
-    fn drop(&mut self) {
-        if let Some(handle) = &self.0 {
-            handle.abort();
-        }
-    }
-}
-
 /// Join `guards` in order, collecting each task's output. On the first failure (a task
 /// error or a failed join), abort and join every remaining guard before surfacing it, so
 /// no task outlives the failure (dropping a guard only signals the abort without awaiting
@@ -796,7 +760,7 @@ where
                     per_worker_cache,
                 )
             });
-        handles.push(AbortOnDrop::new(handle));
+        handles.push(handle.abort_on_drop());
     }
 
     // Replay the log and route each keyed op to the worker owning its partition. Decoding
@@ -877,7 +841,7 @@ where
                 .child("snapshot_decoder")
                 .dedicated()
                 .spawn(move |_| decode_snapshot_chunk::<F, C>(log, start, len, routing, tx));
-            pending.push_back((rx, AbortOnDrop::new(handle)));
+            pending.push_back((rx, handle.abort_on_drop()));
         };
 
         for _ in 0..decoders {

--- a/storage/src/qmdb/mod.rs
+++ b/storage/src/qmdb/mod.rs
@@ -685,9 +685,9 @@ where
     let concurrency = init_concurrency.get();
 
     // Inserts cost more CPU than decoding: across widths on both journal types, throughput peaks
-    // near two decoders per five tasks. Once decoding is spawned at all, use at least two
-    // decoders, since a lone decoder starves the workers.
-    let decoders = if concurrency <= 2 {
+    // near two decoders per five tasks. Spawned decoding always uses at least two decoders, since
+    // a lone decoder starves the workers; below four tasks this task decodes inline instead.
+    let decoders = if concurrency <= 3 {
         0
     } else {
         (concurrency * 2 / 5).max(2).min(concurrency / 2)

--- a/storage/src/qmdb/mod.rs
+++ b/storage/src/qmdb/mod.rs
@@ -471,34 +471,6 @@ where
     Ok(None)
 }
 
-/// Join `guards` in order, collecting each task's output. On the first failure (a task
-/// error or a failed join), abort and join every remaining guard before surfacing it, so
-/// no task outlives the failure (dropping a guard only signals the abort without awaiting
-/// it).
-pub(crate) async fn join_all_or_abort<T, E1, E2>(
-    guards: Vec<AbortOnDrop<Result<T, E1>>>,
-) -> Result<Vec<T>, E2>
-where
-    T: Send + 'static,
-    E1: Send + 'static,
-    E2: From<E1> + From<commonware_runtime::Error>,
-{
-    let mut joined = Vec::with_capacity(guards.len());
-    let mut failure: Option<E2> = None;
-    for guard in guards {
-        if failure.is_some() {
-            guard.abort().await;
-            continue;
-        }
-        match guard.join().await {
-            Ok(Ok(output)) => joined.push(output),
-            Ok(Err(err)) => failure = Some(err.into()),
-            Err(err) => failure = Some(err.into()),
-        }
-    }
-    failure.map_or_else(|| Ok(joined), Err)
-}
-
 /// Bounded depth (in batches) of each per-worker channel during a parallel build. Backpressure keeps
 /// the replay from running arbitrarily far ahead of a slow worker.
 const SNAPSHOT_CHANNEL_DEPTH: usize = 4;
@@ -524,28 +496,26 @@ struct SnapshotRouting {
 }
 
 /// Number of operations the snapshot replay batches per worker-channel send during a parallel
-/// build. Build throughput is mostly insensitive to this value, so it is a constant rather
-/// than configuration. Small in tests so ordinary logs exercise batch boundaries.
+/// build. Build throughput is mostly insensitive to this value, so it is a constant rather than
+/// configuration. Small in tests so ordinary logs exercise batch boundaries.
 #[cfg(not(test))]
 const SNAPSHOT_ROUTE_BATCH: usize = 4096;
 #[cfg(test)]
 const SNAPSHOT_ROUTE_BATCH: usize = 3;
 
-/// Operations per decode chunk in a parallel build. Decoding the replay stream is the
-/// build's serial bottleneck at large sizes, so contiguous chunks of this many locations
-/// are decoded (and partition-routed) on concurrent tasks while the coordinator forwards
-/// finished chunks in position order. Together with the decoder count this bounds the
-/// routed operations a build can hold in memory at once. Small in tests so ordinary logs
-/// exercise chunk boundaries.
+/// Operations per decode chunk in a parallel build. Decoding the replay stream is the build's
+/// serial bottleneck at large sizes, so contiguous chunks of this many locations are decoded (and
+/// partition-routed) on concurrent tasks while the coordinator forwards finished chunks in position
+/// order. Together with the decoder count this bounds the routed operations a build can hold in
+/// memory at once. Small in tests so ordinary logs exercise chunk boundaries.
 #[cfg(not(test))]
 const SNAPSHOT_DECODE_CHUNK: u64 = 1 << 17;
 #[cfg(test)]
 const SNAPSHOT_DECODE_CHUNK: u64 = 64;
 
 /// Decode the `len` operations starting at `start` and stream each keyed op's routed batch
-/// (`partition_of(key) / range_size`) over `tx` in sub-batches of at most
-/// [SNAPSHOT_ROUTE_BATCH] ops. Returns without error if the receiver is dropped (routing
-/// was aborted).
+/// (`partition_of(key) / range_size`) over `tx` in sub-batches of at most [SNAPSHOT_ROUTE_BATCH]
+/// ops. Returns without error if the receiver is dropped (routing was aborted).
 async fn decode_snapshot_chunk<F, C>(
     log: Arc<C>,
     start: u64,
@@ -700,10 +670,10 @@ where
 {
     let count = snapshot.partition_count();
 
-    // Split the concurrency budget (less this task, which coordinates and is mostly idle)
-    // between decode tasks and insert workers. Inserts cost more CPU than decoding, so an
-    // odd budget gives the extra thread to the workers. A budget of one yields a single
-    // worker fed by this task decoding inline.
+    // Split the concurrency budget (less this task, which coordinates and is mostly idle) between
+    // decode tasks and insert workers. Inserts cost more CPU than decoding, so an odd budget gives
+    // the extra thread to the workers. A budget of one yields a single worker fed by this task
+    // decoding inline.
     let budget = init_concurrency.get() - 1;
     let decoders = budget / 2;
     let workers = (budget - decoders).min(count);
@@ -764,26 +734,24 @@ where
         handles.push(handle.abort_on_drop());
     }
 
-    // Replay the log and route each keyed op to the worker owning its partition. Decoding
-    // the stream is the build's serial bottleneck at large sizes, so when the budget
-    // grants decode tasks, contiguous position chunks are decoded (and routed) on those
-    // tasks; this task forwards each chunk's batches in position order, preserving the
-    // per-worker op order the insert path relies on. With no decode tasks, this task
-    // decodes and routes inline. Routing runs in an inner future so any decode failure is
-    // captured rather than returned immediately: returning while the worker handles are
-    // merely dropped would leave the workers running detached, retaining the log and
-    // their range allocations after init has already failed.
+    // Replay the log and route each keyed op to the worker owning its partition. Decoding the
+    // stream is the build's serial bottleneck at large sizes, so when the budget grants decode
+    // tasks, contiguous position chunks are decoded (and routed) on those tasks; this task forwards
+    // each chunk's batches in position order, preserving the per-worker op order the insert path
+    // relies on. With no decode tasks, this task decodes and routes inline. Routing runs in an
+    // inner future so any decode failure is captured rather than returned immediately: returning
+    // while the worker handles are merely dropped would leave the workers running detached,
+    // retaining the log and their range allocations after init has already failed.
     //
-    // A closed worker channel means that worker terminated early (e.g. returned an
-    // `Error<F>` while resolving a collision). Routing stops on the first such send
-    // failure and the join below surfaces that worker's error, rather than panicking on
-    // the send.
+    // A closed worker channel means that worker terminated early (e.g. returned an `Error<F>` while
+    // resolving a collision). Routing stops on the first such send failure and the join below
+    // surfaces that worker's error, rather than panicking on the send.
     let mut pending = VecDeque::new();
     let routing_result: Result<(), Error<F>> = async {
-        // With no decode tasks, decode and route on this task over one continuous replay.
-        // Per-chunk replays each open a fresh buffered reader that re-reads its window from
-        // the blob, redundant I/O the concurrent build hides by overlapping decoders but a
-        // serial build pays on its critical path (measured 265s vs 369s on a 1.66B-op log).
+        // With no decode tasks, decode and route on this task over one continuous replay. Per-chunk
+        // replays each open a fresh buffered reader that re-reads its window from the blob,
+        // redundant I/O the concurrent build hides by overlapping decoders but a serial build pays
+        // on its critical path (measured 265s vs 369s on a 1.66B-op log).
         if decoders == 0 {
             let stream = log
                 .replay(floor, init_buffer, ReadOptions::default())
@@ -818,10 +786,10 @@ where
             return Ok(());
         }
 
-        // Each chunk's channel holds the whole chunk (full sub-batches plus a final
-        // partial per worker), so a decoder never blocks mid-chunk: in-flight memory
-        // stays bounded by the decoder count times the chunk size while every decode
-        // task makes progress regardless of which chunk is being forwarded.
+        // Each chunk's channel holds the whole chunk (full sub-batches plus a final partial per
+        // worker), so a decoder never blocks mid-chunk: in-flight memory stays bounded by the
+        // decoder count times the chunk size while every decode task makes progress regardless of
+        // which chunk is being forwarded.
         let chunk_capacity = SNAPSHOT_DECODE_CHUNK as usize / SNAPSHOT_ROUTE_BATCH + workers;
         let routing = SnapshotRouting {
             workers,
@@ -866,15 +834,14 @@ where
     // Close the channels so each worker's stream terminates and it returns its index.
     drop(senders);
 
-    // Abort and join any decode chunks still in flight, so no decoder outlives a failed
-    // init.
+    // Abort and join any decode chunks still in flight, so no decoder outlives a failed init.
     while let Some((rx, decoder)) = pending.pop_front() {
         drop(rx);
         decoder.abort().await;
     }
 
     // Join workers before surfacing any replay failure, so none outlive a failed init.
-    let joined = join_all_or_abort::<_, _, Error<F>>(handles).await;
+    let joined = AbortOnDrop::join_all::<Error<F>>(handles).await;
     routing_result?;
     let joined = joined?;
 

--- a/storage/src/qmdb/mod.rs
+++ b/storage/src/qmdb/mod.rs
@@ -678,12 +678,13 @@ where
 {
     let count = snapshot.partition_count();
 
-    // Split the concurrency between decode tasks and insert workers. With decode tasks this task
-    // only forwards batches and is mostly idle, so like the init overlap task it does not count
-    // against the concurrency. At a concurrency of two it decodes inline (chunked decode pays
-    // redundant reads a lone decoder cannot hide) and counts. Inserts cost more CPU than decoding,
-    // so an odd count gives the extra thread to the workers.
+    // Split the `init_concurrency` budget between decode tasks and insert workers. When there is at
+    // least one decode task, this task only forwards batches and is mostly idle, so it does not
+    // count against the concurrency budget. At a concurrency budget of two, this task counts
+    // against the budget because it performs decoding and forwarding.
     let concurrency = init_concurrency.get();
+
+    // Inserts cost more CPU than decoding, so an odd count gives the extra thread to the workers.
     let decoders = if concurrency <= 2 { 0 } else { concurrency / 2 };
     let workers = if decoders == 0 {
         concurrency.saturating_sub(1).min(count)
@@ -757,8 +758,8 @@ where
     // surfaces that worker's error, rather than panicking on the send.
     let mut pending = VecDeque::new();
     let routing_result: Result<RoutingOutcome, Error<F>> = async {
-        // With no decode tasks, decode and route on this task over one continuous replay to
-        // avoid per-chunk buffered-reader overhead (measured 265s vs 369s on a 1.66B-op log).
+        // With no decode tasks, decode and route on this task over one continuous replay to avoid
+        // per-chunk buffered-reader overhead (measured 265s vs 369s on a 1.66B-op log).
         if decoders == 0 {
             let stream = log
                 .replay(floor, init_buffer, ReadOptions::default())
@@ -852,9 +853,9 @@ where
     let routing = routing_result?;
     let joined = joined?;
 
-    // Routing stops on a closed worker channel so the join above can surface that worker's
-    // failure. Every clean join with cut-short routing therefore dropped routed operations;
-    // fail rather than install a snapshot missing them.
+    // Routing stops on a closed worker channel so the join above can surface that worker's failure.
+    // Every clean join with cut-short routing therefore dropped routed operations; fail rather than
+    // install a snapshot missing them.
     if matches!(routing, RoutingOutcome::CutShort) {
         return Err(Error::DataCorrupted(
             "snapshot routing stopped without a worker failure",

--- a/storage/src/qmdb/mod.rs
+++ b/storage/src/qmdb/mod.rs
@@ -524,7 +524,8 @@ struct SnapshotRouting {
 }
 
 /// Number of operations the snapshot replay batches per worker-channel send during a parallel
-/// build. Small in tests so ordinary logs exercise batch boundaries.
+/// build. Build throughput is mostly insensitive to this value, so it is a constant rather
+/// than configuration. Small in tests so ordinary logs exercise batch boundaries.
 #[cfg(not(test))]
 const SNAPSHOT_ROUTE_BATCH: usize = 4096;
 #[cfg(test)]

--- a/storage/src/qmdb/mod.rs
+++ b/storage/src/qmdb/mod.rs
@@ -854,7 +854,7 @@ where
     let joined = joined?;
 
     // Routing stops on a closed worker channel so the join above can surface that worker's failure.
-    // Every clean join with cut-short routing therefore dropped routed operations; fail rather than
+    // Every clean join with cut-short routing therefore dropped routed operations. Fail rather than
     // install a snapshot missing them.
     if matches!(routing, RoutingOutcome::CutShort) {
         return Err(Error::DataCorrupted(

--- a/storage/src/qmdb/mod.rs
+++ b/storage/src/qmdb/mod.rs
@@ -680,13 +680,13 @@ where
 
     // Split the `init_concurrency` budget between decode tasks and insert workers. When there is at
     // least one decode task, this task only forwards batches and is mostly idle, so it does not
-    // count against the concurrency budget. At a concurrency budget of two, this task counts
-    // against the budget because it performs decoding and forwarding.
+    // count against the concurrency budget. At budgets of three or less, this task decodes inline
+    // and counts against the budget.
     let concurrency = init_concurrency.get();
 
     // Inserts cost more CPU than decoding: across widths on both journal types, throughput peaks
     // near two decoders per five tasks. Spawned decoding always uses at least two decoders, since
-    // a lone decoder starves the workers; below four tasks this task decodes inline instead.
+    // a lone decoder starves the workers. Below four tasks this task decodes inline instead.
     let decoders = if concurrency <= 3 {
         0
     } else {

--- a/storage/src/qmdb/mod.rs
+++ b/storage/src/qmdb/mod.rs
@@ -70,15 +70,15 @@ use crate::{
 };
 use commonware_codec::Encode;
 use commonware_cryptography::Hasher;
-use commonware_runtime::{ReadOptions, Spawner};
+use commonware_runtime::{Handle, ReadOptions, Spawner};
 use commonware_utils::{
     bitmap::{Atomic, BitMap},
     cache::Clock,
     channel::mpsc,
 };
 use core::{num::NonZeroUsize, ops::Range};
-use futures::{StreamExt as _, future::join_all, pin_mut};
-use std::sync::Arc;
+use futures::{StreamExt as _, pin_mut};
+use std::{collections::VecDeque, sync::Arc};
 use thiserror::Error;
 
 pub mod any;
@@ -471,8 +471,69 @@ where
     Ok(None)
 }
 
-/// Number of operations the snapshot replay batches per worker-channel send during a parallel build.
-const SNAPSHOT_ROUTE_BATCH: usize = 4096;
+/// Aborts a spawned init task if dropped before being joined, so cancelling an init future
+/// (e.g. via a timeout) cannot leave the task running (with its log clone) until it happens
+/// to observe a closed channel.
+pub(crate) struct AbortOnDrop<T: Send + 'static>(Option<Handle<T>>);
+
+impl<T: Send + 'static> AbortOnDrop<T> {
+    pub(crate) const fn new(handle: Handle<T>) -> Self {
+        Self(Some(handle))
+    }
+
+    /// Abort the task, then join it.
+    pub(crate) async fn abort(mut self) {
+        let handle = self.0.take().expect("handle joined once");
+        handle.abort();
+        let _ = handle.await;
+    }
+
+    /// Join the task.
+    pub(crate) async fn join(mut self) -> Result<T, commonware_runtime::Error> {
+        // Poll the handle by reference: the guard must keep owning it so dropping this
+        // future mid-join still aborts the task.
+        let handle = self.0.as_mut().expect("handle joined once");
+        let result = handle.await;
+        self.0 = None;
+        result
+    }
+}
+
+impl<T: Send + 'static> Drop for AbortOnDrop<T> {
+    fn drop(&mut self) {
+        if let Some(handle) = &self.0 {
+            handle.abort();
+        }
+    }
+}
+
+/// Join `guards` in order, collecting each task's output. On the first failure (a task
+/// error or a failed join), abort and join every remaining guard before surfacing it, so
+/// no task outlives the failure (dropping a guard only signals the abort without awaiting
+/// it).
+pub(crate) async fn join_all_or_abort<T, E1, E2>(
+    guards: Vec<AbortOnDrop<Result<T, E1>>>,
+) -> Result<Vec<T>, E2>
+where
+    T: Send + 'static,
+    E1: Send + 'static,
+    E2: From<E1> + From<commonware_runtime::Error>,
+{
+    let mut joined = Vec::with_capacity(guards.len());
+    let mut failure: Option<E2> = None;
+    for guard in guards {
+        if failure.is_some() {
+            guard.abort().await;
+            continue;
+        }
+        match guard.join().await {
+            Ok(Ok(output)) => joined.push(output),
+            Ok(Err(err)) => failure = Some(err.into()),
+            Err(err) => failure = Some(err.into()),
+        }
+    }
+    failure.map_or_else(|| Ok(joined), Err)
+}
 
 /// Bounded depth (in batches) of each per-worker channel during a parallel build. Backpressure keeps
 /// the replay from running arbitrarily far ahead of a slow worker.
@@ -481,6 +542,90 @@ const SNAPSHOT_CHANNEL_DEPTH: usize = 4;
 /// A batch of keyed operations routed to a snapshot-build worker: each entry is the op's key, its
 /// location, and whether it is a delete.
 type RoutedBatch<K> = Vec<(K, u64, bool)>;
+
+/// Sends `(worker, batch)` pairs from a decode task to the routing coordinator.
+type RoutedSender<K> = mpsc::Sender<(usize, RoutedBatch<K>)>;
+
+/// Parameters shared by every decode chunk of one parallel build.
+#[derive(Clone, Copy)]
+struct SnapshotRouting {
+    /// Number of insert workers routed to.
+    workers: usize,
+    /// Maps a key to its index partition.
+    partition_of: fn(&[u8]) -> usize,
+    /// Partitions per worker range: worker = `partition_of(key) / range_size`.
+    range_size: usize,
+    /// Replay read-buffer size in bytes.
+    init_buffer: NonZeroUsize,
+}
+
+/// Number of operations the snapshot replay batches per worker-channel send during a parallel
+/// build. Small in tests so ordinary logs exercise batch boundaries.
+#[cfg(not(test))]
+const SNAPSHOT_ROUTE_BATCH: usize = 4096;
+#[cfg(test)]
+const SNAPSHOT_ROUTE_BATCH: usize = 3;
+
+/// Operations per decode chunk in a parallel build. Decoding the replay stream is the
+/// build's serial bottleneck at large sizes, so contiguous chunks of this many locations
+/// are decoded (and partition-routed) on concurrent tasks while the coordinator forwards
+/// finished chunks in position order. Together with the decoder count this bounds the
+/// routed operations a build can hold in memory at once. Small in tests so ordinary logs
+/// exercise chunk boundaries.
+#[cfg(not(test))]
+const SNAPSHOT_DECODE_CHUNK: u64 = 1 << 17;
+#[cfg(test)]
+const SNAPSHOT_DECODE_CHUNK: u64 = 64;
+
+/// Decode the `len` operations starting at `start` and stream each keyed op's routed batch
+/// (`partition_of(key) / range_size`) over `tx` in sub-batches of at most
+/// [SNAPSHOT_ROUTE_BATCH] ops. Returns without error if the receiver is dropped (routing
+/// was aborted).
+async fn decode_snapshot_chunk<F, C>(
+    log: Arc<C>,
+    start: u64,
+    len: u64,
+    routing: SnapshotRouting,
+    tx: RoutedSender<<C::Item as Operation<F>>::Key>,
+) -> Result<(), Error<F>>
+where
+    F: Family,
+    C: Contiguous<Item: Operation<F>>,
+{
+    let mut batches: Vec<RoutedBatch<_>> = (0..routing.workers)
+        .map(|_| Vec::with_capacity(SNAPSHOT_ROUTE_BATCH))
+        .collect();
+    let stream = log
+        .replay_range(
+            start..start + len,
+            routing.init_buffer,
+            ReadOptions::default(),
+        )
+        .await?;
+    pin_mut!(stream);
+    while let Some(result) = stream.next().await {
+        let (loc, op) = result?;
+        let is_delete = op.is_delete();
+        let Some(key) = op.into_key() else { continue };
+        let w = (routing.partition_of)(key.as_ref()) / routing.range_size;
+        batches[w].push((key, loc, is_delete));
+        if batches[w].len() >= SNAPSHOT_ROUTE_BATCH {
+            let batch =
+                std::mem::replace(&mut batches[w], Vec::with_capacity(SNAPSHOT_ROUTE_BATCH));
+            if tx.send((w, batch)).await.is_err() {
+                return Ok(());
+            }
+        }
+    }
+
+    // Flush remaining batches before the channel closes.
+    for (w, batch) in batches.into_iter().enumerate() {
+        if !batch.is_empty() && tx.send((w, batch)).await.is_err() {
+            break;
+        }
+    }
+    Ok(())
+}
 
 /// Build one parallel-init worker's partial snapshot: apply the routed operations (streamed in log
 /// order over `rx`) to `index`, resolving translated-key collisions with the worker's own log
@@ -589,7 +734,14 @@ where
     I: Partitioned + Index<Value = Location<F>>,
 {
     let count = snapshot.partition_count();
-    let workers = (init_concurrency.get() - 1).min(count);
+
+    // Split the concurrency budget (less this task, which coordinates and is mostly idle)
+    // between decode tasks and insert workers. Inserts cost more CPU than decoding, so an
+    // odd budget gives the extra thread to the workers. A budget of one yields a single
+    // worker fed by this task decoding inline.
+    let budget = init_concurrency.get() - 1;
+    let decoders = budget / 2;
+    let workers = (budget - decoders).min(count);
 
     // No workers: build on this task.
     if workers == 0 {
@@ -644,47 +796,103 @@ where
                     per_worker_cache,
                 )
             });
-        handles.push(handle);
+        handles.push(AbortOnDrop::new(handle));
     }
 
-    // Replay the log once and route each keyed op to the worker owning its partition.
-    // Routing runs in an inner future so any replay failure is captured rather than
-    // returned immediately: returning while the worker handles are merely dropped would
-    // leave the workers running detached, retaining the log and their range allocations
-    // after init has already failed. The stream is also released before the join.
+    // Replay the log and route each keyed op to the worker owning its partition. Decoding
+    // the stream is the build's serial bottleneck at large sizes, so when the budget
+    // grants decode tasks, contiguous position chunks are decoded (and routed) on those
+    // tasks; this task forwards each chunk's batches in position order, preserving the
+    // per-worker op order the insert path relies on. With no decode tasks, this task
+    // decodes and routes inline. Routing runs in an inner future so any decode failure is
+    // captured rather than returned immediately: returning while the worker handles are
+    // merely dropped would leave the workers running detached, retaining the log and
+    // their range allocations after init has already failed.
+    //
+    // A closed worker channel means that worker terminated early (e.g. returned an
+    // `Error<F>` while resolving a collision). Routing stops on the first such send
+    // failure and the join below surfaces that worker's error, rather than panicking on
+    // the send.
+    let mut pending = VecDeque::new();
     let routing_result: Result<(), Error<F>> = async {
-        let stream = log
-            .replay(floor, init_buffer, ReadOptions::default())
-            .await?;
-        pin_mut!(stream);
-        let mut batches: Vec<RoutedBatch<_>> = (0..workers)
-            .map(|_| Vec::with_capacity(SNAPSHOT_ROUTE_BATCH))
-            .collect();
+        // With no decode tasks, decode and route on this task over one continuous replay.
+        // Per-chunk replays each open a fresh buffered reader that re-reads its window from
+        // the blob, redundant I/O the concurrent build hides by overlapping decoders but a
+        // serial build pays on its critical path (measured 265s vs 369s on a 1.66B-op log).
+        if decoders == 0 {
+            let stream = log
+                .replay(floor, init_buffer, ReadOptions::default())
+                .await?;
+            pin_mut!(stream);
+            let mut batches: Vec<RoutedBatch<_>> = (0..workers)
+                .map(|_| Vec::with_capacity(SNAPSHOT_ROUTE_BATCH))
+                .collect();
+            while let Some(result) = stream.next().await {
+                let (loc, op) = result?;
+                let is_delete = op.is_delete();
+                let Some(key) = op.into_key() else { continue };
+                let w = I::partition_of(key.as_ref()) / range_size;
+                batches[w].push((key, loc, is_delete));
+                if batches[w].len() >= SNAPSHOT_ROUTE_BATCH {
+                    let batch = std::mem::replace(
+                        &mut batches[w],
+                        Vec::with_capacity(SNAPSHOT_ROUTE_BATCH),
+                    );
+                    if senders[w].send(batch).await.is_err() {
+                        return Ok(());
+                    }
+                }
+            }
 
-        // A closed channel means a worker terminated early (e.g. returned an `Error<F>`
-        // while resolving a collision). Stop routing on the first such send failure and
-        // let the join below surface that worker's error, rather than panicking on the
-        // send.
-        while let Some(result) = stream.next().await {
-            let (loc, op) = result?;
-            let is_delete = op.is_delete();
-            let Some(key) = op.into_key() else { continue };
-            let w = I::partition_of(key.as_ref()) / range_size;
-            batches[w].push((key, loc, is_delete));
-            if batches[w].len() >= SNAPSHOT_ROUTE_BATCH {
-                let batch =
-                    std::mem::replace(&mut batches[w], Vec::with_capacity(SNAPSHOT_ROUTE_BATCH));
+            // Flush remaining batches before the channels close.
+            for (w, batch) in batches.into_iter().enumerate() {
+                if !batch.is_empty() && senders[w].send(batch).await.is_err() {
+                    break;
+                }
+            }
+            return Ok(());
+        }
+
+        // Each chunk's channel holds the whole chunk (full sub-batches plus a final
+        // partial per worker), so a decoder never blocks mid-chunk: in-flight memory
+        // stays bounded by the decoder count times the chunk size while every decode
+        // task makes progress regardless of which chunk is being forwarded.
+        let chunk_capacity = SNAPSHOT_DECODE_CHUNK as usize / SNAPSHOT_ROUTE_BATCH + workers;
+        let routing = SnapshotRouting {
+            workers,
+            partition_of: I::partition_of,
+            range_size,
+            init_buffer,
+        };
+        let mut starts = (floor..end)
+            .step_by(usize::try_from(SNAPSHOT_DECODE_CHUNK).expect("chunk size fits usize"));
+        let mut spawn_next = |pending: &mut VecDeque<_>| {
+            let Some(start) = starts.next() else {
+                return;
+            };
+            let log = log.clone();
+            let len = SNAPSHOT_DECODE_CHUNK.min(end - start);
+            let (tx, rx) = mpsc::channel(chunk_capacity);
+            let handle = context
+                .child("snapshot_decoder")
+                .dedicated()
+                .spawn(move |_| decode_snapshot_chunk::<F, C>(log, start, len, routing, tx));
+            pending.push_back((rx, AbortOnDrop::new(handle)));
+        };
+
+        for _ in 0..decoders {
+            spawn_next(&mut pending);
+        }
+
+        while let Some((rx, _)) = pending.front_mut() {
+            while let Some((w, batch)) = rx.recv().await {
                 if senders[w].send(batch).await.is_err() {
                     return Ok(());
                 }
             }
-        }
-
-        // Flush remaining batches before the channels close.
-        for (w, batch) in batches.into_iter().enumerate() {
-            if !batch.is_empty() && senders[w].send(batch).await.is_err() {
-                break;
-            }
+            let (_, decoder) = pending.pop_front().expect("front exists");
+            decoder.join().await??;
+            spawn_next(&mut pending);
         }
         Ok(())
     }
@@ -693,14 +901,21 @@ where
     // Close the channels so each worker's stream terminates and it returns its index.
     drop(senders);
 
+    // Abort and join any decode chunks still in flight, so no decoder outlives a failed
+    // init.
+    while let Some((rx, decoder)) = pending.pop_front() {
+        drop(rx);
+        decoder.abort().await;
+    }
+
     // Join workers before surfacing any replay failure, so none outlive a failed init.
-    let joined = join_all(handles).await;
+    let joined = join_all_or_abort::<_, _, Error<F>>(handles).await;
     routing_result?;
+    let joined = joined?;
 
     // Install each worker's partition range into the snapshot and fold its active-key count in.
     let mut total_items = 0;
-    for handle in joined {
-        let (worker_index, worker_keys) = handle??;
+    for (worker_index, worker_keys) in joined {
         snapshot.install_range(worker_index);
         total_items += worker_keys;
     }

--- a/storage/src/qmdb/mod.rs
+++ b/storage/src/qmdb/mod.rs
@@ -677,11 +677,11 @@ where
 {
     let count = snapshot.partition_count();
 
-    // Split the concurrency between decode tasks and insert workers. With decode tasks this
-    // task only forwards batches and is mostly idle, so like the init overlap task it does
-    // not count against the concurrency; at a concurrency of two it decodes inline (chunked
-    // decode pays redundant reads a lone decoder cannot hide) and counts. Inserts cost more
-    // CPU than decoding, so an odd count gives the extra thread to the workers.
+    // Split the concurrency between decode tasks and insert workers. With decode tasks this task
+    // only forwards batches and is mostly idle, so like the init overlap task it does not count
+    // against the concurrency. At a concurrency of two it decodes inline (chunked decode pays
+    // redundant reads a lone decoder cannot hide) and counts. Inserts cost more CPU than decoding,
+    // so an odd count gives the extra thread to the workers.
     let concurrency = init_concurrency.get();
     let decoders = if concurrency <= 2 { 0 } else { concurrency / 2 };
     let workers = if decoders == 0 {

--- a/storage/src/qmdb/mod.rs
+++ b/storage/src/qmdb/mod.rs
@@ -482,6 +482,13 @@ type RoutedBatch<K> = Vec<(K, u64, bool)>;
 /// Sends `(worker, batch)` pairs from a decode task to the routing coordinator.
 type RoutedSender<K> = mpsc::Sender<(usize, RoutedBatch<K>)>;
 
+/// Whether the routing loop delivered every batch or stopped early on a closed worker
+/// channel.
+enum RoutingOutcome {
+    Completed,
+    CutShort,
+}
+
 /// Parameters shared by every decode chunk of one parallel build.
 #[derive(Clone, Copy)]
 struct SnapshotRouting {
@@ -747,7 +754,7 @@ where
     // resolving a collision). Routing stops on the first such send failure and the join below
     // surfaces that worker's error, rather than panicking on the send.
     let mut pending = VecDeque::new();
-    let routing_result: Result<(), Error<F>> = async {
+    let routing_result: Result<RoutingOutcome, Error<F>> = async {
         // With no decode tasks, decode and route on this task over one continuous replay. Per-chunk
         // replays each open a fresh buffered reader that re-reads its window from the blob,
         // redundant I/O the concurrent build hides by overlapping decoders but a serial build pays
@@ -772,7 +779,7 @@ where
                         Vec::with_capacity(SNAPSHOT_ROUTE_BATCH),
                     );
                     if senders[w].send(batch).await.is_err() {
-                        return Ok(());
+                        return Ok(RoutingOutcome::CutShort);
                     }
                 }
             }
@@ -780,10 +787,10 @@ where
             // Flush remaining batches before the channels close.
             for (w, batch) in batches.into_iter().enumerate() {
                 if !batch.is_empty() && senders[w].send(batch).await.is_err() {
-                    break;
+                    return Ok(RoutingOutcome::CutShort);
                 }
             }
-            return Ok(());
+            return Ok(RoutingOutcome::Completed);
         }
 
         // Each chunk's channel holds the whole chunk (full sub-batches plus a final partial per
@@ -820,14 +827,14 @@ where
         while let Some((rx, _)) = pending.front_mut() {
             while let Some((w, batch)) = rx.recv().await {
                 if senders[w].send(batch).await.is_err() {
-                    return Ok(());
+                    return Ok(RoutingOutcome::CutShort);
                 }
             }
             let (_, decoder) = pending.pop_front().expect("front exists");
             decoder.join().await??;
             spawn_next(&mut pending);
         }
-        Ok(())
+        Ok(RoutingOutcome::Completed)
     }
     .await;
 
@@ -842,8 +849,17 @@ where
 
     // Join workers before surfacing any replay failure, so none outlive a failed init.
     let joined = AbortOnDrop::join_all::<Error<F>>(handles).await;
-    routing_result?;
+    let routing = routing_result?;
     let joined = joined?;
+
+    // Routing stops on a closed worker channel so the join above can surface that worker's
+    // failure. Every clean join with cut-short routing therefore dropped routed operations;
+    // fail rather than install a snapshot missing them.
+    if matches!(routing, RoutingOutcome::CutShort) {
+        return Err(Error::DataCorrupted(
+            "snapshot routing stopped without a worker failure",
+        ));
+    }
 
     // Install each worker's partition range into the snapshot and fold its active-key count in.
     let mut total_items = 0;

--- a/storage/src/qmdb/mod.rs
+++ b/storage/src/qmdb/mod.rs
@@ -684,9 +684,9 @@ where
     // against the budget because it performs decoding and forwarding.
     let concurrency = init_concurrency.get();
 
-    // Inserts cost more CPU than decoding: across widths on both journal types, throughput
-    // peaks near two decoders per five tasks. Once decoding is spawned at all, use at least
-    // two decoders, since a lone decoder starves the workers.
+    // Inserts cost more CPU than decoding: across widths on both journal types, throughput peaks
+    // near two decoders per five tasks. Once decoding is spawned at all, use at least two
+    // decoders, since a lone decoder starves the workers.
     let decoders = if concurrency <= 2 {
         0
     } else {

--- a/storage/src/qmdb/mod.rs
+++ b/storage/src/qmdb/mod.rs
@@ -747,20 +747,18 @@ where
         handles.push(handle.abort_on_drop());
     }
 
-    // Route each replayed op to the worker owning its partition, forwarding decoded chunks
-    // in position order to preserve the per-worker op order the insert path relies on.
-    // Routing runs in an inner future so a failure here still drains the workers below
-    // rather than leaving them running detached.
+    // Route each replayed op to the worker owning its partition, forwarding decoded chunks in
+    // position order to preserve the per-worker op order the insert path relies on. Routing runs in
+    // an inner future so a failure here still drains the workers below rather than leaving them
+    // running detached.
     //
     // A closed worker channel means that worker terminated early (e.g. returned an `Error<F>` while
     // resolving a collision). Routing stops on the first such send failure and the join below
     // surfaces that worker's error, rather than panicking on the send.
     let mut pending = VecDeque::new();
     let routing_result: Result<RoutingOutcome, Error<F>> = async {
-        // With no decode tasks, decode and route on this task over one continuous replay. Per-chunk
-        // replays each open a fresh buffered reader that re-reads its window from the blob,
-        // redundant I/O the concurrent build hides by overlapping decoders but a serial build pays
-        // on its critical path (measured 265s vs 369s on a 1.66B-op log).
+        // With no decode tasks, decode and route on this task over one continuous replay to
+        // avoid per-chunk buffered-reader overhead (measured 265s vs 369s on a 1.66B-op log).
         if decoders == 0 {
             let stream = log
                 .replay(floor, init_buffer, ReadOptions::default())

--- a/storage/src/qmdb/mod.rs
+++ b/storage/src/qmdb/mod.rs
@@ -677,13 +677,18 @@ where
 {
     let count = snapshot.partition_count();
 
-    // Split the concurrency budget (less this task, which coordinates and is mostly idle) between
-    // decode tasks and insert workers. Inserts cost more CPU than decoding, so an odd budget gives
-    // the extra thread to the workers. A budget of one yields a single worker fed by this task
-    // decoding inline.
-    let budget = init_concurrency.get() - 1;
-    let decoders = budget / 2;
-    let workers = (budget - decoders).min(count);
+    // Split the concurrency between decode tasks and insert workers. With decode tasks this
+    // task only forwards batches and is mostly idle, so like the init overlap task it does
+    // not count against the concurrency; at a concurrency of two it decodes inline (chunked
+    // decode pays redundant reads a lone decoder cannot hide) and counts. Inserts cost more
+    // CPU than decoding, so an odd count gives the extra thread to the workers.
+    let concurrency = init_concurrency.get();
+    let decoders = if concurrency <= 2 { 0 } else { concurrency / 2 };
+    let workers = if decoders == 0 {
+        concurrency.saturating_sub(1).min(count)
+    } else {
+        (concurrency - decoders).min(count)
+    };
 
     // No workers: build on this task.
     if workers == 0 {
@@ -741,14 +746,10 @@ where
         handles.push(handle.abort_on_drop());
     }
 
-    // Replay the log and route each keyed op to the worker owning its partition. Decoding the
-    // stream is the build's serial bottleneck at large sizes, so when the budget grants decode
-    // tasks, contiguous position chunks are decoded (and routed) on those tasks; this task forwards
-    // each chunk's batches in position order, preserving the per-worker op order the insert path
-    // relies on. With no decode tasks, this task decodes and routes inline. Routing runs in an
-    // inner future so any decode failure is captured rather than returned immediately: returning
-    // while the worker handles are merely dropped would leave the workers running detached,
-    // retaining the log and their range allocations after init has already failed.
+    // Route each replayed op to the worker owning its partition, forwarding decoded chunks
+    // in position order to preserve the per-worker op order the insert path relies on.
+    // Routing runs in an inner future so a failure here still drains the workers below
+    // rather than leaving them running detached.
     //
     // A closed worker channel means that worker terminated early (e.g. returned an `Error<F>` while
     // resolving a collision). Routing stops on the first such send failure and the join below

--- a/storage/src/qmdb/mod.rs
+++ b/storage/src/qmdb/mod.rs
@@ -684,8 +684,14 @@ where
     // against the budget because it performs decoding and forwarding.
     let concurrency = init_concurrency.get();
 
-    // Inserts cost more CPU than decoding, so an odd count gives the extra thread to the workers.
-    let decoders = if concurrency <= 2 { 0 } else { concurrency / 2 };
+    // Inserts cost more CPU than decoding: across widths on both journal types, throughput
+    // peaks near two decoders per five tasks. Once decoding is spawned at all, use at least
+    // two decoders, since a lone decoder starves the workers.
+    let decoders = if concurrency <= 2 {
+        0
+    } else {
+        (concurrency * 2 / 5).max(2).min(concurrency / 2)
+    };
     let workers = if decoders == 0 {
         concurrency.saturating_sub(1).min(count)
     } else {

--- a/storage/src/qmdb/mod.rs
+++ b/storage/src/qmdb/mod.rs
@@ -799,12 +799,15 @@ where
             true
         };
 
+        // Start decoding ahead of forwarding, with at most `decoders` chunks in flight.
         for _ in 0..decoders {
             if !spawn_next(&mut pending) {
                 break;
             }
         }
 
+        // Workers need operations in log order even when later chunks finish decoding first.
+        // Reuse each decoder slot only after forwarding its chunk and joining its task.
         while let Some((rx, _)) = pending.front_mut() {
             while let Some((w, batch)) = rx.recv().await {
                 if senders[w].send(batch).await.is_err() {

--- a/storage/src/qmdb/mod.rs
+++ b/storage/src/qmdb/mod.rs
@@ -503,7 +503,7 @@ const SNAPSHOT_ROUTE_BATCH: usize = 3;
 /// Operations per decode chunk in a parallel build. Decoding the replay stream is the build's
 /// serial bottleneck at large sizes, so contiguous chunks of this many locations are decoded (and
 /// partition-routed) on concurrent tasks while the coordinator forwards finished chunks in position
-/// order. Together with the decoder count this bounds the queued operations; each decoder also
+/// order. Together with the decoder count, this bounds the queued operations. Each decoder also
 /// reserves one batch per worker. Small in tests so ordinary logs exercise chunk boundaries.
 #[cfg(not(test))]
 const SNAPSHOT_DECODE_CHUNK: u64 = 1 << 17;
@@ -511,8 +511,10 @@ const SNAPSHOT_DECODE_CHUNK: u64 = 1 << 17;
 const SNAPSHOT_DECODE_CHUNK: u64 = 64;
 
 /// Replay `range` and send each worker's keyed operations in log order, in batches of at most
-/// [SNAPSHOT_ROUTE_BATCH] operations. Stops if `send` returns false; the caller owns the
-/// receiving tasks and observes their errors when joining them.
+/// [SNAPSHOT_ROUTE_BATCH] operations.
+///
+/// Stop if `send` returns false. The caller owns the receiving tasks and observes their errors when
+/// joining them.
 async fn route_snapshot<F, C, Fut>(
     log: &C,
     range: Range<u64>,

--- a/storage/src/qmdb/mod.rs
+++ b/storage/src/qmdb/mod.rs
@@ -479,17 +479,7 @@ const SNAPSHOT_CHANNEL_DEPTH: usize = 4;
 /// location, and whether it is a delete.
 type RoutedBatch<K> = Vec<(K, u64, bool)>;
 
-/// Sends `(worker, batch)` pairs from a decode task to the routing coordinator.
-type RoutedSender<K> = mpsc::Sender<(usize, RoutedBatch<K>)>;
-
-/// Whether the routing loop delivered every batch or stopped early on a closed worker
-/// channel.
-enum RoutingOutcome {
-    Completed,
-    CutShort,
-}
-
-/// Parameters shared by every decode chunk of one parallel build.
+/// Parameters shared by the inline replay and decode chunks of one parallel build.
 #[derive(Clone, Copy)]
 struct SnapshotRouting {
     /// Number of insert workers routed to.
@@ -513,38 +503,34 @@ const SNAPSHOT_ROUTE_BATCH: usize = 3;
 /// Operations per decode chunk in a parallel build. Decoding the replay stream is the build's
 /// serial bottleneck at large sizes, so contiguous chunks of this many locations are decoded (and
 /// partition-routed) on concurrent tasks while the coordinator forwards finished chunks in position
-/// order. Together with the decoder count this bounds the routed operations a build can hold in
-/// memory at once. Small in tests so ordinary logs exercise chunk boundaries.
+/// order. Together with the decoder count this bounds the queued operations; each decoder also
+/// reserves one batch per worker. Small in tests so ordinary logs exercise chunk boundaries.
 #[cfg(not(test))]
 const SNAPSHOT_DECODE_CHUNK: u64 = 1 << 17;
 #[cfg(test)]
 const SNAPSHOT_DECODE_CHUNK: u64 = 64;
 
-/// Decode the `len` operations starting at `start` and stream each keyed op's routed batch
-/// (`partition_of(key) / range_size`) over `tx` in sub-batches of at most [SNAPSHOT_ROUTE_BATCH]
-/// ops. Returns without error if the receiver is dropped (routing was aborted).
-async fn decode_snapshot_chunk<F, C>(
-    log: Arc<C>,
-    start: u64,
-    len: u64,
+/// Replay `range` and send each worker's keyed operations in log order, in batches of at most
+/// [SNAPSHOT_ROUTE_BATCH] operations. Stops if `send` returns false; the caller owns the
+/// receiving tasks and observes their errors when joining them.
+async fn route_snapshot<F, C, Fut>(
+    log: &C,
+    range: Range<u64>,
     routing: SnapshotRouting,
-    tx: RoutedSender<<C::Item as Operation<F>>::Key>,
+    mut send: impl FnMut(usize, RoutedBatch<<C::Item as Operation<F>>::Key>) -> Fut + Send,
 ) -> Result<(), Error<F>>
 where
     F: Family,
     C: Contiguous<Item: Operation<F>>,
+    Fut: Future<Output = bool> + Send,
 {
+    let stream = log
+        .replay_range(range, routing.init_buffer, ReadOptions::default())
+        .await?;
+    pin_mut!(stream);
     let mut batches: Vec<RoutedBatch<_>> = (0..routing.workers)
         .map(|_| Vec::with_capacity(SNAPSHOT_ROUTE_BATCH))
         .collect();
-    let stream = log
-        .replay_range(
-            start..start + len,
-            routing.init_buffer,
-            ReadOptions::default(),
-        )
-        .await?;
-    pin_mut!(stream);
     while let Some(result) = stream.next().await {
         let (loc, op) = result?;
         let is_delete = op.is_delete();
@@ -554,15 +540,15 @@ where
         if batches[w].len() >= SNAPSHOT_ROUTE_BATCH {
             let batch =
                 std::mem::replace(&mut batches[w], Vec::with_capacity(SNAPSHOT_ROUTE_BATCH));
-            if tx.send((w, batch)).await.is_err() {
+            if !send(w, batch).await {
                 return Ok(());
             }
         }
     }
 
-    // Flush remaining batches before the channel closes.
+    // Flush remaining batches before the caller closes the channels.
     for (w, batch) in batches.into_iter().enumerate() {
-        if !batch.is_empty() && tx.send((w, batch)).await.is_err() {
+        if !batch.is_empty() && !send(w, batch).await {
             break;
         }
     }
@@ -765,54 +751,26 @@ where
     // resolving a collision). Routing stops on the first such send failure and the join below
     // surfaces that worker's error, rather than panicking on the send.
     let mut pending = VecDeque::new();
-    let routing_result: Result<RoutingOutcome, Error<F>> = async {
+    let routing = SnapshotRouting {
+        workers,
+        partition_of: I::partition_of,
+        range_size,
+        init_buffer,
+    };
+    let routing_result: Result<(), Error<F>> = async {
         // With no decode tasks, decode and route on this task over one continuous replay to avoid
         // per-chunk buffered-reader overhead (measured 265s vs 369s on a 1.66B-op log).
         if decoders == 0 {
-            let stream = log
-                .replay(floor, init_buffer, ReadOptions::default())
-                .await?;
-            pin_mut!(stream);
-            let mut batches: Vec<RoutedBatch<_>> = (0..workers)
-                .map(|_| Vec::with_capacity(SNAPSHOT_ROUTE_BATCH))
-                .collect();
-            while let Some(result) = stream.next().await {
-                let (loc, op) = result?;
-                let is_delete = op.is_delete();
-                let Some(key) = op.into_key() else { continue };
-                let w = I::partition_of(key.as_ref()) / range_size;
-                batches[w].push((key, loc, is_delete));
-                if batches[w].len() >= SNAPSHOT_ROUTE_BATCH {
-                    let batch = std::mem::replace(
-                        &mut batches[w],
-                        Vec::with_capacity(SNAPSHOT_ROUTE_BATCH),
-                    );
-                    if senders[w].send(batch).await.is_err() {
-                        return Ok(RoutingOutcome::CutShort);
-                    }
-                }
-            }
-
-            // Flush remaining batches before the channels close.
-            for (w, batch) in batches.into_iter().enumerate() {
-                if !batch.is_empty() && senders[w].send(batch).await.is_err() {
-                    return Ok(RoutingOutcome::CutShort);
-                }
-            }
-            return Ok(RoutingOutcome::Completed);
+            let senders = &senders;
+            return route_snapshot::<F, C, _>(&**log, floor..end, routing, |w, batch| async move {
+                senders[w].send(batch).await.is_ok()
+            })
+            .await;
         }
 
         // Each chunk's channel holds the whole chunk (full sub-batches plus a final partial per
-        // worker), so a decoder never blocks mid-chunk: in-flight memory stays bounded by the
-        // decoder count times the chunk size while every decode task makes progress regardless of
-        // which chunk is being forwarded.
+        // worker), so every decoder can finish regardless of which chunk is being forwarded.
         let chunk_capacity = SNAPSHOT_DECODE_CHUNK as usize / SNAPSHOT_ROUTE_BATCH + workers;
-        let routing = SnapshotRouting {
-            workers,
-            partition_of: I::partition_of,
-            range_size,
-            init_buffer,
-        };
         let mut starts = (floor..end)
             .step_by(usize::try_from(SNAPSHOT_DECODE_CHUNK).expect("chunk size fits usize"));
         let mut spawn_next = |pending: &mut VecDeque<_>| {
@@ -825,7 +783,16 @@ where
             let handle = context
                 .child("snapshot_decoder")
                 .dedicated()
-                .spawn(move |_| decode_snapshot_chunk::<F, C>(log, start, len, routing, tx));
+                .spawn(move |_| async move {
+                    let tx = &tx;
+                    route_snapshot::<F, C, _>(
+                        &*log,
+                        start..start + len,
+                        routing,
+                        |w, batch| async move { tx.send((w, batch)).await.is_ok() },
+                    )
+                    .await
+                });
             pending.push_back((rx, handle.abort_on_drop()));
             true
         };
@@ -839,14 +806,14 @@ where
         while let Some((rx, _)) = pending.front_mut() {
             while let Some((w, batch)) = rx.recv().await {
                 if senders[w].send(batch).await.is_err() {
-                    return Ok(RoutingOutcome::CutShort);
+                    return Ok(());
                 }
             }
             let (_, decoder) = pending.pop_front().expect("front exists");
             decoder.join().await??;
             spawn_next(&mut pending);
         }
-        Ok(RoutingOutcome::Completed)
+        Ok(())
     }
     .await;
 
@@ -861,17 +828,8 @@ where
 
     // Join workers before surfacing any replay failure, so none outlive a failed init.
     let joined = AbortOnDrop::join_all::<Error<F>>(handles).await;
-    let routing = routing_result?;
+    routing_result?;
     let joined = joined?;
-
-    // Routing stops on a closed worker channel so the join above can surface that worker's failure.
-    // Every clean join with cut-short routing therefore dropped routed operations. Fail rather than
-    // install a snapshot missing them.
-    if matches!(routing, RoutingOutcome::CutShort) {
-        return Err(Error::DataCorrupted(
-            "snapshot routing stopped without a worker failure",
-        ));
-    }
 
     // Install each worker's partition range into the snapshot and fold its active-key count in.
     let mut total_items = 0;

--- a/storage/src/qmdb/mod.rs
+++ b/storage/src/qmdb/mod.rs
@@ -690,7 +690,9 @@ where
     let decoders = if concurrency <= 3 {
         0
     } else {
-        (concurrency * 2 / 5).max(2).min(concurrency / 2)
+        // Divide before multiplying to preserve the ratio without overflowing large budgets.
+        let share = concurrency / 5 * 2 + concurrency % 5 * 2 / 5;
+        share.max(2).min(concurrency / 2)
     };
     let workers = if decoders == 0 {
         concurrency.saturating_sub(1).min(count)
@@ -815,7 +817,7 @@ where
             .step_by(usize::try_from(SNAPSHOT_DECODE_CHUNK).expect("chunk size fits usize"));
         let mut spawn_next = |pending: &mut VecDeque<_>| {
             let Some(start) = starts.next() else {
-                return;
+                return false;
             };
             let log = log.clone();
             let len = SNAPSHOT_DECODE_CHUNK.min(end - start);
@@ -825,10 +827,13 @@ where
                 .dedicated()
                 .spawn(move |_| decode_snapshot_chunk::<F, C>(log, start, len, routing, tx));
             pending.push_back((rx, handle.abort_on_drop()));
+            true
         };
 
         for _ in 0..decoders {
-            spawn_next(&mut pending);
+            if !spawn_next(&mut pending) {
+                break;
+            }
         }
 
         while let Some((rx, _)) = pending.front_mut() {


### PR DESCRIPTION
## Summary

`build_snapshot_parallel` previously decoded the entire operation log on a single task that routed each operation to the insert workers. At large database sizes this serial stage dominates init wall time: raising `init_concurrency` beyond a few workers has almost no effect because the workers idle waiting on the router.

This change splits `init_concurrency` between decode tasks and insert workers. The budget bounds the CPU-heavy build tasks: the coordinating task counts only while it decodes inline (a value of one builds entirely on it, a value of two adds one insert worker), and once decode tasks exist it merely forwards batches, measured at well under a fifth of one core, and is excluded. Decode tasks each decode a contiguous 128k-operation chunk and partition-route it, streaming sub-batches of at most 4096 operations through a bounded per-chunk channel sized so a decoder never blocks mid-chunk. The coordinator forwards chunks in position order, so every worker still receives its operations in log order, which collision resolution relies on. In-flight routed memory is bounded by the decoder count times the chunk size.

Failure handling: in-flight decode chunks are drained before a failed init surfaces its error, so no decoder task outlives the build (plain runtime handles do not abort on drop). The worker-failure and replay-failure drain paths are unchanged.

Chunk and sub-batch sizes shrink under `cfg(test)`, so the ordinary parallel-init suites cross hundreds of chunk and batch boundaries.

## Benchmarks

Ethereum replay seed (105.8GB database, about 580M replayed operations), AMD EPYC 9354P (32 cores), init cache 2^28 entries. The before column is main; the after column is this PR as it stands. `init_concurrency` bounds the CPU-heavy build tasks (decoders plus insert workers), excluding the forwarding coordinator, which measures well under a fifth of one core once decode tasks exist. Because the coordinator no longer counts, `init_concurrency` at or above the core count oversubscribes the machine by one thread; prefer the core count minus one (measured 57.0s at 32 against 55.8s at 31 on this 32-core box).

The decoder share is tuned from a sweep at fixed totals: two decoders per five tasks, with at least two once any are spawned. A lone decoder starves the workers (204.0s against 146.0s at a concurrency of four), while excess decoders cost more than idling (the even split measures 7.6% slower at 28 and 9.4% slower at 16 with a 2^29 cache), consistent with replay reads contending on the page cache past saturation. Cache-miss-bound builds compress these differences: with collision-resolution reads faulting to disk, a scale-bench sweep on a fixed-item journal measured the split neutral, and 3.6% faster at concurrency 28 once the init cache covered the replay region.

| init_concurrency | before | after |
|---|---|---|
| 8 | 183.0s | 100.5s (-45%) |
| 16 | 180.5s | 64.3s (-64%) |
| 31 | - | 55.8s |

Before, wall time was nearly flat from 4 to 16 workers, the signature of the serial router bottleneck. After, worker count scales. Each timed run applied and validated a block against the freshly built snapshot.

The scale bench's init mode (uniform 50M-key, 200M-update fixed-item database generated once and reopened per point, 63.7M-op replay region, init cache 2^25 unless noted) shows the scaling curve on the cheap-decode extreme, where inserts bound throughout:

| init_concurrency | time |
|---|---|
| 2 | 48.0s |
| 4 | 25.3s |
| 8 | 14.4s |
| 16 | 9.7s |
| 28 | 8.4s |
| 8, full-coverage 2^26 cache | 10.8s |
| 28, full-coverage 2^26 cache | 5.4s |

The full-coverage rows show collision-resolution misses gate the plateau: covering the replay region is worth another 24 to 33 percent on top of the parallel build.

The qmdb `init` criterion group (1M operations, 48 variant and cache-size cases, which exercise the serial build path) measures neutral within noise: the chunked decode machinery costs the serial path nothing at small scale.

End to end, the full init train (this PR plus #4571, #4573, #4570, #4574, and #4547) merged onto current main initializes the same database in 30.9s (three trials, tightest spread) against 191.1s for main on an identical harness and configuration: 6.2x faster.

## Design note: abort on drop is opt-in

`Handle::abort_on_drop` wraps a handle rather than making abort-on-drop the default for every `Handle`. Supervision already ties spawned tasks to their spawning task's lifetime; the guard exists for work spawned from a plain future, which supervision cannot see. Making abort-on-drop the default (with an explicit detach to opt out, as smol does) would be the more misuse-resistant design, but it silently converts every dropped-handle fire-and-forget spawn into a task kill and gives completion handles (whose abort only stops waiting) inconsistent drop semantics, so it needs its own migration with a spawn-site audit rather than a rider here.

## Compatibility

`Contiguous` (BETA) gains a required `replay_range` method; `replay` is now a provided method expressed as the full-tail range. External implementers of the trait must add `replay_range`, a source break permitted at the current stability level. Callers of `replay` are unaffected.

## Validation

The qmdb nextest suite passes, including the parallel init equivalence and failure-drain tests across the any/current, ordered/unordered, and fixed/variable variants, with the reduced `cfg(test)` chunk and batch sizes exercising chunk-boundary handling throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q4BFdANo2LhVEr2ko3FK9n










