### PR TITLE
Optimize BLS12-381 subgroup batch verification with parallel combinations

### DIFF
--- a/cryptography/BATCHED_SUBGROUP.md
+++ b/cryptography/BATCHED_SUBGROUP.md
@@ -6,15 +6,21 @@ The shipping implementation is `bls12381::primitives::subgroup::batch_in_g1`
 (Strategy C below); a naive-bucketing prototype (Strategy B) is preserved on
 `gv/subgroup-bucketed-prototype`.
 
-All timings in this document are from an 18-core Apple Silicon machine.
+Unless stated otherwise, timings in this document come from a 4-core Intel
+Xeon (Cascade Lake, 2.8 GHz, 1 MiB L2 per core, 33 MiB L3) and are single-shot
+best-of-three medians from the manual harnesses in `subgroup.rs`. On that
+machine one exact per-point check costs ~52 µs, one field multiplication
+~43 ns, and one batch-affine point addition ~344 ns, so a check is worth about
+150 point additions — the ratio that decides every number below.
 
 ## The problem
 
 A decoded curve point can lie outside the prime-order subgroup; using it in a
 pairing or scalar multiplication enables small-subgroup attacks. blst's exact
 per-point check (Scott, [2021/1130](https://eprint.iacr.org/2021/1130), the
-endomorphism test) costs **~22 µs per point**, so a 6000-point batch costs
-~127 ms checked one at a time.
+endomorphism test) costs a ~128-bit scalar multiplication — about 1200 field
+multiplications, or ~52 µs here — so a 100 000-point batch costs 5.2 s checked
+one at a time.
 
 Every point splits as `P = G + T` with `G` in-subgroup and `T` a "cofactor
 part" in the group of order
@@ -47,12 +53,12 @@ Verified footguns:
   insufficient. The code divides by a strict lower bound on `log₂3`.
 - **Coefficient uniformity.** The margin is 0.38 bits. A biased `byte % 3`
   (max probability 86/256) yields 127.5 bits — below target. The implementation
-  rejection-samples (bytes < 243 → five exact trits); this is load-bearing.
+  rejection-samples (words < 3²⁰ → twenty exact trits); this is load-bearing.
 - **Odd cofactor required.** An order-2 part `T` has `2T = 0`: escape
   probability 2/3 per combination. BLS12-377 G1 (`2^92 | h`) cannot use this
   scheme as-is.
 
-## Strategy A — one combination per round (previous implementation)
+## Strategy A — one combination per round (first implementation)
 
 Per round: draw `c_i ∈ {0,1,2}` per point, evaluate `Q = Σ c_i·P_i` as one
 2-bit Pippenger MSM (blst), check `Q`. Needs 81 rounds — i.e. **81 full
@@ -62,13 +68,12 @@ accumulation passes over the `n` points**, one check each.
 
 Per round: assign each point a uniform bucket in `{0,…,B−1}`, sum each bucket,
 check **each** bucket sum. A cancelling pair escapes a round only by colliding
-in one bucket → `1/B` per round → `⌈security/log₂B⌉` rounds (32 at B=16).
+in one bucket → `1/B` per round → `⌈security/log₂B⌉` rounds.
 
-Fewer accumulation passes, but a fixed `rounds × B` check floor (512 × 22 µs ≈
-11.3 ms serial at B=16) plus — implemented naively with one `blst_p1s_add` per
-bucket — one field-inversion chain per bucket per round. **Measured: loses to A
-at n=1000 (15.9 vs 12.1 ms serial) and wins only ~1.35× at n=6000 (46 vs
-63 ms).** Rejected; prototype preserved for reference.
+Fewer accumulation passes, but a fixed `rounds × B` check floor that dwarfs
+everything else: at 128-bit security the round count falls only as `1/log₂B`
+while the check count grows as `B`. Rejected; prototype preserved for
+reference.
 
 ## Strategy C — m parallel combinations per round (shipping)
 
@@ -80,76 +85,132 @@ trits = a base-3 bucket id in `[0, 3^m)`), and evaluate all m combinations
    together — `3^m` buckets, but still only `n` point additions total (each
    point lands in exactly one bucket). This is the key: *one accumulation pass
    serves m combinations.*
-2. **Batch-affine accumulation (the inversion trick).** Each pass pairs up the
-   remaining points of every bucket and completes all pairs with a single
-   shared field inversion (Montgomery's trick): ~6 field multiplications per
-   addition instead of an inversion (~150 ns/point measured, flat in bucket
-   count). Hand-rolled over `blst_fp`; blst's Pippenger does not expose bucket
-   sums.
-3. **Combine deterministically.** `Q_j = Σ_{v_j=1} S_v + 2·Σ_{v_j=2} S_v`,
+2. **Combine deterministically.** `Q_j = Σ_{v_j=1} S_v + 2·Σ_{v_j=2} S_v`,
    where `v_j` is the j-th base-3 digit of the bucket index. The weights are
    deterministic digits — all randomness is in the vector assignment — so this
    evaluates exactly the m combinations (it is *not* the unsound re-randomized
    sum over bucket sums, which would collapse back to one combination).
-4. **Check the m outputs.** Soundness per round = `3^-m` (product of m
-   independent 1/3 bounds); `r = ⌈81/m⌉` rounds at 128-bit.
+3. **Check the m outputs.** Soundness per round = `3^-m` (product of m
+   independent 1/3 bounds); `r ≈ 81/m` rounds at 128-bit.
 
 `m` (and whether to batch at all) is chosen per batch by a cost model;
 soundness holds for every choice, so the model's constants only affect
-performance. In practice: n=1000 → m=3 (27 rounds), n=6000 → m=4 (21 rounds);
-n ≲ 120 falls back to per-point checks (run through the strategy, so they
-still parallelize).
+performance.
 
 ### Why C dominates B
 
 At equal per-round soundness (`B = 3^m` buckets), B checks all `3^m` bucket
 sums where C checks only `m` combinations — C's total check count stays at
-`r·m ≈ 81–85` for any m (the same as A), while B's grows as `rounds × B`. And
-C's shared-inversion accumulation removes B's per-bucket inversion chains.
+`r·m ≈ 81` for any m (the same as A), while B's grows as `rounds × B`.
 
-## Cost accounting (128-bit security)
+## What the cost actually is
 
-| quantity                    | A (one RLC) | B naive (B=16) | C (m=4, shipping) |
-|-----------------------------|:-----------:|:--------------:|:-----------------:|
-| accumulation passes over n  | 81          | 32             | **21**            |
-| subgroup checks             | 81          | **512**        | 84                |
-| shared-inversion adds       | yes (blst)  | no             | yes (hand-rolled) |
+A pass over the points buys at most `log₂(3^m)` bits of soundness, whatever
+the round does with its bucket sums: a lone bad point escapes whenever its
+coefficient vector is the zero vector, which has probability `3^-m`. So the
+additions per point are
 
-## Measured results (criterion medians, same machine)
+```
+adds/point ≈ (128 / log₂B) · (1 + B/n),     B = 3^m
+```
 
-| n    | per-point | A serial | A parallel | C serial          | C parallel         |
-|------|-----------|----------|------------|-------------------|--------------------|
-| 100  | 2.14 ms   | 2.18 ms* | 2.19 ms*   | 2.13 ms (fallback)| **0.31 ms (7×)**   |
-| 1000 | 21.4 ms   | 12.1 ms  | 1.59 ms    | **6.50 ms (3.3×)**| **1.16 ms (18.5×)**|
-| 6000 | 126.6 ms  | 63.1 ms  | 6.9 ms     | **22.6 ms (5.6×)**| **4.10 ms (30.9×)**|
+— one addition per point per pass for the accumulation, plus about two per
+occupied bucket for the combine. Minimizing over `B` gives ~10.8 additions per
+point at n = 100 000 and ~9.2 at n = 10⁶; the floor is 9 passes, because
+`⌈81/m⌉ = 9` for every width the cost model will accept. At six field
+multiplications per batch-affine addition, that is 55–65 multiplications per
+point against ~1200 for an exact check — a ceiling of 18–21×, which the
+implementation reaches to within about 15%.
 
-Speedups in parentheses are vs per-point serial. (*) A's n=100 numbers predate
-routing the per-point fallback through the parallel strategy; C's 0.31 ms at
-n=100 comes from that routing, not from batching.
+This is why the speedup grows with the batch and then flattens: the `B/n` term
+and the fixed costs (converting to affine, drawing coefficients) amortize away,
+but nine passes do not.
 
-Isolated accumulator throughput: 146–178 ns/point, flat across 27–243 buckets
-and n up to 100 000 (confirming accumulation cost is independent of bucket
-count, with no cache cliff at large n).
+## The engine
 
-Same-engine strategy comparison (`measure_strategies` harness, single-shot; A
-and B are emulated on the shipped accumulation engine so the comparison
-isolates the strategy — blst's MSM engine runs A's passes ~15% faster):
+Three implementation choices carry most of the constant:
 
-| n       | per-point | A (81 passes)   | B (best of 16/64/256) | C (shipping)          |
-|---------|-----------|-----------------|-----------------------|-----------------------|
-| 1 000   | 21.4 ms   | 15.5 / 2.38 ms  | 15.9 / 2.40 (B=16)    | **6.6 / 1.13 ms**     |
-| 6 000   | 126.5 ms  | 74.9 / 8.86 ms  | 40.1 / 4.49 (B=16)    | **22.4 / 3.62 ms**    |
-| 100 000 | 2 126 ms  | 1 249 / 138 ms  | 353 / 47.8 (B=256)    | **298 / 49.6 ms**     |
+- **Streaming accumulation with shared inversions.** A bucket's slot holds its
+  running sum; additions are queued, and a chunk of 1024 of them shares one
+  field inversion (Montgomery's trick), about six field multiplications per
+  addition. A bucket with a queued addition is closed until its chunk
+  completes, and a point arriving meanwhile is carried to the next pass — with
+  uniform bucket ids only ~5% of points ever are. A point is therefore read
+  once, added once, and never copied to a work list. Slots are touched in
+  random order, so the accumulator prefetches the slot each point will land in
+  a couple of dozen iterations ahead.
+- **A shared collapse for the combine.** Recovering the `m` combinations one at
+  a time touches `2·3^(m-1)` bucket sums each, which caps `m` where the combine
+  costs more than the accumulation it saves. Summing away one digit at a time
+  instead (level `j+1` is level `j` with its lowest remaining digit collapsed)
+  yields every digit's marginals for about two additions per bucket in total,
+  and the marginals of all levels reduce together so a handful of inversions
+  cover the whole combine. This is what makes `m = 9` affordable — and `m = 9`
+  is what turns 17 passes into 9.
+- **Field arithmetic without ceremony.** `blst_fp_add`/`blst_fp_sub` are
+  replaced by inlined carry chains (the call and the mandatory zeroing of the
+  out-parameter cost more than the arithmetic), multiplications write into
+  `MaybeUninit` rather than a zeroed temporary, and each addition consumes its
+  inverse where the inversion's backward walk produces it, so no inverse is
+  ever written to memory.
 
-(serial / parallel per cell.) C wins serially at every size — 7.1× over
-per-point and 4.2× over A at n=100 000 (42.8× parallel). One caveat: at
-n=100 000 parallel, B=256 ties C within noise. B's optimal bucket count grows
-with n, and C's width cap (`m ≤ 5`, u8 bucket ids) binds there — the model puts
-m=6 (u16 ids, 729 buckets) ~13% ahead at that size, a possible follow-up.
+A round's bucket slots are the accumulator's working set, so the cost model
+caps the width at what fits a 2 MiB budget (`3^9` slots). Measured one step
+past it, cost per addition rises 20% at `m = 10` and 34% at `m = 11` — more
+than the extra combinations repay.
 
-External reference: zexe's own batched check (Strategy B with shared
-inversions, arkworks field arithmetic, pre-2021 `[r]P` per-bucket check)
-measured on this machine at n=8192: 207 ms naive → 30.7 ms batched parallel.
+## Measured results
+
+Serial (single-threaded) and parallel (4 threads), against per-point checking:
+
+| n         | per-point | C serial          | C parallel         |
+|-----------|-----------|-------------------|--------------------|
+| 200       | 10.5 ms   | 7.2 ms (1.5×)     | 3.2 ms (3.3×)      |
+| 1 000     | 54.0 ms   | 12.7 ms (4.2×)    | 5.4 ms (10.0×)     |
+| 6 000     | 318 ms    | 39.2 ms (8.1×)    | 19.3 ms (16.5×)    |
+| 100 000   | 5.21 s    | 430 ms (12.1×)    | 174 ms (29.9×)     |
+| 300 000   | 15.6 s    | 1.11 s (14.1×)    | 465 ms (33.6×)     |
+| 1 000 000 | 53.0 s    | **3.52 s (15.1×)**| 1.56 s (34.0×)     |
+| 3 000 000 | 157 s     | 10.8 s (14.5×)    | 4.42 s (35.6×)     |
+
+Run-to-run spread on this (shared, virtualized) machine is ±5% — the large
+sizes have measured anywhere from 14.5× to 15.3× serial across runs — so read
+them as "about 15× serial", not as a sharp figure. The `n = 200` row sits just
+above the per-point fallback threshold: below it the cost model declines to
+batch at all.
+
+For reference, the previous implementation of this same strategy measured
+4.7× serial at n = 100 000 on this machine (1.15 s), against 430 ms now.
+
+Chosen plans: 14 rounds of width 6/5 at n = 200, 13 rounds of width 7/6 at
+n = 6 000, 9 rounds of width 9 from n = 100 000 up.
+
+Phase breakdown at n = 10⁶ (3.5 s total): 3.2 s in the nine rounds, 0.38 s
+converting the batch to affine, 0.04 s drawing coefficients. The conversion is
+7 field multiplications per point against 54 for the rounds, and it disappears
+entirely for callers whose points arrive already affine (as decoded points do).
+
+## Same-engine strategy comparison
+
+All three strategies run on the shipped accumulation engine (`measure_strategies`,
+single-shot), so the comparison isolates the strategy rather than the engine:
+
+| n       | per-point | A (81 passes) | B, best width      | C (shipping)      |
+|---------|-----------|---------------|--------------------|-------------------|
+| 6 000   | 315 ms    | ~167 ms*      | 144 ms (B=81, r=21)| **38.7 ms**       |
+| 100 000 | 5.16 s    | ~2.79 s*      | 1.02 s (B=81, r=21)| **0.41 s**        |
+
+(*) A's row is projected, not measured: `81 · n` additions at the engine's
+measured 344 ns. Running A on this engine literally (`m = 1`) measures 13.4 s at
+n = 100 000, because three buckets leave at most three additions in flight and
+the shared inversion has nothing to amortize over — a batch-affine engine is
+simply the wrong engine for a one-combination round, which is why the original
+Strategy A used blst's Jacobian MSM. Either way A needs 81 passes where C needs
+9.
+
+B was measured at `B ∈ {9, 81, 729}` with `rounds = ⌈81/log₃B⌉`; 81 is its best
+width at both sizes, and its check floor (`rounds × B` exact checks — 1701
+checks at B=81, r=21) is what keeps it 2.5× behind C.
 
 ## Related work
 
@@ -180,24 +241,33 @@ round) reach the target. Points of comparison, from the paper itself:
   appear in the paper.
 
 Strategy C therefore fills exactly the gap their cost model assumes away: it
-makes the no-prefilter multi-combination route cost `⌈81/m⌉` passes instead of
+makes the no-prefilter multi-combination route cost `≈81/m` passes instead of
 81 MSMs, which is what turns batch SMT on **unmodified BLS12-381** from "slower
-than naive" (their result) into 3.2–7.1× serial (7.1–7.4 across runs at
-n=100 000) and 18–43× parallel (ours, at a stronger 2⁻¹²⁸ target). Their binary-coefficient variant also shows how C
+than naive" (their result) into 8–15× serial and 19–37× parallel (ours, at a
+stronger 2⁻¹²⁸ target). Their binary-coefficient variant also shows how C
 extends to even-cofactor curves (e.g. BLS12-377): use `{0,1}` coefficient
 vectors (2^m buckets, 1 bit per combination, 128 total) instead of trits.
+
+Note that a faster field multiplication would *lower* these ratios, not raise
+them: the exact check is almost pure multiplication while the batched path is
+part multiplication and part memory traffic. The multiplication-count ceiling
+above (18–21×) is the machine-independent statement.
 
 ## Status
 
 Strategy C is implemented in `subgroup::batch_in_g1` with:
 
 - soundness-bearing details in the module docs (odd-cofactor proof, exact-trit
-  requirement, deterministic-combine clarification);
+  requirement, deterministic-combine clarification, and why a pass cannot beat
+  `3^-m`);
 - an accumulator oracle test (fuzz vs naive G1 addition over mixed
   good/bad/identity/negated/duplicated points) plus deterministic tests for
   every special-case branch (cancelling pairs, doubling chains, identity
-  inputs, odd leftovers, empty buckets);
-- adversarial batch tests (cancelling bad pair, repeated bad point);
+  inputs, wide plans, empty buckets);
+- an oracle test for the inlined field arithmetic against `blst_fp_add` /
+  `blst_fp_sub`, and for the affine conversion against `blst_p1s_to_affine`;
+- adversarial batch tests (cancelling bad pair, repeated bad point, identity
+  padding);
 - `cargo miri` cannot run the module (blst FFI is unsupported by miri); the
-  unsafe surface is thin per-call FFI wrappers, with all pass-scheduling logic
-  in safe Rust under the oracle tests.
+  unsafe surface is thin per-call FFI wrappers plus prefetch hints, with all
+  pass-scheduling logic in safe Rust under the oracle tests.

--- a/cryptography/BATCHED_SUBGROUP.md
+++ b/cryptography/BATCHED_SUBGROUP.md
@@ -266,10 +266,20 @@ Strategy C is implemented in `subgroup::batch_in_g1` with:
 - soundness-bearing details in the module docs (odd-cofactor proof, exact-trit
   requirement, deterministic-combine clarification, and why a pass cannot beat
   `3^-m`);
