### PR TITLE
[storage] Remove locks and cached state from compact db

### DIFF
--- a/glue/src/stateful/db/immutable/compact.rs
+++ b/glue/src/stateful/db/immutable/compact.rs
@@ -600,7 +600,6 @@ mod tests {
             assert_eq!(guard.get_metadata(), Some(metadata));
 
             let target = <FixedDb as ManagedDb<_>>::sync_target(&guard);
-            assert_eq!(target.root, guard.root());
             assert_eq!(target.size, mmr::Location::new(3));
         });
     }

--- a/glue/src/stateful/db/keyless/compact.rs
+++ b/glue/src/stateful/db/keyless/compact.rs
@@ -591,7 +591,6 @@ mod tests {
             assert_eq!(guard.get_metadata(), Some(U64::new(9)));
 
             let target = <FixedDb as ManagedDb<_>>::sync_target(&guard);
-            assert_eq!(target.root, guard.root());
             assert_eq!(target.size, mmr::Location::new(3));
         });
     }

--- a/storage/src/qmdb/immutable/compact.rs
+++ b/storage/src/qmdb/immutable/compact.rs
@@ -63,8 +63,6 @@ where
     C: Clone + Send + Sync + 'static,
 {
     merkle: compact_merkle::Merkle<F, H::Digest, S>,
-    root: H::Digest,
-    last_commit_loc: Location<F>,
     last_commit_metadata: Option<V::Value>,
     inactivity_floor_loc: Location<F>,
     commit_codec_config: C,
@@ -314,11 +312,8 @@ where
         merkle.prune_to_frontier();
 
         let witness = witness::Store::from_import(journal, imported);
-        let root = witness.tip().root;
         Ok(Self {
             merkle,
-            root,
-            last_commit_loc,
             last_commit_metadata,
             inactivity_floor_loc,
             commit_codec_config,
@@ -357,13 +352,8 @@ where
         let Operation::Commit(last_commit_metadata, inactivity_floor_loc) = last_commit_op else {
             return Err(Error::DataCorrupted("last operation was not a commit"));
         };
-        let last_commit_loc = witness.tip().size() - 1;
-        let root = witness.tip().root;
-
         Ok(Self {
             merkle,
-            root,
-            last_commit_loc,
             last_commit_metadata,
             inactivity_floor_loc,
             commit_codec_config,
@@ -374,17 +364,7 @@ where
 
     /// Return the root of the db.
     pub const fn root(&self) -> H::Digest {
-        self.root
-    }
-
-    /// Return a reference to the merkleization strategy.
-    pub const fn strategy(&self) -> &S {
-        self.merkle.strategy()
-    }
-
-    /// Return the location of the last commit.
-    pub const fn last_commit_loc(&self) -> Location<F> {
-        self.last_commit_loc
+        self.witness.tip().root
     }
 
     /// Return the inactivity floor declared by the last committed batch.
@@ -393,8 +373,8 @@ where
     }
 
     /// Return the location of the next operation appended to this db.
-    pub fn size(&self) -> Location<F> {
-        self.last_commit_loc + 1
+    pub const fn size(&self) -> Location<F> {
+        self.witness.tip().size()
     }
 
     /// Get the metadata associated with the last commit.
@@ -411,8 +391,8 @@ where
     }
 
     /// The [`Commitment`] for the database's current state.
-    pub(crate) fn commitment(&self) -> batch_chain::Commitment<F, H::Digest> {
-        batch_chain::Commitment::new(self.last_commit_loc + 1, self.root())
+    pub(crate) const fn commitment(&self) -> batch_chain::Commitment<F, H::Digest> {
+        batch_chain::Commitment::new(self.size(), self.root())
     }
 
     /// Create a new speculative batch of operations with this database as its parent.
@@ -473,10 +453,8 @@ where
     ) -> Result<(Self, core::ops::Range<Location<F>>), Error<F>> {
         self.validate_batch(&batch)?;
 
-        let start_loc = self.last_commit_loc + 1;
+        let start_loc = self.size();
         self.merkle.apply_batch(&batch.merkle_batch)?;
-        self.root = batch.root();
-        self.last_commit_loc = batch.bounds.tip.size - 1;
         self.last_commit_metadata = batch.commit_metadata.clone();
         self.inactivity_floor_loc = batch.bounds.inactivity_floor;
         let last_commit_metadata = self.last_commit_metadata.clone();
@@ -560,10 +538,7 @@ where
     {
         // A clean current target only needs to settle its pipelined sync. An uncommitted target
         // takes the regular rewind path so the witness journal becomes durable before return.
-        if self.size() == target
-            && self.witness.tip().size() == target
-            && !self.witness.has_uncommitted_state()
-        {
+        if self.witness.tip().size() == target && !self.witness.has_uncommitted_state() {
             self.witness.wait_for_sync().await?;
             return Ok(self);
         }
@@ -578,8 +553,6 @@ where
         };
         self.last_commit_metadata = last_commit_metadata;
         self.inactivity_floor_loc = inactivity_floor_loc;
-        self.last_commit_loc = target - 1;
-        self.root = self.witness.tip().root;
         Ok(self)
     }
 
@@ -1858,7 +1831,6 @@ mod tests {
             let db = db.sync().await.unwrap();
             assert_eq!(db.size(), size_after_first);
             assert_eq!(db.root(), root_after_first);
-            assert_eq!(db.target().root, db.root());
 
             db.destroy().await.unwrap();
         });
@@ -1893,7 +1865,6 @@ mod tests {
             let db = db.sync().await.unwrap();
             assert_eq!(db.size(), size_before_drop);
             assert_eq!(db.root(), root_before_drop);
-            assert_eq!(db.target().root, db.root());
 
             db.destroy().await.unwrap();
         });
@@ -1937,7 +1908,6 @@ mod tests {
             let db = db.sync().await.unwrap();
             assert_eq!(db.size(), size_after_first);
             assert_eq!(db.root(), root_after_first);
-            assert_eq!(db.target().root, db.root());
 
             db.destroy().await.unwrap();
         });

--- a/storage/src/qmdb/immutable/compact.rs
+++ b/storage/src/qmdb/immutable/compact.rs
@@ -465,6 +465,7 @@ where
                 Self::encode_commit_op(last_commit_metadata, inactivity_floor_loc)
             })
             .await?;
