### PR TITLE
[utils/cache] implement SIEVE cache policy

### DIFF
--- a/runtime/src/utils/buffer/paged/cache.rs
+++ b/runtime/src/utils/buffer/paged/cache.rs
@@ -100,17 +100,18 @@ impl Drop for PageFetchGuard {
 /// construction.
 ///
 /// Reads first resolve pages through `hints`, a fixed-size direct-mapped array from
-/// [Self::hint_index] to the cache slot the page was last cached in: a lookup is one array load
-/// instead of a hash-table probe chain, which the out-of-order core cannot overlap across items.
-/// Hints are best-effort, never truth: [cache::Cache::get_at] only resolves a slot that still holds
-/// the page's key live, so entries staled by eviction, invalidation, or hint collisions read as
-/// misses and fall back to the cache's own lookup. Hints need no maintenance on eviction or
-/// invalidation, and their memory is fixed at construction, so no blob offset can grow them.
+/// [Self::hint_index] to the [cache::Cache] slot the page was last cached in: a lookup is one array
+/// load instead of a hash-table probe chain, which the out-of-order core cannot overlap across
+/// items. Hints are best-effort, never truth: [cache::Cache::get_at] only resolves a slot that
+/// still holds the page's key live, so entries staled by eviction, invalidation, or hint collisions
+/// read as misses and fall back to the [cache::Cache]'s own lookup. Hints need no maintenance on
+/// eviction or invalidation, and their memory is fixed at construction, so no blob offset can grow
+/// them.
 struct Cache {
     /// Maps each (blob id, page number) to its logical page buffer.
     cache: cache::Cache<(u64, u64), IoBufMut>,
 
-    /// Direct-mapped cache slot hints, indexed by [Self::hint_index]. Initialized
+    /// Direct-mapped [cache::Cache] slot hints, indexed by [Self::hint_index]. Initialized
     /// out-of-range so untouched entries read as misses. The length is a power of two so
     /// [Self::hint_index] can wrap with a mask instead of a division, and at least twice the
     /// cache capacity: a full cache has one live page per `capacity`, so sizing at capacity
@@ -548,7 +549,7 @@ impl Cache {
         (salted & (self.hints.len() as u64 - 1)) as usize
     }
 
-    /// Look up a page, preferring its direct-mapped slot hint over the cache's own lookup.
+    /// Look up a page, preferring its direct-mapped slot hint over the [cache::Cache]'s own lookup.
     #[inline]
     fn get_page(&self, blob_id: u64, page_num: u64) -> Option<&IoBufMut> {
         let key = (blob_id, page_num);
@@ -1463,9 +1464,9 @@ mod tests {
     #[test_traced]
     fn test_read_cached_many_cross_blob_hint_collision() {
         // Two blobs whose salted ranges overlap share a hint entry, and the later insert
-        // overwrites the earlier blob's hint. The hint only proposes a slot: [cache::Cache::get_at]
-        // validates the full (blob, page) key, so each blob reads back its own bytes (the
-        // clobbered one through the fallback lookup), never the other's.
+        // overwrites the earlier blob's hint. The hint only proposes a [cache::Cache] slot.
+        // [cache::Cache::get_at] validates the full (blob, page) key, so each blob reads back its
+        // own bytes (the clobbered one through the fallback lookup), never the other's.
         let pool = test_pool();
         let cache_ref = CacheRef::new(pool, PAGE_SIZE, NZUsize!(4));
         let blob_a = cache_ref.next_id();

--- a/runtime/src/utils/buffer/paged/cache.rs
+++ b/runtime/src/utils/buffer/paged/cache.rs
@@ -4,7 +4,7 @@
 use super::{CHECKSUM_SIZE, STORAGE_PAGE_SIZE, get_page_from_blob};
 use crate::{Blob, BufferPool, BufferPooler, Error, IoBuf, IoBufMut, ReadOptions};
 use ahash::AHashMap;
-use commonware_utils::{Widen, cache::Clock, sync::RwLock};
+use commonware_utils::{Widen, cache, sync::RwLock};
 use futures::{FutureExt, future::Shared};
 use std::{
     collections::hash_map::Entry,
@@ -95,24 +95,22 @@ impl Drop for PageFetchGuard {
 /// A single page cache can be used to cache data from multiple blobs by assigning a unique id to
 /// each.
 ///
-/// Eviction is delegated to a [Clock], which uses the Clock (second-chance) replacement
-/// policy, a lightweight approximation of LRU. All page buffers are pre-allocated from `pool` at
-/// construction (via [Clock::prefill]) and reused in place, so caching never allocates after
+/// Eviction uses the [cache::Clock] replacement policy. All page buffers are pre-allocated from
+/// `pool` at construction and reused in place, so caching never allocates page buffers after
 /// construction.
 ///
 /// Reads first resolve pages through `hints`, a fixed-size direct-mapped array from
-/// [Self::hint_index] to the [Clock] slot the page was last cached in: a lookup is one array
-/// load instead of a hash-table probe chain, which the out-of-order core cannot overlap across
-/// items. Hints are best-effort, never truth: [Clock::get_at] only resolves a slot that still
-/// holds the page's key live, so entries staled by eviction, invalidation, or hint collisions
-/// read as misses and fall back to the [Clock]'s own lookup. Hints need no maintenance on
-/// eviction or invalidation, and their memory is fixed at construction, so no blob offset can
-/// grow them.
+/// [Self::hint_index] to the cache slot the page was last cached in: a lookup is one array load
+/// instead of a hash-table probe chain, which the out-of-order core cannot overlap across items.
+/// Hints are best-effort, never truth: [cache::Cache::get_at] only resolves a slot that still holds
+/// the page's key live, so entries staled by eviction, invalidation, or hint collisions read as
+/// misses and fall back to the cache's own lookup. Hints need no maintenance on eviction or
+/// invalidation, and their memory is fixed at construction, so no blob offset can grow them.
 struct Cache {
     /// Maps each (blob id, page number) to its logical page buffer.
-    cache: Clock<(u64, u64), IoBufMut>,
+    cache: cache::Cache<(u64, u64), IoBufMut>,
 
-    /// Direct-mapped [Clock] slot hints, indexed by [Self::hint_index]. Initialized
+    /// Direct-mapped cache slot hints, indexed by [Self::hint_index]. Initialized
     /// out-of-range so untouched entries read as misses. The length is a power of two so
     /// [Self::hint_index] can wrap with a mask instead of a division, and at least twice the
     /// cache capacity: a full cache has one live page per `capacity`, so sizing at capacity
@@ -476,7 +474,7 @@ impl Cache {
     /// `page_size` bytes.
     pub fn new(pool: BufferPool, page_size: NonZeroU16, capacity: NonZeroUsize) -> Self {
         let slot_size: usize = page_size.widen();
-        let mut cache = Clock::new(capacity);
+        let mut cache = cache::Cache::new(capacity);
         cache.prefill(|| pool.alloc_zeroed(slot_size));
         let hints = capacity.get().saturating_mul(2).next_power_of_two();
         Self {
@@ -550,7 +548,7 @@ impl Cache {
         (salted & (self.hints.len() as u64 - 1)) as usize
     }
 
-    /// Look up a page, preferring its direct-mapped slot hint over the [Clock]'s own lookup.
+    /// Look up a page, preferring its direct-mapped slot hint over the cache's own lookup.
     #[inline]
     fn get_page(&self, blob_id: u64, page_num: u64) -> Option<&IoBufMut> {
         let key = (blob_id, page_num);
@@ -1465,7 +1463,7 @@ mod tests {
     #[test_traced]
     fn test_read_cached_many_cross_blob_hint_collision() {
         // Two blobs whose salted ranges overlap share a hint entry, and the later insert
-        // overwrites the earlier blob's hint. The hint only proposes a slot: [Clock::get_at]
+        // overwrites the earlier blob's hint. The hint only proposes a slot: [cache::Cache::get_at]
         // validates the full (blob, page) key, so each blob reads back its own bytes (the
         // clobbered one through the fallback lookup), never the other's.
         let pool = test_pool();

--- a/storage/src/qmdb/mod.rs
+++ b/storage/src/qmdb/mod.rs
@@ -73,7 +73,7 @@ use commonware_cryptography::Hasher;
 use commonware_runtime::{ReadOptions, Spawner};
 use commonware_utils::{
     bitmap::{Atomic, BitMap},
-    cache::Clock,
+    cache::Cache,
     channel::mpsc,
 };
 use core::{num::NonZeroUsize, ops::Range};
@@ -290,7 +290,7 @@ where
     // Memoize `(location -> key)` for replayed update ops so collision resolution in
     // `find_update_op` resolves candidates from memory instead of re-reading (and re-decoding) the
     // log.
-    let mut cache = cache_size.map(Clock::<u64, <C::Item as Operation<F>>::Key>::new);
+    let mut cache = cache_size.map(Cache::<u64, <C::Item as Operation<F>>::Key>::new);
 
     let mut active_keys: usize = 0;
     while let Some(result) = stream.next().await {
@@ -329,7 +329,7 @@ async fn delete_key<F, I, R>(
     snapshot: &mut I,
     reader: &R,
     key: &<R::Item as Operation<F>>::Key,
-    cache: Option<&mut Clock<u64, <R::Item as Operation<F>>::Key>>,
+    cache: Option<&mut Cache<u64, <R::Item as Operation<F>>::Key>>,
 ) -> Result<Option<Location<F>>, Error<F>>
 where
     F: Family,
@@ -351,7 +351,7 @@ async fn delete_at_cursor<F, C, R>(
     mut cursor: C,
     reader: &R,
     key: &<R::Item as Operation<F>>::Key,
-    mut cache: Option<&mut Clock<u64, <R::Item as Operation<F>>::Key>>,
+    mut cache: Option<&mut Cache<u64, <R::Item as Operation<F>>::Key>>,
 ) -> Result<Option<Location<F>>, Error<F>>
 where
     F: Family,
@@ -381,7 +381,7 @@ async fn update_key<F, I, R>(
     reader: &R,
     key: &<R::Item as Operation<F>>::Key,
     new_loc: Location<F>,
-    cache: Option<&mut Clock<u64, <R::Item as Operation<F>>::Key>>,
+    cache: Option<&mut Cache<u64, <R::Item as Operation<F>>::Key>>,
 ) -> Result<Option<Location<F>>, Error<F>>
 where
     F: Family,
@@ -406,7 +406,7 @@ async fn update_at_cursor<F, C, R>(
     reader: &R,
     key: &<R::Item as Operation<F>>::Key,
     new_loc: Location<F>,
-    mut cache: Option<&mut Clock<u64, <R::Item as Operation<F>>::Key>>,
+    mut cache: Option<&mut Cache<u64, <R::Item as Operation<F>>::Key>>,
 ) -> Result<Option<Location<F>>, Error<F>>
 where
     F: Family,
@@ -440,7 +440,7 @@ async fn find_update_op<F, R>(
     reader: &R,
     cursor: &mut impl Cursor<Value = Location<F>>,
     key: &<R::Item as Operation<F>>::Key,
-    mut cache: Option<&mut Clock<u64, <R::Item as Operation<F>>::Key>>,
+    mut cache: Option<&mut Cache<u64, <R::Item as Operation<F>>::Key>>,
 ) -> Result<Option<Location<F>>, Error<F>>
 where
     F: Family,
@@ -500,7 +500,7 @@ where
     C: Contiguous<Item: Operation<F>>,
     R: PartitionRange<Value = Location<F>>,
 {
-    let mut cache = cache_size.map(Clock::<u64, <C::Item as Operation<F>>::Key>::new);
+    let mut cache = cache_size.map(Cache::<u64, <C::Item as Operation<F>>::Key>::new);
     while let Some(batch) = rx.recv().await {
         for (key, loc, is_delete) in batch {
             if is_delete {

--- a/utils/fuzz/fuzz_targets/cache.rs
+++ b/utils/fuzz/fuzz_targets/cache.rs
@@ -1,7 +1,7 @@
 #![no_main]
 
 use arbitrary::Arbitrary;
-use commonware_utils::cache::Clock;
+use commonware_utils::cache::Cache;
 use libfuzzer_sys::fuzz_target;
 use std::{collections::HashMap, num::NonZeroUsize};
 
@@ -34,7 +34,7 @@ struct Plan {
 
 fn run(plan: Plan) {
     let cap = (plan.capacity % 16) as usize + 1;
-    let mut cache: Clock<u8, u16> = Clock::new(NonZeroUsize::new(cap).unwrap());
+    let mut cache: Cache<u8, u16> = Cache::new(NonZeroUsize::new(cap).unwrap());
     if plan.prefill {
         cache.prefill(|| 0u16);
     }

--- a/utils/src/cache.rs
+++ b/utils/src/cache.rs
@@ -133,9 +133,16 @@ pub trait Policy<K> {
     /// a victim. The policy commits its choice by calling `claim` exactly once.
     /// Passing `None` claims unused capacity and returns its assigned slot.
     /// Passing `Some(slot)` replaces that slot and returns its previous key.
-    /// The returned [Self::SlotState] becomes the incoming entry's initial
-    /// policy state.
-    fn insert<I, C>(&mut self, states: &I, key: &K, has_vacancy: bool, claim: C) -> Self::SlotState
+    ///
+    /// The returned [Slot] must be the storage resolved by `claim`. The returned
+    /// [Self::SlotState] becomes the incoming entry's initial policy state.
+    fn insert<I, C>(
+        &mut self,
+        states: &I,
+        key: &K,
+        has_vacancy: bool,
+        claim: C,
+    ) -> (Slot, Self::SlotState)
     where
         I: Index<Slot, Output = Self::SlotState>,
         C: FnOnce(Option<Slot>) -> Claimed<K>;
@@ -460,8 +467,17 @@ impl<K: Hash + Eq + Clone, V, P: Policy<K>> Cache<K, V, P> {
         }
     }
 
-    /// Claims storage for an incoming key and returns a reusable slot and its
-    /// initial policy state. A missing slot means the cache should grow.
+    /// Resolves the policy's insertion decision for a confirmed miss.
+    ///
+    /// The policy invokes the cache-provided claim exactly once. `claim(None)`
+    /// asks the cache to use unused capacity. `claim(Some(slot))` asks it to
+    /// evict that resident. The claim resolves the physical slot and returns
+    /// either the assigned vacant slot or the displaced key so the policy can
+    /// finish updating its metadata.
+    ///
+    /// Returns `Some(slot)` when an existing slot can be reused. Returns `None`
+    /// when the policy reserved the next slot and the caller must grow the
+    /// cache.
     fn claim_slot(&mut self, key: &K) -> (Option<Slot>, P::SlotState) {
         let Self {
             index,
@@ -471,31 +487,36 @@ impl<K: Hash + Eq + Clone, V, P: Policy<K>> Cache<K, V, P> {
             policy,
         } = self;
         let has_vacancy = !free.is_empty() || slots.len() < *capacity;
-        let mut claimed_slot = None;
-        let state = policy.insert(&States(slots), key, has_vacancy, |victim| {
-            let (slot, claimed) = victim.map_or_else(
+
+        let (slot, state) = policy.insert(&States(slots), key, has_vacancy, |victim| {
+            victim.map_or_else(
                 || {
                     assert!(has_vacancy, "policy requested unavailable cache capacity");
+
+                    // Reuse a free slot before reserving the next slot for growth.
                     let slot = free.pop().unwrap_or(slots.len());
-                    (slot, Claimed::Vacant(slot))
+                    Claimed::Vacant(slot)
                 },
                 |slot| {
                     let resident = slots
                         .get(slot)
                         .expect("policy selected a slot outside the cache");
                     assert!(resident.live, "policy selected a nonresident slot");
+
+                    // Transfer the displaced key to the policy without cloning it.
                     let (evicted, indexed_slot) = index
                         .remove_entry(&resident.key)
                         .expect("a live victim must be indexed");
                     assert_eq!(indexed_slot, slot, "resident index must match its slot");
-                    (slot, Claimed::Evicted(evicted))
+
+                    Claimed::Evicted(evicted)
                 },
-            );
-            claimed_slot = Some((slot != slots.len()).then_some(slot));
-            claimed
+            )
         });
-        let slot = claimed_slot.expect("policy must claim storage exactly once");
-        (slot, state)
+
+        // Existing slots can be updated in place. The slot at `slots.len()` is
+        // the next vector position and tells the caller to grow instead.
+        ((slot != slots.len()).then_some(slot), state)
     }
 }
 
@@ -566,24 +587,25 @@ mod tests {
 
         fn hit_mut(&mut self, _slot: Slot, _state: &mut ()) {}
 
-        fn insert<I, C>(&mut self, _states: &I, _key: &K, has_vacancy: bool, claim: C)
+        fn insert<I, C>(&mut self, _states: &I, _key: &K, has_vacancy: bool, claim: C) -> (Slot, ())
         where
             I: Index<Slot, Output = ()>,
             C: FnOnce(Option<Slot>) -> Claimed<K>,
         {
             let slot = if has_vacancy {
                 let Claimed::Vacant(slot) = claim(None) else {
-                    panic!("vacancy claim returned an eviction");
+                    unreachable!("vacancy claim returned an eviction");
                 };
                 slot
             } else {
                 let victim = self.residents.remove(0);
                 let Claimed::Evicted(_) = claim(Some(victim)) else {
-                    panic!("victim claim returned vacant capacity");
+                    unreachable!("victim claim returned vacant capacity");
                 };
                 victim
             };
             self.residents.push(slot);
+            (slot, ())
         }
 
         fn remove(&mut self, slot: Option<Slot>, _key: &K) {
@@ -939,14 +961,20 @@ mod tests {
 
         fn hit_mut(&mut self, _slot: Slot, _state: &mut ()) {}
 
-        fn insert<I, C>(&mut self, _states: &I, _key: &u64, has_vacancy: bool, claim: C)
+        fn insert<I, C>(
+            &mut self,
+            _states: &I,
+            _key: &u64,
+            has_vacancy: bool,
+            claim: C,
+        ) -> (Slot, ())
         where
             I: Index<Slot, Output = ()>,
             C: FnOnce(Option<Slot>) -> Claimed<u64>,
         {
             let slot = if let Some(&victim) = self.residents.first() {
                 let Claimed::Evicted(key) = claim(Some(victim)) else {
-                    panic!("early eviction policy must evict a resident");
+                    unreachable!("early eviction policy must evict a resident");
                 };
                 self.residents.remove(0);
                 self.history.push(key);
@@ -954,11 +982,12 @@ mod tests {
             } else {
                 assert!(has_vacancy);
                 let Claimed::Vacant(slot) = claim(None) else {
-                    panic!("early eviction policy must claim vacant capacity");
+                    unreachable!("early eviction policy must claim vacant capacity");
                 };
                 slot
             };
             self.residents.push(slot);
+            (slot, ())
         }
 
         fn remove(&mut self, slot: Option<Slot>, key: &u64) {

--- a/utils/src/cache.rs
+++ b/utils/src/cache.rs
@@ -362,13 +362,29 @@ impl<K: Hash + Eq + Clone, V, P: Policy<K>> Cache<K, V, P> {
             return (slot, &mut self.slots[slot].value);
         }
         let mut value = None;
-        let mut make = Some(make);
         let (slot, state) = self.claim_slot(&key, |growing| {
             if growing {
-                value = Some(make.take().expect("value factory must be available")());
+                value = Some(make());
             }
         });
-        self.install(slot, key, state, value);
+        let index_key = key.clone();
+        if slot == self.slots.len() {
+            self.slots.push(Entry {
+                key,
+                value: value.expect("a new slot requires a value"),
+                state,
+                live: true,
+            });
+        } else {
+            let resident = self
+                .slots
+                .get_mut(slot)
+                .expect("policy selected a slot outside the cache");
+            resident.key = key;
+            resident.state = state;
+            resident.live = true;
+        }
+        let _ = self.index.insert(index_key, slot);
         (slot, &mut self.slots[slot].value)
     }
 
@@ -413,30 +429,6 @@ impl<K: Hash + Eq + Clone, V, P: Policy<K>> Cache<K, V, P> {
         });
     }
 
-    /// Retains resident entries and policy history accepted by `keep`.
-    ///
-    /// This key-only form is useful when nonresident admission history must be
-    /// invalidated by the same predicate as resident entries.
-    pub fn retain_keys<F: FnMut(&K) -> bool>(&mut self, mut keep: F) {
-        let Self {
-            index,
-            slots,
-            free,
-            policy,
-            ..
-        } = self;
-        index.retain(|key, &mut slot| {
-            let keep = keep(key);
-            if !keep {
-                policy.remove(Some(slot), key);
-                slots[slot].live = false;
-                free.push(slot);
-            }
-            keep
-        });
-        policy.retain(keep);
-    }
-
     /// Removes all entries, dropping their values and retaining the allocated
     /// capacity of the index and slot vector.
     pub fn clear(&mut self) {
@@ -449,17 +441,11 @@ impl<K: Hash + Eq + Clone, V, P: Policy<K>> Cache<K, V, P> {
     /// Inserts `value` for a `key` known to be absent, returning its slot.
     fn insert_value(&mut self, key: K, value: V) -> Slot {
         let (slot, state) = self.claim_slot(&key, |_| {});
-        self.install(slot, key, state, Some(value));
-        slot
-    }
-
-    fn install(&mut self, slot: Slot, key: K, state: P::SlotState, value: Option<V>) {
         let index_key = key.clone();
         if slot == self.slots.len() {
-            debug_assert!(slot < self.capacity, "cache cannot grow beyond capacity");
             self.slots.push(Entry {
                 key,
-                value: value.expect("a new slot requires a value"),
+                value,
                 state,
                 live: true,
             });
@@ -469,14 +455,12 @@ impl<K: Hash + Eq + Clone, V, P: Policy<K>> Cache<K, V, P> {
                 .get_mut(slot)
                 .expect("policy selected a slot outside the cache");
             resident.key = key;
-            if let Some(value) = value {
-                resident.value = value;
-            }
+            resident.value = value;
             resident.state = state;
             resident.live = true;
         }
-        let replaced = self.index.insert(index_key, slot);
-        debug_assert!(replaced.is_none(), "an incoming key must not be resident");
+        let _ = self.index.insert(index_key, slot);
+        slot
     }
 
     /// Claims storage for an incoming key and returns its slot and initial
@@ -506,7 +490,7 @@ impl<K: Hash + Eq + Clone, V, P: Policy<K>> Cache<K, V, P> {
                     let (evicted, indexed_slot) = index
                         .remove_entry(&resident.key)
                         .expect("a live victim must be indexed");
-                    debug_assert_eq!(indexed_slot, slot, "resident index must match its slot");
+                    assert_eq!(indexed_slot, slot, "resident index must match its slot");
                     (slot, Claimed::Evicted(evicted))
                 },
             );
@@ -1024,7 +1008,8 @@ mod tests {
         cache.put(3, 30);
         cache.put(4, 40);
         assert_eq!(cache.policy.history, vec![2, 3]);
-        cache.retain_keys(|key| *key >= 3);
+        cache.retain(|key, _| *key >= 3);
+        cache.policy.retain(|key| *key >= 3);
         assert_eq!(cache.policy.history, vec![3]);
 
         cache.clear();

--- a/utils/src/cache.rs
+++ b/utils/src/cache.rs
@@ -357,34 +357,25 @@ impl<K: Hash + Eq + Clone, V, P: Policy<K>> Cache<K, V, P> {
     /// callers can record it in an external index and resolve later reads with
     /// [Self::get_at] instead of a hash lookup.
     pub fn get_or_insert_mut<F: FnOnce() -> V>(&mut self, key: K, make: F) -> (Slot, &mut V) {
-        if let Some(&slot) = self.index.get(&key) {
-            self.policy.hit_mut(slot, &mut self.slots[slot].state);
-            return (slot, &mut self.slots[slot].value);
-        }
-        let mut value = None;
-        let (slot, state) = self.claim_slot(&key, |growing| {
-            if growing {
-                value = Some(make());
+        let slot = match self.index.get(&key) {
+            Some(&slot) => {
+                self.policy.hit_mut(slot, &mut self.slots[slot].state);
+                slot
             }
-        });
-        let index_key = key.clone();
-        if slot == self.slots.len() {
-            self.slots.push(Entry {
-                key,
-                value: value.expect("a new slot requires a value"),
-                state,
-                live: true,
-            });
-        } else {
-            let resident = self
-                .slots
-                .get_mut(slot)
-                .expect("policy selected a slot outside the cache");
-            resident.key = key;
-            resident.state = state;
-            resident.live = true;
-        }
-        let _ = self.index.insert(index_key, slot);
+            None => {
+                let (slot, state) = self.claim_slot(&key);
+                match slot {
+                    Some(slot) => {
+                        self.slots[slot].key = key.clone();
+                        self.slots[slot].state = state;
+                        self.slots[slot].live = true;
+                        self.index.insert(key, slot);
+                        slot
+                    }
+                    None => self.grow(key, make(), state),
+                }
+            }
+        };
         (slot, &mut self.slots[slot].value)
     }
 
@@ -438,34 +429,40 @@ impl<K: Hash + Eq + Clone, V, P: Policy<K>> Cache<K, V, P> {
         self.policy.clear();
     }
 
-    /// Inserts `value` for a `key` known to be absent, returning its slot.
-    fn insert_value(&mut self, key: K, value: V) -> Slot {
-        let (slot, state) = self.claim_slot(&key, |_| {});
-        let index_key = key.clone();
-        if slot == self.slots.len() {
-            self.slots.push(Entry {
-                key,
-                value,
-                state,
-                live: true,
-            });
-        } else {
-            let resident = self
-                .slots
-                .get_mut(slot)
-                .expect("policy selected a slot outside the cache");
-            resident.key = key;
-            resident.value = value;
-            resident.state = state;
-            resident.live = true;
-        }
-        let _ = self.index.insert(index_key, slot);
+    /// Pushes a brand new slot holding `(key, value)` and returns its index.
+    ///
+    /// Only called while the cache is below capacity.
+    fn grow(&mut self, key: K, value: V, state: P::SlotState) -> Slot {
+        let slot = self.slots.len();
+        self.index.insert(key.clone(), slot);
+        self.slots.push(Entry {
+            key,
+            value,
+            state,
+            live: true,
+        });
         slot
     }
 
-    /// Claims storage for an incoming key and returns its slot and initial
-    /// policy state. `on_claim` runs before the policy observes the result.
-    fn claim_slot<F: FnOnce(bool)>(&mut self, key: &K, on_claim: F) -> (Slot, P::SlotState) {
+    /// Inserts `value` for a `key` known to be absent, returning its slot.
+    fn insert_value(&mut self, key: K, value: V) -> Slot {
+        let (slot, state) = self.claim_slot(&key);
+        match slot {
+            Some(slot) => {
+                self.slots[slot].key = key.clone();
+                self.slots[slot].value = value;
+                self.slots[slot].state = state;
+                self.slots[slot].live = true;
+                self.index.insert(key, slot);
+                slot
+            }
+            None => self.grow(key, value, state),
+        }
+    }
+
+    /// Claims storage for an incoming key and returns a reusable slot and its
+    /// initial policy state. A missing slot means the cache should grow.
+    fn claim_slot(&mut self, key: &K) -> (Option<Slot>, P::SlotState) {
         let Self {
             index,
             slots,
@@ -494,8 +491,7 @@ impl<K: Hash + Eq + Clone, V, P: Policy<K>> Cache<K, V, P> {
                     (slot, Claimed::Evicted(evicted))
                 },
             );
-            on_claim(slot == slots.len());
-            claimed_slot = Some(slot);
+            claimed_slot = Some((slot != slots.len()).then_some(slot));
             claimed
         });
         let slot = claimed_slot.expect("policy must claim storage exactly once");

--- a/utils/src/cache.rs
+++ b/utils/src/cache.rs
@@ -152,9 +152,6 @@ pub trait Policy<K> {
     /// `slot` identifies the key's previous slot when it was cached.
     fn remove(&mut self, slot: Option<Slot>, key: &K);
 
-    /// Retains policy state only for keys accepted by `keep`.
-    fn retain<F: FnMut(&K) -> bool>(&mut self, keep: F);
-
     /// Clears all policy-owned state.
     fn clear(&mut self);
 }
@@ -363,6 +360,12 @@ impl<K: Hash + Eq + Clone, V, P: Policy<K>> Cache<K, V, P> {
     /// The slot index identifies the entry until it is evicted or removed, so
     /// callers can record it in an external index and resolve later reads with
     /// [Self::get_at] instead of a hash lookup.
+    ///
+    /// # Panics
+    ///
+    /// If `make` panics while producing a value for a new slot, policy metadata
+    /// may already have been updated. If the panic is caught, this cache must
+    /// not be used again.
     pub fn get_or_insert_mut<F: FnOnce() -> V>(&mut self, key: K, make: F) -> (Slot, &mut V) {
         let slot = match self.index.get(&key) {
             Some(&slot) => {
@@ -618,8 +621,6 @@ mod tests {
                 self.residents.remove(position);
             }
         }
-
-        fn retain<F: FnMut(&K) -> bool>(&mut self, _keep: F) {}
 
         fn clear(&mut self) {
             self.residents.clear();
@@ -992,10 +993,6 @@ mod tests {
             self.history.retain(|historical| historical != key);
         }
 
-        fn retain<F: FnMut(&u64) -> bool>(&mut self, keep: F) {
-            self.history.retain(keep);
-        }
-
         fn clear(&mut self) {
             self.residents.clear();
             self.history.clear();
@@ -1023,9 +1020,6 @@ mod tests {
         cache.put(3, 30);
         cache.put(4, 40);
         assert_eq!(cache.policy.history, vec![2, 3]);
-        cache.retain(|key, _| *key >= 3);
-        cache.policy.retain(|key| *key >= 3);
-        assert_eq!(cache.policy.history, vec![3]);
 
         cache.clear();
         assert!(cache.policy.residents.is_empty());

--- a/utils/src/cache.rs
+++ b/utils/src/cache.rs
@@ -563,7 +563,7 @@ mod tests {
     use super::*;
     use crate::NZUsize;
     use core::{cell::Cell, hash::Hash};
-    use proptest::prelude::*;
+    use proptest::{prelude::*, test_runner::TestCaseResult};
     use std::{
         collections::{HashMap, HashSet},
         rc::Rc,
@@ -1057,73 +1057,92 @@ mod tests {
         ]
     }
 
+    fn exercise_policy<P, F>(
+        capacity: usize,
+        prefill: bool,
+        ops: Vec<Op>,
+        check_policy_invariants: F,
+    ) -> TestCaseResult
+    where
+        P: Policy<u8>,
+        P::SlotState: Default,
+        F: Fn(&Cache<u8, u16, P>),
+    {
+        let mut cache = Cache::<u8, u16, P>::new(NonZeroUsize::new(capacity).unwrap());
+        if prefill {
+            cache.prefill(|| 0u16);
+        }
+        let mut model = HashMap::new();
+
+        for op in ops {
+            match op {
+                Op::Get(key) => {
+                    let value = cache.get(&key).copied();
+                    prop_assert_eq!(value, cache.peek(&key).copied());
+                }
+                Op::Peek(key) => {
+                    let _ = cache.peek(&key);
+                }
+                Op::Put(key, value) => {
+                    cache.put(key, value);
+                    model.insert(key, value);
+                    prop_assert_eq!(cache.peek(&key).copied(), Some(value));
+                }
+                Op::GetOrInsert(key, value) => {
+                    let stored = *cache.get_or_insert_with(key, || value);
+                    model.insert(key, stored);
+                    prop_assert_eq!(cache.peek(&key).copied(), Some(stored));
+                }
+                Op::GetOrInsertMut(key, value) => {
+                    *cache.get_or_insert_mut(key, || value).1 = value;
+                    model.insert(key, value);
+                    prop_assert_eq!(cache.peek(&key).copied(), Some(value));
+                }
+                Op::GetMut(key, value) => {
+                    if let Some(stored) = cache.get_mut(&key) {
+                        *stored = value;
+                        model.insert(key, value);
+                    }
+                }
+                Op::Remove(key) => {
+                    let present = cache.contains(&key);
+                    prop_assert_eq!(cache.remove(&key), present);
+                    model.remove(&key);
+                    prop_assert!(!cache.contains(&key));
+                }
+                Op::Retain(key) => {
+                    cache.retain(|resident, _| *resident < key);
+                    model.retain(|resident, _| *resident < key);
+                    prop_assert!(cache.len() <= usize::from(key).min(capacity));
+                }
+            }
+
+            prop_assert!(cache.len() <= capacity);
+            prop_assert!(cache.slots.len() <= capacity);
+            for key in 0..16u8 {
+                let present = cache.contains(&key);
+                prop_assert_eq!(present, cache.peek(&key).is_some());
+                if present {
+                    prop_assert_eq!(cache.peek(&key).copied(), model.get(&key).copied());
+                }
+            }
+            cache.check_cache_invariants();
+            check_policy_invariants(&cache);
+        }
+
+        Ok(())
+    }
+
     proptest! {
         #[test]
-        fn invariants_hold(
+        fn clock_invariants_hold(
             capacity in 1usize..8,
             prefill in any::<bool>(),
             ops in proptest::collection::vec(op_strategy(), 0..256),
         ) {
-            let mut cache: Cache<u8, u16> = Cache::new(NonZeroUsize::new(capacity).unwrap());
-            if prefill {
-                cache.prefill(|| 0u16);
-            }
-            let mut model = HashMap::new();
-
-            for op in ops {
-                match op {
-                    Op::Get(key) => {
-                        let value = cache.get(&key).copied();
-                        prop_assert_eq!(value, cache.peek(&key).copied());
-                    }
-                    Op::Peek(key) => {
-                        let _ = cache.peek(&key);
-                    }
-                    Op::Put(key, value) => {
-                        cache.put(key, value);
-                        model.insert(key, value);
-                        prop_assert_eq!(cache.peek(&key).copied(), Some(value));
-                    }
-                    Op::GetOrInsert(key, value) => {
-                        let stored = *cache.get_or_insert_with(key, || value);
-                        model.insert(key, stored);
-                        prop_assert_eq!(cache.peek(&key).copied(), Some(stored));
-                    }
-                    Op::GetOrInsertMut(key, value) => {
-                        *cache.get_or_insert_mut(key, || value).1 = value;
-                        model.insert(key, value);
-                        prop_assert_eq!(cache.peek(&key).copied(), Some(value));
-                    }
-                    Op::GetMut(key, value) => {
-                        if let Some(stored) = cache.get_mut(&key) {
-                            *stored = value;
-                            model.insert(key, value);
-                        }
-                    }
-                    Op::Remove(key) => {
-                        let present = cache.contains(&key);
-                        prop_assert_eq!(cache.remove(&key), present);
-                        model.remove(&key);
-                        prop_assert!(!cache.contains(&key));
-                    }
-                    Op::Retain(key) => {
-                        cache.retain(|resident, _| *resident < key);
-                        model.retain(|resident, _| *resident < key);
-                        prop_assert!(cache.len() <= usize::from(key).min(capacity));
-                    }
-                }
-
-                prop_assert!(cache.len() <= capacity);
-                prop_assert!(cache.slots.len() <= capacity);
-                for key in 0..16u8 {
-                    let present = cache.contains(&key);
-                    prop_assert_eq!(present, cache.peek(&key).is_some());
-                    if present {
-                        prop_assert_eq!(cache.peek(&key).copied(), model.get(&key).copied());
-                    }
-                }
-                cache.check_cache_invariants();
-            }
+            exercise_policy::<Clock, _>(capacity, prefill, ops, |cache| {
+                cache.check_policy_invariants();
+            })?;
         }
     }
 }

--- a/utils/src/cache.rs
+++ b/utils/src/cache.rs
@@ -1,124 +1,173 @@
-//! A fixed-capacity cache with CLOCK eviction.
+//! Fixed-capacity key-value caching with pluggable admission and eviction.
 //!
-//! [Clock] is a bounded key-value cache that uses the
-//! [CLOCK](https://en.wikipedia.org/wiki/Page_replacement_algorithm#Clock)
-//! (second-chance) replacement policy, a lightweight approximation of LRU. Each
-//! slot carries a reference bit. Reading an entry sets its bit. When the cache
-//! is full and a new entry must be inserted, a clock hand sweeps the slots:
-//! every slot whose bit is set has it cleared and is skipped (granted a second
-//! chance), and the first slot whose bit is clear is evicted.
+//! [Cache] owns the resident hash index, keys, values, stable slots, and free
+//! slots. A [Policy] owns only the metadata and transitions needed to record
+//! hits, admit entries, and select victims. This keeps storage, full-key
+//! validation, and value reuse consistent across policies without forcing one
+//! metadata layout on every policy.
 //!
-//! # Why CLOCK Instead of Exact LRU
+//! A policy can use [Policy::SlotState] to co-locate hot metadata with each
+//! cache slot. Any other metadata needed for admission or eviction remains
+//! internal to the policy.
 //!
-//! Exact LRU must move an entry to the front of a recency list on every read,
-//! which requires exclusive (`&mut`) access. CLOCK only needs to set a reference
-//! bit, which it does through a shared (`&self`) reference via an atomic. This
-//! lets concurrent readers share the cache without serializing on a write lock,
-//! at the cost of approximating (rather than exactly tracking) recency.
+//! # Stable Slots and Hints
 //!
-//! # Allocation Reuse
+//! A resident keeps the same numeric slot until it is removed or evicted.
+//! [Cache::get_at] uses that slot as a lookup hint and validates both liveness
+//! and the full key before returning a value. A stale hint therefore becomes a
+//! miss when its slot is freed or reused for another key. Callers can fall back
+//! to [Cache::get] without maintaining the hint on every eviction.
 //!
-//! Slots are allocated lazily as the cache grows to capacity and are then reused
-//! in place. Eviction, [Clock::remove], and [Clock::retain] never free
-//! a slot's value; they detach the key and keep the slot (and its allocation)
-//! for the next insert. [Clock::get_or_insert_mut] exposes the reused slot
-//! (and its index) so callers holding pooled buffers can overwrite in place
-//! instead of reallocating. The value-returning inserts ([Clock::put],
-//! [Clock::get_or_insert_with]) drop the displaced value as usual.
+//! Stable slots also give policies durable integer identities for queue links
+//! and dense indexes. They do not pin an entry forever. Once an entry leaves,
+//! the cache can reuse its slot and value for another key.
 //!
-//! # Concurrency
+//! # Value Reuse
 //!
-//! [Clock] performs no internal locking. [Clock::get] takes `&self`
-//! and is the only lookup that records use, so the cache can be wrapped in a
-//! reader-writer lock and queried concurrently on the hit path. Misses, which
-//! must insert, take `&mut self` and therefore the write lock:
+//! Slots grow lazily to capacity and are then reused in place. [Cache::remove]
+//! and [Cache::retain] detach residents while keeping their values available for
+//! later insertion. [Cache::get_or_insert_mut] returns the selected slot and its
+//! existing value so pooled buffers can be overwritten without reallocating.
+//! [Cache::prefill] can allocate every value during construction, which removes
+//! value allocation from steady-state insertion. Value-returning methods such
+//! as [Cache::put] replace and drop displaced values as usual.
 //!
-//! ```
-//! use commonware_utils::cache::Clock;
-//! use core::num::NonZeroUsize;
-//! use std::sync::RwLock;
-//!
-//! let cache = RwLock::new(Clock::<u64, u64>::new(NonZeroUsize::new(4).unwrap()));
-//!
-//! // Hit path: shared read lock, runs concurrently with other readers.
-//! if cache.read().unwrap().get(&7).is_none() {
-//!     // Miss path: exclusive write lock, computes and inserts the value once.
-//!     cache.write().unwrap().get_or_insert_with(7, || 7 * 7);
-//! }
-//! assert_eq!(cache.read().unwrap().get(&7).copied(), Some(49));
-//! ```
-//!
-//! # Example
-//!
-//! ```
-//! use commonware_utils::cache::Clock;
-//! use core::num::NonZeroUsize;
-//!
-//! let mut cache = Clock::new(NonZeroUsize::new(2).unwrap());
-//!
-//! // Compute an expensive value only on a miss.
-//! let value = *cache.get_or_insert_with(1u64, || 1u64 * 1000);
-//! assert_eq!(value, 1000);
-//!
-//! // A second lookup is served from the cache.
-//! assert_eq!(cache.get(&1).copied(), Some(1000));
-//! ```
+//! Replacement policies are provided in submodules. [Cache] uses [Clock] by
+//! default. See the [clock] module for its behavior and concurrency properties.
+
+pub mod clock;
 
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
-use core::{
-    hash::Hash,
-    num::NonZeroUsize,
-    sync::atomic::{AtomicBool, Ordering},
-};
+pub use clock::Clock;
+use core::{hash::Hash, num::NonZeroUsize, ops::Index};
 use hashbrown::HashMap;
 
 type Hasher = ahash::RandomState;
+
+/// Stable identifier for cache storage and policy metadata.
+pub type Slot = usize;
+
+/// Result of claiming storage for an incoming resident.
+pub enum Claimed<K> {
+    /// Vacant capacity was claimed at this slot.
+    Vacant(Slot),
+    /// The requested victim was claimed, yielding its owned key.
+    Evicted(K),
+}
+
+/// Admission and eviction policy for a fixed-capacity [Cache].
+///
+/// A policy never owns resident keys or values. It identifies residents by
+/// stable slot ID and owns only the metadata needed for admission and eviction.
+///
+/// Insertion runs as one exclusive transition. The policy selects either
+/// vacant capacity or a victim, then invokes the cache-provided claim exactly
+/// once. The claim returns the cache-selected vacant slot or transfers the
+/// victim's owned key. The policy finishes its metadata transition and returns
+/// the incoming resident's initial slot state.
+pub trait Policy<K> {
+    /// Policy state stored inline with each cache slot.
+    ///
+    /// A policy that keeps all slot-indexed state in its own arrays may use
+    /// `()`.
+    type SlotState;
+
+    /// Creates empty policy state for `capacity` residents.
+    fn new(capacity: NonZeroUsize) -> Self;
+
+    /// Records a hit for a validated resident slot.
+    ///
+    /// This method may be called concurrently through shared cache references.
+    /// Mutable hit metadata must therefore use atomics or internal
+    /// synchronization.
+    fn hit(&self, slot: Slot, state: &Self::SlotState);
+
+    /// Inserts `key` after a confirmed cache miss.
+    ///
+    /// `states` provides policy state indexed by [Slot]. `has_vacancy` reports
+    /// whether unused capacity is available, though the policy may still choose
+    /// a victim. The policy commits its choice by calling `claim` exactly once.
+    /// Passing `None` claims unused capacity and returns its assigned slot.
+    /// Passing `Some(slot)` replaces that slot and returns its previous key.
+    /// The returned [Self::SlotState] becomes the incoming entry's initial
+    /// policy state.
+    fn insert<I, C>(&mut self, states: &I, key: &K, has_vacancy: bool, claim: C) -> Self::SlotState
+    where
+        I: Index<Slot, Output = Self::SlotState>,
+        C: FnOnce(Option<Slot>) -> Claimed<K>;
+
+    /// Forgets `key` and its policy state.
+    ///
+    /// `slot` identifies the key's previous slot when it was cached.
+    fn remove(&mut self, slot: Option<Slot>, key: &K);
+
+    /// Retains policy state only for keys accepted by `keep`.
+    fn retain<F: FnMut(&K) -> bool>(&mut self, keep: F);
+
+    /// Clears all policy-owned state.
+    fn clear(&mut self);
+}
 
 /// A single cache slot.
 ///
 /// A slot is live when its key is present in the index, and free otherwise.
 /// Free slots keep their (now stale) `key` and `value` until the slot is reused,
-/// with `live` cleared so [Clock::get_at] cannot resolve them.
-struct Slot<K, V> {
+/// with `live` cleared so [Cache::get_at] cannot resolve them.
+struct Entry<K, V, M> {
     key: K,
     value: V,
-    referenced: AtomicBool,
+    state: M,
     live: bool,
 }
 
-/// A fixed-capacity key-value cache that evicts entries using the CLOCK
-/// (second-chance) replacement policy.
+struct States<'a, K, V, S>(&'a [Entry<K, V, S>]);
+
+impl<K, V, S> Index<Slot> for States<'_, K, V, S> {
+    type Output = S;
+
+    #[inline]
+    fn index(&self, slot: Slot) -> &Self::Output {
+        &self.0[slot].state
+    }
+}
+
+/// A fixed-capacity key-value cache with pluggable admission and eviction.
 ///
-/// See the [module documentation](self) for the policy, allocation reuse, and
-/// concurrency details.
-pub struct Clock<K, V> {
+/// The cache owns resident keys and values, stable slots, full-key hint
+/// validation, and allocation reuse. `P` owns only policy metadata and
+/// replacement decisions.
+pub struct Cache<K, V, P = Clock>
+where
+    P: Policy<K>,
+{
     /// Maps each live key to the index of its slot in `slots`.
     ///
     /// `index.len() + free.len() == slots.len()` always holds.
-    index: HashMap<K, usize, Hasher>,
+    index: HashMap<K, Slot, Hasher>,
     /// Backing storage for slots, grown lazily up to `capacity` and then reused.
-    slots: Vec<Slot<K, V>>,
+    slots: Vec<Entry<K, V, P::SlotState>>,
     /// Slots detached from the index and available for reuse. Populated by
     /// [Self::remove] and [Self::retain]; eviction reuses its victim slot
     /// directly, so it never adds here.
-    free: Vec<usize>,
-    /// The clock hand: the next slot the evictor will examine.
-    hand: usize,
-    /// The maximum number of entries the cache will hold.
+    free: Vec<Slot>,
+    /// Maximum number of resident entries.
     capacity: usize,
+    /// Admission and eviction metadata.
+    policy: P,
 }
 
-impl<K: Hash + Eq + Clone, V> Clock<K, V> {
-    /// Creates a cache that holds at most `capacity` entries.
+impl<K: Hash + Eq + Clone, V, P: Policy<K>> Cache<K, V, P> {
+    /// Creates an empty cache with room for `capacity` residents.
     pub fn new(capacity: NonZeroUsize) -> Self {
+        let policy = P::new(capacity);
         let capacity = capacity.get();
         Self {
             index: HashMap::with_capacity_and_hasher(capacity, Hasher::default()),
             slots: Vec::with_capacity(capacity),
-            free: Vec::new(),
-            hand: 0,
+            free: Vec::with_capacity(capacity),
             capacity,
+            policy,
         }
     }
 
@@ -148,8 +197,7 @@ impl<K: Hash + Eq + Clone, V> Clock<K, V> {
 
     /// Returns a reference to the value for `key` without recording use.
     ///
-    /// Unlike [Self::get], this does not set the entry's reference bit, so it
-    /// does not protect the entry from the next eviction sweep.
+    /// Unlike [Self::get], this does not notify the policy of a hit.
     #[inline]
     pub fn peek(&self, key: &K) -> Option<&V> {
         let &slot = self.index.get(key)?;
@@ -158,20 +206,14 @@ impl<K: Hash + Eq + Clone, V> Clock<K, V> {
 
     /// Returns a reference to the value for `key`, recording use.
     ///
-    /// Recording use sets the entry's reference bit so the next eviction sweep
-    /// grants it a second chance. This takes `&self` so it can be called
-    /// concurrently behind a shared lock.
+    /// This takes `&self` so it can be called concurrently behind a shared lock.
+    /// The policy is responsible for synchronizing any metadata changed by
+    /// [Policy::hit].
     #[inline]
     pub fn get(&self, key: &K) -> Option<&V> {
         let &index = self.index.get(key)?;
         let slot = &self.slots[index];
-
-        // Skip the store when the bit is already set. Under concurrent &self
-        // readers an unconditional store would dirty this cache line on every
-        // hit and bounce it between cores
-        if !slot.referenced.load(Ordering::Relaxed) {
-            slot.referenced.store(true, Ordering::Relaxed);
-        }
+        self.policy.hit(index, &slot.state);
         Some(&slot.value)
     }
 
@@ -186,17 +228,14 @@ impl<K: Hash + Eq + Clone, V> Clock<K, V> {
     /// live, and an out-of-range slot does not exist. External indexes
     /// therefore need no maintenance beyond tolerating misses.
     #[inline]
-    pub fn get_at(&self, slot: usize, key: &K) -> Option<&V> {
-        let slot = self.slots.get(slot)?;
-        if !slot.live || slot.key != *key {
+    pub fn get_at(&self, slot: Slot, key: &K) -> Option<&V> {
+        let resident = self.slots.get(slot)?;
+        if !resident.live || resident.key != *key {
             return None;
         }
 
-        // Skip the store when the bit is already set (see [Self::get]).
-        if !slot.referenced.load(Ordering::Relaxed) {
-            slot.referenced.store(true, Ordering::Relaxed);
-        }
-        Some(&slot.value)
+        self.policy.hit(slot, &resident.state);
+        Some(&resident.value)
     }
 
     /// Returns a mutable reference to the value for `key`, recording use.
@@ -204,19 +243,19 @@ impl<K: Hash + Eq + Clone, V> Clock<K, V> {
     pub fn get_mut(&mut self, key: &K) -> Option<&mut V> {
         let &index = self.index.get(key)?;
         let slot = &mut self.slots[index];
-        slot.referenced.store(true, Ordering::Relaxed);
+        self.policy.hit(index, &slot.state);
         Some(&mut slot.value)
     }
 
     /// Inserts `value` for `key`.
     ///
     /// If `key` was already present, replaces and returns the previous value,
-    /// recording use. If inserting a new entry exceeds the capacity, the CLOCK
-    /// evictor reclaims a slot first.
+    /// recording use. If the cache cannot use vacant capacity, the policy
+    /// selects a resident to evict.
     pub fn put(&mut self, key: K, value: V) -> Option<V> {
         if let Some(&index) = self.index.get(&key) {
             let slot = &mut self.slots[index];
-            slot.referenced.store(true, Ordering::Relaxed);
+            self.policy.hit(index, &slot.state);
             return Some(core::mem::replace(&mut slot.value, value));
         }
         self.insert_value(key, value);
@@ -232,7 +271,7 @@ impl<K: Hash + Eq + Clone, V> Clock<K, V> {
     pub fn get_or_insert_with<F: FnOnce() -> V>(&mut self, key: K, f: F) -> &V {
         let slot = match self.index.get(&key) {
             Some(&slot) => {
-                self.slots[slot].referenced.store(true, Ordering::Relaxed);
+                self.policy.hit(slot, &self.slots[slot].state);
                 slot
             }
             None => self.insert_value(key, f()),
@@ -253,7 +292,7 @@ impl<K: Hash + Eq + Clone, V> Clock<K, V> {
     ) -> Result<&V, E> {
         let slot = match self.index.get(&key) {
             Some(&slot) => {
-                self.slots[slot].referenced.store(true, Ordering::Relaxed);
+                self.policy.hit(slot, &self.slots[slot].state);
                 slot
             }
             None => self.insert_value(key, f()?),
@@ -274,26 +313,19 @@ impl<K: Hash + Eq + Clone, V> Clock<K, V> {
     /// The slot index identifies the entry until it is evicted or removed, so
     /// callers can record it in an external index and resolve later reads with
     /// [Self::get_at] instead of a hash lookup.
-    pub fn get_or_insert_mut<F: FnOnce() -> V>(&mut self, key: K, make: F) -> (usize, &mut V) {
-        let slot = match self.index.get(&key) {
-            Some(&slot) => {
-                self.slots[slot].referenced.store(true, Ordering::Relaxed);
-                slot
+    pub fn get_or_insert_mut<F: FnOnce() -> V>(&mut self, key: K, make: F) -> (Slot, &mut V) {
+        if let Some(&slot) = self.index.get(&key) {
+            self.policy.hit(slot, &self.slots[slot].state);
+            return (slot, &mut self.slots[slot].value);
+        }
+        let mut value = None;
+        let mut make = Some(make);
+        let (slot, state) = self.claim_slot(&key, |growing| {
+            if growing {
+                value = Some(make.take().expect("value factory must be available")());
             }
-            None => match self.take_slot() {
-                Some(slot) => {
-                    self.slots[slot].key = key.clone();
-                    self.slots[slot].referenced.store(true, Ordering::Relaxed);
-                    self.slots[slot].live = true;
-                    self.index.insert(key, slot);
-                    slot
-                }
-                None => {
-                    let value = make();
-                    self.grow(key, value)
-                }
-            },
-        };
+        });
+        self.install(slot, key, state, value);
         (slot, &mut self.slots[slot].value)
     }
 
@@ -302,33 +334,62 @@ impl<K: Hash + Eq + Clone, V> Clock<K, V> {
     /// The slot and its allocation are retained for reuse, so the value is not
     /// returned.
     pub fn remove(&mut self, key: &K) -> bool {
-        match self.index.remove(key) {
-            Some(slot) => {
-                self.slots[slot].referenced.store(false, Ordering::Relaxed);
-                self.slots[slot].live = false;
-                self.free.push(slot);
-                true
-            }
-            None => false,
-        }
+        let Some((key, slot)) = self.index.remove_entry(key) else {
+            self.policy.remove(None, key);
+            return false;
+        };
+        self.policy.remove(Some(slot), &key);
+        self.slots[slot].live = false;
+        self.free.push(slot);
+        true
     }
 
     /// Retains only the entries for which `keep` returns `true`.
     ///
     /// Dropped entries' slots and allocations are retained for reuse.
     pub fn retain<F: FnMut(&K, &V) -> bool>(&mut self, mut keep: F) {
-        let Self {
-            index, slots, free, ..
-        } = self;
-        index.retain(|key, &mut slot| {
-            let keep = keep(key, &slots[slot].value);
-            if !keep {
-                slots[slot].referenced.store(false, Ordering::Relaxed);
-                slots[slot].live = false;
-                free.push(slot);
+        for slot in 0..self.slots.len() {
+            let remove = {
+                let resident = &self.slots[slot];
+                resident.live && !keep(&resident.key, &resident.value)
+            };
+            if !remove {
+                continue;
             }
-            keep
-        });
+            let key = self
+                .index
+                .remove_entry(&self.slots[slot].key)
+                .expect("a live slot must be indexed")
+                .0;
+            self.policy.remove(Some(slot), &key);
+            self.slots[slot].live = false;
+            self.free.push(slot);
+        }
+    }
+
+    /// Retains resident entries and policy history accepted by `keep`.
+    ///
+    /// This key-only form is useful when nonresident admission history must be
+    /// invalidated by the same predicate as resident entries.
+    pub fn retain_keys<F: FnMut(&K) -> bool>(&mut self, mut keep: F) {
+        for slot in 0..self.slots.len() {
+            let remove = {
+                let resident = &self.slots[slot];
+                resident.live && !keep(&resident.key)
+            };
+            if !remove {
+                continue;
+            }
+            let key = self
+                .index
+                .remove_entry(&self.slots[slot].key)
+                .expect("a live slot must be indexed")
+                .0;
+            self.policy.remove(Some(slot), &key);
+            self.slots[slot].live = false;
+            self.free.push(slot);
+        }
+        self.policy.retain(keep);
     }
 
     /// Removes all entries, dropping their values and retaining the allocated
@@ -337,67 +398,89 @@ impl<K: Hash + Eq + Clone, V> Clock<K, V> {
         self.index.clear();
         self.slots.clear();
         self.free.clear();
-        self.hand = 0;
-    }
-
-    /// Pushes a brand new slot holding `(key, value)` and returns its index.
-    ///
-    /// Only called while the cache is below capacity.
-    fn grow(&mut self, key: K, value: V) -> usize {
-        let slot = self.slots.len();
-        self.index.insert(key.clone(), slot);
-        self.slots.push(Slot {
-            key,
-            value,
-            referenced: AtomicBool::new(true),
-            live: true,
-        });
-        slot
+        self.policy.clear();
     }
 
     /// Inserts `value` for a `key` known to be absent, returning its slot.
-    fn insert_value(&mut self, key: K, value: V) -> usize {
-        match self.take_slot() {
-            Some(slot) => {
-                self.slots[slot].key = key.clone();
-                self.slots[slot].value = value;
-                self.slots[slot].referenced.store(true, Ordering::Relaxed);
-                self.slots[slot].live = true;
-                self.index.insert(key, slot);
-                slot
-            }
-            None => self.grow(key, value),
-        }
+    #[inline(always)]
+    fn insert_value(&mut self, key: K, value: V) -> Slot {
+        let (slot, state) = self.claim_slot(&key, |_| {});
+        self.install(slot, key, state, Some(value));
+        slot
     }
 
-    /// Selects a slot to receive a new entry, detaching it from the index.
-    ///
-    /// Returns a freed slot if any exist, otherwise an eviction victim chosen by
-    /// the clock sweep. Returns `None` if the cache is below capacity and should
-    /// grow instead. The returned slot keeps its stale value for reuse.
-    fn take_slot(&mut self) -> Option<usize> {
-        if let Some(slot) = self.free.pop() {
-            return Some(slot);
+    #[inline(always)]
+    fn install(&mut self, slot: Slot, key: K, state: P::SlotState, value: Option<V>) {
+        let index_key = key.clone();
+        if slot == self.slots.len() {
+            debug_assert!(slot < self.capacity, "cache cannot grow beyond capacity");
+            self.slots.push(Entry {
+                key,
+                value: value.expect("a new slot requires a value"),
+                state,
+                live: true,
+            });
+        } else {
+            let resident = self
+                .slots
+                .get_mut(slot)
+                .expect("policy selected a slot outside the cache");
+            resident.key = key;
+            if let Some(value) = value {
+                resident.value = value;
+            }
+            resident.state = state;
+            resident.live = true;
         }
-        if self.slots.len() < self.capacity {
-            return None;
-        }
+        let replaced = self.index.insert(index_key, slot);
+        debug_assert!(replaced.is_none(), "an incoming key must not be resident");
+    }
 
-        let len = self.slots.len();
-        while self.slots[self.hand].referenced.load(Ordering::Relaxed) {
-            self.slots[self.hand]
-                .referenced
-                .store(false, Ordering::Relaxed);
-            self.hand = (self.hand + 1) % len;
-        }
-        let slot = self.hand;
-        self.hand = (self.hand + 1) % len;
-        self.index.remove(&self.slots[slot].key);
-        Some(slot)
+    /// Claims storage for an incoming key and returns its slot and initial
+    /// policy state. `on_claim` runs before the policy observes the result.
+    #[inline(always)]
+    fn claim_slot<F: FnOnce(bool)>(&mut self, key: &K, on_claim: F) -> (Slot, P::SlotState) {
+        let Self {
+            index,
+            slots,
+            free,
+            capacity,
+            policy,
+        } = self;
+        let has_vacancy = !free.is_empty() || slots.len() < *capacity;
+        let mut claimed_slot = None;
+        let state = policy.insert(&States(slots), key, has_vacancy, |victim| {
+            let (slot, claimed) = victim.map_or_else(
+                || {
+                    assert!(has_vacancy, "policy requested unavailable cache capacity");
+                    let slot = free.pop().unwrap_or(slots.len());
+                    (slot, Claimed::Vacant(slot))
+                },
+                |slot| {
+                    let resident = slots
+                        .get(slot)
+                        .expect("policy selected a slot outside the cache");
+                    assert!(resident.live, "policy selected a nonresident slot");
+                    let (evicted, indexed_slot) = index
+                        .remove_entry(&resident.key)
+                        .expect("a live victim must be indexed");
+                    debug_assert_eq!(indexed_slot, slot, "resident index must match its slot");
+                    (slot, Claimed::Evicted(evicted))
+                },
+            );
+            on_claim(slot == slots.len());
+            claimed_slot = Some(slot);
+            claimed
+        });
+        let slot = claimed_slot.expect("policy must claim storage exactly once");
+        (slot, state)
     }
 }
 
-impl<K: Hash + Eq + Clone + Default, V> Clock<K, V> {
+impl<K: Hash + Eq + Clone + Default, V, P: Policy<K>> Cache<K, V, P>
+where
+    P::SlotState: Default,
+{
     /// Pre-allocates all slots up to capacity, each holding a value from `make`,
     /// and leaves them free for reuse.
     ///
@@ -410,10 +493,10 @@ impl<K: Hash + Eq + Clone + Default, V> Clock<K, V> {
         let start = self.free.len();
         while self.slots.len() < self.capacity {
             let slot = self.slots.len();
-            self.slots.push(Slot {
+            self.slots.push(Entry {
                 key: K::default(),
                 value: make(),
-                referenced: AtomicBool::new(false),
+                state: P::SlotState::default(),
                 live: false,
             });
             self.free.push(slot);
@@ -424,38 +507,80 @@ impl<K: Hash + Eq + Clone + Default, V> Clock<K, V> {
     }
 }
 
-impl<K, V> core::fmt::Debug for Clock<K, V> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("Clock")
-            .field("len", &self.index.len())
-            .field("capacity", &self.capacity)
-            .finish()
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::NZUsize;
-    use core::cell::Cell;
+    use core::{cell::Cell, hash::Hash};
     use proptest::prelude::*;
-    use std::{collections::HashMap, rc::Rc, thread};
+    use std::{
+        collections::{HashMap, HashSet},
+        rc::Rc,
+    };
 
-    impl<K: Hash + Eq + Clone, V> Clock<K, V> {
-        /// Asserts the structural invariants hold (test-only).
-        fn check_invariants(&self) {
-            assert!(self.slots.len() <= self.capacity);
-            assert_eq!(self.index.len() + self.free.len(), self.slots.len());
-            if self.slots.is_empty() {
-                assert_eq!(self.hand, 0);
-            } else {
-                assert!(self.hand < self.slots.len());
+    struct TestPolicy {
+        residents: Vec<Slot>,
+    }
+
+    impl<K> Policy<K> for TestPolicy {
+        type SlotState = ();
+
+        fn new(capacity: NonZeroUsize) -> Self {
+            Self {
+                residents: Vec::with_capacity(capacity.get()),
             }
-            // The index is a bijection onto the live slots, each slot's key
-            // round-trips, and live slots are disjoint from free slots.
-            let free: std::collections::HashSet<usize> = self.free.iter().copied().collect();
+        }
+
+        fn hit(&self, _slot: Slot, _state: &()) {}
+
+        fn insert<I, C>(&mut self, _states: &I, _key: &K, has_vacancy: bool, claim: C)
+        where
+            I: Index<Slot, Output = ()>,
+            C: FnOnce(Option<Slot>) -> Claimed<K>,
+        {
+            let slot = if has_vacancy {
+                let Claimed::Vacant(slot) = claim(None) else {
+                    panic!("vacancy claim returned an eviction");
+                };
+                slot
+            } else {
+                let victim = self.residents.remove(0);
+                let Claimed::Evicted(_) = claim(Some(victim)) else {
+                    panic!("victim claim returned vacant capacity");
+                };
+                victim
+            };
+            self.residents.push(slot);
+        }
+
+        fn remove(&mut self, slot: Option<Slot>, _key: &K) {
+            if let Some(slot) = slot {
+                let position = self
+                    .residents
+                    .iter()
+                    .position(|resident| *resident == slot)
+                    .unwrap();
+                self.residents.remove(position);
+            }
+        }
+
+        fn retain<F: FnMut(&K) -> bool>(&mut self, _keep: F) {}
+
+        fn clear(&mut self) {
+            self.residents.clear();
+        }
+    }
+
+    type TestCache<K, V> = Cache<K, V, TestPolicy>;
+
+    impl<K: Hash + Eq + Clone, V, P: Policy<K>> Cache<K, V, P> {
+        fn check_cache_invariants(&self) {
+            assert!(self.slots.len() <= self.capacity());
+            assert_eq!(self.index.len() + self.free.len(), self.slots.len());
+
+            let free: HashSet<Slot> = self.free.iter().copied().collect();
             assert_eq!(free.len(), self.free.len(), "duplicate free slot");
-            let mut seen = std::collections::HashSet::new();
+            let mut seen = HashSet::new();
             for (key, &slot) in &self.index {
                 assert!(slot < self.slots.len());
                 assert!(!free.contains(&slot), "slot {slot} both live and free");
@@ -470,131 +595,86 @@ mod tests {
     }
 
     #[test]
-    fn test_basic_put_get_peek() {
-        let mut cache = Clock::new(NZUsize!(2));
+    fn basic_put_get_peek() {
+        let mut cache = TestCache::new(NZUsize!(2));
         assert!(cache.is_empty());
         assert_eq!(cache.capacity(), 2);
 
         assert_eq!(cache.put(1u64, 10u64), None);
         assert_eq!(cache.put(2, 20), None);
         assert_eq!(cache.len(), 2);
-
         assert_eq!(cache.get(&1).copied(), Some(10));
         assert_eq!(cache.peek(&2).copied(), Some(20));
         assert!(cache.contains(&1));
         assert!(!cache.contains(&3));
         assert_eq!(cache.get(&3), None);
-        cache.check_invariants();
+        cache.check_cache_invariants();
     }
 
     #[test]
-    fn test_put_replaces_existing() {
-        let mut cache = Clock::new(NZUsize!(2));
+    fn capacity_is_const() {
+        const fn capacity(cache: &TestCache<u64, u64>) -> usize {
+            cache.capacity()
+        }
+
+        let cache = TestCache::new(NZUsize!(2));
+        assert_eq!(capacity(&cache), 2);
+    }
+
+    #[test]
+    fn put_replaces_existing() {
+        let mut cache = TestCache::new(NZUsize!(2));
         assert_eq!(cache.put(1u64, 10u64), None);
         assert_eq!(cache.put(1, 11), Some(10));
         assert_eq!(cache.get(&1).copied(), Some(11));
         assert_eq!(cache.len(), 1);
-        cache.check_invariants();
+        cache.check_cache_invariants();
     }
 
     #[test]
-    fn test_capacity_one_eviction() {
-        let mut cache = Clock::new(NZUsize!(1));
+    fn capacity_one_reuses_its_only_slot() {
+        let mut cache = TestCache::new(NZUsize!(1));
         cache.put(1u64, 10u64);
         cache.put(2, 20);
         assert!(!cache.contains(&1));
         assert_eq!(cache.get(&2).copied(), Some(20));
         assert_eq!(cache.len(), 1);
-        cache.check_invariants();
+        cache.check_cache_invariants();
     }
 
     #[test]
-    fn test_second_chance_protects_referenced_entry() {
-        // New entries are inserted with their reference bit set, so a referenced
-        // entry only beats an unreferenced one once some bits have been cleared.
-        // Capacity 3, slots index by insertion order.
-        let mut cache = Clock::new(NZUsize!(3));
-        cache.put(1u64, 10u64); // slot 0, ref=1
-        cache.put(2, 20); // slot 1, ref=1
-        cache.put(3, 30); // slot 2, ref=1
-
-        // Full and all referenced. Inserting key 4 sweeps slots 0,1,2 clearing
-        // every bit, wraps to slot 0 (now clear), and evicts key 1. Hand -> 1.
-        // State: slot0=key4(1), slot1=key2(0), slot2=key3(0).
-        cache.put(4, 40);
-        assert!(!cache.contains(&1));
-
-        // Reference key 2 (slot 1), leaving key 3 (slot 2) unreferenced.
-        assert_eq!(cache.get(&2).copied(), Some(20));
-
-        // Inserting key 5 sweeps from slot 1: key 2's bit is set, so it is
-        // cleared and skipped; slot 2 (key 3) is unreferenced and evicted.
-        cache.put(5, 50);
-        assert!(cache.contains(&2));
-        assert!(!cache.contains(&3));
-        assert!(cache.contains(&4));
-        assert!(cache.contains(&5));
-        cache.check_invariants();
-    }
-
-    #[test]
-    fn test_all_referenced_evicts_hand_position() {
-        // When every entry has been referenced, the sweep clears all bits and
-        // evicts the slot the hand started on.
-        let mut cache = Clock::new(NZUsize!(3));
-        cache.put(1u64, 10u64);
-        cache.put(2, 20);
-        cache.put(3, 30);
-        assert!(cache.get(&1).is_some());
-        assert!(cache.get(&2).is_some());
-        assert!(cache.get(&3).is_some());
-
-        // Hand is at slot 0 (key 1). Sweep clears all bits, lands back on slot 0.
-        cache.put(4, 40);
-        assert!(!cache.contains(&1));
-        assert!(cache.contains(&2));
-        assert!(cache.contains(&3));
-        assert!(cache.contains(&4));
-        cache.check_invariants();
-    }
-
-    #[test]
-    fn test_get_or_insert_with_calls_f_only_on_miss() {
-        let mut cache = Clock::new(NZUsize!(2));
+    fn get_or_insert_with_calls_factory_only_on_miss() {
+        let mut cache = TestCache::new(NZUsize!(2));
         let calls = Cell::new(0);
-        let compute = |k: u64| {
+        let compute = |key: u64| {
             calls.set(calls.get() + 1);
-            k * 100
+            key * 100
         };
 
         assert_eq!(*cache.get_or_insert_with(1, || compute(1)), 100);
-        assert_eq!(calls.get(), 1);
-        // Hit: f is not called.
         assert_eq!(*cache.get_or_insert_with(1, || compute(1)), 100);
         assert_eq!(calls.get(), 1);
-        cache.check_invariants();
+        cache.check_cache_invariants();
     }
 
     #[test]
-    fn test_try_get_or_insert_with_does_not_cache_errors() {
-        let mut cache = Clock::new(NZUsize!(2));
+    fn try_get_or_insert_with_does_not_cache_errors() {
+        let mut cache = TestCache::new(NZUsize!(2));
 
-        let err: Result<&u64, &str> = cache.try_get_or_insert_with(1u64, || Err("bad"));
-        assert_eq!(err, Err("bad"));
+        let error: Result<&u64, &str> = cache.try_get_or_insert_with(1u64, || Err("bad"));
+        assert_eq!(error, Err("bad"));
         assert!(!cache.contains(&1));
 
-        let ok: Result<&u64, &str> = cache.try_get_or_insert_with(1, || Ok(10));
-        assert_eq!(ok, Ok(&10));
+        let value: Result<&u64, &str> = cache.try_get_or_insert_with(1, || Ok(10));
+        assert_eq!(value, Ok(&10));
         assert!(cache.contains(&1));
-        cache.check_invariants();
+        cache.check_cache_invariants();
     }
 
     #[test]
-    fn test_remove_keeps_slot_for_reuse() {
-        // A removed entry frees its slot for reuse without growing the slot
-        // vector or calling the factory again.
+    fn remove_keeps_slot_for_reuse() {
         let makes = Cell::new(0);
-        let mut cache: Clock<u64, u64> = Clock::new(NZUsize!(2));
+        let mut cache = TestCache::new(NZUsize!(2));
         cache.get_or_insert_mut(1, || {
             makes.set(makes.get() + 1);
             10
@@ -604,76 +684,63 @@ mod tests {
             20
         });
         assert_eq!(makes.get(), 2);
-        assert_eq!(cache.slots.len(), 2);
 
         assert!(cache.remove(&1));
-        assert!(!cache.contains(&1));
-        assert_eq!(cache.len(), 1);
-
-        // Reusing the freed slot does not call the factory or grow.
         *cache
             .get_or_insert_mut(3, || {
                 makes.set(makes.get() + 1);
                 30
             })
             .1 = 30;
-        assert_eq!(
-            makes.get(),
-            2,
-            "freed slot should be reused, factory not called"
-        );
+
+        assert_eq!(makes.get(), 2);
         assert_eq!(cache.slots.len(), 2);
         assert_eq!(cache.get(&3).copied(), Some(30));
         assert!(!cache.remove(&999));
-        cache.check_invariants();
+        cache.check_cache_invariants();
     }
 
     #[test]
-    fn test_retain() {
-        let mut cache = Clock::new(NZUsize!(4));
-        for i in 0..4u64 {
-            cache.put(i, i * 10);
+    fn retain_frees_slots_for_reuse() {
+        let mut cache = TestCache::new(NZUsize!(4));
+        for key in 0..4u64 {
+            cache.put(key, key * 10);
         }
-        // Keep even keys.
-        cache.retain(|k, _| k % 2 == 0);
+        cache.retain(|key, _| key % 2 == 0);
         assert_eq!(cache.len(), 2);
         assert!(cache.contains(&0));
         assert!(cache.contains(&2));
         assert!(!cache.contains(&1));
         assert!(!cache.contains(&3));
-        // Freed slots are reused for new inserts.
+
         cache.put(10, 100);
         cache.put(12, 120);
         assert_eq!(cache.slots.len(), 4);
         assert_eq!(cache.len(), 4);
-        cache.check_invariants();
+        cache.check_cache_invariants();
     }
 
     #[test]
-    fn test_get_or_insert_mut_reuses_allocations() {
-        // The factory runs at most `capacity` times no matter how many distinct
-        // keys churn through the cache, proving evicted slots are reused.
+    fn get_or_insert_mut_reuses_allocations() {
         let makes = Cell::new(0);
-        let mut cache: Clock<u64, u64> = Clock::new(NZUsize!(3));
-        for k in 0..100u64 {
-            let (_, v) = cache.get_or_insert_mut(k, || {
+        let mut cache = TestCache::new(NZUsize!(3));
+        for key in 0..100u64 {
+            let (_, value) = cache.get_or_insert_mut(key, || {
                 makes.set(makes.get() + 1);
                 0
             });
-            *v = k; // overwrite the (possibly stale) reused slot
+            *value = key;
         }
-        assert_eq!(makes.get(), 3, "factory should run only during growth");
+        assert_eq!(makes.get(), 3);
         assert_eq!(cache.slots.len(), 3);
         assert_eq!(cache.len(), 3);
-        cache.check_invariants();
+        cache.check_cache_invariants();
     }
 
     #[test]
-    fn test_prefill_allocates_once_and_reuses() {
-        // prefill runs the factory exactly capacity times; subsequent inserts
-        // reuse pre-allocated slots without growing or calling the factory.
+    fn prefill_allocates_once_and_reuses() {
         let makes = Cell::new(0);
-        let mut cache: Clock<u64, u64> = Clock::new(NZUsize!(3));
+        let mut cache = TestCache::new(NZUsize!(3));
         cache.prefill(|| {
             makes.set(makes.get() + 1);
             0
@@ -681,257 +748,225 @@ mod tests {
         assert_eq!(makes.get(), 3);
         assert_eq!(cache.slots.len(), 3);
         assert!(cache.is_empty());
-        cache.check_invariants();
 
-        // Churn many keys; no further factory calls, slot vector stays at capacity.
-        for k in 0..100u64 {
+        for key in 0..100u64 {
             *cache
-                .get_or_insert_mut(k, || {
+                .get_or_insert_mut(key, || {
                     makes.set(makes.get() + 1);
                     0
                 })
-                .1 = k;
+                .1 = key;
         }
-        assert_eq!(makes.get(), 3, "prefilled slots must be reused");
+        assert_eq!(makes.get(), 3);
         assert_eq!(cache.slots.len(), 3);
-        assert_eq!(cache.len(), 3);
-        cache.check_invariants();
+        cache.check_cache_invariants();
     }
 
     #[test]
-    fn test_clear() {
-        let mut cache = Clock::new(NZUsize!(4));
-        for i in 0..4u64 {
-            cache.put(i, i);
+    fn clear_drops_entries_and_allows_reuse() {
+        let mut cache = TestCache::new(NZUsize!(4));
+        for key in 0..4u64 {
+            cache.put(key, key);
         }
         cache.clear();
         assert!(cache.is_empty());
-        assert_eq!(cache.len(), 0);
         cache.put(9, 9);
         assert_eq!(cache.get(&9).copied(), Some(9));
-        cache.check_invariants();
+        cache.check_cache_invariants();
     }
 
     #[derive(Clone)]
-    struct Tracked {
-        _counter: Rc<Cell<usize>>,
-    }
+    struct Tracked(Rc<Cell<usize>>);
 
     impl Drop for Tracked {
         fn drop(&mut self) {
-            self._counter.set(self._counter.get() + 1);
+            self.0.set(self.0.get() + 1);
         }
     }
 
     #[test]
-    fn test_values_dropped_on_eviction_and_clear() {
+    fn values_are_dropped_on_replacement_and_clear() {
         let drops = Rc::new(Cell::new(0));
-        let mut cache: Clock<u64, Tracked> = Clock::new(NZUsize!(2));
-        for i in 0..2u64 {
-            cache.put(
-                i,
-                Tracked {
-                    _counter: drops.clone(),
-                },
-            );
+        let mut cache = TestCache::new(NZUsize!(2));
+        for key in 0..2u64 {
+            cache.put(key, Tracked(drops.clone()));
         }
-        assert_eq!(drops.get(), 0);
-
-        // Inserting a third entry evicts one (and drops its value).
-        cache.put(
-            2,
-            Tracked {
-                _counter: drops.clone(),
-            },
-        );
+        cache.put(2, Tracked(drops.clone()));
         assert_eq!(drops.get(), 1);
 
-        // Replacing an existing key drops the old value.
-        cache.put(
-            2,
-            Tracked {
-                _counter: drops.clone(),
-            },
-        );
+        cache.put(2, Tracked(drops.clone()));
         assert_eq!(drops.get(), 2);
 
-        // Clearing drops the remaining two values.
         cache.clear();
         assert_eq!(drops.get(), 4);
     }
 
     #[test]
-    fn test_remove_retains_value_until_reuse() {
-        // remove() does not drop the value; the freed slot keeps it until the
-        // slot is reused by a value-inserting method.
+    fn remove_retains_value_until_reuse() {
         let drops = Rc::new(Cell::new(0));
-        let mut cache: Clock<u64, Tracked> = Clock::new(NZUsize!(2));
-        cache.put(
-            1,
-            Tracked {
-                _counter: drops.clone(),
-            },
-        );
+        let mut cache = TestCache::new(NZUsize!(2));
+        cache.put(1, Tracked(drops.clone()));
         assert!(cache.remove(&1));
-        assert_eq!(drops.get(), 0, "remove must not drop the value");
+        assert_eq!(drops.get(), 0);
 
-        // Reusing the freed slot via a value insert drops the retained value.
-        cache.put(
-            2,
-            Tracked {
-                _counter: drops.clone(),
-            },
-        );
+        cache.put(2, Tracked(drops.clone()));
         assert_eq!(drops.get(), 1);
     }
 
     #[test]
-    fn test_get_at_validates_key() {
-        let mut cache = Clock::new(NZUsize!(2));
-        let (slot1, v) = cache.get_or_insert_mut(1u64, || 0u64);
-        *v = 10;
-        let (slot2, v) = cache.get_or_insert_mut(2u64, || 0u64);
-        *v = 20;
+    fn get_at_validates_key() {
+        let mut cache = TestCache::new(NZUsize!(2));
+        let (first, value) = cache.get_or_insert_mut(1u64, || 0u64);
+        *value = 10;
+        let (second, value) = cache.get_or_insert_mut(2u64, || 0u64);
+        *value = 20;
 
-        // A recorded slot resolves with a key compare, no hash lookup.
-        assert_eq!(cache.get_at(slot1, &1).copied(), Some(10));
-        assert_eq!(cache.get_at(slot2, &2).copied(), Some(20));
-
-        // The wrong key for a slot and an out-of-range slot both read as misses.
-        assert_eq!(cache.get_at(slot1, &2), None);
+        assert_eq!(cache.get_at(first, &1).copied(), Some(10));
+        assert_eq!(cache.get_at(second, &2).copied(), Some(20));
+        assert_eq!(cache.get_at(first, &2), None);
         assert_eq!(cache.get_at(cache.capacity(), &1), None);
-        cache.check_invariants();
+        cache.check_cache_invariants();
     }
 
     #[test]
-    fn test_get_at_stale_slot_after_eviction() {
-        // Evicting key 1 reuses its slot for key 3: the stale index entry fails
-        // the key compare while the new key resolves at the same slot.
-        let mut cache = Clock::new(NZUsize!(1));
-        let (slot, v) = cache.get_or_insert_mut(1u64, || 0u64);
-        *v = 10;
-        let (reused, v) = cache.get_or_insert_mut(3u64, || 0u64);
-        *v = 30;
+    fn get_at_rejects_stale_evicted_slot() {
+        let mut cache = TestCache::new(NZUsize!(1));
+        let (slot, value) = cache.get_or_insert_mut(1u64, || 0u64);
+        *value = 10;
+        let (reused, value) = cache.get_or_insert_mut(3u64, || 0u64);
+        *value = 30;
+
         assert_eq!(slot, reused);
         assert_eq!(cache.get_at(slot, &1), None);
         assert_eq!(cache.get_at(slot, &3).copied(), Some(30));
-        cache.check_invariants();
+        cache.check_cache_invariants();
     }
 
     #[test]
-    fn test_get_at_freed_slot_is_a_miss() {
-        // remove() keeps the slot's stale key for allocation reuse, but get_at must not
-        // resolve it: freed entries read as misses without any external index hygiene.
-        let mut cache = Clock::new(NZUsize!(2));
-        let (slot, v) = cache.get_or_insert_mut(1u64, || 0u64);
-        *v = 10;
+    fn get_at_rejects_freed_slot() {
+        let mut cache = TestCache::new(NZUsize!(2));
+        let (slot, value) = cache.get_or_insert_mut(1u64, || 0u64);
+        *value = 10;
         assert!(cache.remove(&1));
         assert_eq!(cache.get_at(slot, &1), None);
 
-        // Reusing the slot for another key resolves the new key only.
-        let (reused, v) = cache.get_or_insert_mut(2u64, || 0u64);
-        *v = 20;
+        let (reused, value) = cache.get_or_insert_mut(2u64, || 0u64);
+        *value = 20;
         assert_eq!(reused, slot);
         assert_eq!(cache.get_at(slot, &1), None);
         assert_eq!(cache.get_at(slot, &2).copied(), Some(20));
-        cache.check_invariants();
+        cache.check_cache_invariants();
     }
 
     #[test]
-    fn test_get_at_records_use() {
-        // Mirrors test_peek_does_not_record_use's setup: after it, slot1=key2
-        // and slot2=key3 are unreferenced with the hand at slot1. get_at on
-        // key2 must set its bit so the next insert evicts key3 instead.
-        let mut c = Clock::new(NZUsize!(3));
-        c.put(1u64, 10u64);
-        c.put(2, 20);
-        c.put(3, 30);
-        c.put(4, 40); // evicts key1, clears key2/key3 bits, hand -> slot1
-
-        let slot = *c.index.get(&2).unwrap();
-        assert_eq!(c.get_at(slot, &2).copied(), Some(20));
-        c.put(5, 50);
-        assert!(c.contains(&2), "get_at must protect key2 from eviction");
-        assert!(!c.contains(&3));
-        c.check_invariants();
-    }
-
-    #[test]
-    fn test_get_or_insert_mut_slot_stable_on_hit() {
-        let mut cache = Clock::new(NZUsize!(2));
-        let (slot, v) = cache.get_or_insert_mut(1u64, || 0u64);
-        *v = 10;
-        let (hit_slot, v) = cache.get_or_insert_mut(1u64, || unreachable!());
+    fn get_or_insert_mut_slot_is_stable_on_hit() {
+        let mut cache = TestCache::new(NZUsize!(2));
+        let (slot, value) = cache.get_or_insert_mut(1u64, || 0u64);
+        *value = 10;
+        let (hit_slot, value) = cache.get_or_insert_mut(1u64, || unreachable!());
         assert_eq!(slot, hit_slot);
-        assert_eq!(*v, 10);
-        cache.check_invariants();
+        assert_eq!(*value, 10);
+        cache.check_cache_invariants();
     }
 
     #[test]
-    fn test_get_mut() {
-        let mut cache = Clock::new(NZUsize!(2));
+    fn get_mut_updates_resident_value() {
+        let mut cache = TestCache::new(NZUsize!(2));
         cache.put(1u64, 10u64);
         assert_eq!(cache.get_mut(&2), None);
         *cache.get_mut(&1).unwrap() = 11;
         assert_eq!(cache.get(&1).copied(), Some(11));
-        cache.check_invariants();
+        cache.check_cache_invariants();
     }
 
-    #[test]
-    fn test_peek_does_not_record_use() {
-        // After this shared setup (capacity 3): slot1=key2 and slot2=key3 are
-        // both unreferenced and the hand is at slot1. peek(&2) leaves key2
-        // unreferenced, so the next insert evicts it; get(&2) sets its bit, so
-        // key3 is evicted instead. This isolates the one behavioral difference
-        // between peek and get.
-        fn setup() -> Clock<u64, u64> {
-            let mut c = Clock::new(NZUsize!(3));
-            c.put(1, 10);
-            c.put(2, 20);
-            c.put(3, 30);
-            c.put(4, 40); // evicts key1, clears key2/key3 bits, hand -> slot1
-            c
-        }
-
-        // peek does NOT record use: key2 stays evictable.
-        let mut c = setup();
-        assert_eq!(c.peek(&2).copied(), Some(20));
-        c.put(5, 50);
-        assert!(!c.contains(&2), "peek must not protect key2 from eviction");
-        assert!(c.contains(&3));
-
-        // get DOES record use: key2 survives, key3 is evicted instead.
-        let mut c = setup();
-        assert_eq!(c.get(&2).copied(), Some(20));
-        c.put(5, 50);
-        assert!(c.contains(&2), "get must protect key2 from eviction");
-        assert!(!c.contains(&3));
+    struct EarlyEvictionPolicy {
+        residents: Vec<Slot>,
+        history: Vec<u64>,
     }
 
-    #[test]
-    fn test_concurrent_get_is_sound() {
-        // get(&self) records use through an atomic, so many threads can read
-        // concurrently through a shared &Clock with no external lock.
-        let mut cache: Clock<u64, u64> = Clock::new(NZUsize!(64));
-        for i in 0..64u64 {
-            cache.put(i, i * 10);
-        }
-        let cache = &cache;
-        thread::scope(|s| {
-            for _ in 0..4 {
-                s.spawn(move || {
-                    for _ in 0..2_000 {
-                        for i in 0..64u64 {
-                            assert_eq!(cache.get(&i).copied(), Some(i * 10));
-                        }
-                    }
-                });
+    impl Policy<u64> for EarlyEvictionPolicy {
+        type SlotState = ();
+
+        fn new(_capacity: NonZeroUsize) -> Self {
+            Self {
+                residents: Vec::new(),
+                history: Vec::new(),
             }
-        });
-        for i in 0..64u64 {
-            assert_eq!(cache.get(&i).copied(), Some(i * 10));
         }
-        cache.check_invariants();
+
+        fn hit(&self, _slot: Slot, _state: &()) {}
+
+        fn insert<I, C>(&mut self, _states: &I, _key: &u64, has_vacancy: bool, claim: C)
+        where
+            I: Index<Slot, Output = ()>,
+            C: FnOnce(Option<Slot>) -> Claimed<u64>,
+        {
+            let slot = if let Some(&victim) = self.residents.first() {
+                let Claimed::Evicted(key) = claim(Some(victim)) else {
+                    panic!("early eviction policy must evict a resident");
+                };
+                self.residents.remove(0);
+                self.history.push(key);
+                victim
+            } else {
+                assert!(has_vacancy);
+                let Claimed::Vacant(slot) = claim(None) else {
+                    panic!("early eviction policy must claim vacant capacity");
+                };
+                slot
+            };
+            self.residents.push(slot);
+        }
+
+        fn remove(&mut self, slot: Option<Slot>, key: &u64) {
+            if let Some(slot) = slot {
+                let position = self
+                    .residents
+                    .iter()
+                    .position(|resident| *resident == slot)
+                    .unwrap();
+                self.residents.remove(position);
+            }
+            self.history.retain(|historical| historical != key);
+        }
+
+        fn retain<F: FnMut(&u64) -> bool>(&mut self, keep: F) {
+            self.history.retain(keep);
+        }
+
+        fn clear(&mut self) {
+            self.residents.clear();
+            self.history.clear();
+        }
+    }
+
+    #[test]
+    fn policy_can_evict_before_capacity() {
+        let mut cache = Cache::<u64, u64, EarlyEvictionPolicy>::new(NZUsize!(3));
+        cache.prefill(|| 0);
+
+        let (first_slot, first_value) = cache.get_or_insert_mut(1, || unreachable!());
+        *first_value = 10;
+        let (second_slot, second_value) = cache.get_or_insert_mut(2, || unreachable!());
+        *second_value = 20;
+
+        assert_eq!(first_slot, second_slot);
+        assert_eq!(cache.len(), 1);
+        assert_eq!(cache.get(&1), None);
+        assert_eq!(cache.get(&2).copied(), Some(20));
+        assert_eq!(cache.policy.history, vec![1]);
+
+        assert!(!cache.remove(&1));
+        assert!(cache.policy.history.is_empty());
+        cache.put(3, 30);
+        cache.put(4, 40);
+        assert_eq!(cache.policy.history, vec![2, 3]);
+        cache.retain_keys(|key| *key >= 3);
+        assert_eq!(cache.policy.history, vec![3]);
+
+        cache.clear();
+        assert!(cache.policy.residents.is_empty());
+        assert!(cache.policy.history.is_empty());
     }
 
     #[derive(Clone, Debug)]
@@ -950,87 +985,76 @@ mod tests {
         prop_oneof![
             (0u8..16).prop_map(Op::Get),
             (0u8..16).prop_map(Op::Peek),
-            (0u8..16, any::<u16>()).prop_map(|(k, v)| Op::Put(k, v)),
-            (0u8..16, any::<u16>()).prop_map(|(k, v)| Op::GetOrInsert(k, v)),
-            (0u8..16, any::<u16>()).prop_map(|(k, v)| Op::GetOrInsertMut(k, v)),
-            (0u8..16, any::<u16>()).prop_map(|(k, v)| Op::GetMut(k, v)),
+            (0u8..16, any::<u16>()).prop_map(|(key, value)| Op::Put(key, value)),
+            (0u8..16, any::<u16>()).prop_map(|(key, value)| Op::GetOrInsert(key, value)),
+            (0u8..16, any::<u16>()).prop_map(|(key, value)| Op::GetOrInsertMut(key, value)),
+            (0u8..16, any::<u16>()).prop_map(|(key, value)| Op::GetMut(key, value)),
             (0u8..16).prop_map(Op::Remove),
             (0u8..16).prop_map(Op::Retain),
         ]
     }
 
-    const KEY_SPACE: u8 = 16;
-
     proptest! {
         #[test]
-        fn prop_invariants_hold(
-            cap in 1usize..8,
+        fn invariants_hold(
+            capacity in 1usize..8,
             prefill in any::<bool>(),
             ops in proptest::collection::vec(op_strategy(), 0..256),
         ) {
-            let mut cache: Clock<u8, u16> = Clock::new(NonZeroUsize::new(cap).unwrap());
+            let mut cache = TestCache::new(NonZeroUsize::new(capacity).unwrap());
             if prefill {
                 cache.prefill(|| 0u16);
             }
-            // Oracle: last value written for each live key. A key the cache
-            // reports as present must hold its last-written value (no stale or
-            // conjured values); an evicted key is simply absent.
-            let mut model: HashMap<u8, u16> = HashMap::new();
+            let mut model = HashMap::new();
+
             for op in ops {
                 match op {
-                    Op::Get(k) => {
-                        let got = cache.get(&k).copied();
-                        prop_assert_eq!(got, cache.peek(&k).copied());
+                    Op::Get(key) => {
+                        let value = cache.get(&key).copied();
+                        prop_assert_eq!(value, cache.peek(&key).copied());
                     }
-                    Op::Peek(k) => {
-                        let _ = cache.peek(&k);
+                    Op::Peek(key) => {
+                        let _ = cache.peek(&key);
                     }
-                    Op::Put(k, v) => {
-                        cache.put(k, v);
-                        model.insert(k, v);
-                        prop_assert_eq!(cache.peek(&k).copied(), Some(v));
+                    Op::Put(key, value) => {
+                        cache.put(key, value);
+                        model.insert(key, value);
                     }
-                    Op::GetOrInsert(k, v) => {
-                        let stored = *cache.get_or_insert_with(k, || v);
-                        model.insert(k, stored);
-                        prop_assert_eq!(cache.peek(&k).copied(), Some(stored));
+                    Op::GetOrInsert(key, value) => {
+                        let stored = *cache.get_or_insert_with(key, || value);
+                        model.insert(key, stored);
                     }
-                    Op::GetOrInsertMut(k, v) => {
-                        *cache.get_or_insert_mut(k, || v).1 = v;
-                        model.insert(k, v);
-                        prop_assert_eq!(cache.peek(&k).copied(), Some(v));
+                    Op::GetOrInsertMut(key, value) => {
+                        *cache.get_or_insert_mut(key, || value).1 = value;
+                        model.insert(key, value);
                     }
-                    Op::GetMut(k, v) => {
-                        if let Some(slot) = cache.get_mut(&k) {
-                            *slot = v;
-                            model.insert(k, v);
+                    Op::GetMut(key, value) => {
+                        if let Some(stored) = cache.get_mut(&key) {
+                            *stored = value;
+                            model.insert(key, value);
                         }
                     }
-                    Op::Remove(k) => {
-                        let had = cache.contains(&k);
-                        prop_assert_eq!(cache.remove(&k), had);
-                        model.remove(&k);
-                        prop_assert!(!cache.contains(&k));
+                    Op::Remove(key) => {
+                        let present = cache.contains(&key);
+                        prop_assert_eq!(cache.remove(&key), present);
+                        model.remove(&key);
                     }
-                    Op::Retain(k) => {
-                        cache.retain(|key, _| *key < k);
-                        model.retain(|key, _| *key < k);
-                        prop_assert!(cache.len() <= usize::from(k).min(cap));
+                    Op::Retain(key) => {
+                        cache.retain(|resident, _| *resident < key);
+                        model.retain(|resident, _| *resident < key);
                     }
                 }
-                prop_assert!(cache.len() <= cap);
-                // The slot vector never exceeds capacity, proving reuse.
-                prop_assert!(cache.slots.len() <= cap);
-                // Every present key holds its last-written value and was logically
-                // inserted; absent keys are an allowed (evicted) state.
-                for k in 0..KEY_SPACE {
-                    let present = cache.contains(&k);
-                    prop_assert_eq!(present, cache.peek(&k).is_some());
+
+                prop_assert!(cache.len() <= capacity);
+                prop_assert!(cache.slots.len() <= capacity);
+                for key in 0..16u8 {
+                    let present = cache.contains(&key);
+                    prop_assert_eq!(present, cache.peek(&key).is_some());
                     if present {
-                        prop_assert_eq!(cache.peek(&k).copied(), model.get(&k).copied());
+                        prop_assert_eq!(cache.peek(&key).copied(), model.get(&key).copied());
                     }
                 }
-                cache.check_invariants();
+                cache.check_cache_invariants();
             }
         }
     }

--- a/utils/src/cache.rs
+++ b/utils/src/cache.rs
@@ -630,10 +630,13 @@ mod tests {
     type TestCache<K, V> = Cache<K, V, TestPolicy>;
 
     impl<K: Hash + Eq + Clone, V, P: Policy<K>> Cache<K, V, P> {
+        /// Asserts the cache's structural invariants hold.
         pub(super) fn check_cache_invariants(&self) {
             assert!(self.slots.len() <= self.capacity());
             assert_eq!(self.index.len() + self.free.len(), self.slots.len());
 
+            // The index is a bijection onto the live slots, each slot's key
+            // round-trips, and live slots are disjoint from free slots.
             let free: HashSet<Slot> = self.free.iter().copied().collect();
             assert_eq!(free.len(), self.free.len(), "duplicate free slot");
             let mut seen = HashSet::new();
@@ -699,6 +702,7 @@ mod tests {
 
         assert_eq!(*cache.get_or_insert_with(1, || compute(1)), 100);
         assert_eq!(calls.get(), 1);
+        // A hit does not call the factory.
         assert_eq!(*cache.get_or_insert_with(1, || compute(1)), 100);
         assert_eq!(calls.get(), 1);
         cache.check_cache_invariants();
@@ -720,6 +724,8 @@ mod tests {
 
     #[test]
     fn test_remove_keeps_slot_for_reuse() {
+        // A removed entry frees its slot for reuse without growing the slot
+        // vector or calling the factory again.
         let makes = Cell::new(0);
         let mut cache = TestCache::new(NZUsize!(2));
         cache.get_or_insert_mut(1, || {
@@ -736,6 +742,8 @@ mod tests {
         assert!(cache.remove(&1));
         assert!(!cache.contains(&1));
         assert_eq!(cache.len(), 1);
+
+        // Reusing the freed slot does not call the factory or grow.
         *cache
             .get_or_insert_mut(3, || {
                 makes.set(makes.get() + 1);
@@ -743,7 +751,7 @@ mod tests {
             })
             .1 = 30;
 
-        assert_eq!(makes.get(), 2);
+        assert_eq!(makes.get(), 2, "freed slot should not call the factory");
         assert_eq!(cache.slots.len(), 2);
         assert_eq!(cache.get(&3).copied(), Some(30));
         assert!(!cache.remove(&999));
@@ -756,6 +764,7 @@ mod tests {
         for key in 0..4u64 {
             cache.put(key, key * 10);
         }
+        // Keep even keys.
         cache.retain(|key, _| key % 2 == 0);
         assert_eq!(cache.len(), 2);
         assert!(cache.contains(&0));
@@ -763,6 +772,7 @@ mod tests {
         assert!(!cache.contains(&1));
         assert!(!cache.contains(&3));
 
+        // Freed slots are reused for new inserts.
         cache.put(10, 100);
         cache.put(12, 120);
         assert_eq!(cache.slots.len(), 4);
@@ -772,6 +782,8 @@ mod tests {
 
     #[test]
     fn test_get_or_insert_mut_reuses_allocations() {
+        // The factory runs at most `capacity` times no matter how many distinct
+        // keys churn through the cache, proving evicted slots are reused.
         let makes = Cell::new(0);
         let mut cache = TestCache::new(NZUsize!(3));
         for key in 0..100u64 {
@@ -779,9 +791,9 @@ mod tests {
                 makes.set(makes.get() + 1);
                 0
             });
-            *value = key;
+            *value = key; // Overwrite the possibly stale reused value.
         }
-        assert_eq!(makes.get(), 3);
+        assert_eq!(makes.get(), 3, "factory should run only during growth");
         assert_eq!(cache.slots.len(), 3);
         assert_eq!(cache.len(), 3);
         cache.check_cache_invariants();
@@ -789,6 +801,8 @@ mod tests {
 
     #[test]
     fn test_prefill_allocates_once_and_reuses() {
+        // Prefill runs the factory exactly `capacity` times. Subsequent inserts
+        // reuse pre-allocated slots without growing or calling the factory.
         let makes = Cell::new(0);
         let mut cache = TestCache::new(NZUsize!(3));
         cache.prefill(|| {
@@ -800,6 +814,7 @@ mod tests {
         assert!(cache.is_empty());
         cache.check_cache_invariants();
 
+        // Churn many keys without further factory calls or slot growth.
         for key in 0..100u64 {
             *cache
                 .get_or_insert_mut(key, || {
@@ -808,7 +823,7 @@ mod tests {
                 })
                 .1 = key;
         }
-        assert_eq!(makes.get(), 3);
+        assert_eq!(makes.get(), 3, "prefilled slots must be reused");
         assert_eq!(cache.slots.len(), 3);
         assert_eq!(cache.len(), 3);
         cache.check_cache_invariants();
@@ -845,24 +860,31 @@ mod tests {
             cache.put(key, Tracked(drops.clone()));
         }
         assert_eq!(drops.get(), 0);
+
+        // Inserting a third entry evicts one and drops its value.
         cache.put(2, Tracked(drops.clone()));
         assert_eq!(drops.get(), 1);
 
+        // Replacing an existing key drops the old value.
         cache.put(2, Tracked(drops.clone()));
         assert_eq!(drops.get(), 2);
 
+        // Clearing drops the remaining two values.
         cache.clear();
         assert_eq!(drops.get(), 4);
     }
 
     #[test]
     fn test_remove_retains_value_until_reuse() {
+        // remove does not drop the value. The freed slot keeps it until a
+        // value-inserting method reuses the slot.
         let drops = Rc::new(Cell::new(0));
         let mut cache = TestCache::new(NZUsize!(2));
         cache.put(1, Tracked(drops.clone()));
         assert!(cache.remove(&1));
-        assert_eq!(drops.get(), 0);
+        assert_eq!(drops.get(), 0, "remove must not drop the value");
 
+        // Reusing the freed slot through a value insert drops the retained value.
         cache.put(2, Tracked(drops.clone()));
         assert_eq!(drops.get(), 1);
     }
@@ -875,8 +897,11 @@ mod tests {
         let (second, value) = cache.get_or_insert_mut(2u64, || 0u64);
         *value = 20;
 
+        // A recorded slot resolves with a key comparison and no hash lookup.
         assert_eq!(cache.get_at(first, &1).copied(), Some(10));
         assert_eq!(cache.get_at(second, &2).copied(), Some(20));
+
+        // The wrong key for a slot and an out-of-range slot are both misses.
         assert_eq!(cache.get_at(first, &2), None);
         assert_eq!(cache.get_at(cache.capacity(), &1), None);
         cache.check_cache_invariants();
@@ -884,6 +909,8 @@ mod tests {
 
     #[test]
     fn test_get_at_rejects_stale_evicted_slot() {
+        // Evicting key 1 reuses its slot for key 3. The stale hint fails the key
+        // comparison while the new key resolves at the same slot.
         let mut cache = TestCache::new(NZUsize!(1));
         let (slot, value) = cache.get_or_insert_mut(1u64, || 0u64);
         *value = 10;
@@ -898,12 +925,15 @@ mod tests {
 
     #[test]
     fn test_get_at_rejects_freed_slot() {
+        // remove keeps the slot's stale key for allocation reuse, but get_at
+        // must reject a freed slot without requiring external index cleanup.
         let mut cache = TestCache::new(NZUsize!(2));
         let (slot, value) = cache.get_or_insert_mut(1u64, || 0u64);
         *value = 10;
         assert!(cache.remove(&1));
         assert_eq!(cache.get_at(slot, &1), None);
 
+        // Reusing the slot for another key resolves the new key only.
         let (reused, value) = cache.get_or_insert_mut(2u64, || 0u64);
         *value = 20;
         assert_eq!(reused, slot);

--- a/utils/src/cache.rs
+++ b/utils/src/cache.rs
@@ -33,7 +33,46 @@
 //! as [Cache::put] replace and drop displaced values as usual.
 //!
 //! Replacement policies are provided in submodules. [Cache] uses [Clock] by
-//! default. See the [clock] module for its behavior and concurrency properties.
+//! default. See the [clock] module for its behavior.
+//!
+//! # Concurrency
+//!
+//! [Cache] performs no internal locking. Shared lookups record use through
+//! [Policy::hit], whose contract permits concurrent calls through shared
+//! references. Mutating operations, including insertion after a miss, require
+//! `&mut self`. A cache can therefore be wrapped in a reader-writer lock and
+//! queried concurrently on the hit path:
+//!
+//! ```
+//! use commonware_utils::cache::Cache;
+//! use core::num::NonZeroUsize;
+//! use std::sync::RwLock;
+//!
+//! let cache = RwLock::new(Cache::<u64, u64>::new(NonZeroUsize::new(4).unwrap()));
+//!
+//! // Hit path: shared read lock, runs concurrently with other readers.
+//! if cache.read().unwrap().get(&7).is_none() {
+//!     // Miss path: exclusive write lock, computes and inserts the value once.
+//!     cache.write().unwrap().get_or_insert_with(7, || 7 * 7);
+//! }
+//! assert_eq!(cache.read().unwrap().get(&7).copied(), Some(49));
+//! ```
+//!
+//! # Example
+//!
+//! ```
+//! use commonware_utils::cache::Cache;
+//! use core::num::NonZeroUsize;
+//!
+//! let mut cache = Cache::<u64, u64>::new(NonZeroUsize::new(2).unwrap());
+//!
+//! // Compute an expensive value only on a miss.
+//! let value = *cache.get_or_insert_with(1, || 1 * 1000);
+//! assert_eq!(value, 1000);
+//!
+//! // A second lookup is served from the cache.
+//! assert_eq!(cache.get(&1).copied(), Some(1000));
+//! ```
 
 pub mod clock;
 
@@ -69,8 +108,7 @@ pub enum Claimed<K> {
 pub trait Policy<K> {
     /// Policy state stored inline with each cache slot.
     ///
-    /// A policy that keeps all slot-indexed state in its own arrays may use
-    /// `()`.
+    /// A policy that needs no per-slot state may use `()`.
     type SlotState;
 
     /// Creates empty policy state for `capacity` residents.

--- a/utils/src/cache.rs
+++ b/utils/src/cache.rs
@@ -38,16 +38,18 @@
 //!
 //! 1. Start with [Clock]. It is the default when representative benchmarks are
 //!    unavailable, resident metadata matters, or the workload is reasonably
-//!    stable. It has the least admission filtering and scan resistance.
-//! 2. Try [Sieve] when scans, bursts, or many one-hit entries pollute the cache.
-//!    New residents enter unvisited and are immediately evictable until they
-//!    receive a hit. This inexpensive filtering costs two links per resident
-//!    and slightly more insertion bookkeeping than CLOCK.
-//! 3. Try [Clock2QPlus] when misses are expensive and recently evicted entries
-//!    often return after newer traffic pushes them out. Its bounded Ghost
-//!    history recognizes that reuse and admits the entry directly into the
-//!    protected Main region, at the cost of substantially more metadata and
-//!    heavier insertion and eviction.
+//!    stable. It has the least resident metadata and insertion bookkeeping.
+//! 2. Try [Sieve] when bursts or many one-hit entries pollute the cache,
+//!    particularly for web-cache-like workloads. New residents enter
+//!    unvisited and are immediately evictable until they receive a hit. This
+//!    inexpensive filtering costs two links per resident and slightly more
+//!    insertion bookkeeping than CLOCK. Without nonresident history, SIEVE is
+//!    not generally scan-resistant for page or block workloads.
+//! 3. Try [Clock2QPlus] when misses are expensive (for example, when they entail
+//!    I/O) and recently evicted entries often return after newer traffic pushes
+//!    them out. Its bounded Ghost history recognizes that reuse and admits the
+//!    entry directly into the protected Main region, at the cost of
+//!    substantially more metadata and heavier insertion and eviction.
 //!
 //! SIEVE remembers only whether an entry was referenced while resident and
 //! forgets it after eviction. CLOCK2Q+ preserves evidence about recently

--- a/utils/src/cache.rs
+++ b/utils/src/cache.rs
@@ -32,8 +32,7 @@
 //! value allocation from steady-state insertion. Value-returning methods such
 //! as [Cache::put] replace and drop displaced values as usual.
 //!
-//! Replacement policies are provided in submodules. [Cache] uses [Clock] by
-//! default. See the [clock] module for its behavior.
+//! The [clock] module provides [Clock], the default replacement policy.
 //!
 //! # Concurrency
 //!
@@ -121,6 +120,12 @@ pub trait Policy<K> {
     /// synchronization.
     fn hit(&self, slot: Slot, state: &Self::SlotState);
 
+    /// Records a hit while the cache is exclusively borrowed.
+    ///
+    /// Unlike [Self::hit], this method may update policy metadata directly
+    /// without synchronization.
+    fn hit_mut(&mut self, slot: Slot, state: &mut Self::SlotState);
+
     /// Inserts `key` after a confirmed cache miss.
     ///
     /// `states` provides policy state indexed by [Slot]. `has_vacancy` reports
@@ -203,7 +208,7 @@ impl<K: Hash + Eq + Clone, V, P: Policy<K>> Cache<K, V, P> {
         Self {
             index: HashMap::with_capacity_and_hasher(capacity, Hasher::default()),
             slots: Vec::with_capacity(capacity),
-            free: Vec::with_capacity(capacity),
+            free: Vec::new(),
             capacity,
             policy,
         }
@@ -281,7 +286,7 @@ impl<K: Hash + Eq + Clone, V, P: Policy<K>> Cache<K, V, P> {
     pub fn get_mut(&mut self, key: &K) -> Option<&mut V> {
         let &index = self.index.get(key)?;
         let slot = &mut self.slots[index];
-        self.policy.hit(index, &slot.state);
+        self.policy.hit_mut(index, &mut slot.state);
         Some(&mut slot.value)
     }
 
@@ -293,7 +298,7 @@ impl<K: Hash + Eq + Clone, V, P: Policy<K>> Cache<K, V, P> {
     pub fn put(&mut self, key: K, value: V) -> Option<V> {
         if let Some(&index) = self.index.get(&key) {
             let slot = &mut self.slots[index];
-            self.policy.hit(index, &slot.state);
+            self.policy.hit_mut(index, &mut slot.state);
             return Some(core::mem::replace(&mut slot.value, value));
         }
         self.insert_value(key, value);
@@ -309,7 +314,7 @@ impl<K: Hash + Eq + Clone, V, P: Policy<K>> Cache<K, V, P> {
     pub fn get_or_insert_with<F: FnOnce() -> V>(&mut self, key: K, f: F) -> &V {
         let slot = match self.index.get(&key) {
             Some(&slot) => {
-                self.policy.hit(slot, &self.slots[slot].state);
+                self.policy.hit_mut(slot, &mut self.slots[slot].state);
                 slot
             }
             None => self.insert_value(key, f()),
@@ -330,7 +335,7 @@ impl<K: Hash + Eq + Clone, V, P: Policy<K>> Cache<K, V, P> {
     ) -> Result<&V, E> {
         let slot = match self.index.get(&key) {
             Some(&slot) => {
-                self.policy.hit(slot, &self.slots[slot].state);
+                self.policy.hit_mut(slot, &mut self.slots[slot].state);
                 slot
             }
             None => self.insert_value(key, f()?),
@@ -353,7 +358,7 @@ impl<K: Hash + Eq + Clone, V, P: Policy<K>> Cache<K, V, P> {
     /// [Self::get_at] instead of a hash lookup.
     pub fn get_or_insert_mut<F: FnOnce() -> V>(&mut self, key: K, make: F) -> (Slot, &mut V) {
         if let Some(&slot) = self.index.get(&key) {
-            self.policy.hit(slot, &self.slots[slot].state);
+            self.policy.hit_mut(slot, &mut self.slots[slot].state);
             return (slot, &mut self.slots[slot].value);
         }
         let mut value = None;
@@ -372,37 +377,40 @@ impl<K: Hash + Eq + Clone, V, P: Policy<K>> Cache<K, V, P> {
     /// The slot and its allocation are retained for reuse, so the value is not
     /// returned.
     pub fn remove(&mut self, key: &K) -> bool {
-        let Some((key, slot)) = self.index.remove_entry(key) else {
-            self.policy.remove(None, key);
-            return false;
-        };
-        self.policy.remove(Some(slot), &key);
-        self.slots[slot].live = false;
-        self.free.push(slot);
-        true
+        match self.index.remove(key) {
+            Some(slot) => {
+                self.policy.remove(Some(slot), key);
+                self.slots[slot].live = false;
+                self.free.push(slot);
+                true
+            }
+            None => {
+                self.policy.remove(None, key);
+                false
+            }
+        }
     }
 
     /// Retains only the entries for which `keep` returns `true`.
     ///
     /// Dropped entries' slots and allocations are retained for reuse.
     pub fn retain<F: FnMut(&K, &V) -> bool>(&mut self, mut keep: F) {
-        for slot in 0..self.slots.len() {
-            let remove = {
-                let resident = &self.slots[slot];
-                resident.live && !keep(&resident.key, &resident.value)
-            };
-            if !remove {
-                continue;
+        let Self {
+            index,
+            slots,
+            free,
+            policy,
+            ..
+        } = self;
+        index.retain(|key, &mut slot| {
+            let keep = keep(key, &slots[slot].value);
+            if !keep {
+                policy.remove(Some(slot), key);
+                slots[slot].live = false;
+                free.push(slot);
             }
-            let key = self
-                .index
-                .remove_entry(&self.slots[slot].key)
-                .expect("a live slot must be indexed")
-                .0;
-            self.policy.remove(Some(slot), &key);
-            self.slots[slot].live = false;
-            self.free.push(slot);
-        }
+            keep
+        });
     }
 
     /// Retains resident entries and policy history accepted by `keep`.
@@ -410,24 +418,23 @@ impl<K: Hash + Eq + Clone, V, P: Policy<K>> Cache<K, V, P> {
     /// This key-only form is useful when nonresident admission history must be
     /// invalidated by the same predicate as resident entries.
     pub fn retain_keys<F: FnMut(&K) -> bool>(&mut self, mut keep: F) {
-        for slot in 0..self.slots.len() {
-            let remove = {
-                let resident = &self.slots[slot];
-                resident.live && !keep(&resident.key)
-            };
-            if !remove {
-                continue;
+        let Self {
+            index,
+            slots,
+            free,
+            policy,
+            ..
+        } = self;
+        index.retain(|key, &mut slot| {
+            let keep = keep(key);
+            if !keep {
+                policy.remove(Some(slot), key);
+                slots[slot].live = false;
+                free.push(slot);
             }
-            let key = self
-                .index
-                .remove_entry(&self.slots[slot].key)
-                .expect("a live slot must be indexed")
-                .0;
-            self.policy.remove(Some(slot), &key);
-            self.slots[slot].live = false;
-            self.free.push(slot);
-        }
-        self.policy.retain(keep);
+            keep
+        });
+        policy.retain(keep);
     }
 
     /// Removes all entries, dropping their values and retaining the allocated
@@ -440,14 +447,12 @@ impl<K: Hash + Eq + Clone, V, P: Policy<K>> Cache<K, V, P> {
     }
 
     /// Inserts `value` for a `key` known to be absent, returning its slot.
-    #[inline(always)]
     fn insert_value(&mut self, key: K, value: V) -> Slot {
         let (slot, state) = self.claim_slot(&key, |_| {});
         self.install(slot, key, state, Some(value));
         slot
     }
 
-    #[inline(always)]
     fn install(&mut self, slot: Slot, key: K, state: P::SlotState, value: Option<V>) {
         let index_key = key.clone();
         if slot == self.slots.len() {
@@ -476,7 +481,6 @@ impl<K: Hash + Eq + Clone, V, P: Policy<K>> Cache<K, V, P> {
 
     /// Claims storage for an incoming key and returns its slot and initial
     /// policy state. `on_claim` runs before the policy observes the result.
-    #[inline(always)]
     fn claim_slot<F: FnOnce(bool)>(&mut self, key: &K, on_claim: F) -> (Slot, P::SlotState) {
         let Self {
             index,
@@ -545,6 +549,15 @@ where
     }
 }
 
+impl<K, V> core::fmt::Debug for Cache<K, V, Clock> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Cache")
+            .field("len", &self.index.len())
+            .field("capacity", &self.capacity)
+            .finish()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -570,6 +583,8 @@ mod tests {
         }
 
         fn hit(&self, _slot: Slot, _state: &()) {}
+
+        fn hit_mut(&mut self, _slot: Slot, _state: &mut ()) {}
 
         fn insert<I, C>(&mut self, _states: &I, _key: &K, has_vacancy: bool, claim: C)
         where
@@ -942,6 +957,8 @@ mod tests {
 
         fn hit(&self, _slot: Slot, _state: &()) {}
 
+        fn hit_mut(&mut self, _slot: Slot, _state: &mut ()) {}
+
         fn insert<I, C>(&mut self, _states: &I, _key: &u64, has_vacancy: bool, claim: C)
         where
             I: Index<Slot, Output = ()>,
@@ -1047,7 +1064,7 @@ mod tests {
             prefill in any::<bool>(),
             ops in proptest::collection::vec(op_strategy(), 0..256),
         ) {
-            let mut cache = TestCache::new(NonZeroUsize::new(capacity).unwrap());
+            let mut cache: Cache<u8, u16> = Cache::new(NonZeroUsize::new(capacity).unwrap());
             if prefill {
                 cache.prefill(|| 0u16);
             }

--- a/utils/src/cache.rs
+++ b/utils/src/cache.rs
@@ -36,7 +36,8 @@
 //!
 //! The default [Clock] policy provides low-overhead replacement. [Clock2QPlus]
 //! adds scan resistance through separate admission and eviction regions backed
-//! by bounded history.
+//! by bounded history. [Sieve] retains FIFO insertion order and sifts
+//! unvisited entries with a backward-moving hand.
 //!
 //! # Concurrency
 //!
@@ -79,6 +80,7 @@
 
 pub mod clock;
 pub mod clock2qplus;
+pub mod sieve;
 
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
@@ -86,6 +88,7 @@ pub use clock::Clock;
 pub use clock2qplus::Clock2QPlus;
 use core::{hash::Hash, num::NonZeroUsize, ops::Index};
 use hashbrown::HashMap;
+pub use sieve::Sieve;
 
 type Hasher = ahash::RandomState;
 
@@ -1187,6 +1190,17 @@ mod tests {
             ops in proptest::collection::vec(op_strategy(), 0..256),
         ) {
             exercise_policy::<clock2qplus::Clock2QPlus<u8>, _>(capacity, prefill, ops, |cache| {
+                cache.check_policy_invariants();
+            })?;
+        }
+
+        #[test]
+        fn sieve_invariants_hold(
+            capacity in 1usize..8,
+            prefill in any::<bool>(),
+            ops in proptest::collection::vec(op_strategy(), 0..256),
+        ) {
+            exercise_policy::<sieve::Sieve, _>(capacity, prefill, ops, |cache| {
                 cache.check_policy_invariants();
             })?;
         }

--- a/utils/src/cache.rs
+++ b/utils/src/cache.rs
@@ -32,7 +32,11 @@
 //! value allocation from steady-state insertion. Value-returning methods such
 //! as [Cache::put] replace and drop displaced values as usual.
 //!
-//! The [clock] module provides [Clock], the default replacement policy.
+//! # Policies
+//!
+//! The default [Clock] policy provides low-overhead replacement. [Clock2QPlus]
+//! adds scan resistance through separate admission and eviction regions backed
+//! by bounded history.
 //!
 //! # Concurrency
 //!
@@ -74,10 +78,12 @@
 //! ```
 
 pub mod clock;
+pub mod clock2qplus;
 
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 pub use clock::Clock;
+pub use clock2qplus::Clock2QPlus;
 use core::{hash::Hash, num::NonZeroUsize, ops::Index};
 use hashbrown::HashMap;
 
@@ -1170,6 +1176,17 @@ mod tests {
             ops in proptest::collection::vec(op_strategy(), 0..256),
         ) {
             exercise_policy::<Clock, _>(capacity, prefill, ops, |cache| {
+                cache.check_policy_invariants();
+            })?;
+        }
+
+        #[test]
+        fn clock2qplus_invariants_hold(
+            capacity in 1usize..8,
+            prefill in any::<bool>(),
+            ops in proptest::collection::vec(op_strategy(), 0..256),
+        ) {
+            exercise_policy::<clock2qplus::Clock2QPlus<u8>, _>(capacity, prefill, ops, |cache| {
                 cache.check_policy_invariants();
             })?;
         }

--- a/utils/src/cache.rs
+++ b/utils/src/cache.rs
@@ -574,7 +574,7 @@ mod tests {
     type TestCache<K, V> = Cache<K, V, TestPolicy>;
 
     impl<K: Hash + Eq + Clone, V, P: Policy<K>> Cache<K, V, P> {
-        fn check_cache_invariants(&self) {
+        pub(super) fn check_cache_invariants(&self) {
             assert!(self.slots.len() <= self.capacity());
             assert_eq!(self.index.len() + self.free.len(), self.slots.len());
 
@@ -652,6 +652,7 @@ mod tests {
         };
 
         assert_eq!(*cache.get_or_insert_with(1, || compute(1)), 100);
+        assert_eq!(calls.get(), 1);
         assert_eq!(*cache.get_or_insert_with(1, || compute(1)), 100);
         assert_eq!(calls.get(), 1);
         cache.check_cache_invariants();
@@ -684,8 +685,11 @@ mod tests {
             20
         });
         assert_eq!(makes.get(), 2);
+        assert_eq!(cache.slots.len(), 2);
 
         assert!(cache.remove(&1));
+        assert!(!cache.contains(&1));
+        assert_eq!(cache.len(), 1);
         *cache
             .get_or_insert_mut(3, || {
                 makes.set(makes.get() + 1);
@@ -748,6 +752,7 @@ mod tests {
         assert_eq!(makes.get(), 3);
         assert_eq!(cache.slots.len(), 3);
         assert!(cache.is_empty());
+        cache.check_cache_invariants();
 
         for key in 0..100u64 {
             *cache
@@ -759,6 +764,7 @@ mod tests {
         }
         assert_eq!(makes.get(), 3);
         assert_eq!(cache.slots.len(), 3);
+        assert_eq!(cache.len(), 3);
         cache.check_cache_invariants();
     }
 
@@ -770,6 +776,7 @@ mod tests {
         }
         cache.clear();
         assert!(cache.is_empty());
+        assert_eq!(cache.len(), 0);
         cache.put(9, 9);
         assert_eq!(cache.get(&9).copied(), Some(9));
         cache.check_cache_invariants();
@@ -791,6 +798,7 @@ mod tests {
         for key in 0..2u64 {
             cache.put(key, Tracked(drops.clone()));
         }
+        assert_eq!(drops.get(), 0);
         cache.put(2, Tracked(drops.clone()));
         assert_eq!(drops.get(), 1);
 
@@ -1019,14 +1027,17 @@ mod tests {
                     Op::Put(key, value) => {
                         cache.put(key, value);
                         model.insert(key, value);
+                        prop_assert_eq!(cache.peek(&key).copied(), Some(value));
                     }
                     Op::GetOrInsert(key, value) => {
                         let stored = *cache.get_or_insert_with(key, || value);
                         model.insert(key, stored);
+                        prop_assert_eq!(cache.peek(&key).copied(), Some(stored));
                     }
                     Op::GetOrInsertMut(key, value) => {
                         *cache.get_or_insert_mut(key, || value).1 = value;
                         model.insert(key, value);
+                        prop_assert_eq!(cache.peek(&key).copied(), Some(value));
                     }
                     Op::GetMut(key, value) => {
                         if let Some(stored) = cache.get_mut(&key) {
@@ -1038,10 +1049,12 @@ mod tests {
                         let present = cache.contains(&key);
                         prop_assert_eq!(cache.remove(&key), present);
                         model.remove(&key);
+                        prop_assert!(!cache.contains(&key));
                     }
                     Op::Retain(key) => {
                         cache.retain(|resident, _| *resident < key);
                         model.retain(|resident, _| *resident < key);
+                        prop_assert!(cache.len() <= usize::from(key).min(capacity));
                     }
                 }
 

--- a/utils/src/cache.rs
+++ b/utils/src/cache.rs
@@ -650,7 +650,7 @@ mod tests {
     }
 
     #[test]
-    fn basic_put_get_peek() {
+    fn test_basic_put_get_peek() {
         let mut cache = TestCache::new(NZUsize!(2));
         assert!(cache.is_empty());
         assert_eq!(cache.capacity(), 2);
@@ -667,17 +667,7 @@ mod tests {
     }
 
     #[test]
-    fn capacity_is_const() {
-        const fn capacity(cache: &TestCache<u64, u64>) -> usize {
-            cache.capacity()
-        }
-
-        let cache = TestCache::new(NZUsize!(2));
-        assert_eq!(capacity(&cache), 2);
-    }
-
-    #[test]
-    fn put_replaces_existing() {
+    fn test_put_replaces_existing() {
         let mut cache = TestCache::new(NZUsize!(2));
         assert_eq!(cache.put(1u64, 10u64), None);
         assert_eq!(cache.put(1, 11), Some(10));
@@ -687,7 +677,7 @@ mod tests {
     }
 
     #[test]
-    fn capacity_one_reuses_its_only_slot() {
+    fn test_capacity_one_reuses_its_only_slot() {
         let mut cache = TestCache::new(NZUsize!(1));
         cache.put(1u64, 10u64);
         cache.put(2, 20);
@@ -698,7 +688,7 @@ mod tests {
     }
 
     #[test]
-    fn get_or_insert_with_calls_factory_only_on_miss() {
+    fn test_get_or_insert_with_calls_factory_only_on_miss() {
         let mut cache = TestCache::new(NZUsize!(2));
         let calls = Cell::new(0);
         let compute = |key: u64| {
@@ -714,7 +704,7 @@ mod tests {
     }
 
     #[test]
-    fn try_get_or_insert_with_does_not_cache_errors() {
+    fn test_try_get_or_insert_with_does_not_cache_errors() {
         let mut cache = TestCache::new(NZUsize!(2));
 
         let error: Result<&u64, &str> = cache.try_get_or_insert_with(1u64, || Err("bad"));
@@ -728,7 +718,7 @@ mod tests {
     }
 
     #[test]
-    fn remove_keeps_slot_for_reuse() {
+    fn test_remove_keeps_slot_for_reuse() {
         let makes = Cell::new(0);
         let mut cache = TestCache::new(NZUsize!(2));
         cache.get_or_insert_mut(1, || {
@@ -760,7 +750,7 @@ mod tests {
     }
 
     #[test]
-    fn retain_frees_slots_for_reuse() {
+    fn test_retain_frees_slots_for_reuse() {
         let mut cache = TestCache::new(NZUsize!(4));
         for key in 0..4u64 {
             cache.put(key, key * 10);
@@ -780,7 +770,7 @@ mod tests {
     }
 
     #[test]
-    fn get_or_insert_mut_reuses_allocations() {
+    fn test_get_or_insert_mut_reuses_allocations() {
         let makes = Cell::new(0);
         let mut cache = TestCache::new(NZUsize!(3));
         for key in 0..100u64 {
@@ -797,7 +787,7 @@ mod tests {
     }
 
     #[test]
-    fn prefill_allocates_once_and_reuses() {
+    fn test_prefill_allocates_once_and_reuses() {
         let makes = Cell::new(0);
         let mut cache = TestCache::new(NZUsize!(3));
         cache.prefill(|| {
@@ -824,7 +814,7 @@ mod tests {
     }
 
     #[test]
-    fn clear_drops_entries_and_allows_reuse() {
+    fn test_clear_drops_entries_and_allows_reuse() {
         let mut cache = TestCache::new(NZUsize!(4));
         for key in 0..4u64 {
             cache.put(key, key);
@@ -847,7 +837,7 @@ mod tests {
     }
 
     #[test]
-    fn values_are_dropped_on_replacement_and_clear() {
+    fn test_values_are_dropped_on_replacement_and_clear() {
         let drops = Rc::new(Cell::new(0));
         let mut cache = TestCache::new(NZUsize!(2));
         for key in 0..2u64 {
@@ -865,7 +855,7 @@ mod tests {
     }
 
     #[test]
-    fn remove_retains_value_until_reuse() {
+    fn test_remove_retains_value_until_reuse() {
         let drops = Rc::new(Cell::new(0));
         let mut cache = TestCache::new(NZUsize!(2));
         cache.put(1, Tracked(drops.clone()));
@@ -877,7 +867,7 @@ mod tests {
     }
 
     #[test]
-    fn get_at_validates_key() {
+    fn test_get_at_validates_key() {
         let mut cache = TestCache::new(NZUsize!(2));
         let (first, value) = cache.get_or_insert_mut(1u64, || 0u64);
         *value = 10;
@@ -892,7 +882,7 @@ mod tests {
     }
 
     #[test]
-    fn get_at_rejects_stale_evicted_slot() {
+    fn test_get_at_rejects_stale_evicted_slot() {
         let mut cache = TestCache::new(NZUsize!(1));
         let (slot, value) = cache.get_or_insert_mut(1u64, || 0u64);
         *value = 10;
@@ -906,7 +896,7 @@ mod tests {
     }
 
     #[test]
-    fn get_at_rejects_freed_slot() {
+    fn test_get_at_rejects_freed_slot() {
         let mut cache = TestCache::new(NZUsize!(2));
         let (slot, value) = cache.get_or_insert_mut(1u64, || 0u64);
         *value = 10;
@@ -922,7 +912,7 @@ mod tests {
     }
 
     #[test]
-    fn get_or_insert_mut_slot_is_stable_on_hit() {
+    fn test_get_or_insert_mut_slot_is_stable_on_hit() {
         let mut cache = TestCache::new(NZUsize!(2));
         let (slot, value) = cache.get_or_insert_mut(1u64, || 0u64);
         *value = 10;
@@ -933,7 +923,7 @@ mod tests {
     }
 
     #[test]
-    fn get_mut_updates_resident_value() {
+    fn test_get_mut_updates_resident_value() {
         let mut cache = TestCache::new(NZUsize!(2));
         cache.put(1u64, 10u64);
         assert_eq!(cache.get_mut(&2), None);
@@ -1013,7 +1003,7 @@ mod tests {
     }
 
     #[test]
-    fn policy_can_evict_before_capacity() {
+    fn test_policy_can_evict_before_capacity() {
         let mut cache = Cache::<u64, u64, EarlyEvictionPolicy>::new(NZUsize!(3));
         cache.prefill(|| 0);
 
@@ -1058,10 +1048,10 @@ mod tests {
         prop_oneof![
             (0u8..16).prop_map(Op::Get),
             (0u8..16).prop_map(Op::Peek),
-            (0u8..16, any::<u16>()).prop_map(|(key, value)| Op::Put(key, value)),
-            (0u8..16, any::<u16>()).prop_map(|(key, value)| Op::GetOrInsert(key, value)),
-            (0u8..16, any::<u16>()).prop_map(|(key, value)| Op::GetOrInsertMut(key, value)),
-            (0u8..16, any::<u16>()).prop_map(|(key, value)| Op::GetMut(key, value)),
+            (0u8..16, any::<u16>()).prop_map(|(k, v)| Op::Put(k, v)),
+            (0u8..16, any::<u16>()).prop_map(|(k, v)| Op::GetOrInsert(k, v)),
+            (0u8..16, any::<u16>()).prop_map(|(k, v)| Op::GetOrInsertMut(k, v)),
+            (0u8..16, any::<u16>()).prop_map(|(k, v)| Op::GetMut(k, v)),
             (0u8..16).prop_map(Op::Remove),
             (0u8..16).prop_map(Op::Retain),
         ]
@@ -1082,8 +1072,10 @@ mod tests {
         if prefill {
             cache.prefill(|| 0u16);
         }
+        // Oracle: last value written for each live key. A key the cache
+        // reports as present must hold its last-written value (no stale or
+        // conjured values); an evicted key is simply absent.
         let mut model = HashMap::new();
-
         for op in ops {
             match op {
                 Op::Get(key) => {
@@ -1128,7 +1120,10 @@ mod tests {
             }
 
             prop_assert!(cache.len() <= capacity);
+            // The slot vector never exceeds capacity, proving reuse.
             prop_assert!(cache.slots.len() <= capacity);
+            // Every present key holds its last-written value and was logically
+            // inserted; absent keys are an allowed (evicted) state.
             for key in 0..16u8 {
                 let present = cache.contains(&key);
                 prop_assert_eq!(present, cache.peek(&key).is_some());

--- a/utils/src/cache.rs
+++ b/utils/src/cache.rs
@@ -34,10 +34,25 @@
 //!
 //! # Policies
 //!
-//! The default [Clock] policy provides low-overhead replacement. [Clock2QPlus]
-//! adds scan resistance through separate admission and eviction regions backed
-//! by bounded history. [Sieve] retains FIFO insertion order and sifts
-//! unvisited entries with a backward-moving hand.
+//! The policies form an escalation ladder:
+//!
+//! 1. Start with [Clock]. It is the default when representative benchmarks are
+//!    unavailable, resident metadata matters, or the workload is reasonably
+//!    stable. It has the least admission filtering and scan resistance.
+//! 2. Try [Sieve] when scans, bursts, or many one-hit entries pollute the cache.
+//!    New residents enter unvisited and are immediately evictable until they
+//!    receive a hit. This inexpensive filtering costs two links per resident
+//!    and slightly more insertion bookkeeping than CLOCK.
+//! 3. Try [Clock2QPlus] when misses are expensive and recently evicted entries
+//!    often return after newer traffic pushes them out. Its bounded Ghost
+//!    history recognizes that reuse and admits the entry directly into the
+//!    protected Main region, at the cost of substantially more metadata and
+//!    heavier insertion and eviction.
+//!
+//! SIEVE remembers only whether an entry was referenced while resident and
+//! forgets it after eviction. CLOCK2Q+ preserves evidence about recently
+//! evicted probationary entries. Move up this ladder only when benchmarks
+//! representative of the intended workload show a material benefit.
 //!
 //! # Concurrency
 //!

--- a/utils/src/cache/benches/get.rs
+++ b/utils/src/cache/benches/get.rs
@@ -1,6 +1,6 @@
 use commonware_utils::{
     TestRng,
-    cache::{Cache, Clock2QPlus, Policy},
+    cache::{Cache, Clock2QPlus, Policy, Sieve},
 };
 use criterion::{Criterion, criterion_group};
 use rand::RngExt as _;
@@ -53,6 +53,14 @@ fn bench_get(c: &mut Criterion) {
             capacity.get(),
             &keys,
             Cache::<u64, u64, Clock2QPlus<u64>>::new(capacity),
+        );
+
+        bench(
+            c,
+            "sieve",
+            capacity.get(),
+            &keys,
+            Cache::<u64, u64, Sieve>::new(capacity),
         );
     }
 }

--- a/utils/src/cache/benches/get.rs
+++ b/utils/src/cache/benches/get.rs
@@ -1,4 +1,4 @@
-use commonware_utils::{TestRng, cache::Clock};
+use commonware_utils::{TestRng, cache::Cache};
 use criterion::{Criterion, criterion_group};
 use rand::RngExt as _;
 use std::{hint::black_box, num::NonZeroUsize};
@@ -6,7 +6,7 @@ use std::{hint::black_box, num::NonZeroUsize};
 /// Benchmarks the cache-hit read path: a full cache, all lookups present.
 fn bench_get(c: &mut Criterion) {
     for capacity in [1usize << 10, 1 << 14, 1 << 18] {
-        let mut cache: Clock<u64, u64> = Clock::new(NonZeroUsize::new(capacity).unwrap());
+        let mut cache: Cache<u64, u64> = Cache::new(NonZeroUsize::new(capacity).unwrap());
         for i in 0..capacity as u64 {
             cache.put(i, i);
         }

--- a/utils/src/cache/benches/get.rs
+++ b/utils/src/cache/benches/get.rs
@@ -1,26 +1,59 @@
-use commonware_utils::{TestRng, cache::Cache};
+use commonware_utils::{
+    TestRng,
+    cache::{Cache, Clock2QPlus, Policy},
+};
 use criterion::{Criterion, criterion_group};
 use rand::RngExt as _;
 use std::{hint::black_box, num::NonZeroUsize};
 
-/// Benchmarks the cache-hit read path: a full cache, all lookups present.
-fn bench_get(c: &mut Criterion) {
-    for capacity in [1usize << 10, 1 << 14, 1 << 18] {
-        let mut cache: Cache<u64, u64> = Cache::new(NonZeroUsize::new(capacity).unwrap());
-        for i in 0..capacity as u64 {
-            cache.put(i, i);
-        }
-        let mut rng = TestRng::new(capacity as u64);
-        let keys: Vec<u64> = (0..1024)
-            .map(|_| rng.random_range(0..capacity as u64))
-            .collect();
-        c.bench_function(&format!("{}/capacity={capacity}", module_path!()), |b| {
+fn bench<P>(
+    c: &mut Criterion,
+    policy: &str,
+    capacity: usize,
+    keys: &[u64],
+    mut cache: Cache<u64, u64, P>,
+) where
+    P: Policy<u64>,
+{
+    for i in 0..capacity as u64 {
+        cache.put(i, i);
+    }
+    c.bench_function(
+        &format!("{}/policy={policy} capacity={capacity}", module_path!()),
+        |b| {
             b.iter(|| {
-                for k in &keys {
+                for k in keys {
                     black_box(cache.get(black_box(k)));
                 }
             });
-        });
+        },
+    );
+}
+
+/// Benchmarks the cache-hit read path: a full cache, all lookups present.
+fn bench_get(c: &mut Criterion) {
+    for capacity in [1usize << 10, 1 << 14, 1 << 18] {
+        let capacity = NonZeroUsize::new(capacity).unwrap();
+        let mut rng = TestRng::new(capacity.get() as u64);
+        let keys: Vec<u64> = (0..1024)
+            .map(|_| rng.random_range(0..capacity.get() as u64))
+            .collect();
+
+        bench(
+            c,
+            "clock",
+            capacity.get(),
+            &keys,
+            Cache::<u64, u64>::new(capacity),
+        );
+
+        bench(
+            c,
+            "clock2q-plus",
+            capacity.get(),
+            &keys,
+            Cache::<u64, u64, Clock2QPlus<u64>>::new(capacity),
+        );
     }
 }
 

--- a/utils/src/cache/benches/insert.rs
+++ b/utils/src/cache/benches/insert.rs
@@ -1,4 +1,4 @@
-use commonware_utils::cache::{Cache, Clock2QPlus, Policy};
+use commonware_utils::cache::{Cache, Clock2QPlus, Policy, Sieve};
 use criterion::{BatchSize, Criterion, criterion_group};
 use std::{hint::black_box, num::NonZeroUsize};
 
@@ -45,6 +45,12 @@ fn bench_insert(c: &mut Criterion) {
             "clock2q-plus",
             capacity.get(),
             Cache::<u64, u64, Clock2QPlus<u64>>::new(capacity),
+        );
+        bench(
+            c,
+            "sieve",
+            capacity.get(),
+            Cache::<u64, u64, Sieve>::new(capacity),
         );
     }
 }

--- a/utils/src/cache/benches/insert.rs
+++ b/utils/src/cache/benches/insert.rs
@@ -1,26 +1,34 @@
-use commonware_utils::{TestRng, cache::Clock};
-use criterion::{Criterion, criterion_group};
-use rand::RngExt as _;
+use commonware_utils::cache::Cache;
+use criterion::{BatchSize, Criterion, criterion_group};
 use std::{hint::black_box, num::NonZeroUsize};
 
-/// Benchmarks the steady-state insert path under churn: a full cache with a
-/// working set twice the capacity, so most inserts miss and evict (CLOCK sweep,
-/// index remove + insert, slot reuse).
+const INSERTS_PER_ITERATION: usize = 1024;
+
+/// Benchmarks the steady-state insert path under churn. Every key is fresh, so
+/// each insertion into the full cache evicts a CLOCK resident.
 fn bench_insert(c: &mut Criterion) {
     for capacity in [1usize << 10, 1 << 14, 1 << 18] {
-        let working = (capacity as u64) * 2;
-        let mut cache: Clock<u64, u64> = Clock::new(NonZeroUsize::new(capacity).unwrap());
+        let mut cache: Cache<u64, u64> = Cache::new(NonZeroUsize::new(capacity).unwrap());
         for i in 0..capacity as u64 {
             cache.put(i, i);
         }
-        let mut rng = TestRng::new(capacity as u64);
-        let keys: Vec<u64> = (0..1024).map(|_| rng.random_range(0..working)).collect();
+        let mut next = capacity as u64;
         c.bench_function(&format!("{}/capacity={capacity}", module_path!()), |b| {
-            b.iter(|| {
-                for k in &keys {
-                    cache.put(black_box(*k), black_box(*k));
-                }
-            });
+            b.iter_batched(
+                || {
+                    let start = next;
+                    next = next
+                        .checked_add(INSERTS_PER_ITERATION as u64)
+                        .expect("benchmark keys must not overflow");
+                    start..next
+                },
+                |keys| {
+                    for key in keys {
+                        cache.put(black_box(key), black_box(key));
+                    }
+                },
+                BatchSize::SmallInput,
+            );
         });
     }
 }

--- a/utils/src/cache/benches/insert.rs
+++ b/utils/src/cache/benches/insert.rs
@@ -1,19 +1,20 @@
-use commonware_utils::cache::Cache;
+use commonware_utils::cache::{Cache, Clock2QPlus, Policy};
 use criterion::{BatchSize, Criterion, criterion_group};
 use std::{hint::black_box, num::NonZeroUsize};
 
 const INSERTS_PER_ITERATION: usize = 1024;
 
-/// Benchmarks the steady-state insert path under churn. Every key is fresh, so
-/// each insertion into the full cache evicts a CLOCK resident.
-fn bench_insert(c: &mut Criterion) {
-    for capacity in [1usize << 10, 1 << 14, 1 << 18] {
-        let mut cache: Cache<u64, u64> = Cache::new(NonZeroUsize::new(capacity).unwrap());
-        for i in 0..capacity as u64 {
-            cache.put(i, i);
-        }
-        let mut next = capacity as u64;
-        c.bench_function(&format!("{}/capacity={capacity}", module_path!()), |b| {
+fn bench<P>(c: &mut Criterion, policy: &str, capacity: usize, mut cache: Cache<u64, u64, P>)
+where
+    P: Policy<u64>,
+{
+    for i in 0..capacity as u64 {
+        cache.put(i, i);
+    }
+    let mut next = capacity as u64;
+    c.bench_function(
+        &format!("{}/policy={policy} capacity={capacity}", module_path!()),
+        |b| {
             b.iter_batched(
                 || {
                     let start = next;
@@ -29,7 +30,22 @@ fn bench_insert(c: &mut Criterion) {
                 },
                 BatchSize::SmallInput,
             );
-        });
+        },
+    );
+}
+
+/// Benchmarks the steady-state insert path under churn. Every key is fresh, so
+/// each insertion into the full cache invokes the policy's eviction path.
+fn bench_insert(c: &mut Criterion) {
+    for capacity in [1usize << 10, 1 << 14, 1 << 18] {
+        let capacity = NonZeroUsize::new(capacity).unwrap();
+        bench(c, "clock", capacity.get(), Cache::<u64, u64>::new(capacity));
+        bench(
+            c,
+            "clock2q-plus",
+            capacity.get(),
+            Cache::<u64, u64, Clock2QPlus<u64>>::new(capacity),
+        );
     }
 }
 

--- a/utils/src/cache/benches/mixed.rs
+++ b/utils/src/cache/benches/mixed.rs
@@ -1,32 +1,37 @@
-use commonware_utils::{TestRng, cache::Cache};
+use commonware_utils::{
+    TestRng,
+    cache::{Cache, Clock2QPlus, Policy},
+};
 use criterion::{Criterion, criterion_group};
 use rand::RngExt as _;
 use std::{hint::black_box, num::NonZeroUsize};
 
-/// Benchmarks a read-heavy mix under churn: 8 hits per miss insert, so resident
-/// entries keep their reference bits set and every eviction sweep must clear a
-/// run of bits before finding a victim (the CLOCK worst case).
-fn bench_mixed(c: &mut Criterion) {
-    for capacity in [1usize << 10, 1 << 14, 1 << 18] {
-        let mut cache: Cache<u64, u64> = Cache::new(NonZeroUsize::new(capacity).unwrap());
-        for i in 0..capacity as u64 {
-            cache.put(i, i);
-        }
-        let mut rng = TestRng::new(capacity as u64);
-        // Each round reads 8 live slots, then installs one fresh key. Stable
-        // slots let the benchmark update the live key set after each eviction.
-        let rounds: Vec<[usize; 8]> = (0..1024)
-            .map(|_| {
-                let mut reads = [0usize; 8];
-                for slot in &mut reads {
-                    *slot = rng.random_range(0..capacity);
-                }
-                reads
-            })
-            .collect();
-        let mut keys: Vec<u64> = (0..capacity as u64).collect();
-        let mut next = capacity as u64;
-        c.bench_function(&format!("{}/capacity={capacity}", module_path!()), |b| {
+fn bench<P>(c: &mut Criterion, policy: &str, capacity: usize, mut cache: Cache<u64, u64, P>)
+where
+    P: Policy<u64>,
+{
+    for i in 0..capacity as u64 {
+        cache.put(i, i);
+    }
+    let mut rng = TestRng::new(capacity as u64);
+
+    // Each round reads 8 live slots, then installs one fresh key. Stable slots
+    // let the benchmark update the live key set after each eviction.
+    let rounds: Vec<[usize; 8]> = (0..1024)
+        .map(|_| {
+            let mut reads = [0usize; 8];
+            for slot in &mut reads {
+                *slot = rng.random_range(0..capacity);
+            }
+            reads
+        })
+        .collect();
+    let mut keys: Vec<u64> = (0..capacity as u64).collect();
+    let mut next = capacity as u64;
+
+    c.bench_function(
+        &format!("{}/policy={policy} capacity={capacity}", module_path!()),
+        |b| {
             b.iter(|| {
                 for reads in &rounds {
                     for &slot in reads {
@@ -41,7 +46,21 @@ fn bench_mixed(c: &mut Criterion) {
                     keys[slot] = key;
                 }
             });
-        });
+        },
+    );
+}
+
+/// Benchmarks a read-heavy mix under churn with 8 hits per fresh insertion.
+fn bench_mixed(c: &mut Criterion) {
+    for capacity in [1usize << 10, 1 << 14, 1 << 18] {
+        let capacity = NonZeroUsize::new(capacity).unwrap();
+        bench(c, "clock", capacity.get(), Cache::<u64, u64>::new(capacity));
+        bench(
+            c,
+            "clock2q-plus",
+            capacity.get(),
+            Cache::<u64, u64, Clock2QPlus<u64>>::new(capacity),
+        );
     }
 }
 

--- a/utils/src/cache/benches/mixed.rs
+++ b/utils/src/cache/benches/mixed.rs
@@ -1,6 +1,6 @@
 use commonware_utils::{
     TestRng,
-    cache::{Cache, Clock2QPlus, Policy},
+    cache::{Cache, Clock2QPlus, Policy, Sieve},
 };
 use criterion::{Criterion, criterion_group};
 use rand::RngExt as _;
@@ -60,6 +60,12 @@ fn bench_mixed(c: &mut Criterion) {
             "clock2q-plus",
             capacity.get(),
             Cache::<u64, u64, Clock2QPlus<u64>>::new(capacity),
+        );
+        bench(
+            c,
+            "sieve",
+            capacity.get(),
+            Cache::<u64, u64, Sieve>::new(capacity),
         );
     }
 }

--- a/utils/src/cache/benches/mixed.rs
+++ b/utils/src/cache/benches/mixed.rs
@@ -1,4 +1,4 @@
-use commonware_utils::{TestRng, cache::Clock};
+use commonware_utils::{TestRng, cache::Cache};
 use criterion::{Criterion, criterion_group};
 use rand::RngExt as _;
 use std::{hint::black_box, num::NonZeroUsize};
@@ -8,29 +8,37 @@ use std::{hint::black_box, num::NonZeroUsize};
 /// run of bits before finding a victim (the CLOCK worst case).
 fn bench_mixed(c: &mut Criterion) {
     for capacity in [1usize << 10, 1 << 14, 1 << 18] {
-        let mut cache: Clock<u64, u64> = Clock::new(NonZeroUsize::new(capacity).unwrap());
+        let mut cache: Cache<u64, u64> = Cache::new(NonZeroUsize::new(capacity).unwrap());
         for i in 0..capacity as u64 {
             cache.put(i, i);
         }
         let mut rng = TestRng::new(capacity as u64);
-        // Each round reads 8 keys biased to the resident range, then inserts one
-        // key from far outside it (a guaranteed miss that evicts).
-        let rounds: Vec<([u64; 8], u64)> = (0..1024)
-            .map(|round| {
-                let mut reads = [0u64; 8];
+        // Each round reads 8 live slots, then installs one fresh key. Stable
+        // slots let the benchmark update the live key set after each eviction.
+        let rounds: Vec<[usize; 8]> = (0..1024)
+            .map(|_| {
+                let mut reads = [0usize; 8];
                 for slot in &mut reads {
-                    *slot = rng.random_range(0..capacity as u64);
+                    *slot = rng.random_range(0..capacity);
                 }
-                (reads, u64::MAX - round)
+                reads
             })
             .collect();
+        let mut keys: Vec<u64> = (0..capacity as u64).collect();
+        let mut next = capacity as u64;
         c.bench_function(&format!("{}/capacity={capacity}", module_path!()), |b| {
             b.iter(|| {
-                for (reads, insert) in &rounds {
-                    for k in reads {
-                        black_box(cache.get(black_box(k)));
+                for reads in &rounds {
+                    for &slot in reads {
+                        black_box(cache.get(black_box(&keys[slot])));
                     }
-                    cache.put(black_box(*insert), black_box(*insert));
+                    let key = next;
+                    next = next
+                        .checked_add(1)
+                        .expect("benchmark keys must not overflow");
+                    let (slot, value) = cache.get_or_insert_mut(black_box(key), || unreachable!());
+                    *value = key;
+                    keys[slot] = key;
                 }
             });
         });

--- a/utils/src/cache/clock.rs
+++ b/utils/src/cache/clock.rs
@@ -48,7 +48,7 @@ impl<K> Policy<K> for Clock {
 
     #[inline]
     fn hit_mut(&mut self, _slot: Slot, state: &mut AtomicBool) {
-        state.store(true, Ordering::Relaxed);
+        *state.get_mut() = true;
     }
 
     #[inline]

--- a/utils/src/cache/clock.rs
+++ b/utils/src/cache/clock.rs
@@ -1,0 +1,243 @@
+//! CLOCK cache replacement.
+//!
+//! CLOCK approximates least-recently-used replacement with one reference bit
+//! per cache slot. A hit sets the bit. When the cache is full, a clock hand
+//! clears set bits and skips those slots once, then replaces the first slot
+//! whose bit is clear.
+//!
+//! The reference bit is stored inline as [Policy::SlotState]. It uses relaxed
+//! atomic operations so [super::Cache::get] can record hits through a shared
+//! reference. Admission and eviction still require exclusive access to the
+//! cache.
+//!
+//! # Example
+//!
+//! ```
+//! use commonware_utils::cache::Cache;
+//! use core::num::NonZeroUsize;
+//!
+//! let mut cache = Cache::<u64, u64>::new(NonZeroUsize::new(2).unwrap());
+//! cache.put(1, 10);
+//! assert_eq!(cache.get(&1), Some(&10));
+//! ```
+
+use super::{Claimed, Policy, Slot};
+use core::{
+    num::NonZeroUsize,
+    ops::Index,
+    sync::atomic::{AtomicBool, Ordering},
+};
+
+/// CLOCK admission and eviction policy.
+pub struct Clock {
+    /// Next slot examined during eviction.
+    hand: Slot,
+    /// Maximum number of resident slots.
+    capacity: usize,
+}
+
+impl Clock {
+    /// Creates an empty CLOCK policy with the given capacity.
+    pub const fn new(capacity: NonZeroUsize) -> Self {
+        Self {
+            hand: 0,
+            capacity: capacity.get(),
+        }
+    }
+}
+
+impl<K> Policy<K> for Clock {
+    type SlotState = AtomicBool;
+
+    #[inline]
+    fn new(capacity: NonZeroUsize) -> Self {
+        Self::new(capacity)
+    }
+
+    #[inline]
+    fn hit(&self, _slot: Slot, state: &AtomicBool) {
+        // Skip the store when the bit is already set. Under concurrent readers,
+        // an unconditional store would dirty the cache line on every hit and
+        // bounce it between cores.
+        if !state.load(Ordering::Relaxed) {
+            state.store(true, Ordering::Relaxed);
+        }
+    }
+
+    #[inline]
+    fn insert<I, C>(&mut self, states: &I, _key: &K, has_vacancy: bool, claim: C) -> AtomicBool
+    where
+        I: Index<Slot, Output = AtomicBool>,
+        C: FnOnce(Option<Slot>) -> Claimed<K>,
+    {
+        if has_vacancy {
+            claim(None);
+            return AtomicBool::new(true);
+        }
+
+        loop {
+            let referenced = &states[self.hand];
+            if !referenced.load(Ordering::Relaxed) {
+                let victim = self.hand;
+                self.advance();
+                claim(Some(victim));
+                return AtomicBool::new(true);
+            }
+            referenced.store(false, Ordering::Relaxed);
+            self.advance();
+        }
+    }
+
+    #[inline]
+    fn remove(&mut self, _slot: Option<Slot>, _key: &K) {}
+
+    #[inline]
+    fn retain<F: FnMut(&K) -> bool>(&mut self, _keep: F) {}
+
+    #[inline]
+    fn clear(&mut self) {
+        self.hand = 0;
+    }
+}
+
+impl Clock {
+    #[inline]
+    const fn advance(&mut self) {
+        self.hand += 1;
+        if self.hand == self.capacity {
+            self.hand = 0;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{NZUsize, cache::Cache};
+    use core::hash::Hash;
+    use std::thread;
+
+    type ClockCache<K, V> = Cache<K, V, Clock>;
+
+    impl<K: Hash + Eq + Clone, V> Cache<K, V, Clock> {
+        fn check_clock_invariants(&self) {
+            if self.slots.is_empty() {
+                assert_eq!(self.policy.hand, 0);
+            } else {
+                assert!(self.policy.hand < self.slots.len());
+            }
+        }
+    }
+
+    #[test]
+    fn second_chance_protects_referenced_entry() {
+        let mut cache = ClockCache::new(NZUsize!(3));
+        cache.put(1u64, 10u64);
+        cache.put(2, 20);
+        cache.put(3, 30);
+
+        // Sweep all three initial reference bits and evict key 1.
+        cache.put(4, 40);
+        assert!(!cache.contains(&1));
+
+        // Protect key 2. The hand skips it and evicts unreferenced key 3.
+        assert_eq!(cache.get(&2).copied(), Some(20));
+        cache.put(5, 50);
+        assert!(cache.contains(&2));
+        assert!(!cache.contains(&3));
+        cache.check_clock_invariants();
+    }
+
+    #[test]
+    fn all_referenced_evicts_at_hand() {
+        let mut cache = ClockCache::new(NZUsize!(3));
+        cache.put(1u64, 10u64);
+        cache.put(2, 20);
+        cache.put(3, 30);
+        assert!(cache.get(&1).is_some());
+        assert!(cache.get(&2).is_some());
+        assert!(cache.get(&3).is_some());
+
+        cache.put(4, 40);
+        assert!(!cache.contains(&1));
+        assert!(cache.contains(&2));
+        assert!(cache.contains(&3));
+        cache.check_clock_invariants();
+    }
+
+    #[test]
+    fn get_at_records_use() {
+        let mut cache = ClockCache::new(NZUsize!(3));
+        cache.put(1u64, 10u64);
+        cache.put(2, 20);
+        cache.put(3, 30);
+        cache.put(4, 40);
+
+        let slot = *cache.index.get(&2).unwrap();
+        assert_eq!(cache.get_at(slot, &2).copied(), Some(20));
+        cache.put(5, 50);
+        assert!(cache.contains(&2));
+        assert!(!cache.contains(&3));
+        cache.check_clock_invariants();
+    }
+
+    #[test]
+    fn peek_does_not_record_use() {
+        fn setup() -> ClockCache<u64, u64> {
+            let mut cache = ClockCache::new(NZUsize!(3));
+            cache.put(1, 10);
+            cache.put(2, 20);
+            cache.put(3, 30);
+            cache.put(4, 40);
+            cache
+        }
+
+        let mut cache = setup();
+        assert_eq!(cache.peek(&2).copied(), Some(20));
+        cache.put(5, 50);
+        assert!(!cache.contains(&2));
+        assert!(cache.contains(&3));
+
+        let mut cache = setup();
+        assert_eq!(cache.get(&2).copied(), Some(20));
+        cache.put(5, 50);
+        assert!(cache.contains(&2));
+        assert!(!cache.contains(&3));
+    }
+
+    #[test]
+    fn clear_resets_hand() {
+        let mut cache = ClockCache::new(NZUsize!(3));
+        cache.put(1u64, 10u64);
+        cache.put(2, 20);
+        cache.put(3, 30);
+        cache.put(4, 40);
+        assert_ne!(cache.policy.hand, 0);
+
+        cache.clear();
+        assert_eq!(cache.policy.hand, 0);
+        cache.put(5, 50);
+        cache.check_clock_invariants();
+    }
+
+    #[test]
+    fn concurrent_get_records_hits() {
+        let mut cache = ClockCache::new(NZUsize!(64));
+        for i in 0..64u64 {
+            cache.put(i, i * 10);
+        }
+        let cache = &cache;
+        thread::scope(|scope| {
+            for _ in 0..4 {
+                scope.spawn(move || {
+                    for _ in 0..2_000 {
+                        for i in 0..64u64 {
+                            assert_eq!(cache.get(&i).copied(), Some(i * 10));
+                        }
+                    }
+                });
+            }
+        });
+        cache.check_clock_invariants();
+    }
+}

--- a/utils/src/cache/clock.rs
+++ b/utils/src/cache/clock.rs
@@ -52,7 +52,13 @@ impl<K> Policy<K> for Clock {
     }
 
     #[inline]
-    fn insert<I, C>(&mut self, states: &I, _key: &K, has_vacancy: bool, claim: C) -> AtomicBool
+    fn insert<I, C>(
+        &mut self,
+        states: &I,
+        _key: &K,
+        has_vacancy: bool,
+        claim: C,
+    ) -> (Slot, AtomicBool)
     where
         I: Index<Slot, Output = AtomicBool>,
         C: FnOnce(Option<Slot>) -> Claimed<K>,
@@ -60,19 +66,23 @@ impl<K> Policy<K> for Clock {
         if has_vacancy {
             // CLOCK admits into available capacity without scanning. Mark the
             // new resident referenced so it receives a full second chance.
-            let _ = claim(None);
-            return AtomicBool::new(true);
+            let Claimed::Vacant(slot) = claim(None) else {
+                unreachable!("vacancy claim returned an eviction");
+            };
+            return (slot, AtomicBool::new(true));
         }
 
         loop {
             let referenced = &states[self.hand];
             if !referenced.load(Ordering::Relaxed) {
                 let victim = self.hand;
-                let _ = claim(Some(victim));
+                let Claimed::Evicted(_) = claim(Some(victim)) else {
+                    unreachable!("victim claim returned vacant capacity");
+                };
                 // Do not reconsider the new resident until the hand completes
                 // a revolution.
                 self.advance();
-                return AtomicBool::new(true);
+                return (victim, AtomicBool::new(true));
             }
             // A set bit grants one second chance. Clear it and continue from
             // the following slot.

--- a/utils/src/cache/clock.rs
+++ b/utils/src/cache/clock.rs
@@ -25,22 +25,15 @@ pub struct Clock {
     capacity: usize,
 }
 
-impl Clock {
-    /// Creates an empty CLOCK policy with the given capacity.
-    pub const fn new(capacity: NonZeroUsize) -> Self {
-        Self {
-            hand: 0,
-            capacity: capacity.get(),
-        }
-    }
-}
-
 impl<K> Policy<K> for Clock {
     type SlotState = AtomicBool;
 
     #[inline]
     fn new(capacity: NonZeroUsize) -> Self {
-        Self::new(capacity)
+        Self {
+            hand: 0,
+            capacity: capacity.get(),
+        }
     }
 
     #[inline]
@@ -51,6 +44,11 @@ impl<K> Policy<K> for Clock {
         if !state.load(Ordering::Relaxed) {
             state.store(true, Ordering::Relaxed);
         }
+    }
+
+    #[inline]
+    fn hit_mut(&mut self, _slot: Slot, state: &mut AtomicBool) {
+        state.store(true, Ordering::Relaxed);
     }
 
     #[inline]
@@ -71,7 +69,8 @@ impl<K> Policy<K> for Clock {
             if !referenced.load(Ordering::Relaxed) {
                 let victim = self.hand;
                 let _ = claim(Some(victim));
-                // Do not reconsider the new resident until the hand completes a revolution.
+                // Do not reconsider the new resident until the hand completes
+                // a revolution.
                 self.advance();
                 return AtomicBool::new(true);
             }

--- a/utils/src/cache/clock.rs
+++ b/utils/src/cache/clock.rs
@@ -113,13 +113,17 @@ mod tests {
     type ClockCache<K, V> = Cache<K, V, Clock>;
 
     impl<K: Hash + Eq + Clone, V> Cache<K, V, Clock> {
-        fn check_clock_invariants(&self) {
-            self.check_cache_invariants();
+        pub(crate) fn check_policy_invariants(&self) {
             if self.slots.is_empty() {
                 assert_eq!(self.policy.hand, 0);
             } else {
                 assert!(self.policy.hand < self.slots.len());
             }
+        }
+
+        fn check_invariants(&self) {
+            self.check_cache_invariants();
+            self.check_policy_invariants();
         }
     }
 
@@ -141,7 +145,7 @@ mod tests {
         assert!(!cache.contains(&3));
         assert!(cache.contains(&4));
         assert!(cache.contains(&5));
-        cache.check_clock_invariants();
+        cache.check_invariants();
     }
 
     #[test]
@@ -162,7 +166,7 @@ mod tests {
         assert!(cache.contains(&2));
         assert!(cache.contains(&3));
         assert!(cache.contains(&4));
-        cache.check_clock_invariants();
+        cache.check_invariants();
     }
 
     #[test]
@@ -180,7 +184,7 @@ mod tests {
         cache.put(5, 50);
         assert!(cache.contains(&2));
         assert!(!cache.contains(&3));
-        cache.check_clock_invariants();
+        cache.check_invariants();
     }
 
     #[test]
@@ -224,7 +228,7 @@ mod tests {
         cache.clear();
         assert_eq!(cache.policy.hand, 0);
         cache.put(5, 50);
-        cache.check_clock_invariants();
+        cache.check_invariants();
     }
 
     #[test]
@@ -251,6 +255,6 @@ mod tests {
         for i in 0..64u64 {
             assert_eq!(cache.get(&i).copied(), Some(i * 10));
         }
-        cache.check_clock_invariants();
+        cache.check_invariants();
     }
 }

--- a/utils/src/cache/clock.rs
+++ b/utils/src/cache/clock.rs
@@ -79,11 +79,13 @@ impl<K> Policy<K> for Clock {
                 let Claimed::Evicted(_) = claim(Some(victim)) else {
                     unreachable!("victim claim returned vacant capacity");
                 };
+
                 // Do not reconsider the new resident until the hand completes
                 // a revolution.
                 self.advance();
                 return (victim, AtomicBool::new(true));
             }
+
             // A set bit grants one second chance. Clear it and continue from
             // the following slot.
             referenced.store(false, Ordering::Relaxed);

--- a/utils/src/cache/clock.rs
+++ b/utils/src/cache/clock.rs
@@ -122,6 +122,7 @@ mod tests {
     type ClockCache<K, V> = Cache<K, V, Clock>;
 
     impl<K: Hash + Eq + Clone, V> Cache<K, V, Clock> {
+        /// Asserts the CLOCK policy's invariants hold.
         pub(crate) fn check_policy_invariants(&self) {
             if self.slots.is_empty() {
                 assert_eq!(self.policy.hand, 0);
@@ -130,6 +131,7 @@ mod tests {
             }
         }
 
+        /// Asserts both the cache and policy invariants hold.
         fn check_invariants(&self) {
             self.check_cache_invariants();
             self.check_policy_invariants();
@@ -137,18 +139,26 @@ mod tests {
     }
 
     #[test]
-    fn second_chance_protects_referenced_entry() {
+    fn test_second_chance_protects_referenced_entry() {
+        // New entries have their reference bit set, so a referenced entry only
+        // beats an unreferenced one after some bits have been cleared.
+        // Capacity is 3 and slots follow insertion order.
         let mut cache = ClockCache::new(NZUsize!(3));
-        cache.put(1u64, 10u64);
-        cache.put(2, 20);
-        cache.put(3, 30);
+        cache.put(1u64, 10u64); // slot 0, referenced
+        cache.put(2, 20); // slot 1, referenced
+        cache.put(3, 30); // slot 2, referenced
 
-        // Sweep all three initial reference bits and evict key 1.
+        // With all residents referenced, inserting key 4 clears all three
+        // bits, wraps to slot 0, and evicts key 1. The hand advances to slot 1.
+        // Slot 0 now holds referenced key 4. Keys 2 and 3 are unreferenced.
         cache.put(4, 40);
         assert!(!cache.contains(&1));
 
-        // Protect key 2. The hand skips it and evicts unreferenced key 3.
+        // Reference key 2 in slot 1, leaving key 3 in slot 2 unreferenced.
         assert_eq!(cache.get(&2).copied(), Some(20));
+
+        // Inserting key 5 starts at slot 1. It clears and skips key 2, then
+        // evicts unreferenced key 3 from slot 2.
         cache.put(5, 50);
         assert!(cache.contains(&2));
         assert!(!cache.contains(&3));
@@ -158,18 +168,20 @@ mod tests {
     }
 
     #[test]
-    fn all_referenced_evicts_at_hand() {
+    fn test_all_referenced_evicts_at_hand() {
+        // When every resident is referenced, the sweep clears all bits and
+        // evicts the slot where the hand started.
         let mut cache = ClockCache::new(NZUsize!(3));
         cache.put(1u64, 10u64);
         cache.put(2, 20);
         cache.put(3, 30);
 
-        // Re-reference every resident. The sweep clears all three bits, wraps,
-        // and evicts key 1 at the initial hand position.
         assert!(cache.get(&1).is_some());
         assert!(cache.get(&2).is_some());
         assert!(cache.get(&3).is_some());
 
+        // The hand starts at slot 0. The sweep clears every bit, wraps, and
+        // evicts key 1 from slot 0.
         cache.put(4, 40);
         assert!(!cache.contains(&1));
         assert!(cache.contains(&2));
@@ -179,51 +191,54 @@ mod tests {
     }
 
     #[test]
-    fn get_at_records_use() {
+    fn test_get_at_records_use() {
+        // After this setup, keys 2 and 3 are unreferenced and the hand points
+        // at key 2. get_at must set key 2's bit so key 3 is evicted next.
         let mut cache = ClockCache::new(NZUsize!(3));
         cache.put(1u64, 10u64);
         cache.put(2, 20);
         cache.put(3, 30);
-        cache.put(4, 40);
+        cache.put(4, 40); // Evicts key 1 and clears the other reference bits.
 
-        // get_at records use like get, so key 2 receives a second chance and
-        // unreferenced key 3 becomes the next victim.
         let slot = *cache.index.get(&2).unwrap();
         assert_eq!(cache.get_at(slot, &2).copied(), Some(20));
         cache.put(5, 50);
-        assert!(cache.contains(&2));
+        assert!(cache.contains(&2), "get_at must protect key 2");
         assert!(!cache.contains(&3));
         cache.check_invariants();
     }
 
     #[test]
-    fn peek_does_not_record_use() {
+    fn test_peek_does_not_record_use() {
+        // After this shared setup, keys 2 and 3 are unreferenced and the hand
+        // points at key 2. peek leaves key 2 unreferenced, while get sets its
+        // bit. This isolates the behavioral difference between peek and get.
         fn setup() -> ClockCache<u64, u64> {
             let mut cache = ClockCache::new(NZUsize!(3));
             cache.put(1, 10);
             cache.put(2, 20);
             cache.put(3, 30);
-            cache.put(4, 40);
+            cache.put(4, 40); // Evicts key 1 and clears the other reference bits.
             cache
         }
 
-        // peek leaves key 2 unreferenced, so it remains the next victim.
+        // peek does not record use, so key 2 remains the next victim.
         let mut cache = setup();
         assert_eq!(cache.peek(&2).copied(), Some(20));
         cache.put(5, 50);
-        assert!(!cache.contains(&2));
+        assert!(!cache.contains(&2), "peek must not protect key 2");
         assert!(cache.contains(&3));
 
-        // get sets key 2's bit, so the hand skips it and evicts key 3.
+        // get records use, so key 2 survives and key 3 is evicted instead.
         let mut cache = setup();
         assert_eq!(cache.get(&2).copied(), Some(20));
         cache.put(5, 50);
-        assert!(cache.contains(&2));
+        assert!(cache.contains(&2), "get must protect key 2");
         assert!(!cache.contains(&3));
     }
 
     #[test]
-    fn clear_resets_hand() {
+    fn test_clear_resets_hand() {
         let mut cache = ClockCache::new(NZUsize!(3));
         cache.put(1u64, 10u64);
         cache.put(2, 20);
@@ -241,17 +256,19 @@ mod tests {
     }
 
     #[test]
-    fn concurrent_get_records_hits() {
+    fn test_concurrent_get_records_hits() {
+        // get records use through an atomic, so many threads can read through
+        // a shared cache reference without an external lock.
         let mut cache = ClockCache::new(NZUsize!(64));
         for i in 0..64u64 {
             cache.put(i, i * 10);
         }
+
+        // Clear the insertion marks so the readers must set every bit.
         for entry in &mut cache.slots {
             *entry.state.get_mut() = false;
         }
 
-        // Hits update only atomic reference bits, so shared readers can record
-        // use concurrently.
         let cache = &cache;
         thread::scope(|scope| {
             for _ in 0..4 {
@@ -270,6 +287,9 @@ mod tests {
                 .iter()
                 .all(|entry| entry.state.load(Ordering::Relaxed))
         );
+        for i in 0..64u64 {
+            assert_eq!(cache.get(&i).copied(), Some(i * 10));
+        }
         cache.check_invariants();
     }
 }

--- a/utils/src/cache/clock.rs
+++ b/utils/src/cache/clock.rs
@@ -97,9 +97,6 @@ impl<K> Policy<K> for Clock {
     fn remove(&mut self, _slot: Option<Slot>, _key: &K) {}
 
     #[inline]
-    fn retain<F: FnMut(&K) -> bool>(&mut self, _keep: F) {}
-
-    #[inline]
     fn clear(&mut self) {
         self.hand = 0;
     }
@@ -249,6 +246,9 @@ mod tests {
         for i in 0..64u64 {
             cache.put(i, i * 10);
         }
+        for entry in &mut cache.slots {
+            *entry.state.get_mut() = false;
+        }
 
         // Hits update only atomic reference bits, so shared readers can record
         // use concurrently.
@@ -264,9 +264,12 @@ mod tests {
                 });
             }
         });
-        for i in 0..64u64 {
-            assert_eq!(cache.get(&i).copied(), Some(i * 10));
-        }
+        assert!(
+            cache
+                .slots
+                .iter()
+                .all(|entry| entry.state.load(Ordering::Relaxed))
+        );
         cache.check_invariants();
     }
 }

--- a/utils/src/cache/clock.rs
+++ b/utils/src/cache/clock.rs
@@ -1,4 +1,4 @@
-//! CLOCK cache replacement.
+//! CLOCK cache policy.
 //!
 //! CLOCK approximates least-recently-used replacement with one reference bit
 //! per cache slot. A hit sets the bit. When the cache is full, a clock hand
@@ -9,17 +9,6 @@
 //! atomic operations so [super::Cache::get] can record hits through a shared
 //! reference. Admission and eviction still require exclusive access to the
 //! cache.
-//!
-//! # Example
-//!
-//! ```
-//! use commonware_utils::cache::Cache;
-//! use core::num::NonZeroUsize;
-//!
-//! let mut cache = Cache::<u64, u64>::new(NonZeroUsize::new(2).unwrap());
-//! cache.put(1, 10);
-//! assert_eq!(cache.get(&1), Some(&10));
-//! ```
 
 use super::{Claimed, Policy, Slot};
 use core::{
@@ -71,7 +60,9 @@ impl<K> Policy<K> for Clock {
         C: FnOnce(Option<Slot>) -> Claimed<K>,
     {
         if has_vacancy {
-            claim(None);
+            // CLOCK admits into available capacity without scanning. Mark the
+            // new resident referenced so it receives a full second chance.
+            let _ = claim(None);
             return AtomicBool::new(true);
         }
 
@@ -79,10 +70,13 @@ impl<K> Policy<K> for Clock {
             let referenced = &states[self.hand];
             if !referenced.load(Ordering::Relaxed) {
                 let victim = self.hand;
+                let _ = claim(Some(victim));
+                // Do not reconsider the new resident until the hand completes a revolution.
                 self.advance();
-                claim(Some(victim));
                 return AtomicBool::new(true);
             }
+            // A set bit grants one second chance. Clear it and continue from
+            // the following slot.
             referenced.store(false, Ordering::Relaxed);
             self.advance();
         }
@@ -121,6 +115,7 @@ mod tests {
 
     impl<K: Hash + Eq + Clone, V> Cache<K, V, Clock> {
         fn check_clock_invariants(&self) {
+            self.check_cache_invariants();
             if self.slots.is_empty() {
                 assert_eq!(self.policy.hand, 0);
             } else {
@@ -145,6 +140,8 @@ mod tests {
         cache.put(5, 50);
         assert!(cache.contains(&2));
         assert!(!cache.contains(&3));
+        assert!(cache.contains(&4));
+        assert!(cache.contains(&5));
         cache.check_clock_invariants();
     }
 
@@ -154,6 +151,9 @@ mod tests {
         cache.put(1u64, 10u64);
         cache.put(2, 20);
         cache.put(3, 30);
+
+        // Re-reference every resident. The sweep clears all three bits, wraps,
+        // and evicts key 1 at the initial hand position.
         assert!(cache.get(&1).is_some());
         assert!(cache.get(&2).is_some());
         assert!(cache.get(&3).is_some());
@@ -162,6 +162,7 @@ mod tests {
         assert!(!cache.contains(&1));
         assert!(cache.contains(&2));
         assert!(cache.contains(&3));
+        assert!(cache.contains(&4));
         cache.check_clock_invariants();
     }
 
@@ -173,6 +174,8 @@ mod tests {
         cache.put(3, 30);
         cache.put(4, 40);
 
+        // get_at records use like get, so key 2 receives a second chance and
+        // unreferenced key 3 becomes the next victim.
         let slot = *cache.index.get(&2).unwrap();
         assert_eq!(cache.get_at(slot, &2).copied(), Some(20));
         cache.put(5, 50);
@@ -192,12 +195,14 @@ mod tests {
             cache
         }
 
+        // peek leaves key 2 unreferenced, so it remains the next victim.
         let mut cache = setup();
         assert_eq!(cache.peek(&2).copied(), Some(20));
         cache.put(5, 50);
         assert!(!cache.contains(&2));
         assert!(cache.contains(&3));
 
+        // get sets key 2's bit, so the hand skips it and evicts key 3.
         let mut cache = setup();
         assert_eq!(cache.get(&2).copied(), Some(20));
         cache.put(5, 50);
@@ -212,8 +217,11 @@ mod tests {
         cache.put(2, 20);
         cache.put(3, 30);
         cache.put(4, 40);
+
+        // The first eviction moves the hand away from its initial position.
         assert_ne!(cache.policy.hand, 0);
 
+        // Clearing restores the initial hand position for the next population.
         cache.clear();
         assert_eq!(cache.policy.hand, 0);
         cache.put(5, 50);
@@ -226,6 +234,9 @@ mod tests {
         for i in 0..64u64 {
             cache.put(i, i * 10);
         }
+
+        // Hits update only atomic reference bits, so shared readers can record
+        // use concurrently.
         let cache = &cache;
         thread::scope(|scope| {
             for _ in 0..4 {
@@ -238,6 +249,9 @@ mod tests {
                 });
             }
         });
+        for i in 0..64u64 {
+            assert_eq!(cache.get(&i).copied(), Some(i * 10));
+        }
         cache.check_clock_invariants();
     }
 }

--- a/utils/src/cache/clock.rs
+++ b/utils/src/cache/clock.rs
@@ -1,4 +1,4 @@
-//! CLOCK cache policy.
+//! The CLOCK cache replacement policy.
 //!
 //! CLOCK approximates least-recently-used replacement with one reference bit
 //! per cache slot. A hit sets the bit. When the cache is full, a clock hand

--- a/utils/src/cache/clock2qplus.rs
+++ b/utils/src/cache/clock2qplus.rs
@@ -824,256 +824,25 @@ impl<K: Hash + Eq + Clone, V> core::fmt::Debug for Cache<K, V, Clock2QPlus<K>> {
 mod tests {
     use super::*;
     use crate::{NZUsize, cache::Cache, sync::RwLock};
-    use proptest::prelude::*;
     use std::{
-        collections::{HashMap, HashSet, VecDeque},
+        collections::HashSet,
         sync::{Arc, Barrier},
         thread,
     };
 
     type TestCache<K, V> = Cache<K, V, Clock2QPlus<K>>;
 
-    /// Returns the number of residents attached to either partition.
-    const fn residents<K>(policy: &Clock2QPlus<K>) -> usize {
-        policy.small.len + policy.main.len
-    }
-
-    /// Returns the packed policy state observed by tests.
-    fn bits(state: &SlotState) -> u8 {
-        state.0.load(Ordering::Relaxed)
-    }
-
-    /// One resident in the slot-independent reference model.
-    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-    struct ReferenceEntry {
-        /// Resident key.
-        key: u8,
-        /// Whether the resident has earned a second chance or promotion.
-        referenced: bool,
-        /// Small admission generation, or `None` after entering Main.
-        admitted_at: Option<u64>,
-    }
-
-    /// A queue-level Clock2Q+ model independent of cache slots and policy links.
-    struct ReferenceClock2QPlus {
-        /// Maximum number of resident entries.
-        capacity: usize,
-        /// Target number of Small residents.
-        small_capacity: usize,
-        /// Target number of Main residents.
-        main_capacity: usize,
-        /// Number of later Small admissions treated as correlated.
-        correlation_window: usize,
-        /// Maximum number of historical Ghost keys.
-        ghost_capacity: usize,
-        /// Newest Small entry is at the front.
-        small: VecDeque<ReferenceEntry>,
-        /// Counts every Small admission, even if that entry is later removed.
-        small_admissions: u64,
-        /// The Main CLOCK hand is at the front. New entries go immediately before it.
-        main: VecDeque<ReferenceEntry>,
-        /// Newest Ghost key is at the front.
-        ghost: VecDeque<u8>,
-    }
-
-    impl ReferenceClock2QPlus {
-        /// Constructs an empty queue-level model.
-        fn new(capacity: usize) -> Self {
-            let small_capacity = if capacity == 1 {
-                0
-            } else {
-                (capacity / 10).max(1)
-            };
-            Self {
-                capacity,
-                small_capacity,
-                main_capacity: capacity - small_capacity,
-                correlation_window: small_capacity.div_ceil(2),
-                ghost_capacity: capacity / 2,
-                small: VecDeque::new(),
-                small_admissions: 0,
-                main: VecDeque::new(),
-                ghost: VecDeque::new(),
-            }
-        }
-
-        /// Applies one access and reports whether the key was resident.
-        fn access(&mut self, key: u8) -> bool {
-            if let Some(position) = self.small.iter().position(|entry| entry.key == key) {
-                let admitted_at = self.small[position]
-                    .admitted_at
-                    .expect("Small entry must have an admission generation");
-                if self.small_admissions - admitted_at >= self.correlation_window as u64 {
-                    self.small[position].referenced = true;
-                }
-                return true;
-            }
-            if let Some(position) = self.main.iter().position(|entry| entry.key == key) {
-                self.main[position].referenced = true;
-                return true;
-            }
-
-            // Consume Ghost evidence as part of this atomic model admission,
-            // matching the production insertion transition.
-            let ghost_hit = self
-                .ghost
-                .iter()
-                .position(|historical| *historical == key)
-                .map(|position| self.ghost.remove(position).unwrap())
-                .is_some();
-            let has_vacancy = self.small.len() + self.main.len() < self.capacity;
-            let admit_to_main = ghost_hit
-                || self.small_capacity == 0
-                || (has_vacancy && self.small.len() >= self.small_capacity);
-            if admit_to_main {
-                self.admit_main(key, has_vacancy);
-            } else {
-                self.admit_small(key, has_vacancy);
-            }
-            false
-        }
-
-        /// Removes a resident or forgets nonresident history for `key`.
-        fn remove(&mut self, key: u8) -> bool {
-            if let Some(position) = self.small.iter().position(|entry| entry.key == key) {
-                self.small.remove(position);
-                return true;
-            }
-            if let Some(position) = self.main.iter().position(|entry| entry.key == key) {
-                self.main.remove(position);
-                return true;
-            }
-            if let Some(position) = self.ghost.iter().position(|historical| *historical == key) {
-                self.ghost.remove(position);
-            }
-            false
-        }
-
-        /// Retains resident keys below `limit` while preserving Ghost history.
-        fn retain(&mut self, limit: u8) {
-            self.small.retain(|entry| entry.key < limit);
-            self.main.retain(|entry| entry.key < limit);
-        }
-
-        /// Resets all resident and historical model state.
-        fn clear(&mut self) {
-            self.small.clear();
-            self.small_admissions = 0;
-            self.main.clear();
-            self.ghost.clear();
-        }
-
-        /// Admits a cold key to Small, promoting its tail when eligible.
-        fn admit_small(&mut self, key: u8, has_vacancy: bool) {
-            if !has_vacancy {
-                // The partition bounds and full occupancy force both
-                // partitions to their targets, so at most one promotion is
-                // possible before Main must evict.
-                assert_eq!(self.small.len(), self.small_capacity);
-                assert_eq!(self.main.len(), self.main_capacity);
-                let tail = self.small.back().unwrap();
-                let admitted_at = tail
-                    .admitted_at
-                    .expect("Small entry must have an admission generation");
-                let young = self.small_admissions - admitted_at < self.correlation_window as u64;
-                if young || !tail.referenced {
-                    let victim = self.small.pop_back().unwrap().key;
-                    self.push_ghost(victim);
-                } else {
-                    let mut promoted = self.small.pop_back().unwrap();
-                    promoted.referenced = false;
-                    promoted.admitted_at = None;
-                    self.evict_main();
-                    self.main.push_back(promoted);
-                }
-            }
-            self.small_admissions += 1;
-            self.small.push_front(ReferenceEntry {
-                key,
-                referenced: false,
-                admitted_at: Some(self.small_admissions),
-            });
-        }
-
-        /// Admits a Ghost hit or warm-up key directly to Main.
-        fn admit_main(&mut self, key: u8, has_vacancy: bool) {
-            if self.main.len() == self.main_capacity {
-                self.evict_main();
-            } else {
-                // A non-full Main is possible only while the cache has unused
-                // resident capacity.
-                assert!(has_vacancy);
-            }
-            self.main.push_back(ReferenceEntry {
-                key,
-                referenced: false,
-                admitted_at: None,
-            });
-        }
-
-        /// Runs the model's Main CLOCK scan through the first unreferenced key.
-        fn evict_main(&mut self) {
-            loop {
-                let mut candidate = self.main.pop_front().unwrap();
-                if candidate.referenced {
-                    candidate.referenced = false;
-                    self.main.push_back(candidate);
-                } else {
-                    return;
-                }
-            }
-        }
-
-        /// Adds a key to the bounded model Ghost queue.
-        fn push_ghost(&mut self, key: u8) {
-            assert!(!self.ghost.contains(&key));
-            if self.ghost.len() == self.ghost_capacity {
-                self.ghost.pop_back();
-            }
-            self.ghost.push_front(key);
-        }
-
-        /// Returns Small from newest to oldest with reference state.
-        fn small_state(&self) -> Vec<(u8, bool)> {
-            self.small
-                .iter()
-                .map(|entry| (entry.key, entry.referenced))
-                .collect()
-        }
-
-        /// Returns Main from the hand forward with reference state.
-        fn main_state(&self) -> Vec<(u8, bool)> {
-            self.main
-                .iter()
-                .map(|entry| (entry.key, entry.referenced))
-                .collect()
-        }
-    }
-
-    /// Mutation applied to both the cache and queue-level reference model.
-    #[derive(Clone, Debug)]
-    enum ReferenceOp {
-        /// Accesses a key and inserts it on a miss.
-        Access(u8),
-        /// Removes a key or its Ghost history.
-        Remove(u8),
-        /// Retains resident keys below the supplied limit.
-        Retain(u8),
-        /// Clears all policy and cache state.
-        Clear,
-    }
-
-    /// Generates weighted operations for model-based mutation testing.
-    fn reference_op_strategy() -> impl Strategy<Value = ReferenceOp> {
-        prop_oneof![
-            8 => (0u8..64).prop_map(ReferenceOp::Access),
-            2 => (0u8..64).prop_map(ReferenceOp::Remove),
-            1 => (0u8..64).prop_map(ReferenceOp::Retain),
-            1 => Just(ReferenceOp::Clear),
-        ]
-    }
-
     impl<K: Hash + Eq + Clone + core::fmt::Debug, V> Cache<K, V, Clock2QPlus<K>> {
+        /// Returns the number of residents attached to either partition.
+        const fn residents(&self) -> usize {
+            self.policy.small.len + self.policy.main.len
+        }
+
+        /// Returns the packed policy state for a resident slot.
+        fn bits(&self, slot: Slot) -> u8 {
+            self.slots[slot].state.0.load(Ordering::Relaxed)
+        }
+
         /// Returns Small slot order from newest to oldest.
         fn small_order(&self) -> Vec<usize> {
             let mut order = Vec::with_capacity(self.policy.small.len);
@@ -1146,10 +915,10 @@ mod tests {
         /// Asserts the Clock2Q+ policy's invariants hold.
         pub(crate) fn check_policy_invariants(&self) {
             let policy = &self.policy;
-            assert!(residents(policy) <= policy.slots.len());
+            assert!(self.residents() <= policy.slots.len());
             assert!(policy.small.len <= policy.small.capacity);
             assert!(policy.main.len <= policy.main.capacity);
-            assert_eq!(self.index.len(), residents(policy));
+            assert_eq!(self.index.len(), self.residents());
             assert_eq!(self.index.len() + self.free.len(), self.slots.len());
 
             let free: HashSet<_> = self.free.iter().copied().collect();
@@ -1177,7 +946,7 @@ mod tests {
                 assert!(resident.insert(slot), "duplicate Small resident {slot}");
                 assert!(self.slots[slot].live);
                 assert_eq!(policy.slots[slot].location, Location::Small);
-                let state = bits(&self.slots[slot].state);
+                let state = self.bits(slot);
                 let young = rank < young_len;
                 assert_eq!(state & CORRELATED != 0, young);
                 if young {
@@ -1200,7 +969,7 @@ mod tests {
                 assert!(resident.insert(slot), "resident {slot} in two queues");
                 assert!(self.slots[slot].live);
                 assert_eq!(policy.slots[slot].location, Location::Main);
-                assert_eq!(bits(&self.slots[slot].state) & CORRELATED, 0);
+                assert_eq!(self.bits(slot) & CORRELATED, 0);
                 assert_eq!(
                     policy.slots[slot].prev,
                     main[(rank + main.len() - 1) % main.len()]
@@ -1265,32 +1034,6 @@ mod tests {
         }
     }
 
-    /// Returns the implementation's observable Small state for model checks.
-    fn actual_small_state(cache: &TestCache<u8, u8>) -> Vec<(u8, bool)> {
-        cache
-            .small_order()
-            .into_iter()
-            .map(|slot| {
-                let referenced = bits(&cache.slots[slot].state) & REFERENCED != 0;
-                (cache.slots[slot].key, referenced)
-            })
-            .collect()
-    }
-
-    /// Returns the implementation's observable Main state for model checks.
-    fn actual_main_state(cache: &TestCache<u8, u8>) -> Vec<(u8, bool)> {
-        cache
-            .main_order()
-            .into_iter()
-            .map(|slot| {
-                (
-                    cache.slots[slot].key,
-                    bits(&cache.slots[slot].state) & REFERENCED != 0,
-                )
-            })
-            .collect()
-    }
-
     #[test]
     fn test_partitions_round_for_tiny_capacities() {
         // Ratio-derived partitions round down. Capacities above one still keep
@@ -1350,7 +1093,7 @@ mod tests {
         assert_eq!(cache.main_keys(), (2..20).collect::<Vec<_>>());
         for key in 2..20u64 {
             let slot = cache.index[&key];
-            assert_eq!(bits(&cache.slots[slot].state) & REFERENCED, 0);
+            assert_eq!(cache.bits(slot) & REFERENCED, 0);
         }
         cache.check_invariants();
     }
@@ -1371,7 +1114,7 @@ mod tests {
         assert!(!cache.policy.ghost.index.is_empty());
 
         cache.retain(|_, _| false);
-        assert_eq!(residents(&cache.policy), 0);
+        assert_eq!(cache.residents(), 0);
         assert_eq!(cache.ghost_keys(), vec![1]);
         cache.check_invariants();
     }
@@ -1387,7 +1130,7 @@ mod tests {
         assert_eq!(correlated.small_keys(), vec![4, 3, 2, 1]);
         assert_eq!(correlated.get(&4), Some(&4));
         let slot = correlated.index[&4];
-        assert_eq!(bits(&correlated.slots[slot].state) & REFERENCED, 0);
+        assert_eq!(correlated.bits(slot) & REFERENCED, 0);
         for key in 41..=44u64 {
             correlated.put(key, key);
         }
@@ -1407,7 +1150,7 @@ mod tests {
         assert!(reused.small_keys().contains(&41));
         assert!(reused.main_keys().contains(&1));
         let slot = reused.index[&1];
-        assert_eq!(bits(&reused.slots[slot].state) & REFERENCED, 0);
+        assert_eq!(reused.bits(slot) & REFERENCED, 0);
         assert!(reused.ghost_keys().is_empty());
         reused.check_invariants();
     }
@@ -1533,7 +1276,7 @@ mod tests {
         assert_eq!(cache.policy.small.len, 2);
         let slot = cache.index[&0];
         assert!(cache.main_keys().contains(&0));
-        assert_eq!(bits(&cache.slots[slot].state) & REFERENCED, 0);
+        assert_eq!(cache.bits(slot) & REFERENCED, 0);
 
         // Repeat the transition with a full Main CLOCK. The promoted key keeps
         // its slot and starts in Main with a clear reference bit.
@@ -1543,7 +1286,7 @@ mod tests {
 
         assert!(cache.main_keys().contains(&promoted));
         let slot = cache.index[&promoted];
-        assert_eq!(bits(&cache.slots[slot].state) & REFERENCED, 0);
+        assert_eq!(cache.bits(slot) & REFERENCED, 0);
         assert!(cache.small_keys().contains(&21));
         assert_eq!(cache.policy.main.len, cache.policy.main.capacity);
         assert_eq!(cache.policy.small.len, 2);
@@ -1664,7 +1407,7 @@ mod tests {
 
         cache.clear();
         assert!(cache.is_empty());
-        assert_eq!(residents(&cache.policy), 0);
+        assert_eq!(cache.residents(), 0);
         assert!(cache.policy.ghost.index.is_empty());
         assert!(cache.ghost_keys().is_empty());
         cache.check_invariants();
@@ -1723,125 +1466,4 @@ mod tests {
         cache.check_invariants();
     }
 
-    proptest! {
-        #[test]
-        fn test_pure_accesses_match_queue_level_reference(
-            capacity in 1usize..33,
-            accesses in prop::collection::vec(0u8..64, 0..400),
-        ) {
-            let mut cache = TestCache::new(NonZeroUsize::new(capacity).unwrap());
-            let mut reference = ReferenceClock2QPlus::new(capacity);
-
-            // Compare every hit decision and complete queue state against a
-            // slot-independent model of the paper's access transitions.
-            for key in accesses {
-                let expected_hit = reference.access(key);
-                let actual_hit = cache.get(&key).is_some();
-                if !actual_hit {
-                    cache.put(key, key);
-                }
-
-                prop_assert_eq!(actual_hit, expected_hit);
-                prop_assert_eq!(actual_small_state(&cache), reference.small_state());
-                prop_assert_eq!(actual_main_state(&cache), reference.main_state());
-                prop_assert_eq!(cache.ghost_keys(), reference.ghost.iter().copied().collect::<Vec<_>>());
-                cache.check_invariants();
-            }
-        }
-
-        #[test]
-        fn test_mutations_match_queue_level_reference(
-            capacity in 1usize..33,
-            operations in prop::collection::vec(reference_op_strategy(), 0..400),
-        ) {
-            let mut cache = TestCache::new(NonZeroUsize::new(capacity).unwrap());
-            let mut reference = ReferenceClock2QPlus::new(capacity);
-
-            // Removal and retention must not rewind monotonic correlation age
-            // or disturb the Main hand and Ghost queue.
-            for operation in operations {
-                match operation {
-                    ReferenceOp::Access(key) => {
-                        let expected_hit = reference.access(key);
-                        let actual_hit = cache.get(&key).is_some();
-                        if !actual_hit {
-                            cache.put(key, key);
-                        }
-                        prop_assert_eq!(actual_hit, expected_hit);
-                    }
-                    ReferenceOp::Remove(key) => {
-                        prop_assert_eq!(cache.remove(&key), reference.remove(key));
-                    }
-                    ReferenceOp::Retain(limit) => {
-                        cache.retain(|key, _| *key < limit);
-                        reference.retain(limit);
-                    }
-                    ReferenceOp::Clear => {
-                        cache.clear();
-                        reference.clear();
-                    }
-                }
-
-                prop_assert_eq!(actual_small_state(&cache), reference.small_state());
-                prop_assert_eq!(actual_main_state(&cache), reference.main_state());
-                prop_assert_eq!(cache.ghost_keys(), reference.ghost.iter().copied().collect::<Vec<_>>());
-                cache.check_invariants();
-            }
-        }
-
-        #[test]
-        fn test_arbitrary_operations_preserve_invariants(
-            capacity in 1usize..17,
-            operations in prop::collection::vec((0u8..8, 0u8..24, any::<u16>()), 0..300),
-        ) {
-            let mut cache = TestCache::new(NonZeroUsize::new(capacity).unwrap());
-            let mut values = HashMap::new();
-
-            // Exercise every mutating Cache entry point while checking policy
-            // topology and the last value written for each surviving key.
-            for (operation, key, value) in operations {
-                match operation {
-                    0 => {
-                        cache.put(key, value);
-                        values.insert(key, value);
-                    }
-                    1 => {
-                        let _ = cache.get(&key);
-                    }
-                    2 => {
-                        if let Some(stored) = cache.get_mut(&key) {
-                            *stored = value;
-                            values.insert(key, value);
-                        }
-                    }
-                    3 => {
-                        let stored = *cache.get_or_insert_with(key, || value);
-                        values.insert(key, stored);
-                    }
-                    4 => {
-                        *cache.get_or_insert_mut(key, || value).1 = value;
-                        values.insert(key, value);
-                    }
-                    5 => {
-                        cache.remove(&key);
-                        values.remove(&key);
-                    }
-                    6 => {
-                        cache.retain(|stored, _| *stored < key);
-                        values.retain(|stored, _| *stored < key);
-                    }
-                    _ => {
-                        cache.clear();
-                        values.clear();
-                    }
-                }
-
-                cache.check_invariants();
-                prop_assert!(cache.len() <= capacity);
-                for (resident, &slot) in &cache.index {
-                    prop_assert_eq!(cache.slots[slot].value, values[resident]);
-                }
-            }
-        }
-    }
 }

--- a/utils/src/cache/clock2qplus.rs
+++ b/utils/src/cache/clock2qplus.rs
@@ -1,0 +1,1773 @@
+//! The Clock2Q+ cache replacement policy.
+//!
+//! # Admission and Eviction
+//!
+//! Clock2Q+ divides resident entries between a small FIFO queue and a main
+//! CLOCK. New entries normally enter Small. Entries seen in bounded Ghost
+//! history enter Main instead. When an entry reaches the tail of Small, an
+//! unreferenced entry is evicted to Ghost while a referenced entry is promoted
+//! to Main.
+//!
+//! # Correlation Filtering
+//!
+//! Up to the newest half of Small forms a correlation window. Hits in that
+//! window are ignored, which prevents a burst of closely spaced accesses from
+//! making a cold entry appear hot. Once enough newer entries arrive, the entry
+//! leaves the window permanently. A later hit sets its reference bit and
+//! promotes it when it reaches the Small tail.
+//!
+//! # Sizing and State
+//!
+//! This implementation targets the paper's fixed proportions. For integer
+//! capacity `C`, Small is `max(C / 10, 1)` when `C > 1`, Main gets the
+//! remainder, and Ghost is `C / 2`. The correlation window is half of Small,
+//! rounded up. A capacity of one uses Main only. Resident keys and values
+//! remain in stable [super::Cache] slots. Queue topology and Ghost history are
+//! policy-owned, while each slot's correlation marker and reference bit are
+//! stored inline as [Policy::SlotState]. Ghost admission is sampled when
+//! insertion commits.
+//!
+//! # References
+//!
+//! - [Clock2Q+: A Simple and Efficient Replacement Algorithm for Metadata
+//!   Cache in VMware vSAN](https://arxiv.org/abs/2511.21958)
+
+use super::{Cache, Claimed, Hasher, Policy, Slot};
+#[cfg(not(feature = "std"))]
+use alloc::{vec, vec::Vec};
+use core::{
+    hash::Hash,
+    num::NonZeroUsize,
+    ops::Index,
+    sync::atomic::{AtomicU8, Ordering},
+};
+use hashbrown::HashMap;
+
+/// Sentinel used when a policy-owned slot has no neighbor.
+const UNLINKED: usize = usize::MAX;
+/// Slot-state bit set after an eligible resident hit.
+const REFERENCED: u8 = 1 << 0;
+/// Slot-state bit set while a Small resident is in the correlation window.
+const CORRELATED: u8 = 1 << 1;
+
+/// Converts the internal link sentinel into an optional slot.
+#[inline]
+const fn linked(slot: usize) -> Option<usize> {
+    if slot == UNLINKED { None } else { Some(slot) }
+}
+
+/// Where a resident slot participates in the replacement policy.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum Location {
+    /// The cache slot is not attached to either resident partition.
+    Free,
+    /// One of the newest entries in Small. Hits here are correlated and ignored.
+    SmallYoung,
+    /// An older Small entry. A hit here marks the entry for promotion.
+    SmallOld,
+    /// An entry in the Main CLOCK ring.
+    Main,
+}
+
+/// Policy-owned topology for a stable cache slot.
+#[derive(Clone, Copy)]
+struct ResidentSlot {
+    /// Partition containing the resident, or [`Location::Free`] when detached.
+    location: Location,
+    /// Previous entry toward the head of Small, or in Main's circular ring.
+    prev: usize,
+    /// Next entry toward the tail of Small, or in Main's circular ring.
+    next: usize,
+    /// Small admission generation, used only while this entry is correlated.
+    admitted_at: usize,
+}
+
+impl Default for ResidentSlot {
+    /// Returns detached metadata with no queue neighbors.
+    fn default() -> Self {
+        Self {
+            location: Location::Free,
+            prev: UNLINKED,
+            next: UNLINKED,
+            admitted_at: 0,
+        }
+    }
+}
+
+/// A key-only entry in the bounded Ghost FIFO.
+struct GhostSlot<K> {
+    /// Historical key, or `None` when this slot is available for reuse.
+    key: Option<K>,
+    /// Previous entry toward the Ghost head.
+    prev: usize,
+    /// Next entry toward the Ghost tail.
+    next: usize,
+}
+
+/// Resident partition selected for an incoming key.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum Admission {
+    /// Admit at the head of the Small FIFO.
+    Small,
+    /// Admit immediately before the hand in the Main CLOCK ring.
+    Main,
+}
+
+/// Policy state stored inline with each Clock2Q+ cache slot.
+///
+/// The correlation marker and reference bit share one atomic byte, so a shared
+/// hit needs no access to policy-owned queue topology. Relaxed ordering is
+/// sufficient because these bits affect only replacement decisions and do not
+/// publish resident keys or values.
+#[repr(transparent)]
+#[derive(Default)]
+pub struct SlotState(AtomicU8);
+
+impl SlotState {
+    /// Returns the initial state for a resident entering `admission`.
+    #[inline]
+    const fn new(admission: Admission) -> Self {
+        let state = match admission {
+            Admission::Small => CORRELATED,
+            Admission::Main => 0,
+        };
+        Self(AtomicU8::new(state))
+    }
+
+    /// Records a hit through a shared cache reference.
+    ///
+    /// Hits inside the correlation window are ignored. The conditional store
+    /// also avoids dirtying the cache line again after the bit is already set.
+    #[inline]
+    fn record_hit(&self) {
+        let current = self.0.load(Ordering::Relaxed);
+        if current & (CORRELATED | REFERENCED) == 0 {
+            self.0.store(REFERENCED, Ordering::Relaxed);
+        }
+    }
+
+    /// Records a hit while the cache is already exclusively borrowed.
+    #[inline]
+    fn record_hit_mut(&mut self) {
+        let current = self.0.get_mut();
+        if *current & CORRELATED == 0 {
+            *current |= REFERENCED;
+        }
+    }
+}
+
+/// Clock2Q+ admission and eviction policy.
+///
+/// Clock2Q+ divides residents between a Small FIFO and a Main CLOCK ring. New
+/// keys enter Small, while keys found in bounded Ghost history enter Main.
+/// Hits to the newest portion of Small are ignored to filter correlated access.
+/// An eligible Small hit marks the resident for promotion when it reaches the
+/// FIFO tail.
+///
+/// The policy owns queue topology, partition sizes, the Main clock hand, and
+/// exact bounded Ghost history. Resident keys and values remain in [Cache].
+/// The target proportions are 10% Small, 90% Main, and 50% Ghost, with a
+/// correlation window covering half of Small. Integer sizes use floor division,
+/// except that Small receives at least one slot when total capacity exceeds
+/// one. A capacity of one uses Main as a one-entry CLOCK.
+///
+/// Resident values stay in stable cache slots while queue links remain in the
+/// policy. Hits mutate only relaxed atomic slot state, so readers can share the
+/// cache behind a reader-writer lock without serializing.
+///
+/// See [Clock2Q+: A Simple and Efficient Replacement Algorithm for Metadata
+/// Cache in VMware vSAN](https://arxiv.org/abs/2511.21958).
+///
+/// # Example
+///
+/// ```
+/// use commonware_utils::cache::{Cache, Clock2QPlus};
+/// use core::num::NonZeroUsize;
+///
+/// let mut cache = Cache::<u64, u64, Clock2QPlus<u64>>::new(
+///     NonZeroUsize::new(100).unwrap(),
+/// );
+/// cache.put(7, 49);
+/// assert_eq!(cache.get(&7), Some(&49));
+/// ```
+pub struct Clock2QPlus<K> {
+    /// Queue topology and admission age indexed by the cache's stable slots.
+    ///
+    /// The cache owns keys, values, and inline [`SlotState`]. This parallel
+    /// array is required for policy-owned links that must also be available to
+    /// [`Policy::remove`], which receives a slot identifier but no state view.
+    slots: Vec<ResidentSlot>,
+
+    /// Maximum number of residents in the Small partition.
+    small_capacity: usize,
+    /// Small admission age at which a resident leaves the correlation window.
+    correlation_window: usize,
+    /// Newest resident in the Small FIFO.
+    small_head: Option<usize>,
+    /// Oldest resident in the Small FIFO.
+    small_tail: Option<usize>,
+    /// The oldest entry still inside the correlation window.
+    small_young_tail: Option<usize>,
+    /// Monotonic count of Small admissions, including entries later removed.
+    small_admissions: usize,
+    /// Current number of Small residents.
+    small_len: usize,
+
+    /// Maximum number of residents in the Main partition.
+    main_capacity: usize,
+    /// Next Main resident considered for eviction.
+    main_hand: Option<usize>,
+    /// Current number of Main residents.
+    main_len: usize,
+
+    /// Exact Ghost membership mapped to positions in `ghost_slots`.
+    ///
+    /// The index makes admission checks and explicit history removal O(1).
+    ghost_index: HashMap<K, usize, Hasher>,
+    /// Storage for the bounded Ghost FIFO.
+    ghost_slots: Vec<GhostSlot<K>>,
+    /// Detached Ghost slots available for reuse.
+    ghost_free: Vec<usize>,
+    /// Newest key in Ghost.
+    ghost_head: Option<usize>,
+    /// Oldest key in Ghost.
+    ghost_tail: Option<usize>,
+    /// Maximum number of Ghost entries.
+    ghost_capacity: usize,
+}
+
+impl<K: Hash + Eq + Clone> Clock2QPlus<K> {
+    /// Constructs empty policy metadata for `capacity` resident slots.
+    fn with_capacity(capacity: NonZeroUsize) -> Self {
+        let capacity = capacity.get();
+        // Keep tiny caches usable while approaching the paper's target ratios
+        // with integer arithmetic at normal capacities.
+        let small_capacity = if capacity == 1 {
+            0
+        } else {
+            (capacity / 10).max(1)
+        };
+        let main_capacity = capacity - small_capacity;
+        let correlation_window = small_capacity.div_ceil(2);
+        let ghost_capacity = capacity / 2;
+
+        Self {
+            slots: vec![ResidentSlot::default(); capacity],
+            small_capacity,
+            correlation_window,
+            small_head: None,
+            small_tail: None,
+            small_young_tail: None,
+            small_admissions: 0,
+            small_len: 0,
+            main_capacity,
+            main_hand: None,
+            main_len: 0,
+            ghost_index: HashMap::with_capacity_and_hasher(ghost_capacity, Hasher::default()),
+            ghost_slots: Vec::with_capacity(ghost_capacity),
+            ghost_free: Vec::with_capacity(ghost_capacity),
+            ghost_head: None,
+            ghost_tail: None,
+            ghost_capacity,
+        }
+    }
+
+    /// Chooses the resident partition for an incoming key.
+    #[inline]
+    fn admission(&mut self, key: &K, has_vacancy: bool) -> Admission {
+        // A Ghost hit bypasses Small. During warm-up, Small fills to its target
+        // before additional vacant cache slots are assigned to Main.
+        if self.discard_ghost(key)
+            || self.small_capacity == 0
+            || (has_vacancy && self.small_len >= self.small_capacity)
+        {
+            Admission::Main
+        } else {
+            Admission::Small
+        }
+    }
+
+    /// Selects storage for a Small admission and records a pending promotion.
+    ///
+    /// A referenced old tail is promoted in place. The incoming key then uses
+    /// a Main victim, keeping both fixed-size resident partitions within their
+    /// targets. A correlated or unreferenced tail is selected directly.
+    fn select_small<I: Index<Slot, Output = SlotState>>(
+        &mut self,
+        states: &I,
+        promotion: &mut Option<Slot>,
+        has_vacancy: bool,
+    ) -> Option<Slot> {
+        if has_vacancy {
+            return None;
+        }
+
+        let tail = self.small_tail.expect("full cache must have a Small tail");
+        let state = states[tail].0.load(Ordering::Relaxed);
+
+        // Correlated references never earn promotion. The tail is eligible for
+        // promotion only when REFERENCED is set and CORRELATED is clear.
+        if state & (CORRELATED | REFERENCED) != REFERENCED {
+            return Some(tail);
+        }
+
+        // A referenced Small tail is promoted in its existing stable slot.
+        // Since a full cache also has a full Main partition, the incoming
+        // entry reuses the Main victim selected here.
+        self.unlink_small(tail);
+        states[tail].0.store(0, Ordering::Relaxed);
+        *promotion = Some(tail);
+        Some(self.select_main(states))
+    }
+
+    /// Selects storage for a Main admission.
+    ///
+    /// Main may require a victim even while the cache has a vacant Small slot.
+    fn select_for_main<I: Index<Slot, Output = SlotState>>(&mut self, states: &I) -> Option<Slot> {
+        // Main is a fixed-size CLOCK partition. Reusing a Ghost key must
+        // replace a Main resident even when Cache has a free Small slot.
+        if self.main_len == self.main_capacity {
+            return Some(self.select_main(states));
+        }
+        None
+    }
+
+    /// Runs the Main CLOCK hand until it finds an unreferenced victim.
+    fn select_main<I: Index<Slot, Output = SlotState>>(&mut self, states: &I) -> Slot {
+        loop {
+            let slot = self.main_hand.expect("nonempty Main must have a hand");
+            let state = &states[slot];
+            if state.0.load(Ordering::Relaxed) & REFERENCED != 0 {
+                // A set bit grants one second chance. Clear it and continue
+                // from the following resident in the Main ring.
+                state.0.store(0, Ordering::Relaxed);
+                self.main_hand = Some(self.slots[slot].next);
+                continue;
+            }
+            return slot;
+        }
+    }
+
+    /// Attaches a free stable slot to its selected resident partition.
+    fn attach<I: Index<Slot, Output = SlotState>>(
+        &mut self,
+        states: &I,
+        slot: usize,
+        admission: Admission,
+    ) {
+        match admission {
+            Admission::Small => self.insert_small_head(states, slot),
+            Admission::Main => self.insert_main(slot),
+        }
+    }
+
+    /// Detaches a resident from whichever partition currently owns it.
+    fn unlink_resident(&mut self, slot: usize) {
+        match self.slots[slot].location {
+            Location::SmallYoung | Location::SmallOld => self.unlink_small(slot),
+            Location::Main => self.unlink_main(slot),
+            Location::Free => unreachable!("resident slot cannot be free"),
+        }
+    }
+
+    /// Inserts a free slot at the Small head and advances correlation age.
+    fn insert_small_head<I: Index<Slot, Output = SlotState>>(&mut self, states: &I, slot: usize) {
+        // Admission count, rather than live queue length, makes correlation age
+        // monotonic across explicit removal and retention. Wrapping remains
+        // valid because a correlated resident leaves within one bounded window,
+        // long before the counter can complete a full cycle.
+        self.small_admissions = self.small_admissions.wrapping_add(1);
+        let old_head = self.small_head;
+        {
+            let entry = &mut self.slots[slot];
+            assert_eq!(entry.location, Location::Free);
+            entry.location = Location::SmallYoung;
+            entry.prev = UNLINKED;
+            entry.next = old_head.unwrap_or(UNLINKED);
+            entry.admitted_at = self.small_admissions;
+        }
+        if let Some(head) = old_head {
+            self.slots[head].prev = slot;
+        } else {
+            self.small_tail = Some(slot);
+        }
+        self.small_head = Some(slot);
+        self.small_len += 1;
+
+        if self.small_young_tail.is_none() {
+            self.small_young_tail = Some(slot);
+        }
+        // Only the oldest correlated survivor can leave the window after one
+        // new admission because Small preserves admission order.
+        let demoted = self
+            .small_young_tail
+            .expect("nonempty correlation window must have a tail");
+        let age = self
+            .small_admissions
+            .wrapping_sub(self.slots[demoted].admitted_at);
+        if age < self.correlation_window {
+            return;
+        }
+
+        let new_boundary = self.slots[demoted].prev;
+        assert_ne!(new_boundary, UNLINKED);
+        // Discard references made inside the correlation window. Only a hit
+        // after the entry becomes old should promote it to Main.
+        states[demoted].0.store(0, Ordering::Relaxed);
+        self.slots[demoted].location = Location::SmallOld;
+        self.slots[demoted].admitted_at = 0;
+        self.small_young_tail = Some(new_boundary);
+    }
+
+    /// Detaches a resident from Small and repairs its correlation boundary.
+    fn unlink_small(&mut self, slot: usize) {
+        let location = self.slots[slot].location;
+        assert!(matches!(
+            location,
+            Location::SmallYoung | Location::SmallOld
+        ));
+        let prev = self.slots[slot].prev;
+        let next = self.slots[slot].next;
+        if prev != UNLINKED {
+            self.slots[prev].next = next;
+        } else {
+            self.small_head = linked(next);
+        }
+        if next != UNLINKED {
+            self.slots[next].prev = prev;
+        } else {
+            self.small_tail = linked(prev);
+        }
+
+        self.small_len -= 1;
+        // Removing a correlated resident shrinks the live window without
+        // making any older resident young again.
+        if location == Location::SmallYoung && self.small_young_tail == Some(slot) {
+            self.small_young_tail = linked(prev);
+        }
+
+        self.slots[slot] = ResidentSlot::default();
+    }
+
+    /// Inserts a free slot immediately before the Main hand.
+    fn insert_main(&mut self, slot: usize) {
+        assert!(self.main_len < self.main_capacity);
+        let Some(hand) = self.main_hand else {
+            // A one-entry ring links the resident to itself and points the hand
+            // at that sole eviction candidate.
+            let entry = &mut self.slots[slot];
+            assert_eq!(entry.location, Location::Free);
+            entry.location = Location::Main;
+            entry.prev = slot;
+            entry.next = slot;
+            self.main_hand = Some(slot);
+            self.main_len = 1;
+            return;
+        };
+
+        // New residents start behind the current hand, so they are considered
+        // only after the existing CLOCK sweep reaches them.
+        let prev = self.slots[hand].prev;
+        assert_ne!(prev, UNLINKED);
+        {
+            let entry = &mut self.slots[slot];
+            assert_eq!(entry.location, Location::Free);
+            entry.location = Location::Main;
+            entry.prev = prev;
+            entry.next = hand;
+        }
+        self.slots[prev].next = slot;
+        self.slots[hand].prev = slot;
+        self.main_len += 1;
+    }
+
+    /// Detaches a resident from Main and advances the hand when necessary.
+    fn unlink_main(&mut self, slot: usize) {
+        assert_eq!(self.slots[slot].location, Location::Main);
+        if self.main_len == 1 {
+            assert_eq!(self.main_hand, Some(slot));
+            self.main_hand = None;
+            self.main_len = 0;
+        } else {
+            let prev = self.slots[slot].prev;
+            let next = self.slots[slot].next;
+            assert_ne!(prev, UNLINKED);
+            assert_ne!(next, UNLINKED);
+            self.slots[prev].next = next;
+            self.slots[next].prev = prev;
+            if self.main_hand == Some(slot) {
+                self.main_hand = Some(next);
+            }
+            self.main_len -= 1;
+        }
+        self.slots[slot] = ResidentSlot::default();
+    }
+
+    /// Adds an evicted Small key to the bounded Ghost FIFO.
+    fn push_ghost(&mut self, key: K) {
+        if self.ghost_capacity == 0 {
+            return;
+        }
+        // Prefer recycled storage, then grow to the Ghost bound, then reuse
+        // the oldest live slot after removing its previous key.
+        let slot = if let Some(slot) = self.ghost_free.pop() {
+            slot
+        } else if self.ghost_slots.len() < self.ghost_capacity {
+            let slot = self.ghost_slots.len();
+            self.ghost_slots.push(GhostSlot {
+                key: None,
+                prev: UNLINKED,
+                next: UNLINKED,
+            });
+            slot
+        } else {
+            let slot = self.ghost_tail.expect("full Ghost must have a tail");
+            self.remove_ghost(slot, false);
+            slot
+        };
+
+        let old_head = self.ghost_head;
+        {
+            let entry = &mut self.ghost_slots[slot];
+            assert!(entry.key.is_none());
+            // Ghost keeps one key in its hash index and one in its FIFO slot,
+            // which avoids per-entry shared ownership between the structures.
+            entry.key = Some(key.clone());
+            entry.prev = UNLINKED;
+            entry.next = old_head.unwrap_or(UNLINKED);
+        }
+        if let Some(head) = old_head {
+            self.ghost_slots[head].prev = slot;
+        } else {
+            self.ghost_tail = Some(slot);
+        }
+        self.ghost_head = Some(slot);
+        self.ghost_index.insert(key, slot);
+    }
+
+    /// Removes exact history for `key` and reports whether it was present.
+    fn discard_ghost(&mut self, key: &K) -> bool {
+        let Some(slot) = self.ghost_index.remove(key) else {
+            return false;
+        };
+        self.unlink_ghost(slot, true);
+        true
+    }
+
+    /// Removes a Ghost slot from both the FIFO and exact membership index.
+    fn remove_ghost(&mut self, slot: usize, recycle: bool) {
+        let key = self.unlink_ghost(slot, recycle);
+        let removed = self.ghost_index.remove(&key);
+        assert_eq!(removed, Some(slot));
+    }
+
+    /// Detaches a Ghost slot from the FIFO and returns its owned key.
+    ///
+    /// When `recycle` is true, the detached position is added to the free list.
+    fn unlink_ghost(&mut self, slot: usize, recycle: bool) -> K {
+        let prev = self.ghost_slots[slot].prev;
+        let next = self.ghost_slots[slot].next;
+        if prev != UNLINKED {
+            self.ghost_slots[prev].next = next;
+        } else {
+            self.ghost_head = linked(next);
+        }
+        if next != UNLINKED {
+            self.ghost_slots[next].prev = prev;
+        } else {
+            self.ghost_tail = linked(prev);
+        }
+
+        let key = self.ghost_slots[slot]
+            .key
+            .take()
+            .expect("linked Ghost entry must have a key");
+        self.ghost_slots[slot].prev = UNLINKED;
+        self.ghost_slots[slot].next = UNLINKED;
+        if recycle {
+            self.ghost_free.push(slot);
+        }
+        key
+    }
+
+    /// Removes all Ghost history and resets its reusable slot metadata.
+    fn clear_ghost(&mut self) {
+        self.ghost_index.clear();
+        self.ghost_slots.clear();
+        self.ghost_free.clear();
+        self.ghost_head = None;
+        self.ghost_tail = None;
+    }
+}
+
+impl<K: Hash + Eq + Clone> Policy<K> for Clock2QPlus<K> {
+    type SlotState = SlotState;
+
+    /// Constructs an empty Clock2Q+ policy for the cache's capacity.
+    fn new(capacity: NonZeroUsize) -> Self {
+        Self::with_capacity(capacity)
+    }
+
+    /// Records an eligible hit through inline atomic slot state.
+    #[inline]
+    fn hit(&self, _slot: Slot, state: &SlotState) {
+        state.record_hit();
+    }
+
+    /// Records an eligible hit through exclusively borrowed slot state.
+    #[inline]
+    fn hit_mut(&mut self, _slot: Slot, state: &mut SlotState) {
+        state.record_hit_mut();
+    }
+
+    /// Selects storage, applies policy transitions, and returns initial state.
+    fn insert<I, C>(
+        &mut self,
+        states: &I,
+        key: &K,
+        has_vacancy: bool,
+        claim: C,
+    ) -> (Slot, SlotState)
+    where
+        I: Index<Slot, Output = SlotState>,
+        C: FnOnce(Option<Slot>) -> Claimed<K>,
+    {
+        let admission = self.admission(key, has_vacancy);
+        let mut promotion = None;
+        // Selection may detach a Small resident for deferred promotion, but
+        // the cache slot is not claimed until the complete victim is known.
+        let victim = match admission {
+            Admission::Small => self.select_small(states, &mut promotion, has_vacancy),
+            Admission::Main => self.select_for_main(states),
+        };
+
+        // Claim transfers an evicted key to the policy without cloning it.
+        let slot = match claim(victim) {
+            Claimed::Vacant(slot) => slot,
+            Claimed::Evicted(key) => {
+                let slot = victim.expect("an eviction claim requires a victim");
+                let location = self.slots[slot].location;
+                self.unlink_resident(slot);
+                // Only Small evictions become Ghost evidence. Main victims
+                // have already passed the admission filter.
+                if matches!(location, Location::SmallYoung | Location::SmallOld) {
+                    self.push_ghost(key);
+                }
+                slot
+            }
+        };
+
+        assert_eq!(self.slots[slot].location, Location::Free);
+        // Finish a deferred Small-to-Main promotion before attaching the
+        // incoming entry to the slot claimed from Main.
+        if let Some(promoted) = promotion {
+            self.insert_main(promoted);
+        }
+        self.attach(states, slot, admission);
+        (slot, SlotState::new(admission))
+    }
+
+    /// Forgets Ghost history and detaches the resident slot when present.
+    fn remove(&mut self, slot: Option<Slot>, key: &K) {
+        if let Some(slot) = slot {
+            // Resident and Ghost keys are disjoint, so resident removal can
+            // detach directly without probing nonresident history.
+            self.unlink_resident(slot);
+        } else {
+            self.discard_ghost(key);
+        }
+    }
+
+    /// Resets all resident topology and nonresident history.
+    fn clear(&mut self) {
+        self.slots.fill(ResidentSlot::default());
+        self.small_head = None;
+        self.small_tail = None;
+        self.small_young_tail = None;
+        self.small_admissions = 0;
+        self.small_len = 0;
+        self.main_hand = None;
+        self.main_len = 0;
+        self.clear_ghost();
+    }
+}
+
+impl<K: Hash + Eq + Clone, V> core::fmt::Debug for Cache<K, V, Clock2QPlus<K>> {
+    /// Formats cache occupancy and Clock2Q+ partition sizes.
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Clock2QPlus")
+            .field("len", &self.index.len())
+            .field("capacity", &self.policy.slots.len())
+            .field("small_target", &self.policy.small_capacity)
+            .field("small_len", &self.policy.small_len)
+            .field("main_len", &self.policy.main_len)
+            .field("ghost_len", &self.policy.ghost_index.len())
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{NZUsize, cache::Cache, sync::RwLock};
+    use proptest::prelude::*;
+    use std::{
+        collections::{HashMap, HashSet, VecDeque},
+        sync::{Arc, Barrier},
+        thread,
+    };
+
+    /// Cache specialization exercised by the Clock2Q+ tests.
+    type TestCache<K, V> = Cache<K, V, Clock2QPlus<K>>;
+
+    /// Returns the number of residents attached to either partition.
+    const fn residents<K>(policy: &Clock2QPlus<K>) -> usize {
+        policy.small_len + policy.main_len
+    }
+
+    /// One resident in the slot-independent reference model.
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    struct ReferenceEntry {
+        /// Resident key.
+        key: u8,
+        /// Whether the resident has earned a second chance or promotion.
+        referenced: bool,
+        /// Small admission generation, or `None` after entering Main.
+        admitted_at: Option<u64>,
+    }
+
+    /// A queue-level Clock2Q+ model independent of cache slots and policy links.
+    struct ReferenceClock2QPlus {
+        /// Maximum number of resident entries.
+        capacity: usize,
+        /// Target number of Small residents.
+        small_capacity: usize,
+        /// Target number of Main residents.
+        main_capacity: usize,
+        /// Number of later Small admissions treated as correlated.
+        correlation_window: usize,
+        /// Maximum number of historical Ghost keys.
+        ghost_capacity: usize,
+        /// Newest Small entry is at the front.
+        small: VecDeque<ReferenceEntry>,
+        /// Counts every Small admission, even if that entry is later removed.
+        small_admissions: u64,
+        /// The Main CLOCK hand is at the front. New entries go immediately before it.
+        main: VecDeque<ReferenceEntry>,
+        /// Newest Ghost key is at the front.
+        ghost: VecDeque<u8>,
+    }
+
+    impl ReferenceClock2QPlus {
+        /// Constructs an empty queue-level model.
+        fn new(capacity: usize) -> Self {
+            let small_capacity = if capacity == 1 {
+                0
+            } else {
+                (capacity / 10).max(1)
+            };
+            Self {
+                capacity,
+                small_capacity,
+                main_capacity: capacity - small_capacity,
+                correlation_window: small_capacity.div_ceil(2),
+                ghost_capacity: capacity / 2,
+                small: VecDeque::new(),
+                small_admissions: 0,
+                main: VecDeque::new(),
+                ghost: VecDeque::new(),
+            }
+        }
+
+        /// Applies one access and reports whether the key was resident.
+        fn access(&mut self, key: u8) -> bool {
+            if let Some(position) = self.small.iter().position(|entry| entry.key == key) {
+                let admitted_at = self.small[position]
+                    .admitted_at
+                    .expect("Small entry must have an admission generation");
+                if self.small_admissions - admitted_at >= self.correlation_window as u64 {
+                    self.small[position].referenced = true;
+                }
+                return true;
+            }
+            if let Some(position) = self.main.iter().position(|entry| entry.key == key) {
+                self.main[position].referenced = true;
+                return true;
+            }
+
+            // Consume Ghost evidence as part of this atomic model admission,
+            // matching the production insertion transition.
+            let ghost_hit = self
+                .ghost
+                .iter()
+                .position(|historical| *historical == key)
+                .map(|position| self.ghost.remove(position).unwrap())
+                .is_some();
+            let has_vacancy = self.small.len() + self.main.len() < self.capacity;
+            let admit_to_main = ghost_hit
+                || self.small_capacity == 0
+                || (has_vacancy && self.small.len() >= self.small_capacity);
+            if admit_to_main {
+                self.admit_main(key, has_vacancy);
+            } else {
+                self.admit_small(key, has_vacancy);
+            }
+            false
+        }
+
+        /// Removes a resident or forgets nonresident history for `key`.
+        fn remove(&mut self, key: u8) -> bool {
+            if let Some(position) = self.small.iter().position(|entry| entry.key == key) {
+                self.small.remove(position);
+                return true;
+            }
+            if let Some(position) = self.main.iter().position(|entry| entry.key == key) {
+                self.main.remove(position);
+                return true;
+            }
+            if let Some(position) = self.ghost.iter().position(|historical| *historical == key) {
+                self.ghost.remove(position);
+            }
+            false
+        }
+
+        /// Retains resident keys below `limit` while preserving Ghost history.
+        fn retain(&mut self, limit: u8) {
+            self.small.retain(|entry| entry.key < limit);
+            self.main.retain(|entry| entry.key < limit);
+        }
+
+        /// Resets all resident and historical model state.
+        fn clear(&mut self) {
+            self.small.clear();
+            self.small_admissions = 0;
+            self.main.clear();
+            self.ghost.clear();
+        }
+
+        /// Admits a cold key to Small, promoting its tail when eligible.
+        fn admit_small(&mut self, key: u8, has_vacancy: bool) {
+            if !has_vacancy {
+                loop {
+                    let tail = self.small.back().unwrap();
+                    let admitted_at = tail
+                        .admitted_at
+                        .expect("Small entry must have an admission generation");
+                    let young =
+                        self.small_admissions - admitted_at < self.correlation_window as u64;
+                    if young || !tail.referenced {
+                        let victim = self.small.pop_back().unwrap().key;
+                        self.push_ghost(victim);
+                        break;
+                    }
+
+                    let mut promoted = self.small.pop_back().unwrap();
+                    promoted.referenced = false;
+                    promoted.admitted_at = None;
+                    if self.main.len() == self.main_capacity {
+                        self.evict_main();
+                        self.main.push_back(promoted);
+                        break;
+                    }
+                    self.main.push_back(promoted);
+                }
+            }
+            self.small_admissions += 1;
+            self.small.push_front(ReferenceEntry {
+                key,
+                referenced: false,
+                admitted_at: Some(self.small_admissions),
+            });
+        }
+
+        /// Admits a Ghost hit or warm-up key directly to Main.
+        fn admit_main(&mut self, key: u8, has_vacancy: bool) {
+            if self.main.len() == self.main_capacity {
+                self.evict_main();
+            } else if !has_vacancy {
+                loop {
+                    let tail = self.small.back().unwrap();
+                    let admitted_at = tail
+                        .admitted_at
+                        .expect("Small entry must have an admission generation");
+                    let young =
+                        self.small_admissions - admitted_at < self.correlation_window as u64;
+                    if young || !tail.referenced {
+                        let victim = self.small.pop_back().unwrap().key;
+                        self.push_ghost(victim);
+                        break;
+                    }
+
+                    let mut promoted = self.small.pop_back().unwrap();
+                    promoted.referenced = false;
+                    promoted.admitted_at = None;
+                    self.main.push_back(promoted);
+                    if self.main.len() == self.main_capacity {
+                        self.evict_main();
+                        break;
+                    }
+                }
+            }
+            self.main.push_back(ReferenceEntry {
+                key,
+                referenced: false,
+                admitted_at: None,
+            });
+        }
+
+        /// Runs the model's Main CLOCK scan through the first unreferenced key.
+        fn evict_main(&mut self) {
+            loop {
+                let mut candidate = self.main.pop_front().unwrap();
+                if candidate.referenced {
+                    candidate.referenced = false;
+                    self.main.push_back(candidate);
+                } else {
+                    return;
+                }
+            }
+        }
+
+        /// Adds a key to the bounded model Ghost FIFO.
+        fn push_ghost(&mut self, key: u8) {
+            assert!(!self.ghost.contains(&key));
+            if self.ghost.len() == self.ghost_capacity {
+                self.ghost.pop_back();
+            }
+            self.ghost.push_front(key);
+        }
+
+        /// Returns Small from newest to oldest with reference state.
+        fn small_state(&self) -> Vec<(u8, bool)> {
+            self.small
+                .iter()
+                .map(|entry| (entry.key, entry.referenced))
+                .collect()
+        }
+
+        /// Returns Main from the hand forward with reference state.
+        fn main_state(&self) -> Vec<(u8, bool)> {
+            self.main
+                .iter()
+                .map(|entry| (entry.key, entry.referenced))
+                .collect()
+        }
+    }
+
+    /// Mutation applied to both the cache and queue-level reference model.
+    #[derive(Clone, Debug)]
+    enum ReferenceOp {
+        /// Accesses a key and inserts it on a miss.
+        Access(u8),
+        /// Removes a key or its Ghost history.
+        Remove(u8),
+        /// Retains resident keys below the supplied limit.
+        Retain(u8),
+        /// Clears all policy and cache state.
+        Clear,
+    }
+
+    /// Generates weighted operations for model-based mutation testing.
+    fn reference_op_strategy() -> impl Strategy<Value = ReferenceOp> {
+        prop_oneof![
+            8 => (0u8..64).prop_map(ReferenceOp::Access),
+            2 => (0u8..64).prop_map(ReferenceOp::Remove),
+            1 => (0u8..64).prop_map(ReferenceOp::Retain),
+            1 => Just(ReferenceOp::Clear),
+        ]
+    }
+
+    impl<K: Hash + Eq + Clone + core::fmt::Debug, V> Cache<K, V, Clock2QPlus<K>> {
+        /// Returns Small slot order from newest to oldest.
+        fn small_order(&self) -> Vec<usize> {
+            let mut order = Vec::with_capacity(self.policy.small_len);
+            let mut current = self.policy.small_head;
+            while let Some(slot) = current {
+                order.push(slot);
+                current = linked(self.policy.slots[slot].next);
+            }
+            order
+        }
+
+        /// Returns Main slot order starting at the CLOCK hand.
+        fn main_order(&self) -> Vec<usize> {
+            let mut order = Vec::with_capacity(self.policy.main_len);
+            let Some(hand) = self.policy.main_hand else {
+                return order;
+            };
+            let mut current = hand;
+            loop {
+                order.push(current);
+                current = self.policy.slots[current].next;
+                assert_ne!(current, UNLINKED);
+                if current == hand {
+                    return order;
+                }
+            }
+        }
+
+        /// Returns Ghost slot order from newest to oldest.
+        fn ghost_order(&self) -> Vec<usize> {
+            let mut order = Vec::with_capacity(self.policy.ghost_index.len());
+            let mut current = self.policy.ghost_head;
+            while let Some(slot) = current {
+                order.push(slot);
+                current = linked(self.policy.ghost_slots[slot].next);
+            }
+            order
+        }
+
+        /// Returns Small keys from newest to oldest.
+        fn small_keys(&self) -> Vec<K> {
+            self.small_order()
+                .into_iter()
+                .map(|slot| self.slots[slot].key.clone())
+                .collect()
+        }
+
+        /// Returns Main keys starting at the CLOCK hand.
+        fn main_keys(&self) -> Vec<K> {
+            self.main_order()
+                .into_iter()
+                .map(|slot| self.slots[slot].key.clone())
+                .collect()
+        }
+
+        /// Returns Ghost keys from newest to oldest.
+        fn ghost_keys(&self) -> Vec<K> {
+            self.ghost_order()
+                .into_iter()
+                .map(|slot| {
+                    self.policy.ghost_slots[slot]
+                        .key
+                        .as_ref()
+                        .expect("live Ghost entry must have a key")
+                        .clone()
+                })
+                .collect()
+        }
+
+        /// Asserts the Clock2Q+ policy's invariants hold.
+        pub(crate) fn check_policy_invariants(&self) {
+            let policy = &self.policy;
+            assert!(residents(policy) <= policy.slots.len());
+            assert!(policy.small_len <= policy.small_capacity);
+            assert!(policy.main_len <= policy.main_capacity);
+            assert_eq!(self.index.len(), residents(policy));
+            assert_eq!(self.index.len() + self.free.len(), self.slots.len());
+
+            let free: HashSet<_> = self.free.iter().copied().collect();
+            assert_eq!(free.len(), self.free.len(), "duplicate resident free slot");
+            let small = self.small_order();
+            let main = self.main_order();
+            assert_eq!(small.len(), policy.small_len);
+            assert_eq!(main.len(), policy.main_len);
+            let young_len = policy
+                .small_young_tail
+                .map(|tail| {
+                    small
+                        .iter()
+                        .position(|slot| *slot == tail)
+                        .expect("correlation boundary must belong to Small")
+                        + 1
+                })
+                .unwrap_or(0);
+            assert!(young_len <= policy.correlation_window);
+            assert!(young_len <= policy.small_len);
+
+            let mut resident = HashSet::new();
+            for (rank, &slot) in small.iter().enumerate() {
+                assert!(resident.insert(slot), "duplicate Small resident {slot}");
+                assert!(self.slots[slot].live);
+                let expected = if rank < young_len {
+                    Location::SmallYoung
+                } else {
+                    Location::SmallOld
+                };
+                assert_eq!(policy.slots[slot].location, expected);
+                let state = self.slots[slot].state.0.load(Ordering::Relaxed);
+                assert_eq!(state & CORRELATED != 0, expected == Location::SmallYoung);
+                if expected == Location::SmallYoung {
+                    assert_eq!(state, CORRELATED);
+                }
+                let expected_prev = rank.checked_sub(1).map(|rank| small[rank]);
+                let expected_next = small.get(rank + 1).copied();
+                assert_eq!(linked(policy.slots[slot].prev), expected_prev);
+                assert_eq!(linked(policy.slots[slot].next), expected_next);
+            }
+            assert_eq!(policy.small_head, small.first().copied());
+            assert_eq!(policy.small_tail, small.last().copied());
+            let expected_young_tail = young_len
+                .checked_sub(1)
+                .and_then(|rank| small.get(rank))
+                .copied();
+            assert_eq!(policy.small_young_tail, expected_young_tail);
+
+            for (rank, &slot) in main.iter().enumerate() {
+                assert!(resident.insert(slot), "resident {slot} in two queues");
+                assert!(self.slots[slot].live);
+                assert_eq!(policy.slots[slot].location, Location::Main);
+                assert_eq!(
+                    self.slots[slot].state.0.load(Ordering::Relaxed) & CORRELATED,
+                    0
+                );
+                assert_eq!(
+                    policy.slots[slot].prev,
+                    main[(rank + main.len() - 1) % main.len()]
+                );
+                assert_eq!(policy.slots[slot].next, main[(rank + 1) % main.len()]);
+            }
+
+            for (key, &slot) in &self.index {
+                assert!(slot < self.slots.len());
+                assert!(resident.contains(&slot));
+                assert_eq!(&self.slots[slot].key, key);
+            }
+            for slot in 0..self.slots.len() {
+                if resident.contains(&slot) {
+                    assert!(!free.contains(&slot));
+                } else {
+                    assert!(free.contains(&slot));
+                    assert!(!self.slots[slot].live);
+                    assert_eq!(policy.slots[slot].location, Location::Free);
+                }
+            }
+            for slot in self.slots.len()..policy.slots.len() {
+                assert_eq!(policy.slots[slot].location, Location::Free);
+            }
+
+            assert!(policy.ghost_index.len() <= policy.ghost_capacity);
+            let ghost = self.ghost_order();
+            assert_eq!(ghost.len(), policy.ghost_index.len());
+            let ghost_free: HashSet<_> = policy.ghost_free.iter().copied().collect();
+            assert_eq!(ghost_free.len(), policy.ghost_free.len());
+            let mut seen_ghost = HashSet::new();
+            for (rank, &slot) in ghost.iter().enumerate() {
+                assert!(seen_ghost.insert(slot));
+                assert!(!ghost_free.contains(&slot));
+                let key = policy.ghost_slots[slot]
+                    .key
+                    .as_ref()
+                    .expect("linked Ghost entry must have a key");
+                assert_eq!(policy.ghost_index.get(key), Some(&slot));
+                assert!(!self.index.contains_key(key));
+                let expected_prev = rank.checked_sub(1).map(|rank| ghost[rank]);
+                let expected_next = ghost.get(rank + 1).copied();
+                assert_eq!(linked(policy.ghost_slots[slot].prev), expected_prev);
+                assert_eq!(linked(policy.ghost_slots[slot].next), expected_next);
+            }
+            assert_eq!(policy.ghost_head, ghost.first().copied());
+            assert_eq!(policy.ghost_tail, ghost.last().copied());
+            for (slot, entry) in policy.ghost_slots.iter().enumerate() {
+                if seen_ghost.contains(&slot) {
+                    assert!(entry.key.is_some());
+                } else {
+                    assert!(ghost_free.contains(&slot));
+                    assert!(entry.key.is_none());
+                }
+            }
+        }
+
+        /// Asserts both the cache and policy invariants hold.
+        fn check_invariants(&self) {
+            self.check_cache_invariants();
+            self.check_policy_invariants();
+        }
+    }
+
+    /// Returns the implementation's observable Small state for model checks.
+    fn actual_small_state(cache: &TestCache<u8, u8>) -> Vec<(u8, bool)> {
+        cache
+            .small_order()
+            .into_iter()
+            .map(|slot| {
+                let referenced = cache.policy.slots[slot].location == Location::SmallOld
+                    && cache.slots[slot].state.0.load(Ordering::Relaxed) & REFERENCED != 0;
+                (cache.slots[slot].key, referenced)
+            })
+            .collect()
+    }
+
+    /// Returns the implementation's observable Main state for model checks.
+    fn actual_main_state(cache: &TestCache<u8, u8>) -> Vec<(u8, bool)> {
+        cache
+            .main_order()
+            .into_iter()
+            .map(|slot| {
+                (
+                    cache.slots[slot].key,
+                    cache.slots[slot].state.0.load(Ordering::Relaxed) & REFERENCED != 0,
+                )
+            })
+            .collect()
+    }
+
+    #[test]
+    fn partitions_round_for_tiny_capacities() {
+        // Ratio-derived partitions round down. Capacities above one still keep
+        // at least one Small slot, while capacity one uses Main alone.
+        let expected = [
+            (1, 0, 1, 0, 0),
+            (2, 1, 1, 1, 1),
+            (10, 1, 9, 1, 5),
+            (11, 1, 10, 1, 5),
+            (20, 2, 18, 1, 10),
+            (40, 4, 36, 2, 20),
+        ];
+        for (capacity, small, main, window, ghost) in expected {
+            let cache = TestCache::<u64, u64>::new(NonZeroUsize::new(capacity).unwrap());
+            assert_eq!(cache.policy.small_capacity, small);
+            assert_eq!(cache.policy.main_capacity, main);
+            assert_eq!(cache.policy.correlation_window, window);
+            assert_eq!(cache.policy.ghost_capacity, ghost);
+            cache.check_invariants();
+        }
+
+        // Exercise every tiny partition through repeated replacement, where
+        // off-by-one errors in the queue bounds are easiest to expose.
+        for capacity in 1..=20 {
+            let mut cache = TestCache::new(NonZeroUsize::new(capacity).unwrap());
+            for key in 0..200u64 {
+                cache.put(key, key);
+                cache.check_invariants();
+            }
+        }
+    }
+
+    #[test]
+    fn capacity_one_behaves_as_clock() {
+        // With no Small or Ghost capacity, the only Main slot is replaced on
+        // each cold insertion.
+        let mut cache = TestCache::new(NZUsize!(1));
+        cache.put(1u64, 10u64);
+        assert_eq!(cache.get(&1), Some(&10));
+        cache.put(2, 20);
+        assert_eq!(cache.get(&1), None);
+        assert_eq!(cache.get(&2), Some(&20));
+        assert!(cache.ghost_keys().is_empty());
+        cache.check_invariants();
+    }
+
+    #[test]
+    fn warmup_fills_small_then_main_with_cold_entries() {
+        // Warm-up fills the 10% Small partition first, then uses the remaining
+        // vacant slots for unreferenced Main residents.
+        let mut cache = TestCache::new(NZUsize!(20));
+        for key in 0..20u64 {
+            cache.put(key, key);
+        }
+
+        assert_eq!(cache.small_keys(), vec![1, 0]);
+        assert_eq!(cache.main_keys(), (2..20).collect::<Vec<_>>());
+        for key in 2..20u64 {
+            let slot = cache.index[&key];
+            assert_eq!(
+                cache.slots[slot].state.0.load(Ordering::Relaxed) & REFERENCED,
+                0
+            );
+        }
+        cache.check_invariants();
+    }
+
+    #[test]
+    fn policy_empty_state_includes_precise_ghost_history() {
+        // Resident filtering does not erase unrelated Ghost evidence. The
+        // policy may therefore retain useful history with no live residents.
+        let mut cache = TestCache::new(NZUsize!(2));
+        for key in 1..=3u64 {
+            cache.put(key, key);
+        }
+        assert_eq!(cache.ghost_keys(), vec![1]);
+
+        cache.retain(|key, _| *key == 1);
+        assert_eq!(cache.len(), 0);
+        assert_eq!(cache.ghost_keys(), vec![1]);
+        assert!(!cache.policy.ghost_index.is_empty());
+
+        cache.retain(|_, _| false);
+        assert_eq!(residents(&cache.policy), 0);
+        assert_eq!(cache.ghost_keys(), vec![1]);
+        cache.check_invariants();
+    }
+
+    #[test]
+    fn correlation_window_ignores_only_young_hits() {
+        // Key 4 is at the Small head, inside the two-entry correlation window.
+        // Its hit must not set the bit, so a scan ages and evicts it to Ghost.
+        let mut correlated = TestCache::new(NZUsize!(40));
+        for key in 1..=40u64 {
+            correlated.put(key, key);
+        }
+        assert_eq!(correlated.small_keys(), vec![4, 3, 2, 1]);
+        assert_eq!(correlated.get(&4), Some(&4));
+        let slot = correlated.index[&4];
+        assert_eq!(
+            correlated.slots[slot].state.0.load(Ordering::Relaxed) & REFERENCED,
+            0
+        );
+        for key in 41..=44u64 {
+            correlated.put(key, key);
+        }
+        assert!(!correlated.contains(&4));
+        assert!(!correlated.main_keys().contains(&4));
+        assert!(correlated.ghost_keys().contains(&4));
+        correlated.check_invariants();
+
+        // Key 1 is already outside the window. Its hit marks it for promotion
+        // to Main when the next insertion examines the Small tail.
+        let mut reused = TestCache::new(NZUsize!(40));
+        for key in 1..=40u64 {
+            reused.put(key, key);
+        }
+        assert_eq!(reused.get(&1), Some(&1));
+        reused.put(41, 41);
+        assert!(reused.small_keys().contains(&41));
+        assert!(reused.main_keys().contains(&1));
+        let slot = reused.index[&1];
+        assert_eq!(
+            reused.slots[slot].state.0.load(Ordering::Relaxed) & REFERENCED,
+            0
+        );
+        assert!(reused.ghost_keys().is_empty());
+        reused.check_invariants();
+    }
+
+    #[test]
+    fn removing_younger_entry_does_not_rewind_correlation_age() {
+        let mut cache = TestCache::new(NZUsize!(20));
+        for key in 0..20u64 {
+            cache.put(key, key);
+        }
+
+        // Key 0 has left the correlation window, so this hit makes it eligible
+        // for promotion when it reaches the Small tail.
+        assert_eq!(cache.get(&0), Some(&0));
+
+        // Removing the younger key must not move key 0 back into the
+        // correlation window or discard its eligible reference.
+        assert!(cache.remove(&1));
+        cache.put(20, 20);
+        cache.put(21, 21);
+
+        assert!(cache.main_keys().contains(&0));
+        assert!(!cache.ghost_keys().contains(&0));
+        cache.check_invariants();
+    }
+
+    #[test]
+    fn removing_younger_entry_does_not_delay_correlation_age() {
+        let mut cache = TestCache::new(NZUsize!(40));
+        for key in 0..40u64 {
+            cache.put(key, key);
+        }
+        assert_eq!(cache.small_keys(), vec![3, 2, 1, 0]);
+
+        // Removing key 3 must not erase its admission from key 2's age. Key 40
+        // is the second later Small admission, so key 2 leaves the window.
+        assert!(cache.remove(&3));
+        cache.put(40, 40);
+        assert_eq!(cache.get(&2), Some(&2));
+
+        // Advance key 2 to the Small tail. Its eligible hit must promote it
+        // into Main instead of letting the final insertion evict it to Ghost.
+        for key in 41..=43u64 {
+            cache.put(key, key);
+        }
+        assert!(cache.main_keys().contains(&2));
+        assert!(!cache.ghost_keys().contains(&2));
+        cache.check_invariants();
+    }
+
+    #[test]
+    fn ghost_history_is_bounded_and_promotes_reuse() {
+        // Cold churn fills the ten-entry Ghost FIFO and drops its oldest key.
+        let mut cache = TestCache::new(NZUsize!(20));
+        for key in 0..=30u64 {
+            cache.put(key, key);
+        }
+        assert_eq!(cache.small_keys(), vec![30, 29]);
+        assert_eq!(cache.main_keys(), (2..20).collect::<Vec<_>>());
+        assert_eq!(
+            cache.ghost_keys(),
+            (20..=28)
+                .rev()
+                .chain(core::iter::once(1))
+                .collect::<Vec<_>>()
+        );
+
+        // Key 1 is still in Ghost, so reuse consumes its history and admits it
+        // directly to Main without disturbing Small.
+        let (_, value) = cache.get_or_insert_mut(1, || unreachable!());
+        *value = 100;
+        assert_eq!(cache.peek(&1), Some(&100));
+        assert!(cache.main_keys().contains(&1));
+        assert!(!cache.ghost_keys().contains(&1));
+        assert_eq!(cache.small_keys(), vec![30, 29]);
+        assert_eq!(cache.ghost_keys(), (20..=28).rev().collect::<Vec<_>>());
+
+        // Key 0 has already aged out of Ghost and therefore enters Small as a
+        // cold miss, evicting Small's tail into Ghost.
+        cache.put(0, 200);
+        assert_eq!(cache.small_keys()[0], 0);
+        assert!(!cache.main_keys().contains(&0));
+        assert_eq!(cache.ghost_keys()[0], 29);
+        cache.check_invariants();
+    }
+
+    #[test]
+    fn main_evicts_despite_an_offered_vacancy() {
+        // Removing the Small resident leaves a globally vacant slot while Main
+        // remains full and key 1 remains in Ghost.
+        let mut cache = TestCache::new(NZUsize!(2));
+        for key in 1..=3u64 {
+            cache.put(key, key);
+        }
+        assert_eq!(cache.main_keys(), vec![2]);
+        assert!(cache.remove(&3));
+        assert_eq!(cache.len(), 1);
+        assert_eq!(cache.ghost_keys(), vec![1]);
+
+        // Ghost reuse is constrained to Main, so it replaces Main key 2 and
+        // deliberately leaves the Small vacancy unused.
+        cache.put(1, 10);
+        assert_eq!(cache.len(), 1);
+        assert_eq!(cache.main_keys(), vec![1]);
+        assert!(!cache.contains(&2));
+        assert_eq!(cache.free.len(), 1);
+        cache.check_invariants();
+    }
+
+    #[test]
+    fn promoting_small_replaces_from_full_main() {
+        // Reference the original Small tail so the next cold miss promotes it
+        // while keeping both fixed-size resident partitions full.
+        let mut cache = TestCache::new(NZUsize!(20));
+        for key in 0..20u64 {
+            cache.put(key, key);
+        }
+        for key in 0..18u64 {
+            assert_eq!(cache.get(&key), Some(&key));
+        }
+        cache.put(20, 20);
+        assert_eq!(cache.policy.main_len, cache.policy.main_capacity);
+        assert_eq!(cache.policy.small_len, 2);
+        let slot = cache.index[&0];
+        assert!(cache.main_keys().contains(&0));
+        assert_eq!(
+            cache.slots[slot].state.0.load(Ordering::Relaxed) & REFERENCED,
+            0
+        );
+
+        // Repeat the transition with a full Main CLOCK. The promoted key keeps
+        // its slot and starts in Main with a clear reference bit.
+        let promoted = *cache.small_keys().last().unwrap();
+        assert_eq!(cache.get(&promoted), Some(&promoted));
+        cache.put(21, 21);
+
+        assert!(cache.main_keys().contains(&promoted));
+        let slot = cache.index[&promoted];
+        assert_eq!(
+            cache.slots[slot].state.0.load(Ordering::Relaxed) & REFERENCED,
+            0
+        );
+        assert!(cache.small_keys().contains(&21));
+        assert_eq!(cache.policy.main_len, cache.policy.main_capacity);
+        assert_eq!(cache.policy.small_len, 2);
+        cache.check_invariants();
+    }
+
+    #[test]
+    fn slot_stays_stable_on_promotion_and_goes_stale_on_reuse() {
+        // Promotion changes only policy topology, so key 1 keeps its original
+        // slot and the existing lookup hint remains valid.
+        let mut cache = TestCache::new(NZUsize!(40));
+        let (slot1, value) = cache.get_or_insert_mut(1u64, || 0u64);
+        *value = 10;
+        let (slot2, value) = cache.get_or_insert_mut(2, || 0);
+        *value = 20;
+        for key in 3..=40u64 {
+            cache.put(key, key * 10);
+        }
+        assert_eq!(cache.get_at(slot1, &1), Some(&10));
+        cache.put(41, 410);
+        assert_eq!(cache.get_at(slot1, &1), Some(&10));
+        assert!(cache.main_keys().contains(&1));
+
+        // An actual eviction reuses key 2's slot for key 42. The old hint then
+        // fails full-key validation while the new key resolves in that slot.
+        assert!(cache.slots[slot2].live);
+        assert_eq!(cache.slots[slot2].key, 2);
+        cache.put(42, 420);
+        assert_eq!(cache.get_at(slot2, &2), None);
+        let slot42 = *cache.index.get(&42).unwrap();
+        assert_eq!(slot42, slot2);
+        assert_eq!(cache.get_at(slot2, &2), None);
+        assert_eq!(cache.get_at(slot42, &42), Some(&420));
+        cache.check_invariants();
+    }
+
+    #[test]
+    fn scan_does_not_displace_main() {
+        // Warm-up places keys 1 through 9 in Main. A one-cache-capacity scan is
+        // absorbed by Small and leaves that Main working set intact.
+        let mut clock2qplus = TestCache::new(NZUsize!(10));
+        for key in 0..10u64 {
+            clock2qplus.put(key, key);
+        }
+        let mut protected = 1..10u64;
+        assert_eq!(clock2qplus.policy.main_len, 9);
+
+        // Plain CLOCK provides the control case and loses every original key
+        // to the same scan.
+        let mut clock: Cache<u64, u64> = Cache::new(NZUsize!(10));
+        for key in 0..10u64 {
+            clock.put(key, key);
+        }
+
+        for key in 100..110u64 {
+            clock2qplus.put(key, key);
+            clock.put(key, key);
+        }
+        assert!(
+            protected
+                .clone()
+                .all(|key| clock2qplus.peek(&key).is_some())
+        );
+        assert!(protected.all(|key| clock.peek(&key).is_none()));
+        clock2qplus.check_invariants();
+    }
+
+    #[test]
+    fn prefill_reuses_values_through_churn() {
+        // Prefill allocates every value once. Policy churn must keep reusing
+        // those same stable slots without invoking the factory again.
+        let mut makes = 0usize;
+        let mut cache = TestCache::<u64, Vec<u8>>::new(NZUsize!(20));
+        cache.prefill(|| {
+            makes += 1;
+            vec![0; 32]
+        });
+        assert_eq!(makes, 20);
+
+        for key in 0..2_000u64 {
+            let (_, value) = cache.get_or_insert_mut(key, || unreachable!());
+            value[0] = key as u8;
+            cache.check_invariants();
+        }
+        assert_eq!(cache.slots.len(), 20);
+        assert_eq!(makes, 20);
+    }
+
+    #[test]
+    fn remove_retain_and_clear_repair_resident_state() {
+        // Exercise removal from Main and Ghost, then prove a removed Ghost key
+        // returns as cold instead of receiving stale Main admission.
+        let mut cache = TestCache::new(NZUsize!(20));
+        for key in 0..=30u64 {
+            cache.put(key, key);
+        }
+        cache.put(1, 1);
+        assert!(cache.remove(&1));
+        assert!(!cache.remove(&1));
+
+        let ghost = cache.ghost_keys()[0];
+        assert!(!cache.remove(&ghost));
+        assert!(!cache.ghost_keys().contains(&ghost));
+
+        // Replace the vacancy left by the resident removal. With a full cache,
+        // the forgotten Ghost key must now enter Small as a cold admission.
+        cache.put(100, 100);
+        cache.put(ghost, ghost);
+        assert!(cache.small_keys().contains(&ghost));
+        assert!(!cache.main_keys().contains(&ghost));
+
+        // Retain detaches rejected residents but preserves unrelated Ghost
+        // history. Clear resets both resident topology and Ghost history.
+        cache.retain(|key, _| key % 2 == 0);
+        assert!(!cache.ghost_keys().is_empty());
+        assert!(cache.index.keys().all(|key| key % 2 == 0));
+        cache.check_invariants();
+
+        cache.clear();
+        assert!(cache.is_empty());
+        assert_eq!(residents(&cache.policy), 0);
+        assert!(cache.policy.ghost_index.is_empty());
+        assert!(cache.ghost_keys().is_empty());
+        cache.check_invariants();
+    }
+
+    #[test]
+    fn shared_hits_are_concurrent() {
+        // Shared lookups race only on the relaxed per-slot reference bit. The
+        // accumulated hit must still protect key 1 on the next insertion.
+        let mut cache = TestCache::new(NZUsize!(40));
+        for key in 1..=40u64 {
+            cache.put(key, key);
+        }
+        let slot = *cache.index.get(&1).unwrap();
+        let cache = Arc::new(RwLock::new(cache));
+        let barrier = Arc::new(Barrier::new(5));
+        let mut threads = Vec::new();
+        for _ in 0..4 {
+            let cache = Arc::clone(&cache);
+            let barrier = Arc::clone(&barrier);
+            threads.push(thread::spawn(move || {
+                barrier.wait();
+                for _ in 0..1_000 {
+                    let guard = cache.read();
+                    assert_eq!(guard.get_at(slot, &1), Some(&1));
+                }
+            }));
+        }
+        barrier.wait();
+        for thread in threads {
+            thread.join().unwrap();
+        }
+
+        let mut cache = Arc::try_unwrap(cache).unwrap().into_inner();
+        cache.put(41, 41);
+        assert!(cache.main_keys().contains(&1));
+        cache.check_invariants();
+    }
+
+    #[test]
+    fn fallible_factory_error_leaves_policy_unchanged() {
+        // Key 1 is in Ghost. A failed factory must return before policy
+        // insertion consumes that evidence or changes resident topology.
+        let mut cache = TestCache::new(NZUsize!(2));
+        for key in 1..=3u64 {
+            cache.put(key, key);
+        }
+        let small = cache.small_keys();
+        let main = cache.main_keys();
+        let ghost = cache.ghost_keys();
+        let result = cache.try_get_or_insert_with(1, || Err::<u64, _>("failure"));
+        assert_eq!(result, Err("failure"));
+        assert_eq!(cache.small_keys(), small);
+        assert_eq!(cache.main_keys(), main);
+        assert_eq!(cache.ghost_keys(), ghost);
+        cache.check_invariants();
+    }
+
+    proptest! {
+        #[test]
+        fn pure_accesses_match_queue_level_reference(
+            capacity in 1usize..33,
+            accesses in prop::collection::vec(0u8..64, 0..400),
+        ) {
+            let mut cache = TestCache::new(NonZeroUsize::new(capacity).unwrap());
+            let mut reference = ReferenceClock2QPlus::new(capacity);
+
+            // Compare every hit decision and complete queue state against a
+            // slot-independent model of the paper's access transitions.
+            for key in accesses {
+                let expected_hit = reference.access(key);
+                let actual_hit = cache.get(&key).is_some();
+                if !actual_hit {
+                    cache.put(key, key);
+                }
+
+                prop_assert_eq!(actual_hit, expected_hit);
+                prop_assert_eq!(actual_small_state(&cache), reference.small_state());
+                prop_assert_eq!(actual_main_state(&cache), reference.main_state());
+                prop_assert_eq!(cache.ghost_keys(), reference.ghost.iter().copied().collect::<Vec<_>>());
+                cache.check_invariants();
+            }
+        }
+
+        #[test]
+        fn mutations_match_queue_level_reference(
+            capacity in 1usize..33,
+            operations in prop::collection::vec(reference_op_strategy(), 0..400),
+        ) {
+            let mut cache = TestCache::new(NonZeroUsize::new(capacity).unwrap());
+            let mut reference = ReferenceClock2QPlus::new(capacity);
+
+            // Removal and retention must not rewind monotonic correlation age
+            // or disturb the Main hand and Ghost FIFO.
+            for operation in operations {
+                match operation {
+                    ReferenceOp::Access(key) => {
+                        let expected_hit = reference.access(key);
+                        let actual_hit = cache.get(&key).is_some();
+                        if !actual_hit {
+                            cache.put(key, key);
+                        }
+                        prop_assert_eq!(actual_hit, expected_hit);
+                    }
+                    ReferenceOp::Remove(key) => {
+                        prop_assert_eq!(cache.remove(&key), reference.remove(key));
+                    }
+                    ReferenceOp::Retain(limit) => {
+                        cache.retain(|key, _| *key < limit);
+                        reference.retain(limit);
+                    }
+                    ReferenceOp::Clear => {
+                        cache.clear();
+                        reference.clear();
+                    }
+                }
+
+                prop_assert_eq!(actual_small_state(&cache), reference.small_state());
+                prop_assert_eq!(actual_main_state(&cache), reference.main_state());
+                prop_assert_eq!(cache.ghost_keys(), reference.ghost.iter().copied().collect::<Vec<_>>());
+                cache.check_invariants();
+            }
+        }
+
+        #[test]
+        fn arbitrary_operations_preserve_invariants(
+            capacity in 1usize..17,
+            operations in prop::collection::vec((0u8..8, 0u8..24, any::<u16>()), 0..300),
+        ) {
+            let mut cache = TestCache::new(NonZeroUsize::new(capacity).unwrap());
+            let mut values = HashMap::new();
+
+            // Exercise every mutating Cache entry point while checking policy
+            // topology and the last value written for each surviving key.
+            for (operation, key, value) in operations {
+                match operation {
+                    0 => {
+                        cache.put(key, value);
+                        values.insert(key, value);
+                    }
+                    1 => {
+                        let _ = cache.get(&key);
+                    }
+                    2 => {
+                        if let Some(stored) = cache.get_mut(&key) {
+                            *stored = value;
+                            values.insert(key, value);
+                        }
+                    }
+                    3 => {
+                        let stored = *cache.get_or_insert_with(key, || value);
+                        values.insert(key, stored);
+                    }
+                    4 => {
+                        *cache.get_or_insert_mut(key, || value).1 = value;
+                        values.insert(key, value);
+                    }
+                    5 => {
+                        cache.remove(&key);
+                        values.remove(&key);
+                    }
+                    6 => {
+                        cache.retain(|stored, _| *stored < key);
+                        values.retain(|stored, _| *stored < key);
+                    }
+                    _ => {
+                        cache.clear();
+                        values.clear();
+                    }
+                }
+
+                cache.check_invariants();
+                prop_assert!(cache.len() <= capacity);
+                for (resident, &slot) in &cache.index {
+                    prop_assert_eq!(cache.slots[slot].value, values[resident]);
+                }
+            }
+        }
+    }
+}

--- a/utils/src/cache/clock2qplus.rs
+++ b/utils/src/cache/clock2qplus.rs
@@ -1465,5 +1465,4 @@ mod tests {
         assert_eq!(cache.ghost_keys(), ghost);
         cache.check_invariants();
     }
-
 }

--- a/utils/src/cache/clock2qplus.rs
+++ b/utils/src/cache/clock2qplus.rs
@@ -1,12 +1,26 @@
 //! The Clock2Q+ cache replacement policy.
 //!
+//! Clock2Q+ separates resident entries into two partitions:
+//!
+//! - Small is a first-in, first-out probation queue where new entries wait for
+//!   evidence of reuse.
+//! - Main is a CLOCK ring that protects the established working set. A sweep
+//!   gives referenced entries a second chance and evicts the first unreferenced
+//!   entry.
+//!
+//! The policy also keeps a bounded Ghost queue containing only the keys of
+//! entries recently evicted from Small. Ghost does not hold values or consume
+//! resident cache capacity. Finding a requested key in Ghost demonstrates reuse
+//! after eviction, so the key bypasses Small and enters Main. Keys seen only
+//! once pass through Small and leave bounded history in Ghost without
+//! displacing the established Main working set.
+//!
 //! # Admission and Eviction
 //!
-//! Clock2Q+ divides resident entries between a small FIFO queue and a main
-//! CLOCK. New entries normally enter Small. Entries seen in bounded Ghost
-//! history enter Main instead. When an entry reaches the tail of Small, an
-//! unreferenced entry is evicted to Ghost while a referenced entry is promoted
-//! to Main.
+//! New entries normally enter the head of Small. When an entry reaches the
+//! Small tail, an unreferenced entry is evicted and its key is recorded in
+//! Ghost, while a referenced entry is promoted to Main. A Ghost hit enters Main
+//! directly and consumes the matching history entry.
 //!
 //! # Correlation Filtering
 //!
@@ -22,10 +36,9 @@
 //! capacity `C`, Small is `max(C / 10, 1)` when `C > 1`, Main gets the
 //! remainder, and Ghost is `C / 2`. The correlation window is half of Small,
 //! rounded up. A capacity of one uses Main only. Resident keys and values
-//! remain in stable [super::Cache] slots. Queue topology and Ghost history are
+//! remain in stable [super::Cache] slots. Resident topology and Ghost history are
 //! policy-owned, while each slot's correlation marker and reference bit are
-//! stored inline as [Policy::SlotState]. Ghost history is consulted and
-//! consumed when insertion commits.
+//! stored inline as [Policy::SlotState].
 //!
 //! # References
 //!
@@ -61,7 +74,7 @@ const fn linked(slot: usize) -> Option<usize> {
 enum Location {
     /// The cache slot is not attached to either resident partition.
     Free,
-    /// An entry in the Small FIFO.
+    /// An entry in the Small queue.
     Small,
     /// An entry in the Main CLOCK ring.
     Main,
@@ -91,20 +104,10 @@ impl Default for ResidentSlot {
     }
 }
 
-/// A key-only entry in the bounded Ghost FIFO.
-struct GhostSlot<K> {
-    /// Historical key, or `None` when this slot is available for reuse.
-    key: Option<K>,
-    /// Previous entry toward the Ghost head.
-    prev: usize,
-    /// Next entry toward the Ghost tail.
-    next: usize,
-}
-
 /// Resident partition selected for an incoming key.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum Admission {
-    /// Admit at the head of the Small FIFO.
+    /// Admit at the head of the Small queue.
     Small,
     /// Admit immediately before the hand in the Main CLOCK ring.
     Main,
@@ -204,7 +207,7 @@ impl SlotState {
     }
 }
 
-/// State and endpoints for the Small FIFO.
+/// State and endpoints for the Small queue.
 struct SmallQueue {
     /// Maximum number of Small residents.
     capacity: usize,
@@ -223,7 +226,7 @@ struct SmallQueue {
 }
 
 impl SmallQueue {
-    /// Constructs an empty Small FIFO with its derived correlation window.
+    /// Constructs an empty Small queue with its derived correlation window.
     const fn new(capacity: usize) -> Self {
         Self {
             capacity,
@@ -236,9 +239,9 @@ impl SmallQueue {
         }
     }
 
-    /// Attaches a free stable slot at the FIFO head.
+    /// Attaches a free stable slot at the queue head.
     #[inline]
-    fn push_head<I: Index<Slot, Output = SlotState>>(
+    fn push<I: Index<Slot, Output = SlotState>>(
         &mut self,
         states: &I,
         slots: &mut [ResidentSlot],
@@ -267,6 +270,7 @@ impl SmallQueue {
         self.len += 1;
 
         let demoted = *self.young_tail.get_or_insert(slot);
+
         // Only the oldest correlated survivor can leave the window after one
         // new admission because Small preserves admission order.
         let age = self.admissions.wrapping_sub(slots[demoted].admitted_at);
@@ -276,6 +280,7 @@ impl SmallQueue {
 
         let new_boundary = slots[demoted].prev;
         assert_ne!(new_boundary, UNLINKED);
+
         // Discard references made inside the correlation window. Only a hit
         // after the entry becomes old should promote it to Main.
         states[demoted].reset();
@@ -283,7 +288,7 @@ impl SmallQueue {
         self.young_tail = Some(new_boundary);
     }
 
-    /// Detaches a resident and repairs the FIFO and correlation boundary.
+    /// Detaches a resident and repairs the queue and correlation boundary.
     #[inline]
     fn unlink(&mut self, slots: &mut [ResidentSlot], slot: Slot) {
         assert_eq!(slots[slot].location, Location::Small);
@@ -301,6 +306,7 @@ impl SmallQueue {
         }
 
         self.len -= 1;
+
         // Removing the correlation boundary shrinks the live window without
         // making any older resident young again.
         if self.young_tail == Some(slot) {
@@ -319,7 +325,10 @@ impl SmallQueue {
     }
 }
 
-/// State and hand for the Main CLOCK ring.
+/// Circular resident topology and replacement hand for Main.
+///
+/// Unlike the Small and Ghost queues, Main has no head or tail. Its entries
+/// form a ring, and the CLOCK hand sweeps that ring for an unreferenced victim.
 struct MainRing {
     /// Maximum number of Main residents.
     capacity: usize,
@@ -360,7 +369,7 @@ impl MainRing {
 
     /// Attaches a free slot immediately before the hand.
     #[inline]
-    fn insert(&mut self, slots: &mut [ResidentSlot], slot: Slot) {
+    fn push(&mut self, slots: &mut [ResidentSlot], slot: Slot) {
         assert!(self.len < self.capacity);
         let Some(hand) = self.hand else {
             // A one-entry ring links the resident to itself and points the hand
@@ -421,9 +430,25 @@ impl MainRing {
     }
 }
 
-/// Exact bounded history of keys evicted from Small.
-struct GhostFifo<K> {
-    /// Exact key membership mapped to FIFO positions.
+/// A key-only entry in the bounded Ghost queue.
+struct GhostSlot<K> {
+    /// Historical key, or `None` when this slot is available for reuse.
+    key: Option<K>,
+    /// Previous entry toward the Ghost head.
+    prev: usize,
+    /// Next entry toward the Ghost tail.
+    next: usize,
+}
+
+/// Exact bounded history of keys recently evicted from Small.
+///
+/// Ghost stores keys without values, so it records recent eviction history
+/// without consuming resident cache capacity. A later request for a recorded
+/// key demonstrates reuse and admits the key directly to Main. The hash index
+/// provides exact membership checks, while the linked queue discards the oldest
+/// history when it reaches its bound.
+struct GhostQueue<K> {
+    /// Exact key membership mapped to queue positions.
     index: HashMap<K, usize, Hasher>,
     /// Storage for linked historical entries.
     slots: Vec<GhostSlot<K>>,
@@ -437,7 +462,7 @@ struct GhostFifo<K> {
     capacity: usize,
 }
 
-impl<K: Hash + Eq + Clone> GhostFifo<K> {
+impl<K: Hash + Eq + Clone> GhostQueue<K> {
     /// Constructs empty exact history bounded by `capacity`.
     fn new(capacity: usize) -> Self {
         Self {
@@ -450,12 +475,13 @@ impl<K: Hash + Eq + Clone> GhostFifo<K> {
         }
     }
 
-    /// Adds an evicted Small key at the FIFO head.
+    /// Adds an evicted Small key at the queue head.
     #[inline]
     fn push(&mut self, key: K) {
         if self.capacity == 0 {
             return;
         }
+
         // Prefer recycled storage, then grow to the Ghost bound, then reuse
         // the oldest live slot after removing its previous key.
         let slot = if let Some(slot) = self.free.pop() {
@@ -480,7 +506,8 @@ impl<K: Hash + Eq + Clone> GhostFifo<K> {
         {
             let entry = &mut self.slots[slot];
             assert!(entry.key.is_none());
-            // Ghost keeps one key in its hash index and one in its FIFO slot,
+
+            // Ghost keeps one key in its hash index and one in its queue slot,
             // which avoids per-entry shared ownership between the structures.
             entry.key = Some(key.clone());
             entry.prev = UNLINKED;
@@ -546,20 +573,20 @@ impl<K: Hash + Eq + Clone> GhostFifo<K> {
 
 /// Clock2Q+ admission and eviction policy.
 ///
-/// Clock2Q+ divides residents between a Small FIFO and a Main CLOCK ring. New
+/// Clock2Q+ divides residents between a Small queue and a Main CLOCK ring. New
 /// keys enter Small, while keys found in bounded Ghost history enter Main.
 /// Hits to the newest portion of Small are ignored to filter correlated access.
 /// An eligible Small hit marks the resident for promotion when it reaches the
-/// FIFO tail.
+/// queue tail.
 ///
-/// The policy owns queue topology, partition sizes, the Main clock hand, and
+/// The policy owns resident topology, partition sizes, the Main CLOCK hand, and
 /// exact bounded Ghost history. Resident keys and values remain in [Cache].
 /// The target proportions are 10% Small, 90% Main, and 50% Ghost, with a
 /// correlation window covering half of Small. Integer sizes use floor division,
 /// except that Small receives at least one slot when total capacity exceeds
 /// one. A capacity of one uses Main as a one-entry CLOCK.
 ///
-/// Resident values stay in stable cache slots while queue links remain in the
+/// Resident values stay in stable cache slots while resident links remain in the
 /// policy. Hits mutate only relaxed atomic slot state, so readers can share the
 /// cache behind a reader-writer lock without serializing.
 ///
@@ -579,7 +606,7 @@ impl<K: Hash + Eq + Clone> GhostFifo<K> {
 /// assert_eq!(cache.get(&7), Some(&49));
 /// ```
 pub struct Clock2QPlus<K> {
-    /// Queue topology and admission age indexed by the cache's stable slots.
+    /// Resident topology and admission age indexed by the cache's stable slots.
     ///
     /// The cache owns keys, values, and inline [`SlotState`]. This parallel
     /// array is required for policy-owned links that must also be available to
@@ -590,13 +617,14 @@ pub struct Clock2QPlus<K> {
     /// Eviction ring and CLOCK hand.
     main: MainRing,
     /// Exact bounded history used for scan-resistant admission.
-    ghost: GhostFifo<K>,
+    ghost: GhostQueue<K>,
 }
 
 impl<K: Hash + Eq + Clone> Clock2QPlus<K> {
     /// Constructs empty policy metadata for `capacity` resident slots.
     fn with_capacity(capacity: NonZeroUsize) -> Self {
         let capacity = capacity.get();
+
         // Keep tiny caches usable while approaching the paper's target ratios
         // with integer arithmetic at normal capacities.
         let small_capacity = if capacity == 1 {
@@ -611,7 +639,7 @@ impl<K: Hash + Eq + Clone> Clock2QPlus<K> {
             slots: vec![ResidentSlot::default(); capacity],
             small: SmallQueue::new(small_capacity),
             main: MainRing::new(main_capacity),
-            ghost: GhostFifo::new(ghost_capacity),
+            ghost: GhostQueue::new(ghost_capacity),
         }
     }
 
@@ -676,8 +704,8 @@ impl<K: Hash + Eq + Clone> Clock2QPlus<K> {
         admission: Admission,
     ) {
         match admission {
-            Admission::Small => self.small.push_head(states, &mut self.slots, slot),
-            Admission::Main => self.main.insert(&mut self.slots, slot),
+            Admission::Small => self.small.push(states, &mut self.slots, slot),
+            Admission::Main => self.main.push(&mut self.slots, slot),
         }
     }
 
@@ -737,6 +765,7 @@ impl<K: Hash + Eq + Clone> Policy<K> for Clock2QPlus<K> {
                 Claimed::Evicted(key),
             ) => {
                 let location = self.unlink_resident(victim);
+
                 // Only Small evictions become Ghost evidence. Main victims
                 // have already passed the admission filter.
                 if location == Location::Small {
@@ -754,7 +783,7 @@ impl<K: Hash + Eq + Clone> Policy<K> for Clock2QPlus<K> {
             // Small tail into the resulting Main vacancy.
             self.small.unlink(&mut self.slots, promoted);
             states[promoted].reset();
-            self.main.insert(&mut self.slots, promoted);
+            self.main.push(&mut self.slots, promoted);
         }
         self.attach(states, slot, admission);
         (slot, SlotState::new(admission))
@@ -802,7 +831,6 @@ mod tests {
         thread,
     };
 
-    /// Cache specialization exercised by the Clock2Q+ tests.
     type TestCache<K, V> = Cache<K, V, Clock2QPlus<K>>;
 
     /// Returns the number of residents attached to either partition.
@@ -996,7 +1024,7 @@ mod tests {
             }
         }
 
-        /// Adds a key to the bounded model Ghost FIFO.
+        /// Adds a key to the bounded model Ghost queue.
         fn push_ghost(&mut self, key: u8) {
             assert!(!self.ghost.contains(&key));
             if self.ghost.len() == self.ghost_capacity {
@@ -1264,7 +1292,7 @@ mod tests {
     }
 
     #[test]
-    fn partitions_round_for_tiny_capacities() {
+    fn test_partitions_round_for_tiny_capacities() {
         // Ratio-derived partitions round down. Capacities above one still keep
         // at least one Small slot, while capacity one uses Main alone.
         let expected = [
@@ -1296,7 +1324,7 @@ mod tests {
     }
 
     #[test]
-    fn capacity_one_behaves_as_clock() {
+    fn test_capacity_one_behaves_as_clock() {
         // With no Small or Ghost capacity, the only Main slot is replaced on
         // each cold insertion.
         let mut cache = TestCache::new(NZUsize!(1));
@@ -1310,7 +1338,7 @@ mod tests {
     }
 
     #[test]
-    fn warmup_fills_small_then_main_with_cold_entries() {
+    fn test_warmup_fills_small_then_main_with_cold_entries() {
         // Warm-up fills the 10% Small partition first, then uses the remaining
         // vacant slots for unreferenced Main residents.
         let mut cache = TestCache::new(NZUsize!(20));
@@ -1328,7 +1356,7 @@ mod tests {
     }
 
     #[test]
-    fn policy_empty_state_includes_precise_ghost_history() {
+    fn test_policy_empty_state_includes_precise_ghost_history() {
         // Resident filtering does not erase unrelated Ghost evidence. The
         // policy may therefore retain useful history with no live residents.
         let mut cache = TestCache::new(NZUsize!(2));
@@ -1349,7 +1377,7 @@ mod tests {
     }
 
     #[test]
-    fn correlation_window_ignores_only_young_hits() {
+    fn test_correlation_window_ignores_only_young_hits() {
         // Key 4 is at the Small head, inside the two-entry correlation window.
         // Its hit must not set the bit, so a scan ages and evicts it to Ghost.
         let mut correlated = TestCache::new(NZUsize!(40));
@@ -1385,7 +1413,7 @@ mod tests {
     }
 
     #[test]
-    fn removing_younger_entry_does_not_rewind_correlation_age() {
+    fn test_removing_younger_entry_does_not_rewind_correlation_age() {
         let mut cache = TestCache::new(NZUsize!(20));
         for key in 0..20u64 {
             cache.put(key, key);
@@ -1407,7 +1435,7 @@ mod tests {
     }
 
     #[test]
-    fn removing_younger_entry_does_not_delay_correlation_age() {
+    fn test_removing_younger_entry_does_not_delay_correlation_age() {
         let mut cache = TestCache::new(NZUsize!(40));
         for key in 0..40u64 {
             cache.put(key, key);
@@ -1431,8 +1459,8 @@ mod tests {
     }
 
     #[test]
-    fn ghost_history_is_bounded_and_promotes_reuse() {
-        // Cold churn fills the ten-entry Ghost FIFO and drops its oldest key.
+    fn test_ghost_history_is_bounded_and_promotes_reuse() {
+        // Cold churn fills the ten-entry Ghost queue and drops its oldest key.
         let mut cache = TestCache::new(NZUsize!(20));
         for key in 0..=30u64 {
             cache.put(key, key);
@@ -1467,7 +1495,7 @@ mod tests {
     }
 
     #[test]
-    fn main_evicts_despite_an_offered_vacancy() {
+    fn test_main_evicts_despite_an_offered_vacancy() {
         // Removing the Small resident leaves a globally vacant slot while Main
         // remains full and key 1 remains in Ghost.
         let mut cache = TestCache::new(NZUsize!(2));
@@ -1490,7 +1518,7 @@ mod tests {
     }
 
     #[test]
-    fn promoting_small_replaces_from_full_main() {
+    fn test_promoting_small_replaces_from_full_main() {
         // Reference the original Small tail so the next cold miss promotes it
         // while keeping both fixed-size resident partitions full.
         let mut cache = TestCache::new(NZUsize!(20));
@@ -1523,7 +1551,7 @@ mod tests {
     }
 
     #[test]
-    fn slot_stays_stable_on_promotion_and_goes_stale_on_reuse() {
+    fn test_slot_stays_stable_on_promotion_and_goes_stale_on_reuse() {
         // Promotion changes only policy topology, so key 1 keeps its original
         // slot and the existing lookup hint remains valid.
         let mut cache = TestCache::new(NZUsize!(40));
@@ -1553,7 +1581,7 @@ mod tests {
     }
 
     #[test]
-    fn scan_does_not_displace_main() {
+    fn test_scan_does_not_displace_main() {
         // Warm-up places keys 1 through 9 in Main. A one-cache-capacity scan is
         // absorbed by Small and leaves that Main working set intact.
         let mut clock2qplus = TestCache::new(NZUsize!(10));
@@ -1584,7 +1612,7 @@ mod tests {
     }
 
     #[test]
-    fn prefill_reuses_values_through_churn() {
+    fn test_prefill_reuses_values_through_churn() {
         // Prefill allocates every value once. Policy churn must keep reusing
         // those same stable slots without invoking the factory again.
         let mut makes = 0usize;
@@ -1605,7 +1633,7 @@ mod tests {
     }
 
     #[test]
-    fn remove_retain_and_clear_repair_resident_state() {
+    fn test_remove_retain_and_clear_repair_resident_state() {
         // Exercise removal from Main and Ghost, then prove a removed Ghost key
         // returns as cold instead of receiving stale Main admission.
         let mut cache = TestCache::new(NZUsize!(20));
@@ -1643,7 +1671,7 @@ mod tests {
     }
 
     #[test]
-    fn shared_hits_are_concurrent() {
+    fn test_shared_hits_are_concurrent() {
         // Shared lookups race only on the relaxed per-slot reference bit. The
         // accumulated hit must still protect key 1 on the next insertion.
         let mut cache = TestCache::new(NZUsize!(40));
@@ -1677,7 +1705,7 @@ mod tests {
     }
 
     #[test]
-    fn fallible_factory_error_leaves_policy_unchanged() {
+    fn test_fallible_factory_error_leaves_policy_unchanged() {
         // Key 1 is in Ghost. A failed factory must return before policy
         // insertion consumes that evidence or changes resident topology.
         let mut cache = TestCache::new(NZUsize!(2));
@@ -1697,7 +1725,7 @@ mod tests {
 
     proptest! {
         #[test]
-        fn pure_accesses_match_queue_level_reference(
+        fn test_pure_accesses_match_queue_level_reference(
             capacity in 1usize..33,
             accesses in prop::collection::vec(0u8..64, 0..400),
         ) {
@@ -1722,7 +1750,7 @@ mod tests {
         }
 
         #[test]
-        fn mutations_match_queue_level_reference(
+        fn test_mutations_match_queue_level_reference(
             capacity in 1usize..33,
             operations in prop::collection::vec(reference_op_strategy(), 0..400),
         ) {
@@ -1730,7 +1758,7 @@ mod tests {
             let mut reference = ReferenceClock2QPlus::new(capacity);
 
             // Removal and retention must not rewind monotonic correlation age
-            // or disturb the Main hand and Ghost FIFO.
+            // or disturb the Main hand and Ghost queue.
             for operation in operations {
                 match operation {
                     ReferenceOp::Access(key) => {
@@ -1762,7 +1790,7 @@ mod tests {
         }
 
         #[test]
-        fn arbitrary_operations_preserve_invariants(
+        fn test_arbitrary_operations_preserve_invariants(
             capacity in 1usize..17,
             operations in prop::collection::vec((0u8..8, 0u8..24, any::<u16>()), 0..300),
         ) {

--- a/utils/src/cache/clock2qplus.rs
+++ b/utils/src/cache/clock2qplus.rs
@@ -111,7 +111,7 @@ enum Admission {
 }
 
 /// Storage action selected for one confirmed-miss insertion.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy)]
 enum InsertionPlan {
     /// Claim unused cache capacity.
     Vacant,
@@ -502,6 +502,9 @@ impl<K: Hash + Eq + Clone> GhostFifo<K> {
             return false;
         };
         let _historical = self.unlink(slot);
+
+        // Recycle the position before dropping the key, so a panicking
+        // destructor cannot strand the detached slot outside the free list.
         self.free.push(slot);
         true
     }
@@ -669,7 +672,7 @@ impl<K: Hash + Eq + Clone> Clock2QPlus<K> {
     fn attach<I: Index<Slot, Output = SlotState>>(
         &mut self,
         states: &I,
-        slot: usize,
+        slot: Slot,
         admission: Admission,
     ) {
         match admission {

--- a/utils/src/cache/clock2qplus.rs
+++ b/utils/src/cache/clock2qplus.rs
@@ -24,8 +24,8 @@
 //! rounded up. A capacity of one uses Main only. Resident keys and values
 //! remain in stable [super::Cache] slots. Queue topology and Ghost history are
 //! policy-owned, while each slot's correlation marker and reference bit are
-//! stored inline as [Policy::SlotState]. Ghost admission is sampled when
-//! insertion commits.
+//! stored inline as [Policy::SlotState]. Ghost history is consulted and
+//! consumed when insertion commits.
 //!
 //! # References
 //!
@@ -61,10 +61,8 @@ const fn linked(slot: usize) -> Option<usize> {
 enum Location {
     /// The cache slot is not attached to either resident partition.
     Free,
-    /// One of the newest entries in Small. Hits here are correlated and ignored.
-    SmallYoung,
-    /// An older Small entry. A hit here marks the entry for promotion.
-    SmallOld,
+    /// An entry in the Small FIFO.
+    Small,
     /// An entry in the Main CLOCK ring.
     Main,
 }
@@ -83,7 +81,6 @@ struct ResidentSlot {
 }
 
 impl Default for ResidentSlot {
-    /// Returns detached metadata with no queue neighbors.
     fn default() -> Self {
         Self {
             location: Location::Free,
@@ -111,6 +108,35 @@ enum Admission {
     Small,
     /// Admit immediately before the hand in the Main CLOCK ring.
     Main,
+}
+
+/// Storage action selected for one confirmed-miss insertion.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum InsertionPlan {
+    /// Claim unused cache capacity.
+    Vacant,
+    /// Replace one resident.
+    Evict {
+        /// Resident selected for eviction.
+        victim: Slot,
+    },
+    /// Promote a Small resident and replace a separate Main resident.
+    PromoteThenEvict {
+        /// Small tail retained and moved to Main.
+        promoted: Slot,
+        /// Main resident selected for eviction.
+        victim: Slot,
+    },
+}
+
+impl InsertionPlan {
+    /// Returns the resident selected for replacement, if any.
+    const fn victim(self) -> Option<Slot> {
+        match self {
+            Self::Vacant => None,
+            Self::Evict { victim } | Self::PromoteThenEvict { victim, .. } => Some(victim),
+        }
+    }
 }
 
 /// Policy state stored inline with each Clock2Q+ cache slot.
@@ -153,6 +179,365 @@ impl SlotState {
         if *current & CORRELATED == 0 {
             *current |= REFERENCED;
         }
+    }
+
+    /// Returns whether a Small resident has earned promotion.
+    #[inline]
+    fn earned_promotion(&self) -> bool {
+        self.0.load(Ordering::Relaxed) & (CORRELATED | REFERENCED) == REFERENCED
+    }
+
+    /// Consumes one Main reference bit.
+    #[inline]
+    fn take_reference(&self) -> bool {
+        if self.0.load(Ordering::Relaxed) & REFERENCED == 0 {
+            return false;
+        }
+        self.0.store(0, Ordering::Relaxed);
+        true
+    }
+
+    /// Clears correlation and reference state during an exclusive transition.
+    #[inline]
+    fn reset(&self) {
+        self.0.store(0, Ordering::Relaxed);
+    }
+}
+
+/// State and endpoints for the Small FIFO.
+struct SmallQueue {
+    /// Maximum number of Small residents.
+    capacity: usize,
+    /// Admission age at which a resident leaves the correlation window.
+    correlation_window: usize,
+    /// Newest Small resident.
+    head: Option<Slot>,
+    /// Oldest Small resident.
+    tail: Option<Slot>,
+    /// Oldest resident still inside the correlation window.
+    young_tail: Option<Slot>,
+    /// Monotonic count of Small admissions, including removed entries.
+    admissions: usize,
+    /// Current number of Small residents.
+    len: usize,
+}
+
+impl SmallQueue {
+    /// Constructs an empty Small FIFO with its derived correlation window.
+    const fn new(capacity: usize) -> Self {
+        Self {
+            capacity,
+            correlation_window: capacity.div_ceil(2),
+            head: None,
+            tail: None,
+            young_tail: None,
+            admissions: 0,
+            len: 0,
+        }
+    }
+
+    /// Attaches a free stable slot at the FIFO head.
+    #[inline]
+    fn push_head<I: Index<Slot, Output = SlotState>>(
+        &mut self,
+        states: &I,
+        slots: &mut [ResidentSlot],
+        slot: Slot,
+    ) {
+        // Admission count, rather than live queue length, makes correlation age
+        // monotonic across explicit removal and retention. Wrapping remains
+        // valid because a correlated resident leaves within one bounded window,
+        // long before the counter can complete a full cycle.
+        self.admissions = self.admissions.wrapping_add(1);
+        let old_head = self.head;
+        {
+            let entry = &mut slots[slot];
+            assert_eq!(entry.location, Location::Free);
+            entry.location = Location::Small;
+            entry.prev = UNLINKED;
+            entry.next = old_head.unwrap_or(UNLINKED);
+            entry.admitted_at = self.admissions;
+        }
+        if let Some(head) = old_head {
+            slots[head].prev = slot;
+        } else {
+            self.tail = Some(slot);
+        }
+        self.head = Some(slot);
+        self.len += 1;
+
+        let demoted = *self.young_tail.get_or_insert(slot);
+        // Only the oldest correlated survivor can leave the window after one
+        // new admission because Small preserves admission order.
+        let age = self.admissions.wrapping_sub(slots[demoted].admitted_at);
+        if age < self.correlation_window {
+            return;
+        }
+
+        let new_boundary = slots[demoted].prev;
+        assert_ne!(new_boundary, UNLINKED);
+        // Discard references made inside the correlation window. Only a hit
+        // after the entry becomes old should promote it to Main.
+        states[demoted].reset();
+        slots[demoted].admitted_at = 0;
+        self.young_tail = Some(new_boundary);
+    }
+
+    /// Detaches a resident and repairs the FIFO and correlation boundary.
+    #[inline]
+    fn unlink(&mut self, slots: &mut [ResidentSlot], slot: Slot) {
+        assert_eq!(slots[slot].location, Location::Small);
+        let prev = slots[slot].prev;
+        let next = slots[slot].next;
+        if prev != UNLINKED {
+            slots[prev].next = next;
+        } else {
+            self.head = linked(next);
+        }
+        if next != UNLINKED {
+            slots[next].prev = prev;
+        } else {
+            self.tail = linked(prev);
+        }
+
+        self.len -= 1;
+        // Removing the correlation boundary shrinks the live window without
+        // making any older resident young again.
+        if self.young_tail == Some(slot) {
+            self.young_tail = linked(prev);
+        }
+        slots[slot] = ResidentSlot::default();
+    }
+
+    /// Resets all Small endpoints and counters.
+    const fn clear(&mut self) {
+        self.head = None;
+        self.tail = None;
+        self.young_tail = None;
+        self.admissions = 0;
+        self.len = 0;
+    }
+}
+
+/// State and hand for the Main CLOCK ring.
+struct MainRing {
+    /// Maximum number of Main residents.
+    capacity: usize,
+    /// Next resident considered for eviction.
+    hand: Option<Slot>,
+    /// Current number of Main residents.
+    len: usize,
+}
+
+impl MainRing {
+    /// Constructs an empty Main ring.
+    const fn new(capacity: usize) -> Self {
+        Self {
+            capacity,
+            hand: None,
+            len: 0,
+        }
+    }
+
+    /// Sweeps the CLOCK hand to the first unreferenced resident.
+    #[inline]
+    fn select<I: Index<Slot, Output = SlotState>>(
+        &mut self,
+        states: &I,
+        slots: &[ResidentSlot],
+    ) -> Slot {
+        loop {
+            let slot = self.hand.expect("nonempty Main must have a hand");
+            if states[slot].take_reference() {
+                // A set bit grants one second chance. Continue from the next
+                // resident after consuming it.
+                self.hand = Some(slots[slot].next);
+                continue;
+            }
+            return slot;
+        }
+    }
+
+    /// Attaches a free slot immediately before the hand.
+    #[inline]
+    fn insert(&mut self, slots: &mut [ResidentSlot], slot: Slot) {
+        assert!(self.len < self.capacity);
+        let Some(hand) = self.hand else {
+            // A one-entry ring links the resident to itself and points the hand
+            // at that sole eviction candidate.
+            let entry = &mut slots[slot];
+            assert_eq!(entry.location, Location::Free);
+            entry.location = Location::Main;
+            entry.prev = slot;
+            entry.next = slot;
+            self.hand = Some(slot);
+            self.len = 1;
+            return;
+        };
+
+        // New residents start behind the current hand, so they are considered
+        // only after the existing CLOCK sweep reaches them.
+        let prev = slots[hand].prev;
+        assert_ne!(prev, UNLINKED);
+        {
+            let entry = &mut slots[slot];
+            assert_eq!(entry.location, Location::Free);
+            entry.location = Location::Main;
+            entry.prev = prev;
+            entry.next = hand;
+        }
+        slots[prev].next = slot;
+        slots[hand].prev = slot;
+        self.len += 1;
+    }
+
+    /// Detaches a resident and advances the hand when necessary.
+    #[inline]
+    fn unlink(&mut self, slots: &mut [ResidentSlot], slot: Slot) {
+        assert_eq!(slots[slot].location, Location::Main);
+        if self.len == 1 {
+            assert_eq!(self.hand, Some(slot));
+            self.hand = None;
+            self.len = 0;
+        } else {
+            let prev = slots[slot].prev;
+            let next = slots[slot].next;
+            assert_ne!(prev, UNLINKED);
+            assert_ne!(next, UNLINKED);
+            slots[prev].next = next;
+            slots[next].prev = prev;
+            if self.hand == Some(slot) {
+                self.hand = Some(next);
+            }
+            self.len -= 1;
+        }
+        slots[slot] = ResidentSlot::default();
+    }
+
+    /// Resets the Main hand and resident count.
+    const fn clear(&mut self) {
+        self.hand = None;
+        self.len = 0;
+    }
+}
+
+/// Exact bounded history of keys evicted from Small.
+struct GhostFifo<K> {
+    /// Exact key membership mapped to FIFO positions.
+    index: HashMap<K, usize, Hasher>,
+    /// Storage for linked historical entries.
+    slots: Vec<GhostSlot<K>>,
+    /// Detached positions available for reuse.
+    free: Vec<usize>,
+    /// Newest historical entry.
+    head: Option<usize>,
+    /// Oldest historical entry.
+    tail: Option<usize>,
+    /// Maximum number of historical entries.
+    capacity: usize,
+}
+
+impl<K: Hash + Eq + Clone> GhostFifo<K> {
+    /// Constructs empty exact history bounded by `capacity`.
+    fn new(capacity: usize) -> Self {
+        Self {
+            index: HashMap::with_capacity_and_hasher(capacity, Hasher::default()),
+            slots: Vec::with_capacity(capacity),
+            free: Vec::with_capacity(capacity),
+            head: None,
+            tail: None,
+            capacity,
+        }
+    }
+
+    /// Adds an evicted Small key at the FIFO head.
+    #[inline]
+    fn push(&mut self, key: K) {
+        if self.capacity == 0 {
+            return;
+        }
+        // Prefer recycled storage, then grow to the Ghost bound, then reuse
+        // the oldest live slot after removing its previous key.
+        let slot = if let Some(slot) = self.free.pop() {
+            slot
+        } else if self.slots.len() < self.capacity {
+            let slot = self.slots.len();
+            self.slots.push(GhostSlot {
+                key: None,
+                prev: UNLINKED,
+                next: UNLINKED,
+            });
+            slot
+        } else {
+            let slot = self.tail.expect("full Ghost must have a tail");
+            let historical = self.unlink(slot);
+            let removed = self.index.remove(&historical);
+            assert_eq!(removed, Some(slot));
+            slot
+        };
+
+        let old_head = self.head;
+        {
+            let entry = &mut self.slots[slot];
+            assert!(entry.key.is_none());
+            // Ghost keeps one key in its hash index and one in its FIFO slot,
+            // which avoids per-entry shared ownership between the structures.
+            entry.key = Some(key.clone());
+            entry.prev = UNLINKED;
+            entry.next = old_head.unwrap_or(UNLINKED);
+        }
+        if let Some(head) = old_head {
+            self.slots[head].prev = slot;
+        } else {
+            self.tail = Some(slot);
+        }
+        self.head = Some(slot);
+        self.index.insert(key, slot);
+    }
+
+    /// Removes exact history for `key` and reports whether it was present.
+    #[inline]
+    fn discard(&mut self, key: &K) -> bool {
+        let Some(slot) = self.index.remove(key) else {
+            return false;
+        };
+        let _historical = self.unlink(slot);
+        self.free.push(slot);
+        true
+    }
+
+    /// Detaches one historical entry and returns its owned key.
+    #[inline]
+    fn unlink(&mut self, slot: usize) -> K {
+        let prev = self.slots[slot].prev;
+        let next = self.slots[slot].next;
+        if prev != UNLINKED {
+            self.slots[prev].next = next;
+        } else {
+            self.head = linked(next);
+        }
+        if next != UNLINKED {
+            self.slots[next].prev = prev;
+        } else {
+            self.tail = linked(prev);
+        }
+
+        let key = self.slots[slot]
+            .key
+            .take()
+            .expect("linked Ghost entry must have a key");
+        self.slots[slot].prev = UNLINKED;
+        self.slots[slot].next = UNLINKED;
+        key
+    }
+
+    /// Removes all historical entries and reusable positions.
+    fn clear(&mut self) {
+        self.index.clear();
+        self.slots.clear();
+        self.free.clear();
+        self.head = None;
+        self.tail = None;
     }
 }
 
@@ -197,43 +582,12 @@ pub struct Clock2QPlus<K> {
     /// array is required for policy-owned links that must also be available to
     /// [`Policy::remove`], which receives a slot identifier but no state view.
     slots: Vec<ResidentSlot>,
-
-    /// Maximum number of residents in the Small partition.
-    small_capacity: usize,
-    /// Small admission age at which a resident leaves the correlation window.
-    correlation_window: usize,
-    /// Newest resident in the Small FIFO.
-    small_head: Option<usize>,
-    /// Oldest resident in the Small FIFO.
-    small_tail: Option<usize>,
-    /// The oldest entry still inside the correlation window.
-    small_young_tail: Option<usize>,
-    /// Monotonic count of Small admissions, including entries later removed.
-    small_admissions: usize,
-    /// Current number of Small residents.
-    small_len: usize,
-
-    /// Maximum number of residents in the Main partition.
-    main_capacity: usize,
-    /// Next Main resident considered for eviction.
-    main_hand: Option<usize>,
-    /// Current number of Main residents.
-    main_len: usize,
-
-    /// Exact Ghost membership mapped to positions in `ghost_slots`.
-    ///
-    /// The index makes admission checks and explicit history removal O(1).
-    ghost_index: HashMap<K, usize, Hasher>,
-    /// Storage for the bounded Ghost FIFO.
-    ghost_slots: Vec<GhostSlot<K>>,
-    /// Detached Ghost slots available for reuse.
-    ghost_free: Vec<usize>,
-    /// Newest key in Ghost.
-    ghost_head: Option<usize>,
-    /// Oldest key in Ghost.
-    ghost_tail: Option<usize>,
-    /// Maximum number of Ghost entries.
-    ghost_capacity: usize,
+    /// Admission queue and correlation-window state.
+    small: SmallQueue,
+    /// Eviction ring and CLOCK hand.
+    main: MainRing,
+    /// Exact bounded history used for scan-resistant admission.
+    ghost: GhostFifo<K>,
 }
 
 impl<K: Hash + Eq + Clone> Clock2QPlus<K> {
@@ -248,38 +602,24 @@ impl<K: Hash + Eq + Clone> Clock2QPlus<K> {
             (capacity / 10).max(1)
         };
         let main_capacity = capacity - small_capacity;
-        let correlation_window = small_capacity.div_ceil(2);
         let ghost_capacity = capacity / 2;
 
         Self {
             slots: vec![ResidentSlot::default(); capacity],
-            small_capacity,
-            correlation_window,
-            small_head: None,
-            small_tail: None,
-            small_young_tail: None,
-            small_admissions: 0,
-            small_len: 0,
-            main_capacity,
-            main_hand: None,
-            main_len: 0,
-            ghost_index: HashMap::with_capacity_and_hasher(ghost_capacity, Hasher::default()),
-            ghost_slots: Vec::with_capacity(ghost_capacity),
-            ghost_free: Vec::with_capacity(ghost_capacity),
-            ghost_head: None,
-            ghost_tail: None,
-            ghost_capacity,
+            small: SmallQueue::new(small_capacity),
+            main: MainRing::new(main_capacity),
+            ghost: GhostFifo::new(ghost_capacity),
         }
     }
 
     /// Chooses the resident partition for an incoming key.
     #[inline]
-    fn admission(&mut self, key: &K, has_vacancy: bool) -> Admission {
+    const fn admission(&self, ghost_hit: bool, has_vacancy: bool) -> Admission {
         // A Ghost hit bypasses Small. During warm-up, Small fills to its target
         // before additional vacant cache slots are assigned to Main.
-        if self.discard_ghost(key)
-            || self.small_capacity == 0
-            || (has_vacancy && self.small_len >= self.small_capacity)
+        if ghost_hit
+            || self.small.capacity == 0
+            || (has_vacancy && self.small.len >= self.small.capacity)
         {
             Admission::Main
         } else {
@@ -287,68 +627,45 @@ impl<K: Hash + Eq + Clone> Clock2QPlus<K> {
         }
     }
 
-    /// Selects storage for a Small admission and records a pending promotion.
-    ///
-    /// A referenced old tail is promoted in place. The incoming key then uses
-    /// a Main victim, keeping both fixed-size resident partitions within their
-    /// targets. A correlated or unreferenced tail is selected directly.
-    fn select_small<I: Index<Slot, Output = SlotState>>(
+    /// Plans the resident transition for one confirmed-miss insertion.
+    #[inline]
+    fn plan<I: Index<Slot, Output = SlotState>>(
         &mut self,
         states: &I,
-        promotion: &mut Option<Slot>,
+        admission: Admission,
         has_vacancy: bool,
-    ) -> Option<Slot> {
-        if has_vacancy {
-            return None;
-        }
+    ) -> InsertionPlan {
+        match admission {
+            Admission::Small if has_vacancy => InsertionPlan::Vacant,
+            Admission::Small => {
+                let tail = self.small.tail.expect("full cache must have a Small tail");
+                if !states[tail].earned_promotion() {
+                    return InsertionPlan::Evict { victim: tail };
+                }
 
-        let tail = self.small_tail.expect("full cache must have a Small tail");
-        let state = states[tail].0.load(Ordering::Relaxed);
-
-        // Correlated references never earn promotion. The tail is eligible for
-        // promotion only when REFERENCED is set and CORRELATED is clear.
-        if state & (CORRELATED | REFERENCED) != REFERENCED {
-            return Some(tail);
-        }
-
-        // A referenced Small tail is promoted in its existing stable slot.
-        // Since a full cache also has a full Main partition, the incoming
-        // entry reuses the Main victim selected here.
-        self.unlink_small(tail);
-        states[tail].0.store(0, Ordering::Relaxed);
-        *promotion = Some(tail);
-        Some(self.select_main(states))
-    }
-
-    /// Selects storage for a Main admission.
-    ///
-    /// Main may require a victim even while the cache has a vacant Small slot.
-    fn select_for_main<I: Index<Slot, Output = SlotState>>(&mut self, states: &I) -> Option<Slot> {
-        // Main is a fixed-size CLOCK partition. Reusing a Ghost key must
-        // replace a Main resident even when Cache has a free Small slot.
-        if self.main_len == self.main_capacity {
-            return Some(self.select_main(states));
-        }
-        None
-    }
-
-    /// Runs the Main CLOCK hand until it finds an unreferenced victim.
-    fn select_main<I: Index<Slot, Output = SlotState>>(&mut self, states: &I) -> Slot {
-        loop {
-            let slot = self.main_hand.expect("nonempty Main must have a hand");
-            let state = &states[slot];
-            if state.0.load(Ordering::Relaxed) & REFERENCED != 0 {
-                // A set bit grants one second chance. Clear it and continue
-                // from the following resident in the Main ring.
-                state.0.store(0, Ordering::Relaxed);
-                self.main_hand = Some(self.slots[slot].next);
-                continue;
+                // A full cache and bounded partitions imply Main is also full.
+                // Promote the referenced Small tail while the incoming entry
+                // reuses the Main victim selected here.
+                assert_eq!(self.main.len, self.main.capacity);
+                let victim = self.main.select(states, &self.slots);
+                InsertionPlan::PromoteThenEvict {
+                    promoted: tail,
+                    victim,
+                }
             }
-            return slot;
+            Admission::Main if self.main.len == self.main.capacity => InsertionPlan::Evict {
+                victim: self.main.select(states, &self.slots),
+            },
+            Admission::Main => {
+                // Main can grow only while the cache has unused capacity.
+                assert!(has_vacancy);
+                InsertionPlan::Vacant
+            }
         }
     }
 
     /// Attaches a free stable slot to its selected resident partition.
+    #[inline]
     fn attach<I: Index<Slot, Output = SlotState>>(
         &mut self,
         states: &I,
@@ -356,271 +673,41 @@ impl<K: Hash + Eq + Clone> Clock2QPlus<K> {
         admission: Admission,
     ) {
         match admission {
-            Admission::Small => self.insert_small_head(states, slot),
-            Admission::Main => self.insert_main(slot),
+            Admission::Small => self.small.push_head(states, &mut self.slots, slot),
+            Admission::Main => self.main.insert(&mut self.slots, slot),
         }
     }
 
-    /// Detaches a resident from whichever partition currently owns it.
-    fn unlink_resident(&mut self, slot: usize) {
-        match self.slots[slot].location {
-            Location::SmallYoung | Location::SmallOld => self.unlink_small(slot),
-            Location::Main => self.unlink_main(slot),
+    /// Detaches a resident and returns its previous partition.
+    #[inline]
+    fn unlink_resident(&mut self, slot: Slot) -> Location {
+        let location = self.slots[slot].location;
+        match location {
+            Location::Small => self.small.unlink(&mut self.slots, slot),
+            Location::Main => self.main.unlink(&mut self.slots, slot),
             Location::Free => unreachable!("resident slot cannot be free"),
         }
-    }
-
-    /// Inserts a free slot at the Small head and advances correlation age.
-    fn insert_small_head<I: Index<Slot, Output = SlotState>>(&mut self, states: &I, slot: usize) {
-        // Admission count, rather than live queue length, makes correlation age
-        // monotonic across explicit removal and retention. Wrapping remains
-        // valid because a correlated resident leaves within one bounded window,
-        // long before the counter can complete a full cycle.
-        self.small_admissions = self.small_admissions.wrapping_add(1);
-        let old_head = self.small_head;
-        {
-            let entry = &mut self.slots[slot];
-            assert_eq!(entry.location, Location::Free);
-            entry.location = Location::SmallYoung;
-            entry.prev = UNLINKED;
-            entry.next = old_head.unwrap_or(UNLINKED);
-            entry.admitted_at = self.small_admissions;
-        }
-        if let Some(head) = old_head {
-            self.slots[head].prev = slot;
-        } else {
-            self.small_tail = Some(slot);
-        }
-        self.small_head = Some(slot);
-        self.small_len += 1;
-
-        if self.small_young_tail.is_none() {
-            self.small_young_tail = Some(slot);
-        }
-        // Only the oldest correlated survivor can leave the window after one
-        // new admission because Small preserves admission order.
-        let demoted = self
-            .small_young_tail
-            .expect("nonempty correlation window must have a tail");
-        let age = self
-            .small_admissions
-            .wrapping_sub(self.slots[demoted].admitted_at);
-        if age < self.correlation_window {
-            return;
-        }
-
-        let new_boundary = self.slots[demoted].prev;
-        assert_ne!(new_boundary, UNLINKED);
-        // Discard references made inside the correlation window. Only a hit
-        // after the entry becomes old should promote it to Main.
-        states[demoted].0.store(0, Ordering::Relaxed);
-        self.slots[demoted].location = Location::SmallOld;
-        self.slots[demoted].admitted_at = 0;
-        self.small_young_tail = Some(new_boundary);
-    }
-
-    /// Detaches a resident from Small and repairs its correlation boundary.
-    fn unlink_small(&mut self, slot: usize) {
-        let location = self.slots[slot].location;
-        assert!(matches!(
-            location,
-            Location::SmallYoung | Location::SmallOld
-        ));
-        let prev = self.slots[slot].prev;
-        let next = self.slots[slot].next;
-        if prev != UNLINKED {
-            self.slots[prev].next = next;
-        } else {
-            self.small_head = linked(next);
-        }
-        if next != UNLINKED {
-            self.slots[next].prev = prev;
-        } else {
-            self.small_tail = linked(prev);
-        }
-
-        self.small_len -= 1;
-        // Removing a correlated resident shrinks the live window without
-        // making any older resident young again.
-        if location == Location::SmallYoung && self.small_young_tail == Some(slot) {
-            self.small_young_tail = linked(prev);
-        }
-
-        self.slots[slot] = ResidentSlot::default();
-    }
-
-    /// Inserts a free slot immediately before the Main hand.
-    fn insert_main(&mut self, slot: usize) {
-        assert!(self.main_len < self.main_capacity);
-        let Some(hand) = self.main_hand else {
-            // A one-entry ring links the resident to itself and points the hand
-            // at that sole eviction candidate.
-            let entry = &mut self.slots[slot];
-            assert_eq!(entry.location, Location::Free);
-            entry.location = Location::Main;
-            entry.prev = slot;
-            entry.next = slot;
-            self.main_hand = Some(slot);
-            self.main_len = 1;
-            return;
-        };
-
-        // New residents start behind the current hand, so they are considered
-        // only after the existing CLOCK sweep reaches them.
-        let prev = self.slots[hand].prev;
-        assert_ne!(prev, UNLINKED);
-        {
-            let entry = &mut self.slots[slot];
-            assert_eq!(entry.location, Location::Free);
-            entry.location = Location::Main;
-            entry.prev = prev;
-            entry.next = hand;
-        }
-        self.slots[prev].next = slot;
-        self.slots[hand].prev = slot;
-        self.main_len += 1;
-    }
-
-    /// Detaches a resident from Main and advances the hand when necessary.
-    fn unlink_main(&mut self, slot: usize) {
-        assert_eq!(self.slots[slot].location, Location::Main);
-        if self.main_len == 1 {
-            assert_eq!(self.main_hand, Some(slot));
-            self.main_hand = None;
-            self.main_len = 0;
-        } else {
-            let prev = self.slots[slot].prev;
-            let next = self.slots[slot].next;
-            assert_ne!(prev, UNLINKED);
-            assert_ne!(next, UNLINKED);
-            self.slots[prev].next = next;
-            self.slots[next].prev = prev;
-            if self.main_hand == Some(slot) {
-                self.main_hand = Some(next);
-            }
-            self.main_len -= 1;
-        }
-        self.slots[slot] = ResidentSlot::default();
-    }
-
-    /// Adds an evicted Small key to the bounded Ghost FIFO.
-    fn push_ghost(&mut self, key: K) {
-        if self.ghost_capacity == 0 {
-            return;
-        }
-        // Prefer recycled storage, then grow to the Ghost bound, then reuse
-        // the oldest live slot after removing its previous key.
-        let slot = if let Some(slot) = self.ghost_free.pop() {
-            slot
-        } else if self.ghost_slots.len() < self.ghost_capacity {
-            let slot = self.ghost_slots.len();
-            self.ghost_slots.push(GhostSlot {
-                key: None,
-                prev: UNLINKED,
-                next: UNLINKED,
-            });
-            slot
-        } else {
-            let slot = self.ghost_tail.expect("full Ghost must have a tail");
-            self.remove_ghost(slot, false);
-            slot
-        };
-
-        let old_head = self.ghost_head;
-        {
-            let entry = &mut self.ghost_slots[slot];
-            assert!(entry.key.is_none());
-            // Ghost keeps one key in its hash index and one in its FIFO slot,
-            // which avoids per-entry shared ownership between the structures.
-            entry.key = Some(key.clone());
-            entry.prev = UNLINKED;
-            entry.next = old_head.unwrap_or(UNLINKED);
-        }
-        if let Some(head) = old_head {
-            self.ghost_slots[head].prev = slot;
-        } else {
-            self.ghost_tail = Some(slot);
-        }
-        self.ghost_head = Some(slot);
-        self.ghost_index.insert(key, slot);
-    }
-
-    /// Removes exact history for `key` and reports whether it was present.
-    fn discard_ghost(&mut self, key: &K) -> bool {
-        let Some(slot) = self.ghost_index.remove(key) else {
-            return false;
-        };
-        self.unlink_ghost(slot, true);
-        true
-    }
-
-    /// Removes a Ghost slot from both the FIFO and exact membership index.
-    fn remove_ghost(&mut self, slot: usize, recycle: bool) {
-        let key = self.unlink_ghost(slot, recycle);
-        let removed = self.ghost_index.remove(&key);
-        assert_eq!(removed, Some(slot));
-    }
-
-    /// Detaches a Ghost slot from the FIFO and returns its owned key.
-    ///
-    /// When `recycle` is true, the detached position is added to the free list.
-    fn unlink_ghost(&mut self, slot: usize, recycle: bool) -> K {
-        let prev = self.ghost_slots[slot].prev;
-        let next = self.ghost_slots[slot].next;
-        if prev != UNLINKED {
-            self.ghost_slots[prev].next = next;
-        } else {
-            self.ghost_head = linked(next);
-        }
-        if next != UNLINKED {
-            self.ghost_slots[next].prev = prev;
-        } else {
-            self.ghost_tail = linked(prev);
-        }
-
-        let key = self.ghost_slots[slot]
-            .key
-            .take()
-            .expect("linked Ghost entry must have a key");
-        self.ghost_slots[slot].prev = UNLINKED;
-        self.ghost_slots[slot].next = UNLINKED;
-        if recycle {
-            self.ghost_free.push(slot);
-        }
-        key
-    }
-
-    /// Removes all Ghost history and resets its reusable slot metadata.
-    fn clear_ghost(&mut self) {
-        self.ghost_index.clear();
-        self.ghost_slots.clear();
-        self.ghost_free.clear();
-        self.ghost_head = None;
-        self.ghost_tail = None;
+        location
     }
 }
 
 impl<K: Hash + Eq + Clone> Policy<K> for Clock2QPlus<K> {
     type SlotState = SlotState;
 
-    /// Constructs an empty Clock2Q+ policy for the cache's capacity.
     fn new(capacity: NonZeroUsize) -> Self {
         Self::with_capacity(capacity)
     }
 
-    /// Records an eligible hit through inline atomic slot state.
     #[inline]
     fn hit(&self, _slot: Slot, state: &SlotState) {
         state.record_hit();
     }
 
-    /// Records an eligible hit through exclusively borrowed slot state.
     #[inline]
     fn hit_mut(&mut self, _slot: Slot, state: &mut SlotState) {
         state.record_hit_mut();
     }
 
-    /// Selects storage, applies policy transitions, and returns initial state.
     fn insert<I, C>(
         &mut self,
         states: &I,
@@ -632,76 +719,71 @@ impl<K: Hash + Eq + Clone> Policy<K> for Clock2QPlus<K> {
         I: Index<Slot, Output = SlotState>,
         C: FnOnce(Option<Slot>) -> Claimed<K>,
     {
-        let admission = self.admission(key, has_vacancy);
-        let mut promotion = None;
-        // Selection may detach a Small resident for deferred promotion, but
-        // the cache slot is not claimed until the complete victim is known.
-        let victim = match admission {
-            Admission::Small => self.select_small(states, &mut promotion, has_vacancy),
-            Admission::Main => self.select_for_main(states),
-        };
+        // Consult and consume exact Ghost history at insertion time. Keeping
+        // this separate makes partition selection free of hidden mutation.
+        let ghost_hit = self.ghost.discard(key);
+        let admission = self.admission(ghost_hit, has_vacancy);
+        let plan = self.plan(states, admission, has_vacancy);
+        let victim = plan.victim();
 
         // Claim transfers an evicted key to the policy without cloning it.
-        let slot = match claim(victim) {
-            Claimed::Vacant(slot) => slot,
-            Claimed::Evicted(key) => {
-                let slot = victim.expect("an eviction claim requires a victim");
-                let location = self.slots[slot].location;
-                self.unlink_resident(slot);
+        let slot = match (plan, claim(victim)) {
+            (InsertionPlan::Vacant, Claimed::Vacant(slot)) => slot,
+            (
+                InsertionPlan::Evict { victim } | InsertionPlan::PromoteThenEvict { victim, .. },
+                Claimed::Evicted(key),
+            ) => {
+                let location = self.unlink_resident(victim);
                 // Only Small evictions become Ghost evidence. Main victims
                 // have already passed the admission filter.
-                if matches!(location, Location::SmallYoung | Location::SmallOld) {
-                    self.push_ghost(key);
+                if location == Location::Small {
+                    self.ghost.push(key);
                 }
-                slot
+                victim
             }
+            _ => unreachable!("cache claim must match the insertion plan"),
         };
 
         assert_eq!(self.slots[slot].location, Location::Free);
-        // Finish a deferred Small-to-Main promotion before attaching the
-        // incoming entry to the slot claimed from Main.
-        if let Some(promoted) = promotion {
-            self.insert_main(promoted);
+        if let InsertionPlan::PromoteThenEvict { promoted, .. } = plan {
+            // Claim has detached the Main victim from the cache index and the
+            // previous arm has detached it from the ring. Move the retained
+            // Small tail into the resulting Main vacancy.
+            self.small.unlink(&mut self.slots, promoted);
+            states[promoted].reset();
+            self.main.insert(&mut self.slots, promoted);
         }
         self.attach(states, slot, admission);
         (slot, SlotState::new(admission))
     }
 
-    /// Forgets Ghost history and detaches the resident slot when present.
     fn remove(&mut self, slot: Option<Slot>, key: &K) {
         if let Some(slot) = slot {
             // Resident and Ghost keys are disjoint, so resident removal can
             // detach directly without probing nonresident history.
             self.unlink_resident(slot);
         } else {
-            self.discard_ghost(key);
+            self.ghost.discard(key);
         }
     }
 
-    /// Resets all resident topology and nonresident history.
     fn clear(&mut self) {
         self.slots.fill(ResidentSlot::default());
-        self.small_head = None;
-        self.small_tail = None;
-        self.small_young_tail = None;
-        self.small_admissions = 0;
-        self.small_len = 0;
-        self.main_hand = None;
-        self.main_len = 0;
-        self.clear_ghost();
+        self.small.clear();
+        self.main.clear();
+        self.ghost.clear();
     }
 }
 
 impl<K: Hash + Eq + Clone, V> core::fmt::Debug for Cache<K, V, Clock2QPlus<K>> {
-    /// Formats cache occupancy and Clock2Q+ partition sizes.
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("Clock2QPlus")
             .field("len", &self.index.len())
             .field("capacity", &self.policy.slots.len())
-            .field("small_target", &self.policy.small_capacity)
-            .field("small_len", &self.policy.small_len)
-            .field("main_len", &self.policy.main_len)
-            .field("ghost_len", &self.policy.ghost_index.len())
+            .field("small_target", &self.policy.small.capacity)
+            .field("small_len", &self.policy.small.len)
+            .field("main_len", &self.policy.main.len)
+            .field("ghost_len", &self.policy.ghost.index.len())
             .finish()
     }
 }
@@ -722,7 +804,12 @@ mod tests {
 
     /// Returns the number of residents attached to either partition.
     const fn residents<K>(policy: &Clock2QPlus<K>) -> usize {
-        policy.small_len + policy.main_len
+        policy.small.len + policy.main.len
+    }
+
+    /// Returns the packed policy state observed by tests.
+    fn bits(state: &SlotState) -> u8 {
+        state.0.load(Ordering::Relaxed)
     }
 
     /// One resident in the slot-independent reference model.
@@ -848,27 +935,24 @@ mod tests {
         /// Admits a cold key to Small, promoting its tail when eligible.
         fn admit_small(&mut self, key: u8, has_vacancy: bool) {
             if !has_vacancy {
-                loop {
-                    let tail = self.small.back().unwrap();
-                    let admitted_at = tail
-                        .admitted_at
-                        .expect("Small entry must have an admission generation");
-                    let young =
-                        self.small_admissions - admitted_at < self.correlation_window as u64;
-                    if young || !tail.referenced {
-                        let victim = self.small.pop_back().unwrap().key;
-                        self.push_ghost(victim);
-                        break;
-                    }
-
+                // The partition bounds and full occupancy force both
+                // partitions to their targets, so at most one promotion is
+                // possible before Main must evict.
+                assert_eq!(self.small.len(), self.small_capacity);
+                assert_eq!(self.main.len(), self.main_capacity);
+                let tail = self.small.back().unwrap();
+                let admitted_at = tail
+                    .admitted_at
+                    .expect("Small entry must have an admission generation");
+                let young = self.small_admissions - admitted_at < self.correlation_window as u64;
+                if young || !tail.referenced {
+                    let victim = self.small.pop_back().unwrap().key;
+                    self.push_ghost(victim);
+                } else {
                     let mut promoted = self.small.pop_back().unwrap();
                     promoted.referenced = false;
                     promoted.admitted_at = None;
-                    if self.main.len() == self.main_capacity {
-                        self.evict_main();
-                        self.main.push_back(promoted);
-                        break;
-                    }
+                    self.evict_main();
                     self.main.push_back(promoted);
                 }
             }
@@ -884,29 +968,10 @@ mod tests {
         fn admit_main(&mut self, key: u8, has_vacancy: bool) {
             if self.main.len() == self.main_capacity {
                 self.evict_main();
-            } else if !has_vacancy {
-                loop {
-                    let tail = self.small.back().unwrap();
-                    let admitted_at = tail
-                        .admitted_at
-                        .expect("Small entry must have an admission generation");
-                    let young =
-                        self.small_admissions - admitted_at < self.correlation_window as u64;
-                    if young || !tail.referenced {
-                        let victim = self.small.pop_back().unwrap().key;
-                        self.push_ghost(victim);
-                        break;
-                    }
-
-                    let mut promoted = self.small.pop_back().unwrap();
-                    promoted.referenced = false;
-                    promoted.admitted_at = None;
-                    self.main.push_back(promoted);
-                    if self.main.len() == self.main_capacity {
-                        self.evict_main();
-                        break;
-                    }
-                }
+            } else {
+                // A non-full Main is possible only while the cache has unused
+                // resident capacity.
+                assert!(has_vacancy);
             }
             self.main.push_back(ReferenceEntry {
                 key,
@@ -980,8 +1045,8 @@ mod tests {
     impl<K: Hash + Eq + Clone + core::fmt::Debug, V> Cache<K, V, Clock2QPlus<K>> {
         /// Returns Small slot order from newest to oldest.
         fn small_order(&self) -> Vec<usize> {
-            let mut order = Vec::with_capacity(self.policy.small_len);
-            let mut current = self.policy.small_head;
+            let mut order = Vec::with_capacity(self.policy.small.len);
+            let mut current = self.policy.small.head;
             while let Some(slot) = current {
                 order.push(slot);
                 current = linked(self.policy.slots[slot].next);
@@ -991,8 +1056,8 @@ mod tests {
 
         /// Returns Main slot order starting at the CLOCK hand.
         fn main_order(&self) -> Vec<usize> {
-            let mut order = Vec::with_capacity(self.policy.main_len);
-            let Some(hand) = self.policy.main_hand else {
+            let mut order = Vec::with_capacity(self.policy.main.len);
+            let Some(hand) = self.policy.main.hand else {
                 return order;
             };
             let mut current = hand;
@@ -1008,11 +1073,11 @@ mod tests {
 
         /// Returns Ghost slot order from newest to oldest.
         fn ghost_order(&self) -> Vec<usize> {
-            let mut order = Vec::with_capacity(self.policy.ghost_index.len());
-            let mut current = self.policy.ghost_head;
+            let mut order = Vec::with_capacity(self.policy.ghost.index.len());
+            let mut current = self.policy.ghost.head;
             while let Some(slot) = current {
                 order.push(slot);
-                current = linked(self.policy.ghost_slots[slot].next);
+                current = linked(self.policy.ghost.slots[slot].next);
             }
             order
         }
@@ -1038,7 +1103,7 @@ mod tests {
             self.ghost_order()
                 .into_iter()
                 .map(|slot| {
-                    self.policy.ghost_slots[slot]
+                    self.policy.ghost.slots[slot]
                         .key
                         .as_ref()
                         .expect("live Ghost entry must have a key")
@@ -1051,8 +1116,8 @@ mod tests {
         pub(crate) fn check_policy_invariants(&self) {
             let policy = &self.policy;
             assert!(residents(policy) <= policy.slots.len());
-            assert!(policy.small_len <= policy.small_capacity);
-            assert!(policy.main_len <= policy.main_capacity);
+            assert!(policy.small.len <= policy.small.capacity);
+            assert!(policy.main.len <= policy.main.capacity);
             assert_eq!(self.index.len(), residents(policy));
             assert_eq!(self.index.len() + self.free.len(), self.slots.len());
 
@@ -1060,10 +1125,11 @@ mod tests {
             assert_eq!(free.len(), self.free.len(), "duplicate resident free slot");
             let small = self.small_order();
             let main = self.main_order();
-            assert_eq!(small.len(), policy.small_len);
-            assert_eq!(main.len(), policy.main_len);
+            assert_eq!(small.len(), policy.small.len);
+            assert_eq!(main.len(), policy.main.len);
             let young_len = policy
-                .small_young_tail
+                .small
+                .young_tail
                 .map(|tail| {
                     small
                         .iter()
@@ -1072,22 +1138,18 @@ mod tests {
                         + 1
                 })
                 .unwrap_or(0);
-            assert!(young_len <= policy.correlation_window);
-            assert!(young_len <= policy.small_len);
+            assert!(young_len <= policy.small.correlation_window);
+            assert!(young_len <= policy.small.len);
 
             let mut resident = HashSet::new();
             for (rank, &slot) in small.iter().enumerate() {
                 assert!(resident.insert(slot), "duplicate Small resident {slot}");
                 assert!(self.slots[slot].live);
-                let expected = if rank < young_len {
-                    Location::SmallYoung
-                } else {
-                    Location::SmallOld
-                };
-                assert_eq!(policy.slots[slot].location, expected);
-                let state = self.slots[slot].state.0.load(Ordering::Relaxed);
-                assert_eq!(state & CORRELATED != 0, expected == Location::SmallYoung);
-                if expected == Location::SmallYoung {
+                assert_eq!(policy.slots[slot].location, Location::Small);
+                let state = bits(&self.slots[slot].state);
+                let young = rank < young_len;
+                assert_eq!(state & CORRELATED != 0, young);
+                if young {
                     assert_eq!(state, CORRELATED);
                 }
                 let expected_prev = rank.checked_sub(1).map(|rank| small[rank]);
@@ -1095,22 +1157,19 @@ mod tests {
                 assert_eq!(linked(policy.slots[slot].prev), expected_prev);
                 assert_eq!(linked(policy.slots[slot].next), expected_next);
             }
-            assert_eq!(policy.small_head, small.first().copied());
-            assert_eq!(policy.small_tail, small.last().copied());
+            assert_eq!(policy.small.head, small.first().copied());
+            assert_eq!(policy.small.tail, small.last().copied());
             let expected_young_tail = young_len
                 .checked_sub(1)
                 .and_then(|rank| small.get(rank))
                 .copied();
-            assert_eq!(policy.small_young_tail, expected_young_tail);
+            assert_eq!(policy.small.young_tail, expected_young_tail);
 
             for (rank, &slot) in main.iter().enumerate() {
                 assert!(resident.insert(slot), "resident {slot} in two queues");
                 assert!(self.slots[slot].live);
                 assert_eq!(policy.slots[slot].location, Location::Main);
-                assert_eq!(
-                    self.slots[slot].state.0.load(Ordering::Relaxed) & CORRELATED,
-                    0
-                );
+                assert_eq!(bits(&self.slots[slot].state) & CORRELATED, 0);
                 assert_eq!(
                     policy.slots[slot].prev,
                     main[(rank + main.len() - 1) % main.len()]
@@ -1136,29 +1195,29 @@ mod tests {
                 assert_eq!(policy.slots[slot].location, Location::Free);
             }
 
-            assert!(policy.ghost_index.len() <= policy.ghost_capacity);
+            assert!(policy.ghost.index.len() <= policy.ghost.capacity);
             let ghost = self.ghost_order();
-            assert_eq!(ghost.len(), policy.ghost_index.len());
-            let ghost_free: HashSet<_> = policy.ghost_free.iter().copied().collect();
-            assert_eq!(ghost_free.len(), policy.ghost_free.len());
+            assert_eq!(ghost.len(), policy.ghost.index.len());
+            let ghost_free: HashSet<_> = policy.ghost.free.iter().copied().collect();
+            assert_eq!(ghost_free.len(), policy.ghost.free.len());
             let mut seen_ghost = HashSet::new();
             for (rank, &slot) in ghost.iter().enumerate() {
                 assert!(seen_ghost.insert(slot));
                 assert!(!ghost_free.contains(&slot));
-                let key = policy.ghost_slots[slot]
+                let key = policy.ghost.slots[slot]
                     .key
                     .as_ref()
                     .expect("linked Ghost entry must have a key");
-                assert_eq!(policy.ghost_index.get(key), Some(&slot));
+                assert_eq!(policy.ghost.index.get(key), Some(&slot));
                 assert!(!self.index.contains_key(key));
                 let expected_prev = rank.checked_sub(1).map(|rank| ghost[rank]);
                 let expected_next = ghost.get(rank + 1).copied();
-                assert_eq!(linked(policy.ghost_slots[slot].prev), expected_prev);
-                assert_eq!(linked(policy.ghost_slots[slot].next), expected_next);
+                assert_eq!(linked(policy.ghost.slots[slot].prev), expected_prev);
+                assert_eq!(linked(policy.ghost.slots[slot].next), expected_next);
             }
-            assert_eq!(policy.ghost_head, ghost.first().copied());
-            assert_eq!(policy.ghost_tail, ghost.last().copied());
-            for (slot, entry) in policy.ghost_slots.iter().enumerate() {
+            assert_eq!(policy.ghost.head, ghost.first().copied());
+            assert_eq!(policy.ghost.tail, ghost.last().copied());
+            for (slot, entry) in policy.ghost.slots.iter().enumerate() {
                 if seen_ghost.contains(&slot) {
                     assert!(entry.key.is_some());
                 } else {
@@ -1181,8 +1240,7 @@ mod tests {
             .small_order()
             .into_iter()
             .map(|slot| {
-                let referenced = cache.policy.slots[slot].location == Location::SmallOld
-                    && cache.slots[slot].state.0.load(Ordering::Relaxed) & REFERENCED != 0;
+                let referenced = bits(&cache.slots[slot].state) & REFERENCED != 0;
                 (cache.slots[slot].key, referenced)
             })
             .collect()
@@ -1196,7 +1254,7 @@ mod tests {
             .map(|slot| {
                 (
                     cache.slots[slot].key,
-                    cache.slots[slot].state.0.load(Ordering::Relaxed) & REFERENCED != 0,
+                    bits(&cache.slots[slot].state) & REFERENCED != 0,
                 )
             })
             .collect()
@@ -1216,10 +1274,10 @@ mod tests {
         ];
         for (capacity, small, main, window, ghost) in expected {
             let cache = TestCache::<u64, u64>::new(NonZeroUsize::new(capacity).unwrap());
-            assert_eq!(cache.policy.small_capacity, small);
-            assert_eq!(cache.policy.main_capacity, main);
-            assert_eq!(cache.policy.correlation_window, window);
-            assert_eq!(cache.policy.ghost_capacity, ghost);
+            assert_eq!(cache.policy.small.capacity, small);
+            assert_eq!(cache.policy.main.capacity, main);
+            assert_eq!(cache.policy.small.correlation_window, window);
+            assert_eq!(cache.policy.ghost.capacity, ghost);
             cache.check_invariants();
         }
 
@@ -1261,10 +1319,7 @@ mod tests {
         assert_eq!(cache.main_keys(), (2..20).collect::<Vec<_>>());
         for key in 2..20u64 {
             let slot = cache.index[&key];
-            assert_eq!(
-                cache.slots[slot].state.0.load(Ordering::Relaxed) & REFERENCED,
-                0
-            );
+            assert_eq!(bits(&cache.slots[slot].state) & REFERENCED, 0);
         }
         cache.check_invariants();
     }
@@ -1282,7 +1337,7 @@ mod tests {
         cache.retain(|key, _| *key == 1);
         assert_eq!(cache.len(), 0);
         assert_eq!(cache.ghost_keys(), vec![1]);
-        assert!(!cache.policy.ghost_index.is_empty());
+        assert!(!cache.policy.ghost.index.is_empty());
 
         cache.retain(|_, _| false);
         assert_eq!(residents(&cache.policy), 0);
@@ -1301,10 +1356,7 @@ mod tests {
         assert_eq!(correlated.small_keys(), vec![4, 3, 2, 1]);
         assert_eq!(correlated.get(&4), Some(&4));
         let slot = correlated.index[&4];
-        assert_eq!(
-            correlated.slots[slot].state.0.load(Ordering::Relaxed) & REFERENCED,
-            0
-        );
+        assert_eq!(bits(&correlated.slots[slot].state) & REFERENCED, 0);
         for key in 41..=44u64 {
             correlated.put(key, key);
         }
@@ -1324,10 +1376,7 @@ mod tests {
         assert!(reused.small_keys().contains(&41));
         assert!(reused.main_keys().contains(&1));
         let slot = reused.index[&1];
-        assert_eq!(
-            reused.slots[slot].state.0.load(Ordering::Relaxed) & REFERENCED,
-            0
-        );
+        assert_eq!(bits(&reused.slots[slot].state) & REFERENCED, 0);
         assert!(reused.ghost_keys().is_empty());
         reused.check_invariants();
     }
@@ -1449,14 +1498,11 @@ mod tests {
             assert_eq!(cache.get(&key), Some(&key));
         }
         cache.put(20, 20);
-        assert_eq!(cache.policy.main_len, cache.policy.main_capacity);
-        assert_eq!(cache.policy.small_len, 2);
+        assert_eq!(cache.policy.main.len, cache.policy.main.capacity);
+        assert_eq!(cache.policy.small.len, 2);
         let slot = cache.index[&0];
         assert!(cache.main_keys().contains(&0));
-        assert_eq!(
-            cache.slots[slot].state.0.load(Ordering::Relaxed) & REFERENCED,
-            0
-        );
+        assert_eq!(bits(&cache.slots[slot].state) & REFERENCED, 0);
 
         // Repeat the transition with a full Main CLOCK. The promoted key keeps
         // its slot and starts in Main with a clear reference bit.
@@ -1466,13 +1512,10 @@ mod tests {
 
         assert!(cache.main_keys().contains(&promoted));
         let slot = cache.index[&promoted];
-        assert_eq!(
-            cache.slots[slot].state.0.load(Ordering::Relaxed) & REFERENCED,
-            0
-        );
+        assert_eq!(bits(&cache.slots[slot].state) & REFERENCED, 0);
         assert!(cache.small_keys().contains(&21));
-        assert_eq!(cache.policy.main_len, cache.policy.main_capacity);
-        assert_eq!(cache.policy.small_len, 2);
+        assert_eq!(cache.policy.main.len, cache.policy.main.capacity);
+        assert_eq!(cache.policy.small.len, 2);
         cache.check_invariants();
     }
 
@@ -1515,7 +1558,7 @@ mod tests {
             clock2qplus.put(key, key);
         }
         let mut protected = 1..10u64;
-        assert_eq!(clock2qplus.policy.main_len, 9);
+        assert_eq!(clock2qplus.policy.main.len, 9);
 
         // Plain CLOCK provides the control case and loses every original key
         // to the same scan.
@@ -1591,7 +1634,7 @@ mod tests {
         cache.clear();
         assert!(cache.is_empty());
         assert_eq!(residents(&cache.policy), 0);
-        assert!(cache.policy.ghost_index.is_empty());
+        assert!(cache.policy.ghost.index.is_empty());
         assert!(cache.ghost_keys().is_empty());
         cache.check_invariants();
     }

--- a/utils/src/cache/sieve.rs
+++ b/utils/src/cache/sieve.rs
@@ -13,8 +13,12 @@
 //! Keeping survivors in place is the distinguishing feature of SIEVE. Older
 //! residents that continue receiving hits survive repeated passes, while new
 //! one-hit residents remain near the head and are reconsidered quickly as the
-//! hand completes a pass. This provides scan resistance without moving queue
-//! entries on the shared hit path.
+//! hand completes a pass. This provides quick demotion and one-hit filtering
+//! without moving queue entries on the shared hit path.
+//!
+//! SIEVE retains no history after eviction, so it is not generally
+//! scan-resistant when page or block scans intermix with hot entries. Benchmark
+//! it against the intended workload before selecting it over another policy.
 //!
 //! Resident keys and values remain in stable [super::Cache] slots. The visited
 //! bit is stored inline as [Policy::SlotState], while insertion order and the
@@ -103,16 +107,10 @@ impl Sieve {
         self.head = Some(slot);
     }
 
-    /// Detaches a resident from the queue and repairs the eviction hand.
+    /// Detaches a resident from the queue.
     #[inline]
-    fn unlink(&mut self, slot: Slot) {
+    fn detach(&mut self, slot: Slot) {
         let ResidentSlot { previous, next } = self.slots[slot];
-
-        // `previous` points toward the newer head. If the removed resident is
-        // the next candidate, continue the current pass in that direction.
-        if self.hand == Some(slot) {
-            self.hand = linked(previous);
-        }
 
         // Splice the resident out while repairing either its newer neighbor or
         // the head endpoint.
@@ -128,8 +126,6 @@ impl Sieve {
         } else {
             self.tail = linked(previous);
         }
-
-        self.slots[slot] = ResidentSlot::default();
     }
 }
 
@@ -221,7 +217,7 @@ impl<K> Policy<K> for Sieve {
         // Continue the next pass toward the head from the victim's previous
         // neighbor. A missing neighbor restarts the following pass at the tail.
         self.hand = next_hand;
-        self.unlink(victim);
+        self.detach(victim);
 
         // SIEVE keeps survivors stationary, but the incoming resident always
         // reuses the victim's stable slot at the queue head.
@@ -232,7 +228,14 @@ impl<K> Policy<K> for Sieve {
     #[inline]
     fn remove(&mut self, slot: Option<Slot>, _key: &K) {
         if let Some(slot) = slot {
-            self.unlink(slot);
+            // If the removed resident is the next candidate, continue the
+            // current pass toward the newer head.
+            if self.hand == Some(slot) {
+                self.hand = linked(self.slots[slot].previous);
+            }
+
+            self.detach(slot);
+            self.slots[slot] = ResidentSlot::default();
         }
     }
 
@@ -495,6 +498,15 @@ mod tests {
         cache.clear();
         assert!(cache.is_empty());
         assert_eq!(cache.hand_key(), None);
+        cache.check_invariants();
+
+        // Clearing leaves the fixed link arena ready for free-slot reuse.
+        cache.put(7, 70);
+        cache.put(8, 80);
+        assert_eq!(cache.keys(), vec![8, 7]);
+        assert_eq!(cache.hand_key(), None);
+        assert!(!cache.visited(&7));
+        assert!(!cache.visited(&8));
         cache.check_invariants();
     }
 

--- a/utils/src/cache/sieve.rs
+++ b/utils/src/cache/sieve.rs
@@ -1,0 +1,559 @@
+//! The SIEVE cache replacement policy.
+//!
+//! SIEVE keeps residents in a first-in, first-out queue ordered from the newest
+//! entry at the head to the oldest entry at the tail. Each resident has one
+//! visited bit, and an eviction hand moves from the tail toward the head.
+//!
+//! A hit sets the resident's visited bit without changing its queue position.
+//! On a full-cache insertion, the hand examines residents until it finds an
+//! unvisited victim. Visited residents have their bits cleared and remain in
+//! place. The victim is removed, the hand remembers the next position toward
+//! the head, and the new resident enters the head unvisited.
+//!
+//! Keeping survivors in place is the distinguishing feature of SIEVE. Older
+//! residents that continue receiving hits survive repeated passes, while new
+//! one-hit residents remain near the head and are reconsidered quickly as the
+//! hand completes a pass. This provides scan resistance without moving queue
+//! entries on the shared hit path.
+//!
+//! Resident keys and values remain in stable [super::Cache] slots. The visited
+//! bit is stored inline as [Policy::SlotState], while insertion order and the
+//! eviction hand are maintained by the policy.
+//!
+//! # References
+//!
+//! - [SIEVE is Simpler than LRU: an Efficient Turn-Key Eviction Algorithm for
+//!   Web Caches](https://www.usenix.org/system/files/nsdi24-zhang-yazhuo.pdf),
+//!   Algorithm 1.
+
+use super::{Cache, Claimed, Policy, Slot};
+#[cfg(not(feature = "std"))]
+use alloc::{vec, vec::Vec};
+use core::{
+    hash::Hash,
+    num::NonZeroUsize,
+    ops::Index,
+    sync::atomic::{AtomicBool, Ordering},
+};
+
+/// Sentinel used when a policy-owned slot has no neighbor.
+const UNLINKED: Slot = Slot::MAX;
+
+/// Converts the internal link sentinel into an optional slot.
+#[inline]
+const fn linked(slot: Slot) -> Option<Slot> {
+    if slot == UNLINKED { None } else { Some(slot) }
+}
+
+/// Policy-owned queue links for one stable cache slot.
+#[derive(Clone, Copy)]
+struct ResidentSlot {
+    /// Previous resident toward the newer queue head.
+    previous: Slot,
+    /// Next resident toward the older queue tail.
+    next: Slot,
+}
+
+impl Default for ResidentSlot {
+    fn default() -> Self {
+        Self {
+            previous: UNLINKED,
+            next: UNLINKED,
+        }
+    }
+}
+
+/// SIEVE admission and eviction policy.
+///
+/// SIEVE combines a FIFO queue with a backward-moving eviction hand. Shared
+/// hits set one relaxed atomic bit and never mutate queue topology. Full-cache
+/// insertions clear and skip visited residents, evict the first unvisited
+/// resident, and insert the new resident at the queue head as unvisited.
+pub struct Sieve {
+    /// Queue links indexed by stable cache slot.
+    slots: Vec<ResidentSlot>,
+    /// Newest resident in insertion order.
+    head: Option<Slot>,
+    /// Oldest resident in insertion order.
+    tail: Option<Slot>,
+    /// Next resident examined during eviction.
+    hand: Option<Slot>,
+}
+
+impl Sieve {
+    /// Adds a detached slot at the queue head.
+    #[inline]
+    fn push(&mut self, slot: Slot) {
+        let old_head = self.head;
+        self.slots[slot] = ResidentSlot {
+            previous: UNLINKED,
+            next: old_head.unwrap_or(UNLINKED),
+        };
+
+        if let Some(head) = old_head {
+            self.slots[head].previous = slot;
+        } else {
+            self.tail = Some(slot);
+        }
+        self.head = Some(slot);
+    }
+
+    /// Detaches a resident from the queue and repairs the eviction hand.
+    #[inline]
+    fn unlink(&mut self, slot: Slot) {
+        let ResidentSlot { previous, next } = self.slots[slot];
+
+        if self.hand == Some(slot) {
+            self.hand = linked(previous);
+        }
+        if previous != UNLINKED {
+            self.slots[previous].next = next;
+        } else {
+            self.head = linked(next);
+        }
+        if next != UNLINKED {
+            self.slots[next].previous = previous;
+        } else {
+            self.tail = linked(previous);
+        }
+
+        self.slots[slot] = ResidentSlot::default();
+    }
+}
+
+impl<K> Policy<K> for Sieve {
+    type SlotState = AtomicBool;
+
+    #[inline]
+    fn new(capacity: NonZeroUsize) -> Self {
+        Self {
+            slots: vec![ResidentSlot::default(); capacity.get()],
+            head: None,
+            tail: None,
+            hand: None,
+        }
+    }
+
+    #[inline]
+    fn hit(&self, _slot: Slot, state: &AtomicBool) {
+        // Skip the store when the bit is already set. Under concurrent readers,
+        // an unconditional store would dirty the cache line on every hit and
+        // bounce it between cores.
+        if !state.load(Ordering::Relaxed) {
+            state.store(true, Ordering::Relaxed);
+        }
+    }
+
+    #[inline]
+    fn hit_mut(&mut self, _slot: Slot, state: &mut AtomicBool) {
+        *state.get_mut() = true;
+    }
+
+    #[inline]
+    fn insert<I, C>(
+        &mut self,
+        states: &I,
+        _key: &K,
+        has_vacancy: bool,
+        claim: C,
+    ) -> (Slot, AtomicBool)
+    where
+        I: Index<Slot, Output = AtomicBool>,
+        C: FnOnce(Option<Slot>) -> Claimed<K>,
+    {
+        if has_vacancy {
+            let Claimed::Vacant(slot) = claim(None) else {
+                unreachable!("vacancy claim returned an eviction");
+            };
+            self.push(slot);
+            return (slot, AtomicBool::new(false));
+        }
+
+        let mut victim = self
+            .hand
+            .or(self.tail)
+            .expect("a full SIEVE cache must have an eviction candidate");
+
+        loop {
+            let visited = &states[victim];
+            if !visited.load(Ordering::Relaxed) {
+                break;
+            }
+
+            // A visited resident survives in place. Clearing its bit gives the
+            // next pass fresh evidence about whether it remains popular.
+            visited.store(false, Ordering::Relaxed);
+            victim = linked(self.slots[victim].previous)
+                .or(self.tail)
+                .expect("a full SIEVE cache must have a queue tail");
+        }
+
+        let next_hand = linked(self.slots[victim].previous);
+        let Claimed::Evicted(_) = claim(Some(victim)) else {
+            unreachable!("victim claim returned vacant capacity");
+        };
+
+        // Continue the next pass toward the head from the victim's previous
+        // neighbor. A missing neighbor restarts the following pass at the tail.
+        self.hand = next_hand;
+        self.unlink(victim);
+        self.push(victim);
+        (victim, AtomicBool::new(false))
+    }
+
+    #[inline]
+    fn remove(&mut self, slot: Option<Slot>, _key: &K) {
+        if let Some(slot) = slot {
+            self.unlink(slot);
+        }
+    }
+
+    #[inline]
+    fn clear(&mut self) {
+        self.slots.fill(ResidentSlot::default());
+        self.head = None;
+        self.tail = None;
+        self.hand = None;
+    }
+}
+
+impl<K: Hash + Eq + Clone, V> core::fmt::Debug for Cache<K, V, Sieve> {
+    fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        formatter
+            .debug_struct("Sieve")
+            .field("len", &self.index.len())
+            .field("capacity", &self.capacity)
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{NZUsize, cache::Cache};
+    use std::{collections::HashSet, sync::Arc, thread};
+
+    type TestCache<K, V> = Cache<K, V, Sieve>;
+
+    impl<K: Hash + Eq + Clone + core::fmt::Debug, V> Cache<K, V, Sieve> {
+        /// Returns resident slots from the newest head to the oldest tail.
+        fn order(&self) -> Vec<Slot> {
+            let mut order = Vec::with_capacity(self.index.len());
+            let mut current = self.policy.head;
+            while let Some(slot) = current {
+                order.push(slot);
+                current = linked(self.policy.slots[slot].next);
+            }
+            order
+        }
+
+        /// Returns resident keys from the newest head to the oldest tail.
+        fn keys(&self) -> Vec<K> {
+            self.order()
+                .into_iter()
+                .map(|slot| self.slots[slot].key.clone())
+                .collect()
+        }
+
+        /// Returns the key currently selected by the eviction hand.
+        fn hand_key(&self) -> Option<&K> {
+            self.policy.hand.map(|slot| &self.slots[slot].key)
+        }
+
+        /// Returns whether a resident's visited bit is set.
+        fn visited(&self, key: &K) -> bool {
+            let slot = self.index[key];
+            self.slots[slot].state.load(Ordering::Relaxed)
+        }
+
+        /// Asserts the SIEVE policy's invariants hold.
+        pub(crate) fn check_policy_invariants(&self) {
+            assert_eq!(self.policy.slots.len(), self.capacity);
+            assert_eq!(self.policy.head.is_none(), self.index.is_empty());
+            assert_eq!(self.policy.tail.is_none(), self.index.is_empty());
+
+            let mut resident = HashSet::new();
+            let mut previous = UNLINKED;
+            let mut current = self.policy.head;
+            while let Some(slot) = current {
+                assert!(slot < self.slots.len());
+                assert!(resident.insert(slot), "duplicate SIEVE resident slot");
+                assert!(self.slots[slot].live);
+                assert_eq!(self.policy.slots[slot].previous, previous);
+                assert_eq!(self.index.get(&self.slots[slot].key), Some(&slot));
+                previous = slot;
+                current = linked(self.policy.slots[slot].next);
+            }
+            assert_eq!(linked(previous), self.policy.tail);
+            assert_eq!(resident.len(), self.index.len());
+
+            for (key, &slot) in &self.index {
+                assert!(resident.contains(&slot));
+                assert_eq!(self.slots[slot].key, *key);
+            }
+            for slot in &self.free {
+                assert!(!resident.contains(slot));
+            }
+            for slot in 0..self.slots.len() {
+                if resident.contains(&slot) {
+                    continue;
+                }
+                assert_eq!(self.policy.slots[slot].previous, UNLINKED);
+                assert_eq!(self.policy.slots[slot].next, UNLINKED);
+            }
+            if let Some(hand) = self.policy.hand {
+                assert!(resident.contains(&hand));
+            }
+        }
+
+        /// Asserts both cache and SIEVE policy invariants hold.
+        fn check_invariants(&self) {
+            self.check_cache_invariants();
+            self.check_policy_invariants();
+        }
+    }
+
+    #[test]
+    fn test_hand_moves_backward_without_moving_survivors() {
+        // Algorithm 1 inserts at the head and begins the first pass at the
+        // tail. Hits mark keys 1 and 3 without changing insertion order.
+        let mut cache = TestCache::new(NZUsize!(4));
+        for key in 1..=4u64 {
+            cache.put(key, key * 10);
+        }
+        assert_eq!(cache.keys(), vec![4, 3, 2, 1]);
+        assert_eq!(cache.hand_key(), None);
+        assert_eq!(cache.get(&1), Some(&10));
+        assert_eq!(cache.get(&3), Some(&30));
+
+        // The first pass clears and retains key 1, then evicts unvisited key 2.
+        // Key 1 remains at the tail and the hand continues at key 3.
+        cache.put(5, 50);
+        assert_eq!(cache.keys(), vec![5, 4, 3, 1]);
+        assert_eq!(cache.hand_key(), Some(&3));
+        assert!(cache.contains(&1));
+        assert!(!cache.visited(&1));
+
+        // The next pass retains key 3 in place and evicts key 4. Fresh key 5
+        // is then unvisited at the head and is the following victim.
+        cache.put(6, 60);
+        assert_eq!(cache.keys(), vec![6, 5, 3, 1]);
+        assert_eq!(cache.hand_key(), Some(&5));
+        assert!(!cache.visited(&3));
+        cache.put(7, 70);
+        assert_eq!(cache.keys(), vec![7, 6, 3, 1]);
+        assert_eq!(cache.hand_key(), Some(&6));
+        assert!(!cache.contains(&5));
+        cache.check_invariants();
+    }
+
+    #[test]
+    fn test_full_visited_pass_wraps_and_clears_bits() {
+        // When every resident has been visited, one full pass clears every bit
+        // before wrapping to evict the oldest resident.
+        let mut cache = TestCache::new(NZUsize!(3));
+        for key in 1..=3u64 {
+            cache.put(key, key);
+            assert_eq!(cache.get(&key), Some(&key));
+        }
+
+        cache.put(4, 4);
+        assert_eq!(cache.keys(), vec![4, 3, 2]);
+        assert_eq!(cache.hand_key(), Some(&2));
+        assert!(!cache.visited(&2));
+        assert!(!cache.visited(&3));
+        assert!(!cache.visited(&4));
+        cache.check_invariants();
+    }
+
+    #[test]
+    fn test_new_residents_enter_unvisited() {
+        // Unlike CLOCK, SIEVE gives a new resident no automatic second chance.
+        // With no intervening hit, the oldest entry is immediately eligible.
+        let mut cache = TestCache::new(NZUsize!(2));
+        cache.put(1u64, 10u64);
+        cache.put(2, 20);
+        assert!(!cache.visited(&1));
+        assert!(!cache.visited(&2));
+
+        cache.put(3, 30);
+        assert!(!cache.contains(&1));
+        assert_eq!(cache.keys(), vec![3, 2]);
+        assert!(!cache.visited(&3));
+        cache.check_invariants();
+    }
+
+    #[test]
+    fn test_existing_key_put_records_a_hit_without_reordering() {
+        let mut cache = TestCache::new(NZUsize!(2));
+        cache.put(1u64, 10u64);
+        cache.put(2, 20);
+
+        // Replacing a resident value is a hit. It marks the entry visited but
+        // leaves it at its original insertion position.
+        assert_eq!(cache.put(1, 11), Some(10));
+        assert_eq!(cache.keys(), vec![2, 1]);
+        assert!(cache.visited(&1));
+
+        // The recorded hit protects key 1 for this pass, so unvisited key 2 is
+        // discarded even though it is newer in insertion order.
+        cache.put(3, 30);
+        assert!(cache.contains(&1));
+        assert!(!cache.contains(&2));
+        assert_eq!(cache.keys(), vec![3, 1]);
+        cache.check_invariants();
+    }
+
+    #[test]
+    fn test_capacity_one_clears_a_visit_then_reuses_the_slot() {
+        let mut cache = TestCache::new(NZUsize!(1));
+        let (slot, value) = cache.get_or_insert_mut(1u64, || 10u64);
+        assert_eq!(*value, 10);
+        assert_eq!(cache.get(&1), Some(&10));
+
+        // The only resident receives one pass to clear its bit, then its stable
+        // slot and retained value are reused for the incoming key.
+        let (reused, value) = cache.get_or_insert_mut(2, || unreachable!());
+        assert_eq!(reused, slot);
+        assert_eq!(*value, 10);
+        *value = 20;
+        assert_eq!(cache.get(&1), None);
+        assert_eq!(cache.get(&2), Some(&20));
+        assert_eq!(cache.hand_key(), None);
+        cache.check_invariants();
+    }
+
+    #[test]
+    fn test_scan_retains_a_revisited_old_resident() {
+        // Revisit the oldest resident before every insertion. Its visited bit
+        // is refreshed between hand passes, so the scan entries are sifted out
+        // while the resident remains in its original queue position.
+        let mut cache = TestCache::new(NZUsize!(4));
+        for key in 0..4u64 {
+            cache.put(key, key);
+        }
+        for key in 4..100u64 {
+            assert_eq!(cache.get(&0), Some(&0));
+            cache.put(key, key);
+            assert!(cache.contains(&0));
+        }
+        assert_eq!(cache.keys().last(), Some(&0));
+        cache.check_invariants();
+    }
+
+    #[test]
+    fn test_remove_and_retain_repair_the_hand_and_queue() {
+        let mut cache = TestCache::new(NZUsize!(5));
+        for key in 1..=5u64 {
+            cache.put(key, key * 10);
+        }
+        assert_eq!(cache.get(&1), Some(&10));
+        cache.put(6, 60);
+        assert_eq!(cache.keys(), vec![6, 5, 4, 3, 1]);
+        assert_eq!(cache.hand_key(), Some(&3));
+
+        // Removing the hand advances it toward the head before detaching the
+        // slot. Removing other residents preserves that repaired position.
+        assert!(cache.remove(&3));
+        assert_eq!(cache.hand_key(), Some(&4));
+        assert!(!cache.remove(&3));
+        cache.retain(|key, _| key % 2 == 1);
+        assert_eq!(cache.keys(), vec![5, 1]);
+        assert_eq!(cache.hand_key(), Some(&5));
+        cache.check_invariants();
+
+        cache.clear();
+        assert!(cache.is_empty());
+        assert_eq!(cache.hand_key(), None);
+        cache.check_invariants();
+    }
+
+    #[test]
+    fn test_removing_non_hand_endpoints_preserves_the_hand() {
+        let mut cache = TestCache::new(NZUsize!(4));
+        for key in 1..=4u64 {
+            cache.put(key, key);
+        }
+        assert_eq!(cache.get(&1), Some(&1));
+        cache.put(5, 5);
+        assert_eq!(cache.keys(), vec![5, 4, 3, 1]);
+        assert_eq!(cache.hand_key(), Some(&3));
+
+        // Removing the head or tail has no effect when neither is the current
+        // hand. Their links are detached for later stable-slot reuse.
+        let allocated = cache.slots.len();
+        assert!(cache.remove(&5));
+        assert_eq!(cache.hand_key(), Some(&3));
+        assert!(cache.remove(&1));
+        assert_eq!(cache.hand_key(), Some(&3));
+        assert_eq!(cache.keys(), vec![4, 3]);
+
+        cache.put(6, 6);
+        cache.put(7, 7);
+        assert_eq!(cache.slots.len(), allocated);
+        assert_eq!(cache.keys(), vec![7, 6, 4, 3]);
+        assert_eq!(cache.hand_key(), Some(&3));
+        cache.check_invariants();
+    }
+
+    #[test]
+    fn test_peek_does_not_mark_a_resident_visited() {
+        let mut cache = TestCache::new(NZUsize!(2));
+        cache.put(1u64, 10u64);
+        cache.put(2, 20);
+
+        // A non-recording lookup leaves the oldest entry eligible, while get
+        // would set its visited bit and protect it for this pass.
+        assert_eq!(cache.peek(&1), Some(&10));
+        cache.put(3, 30);
+        assert!(!cache.contains(&1));
+        assert!(cache.contains(&2));
+        cache.check_invariants();
+    }
+
+    #[test]
+    fn test_get_at_marks_a_resident_visited() {
+        let mut cache = TestCache::new(NZUsize!(2));
+        cache.put(1u64, 10u64);
+        cache.put(2, 20);
+        let slot = cache.index[&1];
+
+        // A validated stable-slot lookup records the same hit as a hash lookup.
+        // The hand clears and skips key 1, then evicts unvisited key 2.
+        assert_eq!(cache.get_at(slot, &1), Some(&10));
+        cache.put(3, 30);
+        assert!(cache.contains(&1));
+        assert!(!cache.contains(&2));
+        cache.check_invariants();
+    }
+
+    #[test]
+    fn test_shared_hits_are_concurrent_and_do_not_reorder() {
+        let mut cache = TestCache::new(NZUsize!(8));
+        for key in 0..8u64 {
+            cache.put(key, key);
+        }
+        let order = cache.keys();
+        let cache = Arc::new(cache);
+        let mut threads = Vec::new();
+        for worker in 0..8u64 {
+            let cache = Arc::clone(&cache);
+            threads.push(thread::spawn(move || {
+                for round in 0..10_000u64 {
+                    let key = (worker + round) % 8;
+                    assert_eq!(cache.get(&key), Some(&key));
+                }
+            }));
+        }
+        for thread in threads {
+            thread.join().unwrap();
+        }
+
+        // Shared hits update only relaxed atomic bits. The insertion-order
+        // queue remains byte-for-byte equivalent from the policy's view.
+        let cache = Arc::try_unwrap(cache).unwrap();
+        assert_eq!(cache.keys(), order);
+        assert!(cache.index.keys().all(|key| cache.visited(key)));
+        cache.check_invariants();
+    }
+}

--- a/utils/src/cache/sieve.rs
+++ b/utils/src/cache/sieve.rs
@@ -85,14 +85,19 @@ impl Sieve {
     #[inline]
     fn push(&mut self, slot: Slot) {
         let old_head = self.head;
+
+        // The incoming resident becomes newest. Its older neighbor is the
+        // former head, while it has no newer predecessor.
         self.slots[slot] = ResidentSlot {
             previous: UNLINKED,
             next: old_head.unwrap_or(UNLINKED),
         };
 
         if let Some(head) = old_head {
+            // Repair the former head's link toward the new resident.
             self.slots[head].previous = slot;
         } else {
+            // The first resident is both the newest and oldest entry.
             self.tail = Some(slot);
         }
         self.head = Some(slot);
@@ -103,14 +108,21 @@ impl Sieve {
     fn unlink(&mut self, slot: Slot) {
         let ResidentSlot { previous, next } = self.slots[slot];
 
+        // `previous` points toward the newer head. If the removed resident is
+        // the next candidate, continue the current pass in that direction.
         if self.hand == Some(slot) {
             self.hand = linked(previous);
         }
+
+        // Splice the resident out while repairing either its newer neighbor or
+        // the head endpoint.
         if previous != UNLINKED {
             self.slots[previous].next = next;
         } else {
             self.head = linked(next);
         }
+
+        // Repair the older neighbor or the tail endpoint on the other side.
         if next != UNLINKED {
             self.slots[next].previous = previous;
         } else {
@@ -162,6 +174,9 @@ impl<K> Policy<K> for Sieve {
         C: FnOnce(Option<Slot>) -> Claimed<K>,
     {
         if has_vacancy {
+            // Vacant capacity joins the head without disturbing an existing
+            // hand. Starting unvisited makes one-hit entries immediately
+            // eligible when the hand reaches them.
             let Claimed::Vacant(slot) = claim(None) else {
                 unreachable!("vacancy claim returned an eviction");
             };
@@ -169,6 +184,9 @@ impl<K> Policy<K> for Sieve {
             return (slot, AtomicBool::new(false));
         }
 
+        // Continue the current pass at the saved hand. A missing hand denotes
+        // the first pass or a completed pass, both of which restart at the
+        // oldest resident.
         let mut victim = self
             .hand
             .or(self.tail)
@@ -183,12 +201,19 @@ impl<K> Policy<K> for Sieve {
             // A visited resident survives in place. Clearing its bit gives the
             // next pass fresh evidence about whether it remains popular.
             visited.store(false, Ordering::Relaxed);
+
+            // Walk toward the newer head. Moving past it completes one pass
+            // and wraps back to the oldest tail.
             victim = linked(self.slots[victim].previous)
                 .or(self.tail)
                 .expect("a full SIEVE cache must have a queue tail");
         }
 
+        // Save the next hand before unlinking overwrites the victim's links.
         let next_hand = linked(self.slots[victim].previous);
+
+        // Let the cache transfer the victim's key before policy metadata
+        // reuses the same stable slot for the incoming resident.
         let Claimed::Evicted(_) = claim(Some(victim)) else {
             unreachable!("victim claim returned vacant capacity");
         };
@@ -197,6 +222,9 @@ impl<K> Policy<K> for Sieve {
         // neighbor. A missing neighbor restarts the following pass at the tail.
         self.hand = next_hand;
         self.unlink(victim);
+
+        // SIEVE keeps survivors stationary, but the incoming resident always
+        // reuses the victim's stable slot at the queue head.
         self.push(victim);
         (victim, AtomicBool::new(false))
     }
@@ -210,6 +238,8 @@ impl<K> Policy<K> for Sieve {
 
     #[inline]
     fn clear(&mut self) {
+        // Keep the fixed link arena allocated while returning every slot and
+        // endpoint to the empty-policy state.
         self.slots.fill(ResidentSlot::default());
         self.head = None;
         self.tail = None;


### PR DESCRIPTION
This PR implements the SIEVE cache policy (https://junchengyang.com/publication/nsdi24-SIEVE.pdf).
 
## Benchmarks

| Operation | Capacity | Clock | SIEVE | Clock2QPlus |
|---|---:|---:|---:|---:|
| Get | 1,024 | 1.98 ns | 1.99 ns (+0.5%) | 2.08 ns (+5.4%) |
| Get | 16,384 | 2.44 ns | 2.47 ns (+1.2%) | 2.54 ns (+3.9%) |
| Get | 262,144 | 2.38 ns | 2.59 ns (+8.7%) | 2.66 ns (+11.6%) |
| Insert | 1,024 | 22.66 ns | 23.69 ns (+4.5%) | 56.39 ns (+148.8%) |
| Insert | 16,384 | 25.49 ns | 26.77 ns (+5.0%) | 74.65 ns (+192.8%) |
| Insert | 262,144 | 30.21 ns | 30.94 ns (+2.4%) | 63.48 ns (+110.1%) |
| Mixed | 1,024 | 94.55 ns | 35.04 ns (-62.9%) | 122.07 ns (+29.1%) |
| Mixed | 16,384 | 78.70 ns | 63.53 ns (-19.3%) | 123.86 ns (+57.4%) |
| Mixed | 262,144 | 94.94 ns | 95.17 ns (+0.2%) | 131.62 ns (+38.6%) |