+- a differential fuzz of the whole round against a direct computation: every
+  combination is rebuilt from the round's marginals and compared value for
+  value with a direct sum over the coefficient digits, across 400 seeds of
+  adversarial point and id distributions and every width up to 9;
 - an accumulator oracle test (fuzz vs naive G1 addition over mixed
   good/bad/identity/negated/duplicated points) plus deterministic tests for
   every special-case branch (cancelling pairs, doubling chains, identity
-  inputs, wide plans, empty buckets);
+  inputs, single-bucket contention, wide plans, empty buckets);
+- a chi-square bound on the drawn coefficients — overall, per digit position,
+  per adjacent pair, and per slot in the word that produced them; both
+  mutations it is meant to catch (one id too many per word, a widened rejection
+  bound) do fail it;
+- the bounded round-plan search pinned against the exhaustive one it replaces,
+  and against absurd soundness targets;
 - an oracle test for the inlined field arithmetic against `blst_fp_add` /
   `blst_fp_sub`, and for the affine conversion against `blst_p1s_to_affine`;
 - adversarial batch tests (cancelling bad pair, repeated bad point, identity

--- a/cryptography/BATCHED_SUBGROUP.md
+++ b/cryptography/BATCHED_SUBGROUP.md
@@ -154,10 +154,14 @@ Three implementation choices carry most of the constant:
   inverse where the inversion's backward walk produces it, so no inverse is
   ever written to memory.
 
-A round's bucket slots are the accumulator's working set, so the cost model
-caps the width at what fits a 2 MiB budget (`3^9` slots). Measured one step
-past it, cost per addition rises 20% at `m = 10` and 34% at `m = 11` — more
-than the extra combinations repay.
+A round's bucket slots are the accumulator's working set (and its collapse
+workspace is half as large again), so the cost model caps the width at what fits
+a 2 MiB budget — `3^9` slots. Past it, cost per addition rises about 8% at
+`m = 10` and 15% at `m = 11`, while the workspace grows threefold per step, per
+thread: `m = 9` asks for 2.8 MB, `m = 11` for 25 MB. At a million points the
+best plan `m = 11` allows (eight rounds, widths 11/10) measures within run-to-run
+noise of the nine-round plan chosen here; at a hundred thousand it is 36% worse.
+The budget buys the memory bound for no measurable speed.
 
 ## Measured results
 

--- a/cryptography/BATCHED_SUBGROUP.md
+++ b/cryptography/BATCHED_SUBGROUP.md
@@ -169,25 +169,27 @@ Serial (single-threaded) and parallel (4 threads), against per-point checking:
 
 | n         | per-point | C serial          | C parallel         |
 |-----------|-----------|-------------------|--------------------|
-| 200       | 10.5 ms   | 7.2 ms (1.5×)     | 3.2 ms (3.3×)      |
-| 1 000     | 54.0 ms   | 12.7 ms (4.2×)    | 5.4 ms (10.0×)     |
-| 6 000     | 318 ms    | 39.2 ms (8.1×)    | 19.3 ms (16.5×)    |
-| 100 000   | 5.21 s    | 430 ms (12.1×)    | 174 ms (29.9×)     |
-| 300 000   | 15.6 s    | 1.11 s (14.1×)    | 465 ms (33.6×)     |
-| 1 000 000 | 53.0 s    | **3.52 s (15.1×)**| 1.56 s (34.0×)     |
-| 3 000 000 | 157 s     | 10.8 s (14.5×)    | 4.42 s (35.6×)     |
+| 200       | 10.5 ms   | 7.3 ms (1.4×)     | 2.4 ms (4.3×)      |
+| 1 000     | 52.0 ms   | 12.5 ms (4.2×)    | 4.4 ms (11.9×)     |
+| 6 000     | 321 ms    | 39.5 ms (8.1×)    | 14.3 ms (22.5×)    |
+| 100 000   | 5.24 s    | 429 ms (12.2×)    | 166 ms (31.6×)     |
+| 300 000   | 15.8 s    | 1.13 s (14.0×)    | 444 ms (35.5×)     |
+| 1 000 000 | 52.3 s    | **3.57 s (14.6×)**| 1.47 s (35.6×)     |
+| 3 000 000 | 163 s     | 10.5 s (15.5×)    | 4.35 s (37.4×)     |
 
-Run-to-run spread on this (shared, virtualized) machine is ±5% — the large
-sizes have measured anywhere from 14.5× to 15.3× serial across runs — so read
-them as "about 15× serial", not as a sharp figure. The `n = 200` row sits just
-above the per-point fallback threshold: below it the cost model declines to
-batch at all.
+Run-to-run spread on this (shared, virtualized) machine is ±5%: across runs the
+million- and three-million-point rows have measured anywhere from 14.5× to 16.4×
+serial, so read them as "about 15× serial", not as a sharp figure. The
+`n = 200` row sits just above the per-point fallback threshold; below it the
+cost model declines to batch at all.
 
 For reference, the previous implementation of this same strategy measured
 4.7× serial at n = 100 000 on this machine (1.15 s), against 430 ms now.
 
-Chosen plans: 14 rounds of width 6/5 at n = 200, 13 rounds of width 7/6 at
-n = 6 000, 9 rounds of width 9 from n = 100 000 up.
+Chosen plans: 14 rounds of width 6/5 at n = 200, 16 rounds of width 6/5 at
+n = 1 000, 13 rounds of width 7/6 at n = 6 000, and 9 rounds of width 9 from
+n = 100 000 up — nine being the floor, since the slot budget caps the width at
+nine and `ceil(81/9) = 9`.
 
 Phase breakdown at n = 10⁶ (3.5 s total): 3.2 s in the nine rounds, 0.38 s
 converting the batch to affine, 0.04 s drawing coefficients. The conversion is

--- a/cryptography/src/bls12381/benches/subgroup.rs
+++ b/cryptography/src/bls12381/benches/subgroup.rs
@@ -5,7 +5,7 @@ use commonware_cryptography::bls12381::primitives::{
 use commonware_math::algebra::{CryptoGroup, Random};
 use commonware_parallel::{Rayon, Sequential};
 use commonware_utils::test_rng;
-use criterion::{BatchSize, Criterion, criterion_group};
+use criterion::{Criterion, criterion_group};
 use std::{hint::black_box, num::NonZeroUsize, thread::available_parallelism};
 
 /// Compare batched subgroup verification (serial and parallel) against
@@ -13,40 +13,28 @@ use std::{hint::black_box, num::NonZeroUsize, thread::available_parallelism};
 ///
 /// The batched check's advantage grows with the batch, so the sizes span from
 /// below the per-point fallback threshold to a batch large enough for the cost
-/// model to pick its widest round.
+/// model to pick its widest round. Every method reads the same batch and
+/// leaves it untouched, so it is built once per size rather than per iteration
+/// — at the largest size, building it costs more than checking it.
 fn bench_subgroup(c: &mut Criterion) {
     let threads = available_parallelism().unwrap_or(NonZeroUsize::new(1).unwrap());
     let rayon = Rayon::new(threads).unwrap();
     for n in [100usize, 1000, 6000, 100_000] {
-        let make = || {
-            let mut rng = test_rng();
-            (0..n)
-                .map(|_| G1::generator() * &Scalar::random(&mut rng))
-                .collect::<Vec<G1>>()
-        };
+        let mut rng = test_rng();
+        let points: Vec<G1> = (0..n)
+            .map(|_| G1::generator() * &Scalar::random(&mut rng))
+            .collect();
 
         c.bench_function(&format!("{}/method=per_point n={n}", module_path!()), |b| {
-            b.iter_batched(
-                make,
-                |points| black_box(points.iter().all(G1::in_subgroup)),
-                BatchSize::SmallInput,
-            );
+            b.iter(|| black_box(points.iter().all(G1::in_subgroup)));
         });
 
         c.bench_function(&format!("{}/method=serial n={n}", module_path!()), |b| {
-            b.iter_batched(
-                make,
-                |points| black_box(batch_in_g1(&points, 128, &Sequential, &mut test_rng())),
-                BatchSize::SmallInput,
-            );
+            b.iter(|| black_box(batch_in_g1(&points, 128, &Sequential, &mut test_rng())));
         });
 
         c.bench_function(&format!("{}/method=parallel n={n}", module_path!()), |b| {
-            b.iter_batched(
-                make,
-                |points| black_box(batch_in_g1(&points, 128, &rayon, &mut test_rng())),
-                BatchSize::SmallInput,
-            );
+            b.iter(|| black_box(batch_in_g1(&points, 128, &rayon, &mut test_rng())));
         });
     }
 }

--- a/cryptography/src/bls12381/benches/subgroup.rs
+++ b/cryptography/src/bls12381/benches/subgroup.rs
@@ -10,10 +10,14 @@ use std::{hint::black_box, num::NonZeroUsize, thread::available_parallelism};
 
 /// Compare batched subgroup verification (serial and parallel) against
 /// per-point checking.
+///
+/// The batched check's advantage grows with the batch, so the sizes span from
+/// below the per-point fallback threshold to a batch large enough for the cost
+/// model to pick its widest round.
 fn bench_subgroup(c: &mut Criterion) {
     let threads = available_parallelism().unwrap_or(NonZeroUsize::new(1).unwrap());
     let rayon = Rayon::new(threads).unwrap();
-    for n in [100usize, 1000, 6000] {
+    for n in [100usize, 1000, 6000, 100_000] {
         let make = || {
             let mut rng = test_rng();
             (0..n)

--- a/cryptography/src/bls12381/primitives/group.rs
+++ b/cryptography/src/bls12381/primitives/group.rs
@@ -1075,6 +1075,11 @@ impl G1 {
         Self(p)
     }
 
+    /// Borrows the underlying `blst_p1`.
+    pub(crate) const fn as_blst_p1(&self) -> &blst_p1 {
+        &self.0
+    }
+
     /// Batch converts projective G1 points to affine.
     ///
     /// This uses Montgomery's trick to reduce n field inversions to 1,

--- a/cryptography/src/bls12381/primitives/subgroup.rs
+++ b/cryptography/src/bls12381/primitives/subgroup.rs
@@ -28,13 +28,37 @@
 //!
 //! Summing `n` points into `3^m` buckets costs the same `n` point additions as
 //! summing them into one, so a single accumulation pass over the points serves
-//! all `m` combinations, and only `ceil(81/m)` passes are needed at 128-bit
-//! security instead of 81. The additions are batch-affine: each pass pairs up
-//! the remaining points of every bucket and completes all pairs with one shared
-//! field inversion (Montgomery's trick), about six field multiplications per
-//! addition. The per-batch choice of `m` (and of batching at all, versus
-//! checking each point individually) is a pure performance decision made by a
-//! cost model; soundness holds for every choice.
+//! all `m` combinations, and about `81/m` passes are needed at 128-bit security
+//! instead of 81. Four properties keep the constant small:
+//!
+//! - **Batch-affine additions.** Additions are queued rather than performed,
+//!   and a chunk of them shares one field inversion (Montgomery's trick) — six
+//!   field multiplications per addition instead of an inversion.
+//! - **Streaming accumulation.** A bucket's slot holds its running sum, so a
+//!   point is read once, added once, and never copied to a work list. A bucket
+//!   whose addition is still queued is closed until the chunk completes, and a
+//!   point that arrives meanwhile is carried to the next pass; with random
+//!   bucket ids only a few percent of points ever are.
+//! - **A shared collapse for the combine.** Recovering the `m` combinations one
+//!   at a time would touch `2 * 3^(m-1)` bucket sums each, which caps `m` where
+//!   the combine costs more than the accumulation it saves. Summing away one
+//!   digit at a time instead yields every digit's marginals for about two
+//!   additions per bucket in total, which is what makes wide rounds — and so
+//!   few passes — affordable.
+//! - **Widths chosen per round.** The plan spreads the required combinations
+//!   over its rounds as evenly as it can, so a round count that does not divide
+//!   them wastes at most one combination.
+//!
+//! The per-batch choice of widths (and of batching at all, versus checking each
+//! point individually) is a pure performance decision made by a cost model;
+//! soundness holds for every choice.
+//!
+//! What a batch cannot escape is one pass over the points per `log2(3^m)` bits
+//! of soundness (see below), so the cost per point falls only with the
+//! logarithm of the round width — and the width is bounded by what a round's
+//! bucket slots can hold in cache. That is why the speedup over per-point
+//! checking keeps growing with the batch: at `2^-128`, nine passes is the floor,
+//! and the fixed per-round overheads only amortize away as `n` grows.
 //!
 //! # Soundness
 //!
@@ -63,6 +87,13 @@
 //! residue mod 3, so even full-width random weights leave a cancelling pair a
 //! `1/3` escape.
 //!
+//! A round cannot do better than `3^-m` either, whatever it does with the
+//! bucket sums: a lone bad point escapes whenever its coefficient vector is the
+//! zero vector, which happens with probability `3^-m` however the `m`
+//! combinations are wired. A pass over the points is therefore worth at most
+//! `log2(3^m)` bits of soundness, and the accumulation cost is what decides how
+//! large `3^m` can usefully be.
+//!
 //! The bound requires an odd cofactor: an order-2 part `T` has `2*T = 0`, so
 //! `c * T` escapes with probability `2/3` per combination. A curve whose
 //! cofactor is even (e.g. BLS12-377 G1, with `2^92 | h`) cannot use this
@@ -76,11 +107,11 @@ use super::group::G1;
 #[cfg(not(feature = "std"))]
 use alloc::{vec, vec::Vec};
 use blst::{
-    blst_fp, blst_fp_add, blst_fp_inverse, blst_fp_mul, blst_fp_sqr, blst_fp_sub, blst_p1,
-    blst_p1_add_or_double, blst_p1_add_or_double_affine, blst_p1_affine, blst_p1_affine_is_inf,
-    blst_p1_double, blst_p1_in_g1,
+    blst_fp, blst_fp_inverse, blst_fp_mul, blst_fp_sqr, blst_p1, blst_p1_add_or_double_affine,
+    blst_p1_affine, blst_p1_double, blst_p1_from_affine, blst_p1_in_g1,
 };
 use commonware_parallel::Strategy;
+use core::mem::{MaybeUninit, size_of};
 use rand_core::CryptoRng;
 
 /// One thousand times a strict lower bound on `log2(3)`.
@@ -100,39 +131,124 @@ const fn combinations_for_security(security: usize) -> usize {
         .div_ceil(LOG2_3_SCALED_LOWER_BOUND)
 }
 
+/// Largest supported number of parallel combinations per round.
+///
+/// A round's collapse workspace holds about `1.5 * 3^m` points, so this bounds
+/// what a round can allocate; in practice [`SLOT_BUDGET`] binds first.
+const MAX_WIDTH: u32 = 11;
+
+/// Largest bucket-slot footprint a round should ask for, in bytes.
+///
+/// Points arrive in random bucket order, so the accumulator's working set is
+/// the whole slot array. A wider round needs fewer passes over the points, but
+/// once its slots outgrow the cache every point pays a miss that the saved
+/// passes do not repay — measured here as a 20-35% jump in cost per addition
+/// one step past the budget. Two MiB holds `3^9` slots.
+const SLOT_BUDGET: usize = 2 << 20;
+
 /// Approximate cost of one [`G1::in_subgroup`] check, in units of one
 /// batch-affine point addition.
 ///
-/// Machine-rough (measured ~22us per check against ~150ns per addition); it
-/// only steers the cost model's choice of `m` and the per-point fallback,
+/// Machine-rough (measured ~52us per check against ~350ns per addition); it
+/// only steers the cost model's choice of widths and the per-point fallback,
 /// never soundness.
 const CHECK_COST: usize = 150;
 
-/// Approximate cost of one Jacobian mixed addition (used by the bucket
-/// combine), in units of one batch-affine point addition.
-const MIXED_ADD_COST: usize = 3;
-
-/// Pick the number of parallel combinations per round, or `None` if checking
-/// each point individually is cheaper.
+/// Number of point additions completed per shared field inversion.
 ///
-/// Returns `(m, rounds)` minimizing the modeled cost
-/// `rounds * (n additions + combine + m checks)` subject to
-/// `rounds * m >= combinations`; soundness holds for every choice, so the
-/// constants above only affect performance.
-fn plan(n: usize, combinations: usize) -> Option<(u32, usize)> {
+/// Sized so that a chunk's denominators, prefix products and freshly written
+/// results stay in cache while the inversion amortizes to well under one field
+/// multiplication per addition.
+const CHUNK: usize = 1024;
+
+/// Flag stored in the high bit of a queued job's output slot, marking its
+/// operands equal (a doubling rather than a chord).
+const DOUBLE: u32 = 1 << 31;
+
+/// Bucket slot holding nothing, i.e. standing for the identity.
+const EMPTY: u8 = 0;
+
+/// Bucket slot holding a running sum that further points can be added to.
+const FILLED: u8 = 1;
+
+/// Bucket slot closed by an addition that is queued but not yet completed.
+const BUSY: u8 = 2;
+
+/// How far ahead the accumulator prefetches the slot a point will land in.
+///
+/// The loop body is short, so this needs to cover an L2 or L3 miss; overshooting
+/// only costs a cache line that would have been fetched anyway.
+const PREFETCH_DISTANCE: usize = 24;
+
+/// Expected number of occupied buckets when `n` points fall uniformly into `b`
+/// of them: `b * (1 - e^(-n/b))`, with a cheap rational stand-in for the
+/// exponential (the cost model only needs the shape).
+fn expected_occupied(n: usize, b: usize) -> usize {
+    let x = n as f64 / b as f64;
+    if x > 32.0 {
+        return b.min(n);
+    }
+    let series = 1.0 + x + x * x / 2.0 + x * x * x / 6.0;
+    ((b as f64 * (1.0 - 1.0 / series)) as usize).min(n)
+}
+
+/// Modeled cost of one round at width `m`, in units of one batch-affine point
+/// addition.
+///
+/// Summing `n` points into `3^m` buckets takes one addition per point that is
+/// not the last one left in its bucket, and recovering the `m` combinations
+/// takes about two additions per occupied bucket (one for the collapse chain,
+/// one for the marginals it feeds). The `m` exact checks are charged too, since
+/// they are what makes narrow rounds expensive on small batches.
+fn round_cost(n: usize, m: u32) -> usize {
+    let buckets = 3usize.pow(m);
+    let occupied = expected_occupied(n, buckets);
+    (n - occupied) + 2 * occupied + (m as usize) * CHECK_COST
+}
+
+/// Plan the rounds: one width per round, summing to at least `combinations`.
+///
+/// Returns `None` if checking each point individually is cheaper. The widths of
+/// a plan differ by at most one, so a round count that does not divide
+/// `combinations` wastes no more than one combination — which matters, since
+/// the round count is what the batch pays for.
+///
+/// Soundness holds for every plan (a round of width `m` has error `3^-m`, and
+/// the widths sum to at least `combinations`), so the cost model's constants
+/// only affect performance.
+fn plan(n: usize, combinations: usize) -> Option<Vec<u32>> {
+    if combinations == 0 {
+        return Some(Vec::new());
+    }
+    // A width is only usable if its buckets are neither hopelessly sparse nor
+    // too many to keep close to the CPU.
+    let mut widest = 0u32;
+    while widest < MAX_WIDTH
+        && 3usize.pow(widest + 1) <= 4 * n.max(1)
+        && 3usize.pow(widest + 1) * size_of::<blst_p1_affine>() <= SLOT_BUDGET
+    {
+        widest += 1;
+    }
+    if widest == 0 {
+        return None;
+    }
     let mut best_cost = n.saturating_mul(CHECK_COST);
     let mut best = None;
-    let mut pow3 = 1usize;
-    for m in 1..=5u32 {
-        pow3 *= 3;
-        let rounds = combinations.div_ceil(m as usize);
-        // Combining bucket sums into output j touches the 2*3^(m-1) buckets
-        // whose j-th digit is nonzero, for each of the m outputs.
-        let combine = MIXED_ADD_COST * 2 * (m as usize) * (pow3 / 3);
-        let cost = rounds.saturating_mul(n + combine + (m as usize) * CHECK_COST);
+    for rounds in combinations.div_ceil(widest as usize)..=combinations {
+        let width = (combinations / rounds) as u32;
+        let wide = combinations % rounds;
+        // Spreading combinations evenly cannot push a round past `widest`: a
+        // round count that leaves a remainder also leaves `width < widest`.
+        debug_assert!(width < widest || wide == 0);
+        let cost = wide.saturating_mul(round_cost(n, width + 1))
+            + (rounds - wide).saturating_mul(round_cost(n, width));
         if cost < best_cost {
             best_cost = cost;
-            best = Some((m, rounds));
+            best = Some(
+                (0..rounds)
+                    .map(|round| if round < wide { width + 1 } else { width })
+                    .collect(),
+            );
         }
     }
     best
@@ -161,263 +277,799 @@ pub fn batch_in_g1(
     rng: &mut impl CryptoRng,
 ) -> bool {
     let combinations = combinations_for_security(security);
-    // Whether to batch at all, and at what width, is an algorithmic choice the
+    // Whether to batch at all, and at what widths, is an algorithmic choice the
     // cost model makes; it cannot be delegated to `strategy` (which only
     // chooses serial vs parallel execution of a single algorithm). Either
     // path's independent units still run through `strategy`.
-    let Some((m, rounds)) = plan(points.len(), combinations) else {
+    let Some(widths) = plan(points.len(), combinations) else {
         return strategy
             .map_collect_vec_with_multiplier(points.iter(), 1, |point| point.in_subgroup())
             .into_iter()
             .all(|in_subgroup| in_subgroup);
     };
+    let Some(&widest) = widths.iter().max() else {
+        return true;
+    };
     // One shared inversion converts every point to affine; the per-round
     // accumulations then reuse them.
-    let affine = G1::batch_to_affine(points);
+    let affine = to_affine(points);
+
     // The RNG is sequential, so draw every round's coefficient vectors (as
     // base-3 bucket ids) up front; the rounds themselves are independent and
     // run through the strategy, weighted by the per-round accumulation size.
     let mut trits = Trits::new(rng);
-    let id_sets: Vec<Vec<u8>> = (0..rounds)
-        .map(|_| (0..points.len()).map(|_| trits.bucket(m)).collect())
+    let id_sets: Vec<(u32, Vec<u32>)> = widths
+        .iter()
+        .map(|&m| (m, trits.fill(m, affine.len())))
         .collect();
     strategy
-        .map_collect_vec_with_multiplier(id_sets.iter(), points.len(), |ids| {
-            round_in_g1(&affine, ids, m)
-        })
+        .map_init_collect_vec_with_multiplier(
+            id_sets.iter(),
+            affine.len(),
+            || Round::new(widest),
+            |round, (m, ids)| round.run(&affine, ids, *m),
+        )
         .into_iter()
         .all(|in_subgroup| in_subgroup)
 }
 
-/// Run one round: sum the points into `3^m` buckets keyed by coefficient
-/// vector, recover the `m` combinations from the bucket sums, and check each.
-fn round_in_g1(affine: &[blst_p1_affine], ids: &[u8], m: u32) -> bool {
-    let sums = sum_buckets(affine, ids, 3usize.pow(m));
-    for j in 0..m {
-        let divisor = 3usize.pow(j);
-        // Output j is (sum of buckets with digit_j = 1) + 2 * (digit_j = 2).
-        let mut ones = blst_p1::default();
-        let mut twos = blst_p1::default();
-        for (v, sum) in sums.iter().enumerate() {
-            if affine_is_inf(sum) {
+/// Convert `points` to affine, dropping the identities among them.
+///
+/// One shared inversion serves a chunk of the batch (Montgomery's trick), so a
+/// point costs about seven field multiplications. The chunking keeps the
+/// inversion's running products in cache, which on a large batch matters more
+/// than the handful of extra inversions it costs. The identity contributes
+/// nothing to any combination, so dropping it here spares the accumulator a
+/// test for it on every pass.
+fn to_affine(points: &[G1]) -> Vec<blst_p1_affine> {
+    let mut affine = Vec::with_capacity(points.len());
+    let mut inverses = Vec::with_capacity(CHUNK);
+    let mut prefix = Vec::with_capacity(CHUNK);
+    for chunk in points.chunks(CHUNK) {
+        inverses.clear();
+        inverses.extend(
+            chunk
+                .iter()
+                .map(G1::as_blst_p1)
+                .map(|point| point.z)
+                .filter(|z| !fp_is_zero(z) && !fp_is_one(z)),
+        );
+        batch_invert(&mut inverses, &mut prefix);
+        let mut inverses = inverses.iter();
+        for point in chunk.iter().map(G1::as_blst_p1) {
+            if fp_is_zero(&point.z) {
                 continue;
             }
-            let acc = match (v / divisor) % 3 {
-                1 => &mut ones,
-                2 => &mut twos,
-                _ => continue,
-            };
-            // SAFETY: acc and sum are valid points; blst_p1_add_or_double_affine
-            // handles identity and equal operands, and permits out == a.
-            unsafe { blst_p1_add_or_double_affine(acc, acc, sum) };
+            // A point decoded from the wire is already normalized, which is the
+            // common case for a batch of untrusted points.
+            if fp_is_one(&point.z) {
+                affine.push(blst_p1_affine {
+                    x: point.x,
+                    y: point.y,
+                });
+                continue;
+            }
+            let inverse = inverses.next().expect("one inverse per surviving point");
+            let squared = fp_sqr(inverse);
+            let cubed = fp_mul(&squared, inverse);
+            affine.push(blst_p1_affine {
+                x: fp_mul(&point.x, &squared),
+                y: fp_mul(&point.y, &cubed),
+            });
         }
-        let mut combination = blst_p1::default();
-        // SAFETY: all operands are valid blst_p1 values (identity included).
-        unsafe {
-            blst_p1_double(&mut combination, &twos);
-            blst_p1_add_or_double(&mut combination, &combination, &ones);
-            if !blst_p1_in_g1(&combination) {
+    }
+    affine
+}
+
+/// Working state for one round, reused across the round's passes — and, under a
+/// sequential strategy, across every round.
+struct Round {
+    /// Number of parallel combinations of the round being run, i.e. base-3
+    /// digits per bucket id.
+    m: u32,
+    /// Start of each collapse level within [`Self::sums`]. Level `j` holds
+    /// `3^(m-j)` entries: level 0 is the bucket sums themselves (and doubles as
+    /// the accumulator's per-bucket slots), and level `j+1` is level `j` with
+    /// its lowest remaining digit summed away.
+    levels: Vec<usize>,
+    /// The concatenated collapse levels.
+    sums: Vec<blst_p1_affine>,
+    /// Whether the matching entry of [`Self::sums`] holds a point; an entry
+    /// that does not stands for the identity.
+    live: Vec<bool>,
+    /// Per-bucket accumulator state over level 0 of [`Self::sums`]: empty,
+    /// holding a running sum, or closed by an addition awaiting its inversion.
+    state: Vec<u8>,
+    /// Ping-pong lists of points still to be paired, with their bucket ids.
+    lists: [Vec<blst_p1_affine>; 2],
+    ids: [Vec<u32>; 2],
+    /// Additions queued for the next shared inversion.
+    pending: Pending,
+    /// Entries still to be summed for each of the `2m` marginals.
+    marginals: Vec<Vec<u32>>,
+}
+
+impl Round {
+    /// Allocate state able to run any round up to width `widest`.
+    fn new(widest: u32) -> Self {
+        debug_assert!((1..=MAX_WIDTH).contains(&widest));
+        let total = (3usize.pow(widest + 1) - 3) / 2;
+        Self {
+            m: 0,
+            levels: Vec::with_capacity(widest as usize),
+            sums: vec![blst_p1_affine::default(); total],
+            live: vec![false; total],
+            state: vec![EMPTY; 3usize.pow(widest)],
+            lists: [Vec::new(), Vec::new()],
+            ids: [Vec::new(), Vec::new()],
+            pending: Pending::new(),
+            marginals: (0..2 * widest as usize).map(|_| Vec::new()).collect(),
+        }
+    }
+
+    /// Lay out the collapse levels for a round of width `m`.
+    fn widen(&mut self, m: u32) {
+        debug_assert!((1..=MAX_WIDTH).contains(&m));
+        debug_assert!(3usize.pow(m) <= self.state.len());
+        if self.m == m {
+            return;
+        }
+        self.m = m;
+        self.pending.bound(3usize.pow(m));
+        self.levels.clear();
+        let mut total = 0usize;
+        for j in 0..m {
+            self.levels.push(total);
+            total += 3usize.pow(m - j);
+        }
+    }
+
+    /// Sum `points` into the `3^m` buckets named by `ids`, leaving each bucket's
+    /// sum in its slot at level 0 of [`Self::sums`].
+    fn accumulate(&mut self, points: &[blst_p1_affine], ids: &[u32]) {
+        self.state[..3usize.pow(self.m)].fill(EMPTY);
+        accumulate_pass(
+            points,
+            ids,
+            &mut self.lists[0],
+            &mut self.ids[0],
+            &mut self.sums,
+            &mut self.state,
+            &mut self.pending,
+        );
+        while !self.lists[0].is_empty() {
+            let ([front, back], [front_ids, back_ids]) = (&mut self.lists, &mut self.ids);
+            accumulate_pass(
+                front,
+                front_ids,
+                back,
+                back_ids,
+                &mut self.sums,
+                &mut self.state,
+                &mut self.pending,
+            );
+            self.lists.swap(0, 1);
+            self.ids.swap(0, 1);
+        }
+        // The collapse works off the shared liveness flags; level 0's come from
+        // the accumulator's per-bucket state.
+        let buckets = 3usize.pow(self.m);
+        for (live, &state) in self.live[..buckets].iter_mut().zip(&self.state[..buckets]) {
+            *live = state != EMPTY;
+        }
+    }
+
+    /// Run one round: sum the points into `3^m` buckets keyed by coefficient
+    /// vector, recover the `m` combinations from the bucket sums, and check
+    /// each.
+    fn run(&mut self, points: &[blst_p1_affine], ids: &[u32], m: u32) -> bool {
+        self.widen(m);
+        self.accumulate(points, ids);
+
+        // Collapse chain: level `j+1` sums away level `j`'s lowest digit, so
+        // every digit position's marginals come out of one shared walk over the
+        // bucket sums rather than one walk per combination.
+        for j in 0..(self.m as usize).saturating_sub(1) {
+            let (source, target) = (self.levels[j], self.levels[j + 1]);
+            let width = 3usize.pow(self.m - j as u32 - 1);
+            for digit in [1usize, 2] {
+                for k in 0..width {
+                    let out = (target + k) as u32;
+                    let first = if digit == 1 {
+                        (source + 3 * k) as u32
+                    } else {
+                        out
+                    };
+                    queue_add(
+                        &mut self.sums,
+                        &mut self.live,
+                        &mut self.pending,
+                        out,
+                        first,
+                        (source + 3 * k + digit) as u32,
+                    );
+                }
+                complete(&mut self.sums, &mut self.pending);
+            }
+        }
+
+        // Combination `j` is the sum of the buckets whose `j`-th digit is 1 plus
+        // twice the sum of those whose digit is 2, and level `j` has every other
+        // digit already summed away.
+        for j in 0..self.m as usize {
+            let level = self.levels[j];
+            let width = 3usize.pow(self.m - j as u32 - 1);
+            for digit in [1usize, 2] {
+                let list = &mut self.marginals[2 * j + digit - 1];
+                list.clear();
+                list.extend(
+                    (0..width)
+                        .map(|k| (level + digit + 3 * k) as u32)
+                        .filter(|&index| self.live[index as usize]),
+                );
+            }
+        }
+        reduce(
+            &mut self.sums,
+            &mut self.live,
+            &mut self.marginals,
+            &mut self.pending,
+        );
+
+        for j in 0..self.m as usize {
+            let mut combination = blst_p1::default();
+            if let Some(&twos) = self.marginals[2 * j + 1].first() {
+                let mut point = blst_p1::default();
+                // SAFETY: the index names a live affine point, and blst_p1
+                // defaults to the identity.
+                unsafe {
+                    blst_p1_from_affine(&mut point, &self.sums[twos as usize]);
+                    blst_p1_double(&mut combination, &point);
+                }
+            }
+            if let Some(&ones) = self.marginals[2 * j].first() {
+                // SAFETY: both operands are valid; the routine handles the
+                // identity and equal operands, and permits out == a.
+                unsafe {
+                    blst_p1_add_or_double_affine(
+                        &mut combination,
+                        &combination,
+                        &self.sums[ones as usize],
+                    );
+                }
+            }
+            // SAFETY: combination is a valid blst_p1 (identity included).
+            if !unsafe { blst_p1_in_g1(&combination) } {
                 return false;
             }
         }
+        true
     }
-    true
 }
 
-/// A pending affine addition or doubling. Operands are copied out when the
-/// pass is scheduled so results can be written back without aliasing hazards.
-struct Arith {
-    a: blst_p1_affine,
-    b: blst_p1_affine,
-    out: usize,
-    double: bool,
-}
-
-/// Sum `points` into `num_buckets` buckets given by `ids` (each id less than
-/// `num_buckets`), returning one affine sum per bucket (the identity for empty
-/// buckets).
+/// Add each point of `src` into its bucket's running sum.
 ///
-/// Each pass pairs up the remaining points within every bucket and completes
-/// all pairs with a single shared field inversion (Montgomery's trick), so an
-/// addition costs about six field multiplications instead of an inversion.
-fn sum_buckets(points: &[blst_p1_affine], ids: &[u8], num_buckets: usize) -> Vec<blst_p1_affine> {
-    debug_assert_eq!(points.len(), ids.len());
-    // Counting sort the points into contiguous per-bucket runs.
-    let mut lens = vec![0usize; num_buckets];
-    for &id in ids {
-        lens[id as usize] += 1;
-    }
-    let mut starts = vec![0usize; num_buckets];
-    let mut acc = 0;
-    for (start, len) in starts.iter_mut().zip(&lens) {
-        *start = acc;
-        acc += len;
-    }
-    let mut buf = vec![blst_p1_affine::default(); points.len()];
-    let mut cursor = starts.clone();
-    for (point, &id) in points.iter().zip(ids) {
-        buf[cursor[id as usize]] = *point;
-        cursor[id as usize] += 1;
-    }
-
-    // Halve every bucket per pass until each holds at most one point. Copies
-    // (identity-involved pairs and odd leftovers) are deferred alongside the
-    // arithmetic so all reads complete before any write.
-    let mut arith: Vec<Arith> = Vec::new();
-    let mut denominators: Vec<blst_fp> = Vec::new();
-    let mut copies: Vec<(usize, blst_p1_affine)> = Vec::new();
-    loop {
-        arith.clear();
-        denominators.clear();
-        copies.clear();
-        for b in 0..num_buckets {
-            let (start, len) = (starts[b], lens[b]);
-            if len < 2 {
+/// The sum stays in the bucket's slot, so a point is read once and written once
+/// rather than travelling down a pairing tree. An addition is only queued, not
+/// completed, until its chunk shares an inversion, so a bucket with an
+/// outstanding addition is closed and any further point for it moves to
+/// `carry`, to be retried on the next pass. The pass returns with `carry` empty
+/// exactly when every point has been absorbed.
+fn accumulate_pass(
+    src: &[blst_p1_affine],
+    src_ids: &[u32],
+    carry: &mut Vec<blst_p1_affine>,
+    carry_ids: &mut Vec<u32>,
+    slots: &mut [blst_p1_affine],
+    state: &mut [u8],
+    pending: &mut Pending,
+) {
+    debug_assert_eq!(src.len(), src_ids.len());
+    carry.clear();
+    carry_ids.clear();
+    let mut deferred = 0usize;
+    for (index, (point, &id)) in src.iter().zip(src_ids).enumerate() {
+        // Bucket ids are uniform, so the slot a point lands in is a cache miss
+        // the loop can see coming a long way off.
+        if let Some(&ahead) = src_ids.get(index + PREFETCH_DISTANCE) {
+            prefetch(slots, ahead as usize);
+        }
+        let bucket = id as usize;
+        match state[bucket] {
+            EMPTY => {
+                state[bucket] = FILLED;
+                slots[bucket] = *point;
                 continue;
             }
-            for k in 0..len / 2 {
-                let a = buf[start + 2 * k];
-                let c = buf[start + 2 * k + 1];
-                let out = start + k;
-                if affine_is_inf(&a) {
-                    copies.push((out, c));
-                } else if affine_is_inf(&c) {
-                    copies.push((out, a));
-                } else if a.x.l == c.x.l {
-                    // Same x: on the curve y is determined up to sign, so this
-                    // is either P + (-P) = identity or a doubling.
-                    let two_y = fp_add(&a.y, &c.y);
-                    if two_y.l == [0u64; 6] {
-                        copies.push((out, blst_p1_affine::default()));
-                    } else {
-                        // y_a == y_c != 0, so two_y = 2*y_a is the doubling
-                        // denominator. (y == 0 cannot occur: the group order
-                        // h * r is odd, so the curve has no 2-torsion.)
-                        denominators.push(two_y);
-                        arith.push(Arith {
-                            a,
-                            b: c,
-                            out,
-                            double: true,
-                        });
-                    }
-                } else {
-                    denominators.push(fp_sub(&c.x, &a.x));
-                    arith.push(Arith {
-                        a,
-                        b: c,
-                        out,
-                        double: false,
-                    });
+            BUSY => {
+                carry.push(*point);
+                carry_ids.push(id);
+                // Bound the share of a pass that defers, so a batch whose ids
+                // collide constantly still converges in a few passes.
+                deferred += 1;
+                if deferred > pending.jobs.len() {
+                    absorb(src, slots, state, pending);
+                    deferred = 0;
+                }
+                continue;
+            }
+            _ => {}
+        }
+        // Only the x coordinates decide which formula applies, so the running
+        // sum is read a field element at a time rather than copied whole.
+        let held = &slots[bucket];
+        if fp_eq(&held.x, &point.x) {
+            // Same x: on the curve y is determined up to sign, so this is
+            // either P + (-P) = identity or a doubling.
+            let two_y = fp_add(&held.y, &point.y);
+            if fp_is_zero(&two_y) {
+                // The sum cancels, and an empty slot is the identity.
+                state[bucket] = EMPTY;
+                continue;
+            }
+            // y_held == y_point != 0, so two_y = 2*y_held is the doubling
+            // denominator. (y == 0 cannot occur: the group order h * r is odd,
+            // so the curve has no 2-torsion.)
+            pending.push(bucket as u32 | DOUBLE, index as u32, two_y);
+        } else {
+            pending.push(bucket as u32, index as u32, fp_sub(&point.x, &held.x));
+        }
+        state[bucket] = BUSY;
+        if pending.is_full() {
+            absorb(src, slots, state, pending);
+            deferred = 0;
+        }
+    }
+    absorb(src, slots, state, pending);
+}
+
+/// Finish the additions queued by [`accumulate_pass`] and reopen their buckets.
+///
+/// The shared inversion's backward walk hands each addition its inverse just as
+/// the addition needs it, so no inverse is ever written to memory.
+fn absorb(
+    src: &[blst_p1_affine],
+    slots: &mut [blst_p1_affine],
+    state: &mut [u8],
+    pending: &mut Pending,
+) {
+    let Some(mut running) = prefix_inverse(&pending.denominators, &mut pending.prefix) else {
+        return;
+    };
+    for index in (0..pending.jobs.len()).rev() {
+        let (slot, point) = pending.jobs[index];
+        let inverse = pending.unwind(index, &mut running);
+        let bucket = (slot & !DOUBLE) as usize;
+        let sum = chord(
+            &slots[bucket],
+            &src[point as usize],
+            &inverse,
+            slot & DOUBLE != 0,
+        );
+        slots[bucket] = sum;
+        state[bucket] = FILLED;
+    }
+    pending.clear();
+}
+
+/// Queue `slots[out] = slots[first] + slots[second]`.
+///
+/// The first operand is moved into the output slot immediately, so a completed
+/// job needs only the output and the second operand. Queued jobs must never
+/// read a slot another queued job writes; every caller below queues a wave of
+/// disjoint outputs and completes it before starting the next.
+fn queue_add(
+    slots: &mut [blst_p1_affine],
+    live: &mut [bool],
+    pending: &mut Pending,
+    out: u32,
+    first: u32,
+    second: u32,
+) {
+    let (out_index, first_index, second_index) = (out as usize, first as usize, second as usize);
+    if !live[second_index] {
+        if live[first_index] && out != first {
+            slots[out_index] = slots[first_index];
+        }
+        live[out_index] = live[first_index];
+        return;
+    }
+    if !live[first_index] {
+        slots[out_index] = slots[second_index];
+        live[out_index] = true;
+        return;
+    }
+    if out != first {
+        slots[out_index] = slots[first_index];
+    }
+    live[out_index] = true;
+    let (held, point) = (&slots[out_index], &slots[second_index]);
+    if fp_eq(&held.x, &point.x) {
+        let two_y = fp_add(&held.y, &point.y);
+        if fp_is_zero(&two_y) {
+            live[out_index] = false;
+            return;
+        }
+        pending.push(out | DOUBLE, second, two_y);
+    } else {
+        pending.push(out, second, fp_sub(&point.x, &held.x));
+    }
+    if pending.is_full() {
+        complete(slots, pending);
+    }
+}
+
+/// Finish the additions queued by [`queue_add`].
+fn complete(slots: &mut [blst_p1_affine], pending: &mut Pending) {
+    let Some(mut running) = prefix_inverse(&pending.denominators, &mut pending.prefix) else {
+        return;
+    };
+    for index in (0..pending.jobs.len()).rev() {
+        let (slot, second) = pending.jobs[index];
+        let inverse = pending.unwind(index, &mut running);
+        let out = (slot & !DOUBLE) as usize;
+        let sum = chord(
+            &slots[out],
+            &slots[second as usize],
+            &inverse,
+            slot & DOUBLE != 0,
+        );
+        slots[out] = sum;
+    }
+    pending.clear();
+}
+
+/// Sum each list of slot indices down to a single entry, in place.
+///
+/// Every list halves on each wave and all lists share the wave's inversion, so
+/// the whole combine costs a handful of inversions rather than one per list.
+fn reduce(
+    slots: &mut [blst_p1_affine],
+    live: &mut [bool],
+    lists: &mut [Vec<u32>],
+    pending: &mut Pending,
+) {
+    while lists.iter().any(|list| list.len() > 1) {
+        for list in lists.iter() {
+            for pair in list.chunks_exact(2) {
+                queue_add(slots, live, pending, pair[0], pair[0], pair[1]);
+            }
+        }
+        complete(slots, pending);
+        for list in lists.iter_mut() {
+            let len = list.len();
+            let mut kept = 0;
+            for index in 0..len / 2 {
+                let slot = list[2 * index];
+                if live[slot as usize] {
+                    list[kept] = slot;
+                    kept += 1;
                 }
             }
             if len % 2 == 1 {
-                copies.push((start + len / 2, buf[start + len - 1]));
+                list[kept] = list[len - 1];
+                kept += 1;
             }
-            lens[b] = len.div_ceil(2);
+            list.truncate(kept);
         }
-        if arith.is_empty() && copies.is_empty() {
-            break;
-        }
-        batch_invert(&mut denominators);
-        for (op, inverse) in arith.iter().zip(&denominators) {
-            // Affine chord/tangent formulas (curve coefficient a = 0):
-            //   add:    lambda = (y_b - y_a) / (x_b - x_a)
-            //   double: lambda = 3 * x_a^2 / (2 * y_a)
-            //   x_out = lambda^2 - x_a - x_b;  y_out = lambda*(x_a - x_out) - y_a
-            let lambda = if op.double {
-                let x_sq = fp_sqr(&op.a.x);
-                fp_mul(&fp_add(&fp_add(&x_sq, &x_sq), &x_sq), inverse)
-            } else {
-                fp_mul(&fp_sub(&op.b.y, &op.a.y), inverse)
-            };
-            let x_out = fp_sub(&fp_sub(&fp_sqr(&lambda), &op.a.x), &op.b.x);
-            let y_out = fp_sub(&fp_mul(&lambda, &fp_sub(&op.a.x, &x_out)), &op.a.y);
-            buf[op.out] = blst_p1_affine { x: x_out, y: y_out };
-        }
-        for &(out, value) in &copies {
-            buf[out] = value;
+    }
+}
+
+/// Additions queued for the next shared field inversion.
+///
+/// A queued job names the slot its result belongs in (with [`DOUBLE`] set when
+/// its operands are equal) and the second operand; the first operand is
+/// wherever the completing routine knows to find it.
+struct Pending {
+    jobs: Vec<(u32, u32)>,
+    denominators: Vec<blst_fp>,
+    /// Running products of the denominators, walked back down as each addition
+    /// takes its inverse.
+    prefix: Vec<blst_fp>,
+    /// How many additions to queue before sharing an inversion.
+    limit: usize,
+}
+
+impl Pending {
+    fn new() -> Self {
+        Self {
+            jobs: Vec::with_capacity(CHUNK),
+            denominators: Vec::with_capacity(CHUNK),
+            prefix: vec![blst_fp::default(); CHUNK],
+            limit: CHUNK,
         }
     }
 
-    (0..num_buckets)
-        .map(|b| {
-            if lens[b] == 0 {
-                blst_p1_affine::default()
-            } else {
-                buf[starts[b]]
-            }
-        })
-        .collect()
+    /// Bound the chunk so a round with few buckets does not spend most of a
+    /// chunk unable to touch any of them.
+    ///
+    /// An accumulating bucket is closed until its addition completes, so at
+    /// most one addition per bucket can be in flight; queueing past that only
+    /// defers points to another pass.
+    fn bound(&mut self, buckets: usize) {
+        self.limit = CHUNK.min(buckets);
+    }
+
+    /// Queue one addition.
+    #[inline(always)]
+    fn push(&mut self, slot: u32, second: u32, denominator: blst_fp) {
+        self.jobs.push((slot, second));
+        self.denominators.push(denominator);
+    }
+
+    /// Whether the queue has grown to a full inversion's worth of work.
+    #[inline(always)]
+    const fn is_full(&self) -> bool {
+        self.jobs.len() >= self.limit
+    }
+
+    /// Return the inverse of job `index`'s denominator, advancing `running` (the
+    /// inverse of the running product through `index`) to the next job down.
+    #[inline(always)]
+    fn unwind(&self, index: usize, running: &mut blst_fp) -> blst_fp {
+        if index == 0 {
+            return *running;
+        }
+        let inverse = fp_mul(running, &self.prefix[index - 1]);
+        *running = fp_mul(running, &self.denominators[index]);
+        inverse
+    }
+
+    fn clear(&mut self) {
+        self.jobs.clear();
+        self.denominators.clear();
+    }
 }
 
-/// Replace every element with its inverse using Montgomery's trick: one field
-/// inversion plus three multiplications per element.
+/// Complete one affine addition (or doubling) given the inverse of its
+/// denominator.
+///
+/// Chord/tangent formulas for curve coefficient `a = 0`:
+/// `add: lambda = (y_b - y_a) / (x_b - x_a)`,
+/// `double: lambda = 3 x_a^2 / (2 y_a)`,
+/// `x_out = lambda^2 - x_a - x_b`, `y_out = lambda (x_a - x_out) - y_a`.
+#[inline(always)]
+fn chord(
+    first: &blst_p1_affine,
+    second: &blst_p1_affine,
+    inverse: &blst_fp,
+    double: bool,
+) -> blst_p1_affine {
+    let lambda = if double {
+        let square = fp_sqr(&first.x);
+        fp_mul(&fp_add(&fp_add(&square, &square), &square), inverse)
+    } else {
+        fp_mul(&fp_sub(&second.y, &first.y), inverse)
+    };
+    let x = fp_sub(&fp_sub(&fp_sqr(&lambda), &first.x), &second.x);
+    let y = fp_sub(&fp_mul(&lambda, &fp_sub(&first.x, &x)), &first.y);
+    blst_p1_affine { x, y }
+}
+
+/// Fill `prefix` with the running products of `values` and return the inverse
+/// of their total, or `None` when there is nothing to invert.
+///
+/// This is the forward half of Montgomery's trick; each caller walks back down
+/// the prefix products itself so that an element's inverse is consumed where it
+/// is produced. Together the two halves cost one field inversion plus three
+/// multiplications per element.
 ///
 /// Every element MUST be nonzero (`blst_fp_inverse(0) == 0` would silently
-/// poison the shared product); [`sum_buckets`]'s classification guarantees it.
-fn batch_invert(values: &mut [blst_fp]) {
-    if values.is_empty() {
-        return;
+/// poison the shared product); the callers' classification guarantees it.
+fn prefix_inverse(values: &[blst_fp], prefix: &mut Vec<blst_fp>) -> Option<blst_fp> {
+    let (first, rest) = values.split_first()?;
+    if prefix.len() < values.len() {
+        prefix.resize(values.len(), blst_fp::default());
     }
-    // prefix[i] = values[0] * ... * values[i]
-    let mut prefix = Vec::with_capacity(values.len());
-    let mut acc = values[0];
-    prefix.push(acc);
-    for value in &values[1..] {
-        acc = fp_mul(&acc, value);
-        prefix.push(acc);
+    let mut running = *first;
+    prefix[0] = running;
+    for (value, slot) in rest.iter().zip(prefix[1..].iter_mut()) {
+        running = fp_mul(&running, value);
+        *slot = running;
     }
-    // inverse = (values[0] * ... * values[i])^-1, walking i down from the end.
     let mut inverse = blst_fp::default();
     // SAFETY: both pointers reference valid blst_fp values.
-    unsafe { blst_fp_inverse(&mut inverse, &acc) };
-    for i in (1..values.len()).rev() {
-        let value_inverse = fp_mul(&inverse, &prefix[i - 1]);
-        inverse = fp_mul(&inverse, &values[i]);
-        values[i] = value_inverse;
-    }
-    values[0] = inverse;
+    unsafe { blst_fp_inverse(&mut inverse, &running) };
+    Some(inverse)
 }
 
-fn affine_is_inf(p: &blst_p1_affine) -> bool {
-    // SAFETY: p is a valid blst_p1_affine.
-    unsafe { blst_p1_affine_is_inf(p) }
-}
-
-fn fp_add(a: &blst_fp, b: &blst_fp) -> blst_fp {
-    let mut out = blst_fp::default();
-    // SAFETY: all pointers reference valid blst_fp values.
-    unsafe { blst_fp_add(&mut out, a, b) };
-    out
-}
-
-fn fp_sub(a: &blst_fp, b: &blst_fp) -> blst_fp {
-    let mut out = blst_fp::default();
-    // SAFETY: all pointers reference valid blst_fp values.
-    unsafe { blst_fp_sub(&mut out, a, b) };
-    out
-}
-
-fn fp_mul(a: &blst_fp, b: &blst_fp) -> blst_fp {
-    let mut out = blst_fp::default();
-    // SAFETY: all pointers reference valid blst_fp values.
-    unsafe { blst_fp_mul(&mut out, a, b) };
-    out
-}
-
-fn fp_sqr(a: &blst_fp) -> blst_fp {
-    let mut out = blst_fp::default();
-    // SAFETY: all pointers reference valid blst_fp values.
-    unsafe { blst_fp_sqr(&mut out, a) };
-    out
-}
-
-/// A stream of uniform trits over a cryptographic RNG.
+/// Hint that `slots[index]` will be read soon.
 ///
-/// Each accepted byte below `3^5 = 243` yields five independent uniform trits
-/// (its base-3 digits); bytes at or above 243 are rejected so the trits stay
-/// exactly uniform. Bytes are drawn in bulk to amortize RNG calls.
+/// A point spans two cache lines, and the caller reads both.
+#[inline(always)]
+fn prefetch(slots: &[blst_p1_affine], index: usize) {
+    let _ = (slots, index);
+    #[cfg(target_arch = "x86_64")]
+    {
+        use core::arch::x86_64::{_MM_HINT_T0, _mm_prefetch};
+        let base = slots.as_ptr().wrapping_add(index).cast::<i8>();
+        // SAFETY: _mm_prefetch never dereferences its argument, so any address
+        // is allowed; the index is in range for the slice regardless.
+        unsafe {
+            _mm_prefetch(base, _MM_HINT_T0);
+            _mm_prefetch(base.wrapping_add(64), _MM_HINT_T0);
+        }
+    }
+    #[cfg(target_arch = "aarch64")]
+    {
+        use core::arch::aarch64::{_PREFETCH_LOCALITY3, _PREFETCH_READ, _prefetch};
+        let base = slots.as_ptr().wrapping_add(index).cast::<i8>();
+        // SAFETY: _prefetch never dereferences its argument.
+        unsafe {
+            _prefetch::<_PREFETCH_READ, _PREFETCH_LOCALITY3>(base);
+            _prefetch::<_PREFETCH_READ, _PREFETCH_LOCALITY3>(base.wrapping_add(64));
+        }
+    }
+}
+
+/// Replace every element with its inverse, using one shared field inversion.
+fn batch_invert(values: &mut [blst_fp], prefix: &mut Vec<blst_fp>) {
+    let Some(mut running) = prefix_inverse(values, prefix) else {
+        return;
+    };
+    for index in (1..values.len()).rev() {
+        let inverse = fp_mul(&running, &prefix[index - 1]);
+        running = fp_mul(&running, &values[index]);
+        values[index] = inverse;
+    }
+    values[0] = running;
+}
+
+/// The BLS12-381 base field modulus, as little-endian 64-bit limbs.
+///
+/// `2 * MODULUS < 2^384`, so adding two reduced elements never carries out of
+/// the top limb.
+const MODULUS: [u64; 6] = [
+    0xb9fe_ffff_ffff_aaab,
+    0x1eab_fffe_b153_ffff,
+    0x6730_d2a0_f6b0_f624,
+    0x6477_4b84_f385_12bf,
+    0x4b1b_a7b6_434b_acd7,
+    0x1a01_11ea_397f_e69a,
+];
+
+/// Whether two field elements are equal.
+///
+/// Written as a short-circuiting limb comparison: the accumulator's hot path
+/// asks this of two unrelated points, which almost always differ in the first
+/// limb.
+#[inline(always)]
+const fn fp_eq(a: &blst_fp, b: &blst_fp) -> bool {
+    a.l[0] == b.l[0]
+        && a.l[1] == b.l[1]
+        && a.l[2] == b.l[2]
+        && a.l[3] == b.l[3]
+        && a.l[4] == b.l[4]
+        && a.l[5] == b.l[5]
+}
+
+/// Whether a field element is zero.
+#[inline(always)]
+const fn fp_is_zero(a: &blst_fp) -> bool {
+    (a.l[0] | a.l[1] | a.l[2] | a.l[3] | a.l[4] | a.l[5]) == 0
+}
+
+/// One in the field's Montgomery form, `R mod MODULUS` for `R = 2^384`.
+///
+/// A point decoded from the wire carries this as its `z`.
+const MONTGOMERY_ONE: blst_fp = blst_fp {
+    l: [
+        0x7609_0000_0002_fffd,
+        0xebf4_000b_c40c_0002,
+        0x5f48_9857_53c7_58ba,
+        0x77ce_5853_7052_5745,
+        0x5c07_1a97_a256_ec6d,
+        0x15f6_5ec3_fa80_e493,
+    ],
+};
+
+/// Whether a field element is one, i.e. whether a point is already normalized.
+#[inline(always)]
+const fn fp_is_one(a: &blst_fp) -> bool {
+    fp_eq(a, &MONTGOMERY_ONE)
+}
+
+/// Add two reduced field elements.
+///
+/// Inlined rather than delegated to `blst_fp_add`: the batch-affine addition
+/// spends several of these per point addition, where the call and the mandatory
+/// zeroing of the out-parameter cost more than the arithmetic itself. The
+/// carry chains are written in the form that lowers to `adc`/`sbb`.
+#[inline(always)]
+fn fp_add(a: &blst_fp, b: &blst_fp) -> blst_fp {
+    let mut sum = [0u64; 6];
+    let mut carry = false;
+    for (out, (left, right)) in sum.iter_mut().zip(a.l.iter().zip(&b.l)) {
+        let (limb, first) = left.overflowing_add(*right);
+        let (limb, second) = limb.overflowing_add(carry as u64);
+        *out = limb;
+        carry = first | second;
+    }
+    debug_assert!(!carry, "2 * MODULUS fits in 384 bits");
+    subtract_modulus(sum)
+}
+
+/// Subtract one reduced field element from another.
+#[inline(always)]
+fn fp_sub(a: &blst_fp, b: &blst_fp) -> blst_fp {
+    let mut difference = [0u64; 6];
+    let mut borrow = false;
+    for (out, (left, right)) in difference.iter_mut().zip(a.l.iter().zip(&b.l)) {
+        let (limb, first) = left.overflowing_sub(*right);
+        let (limb, second) = limb.overflowing_sub(borrow as u64);
+        *out = limb;
+        borrow = first | second;
+    }
+    // The subtraction underflowed exactly when a < b; add the modulus back.
+    let mask = 0u64.wrapping_sub(borrow as u64);
+    let mut sum = [0u64; 6];
+    let mut carry = false;
+    for (out, (limb, modulus)) in sum.iter_mut().zip(difference.iter().zip(&MODULUS)) {
+        let (limb, first) = limb.overflowing_add(modulus & mask);
+        let (limb, second) = limb.overflowing_add(carry as u64);
+        *out = limb;
+        carry = first | second;
+    }
+    blst_fp { l: sum }
+}
+
+/// Reduce a value known to be below `2 * MODULUS`.
+#[inline(always)]
+fn subtract_modulus(value: [u64; 6]) -> blst_fp {
+    let mut reduced = [0u64; 6];
+    let mut borrow = false;
+    for (out, (limb, modulus)) in reduced.iter_mut().zip(value.iter().zip(&MODULUS)) {
+        let (limb, first) = limb.overflowing_sub(*modulus);
+        let (limb, second) = limb.overflowing_sub(borrow as u64);
+        *out = limb;
+        borrow = first | second;
+    }
+    // Keep the reduced value unless subtracting the modulus underflowed.
+    let mask = 0u64.wrapping_sub(borrow as u64);
+    let mut out = [0u64; 6];
+    for (out, (value, reduced)) in out.iter_mut().zip(value.iter().zip(&reduced)) {
+        *out = (value & mask) | (reduced & !mask);
+    }
+    blst_fp { l: out }
+}
+
+#[inline(always)]
+fn fp_mul(a: &blst_fp, b: &blst_fp) -> blst_fp {
+    let mut out = MaybeUninit::<blst_fp>::uninit();
+    // SAFETY: the operands are valid blst_fp values and blst_fp_mul writes the
+    // whole result before returning.
+    unsafe {
+        blst_fp_mul(out.as_mut_ptr(), a, b);
+        out.assume_init()
+    }
+}
+
+#[inline(always)]
+fn fp_sqr(a: &blst_fp) -> blst_fp {
+    let mut out = MaybeUninit::<blst_fp>::uninit();
+    // SAFETY: the operand is a valid blst_fp value and blst_fp_sqr writes the
+    // whole result before returning.
+    unsafe {
+        blst_fp_sqr(out.as_mut_ptr(), a);
+        out.assume_init()
+    }
+}
+
+/// Number of exactly uniform trits carried by one accepted word.
+///
+/// `3^20 < 2^32 <= 3^21`, so twenty is the most a `u32` can hold.
+const TRITS_PER_WORD: u32 = 20;
+
+/// `3^TRITS_PER_WORD`: the rejection bound for one drawn word.
+const TRIT_WORD_BOUND: u32 = 3u32.pow(TRITS_PER_WORD);
+
+/// A stream of uniform coefficient vectors over a cryptographic RNG.
+///
+/// Each accepted word below `3^20` yields twenty independent uniform trits (its
+/// base-3 digits); words at or above the bound are rejected so the trits stay
+/// exactly uniform. A vector of `m` trits is the word's residue modulo `3^m`,
+/// and the quotient stays uniform over the remaining digits, so one word serves
+/// `floor(20 / m)` vectors. Words are drawn in bulk to amortize RNG calls.
 ///
 /// Exact uniformity is load-bearing: the soundness bound leaves a fraction of
 /// a bit of margin over the security target, and the bias of a `byte % 3`
@@ -425,62 +1077,78 @@ fn fp_sqr(a: &blst_fp) -> blst_fp {
 /// dropping the total below it.
 struct Trits<'a, R: CryptoRng> {
     rng: &'a mut R,
-    buffer: [u8; 256],
+    buffer: [u8; 1024],
     filled: usize,
     position: usize,
-    current: u8,
-    remaining: u8,
 }
 
 impl<'a, R: CryptoRng> Trits<'a, R> {
     const fn new(rng: &'a mut R) -> Self {
         Self {
             rng,
-            buffer: [0u8; 256],
+            buffer: [0u8; 1024],
             filled: 0,
             position: 0,
-            current: 0,
-            remaining: 0,
         }
     }
 
-    /// Return the next uniform value in `{0, 1, 2}`.
-    fn next(&mut self) -> u8 {
-        if self.remaining == 0 {
-            self.current = self.next_byte();
-            self.remaining = 5;
+    /// Draw `count` uniform bucket ids in `[0, 3^m)`.
+    ///
+    /// The width is dispatched once for the whole run rather than per id, so
+    /// the inner loop divides by a literal and the compiler turns each division
+    /// into a multiply and a shift. Trits left over from a word are dropped
+    /// when the run ends; they are only ever a fraction of one draw.
+    fn fill(&mut self, m: u32, count: usize) -> Vec<u32> {
+        debug_assert!((1..=MAX_WIDTH).contains(&m));
+        let mut ids = Vec::with_capacity(count);
+        macro_rules! draw {
+            ($modulus:literal, $per_word:literal) => {{
+                while ids.len() < count {
+                    let mut word = self.next_word();
+                    for _ in 0..$per_word {
+                        if ids.len() == count {
+                            break;
+                        }
+                        ids.push(word % $modulus);
+                        word /= $modulus;
+                    }
+                }
+            }};
         }
-        let trit = self.current % 3;
-        self.current /= 3;
-        self.remaining -= 1;
-        trit
+        match m {
+            1 => draw!(3, 20),
+            2 => draw!(9, 10),
+            3 => draw!(27, 6),
+            4 => draw!(81, 5),
+            5 => draw!(243, 4),
+            6 => draw!(729, 3),
+            7 => draw!(2187, 2),
+            8 => draw!(6561, 2),
+            9 => draw!(19683, 2),
+            10 => draw!(59049, 2),
+            11 => draw!(177147, 1),
+            _ => unreachable!("width is at most MAX_WIDTH"),
+        }
+        ids
     }
 
-    /// Return a uniform bucket id in `[0, 3^m)` — the next `m` trits as base-3
-    /// digits. `m` must be at most 5.
-    fn bucket(&mut self, m: u32) -> u8 {
-        debug_assert!((1..=5).contains(&m));
-        let mut id = 0u8;
-        let mut weight = 1u8;
-        for _ in 0..m {
-            id += weight * self.next();
-            weight = weight.wrapping_mul(3);
-        }
-        id
-    }
-
-    /// Return the next byte strictly below 243, refilling the buffer as needed.
-    fn next_byte(&mut self) -> u8 {
+    /// Return the next word strictly below `3^20`, refilling the buffer as
+    /// needed.
+    fn next_word(&mut self) -> u32 {
         loop {
             if self.position == self.filled {
                 self.rng.fill_bytes(&mut self.buffer);
                 self.filled = self.buffer.len();
                 self.position = 0;
             }
-            let byte = self.buffer[self.position];
-            self.position += 1;
-            if byte < 243 {
-                return byte;
+            let word = u32::from_le_bytes(
+                self.buffer[self.position..self.position + 4]
+                    .try_into()
+                    .expect("four bytes"),
+            );
+            self.position += 4;
+            if word < TRIT_WORD_BOUND {
+                return word;
             }
         }
     }
@@ -490,11 +1158,10 @@ impl<'a, R: CryptoRng> Trits<'a, R> {
 mod tests {
     use super::*;
     use crate::bls12381::primitives::group::{G1, Scalar};
-    use commonware_codec::FixedSize;
+    use commonware_codec::{Encode, FixedSize};
     use commonware_math::algebra::{Additive, CryptoGroup, Random};
     use commonware_parallel::Sequential;
     use commonware_utils::test_rng;
-    use rand_core::Rng;
 
     /// Standard soundness target for the tests.
     const SECURITY: usize = 128;
@@ -502,6 +1169,12 @@ mod tests {
     /// A batch size comfortably above the per-point fallback threshold, so the
     /// batched path is exercised.
     const LARGE: usize = 1000;
+
+    /// Whether an affine point is the point at infinity.
+    fn affine_is_inf(p: &blst_p1_affine) -> bool {
+        // SAFETY: p is a valid blst_p1_affine.
+        unsafe { blst::blst_p1_affine_is_inf(p) }
+    }
 
     fn in_subgroup_point(rng: &mut impl CryptoRng) -> G1 {
         G1::generator() * &Scalar::random(rng)
@@ -526,27 +1199,50 @@ mod tests {
         }
     }
 
-    /// Assert that [`sum_buckets`] agrees with naive per-bucket G1 addition.
-    fn assert_sums_match(points: &[G1], ids: &[u8], num_buckets: usize) {
-        let affine = G1::batch_to_affine(points);
-        let sums = sum_buckets(&affine, ids, num_buckets);
-        assert_eq!(sums.len(), num_buckets);
-        for (b, got) in sums.iter().enumerate() {
+    /// Drop identity points exactly as [`batch_in_g1`] does, keeping the ids
+    /// aligned with the points that survive.
+    fn affine_with_ids(points: &[G1], ids: &[u32]) -> (Vec<blst_p1_affine>, Vec<u32>) {
+        let kept: Vec<u32> = points
+            .iter()
+            .zip(ids)
+            .filter(|(point, _)| !fp_is_zero(&point.as_blst_p1().z))
+            .map(|(_, &id)| id)
+            .collect();
+        (to_affine(points), kept)
+    }
+
+    /// Run the accumulator and return each bucket's sum, with `None` for the
+    /// buckets that sum to the identity.
+    fn bucket_sums(points: &[G1], ids: &[u32], m: u32) -> Vec<Option<blst_p1_affine>> {
+        let (affine, affine_ids) = affine_with_ids(points, ids);
+        let mut round = Round::new(m);
+        round.widen(m);
+        round.accumulate(&affine, &affine_ids);
+        (0..3usize.pow(m))
+            .map(|bucket| round.live[bucket].then_some(round.sums[bucket]))
+            .collect()
+    }
+
+    /// Assert that the accumulator agrees with naive per-bucket G1 addition.
+    fn assert_sums_match(points: &[G1], ids: &[u32], m: u32) {
+        let sums = bucket_sums(points, ids, m);
+        assert_eq!(sums.len(), 3usize.pow(m));
+        for (bucket, got) in sums.iter().enumerate() {
             let mut expected = G1::zero();
             for (point, &id) in points.iter().zip(ids) {
-                if id as usize == b {
+                if id as usize == bucket {
                     expected += point;
                 }
             }
             let expected = G1::batch_to_affine(&[expected]);
-            assert_eq!(
-                affine_is_inf(got),
-                affine_is_inf(&expected[0]),
-                "bucket {b} identity mismatch"
-            );
-            if !affine_is_inf(got) {
-                assert_eq!(got.x.l, expected[0].x.l, "bucket {b} x mismatch");
-                assert_eq!(got.y.l, expected[0].y.l, "bucket {b} y mismatch");
+            let expected = (!affine_is_inf(&expected[0])).then_some(expected[0]);
+            match (got, expected) {
+                (None, None) => {}
+                (Some(got), Some(expected)) => {
+                    assert_eq!(got.x.l, expected.x.l, "bucket {bucket} x mismatch");
+                    assert_eq!(got.y.l, expected.y.l, "bucket {bucket} y mismatch");
+                }
+                _ => panic!("bucket {bucket} identity mismatch"),
             }
         }
     }
@@ -560,27 +1256,50 @@ mod tests {
             // 3^t >= 2^security must hold at the returned t.
             assert!(f64::from(combinations as u32) * 3f64.log2() >= security as f64);
             // Every plan must cover the required number of combinations.
-            for n in [0usize, 1, 50, 130, 200, 1000, 6000, 100_000] {
-                if let Some((m, rounds)) = plan(n, combinations) {
-                    assert!((1..=5).contains(&m));
-                    assert!(rounds * m as usize >= combinations, "n={n} s={security}");
+            for n in [0usize, 1, 50, 130, 200, 1000, 6000, 100_000, 2_000_000] {
+                let Some(widths) = plan(n, combinations) else {
+                    continue;
+                };
+                for &m in &widths {
+                    assert!((1..=MAX_WIDTH).contains(&m));
+                    assert!(3usize.pow(m) <= 4 * n.max(1));
+                    assert!(3usize.pow(m) * size_of::<blst_p1_affine>() <= SLOT_BUDGET);
                 }
+                // Every plan must cover the required number of combinations,
+                // and must not waste more than one on rounding.
+                let total: usize = widths.iter().map(|&m| m as usize).sum();
+                assert!(total >= combinations, "n={n} s={security}");
+                assert!(
+                    total < combinations + widths.len(),
+                    "n={n} s={security} wastes combinations"
+                );
             }
         }
         // Small batches fall back to per-point checking; large ones batch.
         assert!(plan(1, 81).is_none());
         assert!(plan(50, 81).is_none());
         assert!(plan(6000, 81).is_some());
+        // A zero soundness target needs no rounds at all.
+        assert_eq!(plan(6000, 0), Some(Vec::new()));
+        // Wider rounds, and so fewer of them, pay off as the batch grows, until
+        // the slot budget stops the widening.
+        let rounds = |n| plan(n, 81).map(|widths| widths.len());
+        assert!(rounds(1000) > rounds(100_000));
+        assert_eq!(rounds(100_000), rounds(2_000_000));
+        let widest = |n| plan(n, 81).and_then(|widths| widths.into_iter().max());
+        assert!(widest(1000) < widest(100_000));
+        assert_eq!(widest(2_000_000), widest(100_000));
+        let budgeted = widest(2_000_000).expect("batched");
+        assert!(3usize.pow(budgeted) * size_of::<blst_p1_affine>() <= SLOT_BUDGET);
+        assert!(3usize.pow(budgeted + 1) * size_of::<blst_p1_affine>() > SLOT_BUDGET);
     }
 
     #[test]
     fn bucket_ids_are_in_range() {
         let mut rng = test_rng();
         let mut trits = Trits::new(&mut rng);
-        for m in 1..=5u32 {
-            for _ in 0..1000 {
-                assert!((trits.bucket(m) as usize) < 3usize.pow(m));
-            }
+        for m in 1..=MAX_WIDTH {
+            assert!(trits.fill(m, 1000).into_iter().all(|id| id < 3u32.pow(m)));
         }
     }
 
@@ -589,8 +1308,8 @@ mod tests {
         let mut rng = test_rng();
         let mut trits = Trits::new(&mut rng);
         let mut counts = [0usize; 9];
-        for _ in 0..9000 {
-            counts[trits.bucket(2) as usize] += 1;
+        for id in trits.fill(2, 9000) {
+            counts[id as usize] += 1;
         }
         // Expected 1000 per id; the window is ~6.7 standard deviations wide.
         for &count in &counts {
@@ -611,24 +1330,98 @@ mod tests {
         let mut points: Vec<G1> = (0..300).map(|_| in_subgroup_point(&mut rng)).collect();
         let bad_index = points.len();
         points.push(off_subgroup_point(&mut rng));
-        let affine = G1::batch_to_affine(&points);
         // Good points are spread arbitrarily; their in-subgroup parts cannot
         // mask a cofactor part in any combination.
-        let mut ids: Vec<u8> = (0..points.len()).map(|i| (i % 243) as u8).collect();
+        let mut ids: Vec<u32> = (0..points.len()).map(|i| (i % 243) as u32).collect();
+        let mut round = Round::new(M);
         // Vector 0 assigns the bad point coefficient 0 in every combination,
         // so the round must accept.
         ids[bad_index] = 0;
-        assert!(round_in_g1(&affine, &ids, M));
+        let (affine, affine_ids) = affine_with_ids(&points, &ids);
+        assert!(round.run(&affine, &affine_ids, M));
         // Any nonzero vector leaves a nonzero digit in some combination, which
         // must reject: 3^j isolates digit j with value 1; 2 and 162 = 2 * 3^4
         // cover value 2 at the lowest and highest positions.
-        for v in [1u8, 2, 3, 9, 27, 81, 162] {
+        for v in [1u32, 2, 3, 9, 27, 81, 162] {
             ids[bad_index] = v;
+            let (affine, affine_ids) = affine_with_ids(&points, &ids);
             assert!(
-                !round_in_g1(&affine, &ids, M),
+                !round.run(&affine, &affine_ids, M),
                 "bad point at bucket {v} escaped"
             );
         }
+    }
+
+    #[test]
+    fn field_helpers_match_blst() {
+        use blst::{blst_fp_add, blst_fp_sub};
+        let mut rng = test_rng();
+        // Coordinates of random curve points are reduced field elements
+        // covering the whole range, and the modulus-boundary cases are added
+        // explicitly.
+        let points: Vec<G1> = (0..64).map(|_| in_subgroup_point(&mut rng)).collect();
+        let affine = G1::batch_to_affine(&points);
+        let mut values: Vec<blst_fp> = affine.iter().flat_map(|p| [p.x, p.y]).collect();
+        values.push(blst_fp { l: [0u64; 6] });
+        let mut largest = MODULUS;
+        largest[0] -= 1;
+        values.push(blst_fp { l: largest });
+        values.push(blst_fp {
+            l: [1, 0, 0, 0, 0, 0],
+        });
+        for a in &values {
+            for b in &values {
+                let mut expected = blst_fp::default();
+                // SAFETY: all pointers reference valid blst_fp values.
+                unsafe { blst_fp_add(&mut expected, a, b) };
+                assert_eq!(fp_add(a, b).l, expected.l, "add");
+                // SAFETY: all pointers reference valid blst_fp values.
+                unsafe { blst_fp_sub(&mut expected, a, b) };
+                assert_eq!(fp_sub(a, b).l, expected.l, "sub");
+                assert_eq!(fp_eq(a, b), a.l == b.l, "eq");
+            }
+            assert_eq!(fp_is_zero(a), a.l == [0u64; 6], "zero");
+        }
+    }
+
+    #[test]
+    fn montgomery_one_is_one() {
+        use blst::blst_fp_from_uint64;
+        let mut one = blst_fp::default();
+        // SAFETY: both pointers reference valid, correctly sized values.
+        unsafe { blst_fp_from_uint64(&mut one, [1u64, 0, 0, 0, 0, 0].as_ptr()) };
+        assert_eq!(one.l, MONTGOMERY_ONE.l);
+        assert!(fp_is_one(&one));
+        assert!(!fp_is_one(&blst_fp::default()));
+        // A decoded point is normalized, so the conversion's fast path applies.
+        let mut rng = test_rng();
+        let point = in_subgroup_point(&mut rng);
+        let bytes = point.encode();
+        let decoded = G1::read_unchecked(&mut bytes.as_ref()).expect("decodes");
+        assert!(fp_is_one(&decoded.as_blst_p1().z));
+    }
+
+    #[test]
+    fn to_affine_matches_blst() {
+        let mut rng = test_rng();
+        let mut points: Vec<G1> = (0..33).map(|_| in_subgroup_point(&mut rng)).collect();
+        // Identities are dropped, wherever they sit.
+        points[0] = G1::zero();
+        points[17] = G1::zero();
+        points.push(G1::zero());
+        let expected: Vec<blst_p1_affine> = G1::batch_to_affine(&points)
+            .into_iter()
+            .filter(|point| !affine_is_inf(point))
+            .collect();
+        let got = to_affine(&points);
+        assert_eq!(got.len(), expected.len());
+        for (got, expected) in got.iter().zip(&expected) {
+            assert_eq!(got.x.l, expected.x.l);
+            assert_eq!(got.y.l, expected.y.l);
+        }
+        // An all-identity batch converts to nothing.
+        assert!(to_affine(&[G1::zero()]).is_empty());
+        assert!(to_affine(&[]).is_empty());
     }
 
     #[test]
@@ -636,10 +1429,11 @@ mod tests {
         let mut rng = test_rng();
         let points: Vec<G1> = (0..17).map(|_| in_subgroup_point(&mut rng)).collect();
         let affine = G1::batch_to_affine(&points);
+        let mut prefix = Vec::new();
         for take in [0usize, 1, 2, 17] {
             let original: Vec<blst_fp> = affine.iter().take(take).map(|p| p.x).collect();
             let mut inverted = original.clone();
-            batch_invert(&mut inverted);
+            batch_invert(&mut inverted, &mut prefix);
             // value * inverse must be the same element (one) for every entry,
             // and multiplying by it must be the identity map.
             if take == 0 {
@@ -654,11 +1448,11 @@ mod tests {
     }
 
     #[test]
-    fn sum_buckets_handles_special_pairs() {
+    fn accumulator_handles_special_pairs() {
         let mut rng = test_rng();
         let p = in_subgroup_point(&mut rng);
         let q = off_subgroup_point(&mut rng);
-        let cases: Vec<(Vec<G1>, Vec<u8>, usize)> = vec![
+        let cases: Vec<(Vec<G1>, Vec<u32>, u32)> = vec![
             // Cancelling pair produces the identity.
             (vec![p, -p], vec![0, 0], 1),
             // Duplicates force the doubling path.
@@ -672,19 +1466,21 @@ mod tests {
             // Odd leftovers and cancellation combined.
             (vec![p, -p, p], vec![0, 0, 0], 1),
             // Singleton with empty buckets around it.
-            (vec![p], vec![1], 3),
+            (vec![p], vec![1], 1),
+            // A doubling chain that spans several passes.
+            (vec![p; 9], vec![2; 9], 2),
         ];
-        for (points, ids, num_buckets) in cases {
-            assert_sums_match(&points, &ids, num_buckets);
+        for (points, ids, m) in cases {
+            assert_sums_match(&points, &ids, m);
         }
     }
 
     #[test]
-    fn sum_buckets_matches_naive() {
+    fn accumulator_matches_naive() {
         let mut rng = test_rng();
-        for round in 0..20usize {
+        for round in 0..24usize {
             let n = 1 + (round * 37) % 150;
-            let num_buckets = [1usize, 2, 3, 9, 27, 243][round % 6];
+            let m = 1 + (round % 5) as u32;
             let mut points: Vec<G1> = Vec::with_capacity(n);
             for i in 0..n {
                 let point = match i % 7 {
@@ -696,13 +1492,8 @@ mod tests {
                 };
                 points.push(point);
             }
-            let mut id_bytes = vec![0u8; n];
-            rng.fill_bytes(&mut id_bytes);
-            let ids: Vec<u8> = id_bytes
-                .iter()
-                .map(|&b| (b as usize % num_buckets) as u8)
-                .collect();
-            assert_sums_match(&points, &ids, num_buckets);
+            let ids = Trits::new(&mut rng).fill(m, n);
+            assert_sums_match(&points, &ids, m);
         }
     }
 
@@ -726,6 +1517,14 @@ mod tests {
     fn all_identity_batch_is_accepted() {
         let points = vec![G1::zero(); LARGE];
         assert!(batch_in_g1(&points, SECURITY, &Sequential, &mut test_rng()));
+    }
+
+    #[test]
+    fn identity_padding_does_not_hide_a_bad_point() {
+        let mut rng = test_rng();
+        let mut points = vec![G1::zero(); LARGE];
+        points[LARGE / 2] = off_subgroup_point(&mut rng);
+        assert!(!batch_in_g1(&points, SECURITY, &Sequential, &mut rng));
     }
 
     #[test]
@@ -763,6 +1562,20 @@ mod tests {
         let bad = off_subgroup_point(&mut rng);
         // Many duplicates of one bad point stress same-bucket doubling chains.
         let points = vec![bad; LARGE];
+        assert!(!batch_in_g1(&points, SECURITY, &Sequential, &mut rng));
+    }
+
+    #[test]
+    fn wide_rounds_agree_with_per_point() {
+        // A batch large enough for the cost model to pick a wide round, so the
+        // collapse chain runs at full depth.
+        let mut rng = test_rng();
+        let n = 20_000;
+        let widths = plan(n, 81).expect("batched");
+        assert!(widths[0] >= 7, "expected a wide plan, got {widths:?}");
+        let mut points: Vec<G1> = (0..n).map(|_| in_subgroup_point(&mut rng)).collect();
+        assert!(batch_in_g1(&points, SECURITY, &Sequential, &mut rng));
+        points[n - 1] = off_subgroup_point(&mut rng);
         assert!(!batch_in_g1(&points, SECURITY, &Sequential, &mut rng));
     }
 
@@ -809,6 +1622,117 @@ mod tests {
         }
     }
 
+    /// Cost of the pieces of one batch-affine addition. Run with:
+    /// `cargo test -p commonware-cryptography --release --features bls12381 \
+    ///   subgroup::tests::measure_addition -- --ignored --nocapture`
+    #[test]
+    #[ignore = "manual benchmark"]
+    fn measure_addition() {
+        use std::time::Instant;
+        let mut rng = test_rng();
+        let n = 8192;
+        let points: Vec<G1> = (0..2 * n).map(|_| in_subgroup_point(&mut rng)).collect();
+        let affine = G1::batch_to_affine(&points);
+        let originals: Vec<blst_fp> = (0..n)
+            .map(|i| fp_sub(&affine[2 * i + 1].x, &affine[2 * i].x))
+            .collect();
+        let mut prefix = Vec::new();
+
+        // Raw field-op throughput, over arrays rather than a dependency chain.
+        let mut out = vec![blst_fp::default(); n];
+        let reps = 200;
+        let start = Instant::now();
+        for _ in 0..reps {
+            for i in 0..n {
+                out[i] = fp_mul(&affine[i].x, &affine[i].y);
+            }
+            std::hint::black_box(&out);
+        }
+        println!(
+            "fp_mul  array {:.1} ns",
+            start.elapsed().as_nanos() as f64 / (reps * n) as f64
+        );
+        let start = Instant::now();
+        for _ in 0..reps {
+            for i in 0..n {
+                out[i] = fp_sub(&affine[i].x, &affine[i].y);
+            }
+            std::hint::black_box(&out);
+        }
+        println!(
+            "fp_sub  array {:.1} ns",
+            start.elapsed().as_nanos() as f64 / (reps * n) as f64
+        );
+
+        for size in [128usize, 256, 512, 1024, 2048, 8192] {
+            let mut values = originals[..size].to_vec();
+            let reps = 400_000 / size;
+            let start = Instant::now();
+            for _ in 0..reps {
+                values.copy_from_slice(&originals[..size]);
+                batch_invert(&mut values, &mut prefix);
+                std::hint::black_box(&values);
+            }
+            let invert = start.elapsed().as_nanos() as f64 / (reps * size) as f64;
+            println!("batch_invert size={size:>5} {invert:.1} ns/element");
+        }
+
+        let mut values = originals;
+        batch_invert(&mut values, &mut prefix);
+        let mut out = vec![blst_p1_affine::default(); n];
+        let reps = 200;
+        let start = Instant::now();
+        for _ in 0..reps {
+            for i in 0..n {
+                out[i] = chord(&affine[2 * i], &affine[2 * i + 1], &values[i], false);
+            }
+            std::hint::black_box(&out);
+        }
+        let chord_cost = start.elapsed().as_nanos() as f64 / (reps * n) as f64;
+        println!("chord         {chord_cost:.1} ns/addition");
+    }
+
+    /// Where a large batch's time goes, phase by phase. Run with:
+    /// `cargo test -p commonware-cryptography --release --features bls12381 \
+    ///   subgroup::tests::measure_phases -- --ignored --nocapture`
+    #[test]
+    #[ignore = "manual benchmark"]
+    fn measure_phases() {
+        use std::time::Instant;
+        let mut rng = test_rng();
+        let n = 1_000_000usize;
+        let points: Vec<G1> = (0..n).map(|_| in_subgroup_point(&mut rng)).collect();
+        for pass in 0..2 {
+            let total = Instant::now();
+            let start = Instant::now();
+            let affine = to_affine(&points);
+            let converted = start.elapsed();
+            let start = Instant::now();
+            std::hint::black_box(G1::batch_to_affine(&points));
+            let blst_converted = start.elapsed();
+            let start = Instant::now();
+            let widths = plan(n, 81).expect("batched");
+            let mut trits = Trits::new(&mut rng);
+            let id_sets: Vec<(u32, Vec<u32>)> = widths
+                .iter()
+                .map(|&m| (m, trits.fill(m, affine.len())))
+                .collect();
+            let sampled = start.elapsed();
+            let start = Instant::now();
+            let mut round = Round::new(*widths.iter().max().expect("nonempty"));
+            let allocated = start.elapsed();
+            let start = Instant::now();
+            let ok = id_sets.iter().all(|(m, ids)| round.run(&affine, ids, *m));
+            let rounds = start.elapsed();
+            assert!(ok);
+            println!(
+                "pass={pass} to_affine={converted:?} (blst {blst_converted:?}) \
+                 sampling={sampled:?} alloc={allocated:?} rounds={rounds:?} total={:?}",
+                total.elapsed()
+            );
+        }
+    }
+
     /// Stage gate: isolated accumulator throughput. Run with:
     /// `cargo test -p commonware-cryptography --release --features bls12381 \
     ///   subgroup::tests::measure_accumulator -- --ignored --nocapture`
@@ -817,22 +1741,40 @@ mod tests {
     fn measure_accumulator() {
         use std::time::Instant;
         let mut rng = test_rng();
-        for n in [1000usize, 6000, 100_000] {
+        for n in [1000usize, 6000, 100_000, 1_000_000] {
             let points: Vec<G1> = (0..n).map(|_| in_subgroup_point(&mut rng)).collect();
+            let passes = if n > 500_000 { 3 } else { 20 };
+            let start = Instant::now();
+            for _ in 0..passes {
+                std::hint::black_box(G1::batch_to_affine(&points));
+            }
+            println!(
+                "n={n} batch_to_affine={:.0} ns/point",
+                start.elapsed().as_nanos() as f64 / (passes * n) as f64
+            );
             let affine = G1::batch_to_affine(&points);
-            let mut ids = vec![0u8; n];
-            rng.fill_bytes(&mut ids);
-            for num_buckets in [27usize, 81, 243] {
-                for id in &mut ids {
-                    *id %= num_buckets as u8;
+            for m in [6u32, 7, 8, 9] {
+                let ids = Trits::new(&mut rng).fill(m, n);
+                if 3usize.pow(m) > 4 * n {
+                    continue;
                 }
-                let reps = 50;
+                let mut round = Round::new(m);
+                round.widen(m);
+                let reps = if n > 500_000 { 3 } else { 20 };
                 let start = Instant::now();
                 for _ in 0..reps {
-                    std::hint::black_box(sum_buckets(&affine, &ids, num_buckets));
+                    round.accumulate(&affine, &ids);
+                    std::hint::black_box(&round.sums[0]);
                 }
-                let per_point = start.elapsed().as_nanos() as f64 / (reps * n) as f64;
-                println!("n={n} buckets={num_buckets} {per_point:.0} ns/point");
+                let accumulate = start.elapsed().as_nanos() as f64 / (reps * n) as f64;
+                let start = Instant::now();
+                for _ in 0..reps {
+                    std::hint::black_box(round.run(&affine, &ids, m));
+                }
+                let full = start.elapsed().as_nanos() as f64 / (reps * n) as f64;
+                println!(
+                    "n={n} m={m} accumulate={accumulate:.0} ns/point round={full:.0} ns/point"
+                );
             }
         }
     }
@@ -844,32 +1786,62 @@ mod tests {
     #[ignore = "manual benchmark"]
     fn measure_scheme() {
         use commonware_parallel::Rayon;
-        use std::{thread::available_parallelism, time::Instant};
+        use std::{thread::available_parallelism, time::Duration, time::Instant};
+
+        /// Best of three, which on a shared machine is the estimate least
+        /// contaminated by whatever else is running.
+        fn best(mut run: impl FnMut() -> Duration) -> Duration {
+            (0..3).map(|_| run()).min().expect("three runs")
+        }
+
         let threads = available_parallelism().unwrap();
         let rayon = Rayon::new(threads).unwrap();
         println!("threads = {threads}");
-        for n in [200usize, 1000, 6000, 100_000] {
+        for n in [200usize, 1000, 6000, 100_000, 300_000, 1_000_000, 3_000_000] {
             let mut rng = test_rng();
             let points: Vec<G1> = (0..n).map(|_| in_subgroup_point(&mut rng)).collect();
-            println!("n={n} plan={:?}", plan(n, combinations_for_security(128)));
-            let start = Instant::now();
-            assert!(points.iter().all(G1::in_subgroup));
-            println!("n={n} per_point_serial = {:?}", start.elapsed());
-            let start = Instant::now();
-            assert!(batch_in_g1(&points, 128, &Sequential, &mut test_rng()));
-            println!("n={n} batch_serial    = {:?}", start.elapsed());
-            let start = Instant::now();
-            assert!(batch_in_g1(&points, 128, &rayon, &mut test_rng()));
-            println!("n={n} batch_parallel  = {:?}", start.elapsed());
+            let widths = plan(n, combinations_for_security(128)).unwrap_or_default();
+            let mut distinct = widths.clone();
+            distinct.dedup();
+            println!("n={n} rounds={} widths={distinct:?}", widths.len());
+
+            // The per-point cost is exactly linear in n, so a bounded prefix
+            // measures it without spending a minute on the baseline alone.
+            let sample = n.min(20_000);
+            let per_point = best(|| {
+                let start = Instant::now();
+                assert!(points[..sample].iter().all(G1::in_subgroup));
+                start.elapsed()
+            })
+            .mul_f64(n as f64 / sample as f64);
+            println!("n={n} per_point_serial = {per_point:?}");
+            let serial = best(|| {
+                let start = Instant::now();
+                assert!(batch_in_g1(&points, 128, &Sequential, &mut test_rng()));
+                start.elapsed()
+            });
+            println!(
+                "n={n} batch_serial    = {serial:?} ({:.1}x)",
+                per_point.as_secs_f64() / serial.as_secs_f64()
+            );
+            let parallel = best(|| {
+                let start = Instant::now();
+                assert!(batch_in_g1(&points, 128, &rayon, &mut test_rng()));
+                start.elapsed()
+            });
+            println!(
+                "n={n} batch_parallel  = {parallel:?} ({:.1}x)",
+                per_point.as_secs_f64() / parallel.as_secs_f64()
+            );
         }
     }
 
     /// Compare the shipping scheme (C) against the two alternatives from
     /// `cryptography/BATCHED_SUBGROUP.md`, all on the same accumulation engine:
     /// A is one combination per round (m = 1, 81 rounds); B is random bucketing
-    /// with every bucket sum exact-checked (shared-inversion steelman). Run with:
-    /// `cargo test -p commonware-cryptography --release --features bls12381 \
-    ///   subgroup::tests::measure_strategies -- --ignored --nocapture`
+    /// with every bucket sum exact-checked (shared-inversion steelman). Run
+    /// with: `cargo test -p commonware-cryptography --release --features
+    /// bls12381 subgroup::tests::measure_strategies -- --ignored --nocapture`
     #[test]
     #[ignore = "manual benchmark"]
     fn measure_strategies() {
@@ -878,6 +1850,12 @@ mod tests {
         use std::{thread::available_parallelism, time::Instant};
 
         /// Strategy A/C with a forced width and round count.
+        ///
+        /// At `m = 1` this is not a fair rendering of A: three buckets leave at
+        /// most three additions in flight, so the shared inversion has nothing
+        /// to amortize over and the engine is the wrong one for the strategy. A
+        /// real A would accumulate in Jacobian coordinates (as blst's MSM
+        /// does); its cost is 81 passes over the points either way.
         fn forced(
             points: &[G1],
             m: u32,
@@ -887,44 +1865,49 @@ mod tests {
         ) -> bool {
             let affine = G1::batch_to_affine(points);
             let mut trits = Trits::new(rng);
-            let id_sets: Vec<Vec<u8>> = (0..rounds)
-                .map(|_| (0..points.len()).map(|_| trits.bucket(m)).collect())
+            let id_sets: Vec<Vec<u32>> = (0..rounds)
+                .map(|_| trits.fill(m, affine.len()))
                 .collect();
             strategy
-                .map_collect_vec_with_multiplier(id_sets.iter(), points.len(), |ids| {
-                    round_in_g1(&affine, ids, m)
-                })
+                .map_init_collect_vec_with_multiplier(
+                    id_sets.iter(),
+                    affine.len(),
+                    || Round::new(m),
+                    |round, ids| round.run(&affine, ids, m),
+                )
                 .into_iter()
                 .all(|in_subgroup| in_subgroup)
         }
 
-        /// Strategy B: `num_buckets` a power of two, every bucket sum checked.
+        /// Strategy B: `3^m` buckets, every bucket sum exact-checked.
         fn bucketed(
             points: &[G1],
-            num_buckets: usize,
+            m: u32,
             rounds: usize,
             strategy: &impl Strategy,
             rng: &mut impl CryptoRng,
         ) -> bool {
             let affine = G1::batch_to_affine(points);
-            let mask = (num_buckets - 1) as u8;
-            let id_sets: Vec<Vec<u8>> = (0..rounds)
-                .map(|_| {
-                    let mut ids = vec![0u8; points.len()];
-                    rng.fill_bytes(&mut ids);
-                    for id in &mut ids {
-                        *id &= mask;
-                    }
-                    ids
-                })
+            let mut trits = Trits::new(rng);
+            let id_sets: Vec<Vec<u32>> = (0..rounds)
+                .map(|_| trits.fill(m, affine.len()))
                 .collect();
             strategy
-                .map_collect_vec_with_multiplier(id_sets.iter(), points.len(), |ids| {
-                    sum_buckets(&affine, ids, num_buckets).iter().all(|sum| {
-                        // SAFETY: sum is a valid blst_p1_affine.
-                        affine_is_inf(sum) || unsafe { blst_p1_affine_in_g1(sum) }
-                    })
-                })
+                .map_init_collect_vec_with_multiplier(
+                    id_sets.iter(),
+                    affine.len(),
+                    || Round::new(m),
+                    |round, ids| {
+                        round.widen(m);
+                        round.accumulate(&affine, ids);
+                        (0..3usize.pow(m)).all(|bucket| {
+                            // SAFETY: the slot holds a valid affine point.
+                            !round.live[bucket] || unsafe {
+                                blst_p1_affine_in_g1(&round.sums[bucket])
+                            }
+                        })
+                    },
+                )
                 .into_iter()
                 .all(|in_subgroup| in_subgroup)
         }
@@ -945,30 +1928,21 @@ mod tests {
             let start = Instant::now();
             assert!(forced(&points, 1, 81, &rayon, &mut test_rng()));
             println!("n={n} A m=1 r=81 parallel = {:?}", start.elapsed());
-            // B: buckets with per-bucket checks, rounds = ceil(128 / log2 B).
-            for (num_buckets, rounds) in [(16usize, 32usize), (64, 22), (256, 16)] {
+            // B: buckets with per-bucket checks, rounds = ceil(81 / m).
+            for m in [2u32, 4, 6] {
+                let rounds = 81usize.div_ceil(m as usize);
                 let start = Instant::now();
-                assert!(bucketed(
-                    &points,
-                    num_buckets,
-                    rounds,
-                    &Sequential,
-                    &mut test_rng()
-                ));
+                assert!(bucketed(&points, m, rounds, &Sequential, &mut test_rng()));
                 println!(
-                    "n={n} B B={num_buckets:>3} r={rounds}   serial = {:?}",
+                    "n={n} B B={:>5} r={rounds}   serial = {:?}",
+                    3usize.pow(m),
                     start.elapsed()
                 );
                 let start = Instant::now();
-                assert!(bucketed(
-                    &points,
-                    num_buckets,
-                    rounds,
-                    &rayon,
-                    &mut test_rng()
-                ));
+                assert!(bucketed(&points, m, rounds, &rayon, &mut test_rng()));
                 println!(
-                    "n={n} B B={num_buckets:>3} r={rounds} parallel = {:?}",
+                    "n={n} B B={:>5} r={rounds} parallel = {:?}",
+                    3usize.pow(m),
                     start.elapsed()
                 );
             }

--- a/cryptography/src/bls12381/primitives/subgroup.rs
+++ b/cryptography/src/bls12381/primitives/subgroup.rs
@@ -140,10 +140,14 @@ const MAX_WIDTH: u32 = 11;
 /// Largest bucket-slot footprint a round should ask for, in bytes.
 ///
 /// Points arrive in random bucket order, so the accumulator's working set is
-/// the whole slot array. A wider round needs fewer passes over the points, but
-/// once its slots outgrow the cache every point pays a miss that the saved
-/// passes do not repay — measured here as a 20-35% jump in cost per addition
-/// one step past the budget. Two MiB holds `3^9` slots.
+/// the whole slot array, and a round's collapse workspace is half as large
+/// again. A wider round needs fewer passes over the points, but its slots pay
+/// for a deeper level of the memory hierarchy on every point — measured here as
+/// 8% more per addition one step past the budget and 15% two steps past — and
+/// its workspace grows threefold per step, per thread. Two MiB holds `3^9`
+/// slots, which is where the two stop trading well: at a million points, the
+/// widest plan the next step up allows measures within noise of the one chosen
+/// here while asking for an order of magnitude more memory.
 const SLOT_BUDGET: usize = 2 << 20;
 
 /// Approximate cost of one [`G1::in_subgroup`] check, in units of one
@@ -206,16 +210,26 @@ fn round_cost(n: usize, m: u32) -> usize {
     (n - occupied) + 2 * occupied + (m as usize) * CHECK_COST
 }
 
-/// Plan the rounds: one width per round, summing to at least `combinations`.
+/// Plan the rounds: one width per round, together covering `combinations`.
 ///
-/// Returns `None` if checking each point individually is cheaper. The widths of
-/// a plan differ by at most one, so a round count that does not divide
-/// `combinations` wastes no more than one combination — which matters, since
-/// the round count is what the batch pays for.
+/// Returns `None` if checking each point individually is cheaper.
 ///
 /// Soundness holds for every plan (a round of width `m` has error `3^-m`, and
 /// the widths sum to at least `combinations`), so the cost model's constants
 /// only affect performance.
+/// Spread `combinations` over `rounds` rounds as evenly as possible.
+///
+/// The widths differ by at most one, so a round count that does not divide the
+/// combinations wastes none of them — which matters, since the round count is
+/// what the batch pays for.
+fn spread(combinations: usize, rounds: usize) -> Vec<u32> {
+    let width = (combinations / rounds) as u32;
+    let wide = combinations % rounds;
+    (0..rounds)
+        .map(|round| if round < wide { width + 1 } else { width })
+        .collect()
+}
+
 fn plan(n: usize, combinations: usize) -> Option<Vec<u32>> {
     if combinations == 0 {
         return Some(Vec::new());
@@ -235,20 +249,17 @@ fn plan(n: usize, combinations: usize) -> Option<Vec<u32>> {
     let mut best_cost = n.saturating_mul(CHECK_COST);
     let mut best = None;
     for rounds in combinations.div_ceil(widest as usize)..=combinations {
-        let width = (combinations / rounds) as u32;
-        let wide = combinations % rounds;
-        // Spreading combinations evenly cannot push a round past `widest`: a
-        // round count that leaves a remainder also leaves `width < widest`.
-        debug_assert!(width < widest || wide == 0);
-        let cost = wide.saturating_mul(round_cost(n, width + 1))
-            + (rounds - wide).saturating_mul(round_cost(n, width));
+        let widths = spread(combinations, rounds);
+        // Spreading evenly cannot push a round past `widest`: a round count that
+        // leaves a remainder also leaves the base width below it.
+        debug_assert!(widths.iter().all(|&m| m <= widest));
+        let cost = widths
+            .iter()
+            .map(|&m| round_cost(n, m))
+            .fold(0usize, |total, cost| total.saturating_add(cost));
         if cost < best_cost {
             best_cost = cost;
-            best = Some(
-                (0..rounds)
-                    .map(|round| if round < wide { width + 1 } else { width })
-                    .collect(),
-            );
+            best = Some(widths);
         }
     }
     best
@@ -1295,6 +1306,28 @@ mod tests {
     }
 
     #[test]
+    fn spread_is_even_and_complete() {
+        for combinations in [1usize, 2, 7, 81, 128, 255] {
+            for rounds in 1..=combinations {
+                let widths = spread(combinations, rounds);
+                assert_eq!(widths.len(), rounds);
+                // Every combination is placed, and none is wasted.
+                assert_eq!(
+                    widths.iter().map(|&m| m as usize).sum::<usize>(),
+                    combinations
+                );
+                // Widths differ by at most one, widest first.
+                let (&first, &last) = (
+                    widths.first().expect("nonempty"),
+                    widths.last().expect("nonempty"),
+                );
+                assert!(first - last <= 1);
+                assert!(widths.windows(2).all(|pair| pair[0] >= pair[1]));
+            }
+        }
+    }
+
+    #[test]
     fn bucket_ids_are_in_range() {
         let mut rng = test_rng();
         let mut trits = Trits::new(&mut rng);
@@ -1540,6 +1573,286 @@ mod tests {
         }
     }
 
+
+    /// Stress the accumulator where collisions dominate: few buckets, many
+    /// points, and heavy duplication/cancellation.
+    #[test]
+    fn accumulator_stress_collisions() {
+        let mut rng = test_rng();
+        for &(n, m) in &[
+            (3000usize, 1u32),
+            (3000, 2),
+            (5000, 3),
+            (4000, 5),
+            (1, 1),
+            (2, 1),
+        ] {
+            // Pool of distinct points, reused heavily so doublings abound.
+            let pool: Vec<G1> = (0..8).map(|_| in_subgroup_point(&mut rng)).collect();
+            let bad: Vec<G1> = (0..3).map(|_| off_subgroup_point(&mut rng)).collect();
+            let mut points: Vec<G1> = Vec::with_capacity(n);
+            for i in 0..n {
+                let point = match i % 11 {
+                    0 => G1::zero(),
+                    1 => pool[i % pool.len()],
+                    2 => -pool[i % pool.len()],
+                    3 => bad[i % bad.len()],
+                    4 => -bad[i % bad.len()],
+                    5 => pool[0],
+                    6 => -pool[0],
+                    _ => in_subgroup_point(&mut rng),
+                };
+                points.push(point);
+            }
+            let ids = Trits::new(&mut rng).fill(m, n);
+            assert_sums_match(&points, &ids, m);
+        }
+    }
+
+    /// All points land in one bucket, so every pass but the first is pure
+    /// carry: the worst case for termination and for the doubling chain.
+    #[test]
+    fn accumulator_single_bucket() {
+        let mut rng = test_rng();
+        for &n in &[1usize, 2, 3, 7, 64, 1000, 3000] {
+            for m in [1u32, 2, 5] {
+                let p = in_subgroup_point(&mut rng);
+                // Same point repeated: every addition after the first is a
+                // doubling or a chord against a running multiple.
+                let points = vec![p; n];
+                let ids = vec![1u32; n];
+                assert_sums_match(&points, &ids, m);
+            }
+        }
+    }
+
+    /// A wide round with enough points to fill whole inversion chunks, so the
+    /// `is_full` flush path and the collapse chain both run at scale.
+    #[test]
+    fn accumulator_wide_round_chunks() {
+        let mut rng = test_rng();
+        for m in [4u32, 6, 7] {
+            let n = 6 * 3usize.pow(m);
+            let base: Vec<G1> = (0..64).map(|_| in_subgroup_point(&mut rng)).collect();
+            let points: Vec<G1> = (0..n)
+                .map(|i| match i % 5 {
+                    0 => base[i % base.len()],
+                    1 => -base[i % base.len()],
+                    2 => G1::zero(),
+                    _ => in_subgroup_point(&mut rng),
+                })
+                .collect();
+            let ids = Trits::new(&mut rng).fill(m, n);
+            assert_sums_match(&points, &ids, m);
+        }
+    }
+
+    /// Reuse one `Round` across widths, as the strategy does, and check the
+    /// combines still agree with a direct computation of each combination.
+    #[test]
+    fn combinations_match_direct() {
+        let mut rng = test_rng();
+        let widest = 4u32;
+        let mut round = Round::new(widest);
+        for m in [1u32, 3, 4, 2, 4, 1] {
+            let n = 400usize;
+            let points: Vec<G1> = (0..n)
+                .map(|i| match i % 6 {
+                    0 => G1::zero(),
+                    1 => off_subgroup_point(&mut rng),
+                    _ => in_subgroup_point(&mut rng),
+                })
+                .collect();
+            let ids = Trits::new(&mut rng).fill(m, n);
+            let (affine, affine_ids) = affine_with_ids(&points, &ids);
+            // Direct per-combination computation over the surviving points.
+            let mut expected_ok = true;
+            for j in 0..m {
+                let mut acc = G1::zero();
+                for (point, &id) in points.iter().zip(&ids) {
+                    let digit = (id / 3u32.pow(j)) % 3;
+                    for _ in 0..digit {
+                        acc += point;
+                    }
+                }
+                if !acc.in_subgroup() {
+                    expected_ok = false;
+                }
+            }
+            assert_eq!(
+                round.run(&affine, &affine_ids, m),
+                expected_ok,
+                "m={m} mismatch"
+            );
+        }
+    }
+
+
+    /// Randomized differential fuzz: every combination's exact value against a
+    /// direct computation, over adversarial id and point distributions.
+    #[test]
+    fn round_fuzz_against_direct() {
+        use commonware_utils::TestRng;
+        let mut round: Option<(u32, Round)> = None;
+        for seed in 0..400u64 {
+            let mut rng = TestRng::new(seed);
+            let m = 1 + (seed % 9) as u32;
+            let widest = 9u32;
+            let n = match seed % 7 {
+                0 => 1,
+                1 => 2,
+                2 => 17,
+                3 => 300,
+                4 => 3000,
+                5 => 9000,
+                _ => 1 + (seed as usize * 137) % 4000,
+            };
+            let pool: Vec<G1> = (0..4).map(|_| in_subgroup_point(&mut rng)).collect();
+            let points: Vec<G1> = (0..n)
+                .map(|i| match (i as u64 + seed) % 8 {
+                    0 => G1::zero(),
+                    1 => pool[i % pool.len()],
+                    2 => -pool[i % pool.len()],
+                    3 => pool[0],
+                    4 => -pool[0],
+                    _ => in_subgroup_point(&mut rng),
+                })
+                .collect();
+            // Id distributions: uniform, all-equal, and a tiny support.
+            let ids: Vec<u32> = match seed % 4 {
+                0 => Trits::new(&mut rng).fill(m, n),
+                1 => vec![(seed as u32) % 3u32.pow(m); n],
+                2 => (0..n).map(|i| (i as u32) % 3u32.min(3u32.pow(m))).collect(),
+                _ => Trits::new(&mut rng).fill(m, n),
+            };
+            let (affine, affine_ids) = affine_with_ids(&points, &ids);
+            let round = &mut round.get_or_insert_with(|| (widest, Round::new(widest))).1;
+            assert!(round.run(&affine, &affine_ids, m), "seed={seed} rejected");
+            let kept: Vec<G1> = points.iter().copied().filter(|p| p != &G1::zero()).collect();
+            assert_eq!(kept.len(), affine_ids.len());
+            for j in 0..m {
+                let mut expected = G1::zero();
+                for (point, &id) in kept.iter().zip(&affine_ids) {
+                    let digit = (id / 3u32.pow(j)) % 3;
+                    for _ in 0..digit {
+                        expected += point;
+                    }
+                }
+                let mut got = blst_p1::default();
+                if let Some(&twos) = round.marginals[2 * j as usize + 1].first() {
+                    let mut point = blst_p1::default();
+                    unsafe {
+                        blst_p1_from_affine(&mut point, &round.sums[twos as usize]);
+                        blst_p1_double(&mut got, &point);
+                    }
+                }
+                if let Some(&ones) = round.marginals[2 * j as usize].first() {
+                    unsafe {
+                        blst_p1_add_or_double_affine(&mut got, &got, &round.sums[ones as usize]);
+                    }
+                }
+                let mut got_affine = blst_p1_affine::default();
+                unsafe { blst::blst_p1_to_affine(&mut got_affine, &got) };
+                let expected_affine = G1::batch_to_affine(&[expected])[0];
+                assert_eq!(
+                    affine_is_inf(&got_affine),
+                    affine_is_inf(&expected_affine),
+                    "seed={seed} m={m} n={n} j={j} identity mismatch"
+                );
+                if !affine_is_inf(&got_affine) {
+                    assert_eq!(got_affine.x.l, expected_affine.x.l, "seed={seed} m={m} j={j}");
+                    assert_eq!(got_affine.y.l, expected_affine.y.l, "seed={seed} m={m} j={j}");
+                }
+            }
+        }
+    }
+
+    /// Chi-square-ish uniformity of drawn ids, per width and per position in
+    /// the word that produced them.
+    #[test]
+    fn trit_ids_are_uniform_per_position() {
+        let mut rng = test_rng();
+        for m in 1..=MAX_WIDTH {
+            let buckets = 3usize.pow(m) as usize;
+            if buckets > 6561 {
+                continue;
+            }
+            let per_word = (20 / m) as usize;
+            let target = 400usize;
+            let count = buckets * target;
+            let ids = Trits::new(&mut rng).fill(m, count);
+            let mut counts = vec![0usize; buckets];
+            let mut per_pos = vec![vec![0usize; buckets]; per_word];
+            for (i, &id) in ids.iter().enumerate() {
+                counts[id as usize] += 1;
+                per_pos[i % per_word][id as usize] += 1;
+            }
+            let chi: f64 = counts
+                .iter()
+                .map(|&c| {
+                    let d = c as f64 - target as f64;
+                    d * d / target as f64
+                })
+                .sum();
+            let df = (buckets - 1) as f64;
+            assert!(chi < df + 8.0 * (2.0 * df).sqrt(), "m={m} chi={chi} df={df}");
+            for (pos, counts) in per_pos.iter().enumerate() {
+                let expect = count as f64 / per_word as f64 / buckets as f64;
+                let chi: f64 = counts
+                    .iter()
+                    .map(|&c| {
+                        let d = c as f64 - expect;
+                        d * d / expect
+                    })
+                    .sum();
+                assert!(
+                    chi < df + 8.0 * (2.0 * df).sqrt(),
+                    "m={m} pos={pos} chi={chi} df={df}"
+                );
+            }
+        }
+    }
+
+
+    #[test]
+    fn accumulate_large_widths_match_naive() {
+        for seed in 0..3u64 {
+            let mut rng = commonware_utils::TestRng::new(seed);
+            for m in [8u32, 9] {
+                let n = 5 * 3usize.pow(m);
+                let pool: Vec<G1> = (0..16).map(|_| in_subgroup_point(&mut rng)).collect();
+                let points: Vec<G1> = (0..n)
+                    .map(|i| match i % 7 {
+                        0 => G1::zero(),
+                        1 => pool[i % pool.len()],
+                        2 => -pool[i % pool.len()],
+                        3 => pool[0],
+                        _ => in_subgroup_point(&mut rng),
+                    })
+                    .collect();
+                let ids = Trits::new(&mut rng).fill(m, n);
+                // Naive: one running G1 sum per bucket.
+                let mut expected = vec![G1::zero(); 3usize.pow(m)];
+                for (point, &id) in points.iter().zip(&ids) {
+                    expected[id as usize] += point;
+                }
+                let expected = G1::batch_to_affine(&expected);
+                let (affine, affine_ids) = affine_with_ids(&points, &ids);
+                let mut round = Round::new(m);
+                round.widen(m);
+                round.accumulate(&affine, &affine_ids);
+                for bucket in 0..3usize.pow(m) {
+                    let want_inf = affine_is_inf(&expected[bucket]);
+                    assert_eq!(round.live[bucket], !want_inf, "seed {seed} m {m} bucket {bucket} liveness");
+                    if !want_inf {
+                        assert_eq!(round.sums[bucket].x.l, expected[bucket].x.l, "seed {seed} m {m} bucket {bucket} x");
+                        assert_eq!(round.sums[bucket].y.l, expected[bucket].y.l, "seed {seed} m {m} bucket {bucket} y");
+                    }
+                }
+            }
+        }
+    }
+
     #[test]
     fn empty_batch_is_accepted() {
         assert!(batch_in_g1(&[], SECURITY, &Sequential, &mut test_rng()));
@@ -1735,6 +2048,58 @@ mod tests {
         println!("chord         {chord_cost:.1} ns/addition");
     }
 
+    /// Whether the cost model picks the cheapest plan. Run with:
+    /// `cargo test -p commonware-cryptography --release --features bls12381 \
+    ///   subgroup::tests::measure_plans -- --ignored --nocapture`
+    #[test]
+    #[ignore = "manual benchmark"]
+    fn measure_plans() {
+        use std::time::Instant;
+
+        /// Time the rounds of a forced plan, best of three.
+        fn timed(affine: &[blst_p1_affine], widths: &[u32], rng: &mut impl CryptoRng) -> f64 {
+            let widest = *widths.iter().max().expect("nonempty");
+            let mut round = Round::new(widest);
+            let best = (0..3)
+                .map(|_| {
+                    let mut trits = Trits::new(rng);
+                    let id_sets: Vec<(u32, Vec<u32>)> = widths
+                        .iter()
+                        .map(|&m| (m, trits.fill(m, affine.len())))
+                        .collect();
+                    let start = Instant::now();
+                    let ok = id_sets.iter().all(|(m, ids)| round.run(affine, ids, *m));
+                    assert!(ok);
+                    start.elapsed().as_micros()
+                })
+                .min()
+                .expect("three runs");
+            best as f64 / 1000.0
+        }
+
+        let mut rng = test_rng();
+        for n in [100_000usize, 1_000_000] {
+            let points: Vec<G1> = (0..n).map(|_| in_subgroup_point(&mut rng)).collect();
+            let affine = to_affine(&points);
+            let chosen = plan(n, 81).expect("batched");
+            // Compare the model's choice against its neighbours: the same
+            // combinations spread over one fewer and a few more rounds.
+            for rounds in chosen.len().saturating_sub(1)..=chosen.len() + 3 {
+                let widths = spread(81, rounds);
+                if widths.iter().any(|&m| m > MAX_WIDTH) {
+                    continue;
+                }
+                let mut distinct = widths.clone();
+                distinct.dedup();
+                println!(
+                    "n={n} rounds={rounds} widths={distinct:?} rounds_time={:.1} ms{}",
+                    timed(&affine, &widths, &mut rng),
+                    if widths == chosen { "  <- chosen by the model" } else { "" }
+                );
+            }
+        }
+    }
+
     /// Where a large batch's time goes, phase by phase. Run with:
     /// `cargo test -p commonware-cryptography --release --features bls12381 \
     ///   subgroup::tests::measure_phases -- --ignored --nocapture`
@@ -1796,7 +2161,7 @@ mod tests {
                 start.elapsed().as_nanos() as f64 / (passes * n) as f64
             );
             let affine = G1::batch_to_affine(&points);
-            for m in [6u32, 7, 8, 9] {
+            for m in [8u32, 9, 10, 11] {
                 let ids = Trits::new(&mut rng).fill(m, n);
                 if 3usize.pow(m) > 4 * n {
                     continue;

--- a/cryptography/src/bls12381/primitives/subgroup.rs
+++ b/cryptography/src/bls12381/primitives/subgroup.rs
@@ -125,10 +125,18 @@ const LOG2_3_SCALED_LOWER_BOUND: usize = 1584;
 ///
 /// Each combination has error at most `1/3`, so `t` of them give
 /// `3^-t <= 2^-security` once `t >= security / log2(3)` (81 at 128-bit).
+///
+/// The scaling is done in `u128` and saturates upward, so an absurd target asks
+/// for more combinations than any batch can afford — which falls back to
+/// per-point checking — rather than silently asking for fewer.
 const fn combinations_for_security(security: usize) -> usize {
-    security
-        .saturating_mul(1000)
-        .div_ceil(LOG2_3_SCALED_LOWER_BOUND)
+    let scaled = (security as u128) * 1000;
+    let combinations = scaled.div_ceil(LOG2_3_SCALED_LOWER_BOUND as u128);
+    if combinations > usize::MAX as u128 {
+        usize::MAX
+    } else {
+        combinations as usize
+    }
 }
 
 /// Largest supported number of parallel combinations per round.
@@ -210,13 +218,6 @@ fn round_cost(n: usize, m: u32) -> usize {
     (n - occupied) + 2 * occupied + (m as usize) * CHECK_COST
 }
 
-/// Plan the rounds: one width per round, together covering `combinations`.
-///
-/// Returns `None` if checking each point individually is cheaper.
-///
-/// Soundness holds for every plan (a round of width `m` has error `3^-m`, and
-/// the widths sum to at least `combinations`), so the cost model's constants
-/// only affect performance.
 /// Spread `combinations` over `rounds` rounds as evenly as possible.
 ///
 /// The widths differ by at most one, so a round count that does not divide the
@@ -230,6 +231,34 @@ fn spread(combinations: usize, rounds: usize) -> Vec<u32> {
         .collect()
 }
 
+/// Modeled cost of the plan that spreads `combinations` over `rounds` rounds,
+/// or `None` if that spread needs a round wider than `widest`.
+fn plan_cost(n: usize, combinations: usize, rounds: usize, widest: u32) -> Option<usize> {
+    let width = (combinations / rounds) as u32;
+    let wide = combinations % rounds;
+    if width + u32::from(wide > 0) > widest {
+        return None;
+    }
+    Some(
+        wide.saturating_mul(round_cost(n, width + 1))
+            .saturating_add((rounds - wide).saturating_mul(round_cost(n, width))),
+    )
+}
+
+/// Plan the rounds: one width per round, together covering `combinations`.
+///
+/// Returns `None` if checking each point individually is cheaper.
+///
+/// Only a couple of round counts per width can be worth considering. Round
+/// counts sharing a base width form a contiguous band, and within a band the
+/// modeled cost is linear in the round count, so an optimum always sits at a
+/// band's edge — which keeps the search proportional to the widths available
+/// rather than to the combinations required, and so bounded whatever soundness
+/// target a caller asks for.
+///
+/// Soundness holds for every plan (a round of width `m` has error `3^-m`, and
+/// the widths sum to `combinations`), so the cost model's constants only affect
+/// performance.
 fn plan(n: usize, combinations: usize) -> Option<Vec<u32>> {
     if combinations == 0 {
         return Some(Vec::new());
@@ -243,26 +272,26 @@ fn plan(n: usize, combinations: usize) -> Option<Vec<u32>> {
     {
         widest += 1;
     }
-    if widest == 0 {
-        return None;
-    }
     let mut best_cost = n.saturating_mul(CHECK_COST);
     let mut best = None;
-    for rounds in combinations.div_ceil(widest as usize)..=combinations {
-        let widths = spread(combinations, rounds);
-        // Spreading evenly cannot push a round past `widest`: a round count that
-        // leaves a remainder also leaves the base width below it.
-        debug_assert!(widths.iter().all(|&m| m <= widest));
-        let cost = widths
-            .iter()
-            .map(|&m| round_cost(n, m))
-            .fold(0usize, |total, cost| total.saturating_add(cost));
-        if cost < best_cost {
-            best_cost = cost;
-            best = Some(widths);
+    for width in 1..=widest as usize {
+        // The round counts whose spread has base width `width`, which is where
+        // the modeled cost is linear.
+        let band = [combinations / (width + 1) + 1, combinations / width];
+        for rounds in band {
+            if rounds == 0 || rounds > combinations {
+                continue;
+            }
+            let Some(cost) = plan_cost(n, combinations, rounds, widest) else {
+                continue;
+            };
+            if cost < best_cost {
+                best_cost = cost;
+                best = Some(rounds);
+            }
         }
     }
-    best
+    best.map(|rounds| spread(combinations, rounds))
 }
 
 /// Verify that every point in `points` lies in the prime-order subgroup G1,
@@ -539,12 +568,15 @@ impl Round {
                 }
             }
             if let Some(&ones) = self.marginals[2 * j].first() {
-                // SAFETY: both operands are valid; the routine handles the
-                // identity and equal operands, and permits out == a.
+                // Copied rather than passed twice: handing the same local out
+                // as both `&mut` and `&` would alias.
+                let twos = combination;
+                // SAFETY: all operands are valid blst values, the identity
+                // included, and the routine handles equal operands.
                 unsafe {
                     blst_p1_add_or_double_affine(
                         &mut combination,
-                        &combination,
+                        &twos,
                         &self.sums[ones as usize],
                     );
                 }
@@ -886,7 +918,9 @@ fn prefix_inverse(values: &[blst_fp], prefix: &mut Vec<blst_fp>) -> Option<blst_
 
 /// Hint that `slots[index]` will be read soon.
 ///
-/// A point spans two cache lines, and the caller reads both.
+/// A point spans two cache lines, and the caller reads both. This is only a
+/// hint, so a target without one is slower here, never wrong; aarch64's
+/// prefetch intrinsics are still unstable, so it goes without.
 #[inline(always)]
 fn prefetch(slots: &[blst_p1_affine], index: usize) {
     let _ = (slots, index);
@@ -899,16 +933,6 @@ fn prefetch(slots: &[blst_p1_affine], index: usize) {
         unsafe {
             _mm_prefetch(base, _MM_HINT_T0);
             _mm_prefetch(base.wrapping_add(64), _MM_HINT_T0);
-        }
-    }
-    #[cfg(target_arch = "aarch64")]
-    {
-        use core::arch::aarch64::{_PREFETCH_LOCALITY3, _PREFETCH_READ, _prefetch};
-        let base = slots.as_ptr().wrapping_add(index).cast::<i8>();
-        // SAFETY: _prefetch never dereferences its argument.
-        unsafe {
-            _prefetch::<_PREFETCH_READ, _PREFETCH_LOCALITY3>(base);
-            _prefetch::<_PREFETCH_READ, _PREFETCH_LOCALITY3>(base.wrapping_add(64));
         }
     }
 }
@@ -1306,6 +1330,69 @@ mod tests {
     }
 
     #[test]
+    fn plan_matches_exhaustive_search() {
+        // The search only visits the edges of each base-width band, on the
+        // argument that the modeled cost is linear inside one. Check that
+        // against the exhaustive search it replaces.
+        for combinations in [1usize, 2, 5, 37, 81, 128, 200] {
+            for n in [0usize, 1, 7, 130, 200, 999, 1000, 6000, 20_000, 100_000, 400_000] {
+                let mut widest = 0u32;
+                while widest < MAX_WIDTH
+                    && 3usize.pow(widest + 1) <= 4 * n.max(1)
+                    && 3usize.pow(widest + 1) * size_of::<blst_p1_affine>() <= SLOT_BUDGET
+                {
+                    widest += 1;
+                }
+                let mut best = (n.saturating_mul(CHECK_COST), None);
+                for rounds in 1..=combinations {
+                    let Some(cost) = plan_cost(n, combinations, rounds, widest) else {
+                        continue;
+                    };
+                    if cost < best.0 {
+                        best = (cost, Some(rounds));
+                    }
+                }
+                let exhaustive = best.1.map(|rounds| spread(combinations, rounds));
+                let got = plan(n, combinations);
+                // Equal cost is enough; ties may be broken differently.
+                match (&got, &exhaustive) {
+                    (None, None) => {}
+                    (Some(got), Some(exhaustive)) => {
+                        let cost = |widths: &[u32]| {
+                            widths.iter().map(|&m| round_cost(n, m)).sum::<usize>()
+                        };
+                        assert_eq!(
+                            cost(got),
+                            cost(exhaustive),
+                            "n={n} c={combinations}: {got:?} vs {exhaustive:?}"
+                        );
+                    }
+                    _ => panic!("n={n} c={combinations}: {got:?} vs {exhaustive:?}"),
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn plan_is_bounded_for_absurd_targets() {
+        // `security` is a caller-supplied parameter with no upper bound, so the
+        // search must not grow with it. These return promptly, and ask for
+        // per-point checking rather than a plan that is short of the target.
+        for security in [1_000_000usize, usize::MAX / 2, usize::MAX] {
+            let combinations = combinations_for_security(security);
+            assert!(combinations >= security / 2, "saturated downward");
+            for n in [1000usize, 100_000] {
+                assert_eq!(plan(n, combinations), None);
+            }
+        }
+        // The scaling never rounds down below the target either.
+        for security in [1usize, 40, 128, 1000, 100_000] {
+            let combinations = combinations_for_security(security);
+            assert!((combinations as f64) * 3f64.log2() >= security as f64);
+        }
+    }
+
+    #[test]
     fn spread_is_even_and_complete() {
         for combinations in [1usize, 2, 7, 81, 128, 255] {
             for rounds in 1..=combinations {
@@ -1347,6 +1434,64 @@ mod tests {
         // Expected 1000 per id; the window is ~6.7 standard deviations wide.
         for &count in &counts {
             assert!((800..1200).contains(&count), "{counts:?}");
+        }
+    }
+
+    #[test]
+    fn coefficients_are_uniform_and_independent() {
+        // Exact uniformity of every coefficient is soundness-bearing, and the
+        // sampler packs several ids into one drawn word, so a skew could hide in
+        // one digit position or in the correlation between two of them rather
+        // than in the ids overall. Windows below are ~6 standard deviations.
+        const DRAWS: usize = 90_000;
+        let mut rng = test_rng();
+        for m in [5u32, 9, 10] {
+            // Drawing in one call and in many small ones exercise different
+            // word-boundary behaviour; both must be unbiased.
+            for batch in [DRAWS, 7] {
+                let mut trits = Trits::new(&mut rng);
+                let mut ids = Vec::with_capacity(DRAWS);
+                while ids.len() < DRAWS {
+                    ids.extend(trits.fill(m, batch.min(DRAWS - ids.len())));
+                }
+                let mut digits = vec![[0usize; 3]; m as usize];
+                let mut pairs = vec![[0usize; 9]; m as usize - 1];
+                for id in ids {
+                    assert!(id < 3u32.pow(m));
+                    let mut value = id;
+                    let mut previous = None;
+                    for (position, counts) in digits.iter_mut().enumerate() {
+                        let digit = (value % 3) as usize;
+                        value /= 3;
+                        counts[digit] += 1;
+                        if let Some(previous) = previous {
+                            pairs[position - 1][previous * 3 + digit] += 1;
+                        }
+                        previous = Some(digit);
+                    }
+                }
+                for (position, counts) in digits.iter().enumerate() {
+                    let expected = DRAWS / 3;
+                    let window = 6 * ((DRAWS * 2 / 9) as f64).sqrt() as usize;
+                    for &count in counts {
+                        assert!(
+                            count.abs_diff(expected) < window,
+                            "m={m} batch={batch} digit {position} skewed: {counts:?}"
+                        );
+                    }
+                }
+                for (position, counts) in pairs.iter().enumerate() {
+                    let expected = DRAWS / 9;
+                    let window = 6 * ((DRAWS * 8 / 81) as f64).sqrt() as usize;
+                    for &count in counts {
+                        assert!(
+                            count.abs_diff(expected) < window,
+                            "m={m} batch={batch} digits {position},{} correlated: {counts:?}",
+                            position + 1
+                        );
+                    }
+                }
+            }
         }
     }
 
@@ -1687,7 +1832,6 @@ mod tests {
         }
     }
 
-
     /// Randomized differential fuzz: every combination's exact value against a
     /// direct computation, over adversarial id and point distributions.
     #[test]
@@ -1738,20 +1882,32 @@ mod tests {
                         expected += point;
                     }
                 }
+                // Rebuild the combination from the round's marginals exactly
+                // as `run` does, so a wiring bug shows up as a value mismatch.
                 let mut got = blst_p1::default();
                 if let Some(&twos) = round.marginals[2 * j as usize + 1].first() {
                     let mut point = blst_p1::default();
+                    // SAFETY: the index names a live affine point, and blst_p1
+                    // defaults to the identity.
                     unsafe {
                         blst_p1_from_affine(&mut point, &round.sums[twos as usize]);
                         blst_p1_double(&mut got, &point);
                     }
                 }
                 if let Some(&ones) = round.marginals[2 * j as usize].first() {
+                    let doubled = got;
+                    // SAFETY: all operands are valid blst values, the identity
+                    // included, and the routine handles equal operands.
                     unsafe {
-                        blst_p1_add_or_double_affine(&mut got, &got, &round.sums[ones as usize]);
+                        blst_p1_add_or_double_affine(
+                            &mut got,
+                            &doubled,
+                            &round.sums[ones as usize],
+                        );
                     }
                 }
                 let mut got_affine = blst_p1_affine::default();
+                // SAFETY: both pointers reference valid blst values.
                 unsafe { blst::blst_p1_to_affine(&mut got_affine, &got) };
                 let expected_affine = G1::batch_to_affine(&[expected])[0];
                 assert_eq!(
@@ -1773,7 +1929,7 @@ mod tests {
     fn trit_ids_are_uniform_per_position() {
         let mut rng = test_rng();
         for m in 1..=MAX_WIDTH {
-            let buckets = 3usize.pow(m) as usize;
+            let buckets = 3usize.pow(m);
             if buckets > 6561 {
                 continue;
             }
@@ -1813,7 +1969,8 @@ mod tests {
         }
     }
 
-
+    /// The widest plans the cost model can pick, checked bucket by bucket
+    /// against a naive running sum.
     #[test]
     fn accumulate_large_widths_match_naive() {
         for seed in 0..3u64 {
@@ -1841,12 +1998,16 @@ mod tests {
                 let mut round = Round::new(m);
                 round.widen(m);
                 round.accumulate(&affine, &affine_ids);
-                for bucket in 0..3usize.pow(m) {
-                    let want_inf = affine_is_inf(&expected[bucket]);
-                    assert_eq!(round.live[bucket], !want_inf, "seed {seed} m {m} bucket {bucket} liveness");
-                    if !want_inf {
-                        assert_eq!(round.sums[bucket].x.l, expected[bucket].x.l, "seed {seed} m {m} bucket {bucket} x");
-                        assert_eq!(round.sums[bucket].y.l, expected[bucket].y.l, "seed {seed} m {m} bucket {bucket} y");
+                for (bucket, expected) in expected.iter().enumerate() {
+                    let empty = affine_is_inf(expected);
+                    assert_eq!(
+                        round.live[bucket], !empty,
+                        "seed={seed} m={m} bucket {bucket} liveness"
+                    );
+                    if !empty {
+                        let got = round.sums[bucket];
+                        assert_eq!(got.x.l, expected.x.l, "seed={seed} m={m} bucket {bucket} x");
+                        assert_eq!(got.y.l, expected.y.l, "seed={seed} m={m} bucket {bucket} y");
                     }
                 }
             }

--- a/cryptography/src/bls12381/primitives/subgroup.rs
+++ b/cryptography/src/bls12381/primitives/subgroup.rs
@@ -224,6 +224,7 @@ fn round_cost(n: usize, m: u32) -> usize {
 /// combinations wastes none of them — which matters, since the round count is
 /// what the batch pays for.
 fn spread(combinations: usize, rounds: usize) -> Vec<u32> {
+    debug_assert!(combinations / rounds <= MAX_WIDTH as usize);
     let width = (combinations / rounds) as u32;
     let wide = combinations % rounds;
     (0..rounds)
@@ -234,11 +235,14 @@ fn spread(combinations: usize, rounds: usize) -> Vec<u32> {
 /// Modeled cost of the plan that spreads `combinations` over `rounds` rounds,
 /// or `None` if that spread needs a round wider than `widest`.
 fn plan_cost(n: usize, combinations: usize, rounds: usize, widest: u32) -> Option<usize> {
-    let width = (combinations / rounds) as u32;
+    // Compared before narrowing, so a round count far too small to be usable is
+    // rejected rather than wrapping into a plausible-looking width.
+    let width = combinations / rounds;
     let wide = combinations % rounds;
-    if width + u32::from(wide > 0) > widest {
+    if width + usize::from(wide > 0) > widest as usize {
         return None;
     }
+    let width = width as u32;
     Some(
         wide.saturating_mul(round_cost(n, width + 1))
             .saturating_add((rounds - wide).saturating_mul(round_cost(n, width))),
@@ -300,6 +304,9 @@ fn plan(n: usize, combinations: usize) -> Option<Vec<u32>> {
 /// The points must already be valid curve points (for example decoded with
 /// [`G1::read_unchecked`]); this establishes only subgroup membership. An empty
 /// slice is accepted.
+///
+/// A `security` of zero asks for no soundness at all — an error of `2^0` — and
+/// accepts without examining the points; every positive target examines them.
 ///
 /// `rng` must be a cryptographically secure source the prover cannot predict:
 /// the coefficients are the verifier's private randomness, exactly as in a
@@ -2084,16 +2091,41 @@ mod tests {
 
     #[test]
     fn wide_rounds_agree_with_per_point() {
-        // A batch large enough for the cost model to pick a wide round, so the
-        // collapse chain runs at full depth.
+        // A batch large enough for the cost model to pick its widest round, so
+        // the collapse chain runs at full depth end to end. The points are
+        // drawn from a small pool and cycled, both to keep the batch cheap to
+        // build and because the duplicates stress the doubling path.
         let mut rng = test_rng();
-        let n = 20_000;
+        let n = 100_000;
         let widths = plan(n, 81).expect("batched");
-        assert!(widths[0] >= 7, "expected a wide plan, got {widths:?}");
-        let mut points: Vec<G1> = (0..n).map(|_| in_subgroup_point(&mut rng)).collect();
+        let widest = 3usize.pow(*widths.iter().max().expect("nonempty"))
+            * size_of::<blst_p1_affine>();
+        assert!(
+            widest * 3 > SLOT_BUDGET,
+            "expected the budget to bind, got {widths:?}"
+        );
+        let pool: Vec<G1> = (0..64).map(|_| in_subgroup_point(&mut rng)).collect();
+        let mut points: Vec<G1> = (0..n).map(|i| pool[i % pool.len()]).collect();
         assert!(batch_in_g1(&points, SECURITY, &Sequential, &mut rng));
         points[n - 1] = off_subgroup_point(&mut rng);
         assert!(!batch_in_g1(&points, SECURITY, &Sequential, &mut rng));
+    }
+
+    #[test]
+    fn zero_security_accepts_without_checking() {
+        // An error bound of 2^0 is no bound, so the check is entitled to accept
+        // anything. Pin it, so the boundary is a decision rather than an
+        // accident, and pin that the very next target does examine the points.
+        let mut rng = test_rng();
+        let bad: Vec<G1> = (0..LARGE).map(|_| off_subgroup_point(&mut rng)).collect();
+        assert_eq!(combinations_for_security(0), 0);
+        assert_eq!(plan(bad.len(), 0), Some(Vec::new()));
+        assert!(batch_in_g1(&bad, 0, &Sequential, &mut rng));
+        // One bit of soundness is still one round: rejection is then only
+        // probable, so the certain part is that a round runs at all.
+        assert_eq!(combinations_for_security(1), 1);
+        assert_eq!(plan(bad.len(), 1).map(|widths| widths.len()), Some(1));
+        assert!(!batch_in_g1(&bad, SECURITY, &Sequential, &mut rng));
     }
 
     #[test]

--- a/cryptography/src/bls12381/primitives/subgroup.rs
+++ b/cryptography/src/bls12381/primitives/subgroup.rs
@@ -1422,6 +1422,49 @@ mod tests {
         // An all-identity batch converts to nothing.
         assert!(to_affine(&[G1::zero()]).is_empty());
         assert!(to_affine(&[]).is_empty());
+
+        // Decoded points are already normalized and take the fast path; mixing
+        // them with projective ones must keep the shared inversion in step.
+        let mixed: Vec<G1> = points
+            .iter()
+            .enumerate()
+            .map(|(index, point)| {
+                // The wire format has no infinity that decodes back, so the
+                // identities in the batch stay as they are.
+                if index % 3 == 0 && point != &G1::zero() {
+                    G1::read_unchecked(&mut point.encode().as_ref()).expect("decodes")
+                } else {
+                    *point
+                }
+            })
+            .collect();
+        let expected: Vec<blst_p1_affine> = G1::batch_to_affine(&mixed)
+            .into_iter()
+            .filter(|point| !affine_is_inf(point))
+            .collect();
+        let got = to_affine(&mixed);
+        assert_eq!(got.len(), expected.len());
+        for (got, expected) in got.iter().zip(&expected) {
+            assert_eq!(got.x.l, expected.x.l);
+            assert_eq!(got.y.l, expected.y.l);
+        }
+    }
+
+    #[test]
+    fn decoded_points_are_accepted() {
+        // The batch a caller actually has: points decoded from the wire, which
+        // arrive normalized and so skip the affine conversion's inversion.
+        let mut rng = test_rng();
+        let mut points: Vec<G1> = (0..LARGE)
+            .map(|_| {
+                let point = in_subgroup_point(&mut rng);
+                G1::read_unchecked(&mut point.encode().as_ref()).expect("decodes")
+            })
+            .collect();
+        assert!(points.iter().all(|point| fp_is_one(&point.as_blst_p1().z)));
+        assert!(batch_in_g1(&points, SECURITY, &Sequential, &mut rng));
+        points[LARGE / 4] = off_subgroup_point(&mut rng);
+        assert!(!batch_in_g1(&points, SECURITY, &Sequential, &mut rng));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Significantly improves the performance of batched subgroup membership verification for BLS12-381 by implementing Strategy C: parallel base-3 combinations with deterministic evaluation. This reduces the per-point amortized cost from ~52 µs (serial exact checks) to sub-microsecond levels for large batches.

## Key Changes

- **Rewrote subgroup batch verification algorithm** (`subgroup.rs`): Replaced the single-combination-per-round approach with a parallel m-combination strategy that evaluates multiple base-3 digit combinations in a single accumulation pass over the point set. Each point lands in exactly one bucket per pass, enabling efficient amortized checking.

- **Deterministic combination evaluation**: Replaced randomized re-randomization with deterministic digit-weighted sums (`Q_j = Σ_{v_j=1} S_v + 2·Σ_{v_j=2} S_v`), ensuring exact evaluation of all m combinations while keeping randomness only in point-to-bucket assignment.

- **Improved coefficient sampling**: Changed from byte-based rejection sampling (`bytes < 243`) to word-based sampling (`words < 3²⁰`) for drawing base-3 trits, reducing rejection overhead while maintaining the required uniformity margin.

- **Updated documentation** (`BATCHED_SUBGROUP.md`): Revised performance baselines to reflect measurements on a 4-core Intel Xeon (2.8 GHz) instead of Apple Silicon, updated cost model (52 µs per check, 43 ns per field multiplication, 344 ns per batch-affine addition), and clarified why Strategy B (naive bucketing) was rejected despite fewer accumulation passes.

- **Exposed internal API** (`group.rs`): Added `as_blst_p1()` accessor for borrowing the underlying `blst_p1` representation, enabling efficient low-level operations in the batch verification implementation.

- **Updated benchmarks** (`subgroup.rs` benches): Simplified benchmark harness by removing `BatchSize` criterion parameter, added documentation explaining batch size selection rationale.

## Implementation Details

The key insight is that m parallel combinations can share a single accumulation pass: points are assigned to buckets based on their m base-3 digits (trits), all buckets are summed in one pass, and the m combinations are evaluated deterministically from the bucket sums. This reduces the check count from `81 × n` (Strategy A) to roughly `⌈128/log₂(3^m)⌉ × n` while keeping accumulation cost constant.

The coefficient uniformity margin of 0.38 bits is load-bearing; the implementation uses rejection sampling on 20-trit words to maintain the required distribution properties and prevent small-subgroup escape.

https://claude.ai/code/session_01C2LCw7n1LqEty7HQeHP2xp