+        debug_assert_eq!(self.commitment(), batch.bounds.tip);
         Ok((self, start_loc..batch.bounds.tip.size))
     }
 

--- a/storage/src/qmdb/keyless/compact.rs
+++ b/storage/src/qmdb/keyless/compact.rs
@@ -57,8 +57,6 @@ where
     C: Clone + Send + Sync + 'static,
 {
     merkle: compact_merkle::Merkle<F, H::Digest, S>,
-    root: H::Digest,
-    last_commit_loc: Location<F>,
     last_commit_metadata: Option<V::Value>,
     inactivity_floor_loc: Location<F>,
     commit_codec_config: C,
@@ -301,11 +299,8 @@ where
         merkle.prune_to_frontier();
 
         let witness = witness::Store::from_import(journal, imported);
-        let root = witness.tip().root;
         Ok(Self {
             merkle,
-            root,
-            last_commit_loc,
             last_commit_metadata,
             inactivity_floor_loc,
             commit_codec_config,
@@ -343,13 +338,8 @@ where
         let Operation::Commit(last_commit_metadata, inactivity_floor_loc) = last_commit_op else {
             return Err(Error::DataCorrupted("last operation was not a commit"));
         };
-        let last_commit_loc = witness.tip().size() - 1;
-        let root = witness.tip().root;
-
         Ok(Self {
             merkle,
-            root,
-            last_commit_loc,
             last_commit_metadata,
             inactivity_floor_loc,
             commit_codec_config,
@@ -359,17 +349,7 @@ where
 
     /// Return the root of the db.
     pub const fn root(&self) -> H::Digest {
-        self.root
-    }
-
-    /// Return a reference to the merkleization strategy.
-    pub const fn strategy(&self) -> &S {
-        self.merkle.strategy()
-    }
-
-    /// Return the location of the last commit.
-    pub const fn last_commit_loc(&self) -> Location<F> {
-        self.last_commit_loc
+        self.witness.tip().root
     }
 
     /// Return the inactivity floor declared by the last committed batch.
@@ -378,8 +358,8 @@ where
     }
 
     /// Return the location of the next operation appended to this db.
-    pub fn size(&self) -> Location<F> {
-        self.last_commit_loc + 1
+    pub const fn size(&self) -> Location<F> {
+        self.witness.tip().size()
     }
 
     /// Get the metadata associated with the last commit.
@@ -396,8 +376,8 @@ where
     }
 
     /// The [`Commitment`] for the database's current state.
-    pub(crate) fn commitment(&self) -> batch_chain::Commitment<F, H::Digest> {
-        batch_chain::Commitment::new(self.last_commit_loc + 1, self.root())
+    pub(crate) const fn commitment(&self) -> batch_chain::Commitment<F, H::Digest> {
+        batch_chain::Commitment::new(self.size(), self.root())
     }
 
     /// Create a new speculative batch of operations with this database as its parent.
@@ -453,10 +433,8 @@ where
     ) -> Result<(Self, core::ops::Range<Location<F>>), Error<F>> {
         self.validate_batch(&batch)?;
 
-        let start_loc = self.last_commit_loc + 1;
+        let start_loc = self.size();
         self.merkle.apply_batch(&batch.merkle_batch)?;
-        self.root = batch.root();
-        self.last_commit_loc = batch.bounds.tip.size - 1;
         self.last_commit_metadata = batch.commit_metadata.clone();
         self.inactivity_floor_loc = batch.bounds.inactivity_floor;
         let last_commit_metadata = self.last_commit_metadata.clone();
@@ -536,10 +514,7 @@ where
     {
         // A clean current target only needs to settle its pipelined sync. An uncommitted target
         // takes the regular rewind path so the witness journal becomes durable before return.
-        if self.size() == target
-            && self.witness.tip().size() == target
-            && !self.witness.has_uncommitted_state()
-        {
+        if self.witness.tip().size() == target && !self.witness.has_uncommitted_state() {
             self.witness.wait_for_sync().await?;
             return Ok(self);
         }
@@ -554,8 +529,6 @@ where
         };
         self.last_commit_metadata = last_commit_metadata;
         self.inactivity_floor_loc = inactivity_floor_loc;
-        self.last_commit_loc = target - 1;
-        self.root = self.witness.tip().root;
         Ok(self)
     }
 
@@ -2338,7 +2311,6 @@ mod tests {
             let db = db.sync().await.unwrap();
             assert_eq!(db.size(), Location::new(4));
             assert_eq!(db.root(), root_after_first);
-            assert_eq!(db.target().root, db.root());
 
             db.destroy().await.unwrap();
         });
@@ -2371,7 +2343,6 @@ mod tests {
             let db = db.sync().await.unwrap();
             assert_eq!(db.size(), Location::new(4));
             assert_eq!(db.root(), root_before_drop);
-            assert_eq!(db.target().root, db.root());
 
             db.destroy().await.unwrap();
         });
@@ -2407,7 +2378,6 @@ mod tests {
             let db = db.sync().await.unwrap();
             assert_eq!(db.size(), Location::new(4));
             assert_eq!(db.root(), root_after_first);
-            assert_eq!(db.target().root, db.root());
 
             db.destroy().await.unwrap();
         });

--- a/storage/src/qmdb/keyless/compact.rs
+++ b/storage/src/qmdb/keyless/compact.rs
@@ -445,6 +445,7 @@ where
                 Self::encode_commit_op(last_commit_metadata, inactivity_floor_loc)
             })
             .await?;
