### PR TITLE
[runtime, storage] Coalesce batched page faults

### DIFF
--- a/runtime/src/utils/buffer/paged/cache.rs
+++ b/runtime/src/utils/buffer/paged/cache.rs
@@ -26,6 +26,12 @@ use tracing::{debug, error, trace};
 /// while still coalescing the sequential misses common to bulk cold reads.
 const MAX_FAULT_RUN_PAGES: usize = 64;
 
+/// Maximum runs fetched concurrently (and admitted per lock acquisition) by
+/// [`CacheRef::fetch_pages_after_faults`]. Bounds the scratch memory held in flight, the
+/// concurrent blob reads dispatched, and how long one admission holds the cache write lock
+/// against concurrent readers.
+const MAX_FAULT_WAVE_RUNS: usize = 8;
+
 /// Shared future for one logical page fetch. The output uses `Arc<Error>` because `Shared`
 /// requires cloneable results. The `IoBuf` contains only the logical, validated page bytes.
 type PageFetchFuture = Shared<Pin<Box<dyn Future<Output = Result<IoBuf, Arc<Error>>> + Send>>>;
@@ -479,48 +485,52 @@ impl CacheRef {
             }
         }
 
-        // Read all runs concurrently and validate each page's checksum before admission.
-        let fetched = try_join_all(runs.iter().map(|&(start, len)| async move {
-            let offset = start
-                .checked_mul(physical_page_size)
-                .ok_or(Error::OffsetOverflow)?;
-            let read_len = len
-                .checked_mul(physical_page_size as usize)
-                .ok_or(Error::OffsetOverflow)?;
-            let bytes = blob
-                .read_at(offset, read_len, ReadOptions::DONT_CACHE)
-                .await?
-                .coalesce();
-            for i in 0..len {
-                let page = &bytes.as_ref()[i * physical_page_size as usize..]
-                    [..physical_page_size as usize];
-                let Some(checksum) = Checksum::validate_page(page) else {
-                    error!(page_num = start + i as u64, "page fetch failed checksum");
-                    return Err(Error::InvalidChecksum);
-                };
-                // Only full logical pages are cacheable. A non-last page falling back to a
-                // partial CRC indicates corruption, mirroring the single-page fetch path.
-                if checksum.len as u64 != self.page_size {
-                    error!(
-                        page_num = start + i as u64,
-                        expected = self.page_size,
-                        actual = checksum.len,
-                        "attempted to fetch partial page from blob"
-                    );
-                    return Err(Error::InvalidChecksum);
-                }
-            }
-            Ok(bytes)
-        }))
-        .await?;
-
-        // Admit every fetched page under a single lock acquisition.
+        // Fetch runs in bounded waves: each wave reads its runs concurrently, validates
+        // every page's checksum, and admits the wave under one lock acquisition. The bound
+        // caps the scratch buffers held in flight, the concurrent blob reads dispatched,
+        // and how long one admission blocks concurrent readers on the cache lock.
         let page_size = self.page_size as usize;
