### PR TITLE
[codec/utils] Add extensible modes and non-empty iterators

### DIFF
--- a/broadcast/fuzz/fuzz_targets/broadcast_engine_operations.rs
+++ b/broadcast/fuzz/fuzz_targets/broadcast_engine_operations.rs
@@ -14,7 +14,7 @@ use commonware_cryptography::{
 use commonware_p2p::{Recipients, simulated::Network};
 use commonware_runtime::{Buf, BufMut, Clock, Quota, Runner, Supervisor as _, deterministic};
 use commonware_utils::{
-    NZUsize, Probability, TestRng, channel::oneshot, futures::Pool, vec::Bounded,
+    NZUsize, Probability, TestRng, channel::oneshot, futures::Pool, probability, vec::Bounded,
 };
 use futures::FutureExt as _;
 use libfuzzer_sys::fuzz_target;
@@ -163,7 +163,7 @@ impl<'a> arbitrary::Arbitrary<'a> for FuzzInput {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         let num_peers = u.int_in_range(1..=5)?;
         let peer_seeds = (0..num_peers).collect::<Vec<_>>(); // avoid duplicate seeds
-        let network_success_rate = Probability!(u.int_in_range(30..=100)?, 100);
+        let network_success_rate = probability!(u.int_in_range(30..=100)?, 100);
         let network_latency_ms = u.int_in_range(1..=100)?;
         let network_jitter_ms = u.int_in_range(0..=50)?;
         let cache_size = u.int_in_range(5..=10)?;

--- a/broadcast/src/buffered/mod.rs
+++ b/broadcast/src/buffered/mod.rs
@@ -56,7 +56,7 @@ mod tests {
         Clock, Error, IoBuf, Metrics as _, Quota, Runner, Supervisor as _, deterministic,
         telemetry::metrics::count_running_tasks,
     };
-    use commonware_utils::{NZUsize, Probability};
+    use commonware_utils::{NZUsize, Probability, probability};
     use std::{
         collections::{BTreeMap, VecDeque},
         num::NonZeroU32,
@@ -379,7 +379,7 @@ mod tests {
         let runner = deterministic::Runner::timed(Duration::from_secs(5));
         runner.start(|context| async move {
             let (peers, mut registrations, oracle) =
-                initialize_simulation(context.child("network"), 4, Probability!(1.0)).await;
+                initialize_simulation(context.child("network"), 4, probability!(1.0)).await;
             let mailboxes =
                 spawn_peer_engines(context.child("peers"), &oracle, &mut registrations).await;
 
@@ -436,7 +436,7 @@ mod tests {
         runner.start(|context| async move {
             // Initialize simulation with 1 peer
             let (peers, mut registrations, oracle) =
-                initialize_simulation(context.child("network"), 1, Probability!(1.0)).await;
+                initialize_simulation(context.child("network"), 1, probability!(1.0)).await;
             let mailboxes =
                 spawn_peer_engines(context.child("peers"), &oracle, &mut registrations).await;
 
@@ -490,7 +490,7 @@ mod tests {
         let runner = deterministic::Runner::timed(Duration::from_secs(5));
         runner.start(|context| async move {
             let (peers, mut registrations, oracle) =
-                initialize_simulation(context.child("network"), 1, Probability!(1.0)).await;
+                initialize_simulation(context.child("network"), 1, probability!(1.0)).await;
             let mailboxes =
                 spawn_peer_engines(context.child("peers"), &oracle, &mut registrations).await;
             let mailbox = mailboxes.get(&peers[0]).unwrap();
@@ -513,7 +513,7 @@ mod tests {
         let runner = deterministic::Runner::timed(Duration::from_secs(30));
         runner.start(|context| async move {
             let (peers, mut registrations, oracle) =
-                initialize_simulation(context.child("network"), 10, Probability!(0.1)).await;
+                initialize_simulation(context.child("network"), 10, probability!(0.1)).await;
             let mailboxes =
                 spawn_peer_engines(context.child("peers"), &oracle, &mut registrations).await;
 
@@ -559,7 +559,7 @@ mod tests {
         let runner = deterministic::Runner::timed(Duration::from_secs(5));
         runner.start(|context| async move {
             let (peers, mut registrations, oracle) =
-                initialize_simulation(context.child("network"), 2, Probability!(1.0)).await;
+                initialize_simulation(context.child("network"), 2, probability!(1.0)).await;
             let mailboxes =
                 spawn_peer_engines(context.child("peers"), &oracle, &mut registrations).await;
 
@@ -592,7 +592,7 @@ mod tests {
         let runner = deterministic::Runner::timed(Duration::from_secs(5));
         runner.start(|context| async move {
             let (peers, mut registrations, oracle) =
-                initialize_simulation(context.child("network"), 2, Probability!(1.0)).await;
+                initialize_simulation(context.child("network"), 2, probability!(1.0)).await;
             let mailboxes =
                 spawn_peer_engines(context.child("peers"), &oracle, &mut registrations).await;
 
@@ -630,7 +630,7 @@ mod tests {
         let runner = deterministic::Runner::timed(Duration::from_secs(5));
         runner.start(|context| async move {
             let (peers, mut registrations, oracle) =
-                initialize_simulation(context.child("network"), 2, Probability!(1.0)).await;
+                initialize_simulation(context.child("network"), 2, probability!(1.0)).await;
             let mailboxes =
                 spawn_peer_engines(context.child("peers"), &oracle, &mut registrations).await;
 
@@ -674,7 +674,7 @@ mod tests {
         runner.start(|context| async move {
             // Initialize simulation with 3 peers
             let (peers, mut registrations, oracle) =
-                initialize_simulation(context.child("network"), 3, Probability!(1.0)).await;
+                initialize_simulation(context.child("network"), 3, probability!(1.0)).await;
             let mailboxes =
                 spawn_peer_engines(context.child("peers"), &oracle, &mut registrations).await;
 
@@ -735,7 +735,7 @@ mod tests {
         let runner = deterministic::Runner::timed(Duration::from_secs(5));
         runner.start(|context| async move {
             let (peers, mut registrations, oracle) =
-                initialize_simulation(context.child("network"), 4, Probability!(1.0)).await;
+                initialize_simulation(context.child("network"), 4, probability!(1.0)).await;
 
             let sender_pk = peers[0].clone();
             let target_peer = peers[1].clone();
@@ -780,7 +780,7 @@ mod tests {
         runner.start(|context| async move {
             // three peers so we can observe from a third
             let (peers, mut registrations, oracle) =
-                initialize_simulation(context.child("network"), 3, Probability!(1.0)).await;
+                initialize_simulation(context.child("network"), 3, probability!(1.0)).await;
             let mailboxes =
                 spawn_peer_engines(context.child("peers"), &oracle, &mut registrations).await;
 
@@ -831,7 +831,7 @@ mod tests {
             let runner = deterministic::Runner::new(config);
             runner.start(|context| async move {
                 let (peers, mut registrations, oracle) =
-                    initialize_simulation(context.child("network"), 1, Probability!(1.0)).await;
+                    initialize_simulation(context.child("network"), 1, probability!(1.0)).await;
                 let mailboxes =
                     spawn_peer_engines(context.child("peers"), &oracle, &mut registrations).await;
 
@@ -869,7 +869,7 @@ mod tests {
         let runner = deterministic::Runner::timed(Duration::from_secs(10));
         runner.start(|context| async move {
             let (peers, mut registrations, oracle) =
-                initialize_simulation(context.child("network"), 3, Probability!(1.0)).await;
+                initialize_simulation(context.child("network"), 3, probability!(1.0)).await;
 
             let attacker = peers[0].clone();
             let honest = peers[1].clone();
@@ -912,7 +912,7 @@ mod tests {
         let runner = deterministic::Runner::timed(Duration::from_secs(10));
         runner.start(|context| async move {
             let (peers, mut registrations, oracle) =
-                initialize_simulation(context.child("network"), 1, Probability!(1.0)).await;
+                initialize_simulation(context.child("network"), 1, probability!(1.0)).await;
             let peer = peers[0].clone();
             let (sender, receiver) = registrations.remove(&peer).unwrap();
 
@@ -1027,7 +1027,7 @@ mod tests {
         let runner = deterministic::Runner::timed(Duration::from_secs(5));
         runner.start(|context| async move {
             let (peers, mut registrations, oracle) =
-                initialize_simulation(context.child("network"), 2, Probability!(1.0)).await;
+                initialize_simulation(context.child("network"), 2, probability!(1.0)).await;
             let (mut mailboxes, handles) = spawn_peer_engines_with_handles(
                 context.child("peers"),
                 &oracle,
@@ -1082,7 +1082,7 @@ mod tests {
         let runner = deterministic::Runner::new(cfg);
         runner.start(|context| async move {
             let (peers, mut registrations, oracle) =
-                initialize_simulation(context.child("network"), 2, Probability!(1.0)).await;
+                initialize_simulation(context.child("network"), 2, probability!(1.0)).await;
 
             let (mailboxes, handles) = spawn_peer_engines_with_handles(
                 context.child("peers"),
@@ -1146,7 +1146,7 @@ mod tests {
         let runner = deterministic::Runner::timed(Duration::from_secs(5));
         runner.start(|context| async move {
             let (peers, mut registrations, oracle) =
-                initialize_simulation(context.child("network"), 3, Probability!(1.0)).await;
+                initialize_simulation(context.child("network"), 3, probability!(1.0)).await;
 
             let peer_a = peers[0].clone();
             let peer_b = peers[1].clone();
@@ -1249,7 +1249,7 @@ mod tests {
             let link = Link {
                 latency: NETWORK_SPEED,
                 jitter: Duration::ZERO,
-                success_rate: Probability!(1.0),
+                success_rate: probability!(1.0),
             };
             for p1 in peers.iter() {
                 for p2 in peers.iter() {
@@ -1378,7 +1378,7 @@ mod tests {
             let link = Link {
                 latency: NETWORK_SPEED,
                 jitter: Duration::ZERO,
-                success_rate: Probability!(1.0),
+                success_rate: probability!(1.0),
             };
             for p1 in &peers {
                 for p2 in &peers {
@@ -1450,7 +1450,7 @@ mod tests {
         runner.start(|context| async move {
             // Add a sole peer (self) to the network
             let (peers, mut registrations, oracle) =
-                initialize_simulation(context.child("network"), 1, Probability!(1.0)).await;
+                initialize_simulation(context.child("network"), 1, probability!(1.0)).await;
             let peer = peers[0].clone();
             let network = registrations.remove(&peer).unwrap();
             let config = Config {
@@ -1517,7 +1517,7 @@ mod tests {
             let link = Link {
                 latency: NETWORK_SPEED,
                 jitter: Duration::ZERO,
-                success_rate: Probability!(1.0),
+                success_rate: probability!(1.0),
             };
             for p1 in &peers {
                 for p2 in &peers {
@@ -1591,7 +1591,7 @@ mod tests {
         let runner = deterministic::Runner::timed(Duration::from_secs(5));
         runner.start(|context| async move {
             let (peers, mut registrations, oracle) =
-                initialize_simulation(context.child("network"), 3, Probability!(1.0)).await;
+                initialize_simulation(context.child("network"), 3, probability!(1.0)).await;
 
             let peer_a = peers[0].clone();
             let peer_b = peers[1].clone();

--- a/codec/conformance.toml
+++ b/codec/conformance.toml
@@ -1,8 +1,8 @@
-["commonware_codec::modes::tests::conformance::CodecConformance<Modes<1>>"]
+["commonware_codec::mode::tests::conformance::CodecConformance<Modes<1>>"]
 n_cases = 65536
 hash = "39a93e796b1f7608760451ba8c4f9ced2a7d657ceeeab42eeacddef0d0fc9682"
 
-["commonware_codec::modes::tests::conformance::CodecConformance<Modes<2>>"]
+["commonware_codec::mode::tests::conformance::CodecConformance<Modes<2>>"]
 n_cases = 65536
 hash = "1f45aef3f064951930cb46ca33a3bbabb0bd6baf0e0645307a6692fba95a510a"
 

--- a/codec/conformance.toml
+++ b/codec/conformance.toml
@@ -1,3 +1,11 @@
+["commonware_codec::modes::tests::conformance::CodecConformance<Modes<1>>"]
+n_cases = 65536
+hash = "39a93e796b1f7608760451ba8c4f9ced2a7d657ceeeab42eeacddef0d0fc9682"
+
+["commonware_codec::modes::tests::conformance::CodecConformance<Modes<2>>"]
+n_cases = 65536
+hash = "1f45aef3f064951930cb46ca33a3bbabb0bd6baf0e0645307a6692fba95a510a"
+
 ["commonware_codec::types::btree_map::tests::conformance::CodecConformance<BTreeMap<u32,u32>>"]
 n_cases = 65536
 hash = "058879e68cef3db01b165d2577e8b10688acf878cb2c8d76b11d6c31311c86fa"

--- a/codec/src/lib.rs
+++ b/codec/src/lib.rs
@@ -222,6 +222,7 @@ commonware_macros::stability_scope!(BETA {
     pub mod config;
     pub mod error;
     pub mod extensions;
+    pub mod modes;
     pub mod types;
     pub mod util;
     pub mod varint;
@@ -232,6 +233,7 @@ commonware_macros::stability_scope!(BETA {
     pub use config::RangeCfg;
     pub use error::Error;
     pub use extensions::*;
+    pub use modes::Modes;
 });
 
 commonware_macros::stability_scope!(ALPHA {

--- a/codec/src/lib.rs
+++ b/codec/src/lib.rs
@@ -222,7 +222,7 @@ commonware_macros::stability_scope!(BETA {
     pub mod config;
     pub mod error;
     pub mod extensions;
-    pub mod modes;
+    pub mod mode;
     pub mod types;
     pub mod util;
     pub mod varint;
@@ -233,7 +233,7 @@ commonware_macros::stability_scope!(BETA {
     pub use config::RangeCfg;
     pub use error::Error;
     pub use extensions::*;
-    pub use modes::{InvalidMode, Mode, Modes};
+    pub use mode::{InvalidMode, Mode, Modes};
 });
 
 commonware_macros::stability_scope!(ALPHA {

--- a/codec/src/lib.rs
+++ b/codec/src/lib.rs
@@ -233,7 +233,7 @@ commonware_macros::stability_scope!(BETA {
     pub use config::RangeCfg;
     pub use error::Error;
     pub use extensions::*;
-    pub use modes::Modes;
+    pub use modes::{InvalidMode, Mode, Modes};
 });
 
 commonware_macros::stability_scope!(ALPHA {

--- a/codec/src/mode.rs
+++ b/codec/src/mode.rs
@@ -237,12 +237,8 @@ mod tests {
     use super::*;
     use crate::{DecodeExt, Encode};
 
-    fn mode(value: u8) -> Mode {
-        Mode::new(value).unwrap()
-    }
-
     fn assert_encoding<const N: usize>(modes: [u8; N], expected: &[u8]) {
-        let modes = Modes::new(modes.map(mode)).unwrap();
+        let modes = Modes::new(modes.map(|value| mode!(value))).unwrap();
         assert_eq!(modes.encode_size(), expected.len());
         let encoded = modes.encode();
         assert_eq!(encoded.as_ref(), expected);
@@ -253,7 +249,7 @@ mod tests {
     fn encodes_continuations() {
         // Empty and all-default mode lists have no packet.
         assert!(Modes::<0>::new([]).is_none());
-        assert!(Modes::new([mode(0), mode(0)]).is_none());
+        assert!(Modes::new([mode!(0), mode!(0)]).is_none());
 
         // A trailing default is absent, preserving the shorter encoding.
         assert_encoding([1, 0], &[0x01]);
@@ -272,11 +268,11 @@ mod tests {
 
         impl From<Enabled> for Mode {
             fn from(_: Enabled) -> Self {
-                mode(1)
+                mode!(1)
             }
         }
 
-        let modes = modes![Enabled, mode(0), Enabled].unwrap();
+        let modes = modes![Enabled, mode!(0), Enabled].unwrap();
         assert_eq!(modes.encode().as_ref(), &[0x81, 0x80, 0x01]);
     }
 
@@ -300,7 +296,7 @@ mod tests {
         let value = 1u8;
 
         assert_eq!(u8::from(MAX), 0x7f);
-        assert_eq!(mode!(value), mode(1));
+        assert_eq!(mode!(value), mode!(1));
     }
 
     #[test]

--- a/codec/src/mode.rs
+++ b/codec/src/mode.rs
@@ -134,6 +134,8 @@ macro_rules! modes {
 
 /// A canonical packet of ordered mode values.
 ///
+/// `N` is the maximum number of modes and must be greater than zero.
+///
 /// The high bit indicates that another mode follows, and trailing zero-valued
 /// modes are omitted. Appending a new mode with value zero therefore preserves
 /// the existing encoding. A `Modes` value denotes a present packet. An all-zero
@@ -149,6 +151,12 @@ macro_rules! modes {
 /// assert_eq!(encoded.as_ref(), &[0x81, 0x80, 0x02]);
 /// assert_eq!(Modes::<3>::decode(encoded).unwrap(), modes);
 /// ```
+///
+/// ```compile_fail
+/// use commonware_codec::Modes;
+///
+/// let _ = Modes::<0>::new([]);
+/// ```
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub struct Modes<const N: usize> {
     encoded: [u8; N],
@@ -162,6 +170,10 @@ impl<const N: usize> Modes<N> {
     /// absent packet rather than an empty packet.
     ///
     pub fn new(modes: [Mode; N]) -> Option<Self> {
+        const {
+            assert!(N > 0, "N must be greater than 0");
+        }
+
         let mut encoded = modes.map(u8::from);
         let last = encoded.iter().rposition(|&mode| mode != 0)?;
         for mode in &mut encoded[..last] {
@@ -190,8 +202,8 @@ impl<const N: usize> Read for Modes<N> {
     type Cfg = ();
 
     fn read_cfg(buf: &mut impl Buf, _: &()) -> Result<Self, Error> {
-        if N == 0 {
-            return Err(Error::Invalid("Modes", "no mode values configured"));
+        const {
+            assert!(N > 0, "N must be greater than 0");
         }
 
         // Preserve framing bits in the stored representation while locating the
@@ -218,8 +230,8 @@ impl<const N: usize> Read for Modes<N> {
 #[cfg(feature = "arbitrary")]
 impl<'a, const N: usize> arbitrary::Arbitrary<'a> for Modes<N> {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
-        if N == 0 {
-            return Err(arbitrary::Error::IncorrectFormat);
+        const {
+            assert!(N > 0, "N must be greater than 0");
         }
 
         let len = u.int_in_range(1..=N)?;
@@ -247,8 +259,7 @@ mod tests {
 
     #[test]
     fn encodes_continuations() {
-        // Empty and all-default mode lists have no packet.
-        assert!(Modes::<0>::new([]).is_none());
+        // All-default mode lists have no packet.
         assert!(Modes::new([mode!(0), mode!(0)]).is_none());
 
         // A trailing default is absent, preserving the shorter encoding.
@@ -308,10 +319,6 @@ mod tests {
 
     #[test]
     fn rejects_truncated_and_oversized_packets() {
-        assert!(matches!(
-            Modes::<0>::decode(&[][..]),
-            Err(Error::Invalid("Modes", _))
-        ));
         assert!(matches!(
             Modes::<2>::decode(&[][..]),
             Err(Error::EndOfBuffer)

--- a/codec/src/modes.rs
+++ b/codec/src/modes.rs
@@ -3,19 +3,104 @@
 use crate::{EncodeSize, Error, Read, ReadExt, Write};
 use bytes::{Buf, BufMut};
 
-/// A canonical packet of ordered mode values.
+// The high bit is packet framing rather than mode value data.
+const CONTINUATION_BIT: u8 = 1 << 7;
+
+/// Error returned when a value cannot be represented as a [`Mode`].
+#[derive(Clone, Copy, Debug, Eq, PartialEq, thiserror::Error)]
+#[error("mode value must fit in seven bits")]
+pub struct InvalidMode;
+
+/// A seven-bit value in an ordered [`Modes`] packet.
 ///
-/// Each mode supports values from 0 through 127. The high bit indicates that
-/// another mode follows, and trailing zero-valued modes are omitted. Appending
-/// a new mode with value zero therefore preserves the existing encoding. A
-/// `Modes` value denotes a present packet. An all-zero list denotes no packet.
+/// The high bit is reserved for packet framing and cannot be represented by this type.
 ///
 /// # Examples
 ///
 /// ```
-/// use commonware_codec::{DecodeExt, Encode, Modes};
+/// use commonware_codec::Mode;
 ///
-/// let modes = Modes::new([1, 0, 2]).unwrap();
+/// let mode = Mode::new(0x7f).unwrap();
+/// assert_eq!(u8::from(mode), 0x7f);
+/// assert!(Mode::new(0x80).is_none());
+/// ```
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct Mode(u8);
+
+impl Mode {
+    /// Creates a mode value, or returns `None` when the reserved high bit is set.
+    pub const fn new(value: u8) -> Option<Self> {
+        if value < CONTINUATION_BIT {
+            Some(Self(value))
+        } else {
+            None
+        }
+    }
+}
+
+impl TryFrom<u8> for Mode {
+    type Error = InvalidMode;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        Self::new(value).ok_or(InvalidMode)
+    }
+}
+
+impl From<Mode> for u8 {
+    fn from(mode: Mode) -> Self {
+        mode.0
+    }
+}
+
+/// Creates a canonical [`Modes`] packet from values convertible to [`Mode`].
+///
+/// Each expression is converted independently before the packet is constructed, so mode values
+/// may have different source types. Returns `None` when every converted value is zero.
+///
+/// # Examples
+///
+/// ```
+/// use commonware_codec::{Encode, Mode, modes};
+///
+/// let enabled = Mode::new(1).unwrap();
+/// let modes = modes![enabled, enabled].unwrap();
+/// assert_eq!(modes.encode().as_ref(), &[0x81, 0x01]);
+/// ```
+///
+/// ```compile_fail
+/// use commonware_codec::modes;
+///
+/// let _ = modes![1u8];
+/// ```
+#[cfg(not(any(
+    commonware_stability_GAMMA,
+    commonware_stability_DELTA,
+    commonware_stability_EPSILON,
+    commonware_stability_RESERVED
+)))] // BETA
+#[macro_export]
+macro_rules! modes {
+    ($($mode:expr),* $(,)?) => {
+        $crate::Modes::new([
+            $(::core::convert::Into::<$crate::Mode>::into($mode)),*
+        ])
+    };
+}
+
+/// A canonical packet of ordered mode values.
+///
+/// The high bit indicates that another mode follows, and trailing zero-valued
+/// modes are omitted. Appending a new mode with value zero therefore preserves
+/// the existing encoding. A `Modes` value denotes a present packet. An all-zero
+/// list denotes no packet.
+///
+/// # Examples
+///
+/// ```
+/// use commonware_codec::{DecodeExt, Encode, Mode, Modes};
+///
+/// let modes = [1, 0, 2].map(|value| Mode::new(value).unwrap());
+/// let modes = Modes::new(modes).unwrap();
 /// let encoded = modes.encode();
 /// assert_eq!(encoded.as_ref(), &[0x81, 0x80, 0x02]);
 /// assert_eq!(Modes::<3>::decode(encoded).unwrap(), modes);
@@ -27,28 +112,19 @@ pub struct Modes<const N: usize> {
 }
 
 impl<const N: usize> Modes<N> {
-    // The high bit is framing rather than value data; when set, another mode follows.
-    const CONTINUATION_BIT: u8 = 1 << 7;
-
     /// Creates a canonical packet from `modes`.
     ///
     /// Returns `None` when every mode is zero. Callers must represent this as an
     /// absent packet rather than an empty packet.
     ///
-    /// # Panics
-    ///
-    /// Panics if any mode uses the reserved high bit.
-    pub fn new(mut modes: [u8; N]) -> Option<Self> {
-        assert!(
-            modes.iter().all(|&mode| mode < Self::CONTINUATION_BIT),
-            "mode must fit in seven bits"
-        );
-        let last = modes.iter().rposition(|&mode| mode != 0)?;
-        for mode in &mut modes[..last] {
-            *mode |= Self::CONTINUATION_BIT;
+    pub fn new(modes: [Mode; N]) -> Option<Self> {
+        let mut encoded = modes.map(u8::from);
+        let last = encoded.iter().rposition(|&mode| mode != 0)?;
+        for mode in &mut encoded[..last] {
+            *mode |= CONTINUATION_BIT;
         }
         Some(Self {
-            encoded: modes,
+            encoded,
             len: last + 1,
         })
     }
@@ -80,7 +156,7 @@ impl<const N: usize> Read for Modes<N> {
         for index in 0..N {
             let byte = u8::read(buf)?;
             encoded[index] = byte;
-            if byte & Self::CONTINUATION_BIT == 0 {
+            if byte & CONTINUATION_BIT == 0 {
                 if byte == 0 {
                     return Err(Error::Invalid("Modes", "trailing mode must be non-zero"));
                 }
@@ -108,6 +184,7 @@ impl<'a, const N: usize> arbitrary::Arbitrary<'a> for Modes<N> {
             *mode = u.int_in_range(0..=0x7f)?;
         }
         modes[len - 1] = u.int_in_range(1..=0x7f)?;
+        let modes = modes.map(|mode| Mode::new(mode).expect("generated mode fits in seven bits"));
         Self::new(modes).ok_or(arbitrary::Error::IncorrectFormat)
     }
 }
@@ -117,8 +194,12 @@ mod tests {
     use super::*;
     use crate::{DecodeExt, Encode};
 
+    fn mode(value: u8) -> Mode {
+        Mode::new(value).unwrap()
+    }
+
     fn assert_encoding<const N: usize>(modes: [u8; N], expected: &[u8]) {
-        let modes = Modes::new(modes).unwrap();
+        let modes = Modes::new(modes.map(mode)).unwrap();
         assert_eq!(modes.encode_size(), expected.len());
         let encoded = modes.encode();
         assert_eq!(encoded.as_ref(), expected);
@@ -129,7 +210,7 @@ mod tests {
     fn encodes_continuations() {
         // Empty and all-default mode lists have no packet.
         assert!(Modes::<0>::new([]).is_none());
-        assert!(Modes::new([0, 0]).is_none());
+        assert!(Modes::new([mode(0), mode(0)]).is_none());
 
         // A trailing default is absent, preserving the shorter encoding.
         assert_encoding([1, 0], &[0x01]);
@@ -143,9 +224,31 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "mode must fit in seven bits")]
-    fn reserved_bit_panics() {
-        let _ = Modes::new([0, 0x80]);
+    fn macro_converts_heterogeneous_values() {
+        struct Enabled;
+
+        impl From<Enabled> for Mode {
+            fn from(_: Enabled) -> Self {
+                mode(1)
+            }
+        }
+
+        let modes = modes![Enabled, mode(0), Enabled].unwrap();
+        assert_eq!(modes.encode().as_ref(), &[0x81, 0x80, 0x01]);
+    }
+
+    #[test]
+    fn mode_enforces_seven_bit_values() {
+        for value in [0, 0x7f] {
+            let mode = Mode::new(value).unwrap();
+            assert_eq!(u8::from(mode), value);
+            assert_eq!(Mode::try_from(value), Ok(mode));
+        }
+
+        for value in [0x80, 0xff] {
+            assert_eq!(Mode::new(value), None);
+            assert_eq!(Mode::try_from(value), Err(InvalidMode));
+        }
     }
 
     #[test]

--- a/codec/src/modes.rs
+++ b/codec/src/modes.rs
@@ -52,6 +52,45 @@ impl From<Mode> for u8 {
     }
 }
 
+/// Creates a [`Mode`] from a `u8` literal or expression.
+///
+/// Literals are validated at compile time. Expressions are validated at runtime.
+///
+/// # Panics
+///
+/// The expression form panics if the reserved high bit is set. Use [`Mode::new`] or
+/// [`Mode::try_from`] to validate untrusted values without panicking.
+///
+/// # Examples
+///
+/// ```
+/// use commonware_codec::{Mode, mode};
+///
+/// const ENABLED: Mode = mode!(1);
+/// assert_eq!(u8::from(ENABLED), 1);
+/// ```
+///
+/// ```compile_fail
+/// use commonware_codec::{Mode, mode};
+///
+/// const INVALID: Mode = mode!(0x80);
+/// ```
+#[cfg(not(any(
+    commonware_stability_GAMMA,
+    commonware_stability_DELTA,
+    commonware_stability_EPSILON,
+    commonware_stability_RESERVED
+)))] // BETA
+#[macro_export]
+macro_rules! mode {
+    ($value:literal) => {
+        const { $crate::Mode::new($value).expect("mode value must fit in seven bits") }
+    };
+    ($value:expr) => {
+        $crate::Mode::new($value).expect("mode value must fit in seven bits")
+    };
+}
+
 /// Creates a canonical [`Modes`] packet from values convertible to [`Mode`].
 ///
 /// Each expression is converted independently before the packet is constructed, so mode values
@@ -60,10 +99,9 @@ impl From<Mode> for u8 {
 /// # Examples
 ///
 /// ```
-/// use commonware_codec::{Encode, Mode, modes};
+/// use commonware_codec::{Encode, mode, modes};
 ///
-/// let enabled = Mode::new(1).unwrap();
-/// let modes = modes![enabled, enabled].unwrap();
+/// let modes = modes![mode!(1), mode!(1)].unwrap();
 /// assert_eq!(modes.encode().as_ref(), &[0x81, 0x01]);
 /// ```
 ///
@@ -97,10 +135,9 @@ macro_rules! modes {
 /// # Examples
 ///
 /// ```
-/// use commonware_codec::{DecodeExt, Encode, Mode, Modes};
+/// use commonware_codec::{DecodeExt, Encode, Modes, mode};
 ///
-/// let modes = [1, 0, 2].map(|value| Mode::new(value).unwrap());
-/// let modes = Modes::new(modes).unwrap();
+/// let modes = Modes::new([mode!(1), mode!(0), mode!(2)]).unwrap();
 /// let encoded = modes.encode();
 /// assert_eq!(encoded.as_ref(), &[0x81, 0x80, 0x02]);
 /// assert_eq!(Modes::<3>::decode(encoded).unwrap(), modes);
@@ -249,6 +286,22 @@ mod tests {
             assert_eq!(Mode::new(value), None);
             assert_eq!(Mode::try_from(value), Err(InvalidMode));
         }
+    }
+
+    #[test]
+    fn mode_macro_constructs_literals_and_expressions() {
+        const MAX: Mode = mode!(0x7f);
+        let value = 1u8;
+
+        assert_eq!(u8::from(MAX), 0x7f);
+        assert_eq!(mode!(value), mode(1));
+    }
+
+    #[test]
+    #[should_panic(expected = "mode value must fit in seven bits")]
+    fn mode_macro_rejects_invalid_expressions() {
+        let value = 0x80u8;
+        let _ = mode!(value);
     }
 
     #[test]

--- a/codec/src/modes.rs
+++ b/codec/src/modes.rs
@@ -1,0 +1,217 @@
+//! Compact encoding for ordered, extensible mode values.
+
+use crate::{EncodeSize, Error, Read, ReadExt, Write};
+use bytes::{Buf, BufMut};
+
+/// A canonical packet of ordered mode values.
+///
+/// Each mode supports values from 0 through 127. The high bit indicates that
+/// another mode follows, and trailing zero-valued modes are omitted. Appending
+/// a new mode with value zero therefore preserves the existing encoding. A
+/// `Modes` value denotes a present packet. An all-zero list denotes no packet.
+///
+/// # Examples
+///
+/// ```
+/// use commonware_codec::{DecodeExt, Encode, Modes};
+///
+/// let modes = Modes::new([1, 0, 2]).unwrap();
+/// let encoded = modes.encode();
+/// assert_eq!(encoded.as_ref(), &[0x81, 0x80, 0x02]);
+/// assert_eq!(Modes::<3>::decode(encoded).unwrap(), modes);
+/// ```
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct Modes<const N: usize> {
+    encoded: [u8; N],
+    len: usize,
+}
+
+impl<const N: usize> Modes<N> {
+    // The high bit is framing rather than value data; when set, another mode follows.
+    const CONTINUATION_BIT: u8 = 1 << 7;
+
+    /// Creates a canonical packet from `modes`.
+    ///
+    /// Returns `None` when every mode is zero. Callers must represent this as an
+    /// absent packet rather than an empty packet.
+    ///
+    /// # Panics
+    ///
+    /// Panics if any mode uses the reserved high bit.
+    pub fn new(mut modes: [u8; N]) -> Option<Self> {
+        assert!(
+            modes.iter().all(|&mode| mode < Self::CONTINUATION_BIT),
+            "mode must fit in seven bits"
+        );
+        let last = modes.iter().rposition(|&mode| mode != 0)?;
+        for mode in &mut modes[..last] {
+            *mode |= Self::CONTINUATION_BIT;
+        }
+        Some(Self {
+            encoded: modes,
+            len: last + 1,
+        })
+    }
+}
+
+impl<const N: usize> Write for Modes<N> {
+    fn write(&self, buf: &mut impl BufMut) {
+        buf.put_slice(&self.encoded[..self.len]);
+    }
+}
+
+impl<const N: usize> EncodeSize for Modes<N> {
+    fn encode_size(&self) -> usize {
+        self.len
+    }
+}
+
+impl<const N: usize> Read for Modes<N> {
+    type Cfg = ();
+
+    fn read_cfg(buf: &mut impl Buf, _: &()) -> Result<Self, Error> {
+        if N == 0 {
+            return Err(Error::Invalid("Modes", "no mode values configured"));
+        }
+
+        // Preserve framing bits in the stored representation while locating the
+        // canonical non-zero terminator.
+        let mut encoded = [0; N];
+        for index in 0..N {
+            let byte = u8::read(buf)?;
+            encoded[index] = byte;
+            if byte & Self::CONTINUATION_BIT == 0 {
+                if byte == 0 {
+                    return Err(Error::Invalid("Modes", "trailing mode must be non-zero"));
+                }
+                return Ok(Self {
+                    encoded,
+                    len: index + 1,
+                });
+            }
+        }
+
+        Err(Error::Invalid("Modes", "too many mode values"))
+    }
+}
+
+#[cfg(feature = "arbitrary")]
+impl<'a, const N: usize> arbitrary::Arbitrary<'a> for Modes<N> {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        if N == 0 {
+            return Err(arbitrary::Error::IncorrectFormat);
+        }
+
+        let len = u.int_in_range(1..=N)?;
+        let mut modes = [0; N];
+        for mode in &mut modes[..len - 1] {
+            *mode = u.int_in_range(0..=0x7f)?;
+        }
+        modes[len - 1] = u.int_in_range(1..=0x7f)?;
+        Self::new(modes).ok_or(arbitrary::Error::IncorrectFormat)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{DecodeExt, Encode};
+
+    fn assert_encoding<const N: usize>(modes: [u8; N], expected: &[u8]) {
+        let modes = Modes::new(modes).unwrap();
+        assert_eq!(modes.encode_size(), expected.len());
+        let encoded = modes.encode();
+        assert_eq!(encoded.as_ref(), expected);
+        assert_eq!(Modes::<N>::decode(encoded).unwrap(), modes);
+    }
+
+    #[test]
+    fn encodes_continuations() {
+        // Empty and all-default mode lists have no packet.
+        assert!(Modes::<0>::new([]).is_none());
+        assert!(Modes::new([0, 0]).is_none());
+
+        // A trailing default is absent, preserving the shorter encoding.
+        assert_encoding([1, 0], &[0x01]);
+
+        // Defaults before or between later values remain positionally encoded.
+        assert_encoding([0, 1], &[0x80, 0x01]);
+        assert_encoding([1, 0, 1], &[0x81, 0x80, 0x01]);
+
+        // The largest mode value remains valid while continuation uses its high bit.
+        assert_encoding([0x7f, 0x7f], &[0xff, 0x7f]);
+    }
+
+    #[test]
+    #[should_panic(expected = "mode must fit in seven bits")]
+    fn reserved_bit_panics() {
+        let _ = Modes::new([0, 0x80]);
+    }
+
+    #[test]
+    fn rejects_truncated_and_oversized_packets() {
+        assert!(matches!(
+            Modes::<0>::decode(&[][..]),
+            Err(Error::Invalid("Modes", _))
+        ));
+        assert!(matches!(
+            Modes::<2>::decode(&[][..]),
+            Err(Error::EndOfBuffer)
+        ));
+        assert!(matches!(
+            Modes::<2>::decode(&[0x80][..]),
+            Err(Error::EndOfBuffer)
+        ));
+        assert!(matches!(
+            Modes::<1>::decode(&[0x80][..]),
+            Err(Error::Invalid("Modes", _))
+        ));
+        assert!(matches!(
+            Modes::<2>::decode(&[0x80, 0x80][..]),
+            Err(Error::Invalid("Modes", _))
+        ));
+        assert!(matches!(
+            Modes::<2>::decode(&[0x80, 0x80, 0x01][..]),
+            Err(Error::Invalid("Modes", _))
+        ));
+    }
+
+    #[test]
+    fn rejects_non_canonical_packets() {
+        assert!(matches!(
+            Modes::<1>::decode(&[0x00][..]),
+            Err(Error::Invalid("Modes", _))
+        ));
+        assert!(matches!(
+            Modes::<2>::decode(&[0x80, 0x00][..]),
+            Err(Error::Invalid("Modes", _))
+        ));
+        assert!(matches!(
+            Modes::<2>::decode(&[0x81, 0x00][..]),
+            Err(Error::Invalid("Modes", _))
+        ));
+    }
+
+    #[test]
+    fn read_stops_at_packet_boundary() {
+        let mut encoded = &[0x01, 0x02][..];
+        let modes = Modes::<2>::read(&mut encoded).unwrap();
+        assert_eq!(modes.encode().as_ref(), &[0x01]);
+        assert_eq!(encoded, &[0x02]);
+        assert!(matches!(
+            Modes::<2>::decode(&[0x01, 0x02][..]),
+            Err(Error::ExtraData(1))
+        ));
+    }
+
+    #[cfg(feature = "arbitrary")]
+    mod conformance {
+        use super::*;
+        use crate::conformance::CodecConformance;
+
+        commonware_conformance::conformance_tests! {
+            CodecConformance<Modes<1>>,
+            CodecConformance<Modes<2>>,
+        }
+    }
+}

--- a/codec/src/modes.rs
+++ b/codec/src/modes.rs
@@ -52,6 +52,13 @@ impl From<Mode> for u8 {
     }
 }
 
+#[cfg(feature = "arbitrary")]
+impl<'a> arbitrary::Arbitrary<'a> for Mode {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        Ok(Self(u.int_in_range(0..=(CONTINUATION_BIT - 1))?))
+    }
+}
+
 /// Creates a [`Mode`] from a `u8` literal or expression.
 ///
 /// Literals are validated at compile time. Expressions are validated at runtime.
@@ -216,12 +223,11 @@ impl<'a, const N: usize> arbitrary::Arbitrary<'a> for Modes<N> {
         }
 
         let len = u.int_in_range(1..=N)?;
-        let mut modes = [0; N];
+        let mut modes = [Mode(0); N];
         for mode in &mut modes[..len - 1] {
-            *mode = u.int_in_range(0..=0x7f)?;
+            *mode = u.arbitrary()?;
         }
-        modes[len - 1] = u.int_in_range(1..=0x7f)?;
-        let modes = modes.map(|mode| Mode::new(mode).expect("generated mode fits in seven bits"));
+        modes[len - 1] = Mode(u.int_in_range(1..=(CONTINUATION_BIT - 1))?);
         Self::new(modes).ok_or(arbitrary::Error::IncorrectFormat)
     }
 }

--- a/collector/src/p2p/mod.rs
+++ b/collector/src/p2p/mod.rs
@@ -66,7 +66,7 @@ mod tests {
         Clock, Quota, Runner, Supervisor as _, deterministic,
         telemetry::metrics::count_running_tasks,
     };
-    use commonware_utils::{NZU32, NZUsize, Probability, ordered::Set};
+    use commonware_utils::{NZU32, NZUsize, ordered::Set, probability};
     use std::{num::NonZeroUsize, time::Duration};
 
     /// Default rate limit quota for tests (high enough to not interfere with normal operation)
@@ -76,12 +76,12 @@ mod tests {
     const LINK: Link = Link {
         latency: Duration::from_millis(10),
         jitter: Duration::from_millis(1),
-        success_rate: Probability!(1.0),
+        success_rate: probability!(1.0),
     };
     const LINK_SLOW: Link = Link {
         latency: Duration::from_secs(1),
         jitter: Duration::from_millis(1),
-        success_rate: Probability!(1.0),
+        success_rate: probability!(1.0),
     };
 
     async fn setup_network_and_peers(

--- a/consensus/fuzz/src/lib.rs
+++ b/consensus/fuzz/src/lib.rs
@@ -36,7 +36,7 @@ use commonware_parallel::Sequential;
 use commonware_runtime::{
     Clock, IoBuf, Runner, Spawner, Supervisor as _, buffer::paged::CacheRef, deterministic,
 };
-use commonware_utils::{FuzzRng, NZU16, NZU32, NZUsize, Probability, channel::mpsc::Receiver};
+use commonware_utils::{FuzzRng, NZU16, NZU32, NZUsize, channel::mpsc::Receiver, probability};
 use futures::future::join_all;
 pub use simplex::{
     SimplexBls12381MinPk, SimplexBls12381MinSig, SimplexBls12381MultisigMinPk,
@@ -100,7 +100,7 @@ async fn setup_degraded_network<E: Clock>(
     let degraded = Link {
         latency: Duration::from_millis(50),
         jitter: Duration::from_millis(50),
-        success_rate: Probability!(0.6),
+        success_rate: probability!(0.6),
     };
     for (peer_idx, peer) in participants.iter().enumerate() {
         if peer_idx == victim_idx {
@@ -269,7 +269,7 @@ async fn setup_network<P: simplex::Simplex>(
     let link = Link {
         latency: Duration::from_millis(10),
         jitter: Duration::from_millis(1),
-        success_rate: Probability!(1.0),
+        success_rate: probability!(1.0),
     };
     link_peers(
         &mut oracle,
@@ -542,7 +542,7 @@ fn run_with_twin_mutator<P: simplex::Simplex>(input: FuzzInput) {
             Action::Update(Link {
                 latency: Duration::from_millis(500),
                 jitter: Duration::from_millis(500),
-                success_rate: Probability!(1.0),
+                success_rate: probability!(1.0),
             }),
             input.partition.filter(),
         )

--- a/consensus/src/aggregation/mod.rs
+++ b/consensus/src/aggregation/mod.rs
@@ -117,9 +117,9 @@ mod tests {
         deterministic::{self, Context},
     };
     use commonware_utils::{
-        NZU16, NZUsize, NonZeroDuration, Probability, TestRng,
+        NZU16, NZUsize, NonZeroDuration, TestRng,
         channel::{fallible::OneshotExt, oneshot},
-        test_rng,
+        probability, test_rng,
     };
     use futures::future::join_all;
     use rand::RngExt as _;
@@ -174,7 +174,7 @@ mod tests {
     const RELIABLE_LINK: Link = Link {
         latency: Duration::from_millis(10),
         jitter: Duration::from_millis(1),
-        success_rate: Probability!(1.0),
+        success_rate: probability!(1.0),
     };
 
     /// Register all participants with the network oracle.
@@ -809,7 +809,7 @@ mod tests {
             let degraded_link = Link {
                 latency: Duration::from_millis(200),
                 jitter: Duration::from_millis(150),
-                success_rate: Probability!(0.5),
+                success_rate: probability!(0.5),
             };
 
             let (mut oracle, mut registrations) =
@@ -1116,7 +1116,7 @@ mod tests {
             let delayed_link = Link {
                 latency: Duration::from_millis(80),
                 jitter: Duration::from_millis(10),
-                success_rate: Probability!(0.98),
+                success_rate: probability!(0.98),
             };
 
             // Initialize the simulated network

--- a/consensus/src/marshal/coding/shards/engine.rs
+++ b/consensus/src/marshal/coding/shards/engine.rs
@@ -1899,8 +1899,8 @@ mod tests {
     use commonware_parallel::Sequential;
     use commonware_runtime::{Quota, Runner, Supervisor as _, deterministic};
     use commonware_utils::{
-        N3f1, NZUsize, Participant, Probability, channel::oneshot::error::TryRecvError,
-        ordered::Set,
+        N3f1, NZUsize, Participant, channel::oneshot::error::TryRecvError, ordered::Set,
+        probability,
     };
     use std::{
         future::Future,
@@ -1941,7 +1941,7 @@ mod tests {
     const DEFAULT_LINK: Link = Link {
         latency: Duration::from_millis(50),
         jitter: Duration::ZERO,
-        success_rate: Probability!(1.0),
+        success_rate: probability!(1.0),
     };
 
     /// Rate limit quota for tests (effectively unlimited).

--- a/consensus/src/marshal/mocks/harness.rs
+++ b/consensus/src/marshal/mocks/harness.rs
@@ -49,7 +49,7 @@ use commonware_storage::{
     archive::{immutable, prunable},
     translator::EightCap,
 };
-use commonware_utils::{NZU16, NZU64, NZUsize, Probability, TestRng, test_rng, vec::NonEmptyVec};
+use commonware_utils::{NZU16, NZU64, NZUsize, TestRng, probability, test_rng, vec::NonEmptyVec};
 use futures::StreamExt;
 use rand::{
     RngExt as _,
@@ -88,12 +88,12 @@ pub const BLOCKS_PER_EPOCH: NonZeroU64 = NZU64!(20);
 pub const LINK: Link = Link {
     latency: Duration::from_millis(100),
     jitter: Duration::from_millis(1),
-    success_rate: Probability!(1.0),
+    success_rate: probability!(1.0),
 };
 pub const UNRELIABLE_LINK: Link = Link {
     latency: Duration::from_millis(200),
     jitter: Duration::from_millis(50),
-    success_rate: Probability!(0.7),
+    success_rate: probability!(0.7),
 };
 pub const TEST_QUOTA: Quota = Quota::per_second(NonZeroU32::MAX);
 

--- a/consensus/src/marshal/standard/mod.rs
+++ b/consensus/src/marshal/standard/mod.rs
@@ -101,10 +101,11 @@ mod tests {
         translator::{EightCap, TwoCap},
     };
     use commonware_utils::{
-        Acknowledgement as _, NZU16, NZU64, NZUsize, Probability,
+        Acknowledgement as _, NZU16, NZU64, NZUsize,
         acknowledgement::Exact,
         channel::{fallible::OneshotExt, mpsc, oneshot, oneshot::error::TryRecvError},
         ordered::{Quorum as _, Set},
+        probability,
         sequence::U64,
         sync::Mutex,
         vec::NonEmptyVec,
@@ -3546,7 +3547,7 @@ mod tests {
 
             // Sync failures are fatal to the local storage state. They must not be
             // converted into a `false` certification/verification verdict.
-            context.storage_fault_config().write().sync_rate = Some(Probability!(1.0));
+            context.storage_fault_config().write().sync_rate = Some(probability!(1.0));
 
             let genesis = make_raw_block(Sha256::hash(&[b""]), Height::zero(), 0);
             let round = Round::new(Epoch::zero(), View::new(1));
@@ -3600,7 +3601,7 @@ mod tests {
             assert_eq!(application.acknowledged().await, Height::zero());
             context.sleep(Duration::from_millis(10)).await;
 
-            context.storage_fault_config().write().sync_rate = Some(Probability!(1.0));
+            context.storage_fault_config().write().sync_rate = Some(probability!(1.0));
 
             let genesis = make_raw_block(Sha256::hash(&[b""]), Height::zero(), 0);
             let round = Round::new(Epoch::zero(), View::new(1));
@@ -3653,7 +3654,7 @@ mod tests {
             assert_eq!(application.acknowledged().await, Height::zero());
             context.sleep(Duration::from_millis(10)).await;
 
-            context.storage_fault_config().write().sync_rate = Some(Probability!(1.0));
+            context.storage_fault_config().write().sync_rate = Some(probability!(1.0));
 
             let genesis = make_raw_block(Sha256::hash(&[b""]), Height::zero(), 0);
             let round = Round::new(Epoch::zero(), View::new(1));

--- a/consensus/src/simplex/actors/batcher/mod.rs
+++ b/consensus/src/simplex/actors/batcher/mod.rs
@@ -88,7 +88,7 @@ mod tests {
         telemetry::traces::{TracedExt as _, collector::TraceStorage},
         tokio,
     };
-    use commonware_utils::{NZUsize, Probability, TestRng, ordered::Set, sync::Mutex, test_rng};
+    use commonware_utils::{NZUsize, TestRng, ordered::Set, probability, sync::Mutex, test_rng};
     use std::{marker::PhantomData, num::NonZeroU32, sync::Arc, time::Duration};
     use tracing::{Level, Span};
 
@@ -173,7 +173,7 @@ mod tests {
                 Link {
                     latency,
                     jitter: Duration::from_millis(0),
-                    success_rate: Probability!(1.0),
+                    success_rate: probability!(1.0),
                 },
             )
             .await
@@ -1765,7 +1765,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: Probability!(1.0),
+                success_rate: probability!(1.0),
             };
             oracle
                 .add_link(injector_pk.clone(), me.clone(), link)
@@ -1917,7 +1917,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: Probability!(1.0),
+                success_rate: probability!(1.0),
             };
             let mut finalize_senders = Vec::new();
             for (i, participant) in participants
@@ -2518,7 +2518,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: Probability!(1.0),
+                success_rate: probability!(1.0),
             };
             let mut participant_senders = Vec::new();
             for (i, pk) in participants.iter().enumerate() {
@@ -2722,7 +2722,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: Probability!(1.0),
+                success_rate: probability!(1.0),
             };
             let mut participant_senders = Vec::new();
             for (i, pk) in participants.iter().enumerate() {
@@ -2889,7 +2889,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: Probability!(1.0),
+                success_rate: probability!(1.0),
             };
             let mut participant_senders = Vec::new();
             for (i, pk) in participants.iter().enumerate() {
@@ -3117,7 +3117,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: Probability!(1.0),
+                success_rate: probability!(1.0),
             };
             let mut participant_senders = Vec::new();
             for (i, pk) in participants.iter().enumerate() {
@@ -3330,7 +3330,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: Probability!(1.0),
+                success_rate: probability!(1.0),
             };
             let injector_pk = PrivateKey::from_seed(3_000_000).public_key();
             let (mut injector_sender, _injector_receiver) = oracle
@@ -3496,7 +3496,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: Probability!(1.0),
+                success_rate: probability!(1.0),
             };
             let mut participant_senders = Vec::new();
             for (i, pk) in participants.iter().enumerate() {
@@ -3705,7 +3705,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: Probability!(1.0),
+                success_rate: probability!(1.0),
             };
             let mut participant_senders = Vec::new();
             for (i, pk) in participants.iter().enumerate() {
@@ -3899,7 +3899,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: Probability!(1.0),
+                success_rate: probability!(1.0),
             };
             let mut participant_senders = Vec::new();
             for (i, pk) in participants.iter().enumerate() {
@@ -4086,7 +4086,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: Probability!(1.0),
+                success_rate: probability!(1.0),
             };
             let mut participant_senders = Vec::new();
             for (i, pk) in participants.iter().enumerate() {
@@ -4283,7 +4283,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: Probability!(1.0),
+                success_rate: probability!(1.0),
             };
             let leader_pk = participants[1].clone();
             let (mut leader_sender, _leader_receiver) = oracle
@@ -4405,7 +4405,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: Probability!(1.0),
+                success_rate: probability!(1.0),
             };
             let leader_pk = participants[1].clone();
             let (mut leader_sender, _leader_receiver) = oracle
@@ -4636,7 +4636,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: Probability!(1.0),
+                success_rate: probability!(1.0),
             };
             let mut peer_senders = Vec::new();
             for (i, pk) in participants.iter().enumerate().skip(1) {
@@ -5008,7 +5008,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: Probability!(1.0),
+                success_rate: probability!(1.0),
             };
             let leader_pk = participants[1].clone();
             let (mut leader_sender, _leader_receiver) = oracle
@@ -5153,7 +5153,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: Probability!(1.0),
+                success_rate: probability!(1.0),
             };
             let leader = Participant::new(1);
             let leader_pk = participants[usize::from(leader)].clone();
@@ -5318,7 +5318,7 @@ mod tests {
                     Link {
                         latency: Duration::from_millis(0),
                         jitter: Duration::from_millis(0),
-                        success_rate: Probability!(1.0),
+                        success_rate: probability!(1.0),
                     },
                 )
                 .await
@@ -5435,7 +5435,7 @@ mod tests {
                     Link {
                         latency: Duration::from_millis(0),
                         jitter: Duration::from_millis(0),
-                        success_rate: Probability!(1.0),
+                        success_rate: probability!(1.0),
                     },
                 )
                 .await
@@ -5808,7 +5808,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: Probability!(1.0),
+                success_rate: probability!(1.0),
             };
             let mut participant_senders = Vec::new();
             for (i, pk) in participants.iter().enumerate() {
@@ -5989,7 +5989,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: Probability!(1.0),
+                success_rate: probability!(1.0),
             };
             let (mut peer_sender, _receiver) = oracle
                 .control(participants[1].clone())
@@ -6128,7 +6128,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: Probability!(1.0),
+                success_rate: probability!(1.0),
             };
             let (mut peer_sender, _receiver) = oracle
                 .control(participants[1].clone())
@@ -6436,7 +6436,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: Probability!(1.0),
+                success_rate: probability!(1.0),
             };
             let mut participant_senders = Vec::new();
             for (i, pk) in participants.iter().enumerate() {
@@ -6658,7 +6658,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: Probability!(1.0),
+                success_rate: probability!(1.0),
             };
             oracle
                 .add_link(sender_pk.clone(), me.clone(), link)
@@ -6851,7 +6851,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: Probability!(1.0),
+                success_rate: probability!(1.0),
             };
             oracle
                 .add_link(sender_pk.clone(), me.clone(), link)

--- a/consensus/src/simplex/actors/resolver/actor.rs
+++ b/consensus/src/simplex/actors/resolver/actor.rs
@@ -650,7 +650,7 @@ mod tests {
     use commonware_parallel::Sequential;
     use commonware_runtime::{Quota, Runner, Supervisor, deterministic};
     use commonware_utils::{
-        NZU32, NZUsize, Probability, channel::oneshot, non_empty_vec, sync::Mutex,
+        NZU32, NZUsize, channel::oneshot, non_empty_vec, probability, sync::Mutex,
     };
     use std::{collections::BTreeSet, sync::Arc};
 
@@ -833,7 +833,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: Probability!(1.0),
+                success_rate: probability!(1.0),
             };
             oracle
                 .add_link(
@@ -1018,7 +1018,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: Probability!(1.0),
+                success_rate: probability!(1.0),
             };
             oracle
                 .add_link(

--- a/consensus/src/simplex/actors/voter/mod.rs
+++ b/consensus/src/simplex/actors/voter/mod.rs
@@ -95,7 +95,7 @@ mod tests {
         telemetry::traces::collector::{RecordedEvents, TraceStorage},
     };
     use commonware_storage::journal::segmented::variable::{Config as JConfig, Journal};
-    use commonware_utils::{NZU16, NZU32, NZUsize, Probability, sync::Mutex};
+    use commonware_utils::{NZU16, NZU32, NZUsize, probability, sync::Mutex};
     use futures::FutureExt;
     use rand_core::CryptoRng;
     use std::{
@@ -2572,7 +2572,7 @@ mod tests {
                     Link {
                         latency: Duration::ZERO,
                         jitter: Duration::ZERO,
-                        success_rate: Probability!(1.0),
+                        success_rate: probability!(1.0),
                     },
                 )
                 .await
@@ -4949,7 +4949,7 @@ mod tests {
                     Link {
                         latency: Duration::from_millis(0),
                         jitter: Duration::from_millis(0),
-                        success_rate: Probability!(1.0),
+                        success_rate: probability!(1.0),
                     },
                 )
                 .await
@@ -9725,7 +9725,7 @@ mod tests {
                     Link {
                         latency: Duration::ZERO,
                         jitter: Duration::ZERO,
-                        success_rate: Probability!(1.0),
+                        success_rate: probability!(1.0),
                     },
                 )
                 .await

--- a/consensus/src/simplex/mod.rs
+++ b/consensus/src/simplex/mod.rs
@@ -697,7 +697,7 @@ mod tests {
         buffer::paged::CacheRef, deterministic, telemetry::metrics::count_running_tasks,
     };
     use commonware_utils::{
-        Faults, N3f1, NZU16, NZU32, NZUsize, Probability, TestRng, ordered::Set, sync::Mutex,
+        Faults, N3f1, NZU16, NZU32, NZUsize, TestRng, ordered::Set, probability, sync::Mutex,
         test_rng,
     };
     use engine::Engine;
@@ -1084,7 +1084,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(200),
                 jitter: Duration::from_millis(1),
-                success_rate: Probability!(1.0),
+                success_rate: probability!(1.0),
             };
             link_validators(&mut oracle, &participants, Action::Link(link), None).await;
 
@@ -1337,7 +1337,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: Probability!(1.0),
+                success_rate: probability!(1.0),
             };
             link_validators(&mut oracle, active, Action::Link(link.clone()), None).await;
 
@@ -1605,7 +1605,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: Probability!(1.0),
+                success_rate: probability!(1.0),
             };
             link_validators(&mut oracle, &participants, Action::Link(link), None).await;
 
@@ -1845,7 +1845,7 @@ mod tests {
                 Link {
                     latency: link_latency,
                     jitter: Duration::from_millis(0),
-                    success_rate: Probability!(1.0),
+                    success_rate: probability!(1.0),
                 },
                 TermLength::new(NZU32!(128)),
                 ViewDelta::new(128),
@@ -1896,7 +1896,7 @@ mod tests {
                 Link {
                     latency: Duration::from_millis(1_000),
                     jitter: Duration::from_millis(1),
-                    success_rate: Probability!(1.0),
+                    success_rate: probability!(1.0),
                 },
                 TermLength::new(NZU32!(1000)),
                 ViewDelta::new(100),
@@ -2032,7 +2032,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: Probability!(1.0),
+                success_rate: probability!(1.0),
             };
             link_validators(&mut oracle, &all_validators, Action::Link(link), None).await;
 
@@ -2202,7 +2202,7 @@ mod tests {
                 let link = Link {
                     latency: Duration::from_millis(50),
                     jitter: Duration::from_millis(50),
-                    success_rate: Probability!(1.0),
+                    success_rate: probability!(1.0),
                 };
                 link_validators(&mut oracle, &participants, Action::Link(link), None).await;
 
@@ -2397,7 +2397,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: Probability!(1.0),
+                success_rate: probability!(1.0),
             };
             link_validators(
                 &mut oracle,
@@ -2497,7 +2497,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_secs(3),
                 jitter: Duration::from_millis(0),
-                success_rate: Probability!(1.0),
+                success_rate: probability!(1.0),
             };
             link_validators(
                 &mut oracle,
@@ -2536,7 +2536,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(3),
-                success_rate: Probability!(1.0),
+                success_rate: probability!(1.0),
             };
             link_validators(
                 &mut oracle,
@@ -2670,7 +2670,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: Probability!(1.0),
+                success_rate: probability!(1.0),
             };
             link_validators(
                 &mut oracle,
@@ -2907,7 +2907,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: Probability!(1.0),
+                success_rate: probability!(1.0),
             };
             link_validators(&mut oracle, &participants, Action::Link(link), None).await;
 
@@ -3079,7 +3079,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_secs(3),
                 jitter: Duration::from_millis(0),
-                success_rate: Probability!(1.0),
+                success_rate: probability!(1.0),
             };
             link_validators(&mut oracle, &participants, Action::Link(link), None).await;
 
@@ -3187,7 +3187,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: Probability!(1.0),
+                success_rate: probability!(1.0),
             };
             link_validators(&mut oracle, &participants, Action::Link(link), None).await;
 
@@ -3381,7 +3381,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: Probability!(1.0),
+                success_rate: probability!(1.0),
             };
             link_validators(
                 &mut oracle,
@@ -3517,7 +3517,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: Probability!(1.0),
+                success_rate: probability!(1.0),
             };
             link_validators(&mut oracle, &participants, Action::Link(link.clone()), None).await;
 
@@ -3724,7 +3724,7 @@ mod tests {
             let degraded_link = Link {
                 latency: Duration::from_millis(200),
                 jitter: Duration::from_millis(150),
-                success_rate: Probability!(0.5),
+                success_rate: probability!(0.5),
             };
             link_validators(
                 &mut oracle,
@@ -3927,7 +3927,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: Probability!(1.0),
+                success_rate: probability!(1.0),
             };
             link_validators(&mut oracle, &participants, Action::Link(link), None).await;
 
@@ -4107,7 +4107,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: Probability!(1.0),
+                success_rate: probability!(1.0),
             };
             link_validators(&mut oracle, &participants, Action::Link(link), None).await;
 
@@ -4262,7 +4262,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(100),
                 jitter: Duration::from_millis(1),
-                success_rate: Probability!(1.0),
+                success_rate: probability!(1.0),
             };
             fn link_graph(_: usize, i: usize, j: usize) -> bool {
                 if i == 0 || j == 0 {
@@ -4422,7 +4422,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(0),
                 jitter: Duration::from_millis(0),
-                success_rate: Probability!(1.0),
+                success_rate: probability!(1.0),
             };
             oracle
                 .add_link(injector_pk.clone(), me.clone(), link)
@@ -4563,7 +4563,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: Probability!(1.0),
+                success_rate: probability!(1.0),
             };
             link_validators(&mut oracle, &participants, Action::Link(link), None).await;
 
@@ -4721,7 +4721,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: Probability!(1.0),
+                success_rate: probability!(1.0),
             };
             link_validators(&mut oracle, &participants, Action::Link(link), None).await;
 
@@ -4990,7 +4990,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: Probability!(1.0),
+                success_rate: probability!(1.0),
             };
             link_validators(&mut oracle, &participants, Action::Link(link), None).await;
 
@@ -5138,7 +5138,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: Probability!(1.0),
+                success_rate: probability!(1.0),
             };
             link_validators(&mut oracle, &participants, Action::Link(link), None).await;
 
@@ -5299,7 +5299,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: Probability!(1.0),
+                success_rate: probability!(1.0),
             };
             link_validators(&mut oracle, &participants, Action::Link(link), None).await;
 
@@ -5438,7 +5438,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(80),
                 jitter: Duration::from_millis(10),
-                success_rate: Probability!(0.98),
+                success_rate: probability!(0.98),
             };
             link_validators(&mut oracle, &participants, Action::Link(link), None).await;
 
@@ -5572,7 +5572,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::from_millis(0),
-                success_rate: Probability!(1.0),
+                success_rate: probability!(1.0),
             };
             link_validators(&mut oracle, &participants, Action::Link(link), None).await;
 
@@ -5728,7 +5728,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: Probability!(1.0),
+                success_rate: probability!(1.0),
             };
             link_validators(&mut oracle, &participants, Action::Link(link), None).await;
 
@@ -6002,7 +6002,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(0),
-                success_rate: Probability!(1.0),
+                success_rate: probability!(1.0),
             };
             for p in participants.iter() {
                 oracle
@@ -6332,7 +6332,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(0),
-                success_rate: Probability!(1.0),
+                success_rate: probability!(1.0),
             };
             for p in participants.iter() {
                 oracle
@@ -6617,7 +6617,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(0),
-                success_rate: Probability!(1.0),
+                success_rate: probability!(1.0),
             };
             for p in participants.iter() {
                 oracle
@@ -6906,7 +6906,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(0),
-                success_rate: Probability!(1.0),
+                success_rate: probability!(1.0),
             };
             for p in participants.iter() {
                 oracle
@@ -7142,7 +7142,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(5),
-                success_rate: Probability!(1.0),
+                success_rate: probability!(1.0),
             };
             link_validators(&mut oracle, &participants, Action::Link(link), None).await;
 
@@ -7294,7 +7294,7 @@ mod tests {
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(1),
-                success_rate: Probability!(1.0),
+                success_rate: probability!(1.0),
             };
             link_validators(&mut oracle, &participants, Action::Link(link), None).await;
 
@@ -8107,7 +8107,7 @@ mod tests {
     const TWINS_LINK: Link = Link {
         latency: Duration::from_millis(500),
         jitter: Duration::from_millis(500),
-        success_rate: Probability!(1.0),
+        success_rate: probability!(1.0),
     };
 
     /// Runs `campaign` with `elector` over a fast link and the slow [TWINS_LINK].
@@ -8116,7 +8116,7 @@ mod tests {
             Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(10),
-                success_rate: Probability!(1.0),
+                success_rate: probability!(1.0),
             },
             TWINS_LINK,
         ] {

--- a/examples/estimator/src/main.rs
+++ b/examples/estimator/src/main.rs
@@ -15,6 +15,7 @@ use commonware_runtime::{
 use commonware_utils::{
     NZUsize, Probability,
     channel::{mpsc, oneshot},
+    probability,
 };
 use estimator::{
     Command, Distribution, Latencies, RegionConfig, calculate_proposer_region, calculate_threshold,
@@ -36,7 +37,7 @@ const DEFAULT_QUOTA: Quota = Quota::per_second(NonZeroU32::MAX);
 const DEFAULT_CHANNEL: u64 = 0;
 
 /// The success probability over all links (100%).
-const DEFAULT_SUCCESS_RATE: Probability = Probability!(1.0);
+const DEFAULT_SUCCESS_RATE: Probability = probability!(1.0);
 
 /// Returns a network configuration that accepts every supported application payload size.
 const fn network_config(max_peers_per_set: usize) -> Config {

--- a/examples/flood/src/bin/flood.rs
+++ b/examples/flood/src/bin/flood.rs
@@ -16,7 +16,7 @@ use commonware_runtime::{
     telemetry::metrics::{HistogramExt as _, MetricsExt as _},
     tokio,
 };
-use commonware_utils::{Probability, TryCollect, ordered::Set, union};
+use commonware_utils::{TryCollect, ordered::Set, probability, union};
 use rand::{Rng, SeedableRng, rngs::SmallRng};
 use std::{
     collections::HashMap,
@@ -82,7 +82,7 @@ fn main() {
             Some(tokio::tracing::Config {
                 endpoint: format!("http://{}:4318/v1/traces", hosts.monitoring.private),
                 name: public_key.to_string(),
-                rate: Probability!(1.0),
+                rate: probability!(1.0),
             })
         } else {
             None

--- a/glue/src/dkg/orchestrator/mod.rs
+++ b/glue/src/dkg/orchestrator/mod.rs
@@ -107,8 +107,8 @@ mod tests {
     };
     use commonware_storage::archive::immutable;
     use commonware_utils::{
-        Acknowledgement, N3f1, NZU16, NZU32, NZU64, NZUsize, Probability, TestRng,
-        acknowledgement::Exact, ordered::Set, sequence::Unit,
+        Acknowledgement, N3f1, NZU16, NZU32, NZU64, NZUsize, TestRng, acknowledgement::Exact,
+        ordered::Set, probability, sequence::Unit,
     };
     use std::{
         net::{IpAddr, Ipv4Addr, SocketAddr},
@@ -124,7 +124,7 @@ mod tests {
     const LINK: Link = Link {
         latency: Duration::from_millis(1),
         jitter: Duration::ZERO,
-        success_rate: Probability!(1.0),
+        success_rate: probability!(1.0),
     };
     type TestStateSync = StateSync<mocks::TestScheme, mocks::TestDigest, mocks::TestBlsVariant>;
 

--- a/glue/src/dkg/probe/mod.rs
+++ b/glue/src/dkg/probe/mod.rs
@@ -267,8 +267,8 @@ mod tests {
     };
     use commonware_storage::archive::immutable;
     use commonware_utils::{
-        N3f1, NZDuration, NZU16, NZU32, NZU64, NZUsize, Probability, TestRng, channel::oneshot,
-        ordered::Set, sequence::Unit,
+        N3f1, NZDuration, NZU16, NZU32, NZU64, NZUsize, TestRng, channel::oneshot, ordered::Set,
+        probability, sequence::Unit,
     };
     use std::{num::NonZeroU64, time::Duration};
 
@@ -279,7 +279,7 @@ mod tests {
     const LINK: Link = Link {
         latency: Duration::from_millis(1),
         jitter: Duration::ZERO,
-        success_rate: Probability!(1.0),
+        success_rate: probability!(1.0),
     };
 
     struct Harness {

--- a/glue/src/dkg/tests/dkg/harness.rs
+++ b/glue/src/dkg/tests/dkg/harness.rs
@@ -39,7 +39,7 @@ use commonware_runtime::{
     telemetry::metrics::count_running_tasks,
 };
 use commonware_utils::{
-    NZU32, NZU64, NZUsize, Participant, Probability, channel::oneshot, ordered::Set,
+    NZU32, NZU64, NZUsize, Participant, channel::oneshot, ordered::Set, probability,
     sequence::Unit, sync::Mutex, test_rng,
 };
 use futures::future::pending;
@@ -342,7 +342,7 @@ pub(super) fn good_link() -> Link {
     Link {
         latency: Duration::from_millis(20),
         jitter: Duration::from_millis(5),
-        success_rate: Probability!(1.0),
+        success_rate: probability!(1.0),
     }
 }
 

--- a/glue/src/dkg/tests/dkg/mod.rs
+++ b/glue/src/dkg/tests/dkg/mod.rs
@@ -4,7 +4,7 @@ mod properties;
 use crate::simulate::action::{Action, Crash, Schedule};
 use commonware_macros::{test_group, test_traced};
 use commonware_p2p::simulated::Link;
-use commonware_utils::Probability;
+use commonware_utils::probability;
 use harness::{
     DkgEngine, good_link, run_activation_failure_completes_empty, run_closed_network_receiver,
     run_plan, run_restart_completion_state_is_fresh,
@@ -30,7 +30,7 @@ fn dkg_e2e_lossy_network() {
         Link {
             latency: Duration::from_millis(60),
             jitter: Duration::from_millis(20),
-            success_rate: Probability!(0.75),
+            success_rate: probability!(0.75),
         },
         vec![],
         ExpectedOutcome::Success,

--- a/glue/src/dkg/tests/reshare/mod.rs
+++ b/glue/src/dkg/tests/reshare/mod.rs
@@ -3,7 +3,7 @@ use commonware_consensus::types::{Epoch, Epocher, FixedEpocher, Height};
 use commonware_cryptography::{bls12381::primitives::sharing::Mode, ed25519};
 use commonware_macros::{test_group, test_traced};
 use commonware_p2p::simulated::Link;
-use commonware_utils::Probability;
+use commonware_utils::probability;
 use rstest::rstest;
 use std::time::Duration;
 
@@ -483,7 +483,7 @@ fn reshare_e2e_state_sync_restart_before_epoch_boundary(#[case] network: Network
     .link(Link {
         latency: Duration::from_millis(4),
         jitter: Duration::from_millis(1),
-        success_rate: Probability!(1.0),
+        success_rate: probability!(1.0),
     })
     .crash(Crash::ProcessedHeight {
         participant: delayed.clone(),
@@ -532,7 +532,7 @@ fn reshare_e2e_state_sync_active_player_late_restart(#[case] network: Network) {
     .link(Link {
         latency: Duration::from_millis(4),
         jitter: Duration::from_millis(1),
-        success_rate: Probability!(1.0),
+        success_rate: probability!(1.0),
     })
     .crash(Crash::DelayRound {
         participants: vec![delayed.clone()],
@@ -590,7 +590,7 @@ fn reshare_e2e_late_state_sync_carries_share_across_failure(#[case] network: Net
     .link(Link {
         latency: Duration::from_millis(4),
         jitter: Duration::from_millis(1),
-        success_rate: Probability!(1.0),
+        success_rate: probability!(1.0),
     })
     .crash(Crash::DelayRound {
         participants: vec![delayed.clone()],
@@ -758,7 +758,7 @@ fn reshare_e2e_lossy_network(#[case] network: Network) {
     .link(Link {
         latency: Duration::from_millis(100),
         jitter: Duration::from_millis(50),
-        success_rate: Probability!(0.7),
+        success_rate: probability!(0.7),
     })
     .timeout(Duration::from_secs(720))
     .run()

--- a/glue/src/simulate/plan.rs
+++ b/glue/src/simulate/plan.rs
@@ -16,7 +16,7 @@ use commonware_p2p::{
     simulated::{self, Link, Network},
 };
 use commonware_runtime::{Clock, Runner as _, Spawner, Supervisor as _, deterministic};
-use commonware_utils::{NZUsize, Probability, TryCollect, channel::mpsc, ordered::Set};
+use commonware_utils::{NZUsize, TryCollect, channel::mpsc, ordered::Set, probability};
 use rand::seq::IndexedRandom;
 use std::{
     collections::HashSet,
@@ -147,7 +147,7 @@ impl<D: EngineDefinition> PlanBuilder<D> {
             link: Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(5),
-                success_rate: Probability!(1.0),
+                success_rate: probability!(1.0),
             },
             max_message_size: 1024 * 1024,
             engine,
@@ -980,7 +980,7 @@ mod tests {
             ctx: super::super::engine::InitContext<'_, Self::PublicKey>,
         ) -> impl Future<Output = (Self::Engine, Self::State)> + Send {
             let saw_fault =
-                ctx.context.storage_fault_config().read().open_rate == Some(Probability!(1.0));
+                ctx.context.storage_fault_config().read().open_rate == Some(probability!(1.0));
             async move {
                 (
                     FaultObservingNode {
@@ -1087,7 +1087,7 @@ mod tests {
         let link = Link {
             latency: Duration::from_millis(10),
             jitter: Duration::from_millis(0),
-            success_rate: Probability!(1.0),
+            success_rate: probability!(1.0),
         };
         let result = PlanBuilder::new(FinalizingEngine::new(1, Duration::from_millis(100), 1))
             .required_finalizations(1)
@@ -1114,7 +1114,7 @@ mod tests {
         let link = Link {
             latency: Duration::from_millis(10),
             jitter: Duration::from_millis(0),
-            success_rate: Probability!(1.0),
+            success_rate: probability!(1.0),
         };
         let engine = FinalizingEngine::new(2, Duration::from_millis(100), 2);
         let delayed = engine.participants[0].clone();
@@ -1200,7 +1200,7 @@ mod tests {
     #[test]
     fn storage_fault_is_visible_during_engine_init() {
         PlanBuilder::new(FaultObservingEngine::new(1))
-            .with_storage_fault(deterministic::FaultConfig::default().open(Probability!(1.0)))
+            .with_storage_fault(deterministic::FaultConfig::default().open(probability!(1.0)))
             .timeout(Duration::from_secs(1))
             .required_finalizations(1)
             .property(AllStatesSawFault)

--- a/glue/src/stateful/probe/mod.rs
+++ b/glue/src/stateful/probe/mod.rs
@@ -169,8 +169,8 @@ mod test {
     };
     use commonware_storage::archive::immutable;
     use commonware_utils::{
-        Acknowledgement, NZDuration, NZU16, NZU64, NZUsize, NonZeroDuration, Probability, TestRng,
-        channel::oneshot, sync::Mutex, test_rng,
+        Acknowledgement, NZDuration, NZU16, NZU64, NZUsize, NonZeroDuration, TestRng,
+        channel::oneshot, probability, sync::Mutex, test_rng,
     };
     use std::{
         collections::BTreeMap,
@@ -185,7 +185,7 @@ mod test {
     const LINK: Link = Link {
         latency: Duration::from_millis(10),
         jitter: Duration::from_millis(1),
-        success_rate: Probability!(1.0),
+        success_rate: probability!(1.0),
     };
     const PROBE_CHANNEL: u64 = 0;
     const BACKFILL_CHANNEL: u64 = 1;

--- a/glue/src/stateful/tests/mod.rs
+++ b/glue/src/stateful/tests/mod.rs
@@ -58,8 +58,8 @@ use commonware_storage::{
     },
 };
 use commonware_utils::{
-    Acknowledgement as _, NZU64, NZUsize, Probability, acknowledgement::Exact, channel::oneshot,
-    non_empty_range, sync::Mutex,
+    Acknowledgement as _, NZU64, NZUsize, acknowledgement::Exact, channel::oneshot,
+    non_empty_range, probability, sync::Mutex,
 };
 use properties::{
     BlockAgreementAtHeight, CrashDuringStateSyncRecovery, LateJoinerStateSyncHandoff,
@@ -159,7 +159,7 @@ fn state_sync_lossy_network() {
     let link = Link {
         latency: Duration::from_millis(200),
         jitter: Duration::from_millis(150),
-        success_rate: Probability!(0.7),
+        success_rate: probability!(0.7),
     };
     run_state_sync_lossy(
         SingleDbEngine::new(NUM_VALIDATORS).with_state_sync(),
@@ -174,7 +174,7 @@ fn lossy_network() {
     let link = Link {
         latency: Duration::from_millis(200),
         jitter: Duration::from_millis(150),
-        success_rate: Probability!(0.7),
+        success_rate: probability!(0.7),
     };
     run_lossy(SingleDbEngine::new(NUM_VALIDATORS), link.clone());
     run_lossy(MultiDbEngine::new(NUM_VALIDATORS), link);
@@ -293,7 +293,7 @@ where
 }
 
 fn storage_fault_config() -> deterministic::FaultConfig {
-    deterministic::FaultConfig::default().sync(Probability!(0.01))
+    deterministic::FaultConfig::default().sync(probability!(0.01))
 }
 
 fn default_storage_fault_schedule<P>(restart_order: impl IntoIterator<Item = P>) -> Schedule<P>
@@ -496,7 +496,7 @@ where
     let dead_link = Link {
         latency: Duration::from_secs(1),
         jitter: Duration::ZERO,
-        success_rate: Probability!(0.0),
+        success_rate: probability!(0.0),
     };
 
     let mut schedule = Schedule::new();
@@ -601,7 +601,7 @@ where
         .link(Link {
             latency: Duration::from_millis(100),
             jitter: Duration::from_millis(5),
-            success_rate: Probability!(1.0),
+            success_rate: probability!(1.0),
         })
         .crash(Crash::Random {
             // A full-cluster crash discards all in-flight votes, and a
@@ -799,12 +799,12 @@ where
     let good_link = Link {
         latency: Duration::from_millis(10),
         jitter: Duration::from_millis(5),
-        success_rate: Probability!(1.0),
+        success_rate: probability!(1.0),
     };
     let dead_link = Link {
         latency: Duration::from_secs(1),
         jitter: Duration::ZERO,
-        success_rate: Probability!(0.0),
+        success_rate: probability!(0.0),
     };
 
     // Build a schedule that kills all links to/from the isolated node at

--- a/p2p/TESTING.md
+++ b/p2p/TESTING.md
@@ -28,7 +28,7 @@ let (certificate_sender, certificate_receiver) = oracle
 oracle.add_link(pk1, pk2, Link {
     latency: Duration::from_millis(10),
     jitter: Duration::from_millis(3),
-    success_rate: commonware_utils::Probability!(0.95),
+    success_rate: commonware_utils::probability!(0.95),
 }).await.unwrap();
 ```
 

--- a/p2p/src/simulated/mod.rs
+++ b/p2p/src/simulated/mod.rs
@@ -62,7 +62,7 @@
 //! use commonware_p2p::simulated::{Config, Link, Network};
 //! use commonware_cryptography::{ed25519, PrivateKey, Signer as _, PublicKey as _, };
 //! use commonware_runtime::{deterministic, Metrics, Quota, Runner, Spawner, Supervisor};
-//! use commonware_utils::{NZU32, NZUsize, Probability};
+//! use commonware_utils::{NZU32, NZUsize, probability};
 //! use std::time::Duration;
 //!
 //! // Generate peers
@@ -111,7 +111,7 @@
 //!         Link {
 //!             latency: Duration::from_millis(5),
 //!             jitter: Duration::from_millis(2),
-//!             success_rate: Probability!(0.75),
+//!             success_rate: probability!(0.75),
 //!         },
 //!     ).await.unwrap();
 //!
@@ -128,7 +128,7 @@
 //!         Link {
 //!             latency: Duration::from_millis(100),
 //!             jitter: Duration::from_millis(25),
-//!             success_rate: Probability!(0.8),
+//!             success_rate: probability!(0.8),
 //!         },
 //!     ).await.unwrap();
 //!
@@ -195,10 +195,11 @@ mod tests {
         telemetry::metrics::count_running_tasks,
     };
     use commonware_utils::{
-        NZU32, NZUsize, Probability,
+        NZU32, NZUsize,
         channel::mpsc,
         hostname, ordered,
         ordered::{Map, Set},
+        probability,
     };
     use rand::RngExt as _;
     use std::{
@@ -289,7 +290,7 @@ mod tests {
                             Link {
                                 latency: Duration::from_millis(5),
                                 jitter: Duration::from_millis(2),
-                                success_rate: Probability!(0.75),
+                                success_rate: probability!(0.75),
                             },
                         )
                         .await;
@@ -424,7 +425,7 @@ mod tests {
                     Link {
                         latency: Duration::from_millis(5),
                         jitter: Duration::from_millis(2),
-                        success_rate: Probability!(0.75),
+                        success_rate: probability!(0.75),
                     },
                 )
                 .await;
@@ -462,7 +463,7 @@ mod tests {
                     Link {
                         latency: Duration::from_millis(10),
                         jitter: Duration::from_millis(1),
-                        success_rate: Probability!(1.0),
+                        success_rate: probability!(1.0),
                     },
                 )
                 .await
@@ -474,7 +475,7 @@ mod tests {
                     Link {
                         latency: Duration::from_millis(10),
                         jitter: Duration::from_millis(1),
-                        success_rate: Probability!(1.0),
+                        success_rate: probability!(1.0),
                     },
                 )
                 .await
@@ -567,7 +568,7 @@ mod tests {
                     Link {
                         latency: Duration::ZERO,
                         jitter: Duration::ZERO,
-                        success_rate: Probability!(1.0),
+                        success_rate: probability!(1.0),
                     },
                 )
                 .await
@@ -647,7 +648,7 @@ mod tests {
                     Link {
                         latency: Duration::from_millis(5),
                         jitter: Duration::from_millis(2),
-                        success_rate: Probability!(1.0),
+                        success_rate: probability!(1.0),
                     },
                 )
                 .await
@@ -659,7 +660,7 @@ mod tests {
                     Link {
                         latency: Duration::from_millis(5),
                         jitter: Duration::from_millis(2),
-                        success_rate: Probability!(1.0),
+                        success_rate: probability!(1.0),
                     },
                 )
                 .await
@@ -722,7 +723,7 @@ mod tests {
                     Link {
                         latency: Duration::from_millis(5),
                         jitter: Duration::ZERO,
-                        success_rate: Probability!(1.0),
+                        success_rate: probability!(1.0),
                     },
                 )
                 .await
@@ -783,7 +784,7 @@ mod tests {
                     Link {
                         latency: Duration::from_millis(5),
                         jitter: Duration::from_millis(2),
-                        success_rate: Probability!(1.0),
+                        success_rate: probability!(1.0),
                     },
                 )
                 .await
@@ -795,7 +796,7 @@ mod tests {
                     Link {
                         latency: Duration::from_millis(5),
                         jitter: Duration::from_millis(2),
-                        success_rate: Probability!(1.0),
+                        success_rate: probability!(1.0),
                     },
                 )
                 .await
@@ -875,7 +876,7 @@ mod tests {
                     Link {
                         latency: Duration::from_millis(5),
                         jitter: Duration::from_millis(2),
-                        success_rate: Probability!(1.0),
+                        success_rate: probability!(1.0),
                     },
                 )
                 .await
@@ -887,7 +888,7 @@ mod tests {
                     Link {
                         latency: Duration::from_millis(5),
                         jitter: Duration::from_millis(2),
-                        success_rate: Probability!(1.0),
+                        success_rate: probability!(1.0),
                     },
                 )
                 .await
@@ -978,7 +979,7 @@ mod tests {
                     // No latency so it doesn't interfere with bandwidth delay calculation
                     latency: Duration::ZERO,
                     jitter: Duration::ZERO,
-                    success_rate: Probability!(1.0),
+                    success_rate: probability!(1.0),
                 },
             )
             .await
@@ -1161,7 +1162,7 @@ mod tests {
                         Link {
                             latency: Duration::ZERO,
                             jitter: Duration::ZERO,
-                            success_rate: Probability!(1.0),
+                            success_rate: probability!(1.0),
                         },
                     )
                     .await
@@ -1173,7 +1174,7 @@ mod tests {
                         Link {
                             latency: Duration::ZERO,
                             jitter: Duration::ZERO,
-                            success_rate: Probability!(1.0),
+                            success_rate: probability!(1.0),
                         },
                     )
                     .await
@@ -1294,7 +1295,7 @@ mod tests {
                     Link {
                         latency: Duration::from_millis(50),
                         jitter: Duration::from_millis(40),
-                        success_rate: Probability!(1.0),
+                        success_rate: probability!(1.0),
                     },
                 )
                 .await
@@ -1361,7 +1362,7 @@ mod tests {
                     Link {
                         latency: Duration::from_millis(5_000),
                         jitter: Duration::ZERO,
-                        success_rate: Probability!(1.0),
+                        success_rate: probability!(1.0),
                     },
                 )
                 .await
@@ -1382,7 +1383,7 @@ mod tests {
                     Link {
                         latency: Duration::from_millis(1),
                         jitter: Duration::ZERO,
-                        success_rate: Probability!(1.0),
+                        success_rate: probability!(1.0),
                     },
                 )
                 .await
@@ -1485,7 +1486,7 @@ mod tests {
                         Link {
                             latency: Duration::ZERO,
                             jitter: Duration::ZERO,
-                            success_rate: Probability!(1.0),
+                            success_rate: probability!(1.0),
                         },
                     )
                     .await
@@ -1575,7 +1576,7 @@ mod tests {
                         Link {
                             latency: Duration::ZERO,
                             jitter: Duration::ZERO,
-                            success_rate: Probability!(1.0),
+                            success_rate: probability!(1.0),
                         },
                     )
                     .await
@@ -1672,7 +1673,7 @@ mod tests {
                         Link {
                             latency: Duration::ZERO,
                             jitter: Duration::ZERO,
-                            success_rate: Probability!(1.0),
+                            success_rate: probability!(1.0),
                         },
                     )
                     .await
@@ -1769,7 +1770,7 @@ mod tests {
                         Link {
                             latency: Duration::from_millis(1),
                             jitter: Duration::ZERO,
-                            success_rate: Probability!(1.0),
+                            success_rate: probability!(1.0),
                         },
                     )
                     .await
@@ -1915,7 +1916,7 @@ mod tests {
                         Link {
                             latency: Duration::from_millis(1),
                             jitter: Duration::ZERO,
-                            success_rate: Probability!(1.0),
+                            success_rate: probability!(1.0),
                         },
                     )
                     .await
@@ -2013,7 +2014,7 @@ mod tests {
                     Link {
                         latency: Duration::from_secs(1), // 1 second latency
                         jitter: Duration::ZERO,
-                        success_rate: Probability!(1.0),
+                        success_rate: probability!(1.0),
                     },
                 )
                 .await
@@ -2104,7 +2105,7 @@ mod tests {
                     Link {
                         latency: Duration::from_millis(1), // Small latency
                         jitter: Duration::ZERO,
-                        success_rate: Probability!(1.0),
+                        success_rate: probability!(1.0),
                     },
                 )
                 .await
@@ -2195,7 +2196,7 @@ mod tests {
                     Link {
                         latency: Duration::ZERO,
                         jitter: Duration::ZERO,
-                        success_rate: Probability!(1.0),
+                        success_rate: probability!(1.0),
                     },
                 )
                 .await
@@ -2274,7 +2275,7 @@ mod tests {
                     Link {
                         latency: Duration::ZERO,
                         jitter: Duration::ZERO,
-                        success_rate: Probability!(1.0),
+                        success_rate: probability!(1.0),
                     },
                 )
                 .await
@@ -2679,7 +2680,7 @@ mod tests {
                                 Link {
                                     latency: Duration::from_millis(1),
                                     jitter: Duration::ZERO,
-                                    success_rate: Probability!(1.0),
+                                    success_rate: probability!(1.0),
                                 },
                             )
                             .await
@@ -2820,7 +2821,7 @@ mod tests {
                     Link {
                         latency: Duration::from_millis(1),
                         jitter: Duration::ZERO,
-                        success_rate: Probability!(1.0),
+                        success_rate: probability!(1.0),
                     },
                 )
                 .await
@@ -3161,7 +3162,7 @@ mod tests {
             let link = ingress::Link {
                 latency: Duration::from_millis(0),
                 jitter: Duration::from_millis(0),
-                success_rate: Probability!(1.0),
+                success_rate: probability!(1.0),
             };
             oracle
                 .add_link(pk1.clone(), pk2.clone(), link.clone())
@@ -3229,7 +3230,7 @@ mod tests {
             let link = ingress::Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(0),
-                success_rate: Probability!(1.0),
+                success_rate: probability!(1.0),
             };
             oracle
                 .add_link(pk1.clone(), pk2.clone(), link.clone())
@@ -3295,7 +3296,7 @@ mod tests {
             let link = ingress::Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(0),
-                success_rate: Probability!(1.0),
+                success_rate: probability!(1.0),
             };
             oracle
                 .add_link(pk1.clone(), pk2.clone(), link.clone())

--- a/p2p/src/simulated/network.rs
+++ b/p2p/src/simulated/network.rs
@@ -1507,7 +1507,7 @@ mod tests {
     };
     use commonware_cryptography::{Signer as _, ed25519};
     use commonware_runtime::{Quota, Runner as _, Supervisor as _, deterministic};
-    use commonware_utils::{NZUsize, ordered::Set};
+    use commonware_utils::{NZUsize, ordered::Set, probability};
     use futures::FutureExt;
     use std::num::NonZeroU32;
 
@@ -1569,7 +1569,7 @@ mod tests {
             let link = ingress::Link {
                 latency: Duration::from_millis(2),
                 jitter: Duration::from_millis(1),
-                success_rate: Probability!(0.9),
+                success_rate: probability!(0.9),
             };
             oracle
                 .add_link(pk1.clone(), pk2.clone(), link.clone())
@@ -1646,7 +1646,7 @@ mod tests {
                     ingress::Link {
                         latency: Duration::ZERO,
                         jitter: Duration::ZERO,
-                        success_rate: Probability!(1.0),
+                        success_rate: probability!(1.0),
                     },
                 )
                 .await
@@ -1918,7 +1918,7 @@ mod tests {
             let link = ingress::Link {
                 latency: Duration::from_millis(0),
                 jitter: Duration::from_millis(0),
-                success_rate: Probability!(1.0),
+                success_rate: probability!(1.0),
             };
             oracle
                 .add_link(peer_a.clone(), twin.clone(), link.clone())
@@ -2005,7 +2005,7 @@ mod tests {
             let link = ingress::Link {
                 latency: Duration::from_millis(0),
                 jitter: Duration::from_millis(0),
-                success_rate: Probability!(1.0),
+                success_rate: probability!(1.0),
             };
             oracle
                 .add_link(peer_c.clone(), twin.clone(), link.clone())
@@ -2075,7 +2075,7 @@ mod tests {
             let link = ingress::Link {
                 latency: Duration::from_millis(0),
                 jitter: Duration::from_millis(0),
-                success_rate: Probability!(1.0),
+                success_rate: probability!(1.0),
             };
             oracle
                 .add_link(peer_c.clone(), twin.clone(), link.clone())
@@ -2306,7 +2306,7 @@ mod tests {
                     ingress::Link {
                         latency: Duration::from_millis(0),
                         jitter: Duration::from_millis(0),
-                        success_rate: Probability!(1.0),
+                        success_rate: probability!(1.0),
                     },
                 )
                 .await
@@ -2392,7 +2392,7 @@ mod tests {
             let link = ingress::Link {
                 latency: Duration::from_millis(0),
                 jitter: Duration::from_millis(0),
-                success_rate: Probability!(1.0),
+                success_rate: probability!(1.0),
             };
             oracle
                 .add_link(sender_pk.clone(), recipient_a.clone(), link.clone())
@@ -2480,7 +2480,7 @@ mod tests {
             let link = ingress::Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::ZERO,
-                success_rate: Probability!(1.0),
+                success_rate: probability!(1.0),
             };
             for (a, b) in [(&pk1, &pk2), (&pk1, &pk3), (&pk2, &pk3)] {
                 oracle
@@ -2631,7 +2631,7 @@ mod tests {
             let link = ingress::Link {
                 latency: Duration::from_millis(1),
                 jitter: Duration::ZERO,
-                success_rate: Probability!(1.0),
+                success_rate: probability!(1.0),
             };
             oracle
                 .add_link(primary_1.clone(), secondary_0.clone(), link.clone())

--- a/p2p/src/utils/codec.rs
+++ b/p2p/src/utils/codec.rs
@@ -301,7 +301,7 @@ mod tests {
     use commonware_macros::test_traced;
     use commonware_parallel::{Manual, Sequential, Strategy};
     use commonware_runtime::{Clock as _, IoBuf, Quota, Runner, Supervisor as _, deterministic};
-    use commonware_utils::{NZUsize, Probability, channel::mpsc, ordered::Set};
+    use commonware_utils::{NZUsize, channel::mpsc, ordered::Set, probability};
     use std::{
         io,
         num::{NonZeroU32, NonZeroUsize},
@@ -315,7 +315,7 @@ mod tests {
     const LINK: Link = Link {
         latency: Duration::from_millis(0),
         jitter: Duration::from_millis(0),
-        success_rate: Probability!(1.0),
+        success_rate: probability!(1.0),
     };
 
     const TEST_QUOTA: Quota = Quota::per_second(NonZeroU32::MAX);

--- a/p2p/src/utils/mux.rs
+++ b/p2p/src/utils/mux.rs
@@ -505,7 +505,7 @@ mod tests {
     };
     use commonware_macros::{select, test_traced};
     use commonware_runtime::{IoBuf, Quota, Runner, Supervisor as _, deterministic};
-    use commonware_utils::{NZUsize, Probability, ordered::Set};
+    use commonware_utils::{NZUsize, ordered::Set, probability};
     use std::{
         num::NonZeroU32,
         time::{Duration, SystemTime},
@@ -514,7 +514,7 @@ mod tests {
     const LINK: Link = Link {
         latency: Duration::from_millis(0),
         jitter: Duration::from_millis(0),
-        success_rate: Probability!(1.0),
+        success_rate: probability!(1.0),
     };
     const CAPACITY: usize = 5usize;
 

--- a/resolver/src/p2p/mod.rs
+++ b/resolver/src/p2p/mod.rs
@@ -127,13 +127,14 @@ mod tests {
         telemetry::metrics::count_running_tasks,
     };
     use commonware_utils::{
-        NZU32, NZUsize, Probability,
+        NZU32, NZUsize,
         channel::{
             fallible::{FallibleExt, OneshotExt},
             mpsc, oneshot,
         },
         non_empty_vec,
         ordered::Set,
+        probability,
         sync::Mutex,
     };
     use std::{
@@ -151,12 +152,12 @@ mod tests {
     const LINK: Link = Link {
         latency: Duration::from_millis(10),
         jitter: Duration::from_millis(1),
-        success_rate: Probability!(1.0),
+        success_rate: probability!(1.0),
     };
     const LINK_UNRELIABLE: Link = Link {
         latency: Duration::from_millis(10),
         jitter: Duration::from_millis(1),
-        success_rate: Probability!(0.5),
+        success_rate: probability!(0.5),
     };
 
     fn status_metric_total(metrics: &str, name: &str, status: &str) -> u64 {

--- a/runtime/src/deterministic.rs
+++ b/runtime/src/deterministic.rs
@@ -1650,7 +1650,7 @@ mod tests {
     use commonware_parallel::Strategy;
     #[cfg(feature = "external")]
     use commonware_utils::channel::mpsc;
-    use commonware_utils::{NZUsize, Probability, ScriptedRng, channel::oneshot};
+    use commonware_utils::{NZUsize, ScriptedRng, channel::oneshot, probability};
     #[cfg(feature = "external")]
     use futures::StreamExt;
     #[cfg(not(feature = "external"))]
@@ -1924,7 +1924,7 @@ mod tests {
         let (stale_config, checkpoint) =
             deterministic::Runner::default().start_and_recover(|context| async move {
                 let config = context.storage_fault_config();
-                *config.write() = FaultConfig::default().open(Probability!(1.0));
+                *config.write() = FaultConfig::default().open(probability!(1.0));
                 config
             });
         *stale_config.write() = FaultConfig::default();
@@ -1940,8 +1940,8 @@ mod tests {
         let cfg = deterministic::Config::default()
             .with_rng(Box::new(ScriptedRng::new(retained_resize)))
             .with_storage_fault_config(FaultConfig::default().resize(ResizeConfig {
-                failure_rate: Probability!(0.5),
-                partial_rate: Probability!(0.0),
+                failure_rate: probability!(0.5),
+                partial_rate: probability!(0.0),
             }));
         let (_, checkpoint) =
             deterministic::Runner::new(cfg).start_and_recover(|context| async move {
@@ -1974,8 +1974,8 @@ mod tests {
             let cfg = deterministic::Config::default()
                 .with_seed(seed)
                 .with_storage_fault_config(FaultConfig::default().write(WriteConfig {
-                    failure_rate: Probability!(0.0),
-                    retention_rate: Probability!(0.5),
+                    failure_rate: probability!(0.0),
+                    retention_rate: probability!(0.5),
                     mode: PartialWriteMode::Subset,
                 }));
             let (_, checkpoint) =
@@ -2355,7 +2355,7 @@ mod tests {
     fn test_storage_fault_injection_and_recovery() {
         // Phase 1: Run with 100% sync failure rate
         let cfg = deterministic::Config::default().with_storage_fault_config(FaultConfig {
-            sync_rate: Some(Probability!(1.0)),
+            sync_rate: Some(probability!(1.0)),
             ..Default::default()
         });
 
@@ -2408,7 +2408,7 @@ mod tests {
 
             // Enable sync faults dynamically
             let storage_fault_cfg = ctx.storage_fault_config();
-            storage_fault_cfg.write().sync_rate = Some(Probability!(1.0));
+            storage_fault_cfg.write().sync_rate = Some(probability!(1.0));
 
             // Now sync should fail
             blob.write_at(0, b"updated".to_vec(), WriteOptions::default())
@@ -2418,7 +2418,7 @@ mod tests {
             assert!(result.is_err(), "sync should fail with faults enabled");
 
             // Disable faults
-            storage_fault_cfg.write().sync_rate = Some(Probability!(0.0));
+            storage_fault_cfg.write().sync_rate = Some(probability!(0.0));
 
             // Sync should succeed again
             blob.sync()
@@ -2434,7 +2434,7 @@ mod tests {
             let cfg = deterministic::Config::default()
                 .with_seed(seed)
                 .with_storage_fault_config(FaultConfig {
-                    open_rate: Some(Probability!(0.5)),
+                    open_rate: Some(probability!(0.5)),
                     ..Default::default()
                 });
 
@@ -2472,13 +2472,13 @@ mod tests {
             let cfg = deterministic::Config::default()
                 .with_seed(seed)
                 .with_storage_fault_config(FaultConfig {
-                    open_rate: Some(Probability!(0.5)),
+                    open_rate: Some(probability!(0.5)),
                     write_rate: Some(WriteConfig {
-                        failure_rate: Probability!(0.3),
-                        retention_rate: Probability!(0.0),
+                        failure_rate: probability!(0.3),
+                        retention_rate: probability!(0.0),
                         mode: PartialWriteMode::Prefix,
                     }),
-                    sync_rate: Some(Probability!(0.2)),
+                    sync_rate: Some(probability!(0.2)),
                     ..Default::default()
                 });
 

--- a/runtime/src/storage/faulty.rs
+++ b/runtime/src/storage/faulty.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use bytes::Buf;
 use commonware_utils::{
-    Probability,
+    Probability, probability,
     sync::{AsyncMutex, Mutex, RwLock},
 };
 use futures::{FutureExt as _, future::Shared};
@@ -104,7 +104,7 @@ impl Config {
             Op::Remove => self.remove_rate,
             Op::Scan => self.scan_rate,
         }
-        .unwrap_or(Probability!(0.0))
+        .unwrap_or(probability!(0.0))
     }
 
     /// Set the open failure rate.
@@ -294,7 +294,7 @@ impl Oracle {
     fn check_resize_fault(&self) -> (bool, Probability, bool) {
         let config = self.config.read();
         let Some(resize_config) = config.resize_rate else {
-            return (false, Probability!(0.0), false);
+            return (false, probability!(0.0), false);
         };
         let failure_rate = config.rate_for(Op::Resize);
         let fail = self.roll(failure_rate);
@@ -673,7 +673,7 @@ impl<B: crate::Blob> Blob<B> {
         }
         if follows_resize {
             let retention = Arc::new(PendingWriteRetention::new(
-                (PartialWriteMode::Prefix, Probability!(1.0)),
+                (PartialWriteMode::Prefix, probability!(1.0)),
                 durable.remaining(),
             ));
             retained.push(PendingMutation::Write {
@@ -982,8 +982,8 @@ mod tests {
     #[tokio::test]
     async fn test_start_sync_returns_before_backing_completion() {
         let h = Harness::new(Config::default().write(WriteConfig {
-            failure_rate: Probability!(0.0),
-            retention_rate: Probability!(1.0),
+            failure_rate: probability!(0.0),
+            retention_rate: probability!(1.0),
             mode: PartialWriteMode::Prefix,
         }));
         let (inner, _) = h.inner.open("partition", b"start-sync").await.unwrap();
@@ -1022,8 +1022,8 @@ mod tests {
 
     async fn run_overlapping_barrier(start: bool) {
         let h = Harness::new(Config::default().write(WriteConfig {
-            failure_rate: Probability!(0.0),
-            retention_rate: Probability!(1.0),
+            failure_rate: probability!(0.0),
+            retention_rate: probability!(1.0),
             mode: PartialWriteMode::Prefix,
         }));
         let (inner, _) = h.inner.open("partition", b"overlap").await.unwrap();
@@ -1087,7 +1087,7 @@ mod tests {
                 } => {
                     assert_eq!(
                         retention.policy,
-                        (PartialWriteMode::Prefix, Probability!(1.0))
+                        (PartialWriteMode::Prefix, probability!(1.0))
                     );
                     blob.inner
                         .retain_crash_write(offset, bufs, || true)
@@ -1112,8 +1112,8 @@ mod tests {
     #[tokio::test]
     async fn test_completed_backing_write_cannot_record_after_later_full_sync() {
         let h = Harness::new(Config::default().write(WriteConfig {
-            failure_rate: Probability!(0.0),
-            retention_rate: Probability!(1.0),
+            failure_rate: probability!(0.0),
+            retention_rate: probability!(1.0),
             mode: PartialWriteMode::Prefix,
         }));
         let (inner, _) = h.inner.open("partition", b"late-record").await.unwrap();
@@ -1171,7 +1171,7 @@ mod tests {
             };
             assert_eq!(
                 retention.policy,
-                (PartialWriteMode::Prefix, Probability!(1.0))
+                (PartialWriteMode::Prefix, probability!(1.0))
             );
             blob.inner
                 .retain_crash_write(offset, bufs, || true)
@@ -1195,8 +1195,8 @@ mod tests {
         let h = Harness::with_seed(
             seed,
             Config::default().write(WriteConfig {
-                failure_rate: Probability!(0.0),
-                retention_rate: Probability!(0.5),
+                failure_rate: probability!(0.0),
+                retention_rate: probability!(0.5),
                 mode: PartialWriteMode::Subset,
             }),
         );
@@ -1209,8 +1209,8 @@ mod tests {
         {
             let mut config = h.config.write();
             config.write_rate = Some(WriteConfig {
-                failure_rate: Probability!(1.0),
-                retention_rate: Probability!(0.5),
+                failure_rate: probability!(1.0),
+                retention_rate: probability!(0.5),
                 mode: PartialWriteMode::Subset,
             });
         }
@@ -1235,8 +1235,8 @@ mod tests {
         let h = Harness::with_seed(
             seed,
             Config::default().write(WriteConfig {
-                failure_rate: Probability!(0.0),
-                retention_rate: Probability!(0.5),
+                failure_rate: probability!(0.0),
+                retention_rate: probability!(0.5),
                 mode: PartialWriteMode::Subset,
             }),
         );
@@ -1265,8 +1265,8 @@ mod tests {
     #[tokio::test]
     async fn test_reopened_sync_clears_prior_handle_crash_writes() {
         let h = Harness::new(Config::default().write(WriteConfig {
-            failure_rate: Probability!(0.0),
-            retention_rate: Probability!(1.0),
+            failure_rate: probability!(0.0),
+            retention_rate: probability!(1.0),
             mode: PartialWriteMode::Prefix,
         }));
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
@@ -1298,8 +1298,8 @@ mod tests {
     #[tokio::test]
     async fn test_dropped_completed_start_sync_clears_the_crash_epoch() {
         let h = Harness::new(Config::default().write(WriteConfig {
-            failure_rate: Probability!(0.0),
-            retention_rate: Probability!(1.0),
+            failure_rate: probability!(0.0),
+            retention_rate: probability!(1.0),
             mode: PartialWriteMode::Prefix,
         }));
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
@@ -1315,8 +1315,8 @@ mod tests {
         drop(completion);
 
         h.config.write().write_rate = Some(WriteConfig {
-            failure_rate: Probability!(0.0),
-            retention_rate: Probability!(1.0),
+            failure_rate: probability!(0.0),
+            retention_rate: probability!(1.0),
             mode: PartialWriteMode::Prefix,
         });
         blob.write_at(5, b"later", WriteOptions::default())
@@ -1339,8 +1339,8 @@ mod tests {
     #[tokio::test]
     async fn test_sync_write_does_not_barrier_disjoint_pending_write() {
         let h = Harness::new(Config::default().write(WriteConfig {
-            failure_rate: Probability!(0.0),
-            retention_rate: Probability!(1.0),
+            failure_rate: probability!(0.0),
+            retention_rate: probability!(1.0),
             mode: PartialWriteMode::Prefix,
         }));
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
@@ -1369,8 +1369,8 @@ mod tests {
     #[tokio::test]
     async fn test_sync_write_retires_only_overlapping_pending_bytes() {
         let h = Harness::new(Config::default().write(WriteConfig {
-            failure_rate: Probability!(0.0),
-            retention_rate: Probability!(1.0),
+            failure_rate: probability!(0.0),
+            retention_rate: probability!(1.0),
             mode: PartialWriteMode::Prefix,
         }));
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
@@ -1419,8 +1419,8 @@ mod tests {
             let h = Harness::with_seed(
                 seed,
                 Config::default().write(WriteConfig {
-                    failure_rate: Probability!(0.0),
-                    retention_rate: Probability!(0.5),
+                    failure_rate: probability!(0.0),
+                    retention_rate: probability!(0.5),
                     mode: PartialWriteMode::Prefix,
                 }),
             );
@@ -1455,13 +1455,13 @@ mod tests {
             Box::new(ScriptedRng::new(retained_resizes)),
             Config::default()
                 .write(WriteConfig {
-                    failure_rate: Probability!(0.0),
-                    retention_rate: Probability!(1.0),
+                    failure_rate: probability!(0.0),
+                    retention_rate: probability!(1.0),
                     mode: PartialWriteMode::Prefix,
                 })
                 .resize(ResizeConfig {
-                    failure_rate: Probability!(0.5),
-                    partial_rate: Probability!(0.0),
+                    failure_rate: probability!(0.5),
+                    partial_rate: probability!(0.0),
                 }),
         );
         let (write_then_resize, _) = h.storage.open("partition", b"first").await.unwrap();
@@ -1516,8 +1516,8 @@ mod tests {
                 retained_resize.into_iter().chain(retained_write_bytes),
             )),
             Config::default().resize(ResizeConfig {
-                failure_rate: Probability!(0.5),
-                partial_rate: Probability!(0.0),
+                failure_rate: probability!(0.5),
+                partial_rate: probability!(0.0),
             }),
         );
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
@@ -1528,8 +1528,8 @@ mod tests {
         {
             let mut config = h.config.write();
             config.write_rate = Some(WriteConfig {
-                failure_rate: Probability!(1.0),
-                retention_rate: Probability!(0.5),
+                failure_rate: probability!(1.0),
+                retention_rate: probability!(0.5),
                 mode: PartialWriteMode::Subset,
             });
         }
@@ -1570,8 +1570,8 @@ mod tests {
     #[tokio::test]
     async fn test_preissued_sync_write_survives_failed_partial_resize() {
         let h = Harness::new(Config::default().resize(ResizeConfig {
-            failure_rate: Probability!(1.0),
-            partial_rate: Probability!(1.0),
+            failure_rate: probability!(1.0),
+            partial_rate: probability!(1.0),
         }));
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
         blob.write_at(0, b"abcdefghij", WriteOptions::SYNC)
@@ -1619,8 +1619,8 @@ mod tests {
     async fn test_partial_sync_write_retires_each_persisted_range() {
         for partial_write_mode in [PartialWriteMode::Prefix, PartialWriteMode::Subset] {
             let h = Harness::new(Config::default().write(WriteConfig {
-                failure_rate: Probability!(0.0),
-                retention_rate: Probability!(1.0),
+                failure_rate: probability!(0.0),
+                retention_rate: probability!(1.0),
                 mode: PartialWriteMode::Prefix,
             }));
             let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
@@ -1633,8 +1633,8 @@ mod tests {
             {
                 let mut config = h.config.write();
                 config.write_rate = Some(WriteConfig {
-                    failure_rate: Probability!(1.0),
-                    retention_rate: Probability!(0.5),
+                    failure_rate: probability!(1.0),
+                    retention_rate: probability!(0.5),
                     mode: partial_write_mode,
                 });
             }
@@ -1694,7 +1694,7 @@ mod tests {
         let expected = expected.storage.ctx.rng.lock().random::<u64>();
 
         let h = Harness::with_seed(0, Config::default());
-        for (probability, outcome) in [(Probability!(0.0), false), (Probability!(1.0), true)] {
+        for (probability, outcome) in [(probability!(0.0), false), (probability!(1.0), true)] {
             assert_eq!(h.storage.ctx.roll(probability), outcome);
             for mode in [PartialWriteMode::Prefix, PartialWriteMode::Subset] {
                 assert_eq!(
@@ -1716,7 +1716,7 @@ mod tests {
             let retained = h
                 .storage
                 .ctx
-                .retained_bytes(4, (PartialWriteMode::Prefix, Probability!(0.5)));
+                .retained_bytes(4, (PartialWriteMode::Prefix, probability!(0.5)));
             let prefix_len = retained.iter().take_while(|&&keep| keep).count();
             assert!(retained[prefix_len..].iter().all(|&keep| !keep));
             observed[prefix_len] = true;
@@ -1726,7 +1726,7 @@ mod tests {
         assert!(
             h.storage
                 .ctx
-                .retained_bytes(0, (PartialWriteMode::Prefix, Probability!(0.5)))
+                .retained_bytes(0, (PartialWriteMode::Prefix, probability!(0.5)))
                 .is_empty()
         );
     }
@@ -1734,8 +1734,8 @@ mod tests {
     #[tokio::test]
     async fn test_write_rejects_offset_overflow_before_retention() {
         let h = Harness::new(Config::default().write(WriteConfig {
-            failure_rate: Probability!(1.0),
-            retention_rate: Probability!(0.5),
+            failure_rate: probability!(1.0),
+            retention_rate: probability!(0.5),
             mode: PartialWriteMode::Subset,
         }));
         let (blob, _) = h.storage.open("partition", b"blob").await.unwrap();
@@ -1751,8 +1751,8 @@ mod tests {
     #[tokio::test]
     async fn test_failed_write_can_retain_every_byte() {
         let h = Harness::new(Config::default().write(WriteConfig {
-            failure_rate: Probability!(1.0),
-            retention_rate: Probability!(1.0),
+            failure_rate: probability!(1.0),
+            retention_rate: probability!(1.0),
             mode: PartialWriteMode::Prefix,
         }));
         let (blob, _) = h.storage.open("partition", b"blob").await.unwrap();
@@ -1801,7 +1801,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_faulty_storage_sync_always_fails() {
-        let h = Harness::new(Config::default().sync(Probability!(1.0)));
+        let h = Harness::new(Config::default().sync(probability!(1.0)));
 
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
         blob.write_at(0, b"data".to_vec(), WriteOptions::default())
@@ -1816,11 +1816,11 @@ mod tests {
         let h = Harness::new(
             Config::default()
                 .write(WriteConfig {
-                    failure_rate: Probability!(0.0),
-                    retention_rate: Probability!(1.0),
+                    failure_rate: probability!(0.0),
+                    retention_rate: probability!(1.0),
                     mode: PartialWriteMode::Prefix,
                 })
-                .sync(Probability!(1.0)),
+                .sync(probability!(1.0)),
         );
 
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
@@ -1836,8 +1836,8 @@ mod tests {
     #[tokio::test]
     async fn test_faulty_storage_write_always_fails() {
         let h = Harness::new(Config::default().write(WriteConfig {
-            failure_rate: Probability!(1.0),
-            retention_rate: Probability!(0.0),
+            failure_rate: probability!(1.0),
+            retention_rate: probability!(0.0),
             mode: PartialWriteMode::Prefix,
         }));
 
@@ -1853,8 +1853,8 @@ mod tests {
     #[tokio::test]
     async fn test_faulty_storage_write_at_sync_write_always_fails() {
         let h = Harness::new(Config::default().write(WriteConfig {
-            failure_rate: Probability!(1.0),
-            retention_rate: Probability!(0.0),
+            failure_rate: probability!(1.0),
+            retention_rate: probability!(0.0),
             mode: PartialWriteMode::Prefix,
         }));
 
@@ -1868,7 +1868,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_faulty_storage_write_at_sync_failure_is_not_durable() {
-        let h = Harness::new(Config::default().sync(Probability!(1.0)));
+        let h = Harness::new(Config::default().sync(probability!(1.0)));
 
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
 
@@ -1883,7 +1883,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_faulty_storage_empty_write_at_sync_does_not_sync_prior_write() {
-        let h = Harness::new(Config::default().sync(Probability!(1.0)));
+        let h = Harness::new(Config::default().sync(probability!(1.0)));
 
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
         blob.write_at(0, b"data".to_vec(), WriteOptions::default())
@@ -1901,8 +1901,8 @@ mod tests {
     #[tokio::test]
     async fn test_empty_unsynced_write_does_not_create_crash_debt() {
         let h = Harness::new(Config::default().write(WriteConfig {
-            failure_rate: Probability!(0.0),
-            retention_rate: Probability!(1.0),
+            failure_rate: probability!(0.0),
+            retention_rate: probability!(1.0),
             mode: PartialWriteMode::Prefix,
         }));
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
@@ -1924,7 +1924,7 @@ mod tests {
         blob.sync().await.unwrap();
 
         // Enable read faults
-        h.config.write().read_rate = Some(Probability!(1.0));
+        h.config.write().read_rate = Some(probability!(1.0));
 
         assert!(matches!(
             blob.read_at(0, 4, ReadOptions::default()).await,
@@ -1934,7 +1934,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_faulty_storage_open_always_fails() {
-        let h = Harness::new(Config::default().open(Probability!(1.0)));
+        let h = Harness::new(Config::default().open(probability!(1.0)));
 
         assert!(matches!(
             h.storage.open("partition", b"test").await,
@@ -1955,7 +1955,7 @@ mod tests {
         drop(blob);
 
         // Enable remove faults
-        h.config.write().remove_rate = Some(Probability!(1.0));
+        h.config.write().remove_rate = Some(probability!(1.0));
 
         assert!(matches!(
             h.storage.remove("partition", Some(b"test")).await,
@@ -1978,7 +1978,7 @@ mod tests {
         }
 
         // Enable scan faults
-        h.config.write().scan_rate = Some(Probability!(1.0));
+        h.config.write().scan_rate = Some(probability!(1.0));
 
         assert!(matches!(
             h.storage.scan("partition").await,
@@ -1998,11 +1998,11 @@ mod tests {
             results
         }
 
-        let results1 = run_ops(42, Probability!(0.5)).await;
-        let results2 = run_ops(42, Probability!(0.5)).await;
+        let results1 = run_ops(42, probability!(0.5)).await;
+        let results2 = run_ops(42, probability!(0.5)).await;
         assert_eq!(results1, results2, "Same seed should produce same results");
 
-        let results3 = run_ops(999, Probability!(0.5)).await;
+        let results3 = run_ops(999, probability!(0.5)).await;
         assert_ne!(
             results1, results3,
             "Different seeds should produce different results"
@@ -2012,22 +2012,22 @@ mod tests {
     #[tokio::test]
     async fn test_faulty_storage_rate_for() {
         let config = Config::default()
-            .open(Probability!(0.1))
+            .open(probability!(0.1))
             .write(WriteConfig {
-                failure_rate: Probability!(0.3),
-                retention_rate: Probability!(0.4),
+                failure_rate: probability!(0.3),
+                retention_rate: probability!(0.4),
                 mode: PartialWriteMode::Subset,
             })
             .resize(ResizeConfig {
-                failure_rate: Probability!(0.7),
-                partial_rate: Probability!(0.8),
+                failure_rate: probability!(0.7),
+                partial_rate: probability!(0.8),
             })
-            .sync(Probability!(0.9));
+            .sync(probability!(0.9));
 
-        assert_eq!(config.rate_for(Op::Open), Probability!(0.1));
-        assert_eq!(config.rate_for(Op::Write), Probability!(0.3));
-        assert_eq!(config.rate_for(Op::Resize), Probability!(0.7));
-        assert_eq!(config.rate_for(Op::Sync), Probability!(0.9));
+        assert_eq!(config.rate_for(Op::Open), probability!(0.1));
+        assert_eq!(config.rate_for(Op::Write), probability!(0.3));
+        assert_eq!(config.rate_for(Op::Resize), probability!(0.7));
+        assert_eq!(config.rate_for(Op::Sync), probability!(0.9));
     }
 
     #[tokio::test]
@@ -2037,18 +2037,18 @@ mod tests {
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
         blob.sync().await.unwrap();
 
-        h.config.write().sync_rate = Some(Probability!(1.0));
+        h.config.write().sync_rate = Some(probability!(1.0));
         assert!(matches!(blob.sync().await, Err(Error::Io(_))));
 
-        h.config.write().sync_rate = Some(Probability!(0.0));
+        h.config.write().sync_rate = Some(probability!(0.0));
         blob.sync().await.unwrap();
     }
 
     #[tokio::test]
     async fn test_write_retention_is_snapshotted_and_replayed_in_order() {
         let h = Harness::new(Config::default().write(WriteConfig {
-            failure_rate: Probability!(0.0),
-            retention_rate: Probability!(1.0),
+            failure_rate: probability!(0.0),
+            retention_rate: probability!(1.0),
             mode: PartialWriteMode::Prefix,
         }));
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
@@ -2064,8 +2064,8 @@ mod tests {
             .await
             .unwrap();
         h.config.write().write_rate = Some(WriteConfig {
-            failure_rate: Probability!(0.0),
-            retention_rate: Probability!(1.0),
+            failure_rate: probability!(0.0),
+            retention_rate: probability!(1.0),
             mode: PartialWriteMode::Prefix,
         });
         blob.write_at(1, b"XY", WriteOptions::default())
@@ -2128,8 +2128,8 @@ mod tests {
                 let h = Harness::with_seed(
                     seed,
                     Config::default().write(WriteConfig {
-                        failure_rate: Probability!(0.0),
-                        retention_rate: Probability!(0.5),
+                        failure_rate: probability!(0.0),
+                        retention_rate: probability!(0.5),
                         mode: PartialWriteMode::Subset,
                     }),
                 );
@@ -2143,8 +2143,8 @@ mod tests {
                 {
                     let mut config = h.config.write();
                     config.write_rate = Some(WriteConfig {
-                        failure_rate: Probability!(1.0),
-                        retention_rate: Probability!(0.5),
+                        failure_rate: probability!(1.0),
+                        retention_rate: probability!(0.5),
                         mode: partial_write_mode,
                     });
                 }
@@ -2177,8 +2177,8 @@ mod tests {
             let h = Harness::with_seed(
                 seed,
                 Config::default().write(WriteConfig {
-                    failure_rate: Probability!(0.0),
-                    retention_rate: Probability!(0.5),
+                    failure_rate: probability!(0.0),
+                    retention_rate: probability!(0.5),
                     mode: PartialWriteMode::Subset,
                 }),
             );
@@ -2192,8 +2192,8 @@ mod tests {
             {
                 let mut config = h.config.write();
                 config.resize_rate = Some(ResizeConfig {
-                    failure_rate: Probability!(1.0),
-                    partial_rate: Probability!(1.0),
+                    failure_rate: probability!(1.0),
+                    partial_rate: probability!(1.0),
                 });
             }
 
@@ -2216,8 +2216,8 @@ mod tests {
     #[tokio::test]
     async fn test_crash_journal_clears_only_after_completed_durability() {
         let h = Harness::new(Config::default().write(WriteConfig {
-            failure_rate: Probability!(0.0),
-            retention_rate: Probability!(1.0),
+            failure_rate: probability!(0.0),
+            retention_rate: probability!(1.0),
             mode: PartialWriteMode::Prefix,
         }));
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
@@ -2226,7 +2226,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(h.storage.pending.lock().len(), 1);
-        h.config.write().sync_rate = Some(Probability!(1.0));
+        h.config.write().sync_rate = Some(probability!(1.0));
         assert!(matches!(blob.sync().await, Err(Error::Io(_))));
         assert_eq!(h.storage.pending.lock().len(), 1);
 
@@ -2268,11 +2268,11 @@ mod tests {
         let h = Harness::new(
             Config::default()
                 .write(WriteConfig {
-                    failure_rate: Probability!(0.0),
-                    retention_rate: Probability!(1.0),
+                    failure_rate: probability!(0.0),
+                    retention_rate: probability!(1.0),
                     mode: PartialWriteMode::Prefix,
                 })
-                .sync(Probability!(1.0)),
+                .sync(probability!(1.0)),
         );
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
         assert!(matches!(
@@ -2297,8 +2297,8 @@ mod tests {
     #[tokio::test]
     async fn test_faulty_storage_zero_write_retention_preserves_nothing() {
         let h = Harness::new(Config::default().write(WriteConfig {
-            failure_rate: Probability!(1.0),
-            retention_rate: Probability!(0.0),
+            failure_rate: probability!(1.0),
+            retention_rate: probability!(0.0),
             mode: PartialWriteMode::Prefix,
         }));
 
@@ -2347,12 +2347,12 @@ mod tests {
     #[tokio::test]
     async fn test_faulty_storage_write_retention_rate_endpoints() {
         for (retention_rate, expected) in [
-            (Probability!(0.0), b"old".as_slice()),
-            (Probability!(1.0), b"new".as_slice()),
+            (probability!(0.0), b"old".as_slice()),
+            (probability!(1.0), b"new".as_slice()),
         ] {
             for mode in [PartialWriteMode::Prefix, PartialWriteMode::Subset] {
                 let failed = Harness::new(Config::default().write(WriteConfig {
-                    failure_rate: Probability!(1.0),
+                    failure_rate: probability!(1.0),
                     retention_rate,
                     mode,
                 }));
@@ -2376,7 +2376,7 @@ mod tests {
                 }
 
                 let crashed = Harness::new(Config::default().write(WriteConfig {
-                    failure_rate: Probability!(0.0),
+                    failure_rate: probability!(0.0),
                     retention_rate,
                     mode,
                 }));
@@ -2416,8 +2416,8 @@ mod tests {
     #[tokio::test]
     async fn test_faulty_storage_partial_resize_grow() {
         let h = Harness::new(Config::default().resize(ResizeConfig {
-            failure_rate: Probability!(1.0),
-            partial_rate: Probability!(1.0),
+            failure_rate: probability!(1.0),
+            partial_rate: probability!(1.0),
         }));
 
         let (blob, initial_size) = h.storage.open("partition", b"test").await.unwrap();
@@ -2447,8 +2447,8 @@ mod tests {
         {
             let mut cfg = h.config.write();
             cfg.resize_rate = Some(ResizeConfig {
-                failure_rate: Probability!(1.0),
-                partial_rate: Probability!(1.0),
+                failure_rate: probability!(1.0),
+                partial_rate: probability!(1.0),
             });
         }
 
@@ -2468,8 +2468,8 @@ mod tests {
     #[tokio::test]
     async fn test_faulty_storage_partial_resize_disabled() {
         let h = Harness::new(Config::default().resize(ResizeConfig {
-            failure_rate: Probability!(1.0),
-            partial_rate: Probability!(0.0),
+            failure_rate: probability!(1.0),
+            partial_rate: probability!(0.0),
         }));
 
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
@@ -2484,8 +2484,8 @@ mod tests {
     #[tokio::test]
     async fn test_faulty_storage_partial_resize_same_size() {
         let h = Harness::new(Config::default().resize(ResizeConfig {
-            failure_rate: Probability!(1.0),
-            partial_rate: Probability!(1.0),
+            failure_rate: probability!(1.0),
+            partial_rate: probability!(1.0),
         }));
 
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();
@@ -2515,8 +2515,8 @@ mod tests {
         {
             let mut cfg = h.config.write();
             cfg.resize_rate = Some(ResizeConfig {
-                failure_rate: Probability!(1.0),
-                partial_rate: Probability!(1.0),
+                failure_rate: probability!(1.0),
+                partial_rate: probability!(1.0),
             });
         }
 
@@ -2536,8 +2536,8 @@ mod tests {
     #[tokio::test]
     async fn test_faulty_storage_partial_resize_one_byte_difference() {
         let h = Harness::new(Config::default().resize(ResizeConfig {
-            failure_rate: Probability!(1.0),
-            partial_rate: Probability!(1.0),
+            failure_rate: probability!(1.0),
+            partial_rate: probability!(1.0),
         }));
 
         let (blob, _) = h.storage.open("partition", b"test").await.unwrap();

--- a/storage/fuzz/fuzz_targets/current_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/current_crash_recovery.rs
@@ -20,7 +20,7 @@ use commonware_storage::{
     qmdb::current::{VariableConfig, unordered::variable::Db as Current},
     translator::TwoCap,
 };
-use commonware_utils::{NZU64, NZUsize, Probability, sequence::FixedBytes};
+use commonware_utils::{NZU64, NZUsize, Probability, probability, sequence::FixedBytes};
 use libfuzzer_sys::fuzz_target;
 use std::{
     collections::HashMap,
@@ -55,7 +55,7 @@ fn bounded_write_buffer(u: &mut Unstructured<'_>) -> Result<usize> {
 
 fn bounded_nonzero_rate(u: &mut Unstructured<'_>) -> Result<Probability> {
     let percent: u8 = u.int_in_range(1..=100)?;
-    Ok(Probability!(u64::from(percent), 100))
+    Ok(probability!(u64::from(percent), 100))
 }
 
 /// State-changing operations that exercise disk writes.
@@ -231,7 +231,7 @@ fn fuzz_family<F: Graftable>(input: &FuzzInput, suffix_base: &str) {
                 sync_rate: Some(sync_failure_rate),
                 write_rate: Some(deterministic::WriteConfig {
                     failure_rate: write_failure_rate,
-                    retention_rate: Probability!(0.0),
+                    retention_rate: probability!(0.0),
                     mode: deterministic::PartialWriteMode::Prefix,
                 }),
                 ..Default::default()

--- a/storage/fuzz/fuzz_targets/journal_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/journal_crash_recovery.rs
@@ -52,7 +52,7 @@ use commonware_storage::journal::{
         variable::{Config as VariableConfig, Journal as VariableJournal},
     },
 };
-use commonware_utils::{NZU64, NZUsize, Probability, sequence::FixedBytes};
+use commonware_utils::{NZU64, NZUsize, Probability, probability, sequence::FixedBytes};
 use futures::StreamExt;
 use libfuzzer_sys::fuzz_target;
 use std::{
@@ -102,7 +102,7 @@ fn bounded_write_buffer(u: &mut Unstructured<'_>) -> arbitrary::Result<usize> {
 /// A fault rate in [0.0, 1.0]. Allows 0 so the fuzzer can disable individual fault types.
 fn bounded_rate(u: &mut Unstructured<'_>) -> arbitrary::Result<Probability> {
     let percent: u8 = u.int_in_range(0..=100)?;
-    Ok(Probability!(u64::from(percent), 100))
+    Ok(probability!(u64::from(percent), 100))
 }
 
 /// Op sequence capped at `MAX_OPERATIONS`; a derived `Vec` would instead grow with input length.

--- a/storage/fuzz/fuzz_targets/merkle_full_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/merkle_full_crash_recovery.rs
@@ -13,7 +13,7 @@ use commonware_storage::merkle::{
     Bagging::ForwardFold, Family as MerkleFamily, Location, full::Config,
     hasher::Standard as StandardHasher, mmb, mmr,
 };
-use commonware_utils::{NZU64, Probability};
+use commonware_utils::{NZU64, Probability, probability};
 use libfuzzer_sys::fuzz_target;
 use std::num::{NonZeroU16, NonZeroUsize};
 
@@ -44,7 +44,7 @@ fn bounded_write_buffer(u: &mut Unstructured<'_>) -> Result<usize> {
 
 fn bounded_nonzero_rate(u: &mut Unstructured<'_>) -> Result<Probability> {
     let percent: u8 = u.int_in_range(1..=100)?;
-    Ok(Probability!(u64::from(percent), 100))
+    Ok(probability!(u64::from(percent), 100))
 }
 
 /// Operations that can be performed on the Merkle structure.
@@ -254,7 +254,7 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
                 sync_rate: Some(sync_failure_rate),
                 write_rate: Some(deterministic::WriteConfig {
                     failure_rate: write_failure_rate,
-                    retention_rate: Probability!(0.0),
+                    retention_rate: probability!(0.0),
                     mode: deterministic::PartialWriteMode::Prefix,
                 }),
                 ..Default::default()

--- a/storage/fuzz/fuzz_targets/queue_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/queue_crash_recovery.rs
@@ -11,7 +11,7 @@
 use arbitrary::{Arbitrary, Result, Unstructured};
 use commonware_runtime::{Runner, Supervisor as _, buffer::paged::CacheRef, deterministic};
 use commonware_storage::queue::{Config, Queue};
-use commonware_utils::Probability;
+use commonware_utils::{Probability, probability};
 use libfuzzer_sys::fuzz_target;
 use std::{
     collections::BTreeMap,
@@ -42,7 +42,7 @@ fn bounded_write_buffer(u: &mut Unstructured<'_>) -> Result<usize> {
 
 fn bounded_nonzero_rate(u: &mut Unstructured<'_>) -> Result<Probability> {
     let percent: u8 = u.int_in_range(1..=100)?;
-    Ok(Probability!(u64::from(percent), 100))
+    Ok(probability!(u64::from(percent), 100))
 }
 
 /// Operations that can be performed on the queue.
@@ -488,7 +488,7 @@ fn fuzz(input: FuzzInput) {
                 sync_rate: Some(sync_failure_rate),
                 write_rate: Some(deterministic::WriteConfig {
                     failure_rate: write_failure_rate,
-                    retention_rate: Probability!(0.0),
+                    retention_rate: probability!(0.0),
                     mode: deterministic::PartialWriteMode::Prefix,
                 }),
                 ..Default::default()

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -1762,7 +1762,7 @@ mod tests {
             drive_pending_syncs, fail_pending_syncs, release_pending_syncs,
         },
     };
-    use commonware_utils::{NZU16, NZU64, NZUsize, Probability};
+    use commonware_utils::{NZU16, NZU64, NZUsize, probability};
     use futures::{StreamExt, pin_mut};
     use std::num::NonZeroU16;
 
@@ -2113,8 +2113,8 @@ mod tests {
             journal.append(&0).await.unwrap();
             *context.storage_fault_config().write() = deterministic::FaultConfig {
                 write_rate: Some(deterministic::WriteConfig {
-                    failure_rate: Probability!(1.0),
-                    retention_rate: Probability!(0.0),
+                    failure_rate: probability!(1.0),
+                    retention_rate: probability!(0.0),
                     mode: deterministic::PartialWriteMode::Prefix,
                 }),
                 ..Default::default()
@@ -2240,7 +2240,7 @@ mod tests {
             // Regression: commit() must force a data sync before callers can rely on recovered
             // bytes beyond the persisted recovery watermark.
             *context.storage_fault_config().write() = deterministic::FaultConfig {
-                sync_rate: Some(Probability!(1.0)),
+                sync_rate: Some(probability!(1.0)),
                 ..Default::default()
             };
             assert!(
@@ -3397,7 +3397,7 @@ mod tests {
             // Inject sync faults. If commit skipped the recovered tail sync, it would succeed
             // despite the fault.
             *context.storage_fault_config().write() = deterministic::FaultConfig {
-                sync_rate: Some(Probability!(1.0)),
+                sync_rate: Some(probability!(1.0)),
                 ..Default::default()
             };
             assert!(

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -2597,7 +2597,7 @@ mod tests {
             fail_pending_syncs, next_pending_sync, release_pending_syncs,
         },
     };
-    use commonware_utils::{NZU16, NZU64, NZUsize, Probability, sequence::FixedBytes};
+    use commonware_utils::{NZU16, NZU64, NZUsize, probability, sequence::FixedBytes};
     use futures::StreamExt as _;
     use std::num::NonZeroU16;
 
@@ -2926,8 +2926,8 @@ mod tests {
             journal.append(&0).await.unwrap();
             *context.storage_fault_config().write() = deterministic::FaultConfig {
                 write_rate: Some(deterministic::WriteConfig {
-                    failure_rate: Probability!(1.0),
-                    retention_rate: Probability!(0.0),
+                    failure_rate: probability!(1.0),
+                    retention_rate: probability!(0.0),
                     mode: deterministic::PartialWriteMode::Prefix,
                 }),
                 ..Default::default()
@@ -6251,7 +6251,7 @@ mod tests {
                 drop(journal);
 
                 *context.storage_fault_config().write() = deterministic::FaultConfig {
-                    sync_rate: Some(Probability!(1.0)),
+                    sync_rate: Some(probability!(1.0)),
                     ..Default::default()
                 };
                 assert!(
@@ -6312,7 +6312,7 @@ mod tests {
                 // Fail the offsets metadata sync inside `stage_clear_intent` so `clear_to_size`
                 // aborts before any data is cleared. The reset intent never becomes durable.
                 *context.storage_fault_config().write() = deterministic::FaultConfig {
-                    sync_rate: Some(Probability!(1.0)),
+                    sync_rate: Some(probability!(1.0)),
                     ..Default::default()
                 };
                 assert!(journal.0.clear_to_size(7).await.is_err());
@@ -6370,7 +6370,7 @@ mod tests {
                 // subsequent `data.clear()` (a blob remove) so `clear_to_size` aborts after the
                 // intent is durable but before the data is cleared.
                 *context.storage_fault_config().write() = deterministic::FaultConfig {
-                    remove_rate: Some(Probability!(1.0)),
+                    remove_rate: Some(probability!(1.0)),
                     ..Default::default()
                 };
                 assert!(journal.0.clear_to_size(7).await.is_err());

--- a/storage/src/journal/segmented/variable.rs
+++ b/storage/src/journal/segmented/variable.rs
@@ -804,7 +804,7 @@ mod tests {
         Blob, BufMut, Runner, Storage, Supervisor as _, WriteOptions, deterministic,
         mocks::{DelayedSyncContext, PendingSyncs, RecordingContext, release_pending_syncs},
     };
-    use commonware_utils::{NZU16, NZUsize, Probability};
+    use commonware_utils::{NZU16, NZUsize, probability};
     use std::num::NonZeroU16;
 
     const PAGE_SIZE: NonZeroU16 = NZU16!(1024);
@@ -1455,8 +1455,8 @@ mod tests {
                 .expect("Failed to re-initialize journal");
             *context.storage_fault_config().write() = deterministic::FaultConfig {
                 resize_rate: Some(deterministic::ResizeConfig {
-                    failure_rate: Probability!(1.0),
-                    partial_rate: Probability!(0.0),
+                    failure_rate: probability!(1.0),
+                    partial_rate: probability!(0.0),
                 }),
                 ..Default::default()
             };
@@ -1520,8 +1520,8 @@ mod tests {
                 .expect("Failed to re-initialize journal");
             *context.storage_fault_config().write() = deterministic::FaultConfig {
                 resize_rate: Some(deterministic::ResizeConfig {
-                    failure_rate: Probability!(1.0),
-                    partial_rate: Probability!(0.0),
+                    failure_rate: probability!(1.0),
+                    partial_rate: probability!(0.0),
                 }),
                 ..Default::default()
             };

--- a/storage/src/qmdb/any/ordered/fixed.rs
+++ b/storage/src/qmdb/any/ordered/fixed.rs
@@ -168,7 +168,7 @@ pub(crate) mod test {
         Runner as _, Supervisor as _,
         deterministic::{self, Context},
     };
-    use commonware_utils::{NZU64, NZUsize, Probability, TestRng, sequence::FixedBytes};
+    use commonware_utils::{NZU64, NZUsize, TestRng, probability, sequence::FixedBytes};
     use futures::StreamExt as _;
     use rand::{Rng, seq::IteratorRandom};
     use std::{
@@ -790,7 +790,7 @@ pub(crate) mod test {
             // across configs, never cached pages), so replay's first item forces a storage read,
             // and with far fewer ops than the routing batch size no batch reaches a worker, so
             // workers never read the log themselves.
-            context.storage_fault_config().write().read_rate = Some(Probability!(1.0));
+            context.storage_fault_config().write().read_rate = Some(probability!(1.0));
             let result = index
                 .build_snapshot(
                     context.child("build"),

--- a/storage/src/qmdb/any/unordered/fixed.rs
+++ b/storage/src/qmdb/any/unordered/fixed.rs
@@ -161,7 +161,7 @@ pub(crate) mod test {
         mocks::{DelayedSyncContext, PendingSyncs, drive_pending_syncs},
         reschedule,
     };
-    use commonware_utils::{NZU16, NZU64, NZUsize, Probability, TestRng};
+    use commonware_utils::{NZU16, NZU64, NZUsize, TestRng, probability};
     use core::num::NonZeroUsize;
     use futures::{FutureExt as _, Stream};
     use rand::Rng;
@@ -904,7 +904,7 @@ pub(crate) mod test {
             // across configs, never cached pages), so replay's first item forces a storage read,
             // and with far fewer ops than the routing batch size no batch reaches a worker, so
             // workers never read the log themselves.
-            context.storage_fault_config().write().read_rate = Some(Probability!(1.0));
+            context.storage_fault_config().write().read_rate = Some(probability!(1.0));
             let result = index
                 .build_snapshot(
                     context.child("build"),

--- a/utils/src/iter.rs
+++ b/utils/src/iter.rs
@@ -4,9 +4,6 @@ use core::iter::{Chain, Once, once};
 
 /// An iterator source guaranteed to yield at least one item.
 ///
-/// `NonEmpty` is consumed when iterated so the first item cannot be removed before the value is
-/// passed to an API that requires non-empty input.
-///
 /// # Examples
 ///
 /// ```

--- a/utils/src/iter.rs
+++ b/utils/src/iter.rs
@@ -1,0 +1,146 @@
+//! Iterator types with additional invariants.
+
+use core::iter::{Chain, Once, once};
+
+/// An iterator source guaranteed to yield at least one item.
+///
+/// `NonEmpty` is consumed when iterated so the first item cannot be removed before the value is
+/// passed to an API that requires non-empty input.
+///
+/// # Examples
+///
+/// ```
+/// use commonware_utils::iter::NonEmpty;
+///
+/// let items = NonEmpty::try_new([1, 2, 3].into_iter()).expect("items are non-empty");
+/// assert_eq!(items.into_iter().collect::<Vec<_>>(), vec![1, 2, 3]);
+/// ```
+#[derive(Clone, Debug)]
+pub struct NonEmpty<I: Iterator> {
+    first: I::Item,
+    rest: I,
+}
+
+impl<I: Iterator> NonEmpty<I> {
+    /// Creates a non-empty iterator from a first item and the remaining items.
+    pub const fn new(first: I::Item, rest: I) -> Self {
+        Self { first, rest }
+    }
+
+    /// Creates a non-empty iterator from `items`, or returns `None` when it is empty.
+    pub fn try_new(mut items: I) -> Option<Self> {
+        let first = items.next()?;
+        Some(Self::new(first, items))
+    }
+}
+
+impl<I: Iterator> IntoIterator for NonEmpty<I> {
+    type Item = I::Item;
+    type IntoIter = Chain<Once<I::Item>, I>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        once(self.first).chain(self.rest)
+    }
+}
+
+/// Creates a [`NonEmpty`] iterator from one or more items.
+///
+/// # Examples
+///
+/// ```
+/// use commonware_utils::non_empty;
+///
+/// let items = non_empty![1, 2, 3];
+/// assert_eq!(items.into_iter().collect::<Vec<_>>(), vec![1, 2, 3]);
+///
+/// let items = non_empty![@1..4];
+/// assert_eq!(items.into_iter().collect::<Vec<_>>(), vec![1, 2, 3]);
+/// ```
+///
+/// ```compile_fail
+/// use commonware_utils::non_empty;
+///
+/// let empty = non_empty![];
+/// ```
+///
+/// # Panics
+///
+/// The `@` form panics if the provided iterator is empty.
+#[cfg(not(any(
+    commonware_stability_GAMMA,
+    commonware_stability_DELTA,
+    commonware_stability_EPSILON,
+    commonware_stability_RESERVED
+)))] // BETA
+#[macro_export]
+macro_rules! non_empty {
+    (@$items:expr) => {{
+        $crate::iter::NonEmpty::try_new(::core::iter::IntoIterator::into_iter($items))
+            .expect("iterator must be non-empty")
+    }};
+    ($first:expr $(, $rest:expr)* $(,)?) => {
+        $crate::iter::NonEmpty::new(
+            $first,
+            ::core::iter::IntoIterator::into_iter([$($rest),*]),
+        )
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::NonEmpty;
+
+    #[test]
+    fn try_new_rejects_empty() {
+        assert!(NonEmpty::try_new(core::iter::empty::<u8>()).is_none());
+    }
+
+    #[test]
+    fn iteration_preserves_every_item() {
+        let items = NonEmpty::try_new([1, 2, 3].into_iter()).expect("items are non-empty");
+        assert_eq!(items.into_iter().collect::<Vec<_>>(), vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn macro_constructs_non_empty_iterators() {
+        assert_eq!(non_empty![1].into_iter().collect::<Vec<_>>(), vec![1]);
+        assert_eq!(
+            non_empty![1, 2, 3].into_iter().collect::<Vec<_>>(),
+            vec![1, 2, 3]
+        );
+        assert_eq!(
+            non_empty![@1..4].into_iter().collect::<Vec<_>>(),
+            vec![1, 2, 3]
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "iterator must be non-empty")]
+    fn macro_rejects_empty_iterators() {
+        let _ = non_empty![@core::iter::empty::<u8>()];
+    }
+
+    mod colliding_method {
+        trait CollidingIntoIterator {
+            fn into_iter(self);
+        }
+
+        impl<T, const N: usize> CollidingIntoIterator for [T; N] {
+            fn into_iter(self) {}
+        }
+
+        #[test]
+        fn macro_ignores_colliding_into_iterator_methods() {
+            CollidingIntoIterator::into_iter([0]);
+
+            assert_eq!(
+                non_empty![1, 2, 3].into_iter().collect::<Vec<_>>(),
+                vec![1, 2, 3]
+            );
+            assert_eq!(
+                non_empty![@[1, 2, 3]].into_iter().collect::<Vec<_>>(),
+                vec![1, 2, 3]
+            );
+        }
+    }
+}

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -28,6 +28,7 @@ commonware_macros::stability_scope!(BETA {
 
     pub mod bitmap;
     pub mod cache;
+    pub mod iter;
     pub mod ordered;
     pub mod probability;
     pub use probability::Probability;

--- a/utils/src/probability.rs
+++ b/utils/src/probability.rs
@@ -151,24 +151,24 @@ impl fmt::Debug for Probability {
 /// # Examples
 ///
 /// ```
-/// use commonware_utils::Probability;
+/// use commonware_utils::{Probability, probability};
 ///
-/// const HALF: Probability = Probability!(1, 2);
-/// const NINETY_EIGHT_PERCENT: Probability = Probability!(0.98);
+/// const HALF: Probability = probability!(1, 2);
+/// const NINETY_EIGHT_PERCENT: Probability = probability!(0.98);
 /// assert_eq!(HALF.as_f64(), 0.5);
 /// assert_eq!(NINETY_EIGHT_PERCENT.as_f64(), 0.98);
 /// ```
 ///
 /// ```compile_fail
-/// use commonware_utils::Probability;
+/// use commonware_utils::{Probability, probability};
 ///
-/// const INVALID: Probability = Probability!(2, 1);
+/// const INVALID: Probability = probability!(2, 1);
 /// ```
 ///
 /// ```compile_fail
-/// use commonware_utils::Probability;
+/// use commonware_utils::{Probability, probability};
 ///
-/// const REQUIRES_ROUNDING: Probability = Probability!(1e-20);
+/// const REQUIRES_ROUNDING: Probability = probability!(1e-20);
 /// ```
 #[cfg(not(any(
     commonware_stability_GAMMA,
@@ -177,7 +177,7 @@ impl fmt::Debug for Probability {
     commonware_stability_RESERVED
 )))] // BETA
 #[macro_export]
-macro_rules! Probability {
+macro_rules! probability {
     ($value:literal) => {
         const {
             $crate::Probability::from_f64($value).expect(
@@ -230,30 +230,30 @@ mod tests {
 
     #[test]
     fn construction() {
-        assert_eq!(Probability::new(0, u64::MAX), Some(Probability!(0.0)));
+        assert_eq!(Probability::new(0, u64::MAX), Some(probability!(0.0)));
         assert_eq!(
             Probability::new(u64::MAX, u64::MAX),
-            Some(Probability!(1.0))
+            Some(probability!(1.0))
         );
-        assert_eq!(Probability!(1, 2), Probability!(2, 4));
-        assert_eq!(Probability!(1, 2).as_f64(), 0.5);
+        assert_eq!(probability!(1, 2), probability!(2, 4));
+        assert_eq!(probability!(1, 2).as_f64(), 0.5);
         assert!(Probability::new(1, 0).is_none());
         assert!(Probability::new(2, 1).is_none());
     }
 
     #[test]
     fn f64_construction_preserves_clean_binary_value() {
-        const FROM_LITERAL: Probability = Probability!(0.98);
+        const FROM_LITERAL: Probability = probability!(0.98);
         const MINIMUM_INTERIOR: f64 = f64::from_bits(959u64 << 52);
 
         assert_eq!(FROM_LITERAL.0, 18_077_809_192_235_360_256);
         assert_eq!(FROM_LITERAL.as_f64(), 0.98);
-        assert_ne!(FROM_LITERAL, Probability!(49, 50));
-        assert_eq!(Probability!(0.5), Probability!(1, 2));
-        assert_eq!(Probability::try_from(0.5), Ok(Probability!(0.5)));
-        assert_eq!(Probability::from_f64(0.0), Some(Probability!(0.0)));
-        assert_eq!(Probability::from_f64(-0.0), Some(Probability!(0.0)));
-        assert_eq!(Probability::from_f64(1.0), Some(Probability!(1.0)));
+        assert_ne!(FROM_LITERAL, probability!(49, 50));
+        assert_eq!(probability!(0.5), probability!(1, 2));
+        assert_eq!(Probability::try_from(0.5), Ok(probability!(0.5)));
+        assert_eq!(Probability::from_f64(0.0), Some(probability!(0.0)));
+        assert_eq!(Probability::from_f64(-0.0), Some(probability!(0.0)));
+        assert_eq!(Probability::from_f64(1.0), Some(probability!(1.0)));
         assert_eq!(
             Probability::from_f64(MINIMUM_INTERIOR),
             Some(Probability(1))
@@ -295,8 +295,8 @@ mod tests {
 
     #[test]
     fn ratios_use_platform_independent_thresholds() {
-        assert_eq!(Probability!(1, 3).0 as u128, SCALE / 3);
-        assert_eq!(Probability!(2, 3).0 as u128, (2 * SCALE) / 3);
+        assert_eq!(probability!(1, 3).0 as u128, SCALE / 3);
+        assert_eq!(probability!(2, 3).0 as u128, (2 * SCALE) / 3);
 
         let below_one = Probability::new(u64::MAX - 1, u64::MAX).unwrap();
         assert_eq!(below_one.0, u64::MAX - 1);
@@ -306,16 +306,16 @@ mod tests {
     #[test]
     fn sampling_uses_threshold_and_skips_endpoints() {
         let mut rng = CountingRng { value: 0, calls: 0 };
-        assert!(!Probability!(0.0).sample(&mut rng));
-        assert!(Probability!(1.0).sample(&mut rng));
+        assert!(!probability!(0.0).sample(&mut rng));
+        assert!(probability!(1.0).sample(&mut rng));
         assert_eq!(rng.calls, 0);
 
         rng.value = (1u64 << 63) - 1;
-        assert!(Probability!(1, 2).sample(&mut rng));
+        assert!(probability!(1, 2).sample(&mut rng));
         assert_eq!(rng.calls, 1);
 
         rng.value = 1u64 << 63;
-        assert!(!Probability!(1, 2).sample(&mut rng));
+        assert!(!probability!(1, 2).sample(&mut rng));
         assert_eq!(rng.calls, 2);
     }
 
@@ -326,6 +326,6 @@ mod tests {
     fn expression_macro_rejects_invalid_probability() {
         let numerator = 2;
         let denominator = 1;
-        let _ = Probability!(numerator, denominator);
+        let _ = probability!(numerator, denominator);
     }
 }


### PR DESCRIPTION
## Summary

- Adds `NonEmpty<I>` and `non_empty!` to carry a non-empty iterator invariant across API boundaries without allocating.
- Adds `Mode`, a checked seven-bit scalar whose reserved packet-framing bit is unrepresentable. Conversion from raw `u8` is explicitly fallible.
- Adds `Modes<N>` and `modes!` for canonical ordered mode packets. The macro accepts heterogeneous `Into<Mode>` values, while continuation framing and trailing-zero omission let later defaulted modes be appended without changing existing encodings.
- Rejects empty, truncated, oversized, and non-canonical mode packets, with conformance fixtures for `Modes<1>` and `Modes<2>`.