+        debug_assert_eq!(self.commitment(), batch.bounds.tip);
         Ok((self, start_loc..batch.bounds.tip.size))
     }
 


### PR DESCRIPTION
The compact `Merkle` kept its `Arc<Mem>` behind a `RwLock`, and the compact qmdb's witness `Store` kept its cached tip witness behind a `RwLock` and its import flag in an `AtomicBool`. None of these had a second party to exclude. Both types are owned by a db whose mutators take `self` by value, so no reader can exist while a mutation runs. The `append_leaf` doc already said "the caller must have exclusive ownership of the db", and the `import_pending` doc said "mutations are serialized by ownership of the store". If ownership is guaranteed, the locks do nothing, and neither do the closure accessors (`with_mem`, `with`) that both types kept from when a read guard needed scoping.

The same ownership argument retires two cached fields. Each compact `Db` stored `root` and `last_commit_loc` next to a `Store` whose tip already holds `tip().root` and `tip().size()`. Four write sites per db kept the copies equal by hand and eight tests asserted `db.target().root == db.root()` to check that they had. Because every mutator takes `self` by value the copies could never be observed out of step, so they never carried information.

This PR removes the locks, the closure accessors, and the cached copies. `root()` and `size()` now read the tip, so the existing `db.root() == batch.root()` asserts after `apply_batch` compare the root the witness recomputes from the Merkle against the root the batch computed on its own; before, they compared `batch.root()` with a copy of itself. `apply_batch` also `debug_assert`s that the tip's commitment equals the batch's, so that property is checked on every debug-build apply rather than at a handful of test sites.