-        let mut cache = self.cache.write();
-        for (&(start, len), bytes) in runs.iter().zip(&fetched) {
-            for i in 0..len {
-                let page = &bytes.as_ref()[i * physical_page_size as usize..][..page_size];
-                cache.cache(blob_id, page, start + i as u64);
+        for wave in runs.chunks(MAX_FAULT_WAVE_RUNS) {
+            let fetched = try_join_all(wave.iter().map(|&(start, len)| async move {
+                let offset = start
+                    .checked_mul(physical_page_size)
+                    .ok_or(Error::OffsetOverflow)?;
+                let read_len = len
+                    .checked_mul(physical_page_size as usize)
+                    .ok_or(Error::OffsetOverflow)?;
+                let bytes = blob
+                    .read_at(offset, read_len, ReadOptions::DONT_CACHE)
+                    .await?
+                    .coalesce();
+                for i in 0..len {
+                    let page = &bytes.as_ref()[i * physical_page_size as usize..]
+                        [..physical_page_size as usize];
+                    let Some(checksum) = Checksum::validate_page(page) else {
+                        error!(page_num = start + i as u64, "page fetch failed checksum");
+                        return Err(Error::InvalidChecksum);
+                    };
+                    // Only full logical pages are cacheable. A non-last page falling back to a
+                    // partial CRC indicates corruption, mirroring the single-page fetch path.
+                    if checksum.len as u64 != self.page_size {
+                        error!(
+                            page_num = start + i as u64,
+                            expected = self.page_size,
+                            actual = checksum.len,
+                            "attempted to fetch partial page from blob"
+                        );
+                        return Err(Error::InvalidChecksum);
+                    }
+                }
+                Ok(bytes)
+            }))
+            .await?;
+
+            let mut cache = self.cache.write();
+            for (&(start, len), bytes) in wave.iter().zip(&fetched) {
+                for i in 0..len {
+                    let page = &bytes.as_ref()[i * physical_page_size as usize..][..page_size];
+                    cache.cache(blob_id, page, start + i as u64);
+                }
             }
         }
 

--- a/runtime/src/utils/buffer/paged/cache.rs
+++ b/runtime/src/utils/buffer/paged/cache.rs
@@ -21,15 +21,18 @@ use std::{
 };
 use tracing::{debug, error, trace};
 
-/// Maximum consecutive pages fetched per blob read by [`CacheRef::fetch_pages_after_faults`].
-/// Bounds the per-run scratch buffer (pages are copied into pooled cache buffers on admission)
-/// while still coalescing the sequential misses common to bulk cold reads.
+/// Maximum consecutive pages fetched per blob read by [`CacheRef::fetch_pages_after_faults`]. At
+/// the common 4KiB page size a full run is a ~256KiB read, which already sits on the flat region of
+/// NVMe sequential-read efficiency: larger reads grow the per-run scratch buffer (pages are copied
+/// into pooled cache buffers on admission) without materially improving throughput, and smaller
+/// ones pay more dispatches per byte. Throughput is insensitive to this value near that plateau, so
+/// it is a constant rather than configuration.
 const MAX_FAULT_RUN_PAGES: usize = 64;
 
 /// Maximum runs fetched concurrently (and admitted per lock acquisition) by
-/// [`CacheRef::fetch_pages_after_faults`]. Bounds the scratch memory held in flight, the
-/// concurrent blob reads dispatched, and how long one admission holds the cache write lock
-/// against concurrent readers.
+/// [`CacheRef::fetch_pages_after_faults`]. Bounds the scratch memory held in flight (about 2MiB at
+/// 4KiB pages), the concurrent blob reads dispatched, and how long one admission holds the cache
+/// write lock against concurrent readers.
 const MAX_FAULT_WAVE_RUNS: usize = 8;
 
 /// Shared future for one logical page fetch. The output uses `Arc<Error>` because `Shared`
@@ -443,9 +446,9 @@ impl CacheRef {
     }
 
     /// Fetch the pages of `page_nums` absent from the cache and admit them, coalescing runs of
-    /// consecutive pages into single blob reads. `page_nums` must be strictly increasing, and
-    /// every page must lie below the owning view's in-memory tail (so it is a full logical page
-    /// on disk). One read-lock acquisition probes the whole batch for pages already cached.
+    /// consecutive pages into single blob reads. `page_nums` must be strictly increasing, and every
+    /// page must lie below the owning view's in-memory tail (so it is a full logical page on disk).
+    /// One read-lock acquisition probes the whole batch for pages already cached.
     ///
     /// Unlike [`Self::read_after_page_fault`], concurrent fetches of the same page are not
     /// deduplicated: racing fetches admit identical bytes, so bulk callers trade an occasional
@@ -470,9 +473,9 @@ impl CacheRef {
             .checked_add(CHECKSUM_SIZE)
             .ok_or(Error::OffsetOverflow)?;
 
-        // Split the sorted pages into runs of consecutive pages, each served by one blob read.
-        // Runs are capped so one run's scratch buffer stays modest even when a large batch of
-        // adjacent pages misses at once.
+        // Split the sorted pages into runs of consecutive pages, each served by one blob read. Runs
+        // are capped so one run's scratch buffer stays modest even when a large batch of adjacent
+        // pages misses at once.
         let mut runs: Vec<(u64, usize)> = Vec::new();
         for &page_num in &page_nums {
             match runs.last_mut() {
@@ -485,10 +488,10 @@ impl CacheRef {
             }
         }
 
-        // Fetch runs in bounded waves: each wave reads its runs concurrently, validates
-        // every page's checksum, and admits the wave under one lock acquisition. The bound
-        // caps the scratch buffers held in flight, the concurrent blob reads dispatched,
-        // and how long one admission blocks concurrent readers on the cache lock.
+        // Fetch runs in bounded waves: each wave reads its runs concurrently, validates every
+        // page's checksum, and admits the wave under one lock acquisition. The bound caps the
+        // scratch buffers held in flight, the concurrent blob reads dispatched, and how long one
+        // admission blocks concurrent readers on the cache lock.
         let page_size = self.page_size as usize;
         for wave in runs.chunks(MAX_FAULT_WAVE_RUNS) {
             let fetched = try_join_all(wave.iter().map(|&(start, len)| async move {
@@ -509,6 +512,7 @@ impl CacheRef {
                         error!(page_num = start + i as u64, "page fetch failed checksum");
                         return Err(Error::InvalidChecksum);
                     };
+
                     // Only full logical pages are cacheable. A non-last page falling back to a
                     // partial CRC indicates corruption, mirroring the single-page fetch path.
                     if checksum.len as u64 != self.page_size {

--- a/runtime/src/utils/buffer/paged/cache.rs
+++ b/runtime/src/utils/buffer/paged/cache.rs
@@ -468,8 +468,8 @@ impl CacheRef {
             return Ok(());
         }
         trace!(pages = page_nums.len(), blob_id, "bulk page fault");
-        let physical_page_size = self
-            .page_size
+        let page_size_u64: u64 = self.page_size.widen();
+        let physical_page_size = page_size_u64
             .checked_add(CHECKSUM_SIZE)
             .ok_or(Error::OffsetOverflow)?;
 
@@ -492,7 +492,7 @@ impl CacheRef {
         // page's checksum, and admits the wave under one lock acquisition. The bound caps the
         // scratch buffers held in flight, the concurrent blob reads dispatched, and how long one
         // admission blocks concurrent readers on the cache lock.
-        let page_size = self.page_size as usize;
+        let page_size: usize = self.page_size.widen();
         for wave in runs.chunks(MAX_FAULT_WAVE_RUNS) {
             let fetched = try_join_all(wave.iter().map(|&(start, len)| async move {
                 let offset = start
@@ -515,10 +515,10 @@ impl CacheRef {
 
                     // Only full logical pages are cacheable. A non-last page falling back to a
                     // partial CRC indicates corruption, mirroring the single-page fetch path.
-                    if checksum.len as u64 != self.page_size {
+                    if u64::from(checksum.len) != page_size_u64 {
                         error!(
                             page_num = start + i as u64,
-                            expected = self.page_size,
+                            expected = page_size_u64,
                             actual = checksum.len,
                             "attempted to fetch partial page from blob"
                         );

--- a/runtime/src/utils/buffer/paged/cache.rs
+++ b/runtime/src/utils/buffer/paged/cache.rs
@@ -1,11 +1,14 @@
 //! A page cache for caching _logical_ pages of [Blob] data in memory. The cache is unaware of the
 //! physical page format used by the blob, which is left to the blob implementation.
 
-use super::{CHECKSUM_SIZE, STORAGE_PAGE_SIZE, get_page_from_blob};
+use super::{CHECKSUM_SIZE, Checksum, STORAGE_PAGE_SIZE, get_page_from_blob};
 use crate::{Blob, BufferPool, BufferPooler, Error, IoBuf, IoBufMut, ReadOptions};
 use ahash::AHashMap;
 use commonware_utils::{Widen, cache::Clock, sync::RwLock};
-use futures::{FutureExt, future::Shared};
+use futures::{
+    FutureExt,
+    future::{Shared, try_join_all},
+};
 use std::{
     collections::hash_map::Entry,
     future::Future,
@@ -17,6 +20,11 @@ use std::{
     },
 };
 use tracing::{debug, error, trace};
+
+/// Maximum consecutive pages fetched per blob read by [`CacheRef::fetch_pages_after_faults`].
+/// Bounds the per-run scratch buffer (pages are copied into pooled cache buffers on admission)
+/// while still coalescing the sequential misses common to bulk cold reads.
+const MAX_FAULT_RUN_PAGES: usize = 64;
 
 /// Shared future for one logical page fetch. The output uses `Arc<Error>` because `Shared`
 /// requires cloneable results. The `IoBuf` contains only the logical, validated page bytes.
@@ -426,6 +434,97 @@ impl CacheRef {
             .copy_from_slice(&page_buf.as_ref()[offset_in_page..offset_in_page + bytes_to_copy]);
 
         Ok(bytes_to_copy)
+    }
+
+    /// Fetch the pages of `page_nums` absent from the cache and admit them, coalescing runs of
+    /// consecutive pages into single blob reads. `page_nums` must be strictly increasing, and
+    /// every page must lie below the owning view's in-memory tail (so it is a full logical page
+    /// on disk). One read-lock acquisition probes the whole batch for pages already cached.
+    ///
+    /// Unlike [`Self::read_after_page_fault`], concurrent fetches of the same page are not
+    /// deduplicated: racing fetches admit identical bytes, so bulk callers trade an occasional
+    /// duplicate blob read for skipping the per-page fetch bookkeeping (a shared future and two
+    /// cache lock acquisitions per page).
+    pub(super) async fn fetch_pages_after_faults<B: Blob>(
+        &self,
+        blob: &B,
+        blob_id: u64,
+        mut page_nums: Vec<u64>,
+    ) -> Result<(), Error> {
+        {
+            let cache = self.cache.read();
+            page_nums.retain(|&page_num| cache.get_page(blob_id, page_num).is_none());
+        }
+        if page_nums.is_empty() {
+            return Ok(());
+        }
+        trace!(pages = page_nums.len(), blob_id, "bulk page fault");
+        let physical_page_size = self
+            .page_size
+            .checked_add(CHECKSUM_SIZE)
+            .ok_or(Error::OffsetOverflow)?;
+
+        // Split the sorted pages into runs of consecutive pages, each served by one blob read.
+        // Runs are capped so one run's scratch buffer stays modest even when a large batch of
+        // adjacent pages misses at once.
+        let mut runs: Vec<(u64, usize)> = Vec::new();
+        for &page_num in &page_nums {
+            match runs.last_mut() {
+                Some((start, len))
+                    if *len < MAX_FAULT_RUN_PAGES && page_num == *start + *len as u64 =>
+                {
+                    *len += 1;
+                }
+                _ => runs.push((page_num, 1)),
+            }
+        }
+
+        // Read all runs concurrently and validate each page's checksum before admission.
+        let fetched = try_join_all(runs.iter().map(|&(start, len)| async move {
+            let offset = start
+                .checked_mul(physical_page_size)
+                .ok_or(Error::OffsetOverflow)?;
+            let read_len = len
+                .checked_mul(physical_page_size as usize)
+                .ok_or(Error::OffsetOverflow)?;
+            let bytes = blob
+                .read_at(offset, read_len, ReadOptions::DONT_CACHE)
+                .await?
+                .coalesce();
+            for i in 0..len {
+                let page = &bytes.as_ref()[i * physical_page_size as usize..]
+                    [..physical_page_size as usize];
+                let Some(checksum) = Checksum::validate_page(page) else {
+                    error!(page_num = start + i as u64, "page fetch failed checksum");
+                    return Err(Error::InvalidChecksum);
+                };
+                // Only full logical pages are cacheable. A non-last page falling back to a
+                // partial CRC indicates corruption, mirroring the single-page fetch path.
+                if checksum.len as u64 != self.page_size {
+                    error!(
+                        page_num = start + i as u64,
+                        expected = self.page_size,
+                        actual = checksum.len,
+                        "attempted to fetch partial page from blob"
+                    );
+                    return Err(Error::InvalidChecksum);
+                }
+            }
+            Ok(bytes)
+        }))
+        .await?;
+
+        // Admit every fetched page under a single lock acquisition.
+        let page_size = self.page_size as usize;
+        let mut cache = self.cache.write();
+        for (&(start, len), bytes) in runs.iter().zip(&fetched) {
+            for i in 0..len {
+                let page = &bytes.as_ref()[i * physical_page_size as usize..][..page_size];
+                cache.cache(blob_id, page, start + i as u64);
+            }
+        }
+
+        Ok(())
     }
 
     /// Cache the provided pages of data in the page cache, returning the remaining bytes that

--- a/runtime/src/utils/buffer/paged/cache.rs
+++ b/runtime/src/utils/buffer/paged/cache.rs
@@ -7,7 +7,8 @@ use ahash::AHashMap;
 use commonware_utils::{Widen, cache::Clock, sync::RwLock};
 use futures::{
     FutureExt,
-    future::{Shared, try_join_all},
+    future::Shared,
+    stream::{self, StreamExt},
 };
 use std::{
     collections::hash_map::Entry,
@@ -21,7 +22,7 @@ use std::{
 };
 use tracing::{debug, error, trace};
 
-/// Maximum consecutive pages fetched per blob read by [`CacheRef::fetch_pages_after_faults`]. At
+/// Maximum consecutive pages fetched per blob read by [`CacheRef::read_many_after_faults`]. At
 /// the common 4KiB page size a full run is a ~256KiB read, which already sits on the flat region of
 /// NVMe sequential-read efficiency: larger reads grow the per-run scratch buffer (pages are copied
 /// into pooled cache buffers on admission) without materially improving throughput, and smaller
@@ -29,11 +30,16 @@ use tracing::{debug, error, trace};
 /// it is a constant rather than configuration.
 const MAX_FAULT_RUN_PAGES: usize = 64;
 
-/// Maximum runs fetched concurrently (and admitted per lock acquisition) by
-/// [`CacheRef::fetch_pages_after_faults`]. Bounds the scratch memory held in flight (about 2MiB at
-/// 4KiB pages), the concurrent blob reads dispatched, and how long one admission holds the cache
-/// write lock against concurrent readers.
+/// Maximum concurrent runs in a bulk read. Bounds scratch memory (about 2MiB at 4KiB
+/// pages). A completed run frees a slot immediately, without waiting for its peers.
 const MAX_FAULT_WAVE_RUNS: usize = 8;
+
+/// The part of one output range that falls within a missing page.
+struct ReadTarget<'a> {
+    page: u64,
+    offset: usize,
+    buf: &'a mut [u8],
+}
 
 /// Shared future for one logical page fetch. The output uses `Arc<Error>` because `Shared`
 /// requires cloneable results. The `IoBuf` contains only the logical, validated page bytes.
@@ -445,99 +451,112 @@ impl CacheRef {
         Ok(bytes_to_copy)
     }
 
-    /// Fetch the pages of `page_nums` absent from the cache and admit them, coalescing runs of
-    /// consecutive pages into single blob reads. `page_nums` must be strictly increasing, and every
-    /// page must lie below the owning view's in-memory tail (so it is a full logical page on disk).
-    /// One read-lock acquisition probes the whole batch for pages already cached.
-    ///
-    /// Unlike [`Self::read_after_page_fault`], concurrent fetches of the same page are not
-    /// deduplicated: racing fetches admit identical bytes, so bulk callers trade an occasional
-    /// duplicate blob read for skipping the per-page fetch bookkeeping (a shared future and two
-    /// cache lock acquisitions per page).
-    pub(super) async fn fetch_pages_after_faults<B: Blob>(
+    /// Fill sorted, non-overlapping ranges from cached bytes and coalesced page faults.
+    /// Every range must lie below the view's in-memory tail, in full immutable pages.
+    /// Fetched bytes go directly to their output slots before the source buffer is released,
+    /// so cache eviction cannot force those pages to be read again.
+    pub(super) async fn read_many_after_faults<B: Blob>(
         &self,
         blob: &B,
         blob_id: u64,
-        mut page_nums: Vec<u64>,
+        ranges: Vec<(&mut [u8], u64)>,
     ) -> Result<(), Error> {
+        let mut targets = Vec::new();
         {
             let cache = self.cache.read();
-            page_nums.retain(|&page_num| cache.get_page(blob_id, page_num).is_none());
+            for (mut buf, mut offset) in ranges {
+                while !buf.is_empty() {
+                    let (page, in_page, remaining) = Cache::locate(self.page_size, offset);
+                    let len = remaining.min(buf.len());
+                    let (target, rest) = buf.split_at_mut(len);
+                    if let Some(cached) = cache.get_page(blob_id, page) {
+                        target.copy_from_slice(&cached.as_ref()[in_page..in_page + len]);
+                    } else {
+                        targets.push(ReadTarget {
+                            page,
+                            offset: in_page,
+                            buf: target,
+                        });
+                    }
+                    offset += len as u64;
+                    buf = rest;
+                }
+            }
         }
-        if page_nums.is_empty() {
+        if targets.is_empty() {
             return Ok(());
         }
-        trace!(pages = page_nums.len(), blob_id, "bulk page fault");
-        let page_size_u64: u64 = self.page_size.widen();
-        let physical_page_size = page_size_u64
-            .checked_add(CHECKSUM_SIZE)
-            .ok_or(Error::OffsetOverflow)?;
 
-        // Split the sorted pages into runs of consecutive pages, each served by one blob read. Runs
-        // are capped so one run's scratch buffer stays modest even when a large batch of adjacent
-        // pages misses at once.
-        let mut runs: Vec<(u64, usize)> = Vec::new();
-        for &page_num in &page_nums {
+        // Each run records its first page, page count, and number of destination fragments.
+        // Multiple items on one page share a single physical read.
+        let mut runs: Vec<(u64, usize, usize)> = Vec::new();
+        for target in &targets {
             match runs.last_mut() {
-                Some((start, len))
-                    if *len < MAX_FAULT_RUN_PAGES && page_num == *start + *len as u64 =>
+                Some((start, pages, count))
+                    if target.page - *start <= *pages as u64
+                        && target.page - *start < MAX_FAULT_RUN_PAGES as u64 =>
                 {
-                    *len += 1;
+                    *pages = (target.page - *start) as usize + 1;
+                    *count += 1;
                 }
-                _ => runs.push((page_num, 1)),
+                _ => runs.push((target.page, 1, 1)),
             }
         }
-
-        // Fetch runs in bounded waves: each wave reads its runs concurrently, validates every
-        // page's checksum, and admits the wave under one lock acquisition. The bound caps the
-        // scratch buffers held in flight, the concurrent blob reads dispatched, and how long one
-        // admission blocks concurrent readers on the cache lock.
+        trace!(runs = runs.len(), blob_id, "bulk page fault");
         let page_size: usize = self.page_size.widen();
-        for wave in runs.chunks(MAX_FAULT_WAVE_RUNS) {
-            let fetched = try_join_all(wave.iter().map(|&(start, len)| async move {
-                let offset = start
-                    .checked_mul(physical_page_size)
-                    .ok_or(Error::OffsetOverflow)?;
-                let read_len = len
-                    .checked_mul(physical_page_size as usize)
-                    .ok_or(Error::OffsetOverflow)?;
-                let bytes = blob
-                    .read_at(offset, read_len, ReadOptions::DONT_CACHE)
-                    .await?
-                    .coalesce();
-                for i in 0..len {
-                    let page = &bytes.as_ref()[i * physical_page_size as usize..]
-                        [..physical_page_size as usize];
-                    let Some(checksum) = Checksum::validate_page(page) else {
-                        error!(page_num = start + i as u64, "page fetch failed checksum");
-                        return Err(Error::InvalidChecksum);
-                    };
-
-                    // Only full logical pages are cacheable. A non-last page falling back to a
-                    // partial CRC indicates corruption, mirroring the single-page fetch path.
-                    if u64::from(checksum.len) != page_size_u64 {
-                        error!(
-                            page_num = start + i as u64,
-                            expected = page_size_u64,
-                            actual = checksum.len,
-                            "attempted to fetch partial page from blob"
-                        );
-                        return Err(Error::InvalidChecksum);
+        let physical_page_size = page_size + CHECKSUM_SIZE as usize;
+        let mut remaining = targets.as_mut_slice();
+        let mut reads = stream::iter(runs)
+            .map(move |(start, len, count)| {
+                let (targets, rest) = std::mem::take(&mut remaining).split_at_mut(count);
+                remaining = rest;
+                async move {
+                    let offset = start
+                        .checked_mul(physical_page_size as u64)
+                        .ok_or(Error::OffsetOverflow)?;
+                    let read_len = len
+                        .checked_mul(physical_page_size)
+                        .ok_or(Error::OffsetOverflow)?;
+                    let bytes = blob
+                        .read_at(offset, read_len, ReadOptions::DONT_CACHE)
+                        .await?
+                        .coalesce();
+                    for (i, page) in bytes.as_ref().chunks_exact(physical_page_size).enumerate() {
+                        let Some(checksum) = Checksum::validate_page(page) else {
+                            error!(page_num = start + i as u64, "page fetch failed checksum");
+                            return Err(Error::InvalidChecksum);
+                        };
+                        if usize::from(checksum.len) != page_size {
+                            error!(
+                                page_num = start + i as u64,
+                                expected = page_size,
+                                actual = checksum.len,
+                                "attempted to fetch partial page from blob"
+                            );
+                            return Err(Error::InvalidChecksum);
+                        }
                     }
-                }
-                Ok(bytes)
-            }))
-            .await?;
 
-            let mut cache = self.cache.write();
-            for (&(start, len), bytes) in wave.iter().zip(&fetched) {
-                for i in 0..len {
-                    let page = &bytes.as_ref()[i * physical_page_size as usize..][..page_size];
-                    cache.cache(blob_id, page, start + i as u64);
+                    // Consume the validated source directly, including when this run alone is
+                    // larger than the cache. No cache lookup is needed after admission.
+                    for target in targets {
+                        let begin =
+                            (target.page - start) as usize * physical_page_size + target.offset;
+                        target
+                            .buf
+                            .copy_from_slice(&bytes.as_ref()[begin..begin + target.buf.len()]);
+                    }
+                    let mut cache = self.cache.write();
+                    for (i, page) in bytes.as_ref().chunks_exact(physical_page_size).enumerate() {
+                        cache.cache(blob_id, &page[..page_size], start + i as u64);
+                    }
+                    Ok(())
                 }
-            }
+            })
+            .buffer_unordered(MAX_FAULT_WAVE_RUNS);
+        while let Some(result) = reads.next().await {
+            result?;
         }
-
         Ok(())
     }
 

--- a/runtime/src/utils/buffer/paged/cache.rs
+++ b/runtime/src/utils/buffer/paged/cache.rs
@@ -32,7 +32,7 @@ const MAX_FAULT_RUN_PAGES: usize = 64;
 
 /// Maximum concurrent runs in a bulk read. Bounds scratch memory (about 2MiB at 4KiB
 /// pages). A completed run frees a slot immediately, without waiting for its peers.
-const MAX_FAULT_WAVE_RUNS: usize = 8;
+const MAX_CONCURRENT_FAULT_RUNS: usize = 8;
 
 /// The part of one output range that falls within a missing page.
 struct ReadTarget<'a> {
@@ -553,7 +553,7 @@ impl CacheRef {
                     Ok(())
                 }
             })
-            .buffer_unordered(MAX_FAULT_WAVE_RUNS);
+            .buffer_unordered(MAX_CONCURRENT_FAULT_RUNS);
         while let Some(result) = reads.next().await {
             result?;
         }

--- a/runtime/src/utils/buffer/paged/sealed.rs
+++ b/runtime/src/utils/buffer/paged/sealed.rs
@@ -701,6 +701,137 @@ mod tests {
         });
     }
 
+    /// A cold `Sealed::read_many_into` fetches the missing pages in coalesced runs and admits
+    /// them, so a subsequent sync probe of the same offsets is a full hit.
+    #[test_traced("DEBUG")]
+    fn test_sealed_read_many_into_bulk_cold() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context: deterministic::Context| async move {
+            let (blob, blob_size) = context.open("test_partition", b"rmany_bulk").await.unwrap();
+            let cache_ref =
+                super::CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
+            let mut append = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref.clone())
+                .await
+                .unwrap();
+
+            let page_size = PAGE_SIZE.get() as usize;
+            let data: Vec<u8> = (0u8..=255).cycle().take(page_size * 6).collect();
+            append.append(&data).await.unwrap();
+            let (sealed, sync) = append.seal().await.unwrap();
+            sync.await.unwrap();
+
+            // Drop pages admitted during the writer's flushes so the batch read is cold.
+            cache_ref.clear();
+
+            // Multiple items per page across two runs of consecutive pages (0-2 and 4-5),
+            // including one straddling the page 1 / page 2 boundary.
+            let offsets: Vec<u64> = [
+                0,
+                50,
+                page_size,
+                page_size * 2 - 2,
+                page_size * 4,
+                page_size * 4 + 60,
+                page_size * 5 + 10,
+            ]
+            .into_iter()
+            .map(|o| o as u64)
+            .collect();
+            let item_size = 4usize;
+            let mut out = vec![0u8; offsets.len() * item_size];
+            sealed
+                .read_many_into(&mut out, &offsets, NZUsize!(item_size))
+                .await
+                .unwrap();
+
+            for (i, &off) in offsets.iter().enumerate() {
+                assert_eq!(
+                    &out[i * item_size..(i + 1) * item_size],
+                    &data[off as usize..off as usize + item_size],
+                );
+            }
+
+            // Every touched page was admitted, so the sync probe misses nothing.
+            let mut out = vec![0u8; offsets.len() * item_size];
+            let misses = sealed.try_read_many_sync_into(&mut out, &offsets, NZUsize!(item_size));
+            assert!(misses.is_empty());
+            for (i, &off) in offsets.iter().enumerate() {
+                assert_eq!(
+                    &out[i * item_size..(i + 1) * item_size],
+                    &data[off as usize..off as usize + item_size],
+                );
+            }
+        });
+    }
+
+    /// A corrupted page inside a coalesced bulk fetch surfaces `InvalidChecksum`.
+    #[test_traced("DEBUG")]
+    fn test_sealed_read_many_into_bulk_corrupt_page() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context: deterministic::Context| async move {
+            let (blob, blob_size) = context
+                .open("test_partition", b"rmany_corrupt")
+                .await
+                .unwrap();
+            let cache_ref =
+                super::CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
+            let mut append = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref.clone())
+                .await
+                .unwrap();
+
+            let page_size = PAGE_SIZE.get() as usize;
+            let data: Vec<u8> = (0u8..=255).cycle().take(page_size * 3).collect();
+            append.append(&data).await.unwrap();
+            let (sealed, sync) = append.seal().await.unwrap();
+            sync.await.unwrap();
+
+            drop(sealed);
+
+            // Flip a data byte in the middle physical page so its checksum no longer matches.
+            let physical_page_size = page_size + CHECKSUM_SIZE as usize;
+            let (raw, _) = context
+                .open("test_partition", b"rmany_corrupt")
+                .await
+                .unwrap();
+            let corrupt_offset = physical_page_size as u64 + 10;
+            let byte = raw
+                .read_at(corrupt_offset, 1, ReadOptions::default())
+                .await
+                .unwrap()
+                .coalesce();
+            raw.write_at(
+                corrupt_offset,
+                vec![byte.as_ref()[0] ^ 0xFF],
+                crate::WriteOptions::default(),
+            )
+            .await
+            .unwrap();
+            raw.sync().await.unwrap();
+            drop(raw);
+
+            // Rebuild the sealed view over the corrupted bytes with a cold cache.
+            let (blob, blob_size) = context
+                .open("test_partition", b"rmany_corrupt")
+                .await
+                .unwrap();
+            let append = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref.clone())
+                .await
+                .unwrap();
+            let (sealed, sync) = append.seal().await.unwrap();
+            sync.await.unwrap();
+            cache_ref.clear();
+
+            // One cold batch spanning all three pages in a single coalesced run.
+            let offsets = [0u64, page_size as u64, (page_size * 2) as u64];
+            let mut out = vec![0u8; offsets.len() * 4];
+            let err = sealed
+                .read_many_into(&mut out, &offsets, NZUsize!(4))
+                .await
+                .unwrap_err();
+            assert!(matches!(err, Error::InvalidChecksum));
+        });
+    }
+
     #[test_traced("DEBUG")]
     #[should_panic(expected = "ranges must be sorted and non-overlapping")]
     fn test_sealed_read_many_into_rejects_unsorted_offsets() {

--- a/runtime/src/utils/buffer/paged/sealed.rs
+++ b/runtime/src/utils/buffer/paged/sealed.rs
@@ -707,8 +707,8 @@ mod tests {
         });
     }
 
-    /// A cold `Sealed::read_many_into` fetches the missing pages in coalesced runs and admits
-    /// them, so a subsequent sync probe of the same offsets is a full hit.
+    /// A cold `Sealed::read_many_into` fetches the missing pages in coalesced runs and admits them,
+    /// so a subsequent sync probe of the same offsets is a full hit.
     #[test_traced("DEBUG")]
     fn test_sealed_read_many_into_bulk_cold() {
         let executor = deterministic::Runner::default();

--- a/runtime/src/utils/buffer/paged/sealed.rs
+++ b/runtime/src/utils/buffer/paged/sealed.rs
@@ -167,6 +167,12 @@ impl<B: Blob> Sealed<B> {
         self.view().try_read_ranges_sync_into(buf, ranges)
     }
 
+    /// Warm the page cache for sorted, non-overlapping `(offset, len)` byte ranges, admitting
+    /// missing pages with coalesced blob reads.
+    pub async fn warm_ranges(&self, ranges: &[(u64, usize)]) -> Result<(), Error> {
+        self.view().warm_ranges(ranges).await
+    }
+
     /// Returns a [Replay] for sequentially reading all logical bytes of the sealed view.
     ///
     /// Sealed values have no write buffer to flush, so unlike [`super::Writer::replay`] this method

--- a/runtime/src/utils/buffer/paged/sealed.rs
+++ b/runtime/src/utils/buffer/paged/sealed.rs
@@ -167,10 +167,14 @@ impl<B: Blob> Sealed<B> {
         self.view().try_read_ranges_sync_into(buf, ranges)
     }
 
-    /// Warm the page cache for sorted, non-overlapping `(offset, len)` byte ranges, admitting
-    /// missing pages with coalesced blob reads.
-    pub async fn warm_ranges(&self, ranges: &[(u64, usize)]) -> Result<(), Error> {
-        self.view().warm_ranges(ranges).await
+    /// Read sorted, non-overlapping `(offset, len)` ranges into one owned buffer, in range order.
+    /// All ranges must be within bounds. Missing pages are coalesced across ranges.
+    ///
+    /// # Panics
+    ///
+    /// Panics if ranges are not sorted and non-overlapping.
+    pub async fn read_ranges(&self, ranges: &[(u64, usize)]) -> Result<IoBufs, Error> {
+        self.view().read_ranges(ranges).await
     }
 
     /// Returns a [Replay] for sequentially reading all logical bytes of the sealed view.

--- a/runtime/src/utils/buffer/paged/view.rs
+++ b/runtime/src/utils/buffer/paged/view.rs
@@ -179,16 +179,56 @@ impl<B: Blob> View<'_, B> {
             return Ok(offsets.len());
         }
 
-        // Slow path: read remaining ranges from the underlying blob, concurrently.
-        let mut reads = cache_ranges
-            .iter_mut()
-            .map(|(item_buf, offset)| self.cache_ref.read(self.blob, self.id, item_buf, *offset))
-            .collect::<FuturesUnordered<_>>();
-        while let Some(result) = reads.next().await {
-            result?;
+        // Slow path: warm the missing pages behind the remaining ranges with coalesced blob
+        // reads, then serve the ranges from the now-warm cache.
+        let miss_ranges: Vec<(u64, usize)> = cache_ranges
+            .iter()
+            .map(|(item_buf, offset)| (*offset, item_buf.len()))
+            .collect();
+        self.warm_ranges(&miss_ranges).await?;
+        self.cache_ref.read_cached_many(self.id, &mut cache_ranges);
+
+        // Ranges whose pages were evicted between admission and the re-probe (possible only
+        // when the batch exceeds the cache capacity) fall back to per-range reads.
+        if !cache_ranges.is_empty() {
+            let mut reads = cache_ranges
+                .iter_mut()
+                .map(|(item_buf, offset)| {
+                    self.cache_ref.read(self.blob, self.id, item_buf, *offset)
+                })
+                .collect::<FuturesUnordered<_>>();
+            while let Some(result) = reads.next().await {
+                result?;
+            }
         }
 
         Ok(offsets.len() - blob_reads)
+    }
+
+    /// Warm the page cache for the given `(offset, len)` byte ranges: compute the distinct
+    /// pages the ranges touch below the in-memory tail and admit the missing ones with
+    /// coalesced blob reads. Ranges must be sorted by offset and non-overlapping; bytes served
+    /// by the in-memory tail are skipped.
+    pub async fn warm_ranges(&self, ranges: &[(u64, usize)]) -> Result<(), Error> {
+        // The sorted, non-overlapping ranges make the touched pages ascend; adjacent ranges
+        // sharing a page are deduplicated by continuing from one past the last recorded page.
+        let mut pages: Vec<u64> = Vec::new();
+        for &(offset, len) in ranges {
+            if len == 0 || offset >= self.tail_offset {
+                continue;
+            }
+            let end = offset.saturating_add(len as u64).min(self.tail_offset);
+            let (first, _) = self.cache_ref.offset_to_page(offset);
+            let (last, _) = self.cache_ref.offset_to_page(end - 1);
+            let next = match pages.last() {
+                Some(&prev) if prev >= first => prev + 1,
+                _ => first,
+            };
+            pages.extend(next..=last);
+        }
+        self.cache_ref
+            .fetch_pages_after_faults(self.blob, self.id, pages)
+            .await
     }
 
     /// Like [`Self::read_many_into`], but synchronous and cache-only.

--- a/runtime/src/utils/buffer/paged/view.rs
+++ b/runtime/src/utils/buffer/paged/view.rs
@@ -179,8 +179,8 @@ impl<B: Blob> View<'_, B> {
             return Ok(offsets.len());
         }
 
-        // Slow path: warm the missing pages behind the remaining ranges with coalesced blob
-        // reads, then serve the ranges from the now-warm cache.
+        // Slow path: warm the missing pages behind the remaining ranges with coalesced blob reads,
+        // then serve the ranges from the now-warm cache.
         let miss_ranges: Vec<(u64, usize)> = cache_ranges
             .iter()
             .map(|(item_buf, offset)| (*offset, item_buf.len()))
@@ -188,8 +188,8 @@ impl<B: Blob> View<'_, B> {
         self.warm_ranges(&miss_ranges).await?;
         self.cache_ref.read_cached_many(self.id, &mut cache_ranges);
 
-        // Ranges whose pages were evicted between admission and the re-probe (possible only
-        // when the batch exceeds the cache capacity) fall back to per-range reads.
+        // Ranges whose pages were evicted between admission and the re-probe (possible only when
+        // the batch exceeds the cache capacity) fall back to per-range reads.
         if !cache_ranges.is_empty() {
             let mut reads = cache_ranges
                 .iter_mut()
@@ -205,13 +205,11 @@ impl<B: Blob> View<'_, B> {
         Ok(offsets.len() - blob_reads)
     }
 
-    /// Warm the page cache for the given `(offset, len)` byte ranges: compute the distinct
-    /// pages the ranges touch below the in-memory tail and admit the missing ones with
-    /// coalesced blob reads. Ranges must be sorted by offset and non-overlapping; bytes served
-    /// by the in-memory tail are skipped.
+    /// Warm the page cache for the given `(offset, len)` byte ranges. Ranges must be sorted by
+    /// offset and non-overlapping. Bytes already in the in-memory tail are skipped.
     pub async fn warm_ranges(&self, ranges: &[(u64, usize)]) -> Result<(), Error> {
-        // The sorted, non-overlapping ranges make the touched pages ascend; adjacent ranges
-        // sharing a page are deduplicated by continuing from one past the last recorded page.
+        // The sorted, non-overlapping ranges make the touched pages ascend; adjacent ranges sharing
+        // a page are deduplicated by continuing from one past the last recorded page.
         let mut pages: Vec<u64> = Vec::new();
         for &(offset, len) in ranges {
             if len == 0 || offset >= self.tail_offset {

--- a/runtime/src/utils/buffer/paged/view.rs
+++ b/runtime/src/utils/buffer/paged/view.rs
@@ -178,9 +178,12 @@ impl<B: Blob> View<'_, B> {
             return Ok(offsets.len());
         }
 
-        self.cache_ref
-            .read_many_after_faults(self.blob, self.id, cache_ranges)
-            .await?;
+        // Keep the bulk-read state out of cache-hit futures. Only misses allocate it.
+        Box::pin(
+            self.cache_ref
+                .read_many_after_faults(self.blob, self.id, cache_ranges),
+        )
+        .await?;
 
         Ok(offsets.len() - blob_reads)
     }

--- a/runtime/src/utils/buffer/paged/view.rs
+++ b/runtime/src/utils/buffer/paged/view.rs
@@ -8,7 +8,6 @@
 
 use super::CacheRef;
 use crate::{Blob, Error, IoBufMut, IoBufs};
-use futures::stream::{FuturesUnordered, StreamExt};
 use std::num::NonZeroUsize;
 
 /// A borrowed view over a paged blob.
@@ -179,54 +178,40 @@ impl<B: Blob> View<'_, B> {
             return Ok(offsets.len());
         }
 
-        // Slow path: warm the missing pages behind the remaining ranges with coalesced blob reads,
-        // then serve the ranges from the now-warm cache.
-        let miss_ranges: Vec<(u64, usize)> = cache_ranges
-            .iter()
-            .map(|(item_buf, offset)| (*offset, item_buf.len()))
-            .collect();
-        self.warm_ranges(&miss_ranges).await?;
-        self.cache_ref.read_cached_many(self.id, &mut cache_ranges);
-
-        // Ranges whose pages were evicted between admission and the re-probe (possible only when
-        // the batch exceeds the cache capacity) fall back to per-range reads.
-        if !cache_ranges.is_empty() {
-            let mut reads = cache_ranges
-                .iter_mut()
-                .map(|(item_buf, offset)| {
-                    self.cache_ref.read(self.blob, self.id, item_buf, *offset)
-                })
-                .collect::<FuturesUnordered<_>>();
-            while let Some(result) = reads.next().await {
-                result?;
-            }
-        }
+        self.cache_ref
+            .read_many_after_faults(self.blob, self.id, cache_ranges)
+            .await?;
 
         Ok(offsets.len() - blob_reads)
     }
 
-    /// Warm the page cache for the given `(offset, len)` byte ranges. Ranges must be sorted by
-    /// offset and non-overlapping. Bytes already in the in-memory tail are skipped.
-    pub async fn warm_ranges(&self, ranges: &[(u64, usize)]) -> Result<(), Error> {
-        // The sorted, non-overlapping ranges make the touched pages ascend; adjacent ranges sharing
-        // a page are deduplicated by continuing from one past the last recorded page.
-        let mut pages: Vec<u64> = Vec::new();
-        for &(offset, len) in ranges {
-            if len == 0 || offset >= self.tail_offset {
-                continue;
-            }
-            let end = offset.saturating_add(len as u64).min(self.tail_offset);
-            let (first, _) = self.cache_ref.offset_to_page(offset);
-            let (last, _) = self.cache_ref.offset_to_page(end - 1);
-            let next = match pages.last() {
-                Some(&prev) if prev >= first => prev + 1,
-                _ => first,
-            };
-            pages.extend(next..=last);
+    /// Read sorted, non-overlapping `(offset, len)` ranges into one owned buffer, in range order.
+    /// All ranges must be within bounds. Missing pages are coalesced across ranges.
+    ///
+    /// # Panics
+    ///
+    /// Panics if ranges are not sorted and non-overlapping.
+    pub async fn read_ranges(&self, ranges: &[(u64, usize)]) -> Result<IoBufs, Error> {
+        let len = ranges.iter().try_fold(0usize, |total, &(_, len)| {
+            total.checked_add(len).ok_or(Error::OffsetOverflow)
+        })?;
+        super::validate_read_ranges(len, ranges.iter().copied(), self.size)?;
+        // SAFETY: the tail/cache copies and read_many_after_faults fill every byte before the
+        // buffer is returned. Any failed read drops the buffer without exposing its contents.
+        let mut buf = unsafe { self.cache_ref.pool().alloc_len(len) };
+        let mut cache_ranges = super::split_read_ranges(
+            buf.as_mut(),
+            ranges.iter().copied(),
+            self.tail_offset,
+            self.tail,
+        );
+        self.cache_ref.read_cached_many(self.id, &mut cache_ranges);
+        if !cache_ranges.is_empty() {
+            self.cache_ref
+                .read_many_after_faults(self.blob, self.id, cache_ranges)
+                .await?;
         }
-        self.cache_ref
-            .fetch_pages_after_faults(self.blob, self.id, pages)
-            .await
+        Ok(buf.into())
     }
 
     /// Like [`Self::read_many_into`], but synchronous and cache-only.
@@ -302,42 +287,4 @@ fn map_misses(
 }
 
 #[cfg(test)]
-mod tests {
-    use crate::{Runner as _, Storage as _, buffer::paged::Writer, deterministic};
-    use commonware_utils::{NZU16, NZUsize};
-    use std::num::NonZeroU16;
-
-    const PAGE_SIZE: NonZeroU16 = NZU16!(103);
-    const BUFFER_SIZE: usize = PAGE_SIZE.get() as usize * 2;
-
-    /// A read straddling the persisted prefix and the in-memory tail is served synchronously once
-    /// the prefix page is cached (the unified `View` serves the prefix from the cache and the
-    /// suffix from the tail in one call).
-    #[test]
-    fn test_view_try_read_sync_straddles_cache_and_tail() {
-        let executor = deterministic::Runner::default();
-        executor.start(|context: deterministic::Context| async move {
-            let cache_ref =
-                super::CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
-            let (blob, blob_size) = context
-                .open("test_partition", b"view_straddle")
-                .await
-                .unwrap();
-            let mut writer = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref)
-                .await
-                .unwrap();
-
-            // A full page (flushed to the blob) followed by a partial tail kept in the tip buffer.
-            let page_size = PAGE_SIZE.get() as usize;
-            writer.append(&vec![0xAA; page_size]).await.unwrap();
-            writer.append(b"TAIL").await.unwrap();
-            writer.sync().await.unwrap();
-
-            // Warm the cache for the first page, then read across the page/tail boundary.
-            writer.read_at(0, page_size).await.unwrap();
-            let mut buf = [0u8; 4];
-            assert!(writer.try_read_sync_into(&mut buf, page_size as u64 - 2));
-            assert_eq!(&buf, &[0xAA, 0xAA, b'T', b'A']);
-        });
-    }
-}
+mod tests;

--- a/runtime/src/utils/buffer/paged/view/tests.rs
+++ b/runtime/src/utils/buffer/paged/view/tests.rs
@@ -1,0 +1,424 @@
+use super::{
+    super::{CHECKSUM_SIZE, Checksum, cache::CacheRef},
+    View,
+};
+use crate::{
+    Blob, Error, Handle, IoBufs, IoBufsMut, ReadOptions, Runner, Storage as _, WriteOptions,
+    buffer::paged::Writer, deterministic,
+};
+use commonware_cryptography::Crc32;
+use commonware_utils::{NZU16, NZUsize, sync::Mutex};
+use futures::{FutureExt, future::pending};
+use rstest::rstest;
+use std::{
+    num::NonZeroU16,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+    },
+};
+
+const PAGE: usize = 101;
+const PHYSICAL: usize = PAGE + CHECKSUM_SIZE as usize;
+
+#[derive(Clone)]
+struct ProbeBlob {
+    bytes: Arc<Vec<u8>>,
+    reads: Arc<Mutex<Vec<(u64, usize)>>>,
+    block_first: bool,
+    block_all: bool,
+    first_started: Arc<AtomicBool>,
+    fail_offset: Option<u64>,
+    active: Arc<AtomicUsize>,
+}
+
+struct Active(Arc<AtomicUsize>);
+impl Drop for Active {
+    fn drop(&mut self) {
+        self.0.fetch_sub(1, Ordering::Relaxed);
+    }
+}
+
+impl ProbeBlob {
+    fn new(pages: usize) -> Self {
+        let mut bytes = Vec::new();
+        for page in 0..pages {
+            let data = logical(page * PAGE, PAGE);
+            let checksum = Checksum::new(PAGE as u16, Crc32::checksum(&data));
+            bytes.extend_from_slice(&data);
+            bytes.extend_from_slice(&checksum.to_bytes());
+        }
+        Self {
+            bytes: Arc::new(bytes),
+            reads: Default::default(),
+            block_first: false,
+            block_all: false,
+            first_started: Default::default(),
+            fail_offset: None,
+            active: Default::default(),
+        }
+    }
+}
+
+impl Blob for ProbeBlob {
+    async fn read_at(&self, offset: u64, len: usize, _: ReadOptions) -> Result<IoBufsMut, Error> {
+        self.reads.lock().push((offset, len));
+        self.active.fetch_add(1, Ordering::Relaxed);
+        let _active = Active(self.active.clone());
+        if self.block_all || (self.block_first && !self.first_started.swap(true, Ordering::Relaxed))
+        {
+            pending::<()>().await;
+        }
+        if self.fail_offset == Some(offset) {
+            return Err(Error::ReadFailed);
+        }
+        let start = offset as usize;
+        let bytes = self
+            .bytes
+            .get(start..start + len)
+            .ok_or(Error::BlobInsufficientLength)?;
+        Ok(bytes.to_vec().into())
+    }
+    async fn read_at_buf(
+        &self,
+        _: u64,
+        _: usize,
+        _: impl Into<IoBufsMut> + Send,
+        _: ReadOptions,
+    ) -> Result<IoBufsMut, Error> {
+        unreachable!()
+    }
+    async fn write_at(
+        &self,
+        _: u64,
+        _: impl Into<IoBufs> + Send,
+        _: WriteOptions,
+    ) -> Result<(), Error> {
+        unreachable!()
+    }
+    async fn resize(&self, _: u64) -> Result<(), Error> {
+        unreachable!()
+    }
+    async fn sync(&self) -> Result<(), Error> {
+        Ok(())
+    }
+    async fn start_sync(&self) -> Handle<()> {
+        Handle::ready(Ok(()))
+    }
+}
+
+fn logical(offset: usize, len: usize) -> Vec<u8> {
+    (offset..offset + len)
+        .map(|i| (i.wrapping_mul(37) % 251) as u8)
+        .collect()
+}
+
+#[rstest]
+fn test_bulk_boundaries(
+    #[values(63, 64, 65, 511, 512, 513)] pages: usize,
+    #[values(1, 7, 64, 1025)] capacity: usize,
+) {
+    deterministic::Runner::default().start(|context| async move {
+        let blob = ProbeBlob::new(pages);
+        let cache = CacheRef::from_pooler(&context, NZU16!(PAGE as u16), NZUsize!(capacity));
+        let tail = logical(pages * PAGE, 17);
+        let view = View {
+            blob: &blob,
+            cache_ref: &cache,
+            id: 0,
+            size: (pages * PAGE + tail.len()) as u64,
+            tail_offset: (pages * PAGE) as u64,
+            tail: &tail,
+        };
+        let offsets: Vec<_> = (0..pages).map(|p| (p * PAGE + PAGE - 2) as u64).collect();
+        let mut out = vec![0; pages * 4];
+        view.read_many_into(&mut out, &offsets, NZUsize!(4))
+            .await
+            .unwrap();
+        for (&offset, actual) in offsets.iter().zip(out.as_chunks::<4>().0) {
+            assert_eq!(actual.as_slice(), logical(offset as usize, 4));
+        }
+        let reads = blob.reads.lock();
+        assert!(reads.iter().all(|&(off, len)| off % PHYSICAL as u64 == 0
+            && len % PHYSICAL == 0
+            && len <= 64 * PHYSICAL));
+        if capacity >= pages {
+            assert_eq!(reads.len(), pages.div_ceil(64));
+        }
+    });
+}
+
+#[rstest]
+fn test_sparse_waves(#[values(7, 8, 9, 17, 65)] requested: usize) {
+    deterministic::Runner::default().start(|context| async move {
+        let blob = ProbeBlob::new(requested * 2);
+        let cache = CacheRef::from_pooler(&context, NZU16!(PAGE as u16), NZUsize!(requested));
+        let offsets: Vec<_> = (0..requested).map(|p| (p * 2 * PAGE) as u64).collect();
+        let view = View {
+            blob: &blob,
+            cache_ref: &cache,
+            id: 0,
+            size: (requested * 2 * PAGE) as u64,
+            tail_offset: (requested * 2 * PAGE) as u64,
+            tail: &[],
+        };
+        let mut out = vec![0; requested * 4];
+        view.read_many_into(&mut out, &offsets, NZUsize!(4))
+            .await
+            .unwrap();
+        for (&offset, actual) in offsets.iter().zip(out.as_chunks::<4>().0) {
+            assert_eq!(actual.as_slice(), logical(offset as usize, 4));
+        }
+        assert_eq!(blob.reads.lock().len(), requested);
+    });
+}
+
+#[test]
+fn test_bulk_error_cancels_pending_sibling() {
+    deterministic::Runner::default().start(|context| async move {
+        let mut blob = ProbeBlob::new(3);
+        blob.block_first = true;
+        blob.fail_offset = Some((2 * PHYSICAL) as u64);
+        let cache = CacheRef::from_pooler(&context, NZU16!(PAGE as u16), NZUsize!(3));
+        let offsets = [0, (2 * PAGE) as u64];
+        let mut out = [0; 8];
+        let view = View {
+            blob: &blob,
+            cache_ref: &cache,
+            id: 0,
+            size: (3 * PAGE) as u64,
+            tail_offset: (3 * PAGE) as u64,
+            tail: &[],
+        };
+        let result = view
+            .read_many_into(&mut out, &offsets, NZUsize!(4))
+            .now_or_never();
+        assert!(matches!(result, Some(Err(Error::ReadFailed))));
+        assert_eq!(blob.active.load(Ordering::Relaxed), 0);
+        blob.fail_offset = None;
+        let view = View {
+            blob: &blob,
+            cache_ref: &cache,
+            id: 0,
+            size: (3 * PAGE) as u64,
+            tail_offset: (3 * PAGE) as u64,
+            tail: &[],
+        };
+        view.read_many_into(&mut out, &offsets, NZUsize!(4))
+            .await
+            .unwrap();
+    });
+}
+
+#[test]
+fn test_bulk_cancel_then_retry() {
+    deterministic::Runner::default().start(|context| async move {
+        let mut blob = ProbeBlob::new(3);
+        blob.block_first = true;
+        let cache = CacheRef::from_pooler(&context, NZU16!(PAGE as u16), NZUsize!(3));
+        let offsets = [0, (2 * PAGE) as u64];
+        let mut out = [0; 8];
+        let view = View {
+            blob: &blob,
+            cache_ref: &cache,
+            id: 0,
+            size: (3 * PAGE) as u64,
+            tail_offset: (3 * PAGE) as u64,
+            tail: &[],
+        };
+        let mut fetch = view.read_many_into(&mut out, &offsets, NZUsize!(4)).boxed();
+        assert!(futures::poll!(&mut fetch).is_pending());
+        drop(fetch);
+        assert_eq!(blob.active.load(Ordering::Relaxed), 0);
+        view.read_many_into(&mut out, &offsets, NZUsize!(4))
+            .await
+            .unwrap();
+        assert_eq!(&out[..4], logical(0, 4));
+        assert_eq!(&out[4..], logical(2 * PAGE, 4));
+    });
+}
+
+#[test]
+fn test_later_wave_error_is_not_blocked_by_pending_read() {
+    deterministic::Runner::default().start(|context| async move {
+        let mut blob = ProbeBlob::new(18);
+        blob.block_first = true;
+        blob.fail_offset = Some((16 * PHYSICAL) as u64);
+        let cache = CacheRef::from_pooler(&context, NZU16!(PAGE as u16), NZUsize!(18));
+        let view = View {
+            blob: &blob,
+            cache_ref: &cache,
+            id: 0,
+            size: (18 * PAGE) as u64,
+            tail_offset: (18 * PAGE) as u64,
+            tail: &[],
+        };
+        let offsets: Vec<_> = (0..9).map(|p| (p * 2 * PAGE) as u64).collect();
+        let mut out = vec![0; offsets.len() * 4];
+        let result = view
+            .read_many_into(&mut out, &offsets, NZUsize!(4))
+            .now_or_never();
+        assert!(
+            matches!(result, Some(Err(Error::ReadFailed))),
+            "result: {result:?}, issued reads: {:?}",
+            *blob.reads.lock()
+        );
+    });
+}
+
+#[test]
+fn test_sparse_small_cache_does_not_double_io() {
+    deterministic::Runner::default().start(|context| async move {
+        let requested = 32;
+        let blob = ProbeBlob::new(requested * 2);
+        let cache = CacheRef::from_pooler(&context, NZU16!(PAGE as u16), NZUsize!(1));
+        let view = View {
+            blob: &blob,
+            cache_ref: &cache,
+            id: 0,
+            size: (requested * 2 * PAGE) as u64,
+            tail_offset: (requested * 2 * PAGE) as u64,
+            tail: &[],
+        };
+        let offsets: Vec<_> = (0..requested).map(|p| (p * 2 * PAGE) as u64).collect();
+        let mut out = vec![0; requested * 4];
+        view.read_many_into(&mut out, &offsets, NZUsize!(4))
+            .await
+            .unwrap();
+        for (&offset, actual) in offsets.iter().zip(out.as_chunks::<4>().0) {
+            assert_eq!(actual.as_slice(), logical(offset as usize, 4));
+        }
+        let reads = blob.reads.lock().len();
+        assert!(reads <= requested, "{reads} reads for {requested} pages");
+    });
+}
+
+#[test]
+fn test_bulk_limits_pending_reads() {
+    deterministic::Runner::default().start(|context| async move {
+        let mut blob = ProbeBlob::new(32);
+        blob.block_all = true;
+        let cache = CacheRef::from_pooler(&context, NZU16!(PAGE as u16), NZUsize!(1));
+        let view = View {
+            blob: &blob,
+            cache_ref: &cache,
+            id: 0,
+            size: (32 * PAGE) as u64,
+            tail_offset: (32 * PAGE) as u64,
+            tail: &[],
+        };
+        let offsets: Vec<_> = (0..16).map(|p| (p * 2 * PAGE) as u64).collect();
+        let mut out = vec![0; offsets.len() * 4];
+        let mut read = view.read_many_into(&mut out, &offsets, NZUsize!(4)).boxed();
+        assert!(futures::poll!(&mut read).is_pending());
+        assert_eq!(blob.active.load(Ordering::Relaxed), 8);
+        assert_eq!(blob.reads.lock().len(), 8);
+        drop(read);
+        assert_eq!(blob.active.load(Ordering::Relaxed), 0);
+    });
+}
+
+#[rstest]
+fn test_read_ranges_mixed_cache_and_tail(#[values(1, 200)] capacity: usize) {
+    deterministic::Runner::default().start(|context| async move {
+        let blob = ProbeBlob::new(129);
+        let cache = CacheRef::from_pooler(&context, NZU16!(PAGE as u16), NZUsize!(capacity));
+        for page in [2, 62] {
+            cache.cache(0, &logical(page * PAGE, PAGE), (page * PAGE) as u64);
+        }
+        let tail = logical(129 * PAGE, 11);
+        let view = View {
+            blob: &blob,
+            cache_ref: &cache,
+            id: 0,
+            size: (129 * PAGE + tail.len()) as u64,
+            tail_offset: (129 * PAGE) as u64,
+            tail: &tail,
+        };
+        let ranges = [
+            (0, 0),
+            (1, 2),
+            ((PAGE - 1) as u64, PAGE * 65 + 3),
+            ((100 * PAGE + 17) as u64, 5),
+            ((129 * PAGE) as u64, 11),
+        ];
+        let out = view.read_ranges(&ranges).await.unwrap().coalesce();
+        let expected: Vec<_> = ranges
+            .iter()
+            .flat_map(|&(off, len)| logical(off as usize, len))
+            .collect();
+        assert_eq!(out.as_ref(), expected);
+        let mut seen = std::collections::BTreeSet::new();
+        for &(offset, len) in blob.reads.lock().iter() {
+            for page in offset as usize / PHYSICAL..(offset as usize + len) / PHYSICAL {
+                assert!(seen.insert(page), "page {page} was fetched twice");
+            }
+        }
+    });
+}
+
+#[test]
+fn test_read_ranges_validate_before_io() {
+    deterministic::Runner::default().start(|context| async move {
+        let blob = ProbeBlob::new(1);
+        let cache = CacheRef::from_pooler(&context, NZU16!(PAGE as u16), NZUsize!(1));
+        let view = View {
+            blob: &blob,
+            cache_ref: &cache,
+            id: 0,
+            size: PAGE as u64,
+            tail_offset: PAGE as u64,
+            tail: &[],
+        };
+        assert!(view.read_ranges(&[]).await.unwrap().coalesce().is_empty());
+        assert!(
+            view.read_ranges(&[(PAGE as u64, 0)])
+                .await
+                .unwrap()
+                .coalesce()
+                .is_empty()
+        );
+        assert!(matches!(
+            view.read_ranges(&[(u64::MAX, 1)]).await,
+            Err(Error::OffsetOverflow)
+        ));
+        assert!(matches!(
+            view.read_ranges(&[(0, PAGE + 1)]).await,
+            Err(Error::BlobInsufficientLength)
+        ));
+        assert!(blob.reads.lock().is_empty());
+    });
+}
+
+const PAGE_SIZE: NonZeroU16 = NZU16!(103);
+const BUFFER_SIZE: usize = PAGE_SIZE.get() as usize * 2;
+
+/// A read straddling the persisted prefix and the in-memory tail is served synchronously once
+/// the prefix page is cached (the unified `View` serves the prefix from the cache and the
+/// suffix from the tail in one call).
+#[test]
+fn test_view_try_read_sync_straddles_cache_and_tail() {
+    let executor = deterministic::Runner::default();
+    executor.start(|context: deterministic::Context| async move {
+        let cache_ref = super::CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
+        let (blob, blob_size) = context
+            .open("test_partition", b"view_straddle")
+            .await
+            .unwrap();
+        let mut writer = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref)
+            .await
+            .unwrap();
+
+        // A full page (flushed to the blob) followed by a partial tail kept in the tip buffer.
+        let page_size = PAGE_SIZE.get() as usize;
+        writer.append(&vec![0xAA; page_size]).await.unwrap();
+        writer.append(b"TAIL").await.unwrap();
+        writer.sync().await.unwrap();
+
+        // Warm the cache for the first page, then read across the page/tail boundary.
+        writer.read_at(0, page_size).await.unwrap();
+        let mut buf = [0u8; 4];
+        assert!(writer.try_read_sync_into(&mut buf, page_size as u64 - 2));
+        assert_eq!(&buf, &[0xAA, 0xAA, b'T', b'A']);
+    });
+}

--- a/runtime/src/utils/buffer/paged/view/tests.rs
+++ b/runtime/src/utils/buffer/paged/view/tests.rs
@@ -21,17 +21,29 @@ use std::{
 const PAGE: usize = 101;
 const PHYSICAL: usize = PAGE + CHECKSUM_SIZE as usize;
 
+/// Read-only test blob with deterministic page contents and valid checksums.
+///
+/// Records physical reads to check coalescing and cache behavior. Blocking and failure controls
+/// exercise the concurrency limit, error propagation, and cancellation cleanup. Clones share
+/// the data, read log, first-read latch, and active-read count.
 #[derive(Clone)]
 struct ProbeBlob {
     bytes: Arc<Vec<u8>>,
+    /// Physical `(offset, len)` requests, recorded when each read is first polled.
     reads: Arc<Mutex<Vec<(u64, usize)>>>,
+    /// Keep the first read pending forever while allowing subsequent reads to proceed.
     block_first: bool,
+    /// Keep every read pending so tests can inspect the concurrency limit and cancel the batch.
     block_all: bool,
+    /// Shared latch so only one read across all clones is blocked by `block_first`.
     first_started: Arc<AtomicBool>,
+    /// Fail reads starting at this physical offset, unless they are blocked first.
     fail_offset: Option<u64>,
+    /// Reads that have started but have not completed or been cancelled.
     active: Arc<AtomicUsize>,
 }
 
+/// Decrement the active-read count on success, failure, or cancellation of the read future.
 struct Active(Arc<AtomicUsize>);
 impl Drop for Active {
     fn drop(&mut self) {
@@ -40,6 +52,7 @@ impl Drop for Active {
 }
 
 impl ProbeBlob {
+    /// Build full pages with position-dependent payloads to detect incorrect offsets or ordering.
     fn new(pages: usize) -> Self {
         let mut bytes = Vec::new();
         for page in 0..pages {

--- a/runtime/src/utils/buffer/paged/writer.rs
+++ b/runtime/src/utils/buffer/paged/writer.rs
@@ -612,6 +612,12 @@ impl<B: Blob> Writer<B> {
         self.view().try_read_ranges_sync_into(buf, ranges)
     }
 
+    /// Warm the page cache for sorted, non-overlapping `(offset, len)` byte ranges, admitting
+    /// missing pages with coalesced blob reads.
+    pub async fn warm_ranges(&self, ranges: &[(u64, usize)]) -> Result<(), Error> {
+        self.view().warm_ranges(ranges).await
+    }
+
     /// Reads bytes starting at `offset` into `buf`.
     pub async fn read_into(&self, buf: &mut [u8], offset: u64) -> Result<(), Error> {
         self.view().read_into(buf, offset).await

--- a/runtime/src/utils/buffer/paged/writer.rs
+++ b/runtime/src/utils/buffer/paged/writer.rs
@@ -612,8 +612,7 @@ impl<B: Blob> Writer<B> {
         self.view().try_read_ranges_sync_into(buf, ranges)
     }
 
-    /// Warm the page cache for sorted, non-overlapping `(offset, len)` byte ranges, admitting
-    /// missing pages with coalesced blob reads.
+    /// Warm the page cache for sorted, non-overlapping `(offset, len)` byte ranges.
     pub async fn warm_ranges(&self, ranges: &[(u64, usize)]) -> Result<(), Error> {
         self.view().warm_ranges(ranges).await
     }

--- a/runtime/src/utils/buffer/paged/writer.rs
+++ b/runtime/src/utils/buffer/paged/writer.rs
@@ -612,9 +612,14 @@ impl<B: Blob> Writer<B> {
         self.view().try_read_ranges_sync_into(buf, ranges)
     }
 
-    /// Warm the page cache for sorted, non-overlapping `(offset, len)` byte ranges.
-    pub async fn warm_ranges(&self, ranges: &[(u64, usize)]) -> Result<(), Error> {
-        self.view().warm_ranges(ranges).await
+    /// Read sorted, non-overlapping `(offset, len)` ranges into one owned buffer, in range order.
+    /// All ranges must be within bounds. Missing pages are coalesced across ranges.
+    ///
+    /// # Panics
+    ///
+    /// Panics if ranges are not sorted and non-overlapping.
+    pub async fn read_ranges(&self, ranges: &[(u64, usize)]) -> Result<IoBufs, Error> {
+        self.view().read_ranges(ranges).await
     }
 
     /// Reads bytes starting at `offset` into `buf`.

--- a/storage/src/journal/contiguous/blobs.rs
+++ b/storage/src/journal/contiguous/blobs.rs
@@ -620,6 +620,15 @@ impl<'a, B: RBlob> Blob<'a, B> {
             Self::Sealed(sealed) => sealed.try_read_ranges_sync_into(buf, ranges),
         }
     }
+
+    /// Warm the page cache for sorted, non-overlapping `(offset, len)` byte ranges, admitting
+    /// missing pages with coalesced blob reads.
+    pub(super) async fn warm_ranges(&self, ranges: &[(u64, usize)]) -> Result<(), Error> {
+        match self {
+            Self::Writer(writer) => Ok(writer.warm_ranges(ranges).await?),
+            Self::Sealed(sealed) => Ok(sealed.warm_ranges(ranges).await?),
+        }
+    }
 }
 
 impl<B: RBlob> FrameReader for Blob<'_, B> {

--- a/storage/src/journal/contiguous/blobs.rs
+++ b/storage/src/journal/contiguous/blobs.rs
@@ -621,11 +621,11 @@ impl<'a, B: RBlob> Blob<'a, B> {
         }
     }
 
-    /// Warm the page cache for sorted, non-overlapping `(offset, len)` byte ranges.
-    pub(super) async fn warm_ranges(&self, ranges: &[(u64, usize)]) -> Result<(), Error> {
+    /// Read sorted, non-overlapping byte ranges into one owned buffer, in range order.
+    pub(super) async fn read_ranges(&self, ranges: &[(u64, usize)]) -> Result<IoBufs, Error> {
         match self {
-            Self::Writer(writer) => Ok(writer.warm_ranges(ranges).await?),
-            Self::Sealed(sealed) => Ok(sealed.warm_ranges(ranges).await?),
+            Self::Writer(writer) => Ok(writer.read_ranges(ranges).await?),
+            Self::Sealed(sealed) => Ok(sealed.read_ranges(ranges).await?),
         }
     }
 }

--- a/storage/src/journal/contiguous/blobs.rs
+++ b/storage/src/journal/contiguous/blobs.rs
@@ -621,8 +621,7 @@ impl<'a, B: RBlob> Blob<'a, B> {
         }
     }
 
-    /// Warm the page cache for sorted, non-overlapping `(offset, len)` byte ranges, admitting
-    /// missing pages with coalesced blob reads.
+    /// Warm the page cache for sorted, non-overlapping `(offset, len)` byte ranges.
     pub(super) async fn warm_ranges(&self, ranges: &[(u64, usize)]) -> Result<(), Error> {
         match self {
             Self::Writer(writer) => Ok(writer.warm_ranges(ranges).await?),

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -1430,11 +1430,16 @@ impl<E: Context, A: CodecFixedShared> Reader<'_, E, A> {
             positions.is_sorted_by(|a, b| a < b),
             "positions must be strictly increasing"
         );
+        let items_per_blob = self.items_per_blob.get();
+        // Count groups during validation to reserve space for every read future without relocating it.
+        let mut group_count = 1;
+        let mut previous_blob = super::position_to_blob(positions[0], items_per_blob);
         for &pos in positions {
             self.validate_readable(pos)?;
+            let blob = super::position_to_blob(pos, items_per_blob);
+            group_count += usize::from(blob != previous_blob);
+            previous_blob = blob;
         }
-
-        let items_per_blob = self.items_per_blob.get();
 
         // Read all positions grouped by blob. Positions are sorted, so `chunk_by` splits them into
         // maximal runs that share one blob. Each group goes through the blob's batched read,
@@ -1445,7 +1450,7 @@ impl<E: Context, A: CodecFixedShared> Reader<'_, E, A> {
 
         // The buffer is pre-sized for every position, so each group can own a disjoint slice and
         // all groups can read concurrently.
-        let mut reads = Vec::new();
+        let mut reads = Vec::with_capacity(group_count);
         let mut remaining_buf = buf.as_mut_slice();
         for group in positions.chunk_by(|a, b| {
             super::position_to_blob(*a, items_per_blob)

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -862,6 +862,8 @@ impl<'a, E: Context, V: CodecShared> Reader<'a, E, V> {
 struct Miss {
     position: u64,
     offset: Option<u64>,
+    // For a valid position, None means the successor's offset is unresolved. The probe
+    // always supplies the blob's logical size for the final frame in a blob or journal.
     end: Option<u64>,
 }
 
@@ -917,11 +919,7 @@ impl<E: Context, V: CodecShared> Reader<'_, E, V> {
                 unresolved.push(miss.position);
             }
             if miss.end.is_none() {
-                let next = miss.position + 1;
-                // The final frame in a blob gets its end from that blob's logical size.
-                if next < self.bounds.end && !next.is_multiple_of(items_per_blob) {
-                    unresolved.push(next);
-                }
+                unresolved.push(miss.position + 1);
             }
         }
 
@@ -953,14 +951,7 @@ impl<E: Context, V: CodecShared> Reader<'_, E, V> {
             .map(|miss| {
                 let blob = position_to_blob(miss.position, items_per_blob);
                 let start = miss.offset.unwrap_or_else(|| resolve(miss.position));
-                let end = miss.end.unwrap_or_else(|| {
-                    let next = miss.position + 1;
-                    if next < self.bounds.end && !next.is_multiple_of(items_per_blob) {
-                        resolve(next)
-                    } else {
-                        self.data.get(blob).expect("position is in bounds").size()
-                    }
-                });
+                let end = miss.end.unwrap_or_else(|| resolve(miss.position + 1));
                 read_range(blob, start, end)
             })
             .collect::<Result<_, _>>()?;
@@ -2694,6 +2685,16 @@ mod tests {
             assert_eq!(
                 counter(&context.encode(), "offsets_items_read_total") - before,
                 3
+            );
+
+            // Final frames use the blob's size, including a partially filled final blob.
+            cache.clear();
+            let (_, misses) = reader.probe_parts(&[127, 139]);
+            assert_eq!(misses.len(), 2);
+            assert!(misses.iter().all(|m| m.end.is_some()));
+            assert_eq!(
+                reader.fetch_misses(&misses).await.unwrap(),
+                vec![items[127].clone(), items[139].clone()]
             );
             drop(reader);
             journal.destroy().await.unwrap();

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -729,6 +729,25 @@ impl<'a, E: Context, V: CodecShared> Reader<'a, E, V> {
             group_start = group_end;
         }
 
+        // Warm the pages the runs will touch with coalesced blob reads before decoding: the
+        // per-run reads below then hit the page cache instead of faulting page by page. Each
+        // run's last frame has an unknown length, so its range extends only through the page
+        // holding its first byte; the rest of the frame usually shares that page.
+        let mut warm: Vec<(u64, &Blob<'_, E::Blob>, Vec<(u64, usize)>)> = Vec::new();
+        for (run_start, run_end, blob, handle) in &runs {
+            let start = miss_offsets[*run_start];
+            let len = (miss_offsets[*run_end - 1] - start + 1) as usize;
+            match warm.last_mut() {
+                Some((last_blob, _, ranges)) if last_blob == blob => ranges.push((start, len)),
+                _ => warm.push((*blob, handle, vec![(start, len)])),
+            }
+        }
+        try_join_all(
+            warm.iter()
+                .map(|(_, handle, ranges)| handle.warm_ranges(ranges)),
+        )
+        .await?;
+
         let run_items = try_join_all(runs.iter().map(|(run_start, run_end, blob, handle)| {
             self.read_consecutive(handle, *blob, &miss_offsets[*run_start..*run_end])
         }))

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -2635,6 +2635,8 @@ mod tests {
         },
     };
     use commonware_utils::{NZU16, NZU64, NZUsize, probability, sequence::FixedBytes};
+    use futures::StreamExt as _;
+    use std::num::NonZeroU16;
 
     /// Malformed persisted offsets surface as errors from `warm_range`, never as panics.
     #[test]
@@ -2660,8 +2662,6 @@ mod tests {
             Err(Error::OffsetOverflow)
         ));
     }
-    use futures::StreamExt as _;
-    use std::num::NonZeroU16;
 
     // Use some jank sizes to exercise boundary conditions.
     const PAGE_SIZE: NonZeroU16 = NZU16!(101);

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -40,7 +40,8 @@ use commonware_runtime::{
 };
 use futures::{
     FutureExt as _, Stream,
-    future::{try_join, try_join_all},
+    future::try_join,
+    stream::{FuturesUnordered, StreamExt as _},
 };
 use std::{
     collections::BTreeMap,
@@ -79,25 +80,19 @@ fn with_bytes<T>(scratch: &mut BytesMut, f: impl FnOnce(&Bytes) -> T) -> T {
     result
 }
 
-/// Byte ranges to warm on one blob's pages before decoding: `(blob, handle, ranges)`.
-type WarmRanges<'a, 'b, B> = (u64, &'a Blob<'b, B>, Vec<(u64, usize)>);
-
-/// Compute the byte range to warm for one run of consecutive frames at `offsets`, from the first
-/// frame's start through the first byte of the last frame. `offsets` are persisted data: runs whose
-/// endpoints are not increasing return [Error::Corruption], and ranges that do not fit in a `usize`
-/// return [Error::OffsetOverflow].
-fn warm_range(blob: u64, offsets: &[u64]) -> Result<(u64, usize), Error> {
-    let start = offsets[0];
-    let last = offsets[offsets.len() - 1];
-    if offsets.len() > 1 && last <= start {
+/// Validate a frame's persisted byte bounds before allocating or issuing any reads.
+fn read_range(blob: u64, start: u64, end: u64) -> Result<(u64, usize), Error> {
+    if end <= start {
         return Err(Error::Corruption(format!(
-            "non-increasing offsets in blob {blob}: {start} >= {last}"
+            "non-increasing offsets in blob {blob}: {start} >= {end}"
         )));
     }
-    let len = (last - start)
-        .checked_add(1)
-        .and_then(|len| usize::try_from(len).ok())
-        .ok_or(Error::OffsetOverflow)?;
+    let len = usize::try_from(end - start).map_err(|_| Error::OffsetOverflow)?;
+    if end - start > u64::from(u32::MAX) + MAX_U32_VARINT_SIZE as u64 {
+        return Err(Error::Corruption(format!(
+            "frame exceeds u32 length limit in blob {blob}"
+        )));
+    }
     Ok((start, len))
 }
 
@@ -489,84 +484,6 @@ impl<'a, E: Context, V: CodecShared> Reader<'a, E, V> {
             .map(|(_, _, item)| item)
     }
 
-    /// Read consecutive items in one blob. `offsets` must be strictly increasing byte offsets of
-    /// byte-adjacent frames.
-    ///
-    /// Returns [Error::OffsetDataMismatch] if the on-disk varint at any offset reports a size
-    /// inconsistent with the gap to the next offset, or [Error::Corruption] if the offsets are not
-    /// strictly increasing.
-    async fn read_consecutive(
-        &self,
-        blob_handle: &Blob<'_, E::Blob>,
-        blob: u64,
-        offsets: &[u64],
-    ) -> Result<Vec<V>, Error> {
-        // Trivial spans take the single-item path; there is nothing to batch.
-        if offsets.len() <= 1 {
-            let mut items = Vec::with_capacity(offsets.len());
-            for &offset in offsets {
-                items.push(self.read_at_offset(blob_handle, offset).await?);
-            }
-            return Ok(items);
-        }
-
-        for window in offsets.windows(2) {
-            if window[1] <= window[0] {
-                return Err(Error::Corruption(format!(
-                    "non-increasing offsets in blob {blob}: {} >= {}",
-                    window[0], window[1]
-                )));
-            }
-        }
-
-        // Read the byte span covering every item but the last in one operation; the last item's
-        // length is unknown, so it goes through the single-item path.
-        let start = offsets[0];
-        let end = offsets[offsets.len() - 1];
-        let range_len = usize::try_from(end - start).map_err(|_| Error::OffsetOverflow)?;
-        let bytes = Bytes::from(blob_handle.read_at(start, range_len).await?.coalesce());
-
-        let mut items = Vec::with_capacity(offsets.len());
-        let mut local_offset = 0usize;
-        for window in offsets.windows(2) {
-            let offset = window[0];
-            let next_offset = window[1];
-            let item_len =
-                usize::try_from(next_offset - offset).map_err(|_| Error::OffsetOverflow)?;
-
-            let mut cursor = Copying(&bytes[local_offset..]);
-            let (size, varint_len) = decode_length_prefix(&mut cursor)?;
-            let actual_len = size.checked_add(varint_len).ok_or(Error::OffsetOverflow)?;
-            if actual_len != item_len {
-                return Err(Error::OffsetDataMismatch {
-                    section: blob,
-                    offset,
-                    expected_len: item_len,
-                    actual_len,
-                });
-            }
-
-            // Validation above guarantees strictly increasing offsets, so `data_end` never
-            // exceeds `range_len` and these additions stay in bounds.
-            let data_start = local_offset
-                .checked_add(varint_len)
-                .ok_or(Error::OffsetOverflow)?;
-            let data_end = local_offset
-                .checked_add(item_len)
-                .ok_or(Error::OffsetOverflow)?;
-            items.push(decode_item::<V>(
-                bytes.slice(data_start..data_end),
-                &self.codec_config,
-                self.compressed,
-            )?);
-
-            local_offset = data_end;
-        }
-
-        items.push(self.read_at_offset(blob_handle, end).await?);
-        Ok(items)
-    }
-
     /// Read the varint-framed item for `position` at byte `offset` from cached bytes, returning
     /// `None` on any miss.
     fn try_read_frame_sync(&self, position: u64, offset: u64, buf: &mut BytesMut) -> Option<V> {
@@ -707,88 +624,94 @@ impl<'a, E: Context, V: CodecShared> Reader<'a, E, V> {
         Ok(())
     }
 
-    /// Read `miss_positions` from storage and fill their slots in `result`. `miss_offsets[i]`
-    /// is the byte offset of `miss_positions[i]`'s frame, and `miss_indices[i]` is the `result`
-    /// slot for `miss_positions[i]` (identity when `None`).
+    /// Read known frame ranges in batches per blob, filling result slots in position order.
     async fn read_misses(
         &self,
         result: &mut [Option<V>],
-        miss_indices: Option<&[usize]>,
-        miss_positions: &[u64],
-        miss_offsets: &[u64],
+        positions: &[u64],
+        ranges: &[(u64, usize)],
     ) -> Result<(), Error> {
-        // Group runs of consecutive positions that fall into the same blob, then read all runs
-        // concurrently.
         let items_per_blob = self.items_per_blob.get();
-        let mut runs = Vec::new();
-        let mut group_start = 0;
-        while group_start < miss_positions.len() {
-            let blob = position_to_blob(miss_positions[group_start], items_per_blob);
-            let mut group_end = group_start + 1;
-            while group_end < miss_positions.len()
-                && position_to_blob(miss_positions[group_end], items_per_blob) == blob
+        let mut groups = Vec::new();
+        let mut start = 0;
+        while start < positions.len() {
+            let blob = position_to_blob(positions[start], items_per_blob);
+            let mut end = start + 1;
+            while end < positions.len() && position_to_blob(positions[end], items_per_blob) == blob
             {
-                group_end += 1;
+                end += 1;
             }
-
-            let blob_handle = self
+            let handle = self
                 .data
                 .get(blob)
                 .expect("positions in bounds map to a retained blob");
-            // Consecutive positions are byte-adjacent frames, so each next offset gives the
-            // previous frame's encoded length.
-            let mut run_start = group_start;
-            while run_start < group_end {
-                let mut run_end = run_start + 1;
-                while run_end < group_end
-                    && miss_positions[run_end - 1].checked_add(1) == Some(miss_positions[run_end])
-                {
-                    run_end += 1;
+            // Ranges are persisted data. Reject overlapping or out-of-bounds frames before
+            // passing them to the paged reader's caller-validated API.
+            let mut previous_end = None;
+            for &(offset, len) in &ranges[start..end] {
+                let end = offset
+                    .checked_add(len as u64)
+                    .ok_or(Error::OffsetOverflow)?;
+                if previous_end.is_some_and(|previous| offset < previous) {
+                    return Err(Error::Corruption(format!(
+                        "overlapping frame ranges in blob {blob}"
+                    )));
                 }
-                runs.push((run_start, run_end, blob, blob_handle.clone()));
-                run_start = run_end;
+                if end > handle.size() {
+                    return Err(Error::Runtime(
+                        commonware_runtime::Error::BlobInsufficientLength,
+                    ));
+                }
+                previous_end = Some(end);
             }
-            group_start = group_end;
+            groups.push((start, end, blob, handle));
+            start = end;
         }
 
-        // Warm the pages the runs will touch with coalesced blob reads before decoding: the
-        // per-run reads below then hit the page cache instead of faulting page by page. Each
-        // run's last frame has an unknown length, so its range extends only through the page
-        // holding its first byte; the rest of the frame usually shares that page.
-        let mut warm: Vec<WarmRanges<'_, '_, E::Blob>> = Vec::new();
-        for (run_start, run_end, blob, handle) in &runs {
-            let range = warm_range(*blob, &miss_offsets[*run_start..*run_end])?;
-            match warm.last_mut() {
-                Some((last_blob, _, ranges)) if last_blob == blob => ranges.push(range),
-                _ => warm.push((*blob, handle, vec![range])),
+        // Keep fetched bytes in owned output buffers until decoding, so other blobs sharing
+        // the page cache cannot evict this batch's data before it is consumed.
+        let mut reads = groups
+            .into_iter()
+            .map(|(start, end, blob, handle)| async move {
+                let ranges = &ranges[start..end];
+                let bytes = Bytes::from(handle.read_ranges(ranges).await?.coalesce());
+                let mut items = Vec::with_capacity(ranges.len());
+                let mut local = 0;
+                for &(offset, len) in ranges {
+                    let mut frame = bytes.slice(local..local + len);
+                    let (size, varint_len) = decode_length_prefix(&mut frame)?;
+                    let actual_len = size.checked_add(varint_len).ok_or(Error::OffsetOverflow)?;
+                    if actual_len != len {
+                        return Err(Error::OffsetDataMismatch {
+                            section: blob,
+                            offset,
+                            expected_len: len,
+                            actual_len,
+                        });
+                    }
+                    items.push(decode_item::<V>(
+                        frame,
+                        &self.codec_config,
+                        self.compressed,
+                    )?);
+                    local += len;
+                }
+                Ok((start, items))
+            })
+            .collect::<FuturesUnordered<_>>();
+        while let Some(read) = reads.next().await {
+            let (start, items) = read?;
+            for (slot, item) in result[start..].iter_mut().zip(items) {
+                *slot = Some(item);
             }
         }
-        try_join_all(
-            warm.iter()
-                .map(|(_, handle, ranges)| handle.warm_ranges(ranges)),
-        )
-        .await?;
-
-        let run_items = try_join_all(runs.iter().map(|(run_start, run_end, blob, handle)| {
-            self.read_consecutive(handle, *blob, &miss_offsets[*run_start..*run_end])
-        }))
-        .await?;
-        for ((run_start, _, _, _), items) in runs.iter().zip(run_items) {
-            for (k, item) in items.into_iter().enumerate() {
-                let slot = miss_indices.map_or(run_start + k, |indices| indices[run_start + k]);
-                result[slot] = Some(item);
-            }
-        }
-
         Ok(())
     }
 
     /// One synchronous batched pass over `positions`, filling `out[i]` for every frame served
-    /// entirely from the page cache. Returns the per-position frame offsets resolved along the
-    /// way: `Some(offset)` whenever the offsets journal served position `i` synchronously, even
-    /// if the data frame itself missed (callers reuse these offsets so the offsets journal is
-    /// not consulted twice).
-    fn read_many_sync_pass(&self, positions: &[u64], out: &mut [Option<V>]) -> Vec<Option<u64>> {
+    /// entirely from the page cache. Misses carry both frame bounds resolved by the offsets
+    /// probe, so completion does not need to look them up again.
+    fn read_many_sync_pass(&self, positions: &[u64], out: &mut [Option<V>]) -> Vec<Miss> {
         if positions.is_empty() {
             return Vec::new();
         }
@@ -810,7 +733,7 @@ impl<'a, E: Context, V: CodecShared> Reader<'a, E, V> {
                 _ => {}
             }
         }
-        let mut offsets = self.offsets.probe_items(&lookups);
+        let offsets = self.offsets.probe_items(&lookups);
 
         // Split queried frames into known extents (served below by one batched cache read per
         // data blob) and unknown extents (the last frame of a blob or of the journal, served by
@@ -823,13 +746,10 @@ impl<'a, E: Context, V: CodecShared> Reader<'a, E, V> {
                 lookup_idx += 1;
             }
             if self.validate_readable(position).is_err() {
-                offsets[idx] = None;
                 continue;
             }
 
-            // Compact resolved offsets in place: idx <= lookup_idx leaves future lookups intact.
             let offset = offsets[lookup_idx];
-            offsets[idx] = offset;
             let Some(offset) = offset else {
                 continue;
             };
@@ -905,17 +825,44 @@ impl<'a, E: Context, V: CodecShared> Reader<'a, E, V> {
         }
         self.metrics.cache_hits.inc_by(hits);
         self.metrics.items_read.inc_by(hits);
-        offsets.truncate(positions.len());
-        offsets
+        let mut lookup_idx = 0;
+        positions
+            .iter()
+            .zip(out)
+            .filter_map(|(&position, item)| {
+                if item.is_some() {
+                    return None;
+                }
+                while lookups[lookup_idx] != position {
+                    lookup_idx += 1;
+                }
+                let end = match position.checked_add(1) {
+                    Some(next)
+                        if next < self.bounds.end && !next.is_multiple_of(items_per_blob) =>
+                    {
+                        offsets[lookup_idx + 1]
+                    }
+                    _ => self
+                        .data
+                        .get(position_to_blob(position, items_per_blob))
+                        .map(|blob| blob.size()),
+                };
+                Some(Miss {
+                    position,
+                    offset: offsets[lookup_idx],
+                    end,
+                })
+            })
+            .collect()
     }
 }
 
-/// A position the sync pass could not serve, carrying the frame offset the pass resolved from
-/// the offsets journal along the way (when it did).
+/// A position the sync pass could not serve, carrying any resolved frame bounds.
 #[derive(Clone, Copy)]
 struct Miss {
     position: u64,
     offset: Option<u64>,
+    end: Option<u64>,
 }
 
 /// Complete a sync pass's item slots: read `misses` (the positions of the `None` slots, in
@@ -945,21 +892,13 @@ impl<E: Context, V: CodecShared> Reader<'_, E, V> {
     /// the misses, each carrying any frame offset the pass resolved.
     fn probe_parts(&self, positions: &[u64]) -> (Vec<Option<V>>, Vec<Miss>) {
         let mut items: Vec<Option<V>> = (0..positions.len()).map(|_| None).collect();
-        let resolved = self.read_many_sync_pass(positions, &mut items);
-        let misses = positions
-            .iter()
-            .zip(&items)
-            .zip(resolved)
-            .filter_map(|((&position, item), offset)| {
-                item.is_none().then_some(Miss { position, offset })
-            })
-            .collect();
+        let misses = self.read_many_sync_pass(positions, &mut items);
         (items, misses)
     }
 
     /// Complete probe misses (strictly increasing by position): resolve outstanding offsets
     /// without the offsets journal's cache pass (those positions just missed it) and read the
-    /// frames with one batched pass per blob run. Returns one item per miss, in order.
+    /// frames with one batched pass per blob. Returns one item per miss, in order.
     async fn fetch_misses(&self, misses: &[Miss]) -> Result<Vec<V>, Error> {
         if misses.is_empty() {
             return Ok(Vec::new());
@@ -971,11 +910,20 @@ impl<E: Context, V: CodecShared> Reader<'_, E, V> {
             self.validate_readable(miss.position)?;
         }
 
-        let unresolved: Vec<u64> = misses
-            .iter()
-            .filter(|miss| miss.offset.is_none())
-            .map(|miss| miss.position)
-            .collect();
+        let items_per_blob = self.items_per_blob.get();
+        let mut unresolved = Vec::new();
+        for miss in misses {
+            if miss.offset.is_none() && unresolved.last() != Some(&miss.position) {
+                unresolved.push(miss.position);
+            }
+            if miss.end.is_none() {
+                let next = miss.position + 1;
+                // The final frame in a blob gets its end from that blob's logical size.
+                if next < self.bounds.end && !next.is_multiple_of(items_per_blob) {
+                    unresolved.push(next);
+                }
+            }
+        }
 
         // Range errors from the offsets journal are corruption: the positions were already
         // validated against `bounds`, so the offsets journal must have them.
@@ -989,22 +937,37 @@ impl<E: Context, V: CodecShared> Reader<'_, E, V> {
                 }
                 other => other,
             })?;
-        let mut fetched = fetched.into_iter();
-        let offsets: Vec<u64> = misses
+        let mut fetched = unresolved.into_iter().zip(fetched).peekable();
+        let mut resolve = |position| {
+            while fetched.peek().is_some_and(|&(p, _)| p < position) {
+                fetched.next();
+            }
+            let &(p, offset) = fetched
+                .peek()
+                .expect("one fetched offset per unresolved position");
+            assert_eq!(p, position);
+            offset
+        };
+        let ranges: Vec<_> = misses
             .iter()
             .map(|miss| {
-                miss.offset.unwrap_or_else(|| {
-                    fetched
-                        .next()
-                        .expect("one fetched offset per unresolved miss")
-                })
+                let blob = position_to_blob(miss.position, items_per_blob);
+                let start = miss.offset.unwrap_or_else(|| resolve(miss.position));
+                let end = miss.end.unwrap_or_else(|| {
+                    let next = miss.position + 1;
+                    if next < self.bounds.end && !next.is_multiple_of(items_per_blob) {
+                        resolve(next)
+                    } else {
+                        self.data.get(blob).expect("position is in bounds").size()
+                    }
+                });
+                read_range(blob, start, end)
             })
-            .collect();
+            .collect::<Result<_, _>>()?;
         let positions: Vec<u64> = misses.iter().map(|miss| miss.position).collect();
 
         let mut result: Vec<Option<V>> = (0..misses.len()).map(|_| None).collect();
-        self.read_misses(&mut result, None, &positions, &offsets)
-            .await?;
+        self.read_misses(&mut result, &positions, &ranges).await?;
         self.metrics.cache_misses.inc_by(positions.len() as u64);
         self.metrics.items_read.inc_by(positions.len() as u64);
         Ok(result
@@ -2635,32 +2598,106 @@ mod tests {
         },
     };
     use commonware_utils::{NZU16, NZU64, NZUsize, probability, sequence::FixedBytes};
-    use futures::StreamExt as _;
     use std::num::NonZeroU16;
 
-    /// Malformed persisted offsets surface as errors from `warm_range`, never as panics.
     #[test]
-    fn test_warm_range_rejects_malformed_offsets() {
-        // A singleton run warms one byte and a longer run spans through the last frame's
-        // first byte.
-        assert_eq!(warm_range(0, &[10]).unwrap(), (10, 1));
-        assert_eq!(warm_range(0, &[10, 25, 40]).unwrap(), (10, 31));
+    fn test_read_range_rejects_malformed_offsets() {
+        assert_eq!(read_range(0, 10, 11).unwrap(), (10, 1));
+        assert_eq!(read_range(0, 10, 40).unwrap(), (10, 30));
+        assert!(matches!(read_range(0, 40, 10), Err(Error::Corruption(_))));
+        assert!(matches!(read_range(0, 40, 40), Err(Error::Corruption(_))));
+        assert!(read_range(0, 0, u64::MAX).is_err());
+    }
 
-        // Non-increasing endpoints are corruption.
-        assert!(matches!(
-            warm_range(0, &[40, 10]),
-            Err(Error::Corruption(_))
-        ));
-        assert!(matches!(
-            warm_range(0, &[40, 40]),
-            Err(Error::Corruption(_))
-        ));
+    #[test_traced]
+    fn test_read_many_coalesces_with_one_cached_page() {
+        deterministic::Runner::default().start(|context| async move {
+            let (context, recordings) = RecordingContext::new(context);
+            let cache = CacheRef::from_pooler(&context, NZU16!(512), NZUsize!(1));
+            let cfg = Config {
+                partition: "read-many-direct".into(),
+                items_per_section: NZU64!(64),
+                compression: None,
+                codec_config: (),
+                page_cache: cache.clone(),
+                write_buffer: NZUsize!(1024),
+                replay_buffer: NZUsize!(1024),
+            };
+            let items: Vec<_> = (0..32).map(|i| FixedBytes::new([i; 300])).collect();
+            let mut journal = Journal::<_, FixedBytes<300>>::init(context.child("journal"), cfg)
+                .await
+                .unwrap();
+            (journal, _) = journal.append_many(Many::Flat(&items)).await.unwrap();
+            journal = journal.sync().await.unwrap();
+            let reader;
+            (journal, reader) = journal.snapshot().await.unwrap();
+            cache.clear();
+            recordings.clear();
+            // The offsets fit in the in-memory tail. The requested data touches eighteen
+            // consecutive full pages, with gaps between requested frames and a partial tail.
+            let positions: Vec<_> = (0..32).step_by(2).chain([31]).collect();
+            let expected: Vec<_> = positions
+                .iter()
+                .map(|&p| items[p as usize].clone())
+                .collect();
+            assert_eq!(reader.read_many(&positions).await.unwrap(), expected);
+            assert_eq!(recordings.snapshot().reads.len(), 1);
+            drop(reader);
+            journal.destroy().await.unwrap();
+        });
+    }
 
-        // A range too large for the platform is an overflow error.
-        assert!(matches!(
-            warm_range(0, &[0, u64::MAX]),
-            Err(Error::OffsetOverflow)
-        ));
+    #[test_traced]
+    fn test_read_many_resolves_only_missing_frame_bounds() {
+        deterministic::Runner::default().start(|context| async move {
+            let cache = CacheRef::from_pooler(&context, NZU16!(512), NZUsize!(1));
+            let cfg = Config {
+                partition: "read-many-frame-bounds".into(),
+                items_per_section: NZU64!(128),
+                compression: None,
+                codec_config: (),
+                page_cache: cache.clone(),
+                write_buffer: NZUsize!(1024),
+                replay_buffer: NZUsize!(1024),
+            };
+            let items: Vec<_> = (0..140).map(|i| FixedBytes::new([i as u8; 300])).collect();
+            let mut journal = Journal::<_, FixedBytes<300>>::init(context.child("journal"), cfg)
+                .await
+                .unwrap();
+            (journal, _) = journal.append_many(Many::Flat(&items)).await.unwrap();
+            journal = journal.sync().await.unwrap();
+            let reader;
+            (journal, reader) = journal.snapshot().await.unwrap();
+            cache.clear();
+            reader.offsets.read(63).await.unwrap();
+            let (_, misses) = reader.probe_parts(&[63]);
+            assert_eq!(misses.len(), 1);
+            assert!(misses[0].offset.is_some());
+            assert!(misses[0].end.is_none());
+            let before = counter(&context.encode(), "offsets_items_read_total");
+            assert_eq!(
+                reader.fetch_misses(&misses).await.unwrap(),
+                vec![items[63].clone()]
+            );
+            assert_eq!(
+                counter(&context.encode(), "offsets_items_read_total") - before,
+                1
+            );
+
+            // The successor of frame 63 is also frame 64's start. Resolve it only once.
+            cache.clear();
+            let (_, misses) = reader.probe_parts(&[63, 64]);
+            assert_eq!(misses.len(), 2);
+            assert!(misses.iter().all(|m| m.offset.is_none() && m.end.is_none()));
+            let before = counter(&context.encode(), "offsets_items_read_total");
+            assert_eq!(reader.fetch_misses(&misses).await.unwrap(), items[63..65]);
+            assert_eq!(
+                counter(&context.encode(), "offsets_items_read_total") - before,
+                3
+            );
+            drop(reader);
+            journal.destroy().await.unwrap();
+        });
     }
 
     // Use some jank sizes to exercise boundary conditions.

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -82,10 +82,10 @@ fn with_bytes<T>(scratch: &mut BytesMut, f: impl FnOnce(&Bytes) -> T) -> T {
 /// Byte ranges to warm on one blob's pages before decoding: `(blob, handle, ranges)`.
 type WarmRanges<'a, 'b, B> = (u64, &'a Blob<'b, B>, Vec<(u64, usize)>);
 
-/// Compute the byte range to warm for one run of consecutive frames at `offsets`, from the
-/// first frame's start through the first byte of the last frame. `offsets` are persisted
-/// data: runs whose endpoints are not increasing return [Error::Corruption], and ranges
-/// that do not fit in a `usize` return [Error::OffsetOverflow].
+/// Compute the byte range to warm for one run of consecutive frames at `offsets`, from the first
+/// frame's start through the first byte of the last frame. `offsets` are persisted data: runs whose
+/// endpoints are not increasing return [Error::Corruption], and ranges that do not fit in a `usize`
+/// return [Error::OffsetOverflow].
 fn warm_range(blob: u64, offsets: &[u64]) -> Result<(u64, usize), Error> {
     let start = offsets[0];
     let last = offsets[offsets.len() - 1];

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -79,6 +79,28 @@ fn with_bytes<T>(scratch: &mut BytesMut, f: impl FnOnce(&Bytes) -> T) -> T {
     result
 }
 
+/// Byte ranges to warm on one blob's pages before decoding: `(blob, handle, ranges)`.
+type WarmRanges<'a, 'b, B> = (u64, &'a Blob<'b, B>, Vec<(u64, usize)>);
+
+/// Compute the byte range to warm for one run of consecutive frames at `offsets`, from the
+/// first frame's start through the first byte of the last frame. `offsets` are persisted
+/// data: runs whose endpoints are not increasing return [Error::Corruption], and ranges
+/// that do not fit in a `usize` return [Error::OffsetOverflow].
+fn warm_range(blob: u64, offsets: &[u64]) -> Result<(u64, usize), Error> {
+    let start = offsets[0];
+    let last = offsets[offsets.len() - 1];
+    if offsets.len() > 1 && last <= start {
+        return Err(Error::Corruption(format!(
+            "non-increasing offsets in blob {blob}: {start} >= {last}"
+        )));
+    }
+    let len = (last - start)
+        .checked_add(1)
+        .and_then(|len| usize::try_from(len).ok())
+        .ok_or(Error::OffsetOverflow)?;
+    Ok((start, len))
+}
+
 /// Decode one varint-framed item from `bytes`, which must hold exactly that frame (the span to
 /// the next frame's offset). Returns `None` on any mismatch or decode failure. The async read
 /// path reports such errors.
@@ -733,13 +755,12 @@ impl<'a, E: Context, V: CodecShared> Reader<'a, E, V> {
         // per-run reads below then hit the page cache instead of faulting page by page. Each
         // run's last frame has an unknown length, so its range extends only through the page
         // holding its first byte; the rest of the frame usually shares that page.
-        let mut warm: Vec<(u64, &Blob<'_, E::Blob>, Vec<(u64, usize)>)> = Vec::new();
+        let mut warm: Vec<WarmRanges<'_, '_, E::Blob>> = Vec::new();
         for (run_start, run_end, blob, handle) in &runs {
-            let start = miss_offsets[*run_start];
-            let len = (miss_offsets[*run_end - 1] - start + 1) as usize;
+            let range = warm_range(*blob, &miss_offsets[*run_start..*run_end])?;
             match warm.last_mut() {
-                Some((last_blob, _, ranges)) if last_blob == blob => ranges.push((start, len)),
-                _ => warm.push((*blob, handle, vec![(start, len)])),
+                Some((last_blob, _, ranges)) if last_blob == blob => ranges.push(range),
+                _ => warm.push((*blob, handle, vec![range])),
             }
         }
         try_join_all(
@@ -2614,6 +2635,31 @@ mod tests {
         },
     };
     use commonware_utils::{NZU16, NZU64, NZUsize, probability, sequence::FixedBytes};
+
+    /// Malformed persisted offsets surface as errors from `warm_range`, never as panics.
+    #[test]
+    fn test_warm_range_rejects_malformed_offsets() {
+        // A singleton run warms one byte and a longer run spans through the last frame's
+        // first byte.
+        assert_eq!(warm_range(0, &[10]).unwrap(), (10, 1));
+        assert_eq!(warm_range(0, &[10, 25, 40]).unwrap(), (10, 31));
+
+        // Non-increasing endpoints are corruption.
+        assert!(matches!(
+            warm_range(0, &[40, 10]),
+            Err(Error::Corruption(_))
+        ));
+        assert!(matches!(
+            warm_range(0, &[40, 40]),
+            Err(Error::Corruption(_))
+        ));
+
+        // A range too large for the platform is an overflow error.
+        assert!(matches!(
+            warm_range(0, &[0, u64::MAX]),
+            Err(Error::OffsetOverflow)
+        ));
+    }
     use futures::StreamExt as _;
     use std::num::NonZeroU16;
 


### PR DESCRIPTION
Batched page-cache misses are coalesced into reads of up to 64 consecutive pages, with at most eight runs in flight per blob. Completed runs immediately free a slot. Validated bytes are copied into output buffers before cache admission, so batches larger than the cache do not reread their own evicted pages.

Variable journals reuse known frame bounds and batch reads into owned decode buffers via `read_ranges`. The bulk-read future is boxed only on cache misses. Fixed journals count blob groups during existing validation and reserve the vector of read futures once. Concurrent batches can still duplicate page reads because bulk reads bypass single-flight bookkeeping.

Linux AMD EPYC 9354P, `journal::*_read_random`, `mode=read_many`: 5M items, 10k-page cache. PR columns are medians from fresh repeated runs; main figures are from earlier runs.

| Journal | Items | Earlier main | Before reservation (`5efa9abba`) | With reservation (`5c47a409b`) |
|---|---:|---:|---:|---:|
| Fixed | 1,000 | 142.9us | 150.1us | 145.8us |
| Fixed | 100,000 | 122.3ms | 18.99ms | 19.06ms |
| Variable | 1,000 | 170.6us | 172.5us | 171.5us |
| Variable | 100,000 | 325.6ms | 54.52ms | 54.57ms |

Reservation improves fixed 1,000-item reads by about 2.8%; the other cases are within observed variation. Moderate scattered batches can still be slower than main. A Linux sweep of 1/2/4/8/16 concurrent runs retained 8 as a compromise: lower limits help moderate variable batches but hurt single-blob throughput; 16 offers no broad journal gain at twice the scratch-memory allowance.

Regression coverage includes stalled/cancelled reads, concurrency limits, cache eviction, and frame-bound reuse. Validation includes storage/paged-buffer suites, Clippy, stability, WASM, and Miri; the final simplifications passed 193 paged-buffer, 112 variable-journal, and 24 focused read-many tests, Clippy, and WASM.

<details>
<summary>Earlier application benchmark (before the direct-copy and boxing fixes)</summary>

Eth replay, 50k blocks against 9M-key state on the same Linux machine: threads=8, 512MB init cache, 131072-page cache, OS page cache dropped before each run.

| Implementation | Merkleize |
|---|---:|
| Main | 203.2s |
| Coalesced faults | 182.6s |
| Coalesced faults plus warming | 170.0s |

These application timings have not been rerun on the current head.

</details>
