### PR TITLE
[deployer] Validate tag and instance names before use in generated files

### DIFF
--- a/deployer/src/aws/create.rs
+++ b/deployer/src/aws/create.rs
@@ -67,7 +67,8 @@ fn is_valid_name(name: &str) -> bool {
 /// Validates the deployment tag and instance names.
 ///
 /// Both are written unescaped into file paths, YAML, shell scripts, S3 keys, and AWS tags.
-/// Instance names must also be unique and must not be [`MONITORING_NAME`].
+/// Instance names must also be unique ignoring case, because they name generated files on
+/// the operator's filesystem, and must not be [`MONITORING_NAME`].
 fn validate_names(config: &Config) -> Result<(), Error> {
     if !is_valid_name(&config.tag) {
         return Err(Error::InvalidTag(config.tag.clone()));
@@ -78,7 +79,7 @@ fn validate_names(config: &Config) -> Result<(), Error> {
         if name == MONITORING_NAME || !is_valid_name(name) {
             return Err(Error::InvalidInstanceName(name.clone()));
         }
-        if !instance_names.insert(name) {
+        if !instance_names.insert(name.to_ascii_lowercase()) {
             return Err(Error::DuplicateInstanceName(name.clone()));
         }
     }
@@ -1897,13 +1898,13 @@ mod tests {
             monitoring("gp3", None),
             vec![
                 instance("worker", "us-east-1", "c8g.4xlarge", None),
-                instance("worker", "us-west-2", "c8g.4xlarge", None),
+                instance("Worker", "us-west-2", "c8g.4xlarge", None),
             ],
         );
 
-        let err = validate_names(&cfg).expect_err("duplicate name");
+        let err = validate_names(&cfg).expect_err("duplicate name ignoring case");
 
-        assert!(matches!(err, Error::DuplicateInstanceName(n) if n == "worker"));
+        assert!(matches!(err, Error::DuplicateInstanceName(n) if n == "Worker"));
     }
 
     #[test]

--- a/deployer/src/aws/create.rs
+++ b/deployer/src/aws/create.rs
@@ -66,9 +66,8 @@ fn is_valid_name(name: &str) -> bool {
 
 /// Validates the deployment tag and instance names.
 ///
-/// Both are written unescaped into file paths, YAML, shell scripts, S3 keys, and AWS tags, so
-/// both must satisfy [`is_valid_name`]. Instance names must also be unique and must not be
-/// [`MONITORING_NAME`].
+/// Both are written unescaped into file paths, YAML, shell scripts, S3 keys, and AWS tags.
+/// Instance names must also be unique and must not be [`MONITORING_NAME`].
 fn validate_names(config: &Config) -> Result<(), Error> {
     if !is_valid_name(&config.tag) {
         return Err(Error::InvalidTag(config.tag.clone()));
@@ -1851,7 +1850,7 @@ mod tests {
     }
 
     #[test]
-    fn instance_names_accept_letters_digits_dash_underscore() {
+    fn valid_names_pass() {
         let cfg = config(
             monitoring("gp3", None),
             vec![
@@ -1864,17 +1863,8 @@ mod tests {
     }
 
     #[test]
-    fn instance_names_reject_shell_and_path_characters() {
-        for name in [
-            "",
-            "monitoring",
-            "a b",
-            "a;b",
-            "$(id)",
-            "../x",
-            "a.b",
-            "\u{e9}",
-        ] {
+    fn invalid_instance_names_rejected() {
+        for name in ["", "monitoring", "a b", "$(id)", "../x", "a.b", "\u{e9}"] {
             let cfg = config(
                 monitoring("gp3", None),
                 vec![instance(name, "us-east-1", "c8g.4xlarge", None)],
@@ -1890,8 +1880,8 @@ mod tests {
     }
 
     #[test]
-    fn tag_rejects_path_and_shell_characters() {
-        for tag in ["", "../x", "/tmp", "a b", "$(id)"] {
+    fn invalid_tags_rejected() {
+        for tag in ["", "../x", "/tmp"] {
             let mut cfg = config(monitoring("gp3", None), Vec::new());
             cfg.tag = tag.to_string();
 
@@ -1902,7 +1892,7 @@ mod tests {
     }
 
     #[test]
-    fn instance_names_reject_duplicates() {
+    fn duplicate_instance_names_rejected() {
         let cfg = config(
             monitoring("gp3", None),
             vec![

--- a/deployer/src/aws/create.rs
+++ b/deployer/src/aws/create.rs
@@ -56,20 +56,27 @@ pub struct RegionResources {
     pub monitoring_sg_id: Option<String>,
 }
 
-/// Validates that instance names are unique, non-empty, not reserved, and contain only ASCII
-/// letters, digits, `-`, or `_`.
+/// Returns whether a name is non-empty and contains only ASCII letters, digits, `-`, or `_`.
+fn is_valid_name(name: &str) -> bool {
+    !name.is_empty()
+        && name
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_')
+}
+
+/// Validates the deployment tag and instance names.
 ///
-/// Instance names are written unescaped into file paths, YAML, shell scripts, and AWS tags.
-fn validate_instance_names(config: &Config) -> Result<(), Error> {
+/// The tag and instance names are written unescaped into file paths, YAML, shell scripts, S3
+/// keys, and AWS tags, so both must satisfy [`is_valid_name`]. Instance names must also be
+/// unique and must not be [`MONITORING_NAME`].
+fn validate_names(config: &Config) -> Result<(), Error> {
+    if !is_valid_name(&config.tag) {
+        return Err(Error::InvalidTag(config.tag.clone()));
+    }
     let mut instance_names = HashSet::new();
     for instance in &config.instances {
         let name = &instance.name;
-        if name.is_empty()
-            || name == MONITORING_NAME
-            || !name
-                .bytes()
-                .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_')
-        {
+        if name == MONITORING_NAME || !is_valid_name(name) {
             return Err(Error::InvalidInstanceName(name.clone()));
         }
         if !instance_names.insert(name) {
@@ -173,7 +180,7 @@ pub async fn create(config: &PathBuf, concurrency: usize) -> Result<(), Error> {
     info!(tag = tag.as_str(), "loaded configuration");
 
     // Validate the configuration before allocating any AWS resources.
-    validate_instance_names(&config)?;
+    validate_names(&config)?;
     validate_storage_config(&config)?;
 
     // Determine unique regions
@@ -1521,7 +1528,7 @@ fn grouped_subnets(
 mod tests {
     use super::{
         RegionResources, grouped_subnets, run_launches, select_availability_zone_groups,
-        select_group_availability_zone, validate_instance_names, validate_storage_config,
+        select_group_availability_zone, validate_names, validate_storage_config,
     };
     use crate::aws::{Config, Error, InstanceConfig, MonitoringConfig};
     use std::{
@@ -1853,7 +1860,7 @@ mod tests {
             ],
         );
 
-        validate_instance_names(&cfg).expect("names are valid");
+        validate_names(&cfg).expect("names are valid");
     }
 
     #[test]
@@ -1873,12 +1880,24 @@ mod tests {
                 vec![instance(name, "us-east-1", "c8g.4xlarge", None)],
             );
 
-            let err = validate_instance_names(&cfg).expect_err(name);
+            let err = validate_names(&cfg).expect_err(name);
 
             assert!(
                 matches!(err, Error::InvalidInstanceName(n) if n == name),
                 "{name}"
             );
+        }
+    }
+
+    #[test]
+    fn tag_rejects_path_and_shell_characters() {
+        for tag in ["", "../x", "/tmp", "a b", "$(id)"] {
+            let mut cfg = config(monitoring("gp3", None), Vec::new());
+            cfg.tag = tag.to_string();
+
+            let err = validate_names(&cfg).expect_err(tag);
+
+            assert!(matches!(err, Error::InvalidTag(t) if t == tag), "{tag}");
         }
     }
 
@@ -1892,7 +1911,7 @@ mod tests {
             ],
         );
 
-        let err = validate_instance_names(&cfg).expect_err("duplicate name");
+        let err = validate_names(&cfg).expect_err("duplicate name");
 
         assert!(matches!(err, Error::DuplicateInstanceName(n) if n == "worker"));
     }

--- a/deployer/src/aws/create.rs
+++ b/deployer/src/aws/create.rs
@@ -56,6 +56,30 @@ pub struct RegionResources {
     pub monitoring_sg_id: Option<String>,
 }
 
+/// Validates that instance names are unique, non-empty, not reserved, and contain only ASCII
+/// letters, digits, `-`, or `_`.
+///
+/// Instance names are written unescaped into file paths, YAML, shell scripts, and AWS tags, so
+/// the character set is restricted rather than escaped per destination.
+fn validate_instance_names(config: &Config) -> Result<(), Error> {
+    let mut instance_names = HashSet::new();
+    for instance in &config.instances {
+        let name = &instance.name;
+        if name.is_empty()
+            || name == MONITORING_NAME
+            || !name
+                .bytes()
+                .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_')
+        {
+            return Err(Error::InvalidInstanceName(name.clone()));
+        }
+        if !instance_names.insert(name) {
+            return Err(Error::DuplicateInstanceName(name.clone()));
+        }
+    }
+    Ok(())
+}
+
 /// Validates storage options before create allocates AWS resources.
 fn validate_storage_config(config: &Config) -> Result<(), Error> {
     // Treat monitoring and binary instances uniformly because both launch an EBS volume.
@@ -149,18 +173,8 @@ pub async fn create(config: &PathBuf, concurrency: usize) -> Result<(), Error> {
     let tag = &config.tag;
     info!(tag = tag.as_str(), "loaded configuration");
 
-    // Ensure no instance is duplicated or named MONITORING_NAME
-    let mut instance_names = HashSet::new();
-    for instance in &config.instances {
-        if !instance_names.insert(&instance.name) {
-            return Err(Error::DuplicateInstanceName(instance.name.clone()));
-        }
-        if instance.name == MONITORING_NAME {
-            return Err(Error::InvalidInstanceName(instance.name.clone()));
-        }
-    }
-
-    // Validate storage settings before allocating any AWS resources.
+    // Validate the configuration before allocating any AWS resources.
+    validate_instance_names(&config)?;
     validate_storage_config(&config)?;
 
     // Determine unique regions
@@ -1508,7 +1522,7 @@ fn grouped_subnets(
 mod tests {
     use super::{
         RegionResources, grouped_subnets, run_launches, select_availability_zone_groups,
-        select_group_availability_zone, validate_storage_config,
+        select_group_availability_zone, validate_instance_names, validate_storage_config,
     };
     use crate::aws::{Config, Error, InstanceConfig, MonitoringConfig};
     use std::{
@@ -1828,6 +1842,60 @@ mod tests {
                 storage_throughput,
             } if target == "monitoring" && storage_throughput == 124
         ));
+    }
+
+    #[test]
+    fn instance_names_accept_letters_digits_dash_underscore() {
+        let cfg = config(
+            monitoring("gp3", None),
+            vec![
+                instance("validator-0", "us-east-1", "c8g.4xlarge", None),
+                instance("Worker_1", "us-east-1", "c8g.4xlarge", None),
+            ],
+        );
+
+        validate_instance_names(&cfg).expect("names are valid");
+    }
+
+    #[test]
+    fn instance_names_reject_shell_and_path_characters() {
+        for name in [
+            "",
+            "monitoring",
+            "a b",
+            "a;b",
+            "$(id)",
+            "../x",
+            "a.b",
+            "\u{e9}",
+        ] {
+            let cfg = config(
+                monitoring("gp3", None),
+                vec![instance(name, "us-east-1", "c8g.4xlarge", None)],
+            );
+
+            let err = validate_instance_names(&cfg).expect_err(name);
+
+            assert!(
+                matches!(err, Error::InvalidInstanceName(n) if n == name),
+                "{name}"
+            );
+        }
+    }
+
+    #[test]
+    fn instance_names_reject_duplicates() {
+        let cfg = config(
+            monitoring("gp3", None),
+            vec![
+                instance("worker", "us-east-1", "c8g.4xlarge", None),
+                instance("worker", "us-west-2", "c8g.4xlarge", None),
+            ],
+        );
+
+        let err = validate_instance_names(&cfg).expect_err("duplicate name");
+
+        assert!(matches!(err, Error::DuplicateInstanceName(n) if n == "worker"));
     }
 
     #[test]

--- a/deployer/src/aws/create.rs
+++ b/deployer/src/aws/create.rs
@@ -59,8 +59,7 @@ pub struct RegionResources {
 /// Validates that instance names are unique, non-empty, not reserved, and contain only ASCII
 /// letters, digits, `-`, or `_`.
 ///
-/// Instance names are written unescaped into file paths, YAML, shell scripts, and AWS tags, so
-/// the character set is restricted rather than escaped per destination.
+/// Instance names are written unescaped into file paths, YAML, shell scripts, and AWS tags.
 fn validate_instance_names(config: &Config) -> Result<(), Error> {
     let mut instance_names = HashSet::new();
     for instance in &config.instances {

--- a/deployer/src/aws/create.rs
+++ b/deployer/src/aws/create.rs
@@ -56,7 +56,7 @@ pub struct RegionResources {
     pub monitoring_sg_id: Option<String>,
 }
 
-/// Returns whether a name is non-empty and contains only ASCII letters, digits, `-`, or `_`.
+/// Returns whether `name` matches `[A-Za-z0-9_-]+`.
 fn is_valid_name(name: &str) -> bool {
     !name.is_empty()
         && name
@@ -66,9 +66,9 @@ fn is_valid_name(name: &str) -> bool {
 
 /// Validates the deployment tag and instance names.
 ///
-/// The tag and instance names are written unescaped into file paths, YAML, shell scripts, S3
-/// keys, and AWS tags, so both must satisfy [`is_valid_name`]. Instance names must also be
-/// unique and must not be [`MONITORING_NAME`].
+/// Both are written unescaped into file paths, YAML, shell scripts, S3 keys, and AWS tags, so
+/// both must satisfy [`is_valid_name`]. Instance names must also be unique and must not be
+/// [`MONITORING_NAME`].
 fn validate_names(config: &Config) -> Result<(), Error> {
     if !is_valid_name(&config.tag) {
         return Err(Error::InvalidTag(config.tag.clone()));

--- a/deployer/src/aws/mod.rs
+++ b/deployer/src/aws/mod.rs
@@ -497,9 +497,9 @@ cfg_if::cfg_if! {
             Yaml(#[from] serde_yaml::Error),
             #[error("creation already attempted")]
             CreationAttempted,
-            #[error("invalid tag (must be non-empty and contain only ASCII letters, digits, `-`, or `_`): {0}")]
+            #[error("invalid tag (must match [A-Za-z0-9_-]+): {0}")]
             InvalidTag(String),
-            #[error("invalid instance name (must be non-empty, not `monitoring`, and contain only ASCII letters, digits, `-`, or `_`): {0}")]
+            #[error("invalid instance name (must match [A-Za-z0-9_-]+ and not be `monitoring`): {0}")]
             InvalidInstanceName(String),
             #[error("invalid storage class for {target}: {storage_class}")]
             InvalidStorageClass {
@@ -657,8 +657,7 @@ pub struct PortConfig {
 pub struct InstanceConfig {
     /// Name of the instance.
     ///
-    /// Must be unique, non-empty, not `monitoring`, and contain only ASCII letters, digits,
-    /// `-`, or `_`.
+    /// Must be unique, must not be `monitoring`, and must match `[A-Za-z0-9_-]+`.
     pub name: String,
 
     /// AWS region where the instance is deployed
@@ -728,7 +727,7 @@ pub struct MonitoringConfig {
 pub struct Config {
     /// Unique tag for the deployment.
     ///
-    /// Must be non-empty and contain only ASCII letters, digits, `-`, or `_`.
+    /// Must match `[A-Za-z0-9_-]+`.
     pub tag: String,
 
     /// Monitoring instance configuration

--- a/deployer/src/aws/mod.rs
+++ b/deployer/src/aws/mod.rs
@@ -657,7 +657,7 @@ pub struct PortConfig {
 pub struct InstanceConfig {
     /// Name of the instance.
     ///
-    /// Must be unique, must not be `monitoring`, and must match `[A-Za-z0-9_-]+`.
+    /// Must be unique ignoring case, must not be `monitoring`, and must match `[A-Za-z0-9_-]+`.
     pub name: String,
 
     /// AWS region where the instance is deployed

--- a/deployer/src/aws/mod.rs
+++ b/deployer/src/aws/mod.rs
@@ -497,6 +497,8 @@ cfg_if::cfg_if! {
             Yaml(#[from] serde_yaml::Error),
             #[error("creation already attempted")]
             CreationAttempted,
+            #[error("invalid tag (must be non-empty and contain only ASCII letters, digits, `-`, or `_`): {0}")]
+            InvalidTag(String),
             #[error("invalid instance name (must be non-empty, not `monitoring`, and contain only ASCII letters, digits, `-`, or `_`): {0}")]
             InvalidInstanceName(String),
             #[error("invalid storage class for {target}: {storage_class}")]
@@ -724,7 +726,9 @@ pub struct MonitoringConfig {
 /// Deployer configuration
 #[derive(Serialize, Deserialize, Clone)]
 pub struct Config {
-    /// Unique tag for the deployment
+    /// Unique tag for the deployment.
+    ///
+    /// Must be non-empty and contain only ASCII letters, digits, `-`, or `_`.
     pub tag: String,
 
     /// Monitoring instance configuration

--- a/deployer/src/aws/mod.rs
+++ b/deployer/src/aws/mod.rs
@@ -497,7 +497,7 @@ cfg_if::cfg_if! {
             Yaml(#[from] serde_yaml::Error),
             #[error("creation already attempted")]
             CreationAttempted,
-            #[error("invalid instance name: {0}")]
+            #[error("invalid instance name (must be non-empty, not `monitoring`, and contain only ASCII letters, digits, `-`, or `_`): {0}")]
             InvalidInstanceName(String),
             #[error("invalid storage class for {target}: {storage_class}")]
             InvalidStorageClass {

--- a/deployer/src/aws/mod.rs
+++ b/deployer/src/aws/mod.rs
@@ -653,7 +653,10 @@ pub struct PortConfig {
 /// Instance configuration
 #[derive(Serialize, Deserialize, Clone)]
 pub struct InstanceConfig {
-    /// Name of the instance
+    /// Name of the instance.
+    ///
+    /// Must be unique, non-empty, not `monitoring`, and contain only ASCII letters, digits,
+    /// `-`, or `_`.
     pub name: String,
 
     /// AWS region where the instance is deployed

--- a/deployer/src/aws/services.rs
+++ b/deployer/src/aws/services.rs
@@ -1123,10 +1123,10 @@ scrape_configs:
       - targets:
           - localhost
         labels:
-          deployer_name: {instance_name}
-          deployer_ip: {ip}
-          deployer_region: {region}
-          deployer_arch: {arch}
+          deployer_name: '{instance_name}'
+          deployer_ip: '{ip}'
+          deployer_region: '{region}'
+          deployer_arch: '{arch}'
           __path__: /var/log/binary.log
 "#
     )


### PR DESCRIPTION
The deployment `tag` and instance `name`s are written unescaped into local file paths (`~/.commonware_deployer/{tag}`, `pyroscope-agent_{name}.sh`), Promtail YAML, the Pyroscope agent shell script, S3 keys, and EC2 tags and key-pair names.

Restrict both to non-empty `[A-Za-z0-9_-]` in `validate_names`, which runs with `validate_storage_config` before any AWS resource is created. One rule at the source keeps every destination safe without per-destination escaping. The existing duplicate and `monitoring` checks move into the same function.

`region` needs no rule: it is already checked against the account's enabled AWS regions. Example configs (UUID tags, hex public keys, `node1`) all pass.