## Changes

- `merkle/persisted/compact.rs`: `mem: Arc<Mem>`. `reset_to`, `prune_to_frontier`, `append_leaf` take `&mut self` and mutate through `Arc::make_mut`, like `apply_batch` already did. Readers borrow `self.mem` directly. The `Arc` stays because `snapshot` still hands copy-on-write views to merkleize jobs.
- `merkle/persisted/full.rs`, `merkle/persisted/compact.rs`: `with_mem(|mem| ..)` becomes `mem() -> &Mem` on both. `full` lost its lock a while ago and compact loses it here, so on both the closure wrapped a plain field read. `full`'s field goes private, so the two types end up identical: a private `mem: Arc<Mem>`, `mem()` for borrows, `snapshot()` for `Arc` clones. 125 call sites rewritten: 116 tests, 5 non-test sites (`journal/authenticated.rs` `append` and `align` replay, `qmdb/compact/witness.rs` `build_witness` and `bootstrap_initial_commit`, `merkle/benches/flush.rs`), and 4 in the two `merkle_full` fuzz targets.
- `qmdb/compact/witness.rs`: `tip_witness` and `import_pending` are plain fields and `replace` takes `&mut self`. The helpers that reach a Merkle mutator (`apply`, `persist`, `commit`, `sync`, `start_sync`, `rewind`, `load_tip`, `rebuild`) take `&mut Merkle`; `stage` and `build_witness` only read and stay `&`. `with(|w| ..)` becomes `tip() -> &VerifiedWitness`. `compact_state` used the closure to clone the whole witness out so it could decode outside the lock; it now reads the field and clones only the `proof` and `pinned_nodes` that go into the response. A few readers become `const fn` now that clippy can see they are.
- `qmdb/keyless/compact.rs`, `qmdb/immutable/compact.rs`: the `root` and `last_commit_loc` fields are gone; `root()` and `size()` read `witness.tip()`. The five db mutators pass `&mut self.merkle` into the store, `init_from_sync` binds `let mut merkle`, and the `with` callers become `tip()` reads. The unused `pub` accessors `strategy()` and `last_commit_loc()` are removed from both dbs; nothing called either (the `last_commit_loc()` uses in fuzz and tests are on the full `Keyless`), and `size()` and `CompactConfig::strategy` cover them.
- Tests: the eight `target().root == root()` asserts (six in storage, two in glue) are dropped as tautologies.

`last_commit_metadata` and `inactivity_floor_loc` stay on the `Db` here. The tip holds them too, inside the encoded commit operation, but reading the metadata from there means a decode with the codec config on every call, and the floor would need its own field on the tip. Both move to the tip in #4605, which gives the db a typed commit.
