### PR TITLE
[runtime] Batch the recoverable-prefix page scan

### DIFF
--- a/runtime/src/utils/buffer/paged/writer.rs
+++ b/runtime/src/utils/buffer/paged/writer.rs
@@ -1333,6 +1333,91 @@ mod tests {
         });
     }
 
+    /// The scan advances across multiple read batches on a clean blob longer than the
+    /// per-batch page count.
+    #[test_traced("DEBUG")]
+    fn test_recoverable_prefix_len_multi_batch() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context: deterministic::Context| async move {
+            let (blob, blob_size) = context
+                .open("test_partition", b"prefix_batches")
+                .await
+                .unwrap();
+            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
+            let mut writer = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref)
+                .await
+                .unwrap();
+
+            // Eight full pages plus a partial tail spans three SCAN_PAGES = 3 batches.
+            let total = PAGE_SIZE.get() as usize * 8 + 10;
+            let data: Vec<u8> = (0u8..=255).cycle().take(total).collect();
+            writer.append(&data).await.unwrap();
+            writer.sync().await.unwrap();
+
+            assert_eq!(writer.recoverable_prefix_len().await.unwrap(), total as u64);
+        });
+    }
+
+    /// A batch read that extends past the physical end of the blob falls back to per-page
+    /// reads, which find the stale-short page that ends the prefix before reaching the
+    /// missing region.
+    #[test_traced("DEBUG")]
+    fn test_recoverable_prefix_len_short_tail_fallback() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context: deterministic::Context| async move {
+            let (blob, blob_size) = context
+                .open("test_partition", b"prefix_short_tail")
+                .await
+                .unwrap();
+            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
+            let mut writer = Writer::new(blob.clone(), blob_size, BUFFER_SIZE, cache_ref)
+                .await
+                .unwrap();
+            let physical_page_size = PAGE_SIZE.get() as u64 + CHECKSUM_SIZE;
+
+            // Persist three full pages plus a partial fourth and capture the partial
+            // page's physical bytes.
+            let data: Vec<u8> = (0u8..=255)
+                .cycle()
+                .take(PAGE_SIZE.get() as usize * 6)
+                .collect();
+            writer
+                .append(&data[..PAGE_SIZE.get() as usize * 3 + 20])
+                .await
+                .unwrap();
+            writer.sync().await.unwrap();
+            let stale = blob
+                .read_at(
+                    physical_page_size * 3,
+                    physical_page_size as usize,
+                    ReadOptions::default(),
+                )
+                .await
+                .unwrap()
+                .coalesce();
+            let stale = stale.as_ref().to_vec();
+
+            // Extend to six full pages, persist, then restore page 3 to its stale partial
+            // state and cut the blob mid page 4, as if the extension mostly never reached
+            // disk. The second scan batch (pages 3..6) now extends past the physical end.
+            writer
+                .append(&data[PAGE_SIZE.get() as usize * 3 + 20..])
+                .await
+                .unwrap();
+            writer.sync().await.unwrap();
+            blob.write_at(physical_page_size * 3, stale, WriteOptions::default())
+                .await
+                .unwrap();
+            blob.resize(physical_page_size * 4 + 10).await.unwrap();
+            blob.sync().await.unwrap();
+
+            assert_eq!(
+                writer.recoverable_prefix_len().await.unwrap(),
+                PAGE_SIZE.get() as u64 * 3 + 20
+            );
+        });
+    }
+
     #[test_traced("DEBUG")]
     fn test_read_many_into_empty() {
         let executor = deterministic::Runner::default();

--- a/runtime/src/utils/buffer/paged/writer.rs
+++ b/runtime/src/utils/buffer/paged/writer.rs
@@ -883,32 +883,78 @@ impl<B: Blob> Writer<B> {
     /// Expects all appended bytes to have reached the blob (as after recovery): a partial page
     /// still buffered in this writer is unreadable from the blob and fails the scan.
     pub async fn recoverable_prefix_len(&self) -> Result<u64, Error> {
+        /// Physical pages fetched per blob read while scanning. Batched reads keep the
+        /// scan bounded by read throughput rather than per-page round trips. Small in
+        /// tests so ordinary blobs exercise batch boundaries.
+        #[cfg(not(test))]
+        const SCAN_PAGES: u64 = 256;
+        #[cfg(test)]
+        const SCAN_PAGES: u64 = 3;
         let logical_page_size = self.cache_ref.page_size();
+        let physical_page_size = logical_page_size
+            .checked_add(CHECKSUM_SIZE)
+            .ok_or(Error::OffsetOverflow)?;
         let total_pages = self.current_page + u64::from(self.partial_page_state.is_some());
         let mut valid_len = 0u64;
-        for page in 0..total_pages {
+        let mut page = 0u64;
+        while page < total_pages {
+            let batch = SCAN_PAGES.min(total_pages - page);
+            let start = page
+                .checked_mul(physical_page_size)
+                .ok_or(Error::OffsetOverflow)?;
+            let len = batch
+                .checked_mul(physical_page_size)
+                .ok_or(Error::OffsetOverflow)?;
             // Recovery may replay the validated prefix immediately, so use the
             // default cache policy.
-            match super::get_page_with_checksum_from_blob(
-                &self.blob,
-                page,
-                logical_page_size,
-                ReadOptions::default(),
-            )
-            .await
-            {
-                Ok((logical, _)) => {
-                    let len = logical.len() as u64;
-                    valid_len += len;
-                    // A partial page can only legitimately be the last one, so stop here.
-                    if len < logical_page_size {
-                        break;
+            let Ok(buf) = self
+                .blob
+                .read_at(start, len as usize, ReadOptions::default())
+                .await
+            else {
+                // A batch read can fail on a physically short tail that per-page
+                // validation would never reach (an earlier page in the batch may
+                // already end the prefix), so fall back to per-page reads.
+                for page in page..page + batch {
+                    match super::get_page_with_checksum_from_blob(
+                        &self.blob,
+                        page,
+                        logical_page_size,
+                        ReadOptions::default(),
+                    )
+                    .await
+                    {
+                        Ok((logical, _)) => {
+                            let len = logical.len() as u64;
+                            valid_len += len;
+                            // A partial page can only legitimately be the last one, so
+                            // stop here.
+                            if len < logical_page_size {
+                                return Ok(valid_len);
+                            }
+                        }
+                        // First torn/invalid page: the contiguous valid prefix ends here.
+                        Err(Error::InvalidChecksum) => return Ok(valid_len),
+                        Err(err) => return Err(err),
                     }
                 }
+                page += batch;
+                continue;
+            };
+            let buf = buf.coalesce();
+            for chunk in buf.as_ref().chunks(physical_page_size as usize) {
                 // First torn/invalid page: the contiguous valid prefix ends here.
-                Err(Error::InvalidChecksum) => break,
-                Err(err) => return Err(err),
+                let Some(checksum) = Checksum::validate_page(chunk) else {
+                    return Ok(valid_len);
+                };
+                let len = u64::from(checksum.len);
+                valid_len += len;
+                // A partial page can only legitimately be the last one, so stop here.
+                if len < logical_page_size {
+                    return Ok(valid_len);
+                }
             }
+            page += batch;
         }
         Ok(valid_len)
     }


### PR DESCRIPTION
## Summary

`Writer::recoverable_prefix_len` validated pages one blob read at a time, so scanning a large blob cost one blocking round trip per 4KB page. On a 105.8GB QMDB database, the variable journal's open path spent about 16 seconds in this scan (the two newest blobs hold about 1.1GB each, roughly 540k sequential single-page reads), all of it single-threaded before any other init work could start.

This change fetches 256 physical pages per blob read and validates them in memory, turning the scan into a read-throughput problem. A batch read can fail on a physically short tail that per-page validation would never reach (an earlier page in the batch may already end the prefix), so that case falls back to the original per-page scan, preserving its exact semantics.

`SCAN_PAGES` shrinks under `cfg(test)` so ordinary test blobs exercise batch boundaries and the fallback path.

## Benchmarks

QMDB init on a 105.8GB Ethereum replay seed (AMD EPYC 9354P), identical binaries except this change, three configurations:

| init_concurrency | before | after |
|---|---|---|
| 8 | 104.1s | 99.8s |
| 16 | 65.8s | 59.1s |
| 32 | 54.7s | 50.1s |

The open-phase scan itself went from about 16s to about 3s. These runs read from a warm OS page cache; a cold or disk-bound open benefits proportionally more, since the round trips it removes are true device reads there.

### Criterion init microbenchmarks

The qmdb `init` criterion group (1M operations, all 48 variant and cache-size cases, AMD EPYC 9354P) improves on every case: 6.5% to 17.2% faster than main, strongest on fixed-value variants with a warm location cache. This path runs on every open, so the win applies to the serial init path as well as the parallel one.

## Validation

The runtime paged-buffer suite (including the recoverable-prefix tests, which now cross batch boundaries via the reduced test constant) and the storage variable-journal and journal recovery suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q4BFdANo2LhVEr2ko3FK9n

