### PR TITLE
[storage] Warm variable-journal miss pages before decoding

### DIFF
--- a/runtime/src/utils/buffer/paged/sealed.rs
+++ b/runtime/src/utils/buffer/paged/sealed.rs
@@ -169,6 +169,12 @@ impl<B: Blob> Sealed<B> {
         self.view().try_read_ranges_sync_into(buf, ranges)
     }
 
+    /// Warm the page cache for sorted, non-overlapping `(offset, len)` byte ranges, admitting
+    /// missing pages with coalesced blob reads.
+    pub async fn warm_ranges(&self, ranges: &[(u64, usize)]) -> Result<(), Error> {
+        self.view().warm_ranges(ranges).await
+    }
+
     /// Returns a [Replay] for sequentially reading all logical bytes of the sealed view.
     ///
     /// Sealed values have no write buffer to flush, so unlike [`super::Writer::replay`] this method

--- a/runtime/src/utils/buffer/paged/writer.rs
+++ b/runtime/src/utils/buffer/paged/writer.rs
@@ -546,6 +546,12 @@ impl<B: Blob> Writer<B> {
         self.view().try_read_ranges_sync_into(buf, ranges)
     }
 
+    /// Warm the page cache for sorted, non-overlapping `(offset, len)` byte ranges, admitting
+    /// missing pages with coalesced blob reads.
+    pub async fn warm_ranges(&self, ranges: &[(u64, usize)]) -> Result<(), Error> {
+        self.view().warm_ranges(ranges).await
+    }
+
     /// Reads bytes starting at `offset` into `buf`.
     pub async fn read_into(&self, buf: &mut [u8], offset: u64) -> Result<(), Error> {
         self.view().read_into(buf, offset).await

--- a/storage/src/journal/contiguous/blobs.rs
+++ b/storage/src/journal/contiguous/blobs.rs
@@ -615,6 +615,15 @@ impl<'a, B: RBlob> Blob<'a, B> {
             Self::Sealed(sealed) => sealed.try_read_ranges_sync_into(buf, ranges),
         }
     }
+
+    /// Warm the page cache for sorted, non-overlapping `(offset, len)` byte ranges, admitting
+    /// missing pages with coalesced blob reads.
+    pub(super) async fn warm_ranges(&self, ranges: &[(u64, usize)]) -> Result<(), Error> {
+        match self {
+            Self::Writer(writer) => Ok(writer.warm_ranges(ranges).await?),
+            Self::Sealed(sealed) => Ok(sealed.warm_ranges(ranges).await?),
+        }
+    }
 }
 
 impl<B: RBlob> FrameReader for Blob<'_, B> {

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -716,6 +716,25 @@ impl<'a, E: Context, V: CodecShared> Reader<'a, E, V> {
             group_start = group_end;
         }
 
+        // Warm the pages the runs will touch with coalesced blob reads before decoding: the
+        // per-run reads below then hit the page cache instead of faulting page by page. Each
+        // run's last frame has an unknown length, so its range extends only through the page
+        // holding its first byte; the rest of the frame usually shares that page.
+        let mut warm: Vec<(u64, &Blob<'_, E::Blob>, Vec<(u64, usize)>)> = Vec::new();
+        for (run_start, run_end, blob, handle) in &runs {
+            let start = miss_offsets[*run_start];
+            let len = (miss_offsets[*run_end - 1] - start + 1) as usize;
+            match warm.last_mut() {
+                Some((last_blob, _, ranges)) if last_blob == blob => ranges.push((start, len)),
+                _ => warm.push((*blob, handle, vec![(start, len)])),
+            }
+        }
+        try_join_all(
+            warm.iter()
+                .map(|(_, handle, ranges)| handle.warm_ranges(ranges)),
+        )
+        .await?;
+
         let run_items = try_join_all(runs.iter().map(|(run_start, run_end, blob, handle)| {
             self.read_consecutive(handle, *blob, &miss_offsets[*run_start..*run_end])
         }))


### PR DESCRIPTION
Stacked on #4577.

## Problem

The variable journal's `read_misses` resolves each run through `read_consecutive`, which faults page by page on the calling task, paying the per-page fault machinery for every cold data frame.

## Change

Expose `warm_ranges` on the paged readers (`Writer` and `Sealed`, through the shared `View`): warm the page cache for sorted, non-overlapping byte ranges, admitting missing pages with the parent PR's coalesced bulk-fault path. `read_misses` pre-warms the union of its runs' byte ranges per blob before dispatching the run reads, which then decode from the cache. A run's last frame has an unknown length, so its range extends only through the page holding its first byte; the remainder usually shares that page.

## Results

All measurements on Linux x86_64 (AMD EPYC 9354P).

eth replay demo, 50k blocks against 9M-key state (threads=8, 512MB init cache,
131072-page cache, OS page cache dropped before each run): merkleize phase 182.6s to
170.0s (6.9% faster on top of the parent PR, 16.4% vs main), with the read phase
dropping from 70.8s (main) to 57.0s. Identical operation counts. An earlier warm-cache
run measured 6.6%, so the win does not depend on OS page cache state.

`journal::variable_read_random`, `mode=read_many` (5M items, 10k-page cache):

| items | main | parent PR | this PR |
|---|---|---|---|
| 100 | 19.4us | 19.4us | 20.1us |
| 1,000 | 155.7us | 159.5us | 164.3us |
| 10,000 | 24.7ms | 18.4ms | 12.9ms |
| 100,000 | 324.8ms | 263.8ms | 221.6ms |

`serial` and `concurrent` modes are unchanged.

## Testing

Covered by the variable journal read suites, which drive `read_misses` across cold and mixed cache states. Suites run: storage journal contiguous variable, storage qmdb any, runtime buffer paged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q4BFdANo2LhVEr2ko3FK9n

