### PR TITLE
[storage] Move Merkle ownership to compact witness Store

### DIFF
--- a/storage/src/qmdb/compact/witness.rs
+++ b/storage/src/qmdb/compact/witness.rs
@@ -125,6 +125,18 @@ enum Durability {
     Sync,
 }
 
+/// The tip witness's relationship to the journal.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum TipState {
+    /// Journaled and covered by a durability operation that has at least started.
+    Committed,
+    /// Journaled after the latest durability operation started.
+    Uncommitted,
+    /// From compact sync and not in the journal, which still holds the partition's previous
+    /// contents until the first application replaces them with the tip.
+    Imported,
+}
+
 /// The compact Merkle, the contiguous journal of its witnesses, and an in-memory cache of the
 /// tip witness.
 pub(crate) struct Store<E: Context, F: Family, H: Hasher, S: Strategy> {
@@ -137,14 +149,8 @@ pub(crate) struct Store<E: Context, F: Family, H: Hasher, S: Strategy> {
     /// The verified witness at the journal tip.
     tip_witness: VerifiedWitness<F, H::Digest>,
 
-    /// Whether the cached witness came from compact sync and has not been written to the
-    /// journal yet. While set, the journal still holds the partition's previous contents; the
-    /// first application to the journal replaces them with the cached witness and clears this
-    /// flag.
-    import_pending: bool,
-
-    /// Whether witnesses were appended after the latest durability operation started.
-    uncommitted: bool,
+    /// The tip witness's relationship to the journal.
+    tip_state: TipState,
 
     /// The sync pipelined by the last [`Self::start_sync`], cleared by the next full
     /// journal sync.
@@ -183,8 +189,7 @@ impl<E: Context, F: Family, H: Hasher, S: Strategy> Store<E, F, H, S> {
                 merkle,
                 journal,
                 tip_witness,
-                import_pending: false,
-                uncommitted: false,
+                tip_state: TipState::Committed,
                 pending_sync: None,
             },
             op,
@@ -212,8 +217,7 @@ impl<E: Context, F: Family, H: Hasher, S: Strategy> Store<E, F, H, S> {
             merkle,
             journal,
             tip_witness,
-            import_pending: true,
-            uncommitted: false,
+            tip_state: TipState::Imported,
             pending_sync: None,
         })
     }
