### PR TITLE
[ci] Pass docker release target to shell through environment variables

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -47,10 +47,12 @@ jobs:
           echo "target=$TARGET" >> "$GITHUB_OUTPUT"
       - name: Create matrix
         id: platforms
+        shell: bash
         env:
           TARGET: ${{ steps.target-spec.outputs.target }}
         run: |
-          echo "matrix=$(docker buildx bake -f docker/docker-bake.hcl "$TARGET" --print | jq -cr --arg target "$TARGET" '.target[$target].platforms')" >> "$GITHUB_OUTPUT"
+          matrix="$(docker buildx bake -f docker/docker-bake.hcl "$TARGET" --print | jq -cr --arg target "$TARGET" '.target[$target].platforms')"
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
       - name: Show matrix
         env:
           MATRIX: ${{ steps.platforms.outputs.matrix }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -36,20 +36,26 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: Specify Target
         id: target-spec
+        env:
+          INPUT_TARGET: ${{ inputs.target }}
         run: |
-          export TARGET="${{ inputs.target }}"
-          if [[ -z $TARGET ]]; then
-              export TARGET="${GIT_REF_NAME%/*}"
+          TARGET="$INPUT_TARGET"
+          if [[ -z "$TARGET" ]]; then
+              TARGET="${GIT_REF_NAME%/*}"
           fi
           echo "Target: $TARGET"
-          echo "target=$TARGET" >> $GITHUB_OUTPUT
+          echo "target=$TARGET" >> "$GITHUB_OUTPUT"
       - name: Create matrix
         id: platforms
+        env:
+          TARGET: ${{ steps.target-spec.outputs.target }}
         run: |
-          echo "matrix=$(docker buildx bake -f docker/docker-bake.hcl ${{ steps.target-spec.outputs.target }} --print | jq -cr '.target."${{ steps.target-spec.outputs.target }}".platforms')" >> ${GITHUB_OUTPUT}
+          echo "matrix=$(docker buildx bake -f docker/docker-bake.hcl "$TARGET" --print | jq -cr --arg target "$TARGET" '.target[$target].platforms')" >> "$GITHUB_OUTPUT"
       - name: Show matrix
+        env:
+          MATRIX: ${{ steps.platforms.outputs.matrix }}
         run: |
-          echo ${{ steps.platforms.outputs.matrix }}
+          echo "$MATRIX"
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f # v5.8.0
@@ -158,9 +164,13 @@ jobs:
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
       - name: Create manifest list and push
         working-directory: ${{ runner.temp }}/digests
+        env:
+          IMAGE: ${{ env.REGISTRY_IMAGE }}/${{ needs.prepare.outputs.target }}
         run: |
-          docker buildx imagetools create $(jq -cr '.target."docker-metadata-action".tags | map(select(startswith("${{ env.REGISTRY_IMAGE }}/${{ needs.prepare.outputs.target }}")) | "-t " + .) | join(" ")' ${{ runner.temp }}/bake-meta.json) \
-            $(printf '${{ env.REGISTRY_IMAGE }}/${{ needs.prepare.outputs.target }}@sha256:%s ' *)
+          docker buildx imagetools create $(jq -cr --arg image "$IMAGE" '.target."docker-metadata-action".tags | map(select(startswith($image)) | "-t " + .) | join(" ")' "${{ runner.temp }}/bake-meta.json") \
+            $(for digest in *; do echo "$IMAGE@sha256:$digest"; done)
       - name: Inspect image
+        env:
+          IMAGE: ${{ env.REGISTRY_IMAGE }}/${{ needs.prepare.outputs.target }}
         run: |
-          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}/${{ needs.prepare.outputs.target }}:$(jq -r '.target."docker-metadata-action".args.DOCKER_META_VERSION' ${{ runner.temp }}/bake-meta.json)
+          docker buildx imagetools inspect "$IMAGE:$(jq -r '.target."docker-metadata-action".args.DOCKER_META_VERSION' "${{ runner.temp }}/bake-meta.json")"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -39,12 +39,12 @@ jobs:
         env:
           INPUT_TARGET: ${{ inputs.target }}
         run: |
-          TARGET="$INPUT_TARGET"
-          if [[ -z "$TARGET" ]]; then
-              TARGET="${GIT_REF_NAME%/*}"
+          export TARGET="$INPUT_TARGET"
+          if [[ -z $TARGET ]]; then
+              export TARGET="${GIT_REF_NAME%/*}"
           fi
           echo "Target: $TARGET"
-          echo "target=$TARGET" >> "$GITHUB_OUTPUT"
+          echo "target=$TARGET" >> $GITHUB_OUTPUT
       - name: Create matrix
         id: platforms
         shell: bash
@@ -54,10 +54,8 @@ jobs:
           matrix="$(docker buildx bake -f docker/docker-bake.hcl "$TARGET" --print | jq -cr --arg target "$TARGET" '.target[$target].platforms')"
           echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
       - name: Show matrix
-        env:
-          MATRIX: ${{ steps.platforms.outputs.matrix }}
         run: |
-          echo "$MATRIX"
+          echo ${{ steps.platforms.outputs.matrix }}
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f # v5.8.0


### PR DESCRIPTION
`docker.yml` spliced `${{ steps.target-spec.outputs.target }}`, derived from the pushed tag name, directly into `run:` scripts, a `jq` filter, and a `printf` format. The tag name therefore reached the shell unquoted.

Pass the target and image name through `env:` and quote them, use `jq --arg`, and build the digest list with a loop. Bake rejects unknown targets, so `docker-bake.hcl` stays the only list of valid targets; the matrix step now fails there instead of later at `fromJson`.

Pushing a tag requires write access, so this is hygiene against the standard Actions injection pattern rather than a privilege boundary.