@@ -304,7 +308,7 @@ impl<E: Context, F: Family, H: Hasher, S: Strategy> Store<E, F, H, S> {
     /// Journal a pending compact-sync import, if any.
     async fn flush_import(self) -> Result<Self, Error<F>> {
         debug_assert_eq!(self.tip_witness.size(), self.merkle.leaves());
-        if !self.import_pending {
+        if self.tip_state != TipState::Imported {
             return Ok(self);
         }
         let verified = self.tip_witness.clone();
@@ -317,7 +321,7 @@ impl<E: Context, F: Family, H: Hasher, S: Strategy> Store<E, F, H, S> {
         mut self,
         verified: VerifiedWitness<F, H::Digest>,
     ) -> Result<Self, Error<F>> {
-        if self.import_pending {
+        if self.tip_state == TipState::Imported {
             self = self.clear_for_import().await?;
         }
 
@@ -326,8 +330,7 @@ impl<E: Context, F: Family, H: Hasher, S: Strategy> Store<E, F, H, S> {
         (self.journal, _) = self.journal.append(&verified.witness).await?;
 
         // Publish the applied tip while retaining that it lies outside the durable prefix.
-        self.import_pending = false;
-        self.uncommitted = true;
+        self.tip_state = TipState::Uncommitted;
         self.merkle.prune_to_frontier();
         self.tip_witness = verified;
         Ok(self)
@@ -359,14 +362,16 @@ impl<E: Context, F: Family, H: Hasher, S: Strategy> Store<E, F, H, S> {
 
         // A commit leaves `pending_sync` set so the next full sync still persists all metadata.
         match durability {
-            Durability::Commit if self.uncommitted => {
+            Durability::Commit if self.tip_state == TipState::Uncommitted => {
                 self.journal = self.journal.commit().await?;
-                self.uncommitted = false;
+                self.tip_state = TipState::Committed;
             }
-            Durability::Sync if self.uncommitted || self.pending_sync.is_some() => {
+            Durability::Sync
+                if self.tip_state == TipState::Uncommitted || self.pending_sync.is_some() =>
+            {
                 let journal = self.journal.sync().await?;
                 self.pending_sync = None;
-                self.uncommitted = false;
+                self.tip_state = TipState::Committed;
                 self.journal = journal;
             }
             Durability::Commit | Durability::Sync => {}
@@ -398,7 +403,7 @@ impl<E: Context, F: Family, H: Hasher, S: Strategy> Store<E, F, H, S> {
         let handle;
         (self.journal, handle) = self.journal.start_sync().await?;
         let completion: SyncCompletion = handle.boxed().shared();
-        self.uncommitted = false;
+        self.tip_state = TipState::Committed;
         self.pending_sync = Some(completion.clone());
         Ok((self, Handle::from_future(completion)))
     }
@@ -440,7 +445,7 @@ impl<E: Context, F: Family, H: Hasher, S: Strategy> Store<E, F, H, S> {
             rebuild::<F, H::Digest, H, S, Op>(entry, &mut self.merkle, commit_codec_config)?;
         self.journal = self.journal.rewind(pos + 1).await?.sync().await?;
         self.pending_sync = None;
-        self.uncommitted = false;
+        self.tip_state = TipState::Committed;
         self.tip_witness = witness;
         Ok((self, op))
     }
@@ -462,19 +467,19 @@ impl<E: Context, F: Family, H: Hasher, S: Strategy> Store<E, F, H, S> {
         (self.journal, _) = self.journal.prune(pos).await?;
         self.journal = self.journal.sync().await?;
         self.pending_sync = None;
-        self.uncommitted = false;
+        self.tip_state = TipState::Committed;
         Ok(self)
     }
 
     /// Whether the current cached state is not covered by a durability operation.
     pub(crate) const fn has_uncommitted_state(&self) -> bool {
-        self.import_pending || self.uncommitted
+        !matches!(self.tip_state, TipState::Committed)
     }
 
     /// Reject operations on a journal whose contents an unapplied compact-sync import is
     /// about to replace.
     const fn check_import_applied(&self) -> Result<(), Error<F>> {
-        if self.import_pending {
+        if matches!(self.tip_state, TipState::Imported) {
             return Err(Error::DataCorrupted("compact-sync import not applied"));
         }
         Ok(())

--- a/storage/src/qmdb/compact/witness.rs
+++ b/storage/src/qmdb/compact/witness.rs
@@ -17,7 +17,7 @@
 use crate::{
     Context, SyncCompletion,
     journal::contiguous::{Contiguous, variable},
-    merkle::{self, Family, Location, MAX_PINNED_NODES, Proof, compact},
+    merkle::{self, Family, Location, MAX_PINNED_NODES, Proof, batch, compact},
     qmdb::{
         self, Error,
         operation::Floored,
@@ -28,6 +28,7 @@ use commonware_codec::{Decode as _, EncodeSize, Read, Write};
 use commonware_cryptography::{Digest, Hasher};
 use commonware_parallel::Strategy;
 use commonware_runtime::{Error as RError, Handle};
+use core::cmp::Ordering;
 use futures::FutureExt as _;
 
 /// An applied state persisted by the witness journal.
@@ -124,11 +125,17 @@ enum Durability {
     Sync,
 }
 
-/// A contiguous journal plus an in-memory cache of the tip witness.
-pub(crate) struct Store<E: Context, F: Family, D: Digest> {
-    journal: Journal<E, F, D>,
+/// The compact Merkle, the contiguous journal of its witnesses, and an in-memory cache of the
+/// tip witness.
+pub(crate) struct Store<E: Context, F: Family, H: Hasher, S: Strategy> {
+    /// The peak-only Merkle the witnesses describe.
+    merkle: compact::Merkle<F, H::Digest, S>,
 
-    tip_witness: VerifiedWitness<F, D>,
+    /// The journal of witnesses, one per applied batch.
+    journal: Journal<E, F, H::Digest>,
+
+    /// The verified witness at the journal tip.
+    tip_witness: VerifiedWitness<F, H::Digest>,
 
     /// Whether the cached witness came from compact sync and has not been written to the
     /// journal yet. While set, the journal still holds the partition's previous contents; the
@@ -144,38 +151,81 @@ pub(crate) struct Store<E: Context, F: Family, D: Digest> {
     pending_sync: Option<SyncCompletion>,
 }
 
-impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
-    /// Wrap an opened journal and a verified witness into a store.
-    pub(crate) const fn new(journal: Journal<E, F, D>, witness: VerifiedWitness<F, D>) -> Self {
-        Self {
-            journal,
-            tip_witness: witness,
-            import_pending: false,
-            uncommitted: false,
-            pending_sync: None,
+impl<E: Context, F: Family, H: Hasher, S: Strategy> Store<E, F, H, S> {
+    /// Open the store for an existing or new compact db, returning it with the decoded
+    /// last-commit operation.
+    ///
+    /// A new db starts with one committed operation, the initial commit: it is inserted into the
+    /// compact Merkle and persisted as the first witness entry, so reopen and rewind never see an
+    /// empty journal. An existing db reloads and re-verifies its tip witness.
+    pub(crate) async fn init<Op>(
+        mut journal: Journal<E, F, H::Digest>,
+        strategy: S,
+        commit_codec_config: &Op::Cfg,
+        initial_commit_op_bytes: Vec<u8>,
+    ) -> Result<(Self, Op), Error<F>>
+    where
+        Op: Read + Floored<F>,
+    {
+        let mut merkle = compact::Merkle::new(strategy);
+        if journal.size() == 0 {
+            journal = bootstrap_initial_commit::<E, F, H, S>(
+                journal,
+                &mut merkle,
+                initial_commit_op_bytes,
+            )
+            .await?;
         }
+        let (tip_witness, op) =
+            load_tip::<E, F, H, S, Op>(&journal, &mut merkle, commit_codec_config).await?;
+        Ok((
+            Self {
+                merkle,
+                journal,
+                tip_witness,
+                import_pending: false,
+                uncommitted: false,
+                pending_sync: None,
+            },
+            op,
+        ))
     }
 
-    /// Create a store from a validated compact-sync import that has not been applied to the
-    /// witness journal yet. The journal is untouched until the first application replaces its
-    /// contents with `witness`. A crash during that replacement leaves a journal that fails to
-    /// reopen; re-syncing recovers it.
-    pub(crate) const fn from_import(
-        journal: Journal<E, F, D>,
-        witness: VerifiedWitness<F, D>,
-    ) -> Self {
-        Self {
+    /// Create a store from a validated compact-sync import. The journal is left untouched until
+    /// the first application replaces its contents with the imported witness; a crash during
+    /// that replacement leaves a journal that fails to reopen, and re-syncing recovers it.
+    pub(crate) fn from_import(
+        journal: Journal<E, F, H::Digest>,
+        strategy: S,
+        last_commit_loc: Location<F>,
+        pinned_nodes: Vec<H::Digest>,
+        inactivity_floor_loc: Location<F>,
+        op_bytes: Vec<u8>,
+    ) -> Result<Self, Error<F>> {
+        let mut merkle =
+            compact::Merkle::from_compact_state(strategy, last_commit_loc, pinned_nodes)?;
+        let hasher = qmdb::hasher::<H>();
+        merkle.append_leaf(&hasher, &op_bytes)?;
+        let tip_witness = build_witness::<F, H, S>(&merkle, inactivity_floor_loc, op_bytes)?;
+        merkle.prune_to_frontier();
+        Ok(Self {
+            merkle,
             journal,
-            tip_witness: witness,
+            tip_witness,
             import_pending: true,
             uncommitted: false,
             pending_sync: None,
-        }
+        })
     }
 
     /// The cached tip witness.
-    pub(crate) const fn tip(&self) -> &VerifiedWitness<F, D> {
+    pub(crate) const fn tip(&self) -> &VerifiedWitness<F, H::Digest> {
         &self.tip_witness
+    }
+
+    /// The compact Merkle.
+    pub(crate) const fn merkle(&self) -> &compact::Merkle<F, H::Digest, S> {
+        &self.merkle
     }
 
     /// Serve `request` from the single committed state this witness retains.
@@ -197,7 +247,7 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
         &self,
         cfg: &Op::Cfg,
         request: Request<F>,
-    ) -> Result<Response<F, Op, D>, Error<F>> {
+    ) -> Result<Response<F, Op, H::Digest>, Error<F>> {
         let size = self.tip_witness.size();
         let last_commit_loc = size - 1;
         if request.size() > size || request.size() == 0 {
@@ -229,30 +279,47 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
         })
     }
 
-    /// Replace the cached witness after the matching compact Merkle state is staged or loaded.
-    pub(crate) fn replace(&mut self, witness: VerifiedWitness<F, D>) {
-        self.tip_witness = witness;
+    /// Apply `merkle_batch` to the Merkle and journal the witness for the new state. A batch
+    /// that adds no leaves only journals a pending compact-sync import.
+    pub(crate) async fn apply(
+        mut self,
+        merkle_batch: &batch::MerkleizedBatch<F, H::Digest, S>,
+        inactivity_floor_loc: Location<F>,
+        last_commit_op_bytes: Vec<u8>,
+    ) -> Result<Self, Error<F>> {
+        self.merkle.apply_batch(merkle_batch)?;
+        let verified = match self.tip_witness.size().cmp(&self.merkle.leaves()) {
+            Ordering::Equal => return self.flush_import().await,
+            Ordering::Greater => {
+                return Err(Error::DataCorrupted("witness ahead of in-memory state"));
+            }
+            // Build before pruning because the commit proof needs the unpruned Merkle.
+            Ordering::Less => {
+                build_witness::<F, H, S>(&self.merkle, inactivity_floor_loc, last_commit_op_bytes)?
+            }
+        };
+        self.append_witness(verified).await
     }
 
-    /// Apply the current compact state to the witness journal.
-    pub(crate) async fn apply<H, S>(
-        mut self,
-        merkle: &mut compact::Merkle<F, D, S>,
-        inactivity_floor_loc: Location<F>,
-        last_commit_op_bytes: impl FnOnce() -> Vec<u8>,
-    ) -> Result<Self, Error<F>>
-    where
-        H: Hasher<Digest = D>,
-        S: Strategy,
-    {
-        // Stage before pruning because a new witness's commit proof needs the unpruned Merkle.
-        let verified;
-        (self, verified) = self
-            .stage::<H, S>(merkle, inactivity_floor_loc, last_commit_op_bytes)
-            .await?;
-        let Some(verified) = verified else {
+    /// Journal a pending compact-sync import, if any.
+    async fn flush_import(self) -> Result<Self, Error<F>> {
+        debug_assert_eq!(self.tip_witness.size(), self.merkle.leaves());
+        if !self.import_pending {
             return Ok(self);
-        };
+        }
+        let verified = self.tip_witness.clone();
+        self.append_witness(verified).await
+    }
+
+    /// Append `verified` to the journal (replacing the journal's contents when an import is
+    /// pending), prune the Merkle to its frontier, and install `verified` as the tip.
+    async fn append_witness(
+        mut self,
+        verified: VerifiedWitness<F, H::Digest>,
+    ) -> Result<Self, Error<F>> {
+        if self.import_pending {
+            self = self.clear_for_import().await?;
+        }
 
         // Append before pruning and clearing import state so every successful apply has a matching
         // journal entry.
@@ -261,77 +328,34 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
         // Publish the applied tip while retaining that it lies outside the durable prefix.
         self.import_pending = false;
         self.uncommitted = true;
-        merkle.prune_to_frontier();
-        self.replace(verified);
+        self.merkle.prune_to_frontier();
+        self.tip_witness = verified;
         Ok(self)
     }
 
-    /// Persist the current compact state as a new witness journal entry, committing the journal
-    /// so the entry survives a crash. Journal recovery may be required on reopen.
+    /// Make the applied state durable by committing the journal, so every journaled witness
+    /// survives a crash. Journal recovery may be required on reopen.
     ///
     /// First waits for any sync pipelined by [`Self::start_sync`], surfacing its failure, then
-    /// commits every applied witness.
-    pub(crate) async fn commit<H, S>(
-        self,
-        merkle: &mut compact::Merkle<F, D, S>,
-        inactivity_floor_loc: Location<F>,
-        last_commit_op_bytes: impl FnOnce() -> Vec<u8>,
-    ) -> Result<Self, Error<F>>
-    where
-        H: Hasher<Digest = D>,
-        S: Strategy,
-    {
+    /// journals a pending compact-sync import and commits.
+    pub(crate) async fn commit(self) -> Result<Self, Error<F>> {
         self.wait_for_sync().await?;
-        self.persist::<H, S>(
-            merkle,
-            inactivity_floor_loc,
-            last_commit_op_bytes,
-            Durability::Commit,
-        )
-        .await
+        self.persist(Durability::Commit).await
     }
 
-    /// Persist the current compact state as a new witness journal entry, syncing the journal and
-    /// all of its metadata to minimize recovery work on reopen.
+    /// Make the applied state durable by syncing the journal and all of its metadata, minimizing
+    /// recovery work on reopen.
     ///
-    /// This also settles any sync pipelined by [`Self::start_sync`].
-    pub(crate) async fn sync<H, S>(
-        self,
-        merkle: &mut compact::Merkle<F, D, S>,
-        inactivity_floor_loc: Location<F>,
-        last_commit_op_bytes: impl FnOnce() -> Vec<u8>,
-    ) -> Result<Self, Error<F>>
-    where
-        H: Hasher<Digest = D>,
-        S: Strategy,
-    {
-        self.persist::<H, S>(
-            merkle,
-            inactivity_floor_loc,
-            last_commit_op_bytes,
-            Durability::Sync,
-        )
-        .await
+    /// Journals a pending compact-sync import first. This also settles any sync pipelined by
+    /// [`Self::start_sync`].
+    pub(crate) async fn sync(self) -> Result<Self, Error<F>> {
+        self.persist(Durability::Sync).await
     }
 
-    /// Shared body of [`Self::commit`] and [`Self::sync`]: apply the current state, then make
+    /// Shared body of [`Self::commit`] and [`Self::sync`]: journal a pending import, then make
     /// every uncommitted witness durable according to `durability`.
-    async fn persist<H, S>(
-        mut self,
-        merkle: &mut compact::Merkle<F, D, S>,
-        inactivity_floor_loc: Location<F>,
-        last_commit_op_bytes: impl FnOnce() -> Vec<u8>,
-        durability: Durability,
-    ) -> Result<Self, Error<F>>
-    where
-        H: Hasher<Digest = D>,
-        S: Strategy,
-    {
-        // Compact-sync imports enter with a cached witness that is absent from the journal.
-        // Apply the current state before making the requested durability guarantee.
-        self = self
-            .apply::<H, S>(merkle, inactivity_floor_loc, last_commit_op_bytes)
-            .await?;
+    async fn persist(mut self, durability: Durability) -> Result<Self, Error<F>> {
+        self = self.flush_import().await?;
 
         // A commit leaves `pending_sync` set so the next full sync still persists all metadata.
         match durability {
@@ -350,35 +374,24 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
         Ok(self)
     }
 
-    /// Persist the current compact state as a new witness journal entry, starting the journal
-    /// sync instead of awaiting it.
+    /// Make the applied state durable by starting the journal sync instead of awaiting it.
     ///
-    /// Awaiting the returned [Handle] provides the same durability guarantee as [Self::commit],
-    /// plus a best-effort attempt to bound the recovery needed on reopen. When nothing new must
-    /// be appended, the handle still proves the current tip durable and resurfaces any retained
-    /// sync failure.
-    pub(crate) async fn start_sync<H, S>(
-        mut self,
-        merkle: &mut compact::Merkle<F, D, S>,
-        inactivity_floor_loc: Location<F>,
-        last_commit_op_bytes: impl FnOnce() -> Vec<u8>,
-    ) -> Result<(Self, Handle<()>), Error<F>>
-    where
-        H: Hasher<Digest = D>,
-        S: Strategy,
-    {
+    /// Journals a pending compact-sync import first. Awaiting the returned [Handle] provides the
+    /// same durability guarantee as [Self::commit], plus a best-effort attempt to bound the
+    /// recovery needed on reopen. When nothing new must be appended, the handle still proves the
+    /// current tip durable and resurfaces any retained sync failure.
+    pub(crate) async fn start_sync(mut self) -> Result<(Self, Handle<()>), Error<F>> {
         // Match the deferred-failure convention used by the journal: return a prior completion's
         // error through a ready handle before a later completion can replace it. Errors while
-        // staging or initiating this sync continue to use the outer result.
+        // journaling an import or initiating this sync continue to use the outer result.
         if let Err(err) = self.wait_for_sync().await {
             return Ok((self, Handle::ready(Err(err))));
         }
 
-        // Apply before starting the journal sync so the returned handle covers the current tip.
-        // A later apply remains uncommitted and requires a successor durability operation.
-        self = self
-            .apply::<H, S>(merkle, inactivity_floor_loc, last_commit_op_bytes)
-            .await?;
+        // Journal a pending import before starting the sync so the returned handle covers the
+        // current tip. A later apply remains uncommitted and requires a successor durability
+        // operation.
+        self = self.flush_import().await?;
 
         // Share one completion between the caller and the store. Retaining a clone keeps a
         // dropped handle's failure observable by the next durability operation.
@@ -401,42 +414,6 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
         pending.await
     }
 
-    /// Decide what a persist must write, clearing the journal first when an import is pending.
-    ///
-    /// Returns `None` if the cached tip already matches the in-memory Merkle and no import is
-    /// pending, otherwise the witness to append and install in the cache.
-    async fn stage<H, S>(
-        mut self,
-        merkle: &compact::Merkle<F, D, S>,
-        inactivity_floor_loc: Location<F>,
-        last_commit_op_bytes: impl FnOnce() -> Vec<u8>,
-    ) -> Result<(Self, Option<VerifiedWitness<F, D>>), Error<F>>
-    where
-        H: Hasher<Digest = D>,
-        S: Strategy,
-    {
-        // An equal size means no commit has been applied since the cache was set.
-        // Normally the cache mirrors the journal tip, so there is no witness to append. A
-        // start_sync may still be proving that tip durable, which pending_sync tracks separately.
-        // During a pending import the cached witness is not in the journal yet, so it is exactly
-        // what must be persisted. Replace the journal's contents with it.
-        let cached_size = self.tip().size();
-        let verified = if cached_size == merkle.leaves() {
-            if !self.import_pending {
-                return Ok((self, None));
-            }
-            self.tip().clone()
-        } else if cached_size > merkle.leaves() {
-            return Err(Error::DataCorrupted("witness ahead of in-memory state"));
-        } else {
-            build_witness::<F, H, S>(merkle, inactivity_floor_loc, last_commit_op_bytes())?
-        };
-        if self.import_pending {
-            self = self.clear_for_import().await?;
-        }
-        Ok((self, Some(verified)))
-    }
-
     /// Rewind the journal so the entry committing exactly `target` leaves becomes the tip, then
     /// rebuild and re-verify the Merkle and cache from it. Returns the decoded commit operation
     /// of the restored tip.
@@ -445,15 +422,12 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
     /// [`merkle::Error::RewindBeyondHistory`]. The target entry is derived before the journal
     /// is truncated, so a corrupt entry fails the rewind with the journal intact. The rewind is
     /// made durable before returning.
-    pub(crate) async fn rewind<H, S, Op>(
+    pub(crate) async fn rewind<Op>(
         mut self,
-        merkle: &mut compact::Merkle<F, D, S>,
         target: Location<F>,
         commit_codec_config: &Op::Cfg,
     ) -> Result<(Self, Op), Error<F>>
     where
-        H: Hasher<Digest = D>,
-        S: Strategy,
         Op: Read + Floored<F>,
     {
         self.check_import_applied()?;
@@ -462,11 +436,12 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
             .position_of(target)
             .await?
             .ok_or(Error::Merkle(merkle::Error::RewindBeyondHistory))?;
-        let (witness, op) = rebuild::<F, D, H, S, Op>(entry, merkle, commit_codec_config)?;
+        let (witness, op) =
+            rebuild::<F, H::Digest, H, S, Op>(entry, &mut self.merkle, commit_codec_config)?;
         self.journal = self.journal.rewind(pos + 1).await?.sync().await?;
         self.pending_sync = None;
         self.uncommitted = false;
-        self.replace(witness);
+        self.tip_witness = witness;
         Ok((self, op))
     }
 
@@ -510,7 +485,7 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
     async fn position_of(
         &self,
         target: Location<F>,
-    ) -> Result<Option<(u64, Witness<F, D>)>, Error<F>> {
+    ) -> Result<Option<(u64, Witness<F, H::Digest>)>, Error<F>> {
         let pos = Self::first_at_or_above(&self.journal, target).await?;
         if pos >= self.journal.bounds().end {
             return Ok(None);
@@ -522,7 +497,7 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
     /// Binary search for the first retained position whose entry commits at least `size`
     /// leaves, or the end of the journal if none does.
     async fn first_at_or_above(
-        reader: &impl Contiguous<Item = Witness<F, D>>,
+        reader: &impl Contiguous<Item = Witness<F, H::Digest>>,
         size: Location<F>,
     ) -> Result<u64, Error<F>> {
         let bounds = reader.bounds();
@@ -561,7 +536,7 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
 ///
 /// The tip operation's inclusion proof is only computable before the Merkle is pruned to its
 /// frontier.
-pub(crate) fn build_witness<F, H, S>(
+fn build_witness<F, H, S>(
     merkle: &compact::Merkle<F, H::Digest, S>,
     inactivity_floor_loc: Location<F>,
     last_commit_op_bytes: Vec<u8>,
@@ -671,33 +646,6 @@ where
         .map_err(|_| Error::DataCorrupted("invalid compact witness"))?;
     merkle.prune_to_frontier();
     Ok((verified, last_commit_op))
-}
-
-/// Open the witness store for an existing or new compact db, returning it with the decoded
-/// last-commit operation.
-///
-/// A new db starts with one committed operation, the initial commit: it is inserted into the
-/// compact Merkle and persisted as the first witness entry, so reopen and rewind never see an
-/// empty journal. An existing db reloads and re-verifies its tip witness.
-pub(crate) async fn init<E, F, H, S, Op>(
-    mut journal: Journal<E, F, H::Digest>,
-    merkle: &mut compact::Merkle<F, H::Digest, S>,
-    commit_codec_config: &Op::Cfg,
-    initial_commit_op_bytes: Vec<u8>,
-) -> Result<(Store<E, F, H::Digest>, Op), Error<F>>
-where
-    E: Context,
-    F: Family,
-    H: Hasher,
-    S: Strategy,
-    Op: Read + Floored<F>,
-{
-    if journal.size() == 0 {
-        journal = bootstrap_initial_commit::<E, F, H, S>(journal, merkle, initial_commit_op_bytes)
-            .await?;
-    }
-    let (witness, op) = load_tip::<E, F, H, S, Op>(&journal, merkle, commit_codec_config).await?;
-    Ok((Store::new(journal, witness), op))
 }
 
 /// Insert and persist the initial `Commit(None, 0)` for a new compact db.

--- a/storage/src/qmdb/immutable/compact.rs
+++ b/storage/src/qmdb/immutable/compact.rs
@@ -27,7 +27,6 @@ use super::operation::Operation;
 pub use crate::qmdb::compact::Config;
 use crate::{
     Context,
-    journal::contiguous::variable::{self, Config as JournalConfig},
     merkle::{Family, Location, batch, compact as compact_merkle},
     qmdb::{
         self, Error,
@@ -62,11 +61,10 @@ where
     Operation<F, K, V>: Read<Cfg = C>,
     C: Clone + Send + Sync + 'static,
 {
-    merkle: compact_merkle::Merkle<F, H::Digest, S>,
     last_commit_metadata: Option<V::Value>,
     inactivity_floor_loc: Location<F>,
     commit_codec_config: C,
-    witness: witness::Store<E, F, H::Digest>,
+    witness: witness::Store<E, F, H, S>,
     _key: PhantomData<K>,
 }
 
@@ -174,7 +172,7 @@ where
         Operation<F, K, V>: Read<Cfg = C>,
     {
         Self {
-            merkle_batch: db.merkle.new_batch(),
+            merkle_batch: db.witness.merkle().new_batch(),
             mutations: BTreeMap::new(),
             parent: None,
             base,
@@ -236,7 +234,7 @@ where
         let total_size = self.base.size + ops.len() as u64;
         let inactive_peaks = F::inactive_peaks(total_size, inactivity_floor);
         let (merkle, root) = compact_batch::merkleize_ops::<F, H, S, _>(
-            &db.merkle,
+            db.witness.merkle(),
             self.merkle_batch,
             ops,
             inactive_peaks,
@@ -304,16 +302,15 @@ where
         witness::validate_inactivity_floor(inactivity_floor_loc, last_commit_loc)?;
 
         let op_bytes = Self::encode_commit_op(last_commit_metadata.clone(), inactivity_floor_loc);
-        let mut merkle =
-            compact_merkle::Merkle::from_compact_state(strategy, last_commit_loc, pinned_nodes)?;
-        let hasher = qmdb::hasher::<H>();
-        merkle.append_leaf(&hasher, &op_bytes)?;
-        let imported = witness::build_witness::<F, H, S>(&merkle, inactivity_floor_loc, op_bytes)?;
-        merkle.prune_to_frontier();
-
-        let witness = witness::Store::from_import(journal, imported);
+        let witness = witness::Store::from_import(
+            journal,
+            strategy,
+            last_commit_loc,
+            pinned_nodes,
+            inactivity_floor_loc,
+            op_bytes,
+        )?;
         Ok(Self {
-            merkle,
             last_commit_metadata,
             inactivity_floor_loc,
             commit_codec_config,
@@ -322,15 +319,14 @@ where
         })
     }
 
-    /// Open a compact db from persisted compact state and rebuild its witness store.
+    /// Open a compact db from its witness journal, rebuilding the Merkle from the tip witness.
     ///
     /// On first open, this bootstraps the initial commit and its witness so every later reopen and
     /// rewind can assume the journal tip is a complete compact witness.
     #[boxed]
-    pub(crate) async fn init_from_merkle(
-        mut merkle: compact_merkle::Merkle<F, H::Digest, S>,
-        witness_context: E,
-        witness_config: JournalConfig<()>,
+    pub(crate) async fn init_from_journal(
+        strategy: S,
+        journal: witness::Journal<E, F, H::Digest>,
         commit_codec_config: C,
     ) -> Result<Self, Error<F>>
     where
@@ -338,11 +334,9 @@ where
         Operation<F, K, V>: Read<Cfg = C>,
     {
         // Bootstrap: append an initial Commit(None, 0) on first open.
-        let journal: witness::Journal<E, F, H::Digest> =
-            variable::Journal::init(witness_context, witness_config).await?;
-        let (witness, last_commit_op) = witness::init::<E, F, H, S, Operation<F, K, V>>(
+        let (witness, last_commit_op) = witness::Store::init::<Operation<F, K, V>>(
             journal,
-            &mut merkle,
+            strategy,
             &commit_codec_config,
             Operation::<F, K, V>::Commit(None, Location::new(0))
                 .encode()
@@ -353,7 +347,6 @@ where
             return Err(Error::DataCorrupted("last operation was not a commit"));
         };
         Ok(Self {
-            merkle,
             last_commit_metadata,
             inactivity_floor_loc,
             commit_codec_config,
@@ -406,7 +399,7 @@ where
         F: Family,
     {
         Arc::new(MerkleizedBatch {
-            merkle_batch: self.merkle.to_batch(),
+            merkle_batch: self.witness.merkle().to_batch(),
             commit_metadata: self.last_commit_metadata.clone(),
             parent: None,
             bounds: batch_chain::Bounds::from_db(self.commitment(), self.inactivity_floor_loc),
@@ -454,17 +447,14 @@ where
         self.validate_batch(&batch)?;
 
         let start_loc = self.size();
-        self.merkle.apply_batch(&batch.merkle_batch)?;
-        self.last_commit_metadata = batch.commit_metadata.clone();
-        self.inactivity_floor_loc = batch.bounds.inactivity_floor;
-        let last_commit_metadata = self.last_commit_metadata.clone();
-        let inactivity_floor_loc = self.inactivity_floor_loc;
+        let op_bytes =
+            Self::encode_commit_op(batch.commit_metadata.clone(), batch.bounds.inactivity_floor);
         self.witness = self
             .witness
-            .apply::<H, S>(&mut self.merkle, inactivity_floor_loc, || {
-                Self::encode_commit_op(last_commit_metadata, inactivity_floor_loc)
-            })
+            .apply(&batch.merkle_batch, batch.bounds.inactivity_floor, op_bytes)
             .await?;
+        self.last_commit_metadata = batch.commit_metadata.clone();
+        self.inactivity_floor_loc = batch.bounds.inactivity_floor;
         Ok((self, start_loc..batch.bounds.tip.size))
     }
 
@@ -481,15 +471,8 @@ where
         skip_all
     )]
     pub async fn start_sync(mut self) -> Result<(Self, Handle<()>), Error<F>> {
-        let last_commit_metadata = self.last_commit_metadata.clone();
-        let inactivity_floor_loc = self.inactivity_floor_loc;
         let handle;
-        (self.witness, handle) = self
-            .witness
-            .start_sync::<H, S>(&mut self.merkle, inactivity_floor_loc, || {
-                Self::encode_commit_op(last_commit_metadata, inactivity_floor_loc)
-            })
-            .await?;
+        (self.witness, handle) = self.witness.start_sync().await?;
         Ok((self, handle))
     }
 
@@ -497,14 +480,7 @@ where
     /// reopen may need to replay the witness journal's tail to recover.
     #[tracing::instrument(name = "qmdb.immutable.compact.db.commit", level = "info", skip_all)]
     pub async fn commit(mut self) -> Result<Self, Error<F>> {
-        let last_commit_metadata = self.last_commit_metadata.clone();
-        let inactivity_floor_loc = self.inactivity_floor_loc;
-        self.witness = self
-            .witness
-            .commit::<H, S>(&mut self.merkle, inactivity_floor_loc, || {
-                Self::encode_commit_op(last_commit_metadata, inactivity_floor_loc)
-            })
-            .await?;
+        self.witness = self.witness.commit().await?;
         Ok(self)
     }
 
@@ -512,14 +488,7 @@ where
     /// minimize recovery work on reopen.
     #[tracing::instrument(name = "qmdb.immutable.compact.db.sync", level = "info", skip_all)]
     pub async fn sync(mut self) -> Result<Self, Error<F>> {
-        let last_commit_metadata = self.last_commit_metadata.clone();
-        let inactivity_floor_loc = self.inactivity_floor_loc;
-        self.witness = self
-            .witness
-            .sync::<H, S>(&mut self.merkle, inactivity_floor_loc, || {
-                Self::encode_commit_op(last_commit_metadata, inactivity_floor_loc)
-            })
-            .await?;
+        self.witness = self.witness.sync().await?;
         Ok(self)
     }
 
@@ -546,7 +515,7 @@ where
         let last_commit_op;
         (self.witness, last_commit_op) = self
             .witness
-            .rewind::<H, S, Operation<F, K, V>>(&mut self.merkle, target, &self.commit_codec_config)
+            .rewind::<Operation<F, K, V>>(target, &self.commit_codec_config)
             .await?;
         let Operation::Commit(last_commit_metadata, inactivity_floor_loc) = last_commit_op else {
             return Err(Error::DataCorrupted("last operation was not a commit"));
@@ -611,6 +580,7 @@ where
 mod tests {
     use super::*;
     use crate::{
+        journal::contiguous::variable::Config as JournalConfig,
         merkle::mmr,
         qmdb::{any::value::FixedEncoding, compact::witness},
     };
@@ -647,8 +617,10 @@ mod tests {
 
     async fn open_db<F: Family>(context: deterministic::Context, partition: &str) -> TestDb<F> {
         let witness_cfg = witness_config(partition, &context);
-        let merkle = crate::merkle::compact::Merkle::new(Sequential);
-        Db::init_from_merkle(merkle, context.child("witness"), witness_cfg, ())
+        let journal = witness::Journal::init(context.child("witness"), witness_cfg)
+            .await
+            .unwrap();
+        Db::init_from_journal(Sequential, journal, ())
             .await
             .unwrap()
     }
@@ -684,12 +656,14 @@ mod tests {
         pending: &PendingSyncs,
     ) -> impl Future<Output = Result<DelayedDb, Error<mmr::Family>>> {
         let witness_cfg = witness_config(partition, context);
-        let merkle = crate::merkle::compact::Merkle::new(Sequential);
         let context = DelayedSyncContext {
             inner: context.child(label),
             pending: pending.clone(),
         };
-        DelayedDb::init_from_merkle(merkle, context.child("witness"), witness_cfg, ())
+        async move {
+            let journal = witness::Journal::init(context.child("witness"), witness_cfg).await?;
+            DelayedDb::init_from_journal(Sequential, journal, ()).await
+        }
     }
 
     /// Apply a single-key batch writing `key -> value` with `metadata`.
@@ -1325,14 +1299,8 @@ mod tests {
             pinned_nodes.push(Sha256::fill(0xff));
             witness::tests::overwrite_tip(journal, op_bytes, size, pinned_nodes).await;
 
-            let merkle = crate::merkle::compact::Merkle::new(Sequential);
-            let reopened = TestDb::<mmr::Family>::init_from_merkle(
-                merkle,
-                context.child("reopen_witness"),
-                witness_config(partition, &context),
-                (),
-            )
-            .await;
+            let journal = open_witness_journal(context.child("reopen_witness"), partition).await;
+            let reopened = TestDb::<mmr::Family>::init_from_journal(Sequential, journal, ()).await;
             assert!(matches!(reopened, Err(Error::DataCorrupted(_))));
         });
     }
@@ -1369,15 +1337,10 @@ mod tests {
             drop(journal);
 
             // The tip entry is intact, so reopen succeeds.
-            let merkle = crate::merkle::compact::Merkle::new(Sequential);
-            let reopened = TestDb::<mmr::Family>::init_from_merkle(
-                merkle,
-                context.child("reopen"),
-                witness_config(partition, &context),
-                (),
-            )
-            .await
-            .unwrap();
+            let journal = open_witness_journal(context.child("reopen"), partition).await;
+            let reopened = TestDb::<mmr::Family>::init_from_journal(Sequential, journal, ())
+                .await
+                .unwrap();
             assert_eq!(reopened.target(), tip_target);
 
             // The corrupt entry fails the rewind before any truncation.
@@ -1387,15 +1350,10 @@ mod tests {
             ));
 
             // The newer history survives: reopen still lands on the original tip.
-            let merkle = crate::merkle::compact::Merkle::new(Sequential);
-            let reopened = TestDb::<mmr::Family>::init_from_merkle(
-                merkle,
-                context.child("reopen2"),
-                witness_config(partition, &context),
-                (),
-            )
-            .await
-            .unwrap();
+            let journal = open_witness_journal(context.child("reopen2"), partition).await;
+            let reopened = TestDb::<mmr::Family>::init_from_journal(Sequential, journal, ())
+                .await
+                .unwrap();
             assert_eq!(reopened.target(), tip_target);
             reopened.destroy().await.unwrap();
         });
@@ -1423,14 +1381,8 @@ mod tests {
             drop(journal);
 
             // Reopen must fail rather than bootstrap a fresh db.
-            let merkle = crate::merkle::compact::Merkle::new(Sequential);
-            let reopened = TestDb::<mmr::Family>::init_from_merkle(
-                merkle,
-                context.child("reopen_witness"),
-                witness_config(partition, &context),
-                (),
-            )
-            .await;
+            let journal = open_witness_journal(context.child("reopen_witness"), partition).await;
+            let reopened = TestDb::<mmr::Family>::init_from_journal(Sequential, journal, ()).await;
             assert!(matches!(reopened, Err(Error::Journal(_))));
         });
     }
@@ -1461,14 +1413,8 @@ mod tests {
             .to_vec();
             witness::tests::overwrite_tip(journal, bad_op, size, pinned_nodes).await;
 
-            let merkle = crate::merkle::compact::Merkle::new(Sequential);
-            let reopened = TestDb::<mmr::Family>::init_from_merkle(
-                merkle,
-                context.child("reopen_witness"),
-                witness_config(partition, &context),
-                (),
-            )
-            .await;
+            let journal = open_witness_journal(context.child("reopen_witness"), partition).await;
+            let reopened = TestDb::<mmr::Family>::init_from_journal(Sequential, journal, ()).await;
             assert!(matches!(
                 reopened,
                 Err(Error::DataCorrupted("invalid compact witness"))
@@ -1499,15 +1445,10 @@ mod tests {
             pinned_nodes[0] = Sha256::fill(0xff);
             witness::tests::overwrite_tip(journal, op_bytes, size, pinned_nodes).await;
 
-            let merkle = crate::merkle::compact::Merkle::new(Sequential);
-            let reopened = TestDb::<mmr::Family>::init_from_merkle(
-                merkle,
-                context.child("reopen_witness"),
-                witness_config(partition, &context),
-                (),
-            )
-            .await
-            .unwrap();
+            let journal = open_witness_journal(context.child("reopen_witness"), partition).await;
+            let reopened = TestDb::<mmr::Family>::init_from_journal(Sequential, journal, ())
+                .await
+                .unwrap();
             assert_ne!(reopened.target(), tampered_target);
             reopened.destroy().await.unwrap();
         });
@@ -1694,11 +1635,12 @@ mod tests {
             // section-aligned and never drops a partial section).
             let mut witness_cfg = witness_config("immutable-prune-rewind", &context);
             witness_cfg.items_per_section = NZU64!(1);
-            let merkle = crate::merkle::compact::Merkle::new(Sequential);
-            let mut db: TestDb<mmr::Family> =
-                Db::init_from_merkle(merkle, context.child("witness"), witness_cfg.clone(), ())
-                    .await
-                    .unwrap();
+            let journal = witness::Journal::init(context.child("witness"), witness_cfg.clone())
+                .await
+                .unwrap();
+            let mut db: TestDb<mmr::Family> = Db::init_from_journal(Sequential, journal, ())
+                .await
+                .unwrap();
 
             // Commit A, B, C.
             let mut sizes = Vec::new();
@@ -1721,15 +1663,15 @@ mod tests {
             ));
 
             // The prune was durable, so reopen and rewind to B.
-            let merkle = crate::merkle::compact::Merkle::new(Sequential);
-            let db: TestDb<mmr::Family> = Db::init_from_merkle(
-                merkle,
+            let journal = witness::Journal::init(
                 context.child("witness").with_attribute("index", 2),
                 witness_cfg,
-                (),
             )
             .await
             .unwrap();
+            let db: TestDb<mmr::Family> = Db::init_from_journal(Sequential, journal, ())
+                .await
+                .unwrap();
             let db = db.rewind(sizes[1]).await.unwrap();
             assert_eq!(db.size(), sizes[1]);
             assert_eq!(db.get_metadata(), Some(Sha256::fill(2)));

--- a/storage/src/qmdb/immutable/fixed.rs
+++ b/storage/src/qmdb/immutable/fixed.rs
@@ -7,7 +7,10 @@ use crate::{
     Context,
     journal::{
         authenticated,
-        contiguous::fixed::{self, Config as JournalConfig},
+        contiguous::{
+            fixed::{self, Config as JournalConfig},
+            variable,
+        },
     },
     merkle::Family,
     qmdb::{
@@ -69,8 +72,8 @@ impl<F: Family, E: Context, K: Array, V: FixedValue, H: Hasher, S: Strategy>
 {
     /// Returns a [CompactDb] initialized from `cfg`.
     pub async fn init(context: E, cfg: CompactConfig<S>) -> Result<Self, Error<F>> {
-        let merkle = crate::merkle::compact::Merkle::new(cfg.strategy);
-        Self::init_from_merkle(merkle, context.child("witness"), cfg.witness, ()).await
+        let journal = variable::Journal::init(context.child("witness"), cfg.witness).await?;
+        Self::init_from_journal(cfg.strategy, journal, ()).await
     }
 }
 

--- a/storage/src/qmdb/immutable/variable.rs
+++ b/storage/src/qmdb/immutable/variable.rs
@@ -82,14 +82,8 @@ where
 {
     /// Returns a [CompactDb] initialized from `cfg`.
     pub async fn init(context: E, cfg: CompactConfig<C, S>) -> Result<Self, Error<F>> {
-        let merkle = crate::merkle::compact::Merkle::new(cfg.strategy);
-        Self::init_from_merkle(
-            merkle,
-            context.child("witness"),
-            cfg.witness,
-            cfg.commit_codec_config,
-        )
-        .await
+        let journal = variable::Journal::init(context.child("witness"), cfg.witness).await?;
+        Self::init_from_journal(cfg.strategy, journal, cfg.commit_codec_config).await
     }
 }
 

--- a/storage/src/qmdb/keyless/compact.rs
+++ b/storage/src/qmdb/keyless/compact.rs
@@ -27,7 +27,6 @@ use super::operation::Operation;
 pub use crate::qmdb::compact::Config;
 use crate::{
     Context,
-    journal::contiguous::variable::{self, Config as JournalConfig},
     merkle::{Family, Location, batch, compact as compact_merkle},
     qmdb::{
         self, Error,
@@ -56,11 +55,10 @@ where
     Operation<F, V>: Read<Cfg = C>,
     C: Clone + Send + Sync + 'static,
 {
-    merkle: compact_merkle::Merkle<F, H::Digest, S>,
     last_commit_metadata: Option<V::Value>,
     inactivity_floor_loc: Location<F>,
     commit_codec_config: C,
-    witness: witness::Store<E, F, H::Digest>,
+    witness: witness::Store<E, F, H, S>,
 }
 
 impl<F, E, V, H, C, S: Strategy> std::fmt::Debug for Db<F, E, V, H, C, S>
@@ -163,7 +161,7 @@ where
         Operation<F, V>: Read<Cfg = C>,
     {
         Self {
-            merkle_batch: db.merkle.new_batch(),
+            merkle_batch: db.witness.merkle().new_batch(),
             appends: Vec::new(),
             parent: None,
             base,
@@ -225,7 +223,7 @@ where
         let total_size = self.base.size + ops.len() as u64;
         let inactive_peaks = F::inactive_peaks(total_size, inactivity_floor);
         let (merkle, root) = compact_batch::merkleize_ops::<F, H, S, _>(
-            &db.merkle,
+            db.witness.merkle(),
             self.merkle_batch,
             ops,
             inactive_peaks,
@@ -291,16 +289,15 @@ where
         witness::validate_inactivity_floor(inactivity_floor_loc, last_commit_loc)?;
 
         let op_bytes = Self::encode_commit_op(last_commit_metadata.clone(), inactivity_floor_loc);
-        let mut merkle =
-            compact_merkle::Merkle::from_compact_state(strategy, last_commit_loc, pinned_nodes)?;
-        let hasher = qmdb::hasher::<H>();
-        merkle.append_leaf(&hasher, &op_bytes)?;
-        let imported = witness::build_witness::<F, H, S>(&merkle, inactivity_floor_loc, op_bytes)?;
-        merkle.prune_to_frontier();
-
-        let witness = witness::Store::from_import(journal, imported);
+        let witness = witness::Store::from_import(
+            journal,
+            strategy,
+            last_commit_loc,
+            pinned_nodes,
+            inactivity_floor_loc,
+            op_bytes,
+        )?;
         Ok(Self {
-            merkle,
             last_commit_metadata,
             inactivity_floor_loc,
             commit_codec_config,
@@ -308,15 +305,14 @@ where
         })
     }
 
-    /// Open a compact db from persisted compact state and rebuild its witness store.
+    /// Open a compact db from its witness journal, rebuilding the Merkle from the tip witness.
     ///
     /// On first open, this bootstraps the initial commit and its witness so every later reopen and
     /// rewind can assume the journal tip is a complete compact witness.
     #[boxed]
-    pub(crate) async fn init_from_merkle(
-        mut merkle: compact_merkle::Merkle<F, H::Digest, S>,
-        witness_context: E,
-        witness_config: JournalConfig<()>,
+    pub(crate) async fn init_from_journal(
+        strategy: S,
+        journal: witness::Journal<E, F, H::Digest>,
         commit_codec_config: C,
     ) -> Result<Self, Error<F>>
     where
@@ -324,11 +320,9 @@ where
         Operation<F, V>: Read<Cfg = C>,
     {
         // Bootstrap: append an initial Commit(None, 0) on first open.
-        let journal: witness::Journal<E, F, H::Digest> =
-            variable::Journal::init(witness_context, witness_config).await?;
-        let (witness, last_commit_op) = witness::init::<E, F, H, S, Operation<F, V>>(
+        let (witness, last_commit_op) = witness::Store::init::<Operation<F, V>>(
             journal,
-            &mut merkle,
+            strategy,
             &commit_codec_config,
             Operation::<F, V>::Commit(None, Location::new(0))
                 .encode()
@@ -339,7 +333,6 @@ where
             return Err(Error::DataCorrupted("last operation was not a commit"));
         };
         Ok(Self {
-            merkle,
             last_commit_metadata,
             inactivity_floor_loc,
             commit_codec_config,
@@ -391,7 +384,7 @@ where
         F: Family,
     {
         Arc::new(MerkleizedBatch {
-            merkle_batch: self.merkle.to_batch(),
+            merkle_batch: self.witness.merkle().to_batch(),
             commit_metadata: self.last_commit_metadata.clone(),
             parent: None,
             bounds: batch_chain::Bounds::from_db(self.commitment(), self.inactivity_floor_loc),
@@ -434,17 +427,14 @@ where
         self.validate_batch(&batch)?;
 
         let start_loc = self.size();
-        self.merkle.apply_batch(&batch.merkle_batch)?;
-        self.last_commit_metadata = batch.commit_metadata.clone();
-        self.inactivity_floor_loc = batch.bounds.inactivity_floor;
-        let last_commit_metadata = self.last_commit_metadata.clone();
-        let inactivity_floor_loc = self.inactivity_floor_loc;
+        let op_bytes =
+            Self::encode_commit_op(batch.commit_metadata.clone(), batch.bounds.inactivity_floor);
         self.witness = self
             .witness
-            .apply::<H, S>(&mut self.merkle, inactivity_floor_loc, || {
-                Self::encode_commit_op(last_commit_metadata, inactivity_floor_loc)
-            })
+            .apply(&batch.merkle_batch, batch.bounds.inactivity_floor, op_bytes)
             .await?;
+        self.last_commit_metadata = batch.commit_metadata.clone();
+        self.inactivity_floor_loc = batch.bounds.inactivity_floor;
         Ok((self, start_loc..batch.bounds.tip.size))
     }
 
@@ -457,15 +447,8 @@ where
     /// operation.
     #[tracing::instrument(name = "qmdb.keyless.compact.db.start_sync", level = "info", skip_all)]
     pub async fn start_sync(mut self) -> Result<(Self, Handle<()>), Error<F>> {
-        let last_commit_metadata = self.last_commit_metadata.clone();
-        let inactivity_floor_loc = self.inactivity_floor_loc;
         let handle;
-        (self.witness, handle) = self
-            .witness
-            .start_sync::<H, S>(&mut self.merkle, inactivity_floor_loc, || {
-                Self::encode_commit_op(last_commit_metadata, inactivity_floor_loc)
-            })
-            .await?;
+        (self.witness, handle) = self.witness.start_sync().await?;
         Ok((self, handle))
     }
 
@@ -473,14 +456,7 @@ where
     /// reopen may need to replay the witness journal's tail to recover.
     #[tracing::instrument(name = "qmdb.keyless.compact.db.commit", level = "info", skip_all)]
     pub async fn commit(mut self) -> Result<Self, Error<F>> {
-        let last_commit_metadata = self.last_commit_metadata.clone();
-        let inactivity_floor_loc = self.inactivity_floor_loc;
-        self.witness = self
-            .witness
-            .commit::<H, S>(&mut self.merkle, inactivity_floor_loc, || {
-                Self::encode_commit_op(last_commit_metadata, inactivity_floor_loc)
-            })
-            .await?;
+        self.witness = self.witness.commit().await?;
         Ok(self)
     }
 
@@ -488,14 +464,7 @@ where
     /// minimize recovery work on reopen.
     #[tracing::instrument(name = "qmdb.keyless.compact.db.sync", level = "info", skip_all)]
     pub async fn sync(mut self) -> Result<Self, Error<F>> {
-        let last_commit_metadata = self.last_commit_metadata.clone();
-        let inactivity_floor_loc = self.inactivity_floor_loc;
-        self.witness = self
-            .witness
-            .sync::<H, S>(&mut self.merkle, inactivity_floor_loc, || {
-                Self::encode_commit_op(last_commit_metadata, inactivity_floor_loc)
-            })
-            .await?;
+        self.witness = self.witness.sync().await?;
         Ok(self)
     }
 
@@ -522,7 +491,7 @@ where
         let last_commit_op;
         (self.witness, last_commit_op) = self
             .witness
-            .rewind::<H, S, Operation<F, V>>(&mut self.merkle, target, &self.commit_codec_config)
+            .rewind::<Operation<F, V>>(target, &self.commit_codec_config)
             .await?;
         let Operation::Commit(last_commit_metadata, inactivity_floor_loc) = last_commit_op else {
             return Err(Error::DataCorrupted("last operation was not a commit"));
@@ -586,6 +555,7 @@ where
 mod tests {
     use super::*;
     use crate::{
+        journal::contiguous::variable::Config as JournalConfig,
         merkle::mmr,
         qmdb::{any::value::FixedEncoding, compact::witness},
     };
@@ -622,8 +592,10 @@ mod tests {
 
     async fn open_db<F: Family>(context: deterministic::Context, partition: &str) -> TestDb<F> {
         let witness_cfg = witness_config(partition, &context);
-        let merkle = crate::merkle::compact::Merkle::new(Sequential);
-        Db::init_from_merkle(merkle, context.child("witness"), witness_cfg, ())
+        let journal = witness::Journal::init(context.child("witness"), witness_cfg)
+            .await
+            .unwrap();
+        Db::init_from_journal(Sequential, journal, ())
             .await
             .unwrap()
     }
@@ -726,12 +698,14 @@ mod tests {
         pending: &PendingSyncs,
     ) -> impl Future<Output = Result<DelayedDb, Error<mmr::Family>>> {
         let witness_cfg = witness_config(partition, context);
-        let merkle = crate::merkle::compact::Merkle::new(Sequential);
         let context = DelayedSyncContext {
             inner: context.child(label),
             pending: pending.clone(),
         };
-        DelayedDb::init_from_merkle(merkle, context.child("witness"), witness_cfg, ())
+        async move {
+            let journal = witness::Journal::init(context.child("witness"), witness_cfg).await?;
+            DelayedDb::init_from_journal(Sequential, journal, ()).await
+        }
     }
 
     /// Apply a single-append batch carrying `seed` as both value and metadata.
@@ -1812,14 +1786,8 @@ mod tests {
             pinned_nodes.push(Sha256::fill(0xff));
             witness::tests::overwrite_tip(journal, op_bytes, size, pinned_nodes).await;
 
-            let merkle = crate::merkle::compact::Merkle::new(Sequential);
-            let reopened = TestDb::<mmr::Family>::init_from_merkle(
-                merkle,
-                context.child("reopen_witness"),
-                witness_config(partition, &context),
-                (),
-            )
-            .await;
+            let journal = open_witness_journal(context.child("reopen_witness"), partition).await;
+            let reopened = TestDb::<mmr::Family>::init_from_journal(Sequential, journal, ()).await;
             assert!(matches!(reopened, Err(Error::DataCorrupted(_))));
         });
     }
@@ -1856,15 +1824,10 @@ mod tests {
             drop(journal);
 
             // The tip entry is intact, so reopen succeeds.
-            let merkle = crate::merkle::compact::Merkle::new(Sequential);
-            let reopened = TestDb::<mmr::Family>::init_from_merkle(
-                merkle,
-                context.child("reopen"),
-                witness_config(partition, &context),
-                (),
-            )
-            .await
-            .unwrap();
+            let journal = open_witness_journal(context.child("reopen"), partition).await;
+            let reopened = TestDb::<mmr::Family>::init_from_journal(Sequential, journal, ())
+                .await
+                .unwrap();
             assert_eq!(reopened.target(), tip_target);
 
             // The corrupt entry fails the rewind before any truncation.
@@ -1874,15 +1837,10 @@ mod tests {
             ));
 
             // The newer history survives: reopen still lands on the original tip.
-            let merkle = crate::merkle::compact::Merkle::new(Sequential);
-            let reopened = TestDb::<mmr::Family>::init_from_merkle(
-                merkle,
-                context.child("reopen2"),
-                witness_config(partition, &context),
-                (),
-            )
-            .await
-            .unwrap();
+            let journal = open_witness_journal(context.child("reopen2"), partition).await;
+            let reopened = TestDb::<mmr::Family>::init_from_journal(Sequential, journal, ())
+                .await
+                .unwrap();
             assert_eq!(reopened.target(), tip_target);
             reopened.destroy().await.unwrap();
         });
@@ -1910,14 +1868,8 @@ mod tests {
             drop(journal);
 
             // Reopen must fail rather than bootstrap a fresh db.
-            let merkle = crate::merkle::compact::Merkle::new(Sequential);
-            let reopened = TestDb::<mmr::Family>::init_from_merkle(
-                merkle,
-                context.child("reopen_witness"),
-                witness_config(partition, &context),
-                (),
-            )
-            .await;
+            let journal = open_witness_journal(context.child("reopen_witness"), partition).await;
+            let reopened = TestDb::<mmr::Family>::init_from_journal(Sequential, journal, ()).await;
             assert!(matches!(reopened, Err(Error::Journal(_))));
         });
     }
@@ -1948,14 +1900,8 @@ mod tests {
             .to_vec();
             witness::tests::overwrite_tip(journal, bad_op, size, pinned_nodes).await;
 
-            let merkle = crate::merkle::compact::Merkle::new(Sequential);
-            let reopened = TestDb::<mmr::Family>::init_from_merkle(
-                merkle,
-                context.child("reopen_witness"),
-                witness_config(partition, &context),
-                (),
-            )
-            .await;
+            let journal = open_witness_journal(context.child("reopen_witness"), partition).await;
+            let reopened = TestDb::<mmr::Family>::init_from_journal(Sequential, journal, ()).await;
             assert!(matches!(
                 reopened,
                 Err(Error::DataCorrupted("invalid compact witness"))
@@ -1986,15 +1932,10 @@ mod tests {
             pinned_nodes[0] = Sha256::fill(0xff);
             witness::tests::overwrite_tip(journal, op_bytes, size, pinned_nodes).await;
 
-            let merkle = crate::merkle::compact::Merkle::new(Sequential);
-            let reopened = TestDb::<mmr::Family>::init_from_merkle(
-                merkle,
-                context.child("reopen_witness"),
-                witness_config(partition, &context),
-                (),
-            )
-            .await
-            .unwrap();
+            let journal = open_witness_journal(context.child("reopen_witness"), partition).await;
+            let reopened = TestDb::<mmr::Family>::init_from_journal(Sequential, journal, ())
+                .await
+                .unwrap();
             assert_ne!(reopened.target(), tampered_target);
             reopened.destroy().await.unwrap();
         });
@@ -2207,11 +2148,12 @@ mod tests {
             // section-aligned and never drops a partial section).
             let mut witness_cfg = witness_config("keyless-prune-rewind", &context);
             witness_cfg.items_per_section = NZU64!(1);
-            let merkle = crate::merkle::compact::Merkle::new(Sequential);
-            let mut db: TestDb<mmr::Family> =
-                Db::init_from_merkle(merkle, context.child("witness"), witness_cfg.clone(), ())
-                    .await
-                    .unwrap();
+            let journal = witness::Journal::init(context.child("witness"), witness_cfg.clone())
+                .await
+                .unwrap();
+            let mut db: TestDb<mmr::Family> = Db::init_from_journal(Sequential, journal, ())
+                .await
+                .unwrap();
 
             // Commit A, B, C.
             let mut sizes = Vec::new();
@@ -2234,15 +2176,15 @@ mod tests {
             ));
 
             // The prune was durable, so reopen and rewind to B.
-            let merkle = crate::merkle::compact::Merkle::new(Sequential);
-            let db: TestDb<mmr::Family> = Db::init_from_merkle(
-                merkle,
+            let journal = witness::Journal::init(
                 context.child("witness").with_attribute("index", 2),
                 witness_cfg,
-                (),
             )
             .await
             .unwrap();
+            let db: TestDb<mmr::Family> = Db::init_from_journal(Sequential, journal, ())
+                .await
+                .unwrap();
             let db = db.rewind(sizes[1]).await.unwrap();
             assert_eq!(db.size(), sizes[1]);
             assert_eq!(db.get_metadata(), Some(U64::new(22)));

--- a/storage/src/qmdb/keyless/fixed.rs
+++ b/storage/src/qmdb/keyless/fixed.rs
@@ -6,7 +6,10 @@ use crate::{
     Context,
     journal::{
         authenticated,
-        contiguous::fixed::{self, Config as JournalConfig},
+        contiguous::{
+            fixed::{self, Config as JournalConfig},
+            variable,
+        },
     },
     merkle::Family,
     qmdb::{
@@ -57,8 +60,8 @@ impl<F: Family, E: Context, V: FixedValue, H: Hasher, S: Strategy> Db<F, E, V, H
 impl<F: Family, E: Context, V: FixedValue, H: Hasher, S: Strategy> CompactDb<F, E, V, H, S> {
     /// Returns a [CompactDb] initialized from `cfg`.
     pub async fn init(context: E, cfg: CompactConfig<S>) -> Result<Self, Error<F>> {
-        let merkle = crate::merkle::compact::Merkle::new(cfg.strategy);
-        Self::init_from_merkle(merkle, context.child("witness"), cfg.witness, ()).await
+        let journal = variable::Journal::init(context.child("witness"), cfg.witness).await?;
+        Self::init_from_journal(cfg.strategy, journal, ()).await
     }
 }
 

--- a/storage/src/qmdb/keyless/variable.rs
+++ b/storage/src/qmdb/keyless/variable.rs
@@ -71,14 +71,8 @@ where
 {
     /// Returns a [CompactDb] initialized from `cfg`.
     pub async fn init(context: E, cfg: CompactConfig<C, S>) -> Result<Self, Error<F>> {
-        let merkle = crate::merkle::compact::Merkle::new(cfg.strategy);
-        Self::init_from_merkle(
-            merkle,
-            context.child("witness"),
-            cfg.witness,
-            cfg.commit_codec_config,
-        )
-        .await
+        let journal = variable::Journal::init(context.child("witness"), cfg.witness).await?;
+        Self::init_from_journal(cfg.strategy, journal, cfg.commit_codec_config).await
     }
 }
 


### PR DESCRIPTION
The compact `Db` held `merkle` and `witness` as sibling fields that were only ever mutated together. Because the store did not own the tree, six of its methods and four free fns took `merkle: &mut Merkle`, every db durability method passed `&mut self.merkle` plus the floor and an encode closure, and opening a db meant building a `Merkle` outside, handing it to `witness::init` to mutate, and then storing both. This PR moves the `Merkle` into the `Store`.

Owning the tree also shows that `commit`, `sync`, and `start_sync` never have a witness to build: the tip witness and the tree are in step at every `Store` boundary (after `init`, `from_import`, `apply`, and `rewind`), so the only thing a durability method may still need to journal is a pending compact-sync import.

## Changes

- `qmdb/compact/witness.rs`: `Store<E, F, D, S>` gains `merkle: compact::Merkle<F, D, S>`. Two constructors replace the outside-in setup: `Store::init(journal, strategy, commit_codec_config, initial_commit_op_bytes)` builds a fresh tree, bootstraps or reloads the tip from the journal, and returns the store with the decoded commit op (this was the free fn `init`, which is gone along with `Store::new` and `Store::replace`); `Store::from_import(journal, strategy, last_commit_loc, pinned_nodes, inactivity_floor_loc, op_bytes)` rebuilds the tree from a compact-sync import (the body `init_from_sync` used to inline) and now returns `Result`. `apply(merkle_batch, inactivity_floor_loc, last_commit_op_bytes)` applies the batch to `self.merkle` and journals the new witness. `commit`, `sync`, and `start_sync` become argless: they only journal a pending import (via the private `flush_import`) and then make the journal durable. `stage` is gone; its two halves are `flush_import` and `append_witness`. `rewind` loses its `merkle` parameter and `S` method generic. `Store` is parameterized on the hasher `H` rather than its digest, so `init`, `from_import`, `apply`, and `rewind` lose their `H: Hasher<Digest = D>` method generics and the db call sites their `::<H>` turbofish; `Witness`, `VerifiedWitness`, and `Journal` stay on `D`. `build_witness` becomes private. `bootstrap_initial_commit`, `load_tip`, and `rebuild` stay free fns on `&mut Merkle`: the first two run inside `Store::init` before a store exists, and `rebuild` is shared by `load_tip` and `rewind`. The db reads the tree through `merkle()` for `new_batch`, `merkleize_ops`, and `to_batch`; the one mutation it drives goes through `apply`.
- `qmdb/keyless/compact.rs`, `qmdb/immutable/compact.rs`: the `merkle` field is gone. `init_from_merkle(merkle, context, journal_config, cfg)` becomes `init_from_journal(strategy, journal, cfg)`, parallel to `init_from_sync` and to the full dbs' `init_from_journal`; the caller opens the witness journal. `init_from_sync` shrinks to validating the commit op, encoding it, and calling `Store::from_import`. Batch code uses `db.witness.merkle()`. `apply_batch` encodes the commit op and passes it with the merkle batch to `Store::apply`; `commit`, `sync`, and `start_sync` call the store with no arguments.
- `qmdb/{keyless,immutable}/{fixed,variable}.rs`: each `init` opens the witness journal and passes `cfg.strategy` instead of a pre-built `Merkle`.
- `import_pending` and `uncommitted` become one `TipState` (`Committed` / `Uncommitted` / `Imported`), so the never-valid both-true combination is unrepresentable; `pending_sync` stays separate because it is orthogonal.
