### PR TITLE
[workspace] rustfmt

### DIFF
--- a/consensus/src/marshal/coding/shards/engine.rs
+++ b/consensus/src/marshal/coding/shards/engine.rs
@@ -3668,11 +3668,9 @@ mod tests {
                 peers[receivers[0]]
                     .mailbox
                     .notarized(live_commitment, later_round);
-                peers[receivers[1]].mailbox.discovered(
-                    live_commitment,
-                    leader,
-                    later_round,
-                );
+                peers[receivers[1]]
+                    .mailbox
+                    .discovered(live_commitment, leader, later_round);
                 context.sleep(Duration::from_millis(10)).await;
 
                 let prune_round = Round::new(Epoch::zero(), View::new(3));
@@ -3716,7 +3714,9 @@ mod tests {
 
                 select! {
                     result = notarized_sub => {
-                        result.expect("notarized reconstruction state should accept the leader shard");
+                        result.expect(
+                            "notarized reconstruction state should accept the leader shard",
+                        );
                     },
                     _ = context.sleep(config.link.latency * 10) => {
                         panic!("notarized reconstruction state did not accept the leader shard");
@@ -3724,7 +3724,9 @@ mod tests {
                 }
                 select! {
                     result = discovered_sub => {
-                        result.expect("discovered reconstruction state should accept the leader shard");
+                        result.expect(
+                            "discovered reconstruction state should accept the leader shard",
+                        );
                     },
                     _ = context.sleep(config.link.latency * 10) => {
                         panic!("discovered reconstruction state did not accept the leader shard");

--- a/consensus/src/marshal/standard/mod.rs
+++ b/consensus/src/marshal/standard/mod.rs
@@ -2098,11 +2098,7 @@ mod tests {
                 participants,
                 schemes,
                 ..
-            } = bls12381_threshold_vrf::fixture::<V, _>(
-                &mut context,
-                NAMESPACE,
-                NUM_VALIDATORS,
-            );
+            } = bls12381_threshold_vrf::fixture::<V, _>(&mut context, NAMESPACE, NUM_VALIDATORS);
             // At epoch 0, round-robin elects participant 3 for view 3. Pin the
             // mapping: with a different leader the scripted proposal never
             // reaches verify, and certification would pass through the no-gate
@@ -2179,17 +2175,10 @@ mod tests {
                 leader: byzantine.clone(),
                 parent: (View::new(2), skipped_digest),
             };
-            let block = B::new::<Sha256>(
-                embedded_context,
-                skipped_digest,
-                Height::new(3),
-                300,
-            );
+            let block = B::new::<Sha256>(embedded_context, skipped_digest, Height::new(3), 300);
             let digest = block.digest();
             assert!(
-                buffer
-                    .broadcast(Recipients::Some(vec![]), block)
-                    .accepted(),
+                buffer.broadcast(Recipients::Some(vec![]), block).accepted(),
                 "candidate broadcast should be accepted"
             );
 
@@ -2256,7 +2245,8 @@ mod tests {
                 .map(|index| Nullify::sign::<D>(&schemes[index], skipped_round).unwrap())
                 .collect();
             let nullification =
-                Nullification::from_nullifies(&schemes[0], non_empty![@&nullifies], &Sequential).unwrap();
+                Nullification::from_nullifies(&schemes[0], non_empty![@&nullifies], &Sequential)
+                    .unwrap();
             byzantine_certificate_sender.send(
                 Recipients::One(victim.clone()),
                 Certificate::<S, D>::Nullification(nullification).encode(),
@@ -2303,7 +2293,8 @@ mod tests {
                 .map(|index| Notarize::sign(&schemes[index], good_proposal.clone()).unwrap())
                 .collect();
             let notarization =
-                Notarization::from_notarizes(&schemes[0], non_empty![@&good_votes], &Sequential).unwrap();
+                Notarization::from_notarizes(&schemes[0], non_empty![@&good_votes], &Sequential)
+                    .unwrap();
             byzantine_certificate_sender.send(
                 Recipients::One(victim),
                 Certificate::<S, D>::Notarization(notarization).encode(),
@@ -2323,7 +2314,8 @@ mod tests {
                     loop {
                         let (_, message) = observer_vote_receiver.recv().await.unwrap();
                         let vote = Vote::<S, D>::decode(message).unwrap();
-                        if matches!(vote, Vote::Nullify(ref nullify) if nullify.round == next_round) {
+                        if matches!(vote, Vote::Nullify(ref nullify) if nullify.round == next_round)
+                        {
                             break;
                         }
                     }

--- a/consensus/src/simplex/actors/batcher/actor.rs
+++ b/consensus/src/simplex/actors/batcher/actor.rs
@@ -502,7 +502,6 @@ where
                             let participants = self.forward_targets(round, &proposal, leader);
                             self.forward_proposal(proposal, participants);
                         }
-
                     }
                     Message::Constructed(message) => {
                         // Skip votes below the viewport floor. Our own votes
@@ -554,7 +553,10 @@ where
                 self.record_peer_activity(&sender);
 
                 // Skip certificates outside the viewport
-                if !self.viewport(finalized, current.view).admits_certificate(view) {
+                if !self
+                    .viewport(finalized, current.view)
+                    .admits_certificate(view)
+                {
                     continue;
                 }
 

--- a/consensus/src/simplex/actors/resolver/actor.rs
+++ b/consensus/src/simplex/actors/resolver/actor.rs
@@ -1115,9 +1115,7 @@ mod tests {
                 &schemes, &verifier, EPOCH, notarized,
             )));
             let first = select! {
-                message = requester_voter_receiver.recv() => {
-                    message.expect("voter mailbox closed")
-                },
+                message = requester_voter_receiver.recv() => message.expect("voter mailbox closed"),
                 _ = context.sleep(Duration::from_secs(2)) => {
                     panic!("notarization was not fetched");
                 },
@@ -1163,9 +1161,7 @@ mod tests {
                 Some(participants[2].clone()),
             );
             let recovered = select! {
-                message = requester_voter_receiver.recv() => {
-                    message.expect("voter mailbox closed")
-                },
+                message = requester_voter_receiver.recv() => message.expect("voter mailbox closed"),
                 _ = context.sleep(Duration::from_secs(2)) => {
                     panic!("ambiguous notarization answer blocked ancestry repair");
                 },

--- a/consensus/src/simplex/actors/voter/actor.rs
+++ b/consensus/src/simplex/actors/voter/actor.rs
@@ -1125,7 +1125,8 @@ impl<
                     &mut resolver,
                     &mut pending_propose,
                     &mut pending_verify,
-                ).await;
+                )
+                .await;
 
                 // Attempt to certify any views that we have notarizations for.
                 //
@@ -1135,7 +1136,13 @@ impl<
                 // journal sync completed before this block runs, a child made
                 // eligible by its parent cannot become durable first.
                 let (candidates, fetches) = self.state.certify_candidates();
-                for CertificateFetch { proposal, view, kind, target } in fetches {
+                for CertificateFetch {
+                    proposal,
+                    view,
+                    kind,
+                    target,
+                } in fetches
+                {
                     resolver.resolve(proposal, view, kind, target);
                 }
                 for proposal in candidates {
@@ -1258,9 +1265,7 @@ impl<
                 self = async {
                     // Build and record everything that became available for `view`.
                     let mut staged;
-                    (self, staged) = self
-                        .construct(&mut resolver, view, resolved)
-                        .await;
+                    (self, staged) = self.construct(&mut resolver, view, resolved).await;
                     staged.nullify = nullify;
                     staged.certification = certification;
 
@@ -1272,7 +1277,8 @@ impl<
                         &mut resolver,
                         &mut pending_propose,
                         &mut pending_verify,
-                    ).await;
+                    )
+                    .await;
 
                     // Sync everything appended this iteration (during message
                     // processing and construction) in a single coalesced sync.

--- a/consensus/src/simplex/actors/voter/mod.rs
+++ b/consensus/src/simplex/actors/voter/mod.rs
@@ -2986,7 +2986,7 @@ mod tests {
                 },
                 _ = context.sleep(Duration::from_secs(2)) => {
                     panic!("expected current-view nullify before leader timeout expired");
-                }
+                },
             }
         });
     }
@@ -3251,12 +3251,9 @@ mod tests {
                 ..
             } = ed25519::fixture(&mut context, &namespace, n);
 
-            let oracle = start_test_network_with_peers(
-                context.child("network"),
-                participants.clone(),
-                true,
-            )
-            .await;
+            let oracle =
+                start_test_network_with_peers(context.child("network"), participants.clone(), true)
+                    .await;
 
             let elector = RoundRobin::<Sha256>::default().with_term(
                 term_length,
@@ -3328,7 +3325,8 @@ mod tests {
             loop {
                 select! {
                     msg = batcher_receiver.recv() => {
-                        if let batcher::Message::Constructed(Vote::Notarize(notarize)) = msg.unwrap()
+                        if let batcher::Message::Constructed(Vote::Notarize(notarize)) =
+                            msg.unwrap()
                             && notarize.view() == View::new(1)
                         {
                             break;
@@ -3336,7 +3334,7 @@ mod tests {
                     },
                     _ = context.sleep(Duration::from_secs(5)) => {
                         panic!("expected notarize for view 1 after journal sync");
-                    }
+                    },
                 }
             }
         });
@@ -3401,7 +3399,7 @@ mod tests {
                     },
                     _ = context.sleep(Duration::from_secs(5)) => {
                         panic!("expected nullify for view 1");
-                    }
+                    },
                 }
             };
             let nullification =
@@ -3519,22 +3517,20 @@ mod tests {
 
             loop {
                 select! {
-                    msg = batcher_receiver.recv() => {
-                        match msg.unwrap() {
-                            batcher::Message::Update { .. } => {}
-                            batcher::Message::Constructed(Vote::Notarize(notarize))
-                                if notarize.view() == View::new(2) =>
-                            {
-                                break;
-                            }
-                            _ => {}
+                    msg = batcher_receiver.recv() => match msg.unwrap() {
+                        batcher::Message::Update { .. } => {}
+                        batcher::Message::Constructed(Vote::Notarize(notarize))
+                            if notarize.view() == View::new(2) =>
+                        {
+                            break;
                         }
+                        _ => {}
                     },
                     _ = context.sleep(Duration::from_secs(8)) => {
                         panic!(
                             "expected optimistic notarize for view 2 after local parent notarize"
                         );
-                    }
+                    },
                 }
             }
 
@@ -3636,7 +3632,8 @@ mod tests {
             loop {
                 select! {
                     msg = batcher_receiver.recv() => {
-                        if let batcher::Message::Constructed(Vote::Notarize(notarize)) = msg.unwrap()
+                        if let batcher::Message::Constructed(Vote::Notarize(notarize)) =
+                            msg.unwrap()
                             && notarize.view() == View::new(1)
                         {
                             break;
@@ -3644,7 +3641,7 @@ mod tests {
                     },
                     _ = context.sleep(Duration::from_secs(5)) => {
                         panic!("expected notarize for view 1");
-                    }
+                    },
                 }
             }
 
@@ -3662,7 +3659,8 @@ mod tests {
             loop {
                 select! {
                     msg = batcher_receiver.recv() => {
-                        if let batcher::Message::Constructed(Vote::Notarize(notarize)) = msg.unwrap()
+                        if let batcher::Message::Constructed(Vote::Notarize(notarize)) =
+                            msg.unwrap()
                             && notarize.view() == View::new(2)
                         {
                             break;
@@ -3670,7 +3668,7 @@ mod tests {
                     },
                     _ = context.sleep(Duration::from_secs(5)) => {
                         panic!("expected optimistic notarize for view 2");
-                    }
+                    },
                 }
             }
 
@@ -3692,7 +3690,7 @@ mod tests {
                     },
                     _ = context.sleep(Duration::from_secs(5)) => {
                         panic!("expected failed certification to nullify view 1");
-                    }
+                    },
                 }
             }
 
@@ -3712,7 +3710,8 @@ mod tests {
             loop {
                 select! {
                     msg = batcher_receiver.recv() => {
-                        if let batcher::Message::Constructed(Vote::Notarize(notarize)) = msg.unwrap()
+                        if let batcher::Message::Constructed(Vote::Notarize(notarize)) =
+                            msg.unwrap()
                             && notarize.view() == View::new(3)
                         {
                             panic!("rejected ancestry must not produce a view 3 notarize");
@@ -3742,7 +3741,7 @@ mod tests {
                     },
                     _ = context.sleep(Duration::from_secs(5)) => {
                         panic!("expected nullification to advance to the next term");
-                    }
+                    },
                 }
             }
         });
@@ -4056,13 +4055,17 @@ mod tests {
                             kind,
                             target,
                             ..
-                        } = message.unwrap() else {
+                        } = message.unwrap()
+                        else {
                             continue;
                         };
                         assert_eq!(proposal, View::new(3));
                         assert_eq!(view, View::new(2));
                         assert!(matches!(kind, crate::simplex::actors::Kind::Notarization));
-                        assert!(target.is_some(), "certification repair should retain leader affinity");
+                        assert!(
+                            target.is_some(),
+                            "certification repair should retain leader affinity"
+                        );
                         break;
                     },
                     _ = context.sleep(Duration::from_secs(20)) => {
@@ -7575,13 +7578,14 @@ mod tests {
                         {
                             panic!("stale verification failure nullified the replacement proposal");
                         }
-                        batcher::Message::Update { .. }
-                        | batcher::Message::Constructed(_) => {}
+                        batcher::Message::Update { .. } | batcher::Message::Constructed(_) => {}
                     },
                     message = resolver_receiver.recv() => match message.unwrap() {
-                        MailboxMessage::Certified { view: certified, success, .. }
-                            if certified == view =>
-                        {
+                        MailboxMessage::Certified {
+                            view: certified,
+                            success,
+                            ..
+                        } if certified == view => {
                             assert!(success);
                             break;
                         }
@@ -7723,9 +7727,7 @@ mod tests {
             let reported = loop {
                 select! {
                     msg = resolver_receiver.recv() => match msg.unwrap() {
-                        MailboxMessage::Certified { view, success, .. }
-                            if view == view5 =>
-                        {
+                        MailboxMessage::Certified { view, success, .. } if view == view5 => {
                             break Some(success);
                         }
                         MailboxMessage::Certified { .. }
@@ -7844,9 +7846,7 @@ mod tests {
             let certified = loop {
                 select! {
                     msg = resolver_receiver.recv() => match msg.unwrap() {
-                        MailboxMessage::Certified { view, success, .. }
-                            if view == target_view =>
-                        {
+                        MailboxMessage::Certified { view, success, .. } if view == target_view => {
                             break Some(success);
                         }
                         MailboxMessage::Certified { .. }
@@ -10501,9 +10501,7 @@ mod tests {
             loop {
                 select! {
                     msg = resolver_receiver.recv() => match msg.unwrap() {
-                        MailboxMessage::Certified { view, success, .. }
-                            if view == target_view =>
-                        {
+                        MailboxMessage::Certified { view, success, .. } if view == target_view => {
                             assert!(!success, "expected failed certification");
                             break;
                         }
@@ -10588,9 +10586,7 @@ mod tests {
             loop {
                 select! {
                     msg = resolver_receiver.recv() => match msg.unwrap() {
-                        MailboxMessage::Certified { view, success, .. }
-                            if view == target_view =>
-                        {
+                        MailboxMessage::Certified { view, success, .. } if view == target_view => {
                             assert!(!success, "replayed certification should be a failure");
                             replayed_certified = true;
                         }

--- a/glue/src/dkg/orchestrator/actor.rs
+++ b/glue/src/dkg/orchestrator/actor.rs
@@ -405,11 +405,17 @@ where
             },
             result = &mut active.handle => match result {
                 Ok(()) => {
-                    debug!(epoch = active.epoch.get(), "simplex engine stopped, shutting down orchestrator");
+                    debug!(
+                        epoch = active.epoch.get(),
+                        "simplex engine stopped, shutting down orchestrator"
+                    );
                     break;
                 }
                 Err(error) => {
-                    panic!("simplex engine for epoch {} stopped unexpectedly: {error}", active.epoch);
+                    panic!(
+                        "simplex engine for epoch {} stopped unexpectedly: {error}",
+                        active.epoch
+                    );
                 }
             },
             Some(message) = self.mailbox.recv() else {

--- a/glue/src/dkg/probe/actor/discovery.rs
+++ b/glue/src/dkg/probe/actor/discovery.rs
@@ -184,7 +184,10 @@ where
                 if self.pending.is_some() {
                     self.retry_boundary(&mut boundary_sender);
                 } else if self.sample.floor().is_none() {
-                    debug!(reason = "deadline elapsed", "re-soliciting latest finalizations");
+                    debug!(
+                        reason = "deadline elapsed",
+                        "re-soliciting latest finalizations"
+                    );
                     self.request_latest(&mut boundary_sender);
                 }
                 deadline = self.context.current() + self.retry_timeout.get();

--- a/glue/src/dkg/reshare/actor/inclusion.rs
+++ b/glue/src/dkg/reshare/actor/inclusion.rs
@@ -725,138 +725,138 @@ where
                 return ControlFlow::Break(());
             } => {
                 match message {
-                Message::NextLog {
-                    span,
-                    height,
-                    release,
-                    response,
-                } => {
-                    Self::handle_next_log(
-                        dealer.as_deref(),
-                        &mut served_at,
+                    Message::NextLog {
                         span,
                         height,
                         release,
                         response,
-                    );
-                }
-                Message::ReleaseLog { height } => {
-                    if served_at == Some(height)
-                        && dealer
-                            .as_ref()
-                            .is_some_and(|dealer| dealer.finalized().is_some())
-                    {
-                        served_at = None;
-                    }
-                }
-                Message::EpochInfo {
-                    span,
-                    ancestry,
-                    response,
-                } => {
-                    if !response.is_closed() {
-                        work.requests.push(span, ancestry, response);
-                        if advance.is_none() {
-                            self.advance_artifact_requests(
-                                epoch,
-                                info,
-                                finalized_tip,
-                                &mut scan,
-                                &mut work,
-                            );
-                        }
-                    }
-                }
-                Message::Finalized {
-                    span,
-                    block,
-                    response,
-                } => {
-                    let process = info_span!(
-                        parent: &span,
-                        "dkg.reshare.actor.inclusion.finalized",
-                        height = block.height().traced()
-                    );
-                    let outcome = async {
-                        let bounds = self
-                            .epocher
-                            .containing(block.height())
-                            .expect("epocher must know of block height");
-                        assert_eq!(
-                            bounds.epoch(),
-                            epoch,
-                            "inclusion received future epoch block"
+                    } => {
+                        Self::handle_next_log(
+                            dealer.as_deref(),
+                            &mut served_at,
+                            span,
+                            height,
+                            release,
+                            response,
                         );
-                        assert!(
-                            matches!(bounds.phase(), EpochPhase::Midpoint | EpochPhase::Late),
-                            "inclusion received block before midpoint"
-                        );
-
-                        // A pending ancestry has not established a stable view.
-                        // Restart it after this block's durable effects so its
-                        // lower anchor follows the canonical prefix.
-                        if let Some(request) = scan.take_request() {
-                            work.requests.push_front(request);
-                        }
-
-                        let public_key = self.signer.public_key();
-                        Self::observe_dealer_log(
-                            &public_key,
-                            info,
-                            store,
-                            epoch,
-                            dealer.as_deref_mut(),
-                            block.payload(),
-                        )
-                        .await;
-
-                        let done = block.height() == bounds.last();
-                        if done
-                            && self
-                                .complete_epoch_artifact(
-                                epoch,
-                                info,
-                                store,
-                                &mut work,
-                                block.as_ref(),
-                            )
-                            .await
-                            .is_break()
-                        {
-                            return ControlFlow::Break(());
-                        }
-
-                        finalized_tip = Some(FinalizedTip {
-                            height: block.height(),
-                            digest: block.digest(),
-                        });
-
-                        // Re-offer our dealer log if finalization reached the height we
-                        // served it into without the log landing on-chain. When our log
-                        // does finalize, observe_dealer_log above clears it via
-                        // clear_finalized, so a still-present finalized log here means
-                        // the proposal we served into lost the view.
-                        if served_at.is_some_and(|served| block.height() >= served)
+                    }
+                    Message::ReleaseLog { height } => {
+                        if served_at == Some(height)
                             && dealer
                                 .as_ref()
                                 .is_some_and(|dealer| dealer.finalized().is_some())
                         {
                             served_at = None;
                         }
+                    }
+                    Message::EpochInfo {
+                        span,
+                        ancestry,
+                        response,
+                    } => {
+                        if !response.is_closed() {
+                            work.requests.push(span, ancestry, response);
+                            if advance.is_none() {
+                                self.advance_artifact_requests(
+                                    epoch,
+                                    info,
+                                    finalized_tip,
+                                    &mut scan,
+                                    &mut work,
+                                );
+                            }
+                        }
+                    }
+                    Message::Finalized {
+                        span,
+                        block,
+                        response,
+                    } => {
+                        let process = info_span!(
+                            parent: &span,
+                            "dkg.reshare.actor.inclusion.finalized",
+                            height = block.height().traced()
+                        );
+                        let outcome = async {
+                            let bounds = self
+                                .epocher
+                                .containing(block.height())
+                                .expect("epocher must know of block height");
+                            assert_eq!(
+                                bounds.epoch(),
+                                epoch,
+                                "inclusion received future epoch block"
+                            );
+                            assert!(
+                                matches!(bounds.phase(), EpochPhase::Midpoint | EpochPhase::Late),
+                                "inclusion received block before midpoint"
+                            );
 
-                        response.acknowledge();
-                        ControlFlow::Continue(done)
+                            // A pending ancestry has not established a stable view.
+                            // Restart it after this block's durable effects so its
+                            // lower anchor follows the canonical prefix.
+                            if let Some(request) = scan.take_request() {
+                                work.requests.push_front(request);
+                            }
+
+                            let public_key = self.signer.public_key();
+                            Self::observe_dealer_log(
+                                &public_key,
+                                info,
+                                store,
+                                epoch,
+                                dealer.as_deref_mut(),
+                                block.payload(),
+                            )
+                            .await;
+
+                            let done = block.height() == bounds.last();
+                            if done
+                                && self
+                                    .complete_epoch_artifact(
+                                        epoch,
+                                        info,
+                                        store,
+                                        &mut work,
+                                        block.as_ref(),
+                                    )
+                                    .await
+                                    .is_break()
+                            {
+                                return ControlFlow::Break(());
+                            }
+
+                            finalized_tip = Some(FinalizedTip {
+                                height: block.height(),
+                                digest: block.digest(),
+                            });
+
+                            // Re-offer our dealer log if finalization reached the height we
+                            // served it into without the log landing on-chain. When our log
+                            // does finalize, observe_dealer_log above clears it via
+                            // clear_finalized, so a still-present finalized log here means
+                            // the proposal we served into lost the view.
+                            if served_at.is_some_and(|served| block.height() >= served)
+                                && dealer
+                                    .as_ref()
+                                    .is_some_and(|dealer| dealer.finalized().is_some())
+                            {
+                                served_at = None;
+                            }
+
+                            response.acknowledge();
+                            ControlFlow::Continue(done)
+                        }
+                        .instrument(process)
+                        .await;
+                        let ControlFlow::Continue(done) = outcome else {
+                            return ControlFlow::Break(());
+                        };
+                        if done {
+                            return ControlFlow::Continue(());
+                        }
+                        advance = Some(std::future::ready(())).into();
                     }
-                    .instrument(process)
-                    .await;
-                    let ControlFlow::Continue(done) = outcome else {
-                        return ControlFlow::Break(());
-                    };
-                    if done {
-                        return ControlFlow::Continue(());
-                    }
-                    advance = Some(std::future::ready(())).into();
-                }
                 }
             },
             // Mailbox traffic precedes speculative scan completion. An admitted
@@ -866,26 +866,13 @@ where
                 let request = scan
                     .take_request()
                     .expect("completed artifact scan must own a request");
-                self.complete_artifact_scan(
-                    epoch,
-                    info,
-                    store,
-                    request,
-                    pending,
-                    &mut work,
-                )
-                .await;
+                self.complete_artifact_scan(epoch, info, store, request, pending, &mut work)
+                    .await;
                 advance = Some(std::future::ready(())).into();
             },
             _ = &mut advance => {
                 advance = None.into();
-                self.advance_artifact_requests(
-                    epoch,
-                    info,
-                    finalized_tip,
-                    &mut scan,
-                    &mut work,
-                );
+                self.advance_artifact_requests(epoch, info, finalized_tip, &mut scan, &mut work);
             },
         };
 

--- a/glue/src/dkg/reshare/actor/inclusion.rs
+++ b/glue/src/dkg/reshare/actor/inclusion.rs
@@ -723,140 +723,73 @@ where
             Some(message) = self.mailbox.recv() else {
                 debug!("mailbox closed, shutting down");
                 return ControlFlow::Break(());
-            } => {
-                match message {
-                    Message::NextLog {
+            } => match message {
+                Message::NextLog {
+                    span,
+                    height,
+                    release,
+                    response,
+                } => {
+                    Self::handle_next_log(
+                        dealer.as_deref(),
+                        &mut served_at,
                         span,
                         height,
                         release,
                         response,
-                    } => {
-                        Self::handle_next_log(
-                            dealer.as_deref(),
-                            &mut served_at,
-                            span,
-                            height,
-                            release,
-                            response,
-                        );
+                    );
+                }
+                Message::ReleaseLog { height } => {
+                    if served_at == Some(height)
+                        && dealer
+                            .as_ref()
+                            .is_some_and(|dealer| dealer.finalized().is_some())
+                    {
+                        served_at = None;
                     }
-                    Message::ReleaseLog { height } => {
-                        if served_at == Some(height)
-                            && dealer
-                                .as_ref()
-                                .is_some_and(|dealer| dealer.finalized().is_some())
-                        {
-                            served_at = None;
-                        }
-                    }
-                    Message::EpochInfo {
-                        span,
-                        ancestry,
-                        response,
-                    } => {
-                        if !response.is_closed() {
-                            work.requests.push(span, ancestry, response);
-                            if advance.is_none() {
-                                self.advance_artifact_requests(
-                                    epoch,
-                                    info,
-                                    finalized_tip,
-                                    &mut scan,
-                                    &mut work,
-                                );
-                            }
-                        }
-                    }
-                    Message::Finalized {
-                        span,
-                        block,
-                        response,
-                    } => {
-                        let process = info_span!(
-                            parent: &span,
-                            "dkg.reshare.actor.inclusion.finalized",
-                            height = block.height().traced()
-                        );
-                        let outcome = async {
-                            let bounds = self
-                                .epocher
-                                .containing(block.height())
-                                .expect("epocher must know of block height");
-                            assert_eq!(
-                                bounds.epoch(),
+                }
+                Message::EpochInfo {
+                    span,
+                    ancestry,
+                    response,
+                } => {
+                    if !response.is_closed() {
+                        work.requests.push(span, ancestry, response);
+                        if advance.is_none() {
+                            self.advance_artifact_requests(
                                 epoch,
-                                "inclusion received future epoch block"
-                            );
-                            assert!(
-                                matches!(bounds.phase(), EpochPhase::Midpoint | EpochPhase::Late),
-                                "inclusion received block before midpoint"
-                            );
-
-                            // A pending ancestry has not established a stable view.
-                            // Restart it after this block's durable effects so its
-                            // lower anchor follows the canonical prefix.
-                            if let Some(request) = scan.take_request() {
-                                work.requests.push_front(request);
-                            }
-
-                            let public_key = self.signer.public_key();
-                            Self::observe_dealer_log(
-                                &public_key,
                                 info,
-                                store,
-                                epoch,
-                                dealer.as_deref_mut(),
-                                block.payload(),
-                            )
-                            .await;
-
-                            let done = block.height() == bounds.last();
-                            if done
-                                && self
-                                    .complete_epoch_artifact(
-                                        epoch,
-                                        info,
-                                        store,
-                                        &mut work,
-                                        block.as_ref(),
-                                    )
-                                    .await
-                                    .is_break()
-                            {
-                                return ControlFlow::Break(());
-                            }
-
-                            finalized_tip = Some(FinalizedTip {
-                                height: block.height(),
-                                digest: block.digest(),
-                            });
-
-                            // Re-offer our dealer log if finalization reached the height we
-                            // served it into without the log landing on-chain. When our log
-                            // does finalize, observe_dealer_log above clears it via
-                            // clear_finalized, so a still-present finalized log here means
-                            // the proposal we served into lost the view.
-                            if served_at.is_some_and(|served| block.height() >= served)
-                                && dealer
-                                    .as_ref()
-                                    .is_some_and(|dealer| dealer.finalized().is_some())
-                            {
-                                served_at = None;
-                            }
-
-                            response.acknowledge();
-                            ControlFlow::Continue(done)
+                                finalized_tip,
+                                &mut scan,
+                                &mut work,
+                            );
                         }
-                        .instrument(process)
-                        .await;
-                        let ControlFlow::Continue(done) = outcome else {
-                            return ControlFlow::Break(());
-                        };
-                        if done {
-                            return ControlFlow::Continue(());
-                        }
-                        advance = Some(std::future::ready(())).into();
                     }
+                }
+                Message::Finalized {
+                    span,
+                    block,
+                    response,
+                } => {
+                    if let Some(outcome) = self
+                        .handle_finalized(
+                            epoch,
+                            info,
+                            store,
+                            dealer.as_deref_mut(),
+                            &mut served_at,
+                            &mut finalized_tip,
+                            &mut scan,
+                            &mut work,
+                            span,
+                            block,
+                            response,
+                        )
+                        .await
+                    {
+                        return outcome;
+                    }
+                    advance = Some(std::future::ready(())).into();
                 }
             },
             // Mailbox traffic precedes speculative scan completion. An admitted
@@ -877,6 +810,95 @@ where
         };
 
         ControlFlow::Break(())
+    }
+
+    /// Applies a finalized inclusion block and returns an outcome when it ends the phase.
+    #[allow(clippy::too_many_arguments)]
+    async fn handle_finalized(
+        &mut self,
+        epoch: Epoch,
+        info: &Info<V, C::PublicKey>,
+        store: &mut Store<E, SS, V, C::PublicKey, B::Directory>,
+        mut dealer: Option<&mut Dealer<V, C>>,
+        served_at: &mut Option<Height>,
+        finalized_tip: &mut Option<FinalizedTip<B::Digest>>,
+        scan: &mut ArtifactScan<'_, B, V, C>,
+        work: &mut ArtifactWork<B, V, C>,
+        span: Span,
+        block: Arc<B>,
+        response: A,
+    ) -> Option<ControlFlow<()>> {
+        let process = info_span!(
+            parent: &span,
+            "dkg.reshare.actor.inclusion.finalized",
+            height = block.height().traced()
+        );
+        async {
+            let bounds = self
+                .epocher
+                .containing(block.height())
+                .expect("epocher must know of block height");
+            assert_eq!(
+                bounds.epoch(),
+                epoch,
+                "inclusion received future epoch block"
+            );
+            assert!(
+                matches!(bounds.phase(), EpochPhase::Midpoint | EpochPhase::Late),
+                "inclusion received block before midpoint"
+            );
+
+            // A pending ancestry has not established a stable view.
+            // Restart it after this block's durable effects so its
+            // lower anchor follows the canonical prefix.
+            if let Some(request) = scan.take_request() {
+                work.requests.push_front(request);
+            }
+
+            let public_key = self.signer.public_key();
+            Self::observe_dealer_log(
+                &public_key,
+                info,
+                store,
+                epoch,
+                dealer.as_deref_mut(),
+                block.payload(),
+            )
+            .await;
+
+            let done = block.height() == bounds.last();
+            if done
+                && self
+                    .complete_epoch_artifact(epoch, info, store, work, block.as_ref())
+                    .await
+                    .is_break()
+            {
+                return Some(ControlFlow::Break(()));
+            }
+
+            *finalized_tip = Some(FinalizedTip {
+                height: block.height(),
+                digest: block.digest(),
+            });
+
+            // Re-offer our dealer log if finalization reached the height we
+            // served it into without the log landing on-chain. When our log
+            // does finalize, observe_dealer_log above clears it via
+            // clear_finalized, so a still-present finalized log here means
+            // the proposal we served into lost the view.
+            if served_at.is_some_and(|served| block.height() >= served)
+                && dealer
+                    .as_ref()
+                    .is_some_and(|dealer| dealer.finalized().is_some())
+            {
+                *served_at = None;
+            }
+
+            response.acknowledge();
+            done.then_some(ControlFlow::Continue(()))
+        }
+        .instrument(process)
+        .await
     }
 
     /// Offers the finalized local dealer log and records its height after delivery.

--- a/glue/src/dkg/tests/dkg/harness.rs
+++ b/glue/src/dkg/tests/dkg/harness.rs
@@ -488,9 +488,7 @@ pub(super) fn run_activation_failure_completes_empty() {
         );
 
         let completion = select! {
-            result = completion => {
-                result.expect("activation failure should report DKG completion")
-            },
+            result = completion => result.expect("activation failure should report DKG completion"),
             _ = context.sleep(Duration::from_secs(1)) => {
                 panic!("activation failure did not report DKG completion");
             },

--- a/glue/src/stateful/actor/core/mailbox.rs
+++ b/glue/src/stateful/actor/core/mailbox.rs
@@ -28,7 +28,7 @@ use tracing::{Span, info_span};
 
 /// Re-enqueues live verification requests after finalization or pruning stops
 /// their active attempt.
-type RetryMailbox<E, A> = Arc<dyn Fn(Message<E, A>) + Send + Sync>;
+pub(super) type RetryMailbox<E, A> = Arc<dyn Fn(Message<E, A>) + Send + Sync>;
 
 /// A non-owning reference to ancestry owned by the verification caller.
 ///

--- a/glue/src/stateful/actor/core/processing.rs
+++ b/glue/src/stateful/actor/core/processing.rs
@@ -2,10 +2,10 @@ use crate::stateful::{
     Application, Input,
     actor::{
         core::{
-            mailbox::Message,
+            mailbox::{Message, RetryMailbox},
             verifications::{Handler as Verifications, Request as VerificationRequest},
         },
-        processor::{Applied, Processor},
+        processor::{Applied, PendingSyncTargets, Processor, Prune},
     },
     db::{Barrier, DatabaseSet},
 };
@@ -13,7 +13,7 @@ use commonware_actor::mailbox as actor_mailbox;
 use commonware_consensus::{
     Heightable,
     marshal::{
-        ancestry::BlockProvider,
+        ancestry::{BlockProvider, BoxedAncestry},
         core::{Mailbox as MarshalMailbox, Variant},
     },
     types::Height,
@@ -22,15 +22,20 @@ use commonware_cryptography::certificate::Scheme;
 use commonware_macros::{select, select_loop};
 use commonware_runtime::{Clock, ContextCell, Handle, Metrics, Spawner};
 use commonware_utils::{
-    Acknowledgement as _, acknowledgement::Exact, channel::fallible::OneshotExt,
+    Acknowledgement as _,
+    acknowledgement::Exact,
+    channel::{fallible::OneshotExt, oneshot},
 };
 use futures::{
     FutureExt as _,
     future::{Either, pending, ready},
 };
 use rand_core::Rng;
-use std::{collections::VecDeque, sync::mpsc::TryRecvError};
-use tracing::{Instrument as _, debug, info_span};
+use std::{
+    collections::VecDeque,
+    sync::{Arc, mpsc::TryRecvError},
+};
+use tracing::{Instrument as _, Span, debug, info_span};
 
 /// Work selected for one iteration of the processing actor.
 enum Step<M, P> {
@@ -41,6 +46,9 @@ enum Step<M, P> {
     /// Completion of the active database durability barrier.
     Sync((Height, bool)),
 }
+
+/// A deferred prune and the mailbox used to retry verifications after it completes.
+type PendingPrune<E, A> = (Prune<PendingSyncTargets<A, E>>, RetryMailbox<E, A>);
 
 /// Tracks the durable database prefix and marshal acknowledgements awaiting it.
 ///
@@ -324,216 +332,279 @@ where
             Some(step) = next else {
                 debug!("mailbox closed, stopping processing");
                 break;
-            } => {
-                match step {
-                    Step::Message(Message::Propose {
-                        span,
-                        context,
-                        ancestry,
-                        upstream,
-                        response,
-                    }) => {
-                        let process = info_span!(parent: &span, "stateful.actor.propose");
-                        let input = Input {
+            } => match step {
+                Step::Message(Message::Propose {
+                    span,
+                    context,
+                    ancestry,
+                    upstream,
+                    response,
+                }) => {
+                    deferred_message = self
+                        .handle_proposal(
+                            span,
+                            context,
+                            ancestry,
                             upstream,
-                            provider: self.provider.clone(),
-                        };
-                        let verifier = self.processor.verifier();
-                        let actor_context = self.context.as_present();
-                        let marshal = self.marshal.clone();
-                        let proposal = self
-                            .processor
-                            .propose(
-                                actor_context,
-                                marshal.clone(),
-                                context,
-                                ancestry,
-                                input,
-                                response,
-                            )
-                            .instrument(process);
-                        futures::pin_mut!(proposal);
-                        let mut receive_messages = true;
-                        loop {
-                            if receive_messages {
-                                select! {
-                                    _ = &mut proposal => break,
-                                    message = self.mailbox.recv() => match message {
-                                        Some(Message::Verify {
-                                            span,
-                                            context,
-                                            ancestry,
-                                            verification,
-                                        }) => verifications.schedule(
-                                            verifier.clone(),
-                                            VerificationRequest {
-                                                span,
-                                                context,
-                                                ancestry,
-                                                verification,
-                                            },
-                                        ),
-                                        Some(message) => {
-                                            // Only verification may overtake an active proposal. The
-                                            // first other message becomes a FIFO barrier for later
-                                            // mailbox work.
-                                            deferred_message = Some(message);
-                                            receive_messages = false;
-                                        }
-                                        None => receive_messages = false,
-                                    },
-                                    _ = verifications.next_completed() => {},
-                                }
-                            } else {
-                                select! {
-                                    _ = &mut proposal => break,
-                                    _ = verifications.next_completed() => {},
-                                }
-                            }
-                        }
+                            response,
+                            &mut verifications,
+                        )
+                        .await;
+                }
+                Step::Message(Message::Verify {
+                    span,
+                    context,
+                    ancestry,
+                    verification,
+                }) => {
+                    verifications.schedule(
+                        self.processor.verifier(),
+                        VerificationRequest {
+                            span,
+                            context,
+                            ancestry,
+                            verification,
+                        },
+                    );
+                }
+                Step::Message(Message::Finalized {
+                    span,
+                    block,
+                    acknowledgement,
+                    retry_mailbox,
+                }) => {
+                    if let Some(prune) = self
+                        .handle_finalized(
+                            span,
+                            block,
+                            acknowledgement,
+                            retry_mailbox,
+                            &mut verifications,
+                            &mut durability,
+                        )
+                        .await
+                    {
+                        pending_prune = Some(prune);
                     }
-                    Step::Message(Message::Verify {
-                        span,
-                        context,
-                        ancestry,
-                        verification,
-                    }) => {
-                        verifications.schedule(
-                            self.processor.verifier(),
+                }
+                Step::Message(Message::SubscribeDatabases { response }) => {
+                    response.send_lossy(self.processor.databases().clone());
+                }
+                Step::Prune((prune, retry_mailbox)) => {
+                    if !self
+                        .handle_prune(prune, retry_mailbox, &mut verifications, &mut durability)
+                        .await
+                    {
+                        return;
+                    }
+                }
+                Step::Sync(completion) => {
+                    if !durability.complete(completion) {
+                        return;
+                    }
+                }
+            },
+        }
+    }
+
+    /// Runs one proposal while allowing verification requests to overtake it.
+    async fn handle_proposal(
+        &mut self,
+        span: Span,
+        context: (E, A::Context),
+        ancestry: BoxedAncestry<A::Block>,
+        upstream: A::Input,
+        response: oneshot::Sender<Option<A::Block>>,
+        verifications: &mut Verifications<E, A, S, V>,
+    ) -> Option<Message<E, A>> {
+        let process = info_span!(parent: &span, "stateful.actor.propose");
+        let input = Input {
+            upstream,
+            provider: self.provider.clone(),
+        };
+        let verifier = self.processor.verifier();
+        let actor_context = self.context.as_present();
+        let marshal = self.marshal.clone();
+        let proposal = self
+            .processor
+            .propose(
+                actor_context,
+                marshal.clone(),
+                context,
+                ancestry,
+                input,
+                response,
+            )
+            .instrument(process);
+        futures::pin_mut!(proposal);
+        let mut deferred_message = None;
+        let mut receive_messages = true;
+        loop {
+            if receive_messages {
+                select! {
+                    _ = &mut proposal => break,
+                    message = self.mailbox.recv() => match message {
+                        Some(Message::Verify {
+                            span,
+                            context,
+                            ancestry,
+                            verification,
+                        }) => verifications.schedule(
+                            verifier.clone(),
                             VerificationRequest {
                                 span,
                                 context,
                                 ancestry,
                                 verification,
                             },
-                        );
-                    }
-                    Step::Message(Message::Finalized {
-                        span,
-                        block,
-                        acknowledgement,
-                        retry_mailbox,
-                    }) => {
-                        let process = info_span!(parent: &span, "stateful.actor.finalized");
-                        if skip_finalized_block(&mut self.skip_finalized_until, block.height()) {
-                            async {
-                                verifications
-                                    .drive(self.processor.notify_finalized(
-                                        self.context.as_present(),
-                                        block.as_ref(),
-                                    ))
-                                    .await;
-                                acknowledgement.acknowledge();
-                            }
-                            .instrument(process)
-                            .await;
-                        } else {
-                            let boundary = self.processor.finalization_boundary(block.as_ref());
-                            let (retry, reject) = verifications
-                                .quiesce_where(|progress| boundary.disposition(progress))
-                                .await;
-                            drop(boundary);
-                            async {
-                                let should_start_sync = durability.sync.is_none();
-                                let applied = verifications
-                                    .drive(self.processor.finalize(
-                                        &self.context,
-                                        block.as_ref(),
-                                        should_start_sync,
-                                    ))
-                                    .await;
-                                let Some(Applied { barrier, prune }) = applied else {
-                                    // Duplicate report: marshal redelivers a processed
-                                    // height only after a restart, where startup aligned
-                                    // the databases to durable state.
-                                    acknowledgement.acknowledge();
-                                    return;
-                                };
-                                debug!(
-                                    height = block.height().get(),
-                                    "applied finalized database batch"
-                                );
-
-                                // Retain marshal acknowledgements until a barrier makes their database
-                                // prefix durable. This keeps marshal's processed floor within
-                                // recoverable database state while later work proceeds. The
-                                // acknowledgement window bounds the queue; a barrier that returns false
-                                // leaves the suffix unacknowledged for restart replay.
-                                let height = block.height();
-                                durability.applied(height, acknowledgement);
-                                if let Some(barrier) = barrier {
-                                    durability.started(height, barrier);
-                                }
-
-                                // Defer pruning to the loop so it can settle durability and quiesce
-                                // verification readers at one database mutation boundary.
-                                if let Some(prune) = prune {
-                                    pending_prune = Some((prune, retry_mailbox.clone()));
-                                }
-                            }
-                            .instrument(process)
-                            .await;
-                            for verification in reject {
-                                verification.respond(false);
-                            }
-                            requeue_verifications(retry_mailbox.as_ref(), retry);
+                        ),
+                        Some(message) => {
+                            // Only verification may overtake an active proposal. The
+                            // first other message becomes a FIFO barrier for later
+                            // mailbox work.
+                            deferred_message = Some(message);
+                            receive_messages = false;
                         }
-                    }
-                    Step::Message(Message::SubscribeDatabases { response }) => {
-                        response.send_lossy(self.processor.databases().clone());
-                    }
-                    Step::Prune((prune, retry_mailbox)) => {
-                        // Pruning owns a strict database mutation boundary. Observe an existing sync
-                        // before quiescing readers, then run storage maintenance with no sync active.
-                        while durability.sync.is_some() {
-                            select! {
-                                completion = sync_completion(&mut durability.sync) => {
-                                    if !durability.complete(completion) {
-                                        return;
-                                    }
-                                },
-                                _ = verifications.next_completed() => {},
-                            }
-                        }
-                        let retry = verifications.quiesce().await;
-                        assert!(
-                            self.processor.replays_idle(),
-                            "verification replay remained active after quiescence"
-                        );
-
-                        // A prune target applied behind an earlier sync may still need durability.
-                        if !durability.covers(prune.barrier_height) {
-                            assert!(
-                                durability.needs_sync(),
-                                "uncovered prune target must have unapplied durability",
-                            );
-                            if !start_sync::<E, A, S, V>(
-                                &self.context,
-                                &mut durability,
-                                &mut verifications,
-                                self.processor.databases(),
-                            )
-                            .await
-                            {
-                                return;
-                            }
-                            let completion = sync_completion(&mut durability.sync).await;
-                            if !durability.complete(completion) {
-                                return;
-                            }
-                            assert!(durability.covers(prune.barrier_height));
-                        }
-                        prune.run(self.processor.databases(), &self.marshal).await;
-                        requeue_verifications(retry_mailbox.as_ref(), retry);
-                    }
-                    Step::Sync(completion) => {
-                        if !durability.complete(completion) {
-                            return;
-                        }
-                    }
+                        None => receive_messages = false,
+                    },
+                    _ = verifications.next_completed() => {},
                 }
-            },
+            } else {
+                select! {
+                    _ = &mut proposal => break,
+                    _ = verifications.next_completed() => {},
+                }
+            }
         }
+        deferred_message
+    }
+
+    /// Applies one finalized block and returns any prune it schedules.
+    async fn handle_finalized(
+        &mut self,
+        span: Span,
+        block: Arc<A::Block>,
+        acknowledgement: Exact,
+        retry_mailbox: RetryMailbox<E, A>,
+        verifications: &mut Verifications<E, A, S, V>,
+        durability: &mut Durability,
+    ) -> Option<PendingPrune<E, A>> {
+        let process = info_span!(parent: &span, "stateful.actor.finalized");
+        if skip_finalized_block(&mut self.skip_finalized_until, block.height()) {
+            async {
+                verifications
+                    .drive(
+                        self.processor
+                            .notify_finalized(self.context.as_present(), block.as_ref()),
+                    )
+                    .await;
+                acknowledgement.acknowledge();
+            }
+            .instrument(process)
+            .await;
+            return None;
+        }
+
+        let boundary = self.processor.finalization_boundary(block.as_ref());
+        let (retry, reject) = verifications
+            .quiesce_where(|progress| boundary.disposition(progress))
+            .await;
+        drop(boundary);
+        let pending_prune = async {
+            let should_start_sync = durability.sync.is_none();
+            let applied = verifications
+                .drive(
+                    self.processor
+                        .finalize(&self.context, block.as_ref(), should_start_sync),
+                )
+                .await;
+            let Some(Applied { barrier, prune }) = applied else {
+                // Duplicate report: marshal redelivers a processed
+                // height only after a restart, where startup aligned
+                // the databases to durable state.
+                acknowledgement.acknowledge();
+                return None;
+            };
+            debug!(
+                height = block.height().get(),
+                "applied finalized database batch"
+            );
+
+            // Retain marshal acknowledgements until a barrier makes their database
+            // prefix durable. This keeps marshal's processed floor within
+            // recoverable database state while later work proceeds. The
+            // acknowledgement window bounds the queue; a barrier that returns false
+            // leaves the suffix unacknowledged for restart replay.
+            let height = block.height();
+            durability.applied(height, acknowledgement);
+            if let Some(barrier) = barrier {
+                durability.started(height, barrier);
+            }
+
+            // Defer pruning to the loop so it can settle durability and quiesce
+            // verification readers at one database mutation boundary.
+            prune.map(|prune| (prune, retry_mailbox.clone()))
+        }
+        .instrument(process)
+        .await;
+        for verification in reject {
+            verification.respond(false);
+        }
+        requeue_verifications(retry_mailbox.as_ref(), retry);
+        pending_prune
+    }
+
+    /// Runs one prune after establishing its database mutation boundary.
+    async fn handle_prune(
+        &mut self,
+        prune: Prune<PendingSyncTargets<A, E>>,
+        retry_mailbox: RetryMailbox<E, A>,
+        verifications: &mut Verifications<E, A, S, V>,
+        durability: &mut Durability,
+    ) -> bool {
+        // Pruning owns a strict database mutation boundary. Observe an existing sync
+        // before quiescing readers, then run storage maintenance with no sync active.
+        while durability.sync.is_some() {
+            select! {
+                completion = sync_completion(&mut durability.sync) => {
+                    if !durability.complete(completion) {
+                        return false;
+                    }
+                },
+                _ = verifications.next_completed() => {},
+            }
+        }
+        let retry = verifications.quiesce().await;
+        assert!(
+            self.processor.replays_idle(),
+            "verification replay remained active after quiescence"
+        );
+
+        // A prune target applied behind an earlier sync may still need durability.
+        if !durability.covers(prune.barrier_height) {
+            assert!(
+                durability.needs_sync(),
+                "uncovered prune target must have unapplied durability",
+            );
+            if !start_sync::<E, A, S, V>(
+                &self.context,
+                durability,
+                verifications,
+                self.processor.databases(),
+            )
+            .await
+            {
+                return false;
+            }
+            let completion = sync_completion(&mut durability.sync).await;
+            if !durability.complete(completion) {
+                return false;
+            }
+            assert!(durability.covers(prune.barrier_height));
+        }
+        prune.run(self.processor.databases(), &self.marshal).await;
+        requeue_verifications(retry_mailbox.as_ref(), retry);
+        true
     }
 }
 

--- a/glue/src/stateful/actor/core/processing.rs
+++ b/glue/src/stateful/actor/core/processing.rs
@@ -262,7 +262,8 @@ where
                         &mut durability,
                         &mut verifications,
                         self.processor.databases(),
-                    ).await
+                    )
+                    .await
                 {
                     return;
                 }
@@ -323,210 +324,212 @@ where
             Some(step) = next else {
                 debug!("mailbox closed, stopping processing");
                 break;
-            } => match step {
-                Step::Message(Message::Propose {
-                    span,
-                    context,
-                    ancestry,
-                    upstream,
-                    response,
-                }) => {
-                    let process = info_span!(parent: &span, "stateful.actor.propose");
-                    let input = Input {
+            } => {
+                match step {
+                    Step::Message(Message::Propose {
+                        span,
+                        context,
+                        ancestry,
                         upstream,
-                        provider: self.provider.clone(),
-                    };
-                    let verifier = self.processor.verifier();
-                    let actor_context = self.context.as_present();
-                    let marshal = self.marshal.clone();
-                    let proposal = self
-                        .processor
-                        .propose(
-                            actor_context,
-                            marshal.clone(),
-                            context,
-                            ancestry,
-                            input,
-                            response,
-                        )
-                        .instrument(process);
-                    futures::pin_mut!(proposal);
-                    let mut receive_messages = true;
-                    loop {
-                        if receive_messages {
-                            select! {
-                                _ = &mut proposal => break,
-                                message = self.mailbox.recv() => match message {
-                                    Some(Message::Verify {
-                                        span,
-                                        context,
-                                        ancestry,
-                                        verification,
-                                    }) => verifications.schedule(
-                                        verifier.clone(),
-                                        VerificationRequest {
+                        response,
+                    }) => {
+                        let process = info_span!(parent: &span, "stateful.actor.propose");
+                        let input = Input {
+                            upstream,
+                            provider: self.provider.clone(),
+                        };
+                        let verifier = self.processor.verifier();
+                        let actor_context = self.context.as_present();
+                        let marshal = self.marshal.clone();
+                        let proposal = self
+                            .processor
+                            .propose(
+                                actor_context,
+                                marshal.clone(),
+                                context,
+                                ancestry,
+                                input,
+                                response,
+                            )
+                            .instrument(process);
+                        futures::pin_mut!(proposal);
+                        let mut receive_messages = true;
+                        loop {
+                            if receive_messages {
+                                select! {
+                                    _ = &mut proposal => break,
+                                    message = self.mailbox.recv() => match message {
+                                        Some(Message::Verify {
                                             span,
                                             context,
                                             ancestry,
                                             verification,
-                                        },
-                                    ),
-                                    Some(message) => {
-                                        // Only verification may overtake an active proposal. The
-                                        // first other message becomes a FIFO barrier for later
-                                        // mailbox work.
-                                        deferred_message = Some(message);
-                                        receive_messages = false;
+                                        }) => verifications.schedule(
+                                            verifier.clone(),
+                                            VerificationRequest {
+                                                span,
+                                                context,
+                                                ancestry,
+                                                verification,
+                                            },
+                                        ),
+                                        Some(message) => {
+                                            // Only verification may overtake an active proposal. The
+                                            // first other message becomes a FIFO barrier for later
+                                            // mailbox work.
+                                            deferred_message = Some(message);
+                                            receive_messages = false;
+                                        }
+                                        None => receive_messages = false,
+                                    },
+                                    _ = verifications.next_completed() => {},
+                                }
+                            } else {
+                                select! {
+                                    _ = &mut proposal => break,
+                                    _ = verifications.next_completed() => {},
+                                }
+                            }
+                        }
+                    }
+                    Step::Message(Message::Verify {
+                        span,
+                        context,
+                        ancestry,
+                        verification,
+                    }) => {
+                        verifications.schedule(
+                            self.processor.verifier(),
+                            VerificationRequest {
+                                span,
+                                context,
+                                ancestry,
+                                verification,
+                            },
+                        );
+                    }
+                    Step::Message(Message::Finalized {
+                        span,
+                        block,
+                        acknowledgement,
+                        retry_mailbox,
+                    }) => {
+                        let process = info_span!(parent: &span, "stateful.actor.finalized");
+                        if skip_finalized_block(&mut self.skip_finalized_until, block.height()) {
+                            async {
+                                verifications
+                                    .drive(self.processor.notify_finalized(
+                                        self.context.as_present(),
+                                        block.as_ref(),
+                                    ))
+                                    .await;
+                                acknowledgement.acknowledge();
+                            }
+                            .instrument(process)
+                            .await;
+                        } else {
+                            let boundary = self.processor.finalization_boundary(block.as_ref());
+                            let (retry, reject) = verifications
+                                .quiesce_where(|progress| boundary.disposition(progress))
+                                .await;
+                            drop(boundary);
+                            async {
+                                let should_start_sync = durability.sync.is_none();
+                                let applied = verifications
+                                    .drive(self.processor.finalize(
+                                        &self.context,
+                                        block.as_ref(),
+                                        should_start_sync,
+                                    ))
+                                    .await;
+                                let Some(Applied { barrier, prune }) = applied else {
+                                    // Duplicate report: marshal redelivers a processed
+                                    // height only after a restart, where startup aligned
+                                    // the databases to durable state.
+                                    acknowledgement.acknowledge();
+                                    return;
+                                };
+                                debug!(
+                                    height = block.height().get(),
+                                    "applied finalized database batch"
+                                );
+
+                                // Retain marshal acknowledgements until a barrier makes their database
+                                // prefix durable. This keeps marshal's processed floor within
+                                // recoverable database state while later work proceeds. The
+                                // acknowledgement window bounds the queue; a barrier that returns false
+                                // leaves the suffix unacknowledged for restart replay.
+                                let height = block.height();
+                                durability.applied(height, acknowledgement);
+                                if let Some(barrier) = barrier {
+                                    durability.started(height, barrier);
+                                }
+
+                                // Defer pruning to the loop so it can settle durability and quiesce
+                                // verification readers at one database mutation boundary.
+                                if let Some(prune) = prune {
+                                    pending_prune = Some((prune, retry_mailbox.clone()));
+                                }
+                            }
+                            .instrument(process)
+                            .await;
+                            for verification in reject {
+                                verification.respond(false);
+                            }
+                            requeue_verifications(retry_mailbox.as_ref(), retry);
+                        }
+                    }
+                    Step::Message(Message::SubscribeDatabases { response }) => {
+                        response.send_lossy(self.processor.databases().clone());
+                    }
+                    Step::Prune((prune, retry_mailbox)) => {
+                        // Pruning owns a strict database mutation boundary. Observe an existing sync
+                        // before quiescing readers, then run storage maintenance with no sync active.
+                        while durability.sync.is_some() {
+                            select! {
+                                completion = sync_completion(&mut durability.sync) => {
+                                    if !durability.complete(completion) {
+                                        return;
                                     }
-                                    None => receive_messages = false,
                                 },
                                 _ = verifications.next_completed() => {},
                             }
-                        } else {
-                            select! {
-                                _ = &mut proposal => break,
-                                _ = verifications.next_completed() => {},
-                            }
                         }
-                    }
-                }
-                Step::Message(Message::Verify {
-                    span,
-                    context,
-                    ancestry,
-                    verification,
-                }) => {
-                    verifications.schedule(
-                        self.processor.verifier(),
-                        VerificationRequest {
-                            span,
-                            context,
-                            ancestry,
-                            verification,
-                        },
-                    );
-                }
-                Step::Message(Message::Finalized {
-                    span,
-                    block,
-                    acknowledgement,
-                    retry_mailbox,
-                }) => {
-                    let process = info_span!(parent: &span, "stateful.actor.finalized");
-                    if skip_finalized_block(&mut self.skip_finalized_until, block.height()) {
-                        async {
-                            verifications
-                                .drive(self.processor.notify_finalized(
-                                    self.context.as_present(),
-                                    block.as_ref(),
-                                ))
-                                .await;
-                            acknowledgement.acknowledge();
-                        }
-                        .instrument(process)
-                        .await;
-                    } else {
-                        let boundary = self.processor.finalization_boundary(block.as_ref());
-                        let (retry, reject) = verifications
-                            .quiesce_where(|progress| boundary.disposition(progress))
-                            .await;
-                        drop(boundary);
-                        async {
-                            let should_start_sync = durability.sync.is_none();
-                            let applied = verifications
-                                .drive(self.processor.finalize(
-                                    &self.context,
-                                    block.as_ref(),
-                                    should_start_sync,
-                                ))
-                                .await;
-                            let Some(Applied { barrier, prune }) = applied else {
-                                // Duplicate report: marshal redelivers a processed
-                                // height only after a restart, where startup aligned
-                                // the databases to durable state.
-                                acknowledgement.acknowledge();
-                                return;
-                            };
-                            debug!(
-                                height = block.height().get(),
-                                "applied finalized database batch"
+                        let retry = verifications.quiesce().await;
+                        assert!(
+                            self.processor.replays_idle(),
+                            "verification replay remained active after quiescence"
+                        );
+
+                        // A prune target applied behind an earlier sync may still need durability.
+                        if !durability.covers(prune.barrier_height) {
+                            assert!(
+                                durability.needs_sync(),
+                                "uncovered prune target must have unapplied durability",
                             );
-
-                            // Retain marshal acknowledgements until a barrier makes their database
-                            // prefix durable. This keeps marshal's processed floor within
-                            // recoverable database state while later work proceeds. The
-                            // acknowledgement window bounds the queue; a barrier that returns false
-                            // leaves the suffix unacknowledged for restart replay.
-                            let height = block.height();
-                            durability.applied(height, acknowledgement);
-                            if let Some(barrier) = barrier {
-                                durability.started(height, barrier);
+                            if !start_sync::<E, A, S, V>(
+                                &self.context,
+                                &mut durability,
+                                &mut verifications,
+                                self.processor.databases(),
+                            )
+                            .await
+                            {
+                                return;
                             }
-
-                            // Defer pruning to the loop so it can settle durability and quiesce
-                            // verification readers at one database mutation boundary.
-                            if let Some(prune) = prune {
-                                pending_prune = Some((prune, retry_mailbox.clone()));
+                            let completion = sync_completion(&mut durability.sync).await;
+                            if !durability.complete(completion) {
+                                return;
                             }
+                            assert!(durability.covers(prune.barrier_height));
                         }
-                        .instrument(process)
-                        .await;
-                        for verification in reject {
-                            verification.respond(false);
-                        }
+                        prune.run(self.processor.databases(), &self.marshal).await;
                         requeue_verifications(retry_mailbox.as_ref(), retry);
                     }
-                }
-                Step::Message(Message::SubscribeDatabases { response }) => {
-                    response.send_lossy(self.processor.databases().clone());
-                }
-                Step::Prune((prune, retry_mailbox)) => {
-                    // Pruning owns a strict database mutation boundary. Observe an existing sync
-                    // before quiescing readers, then run storage maintenance with no sync active.
-                    while durability.sync.is_some() {
-                        select! {
-                            completion = sync_completion(&mut durability.sync) => {
-                                if !durability.complete(completion) {
-                                    return;
-                                }
-                            },
-                            _ = verifications.next_completed() => {},
-                        }
-                    }
-                    let retry = verifications.quiesce().await;
-                    assert!(
-                        self.processor.replays_idle(),
-                        "verification replay remained active after quiescence"
-                    );
-
-                    // A prune target applied behind an earlier sync may still need durability.
-                    if !durability.covers(prune.barrier_height) {
-                        assert!(
-                            durability.needs_sync(),
-                            "uncovered prune target must have unapplied durability",
-                        );
-                        if !start_sync::<E, A, S, V>(
-                            &self.context,
-                            &mut durability,
-                            &mut verifications,
-                            self.processor.databases(),
-                        ).await {
-                            return;
-                        }
-                        let completion = sync_completion(&mut durability.sync).await;
+                    Step::Sync(completion) => {
                         if !durability.complete(completion) {
                             return;
                         }
-                        assert!(durability.covers(prune.barrier_height));
-                    }
-                    prune
-                        .run(self.processor.databases(), &self.marshal)
-                        .await;
-                    requeue_verifications(retry_mailbox.as_ref(), retry);
-                }
-                Step::Sync(completion) => {
-                    if !durability.complete(completion) {
-                        return;
                     }
                 }
             },
@@ -1447,7 +1450,10 @@ mod tests {
                 .expect("losing child verification should remain active");
             select! {
                 valid = &mut verify_child => {
-                    assert!(valid, "completed branch-relative verification must remain valid");
+                    assert!(
+                        valid,
+                        "completed branch-relative verification must remain valid"
+                    );
                 },
                 _ = context.sleep(Duration::from_millis(100)) => {
                     panic!("deferred finalization blocked completed verification");
@@ -2245,9 +2251,7 @@ mod tests {
                 .expect("first finalization hook should start");
 
             let valid = select! {
-                valid = &mut first_attempt => {
-                    valid
-                },
+                valid = &mut first_attempt => valid,
                 _ = context.sleep(Duration::from_millis(100)) => {
                     panic!("queued finalization blocked retained verification");
                 },
@@ -2737,19 +2741,13 @@ mod tests {
             let block1 = TestBlock::child(&genesis, 1);
             let block2 = TestBlock::child(&block1, 2);
             let (acknowledgement, waiter1) = Exact::handle();
-            let _ = mailbox.report(Update::Block(
-                Arc::new(block1.clone()),
-                acknowledgement,
-            ));
+            let _ = mailbox.report(Update::Block(Arc::new(block1.clone()), acknowledgement));
             while control.flushes.lock().is_empty() {
                 context.sleep(Duration::from_millis(10)).await;
             }
 
             let (acknowledgement, mut waiter2) = Exact::handle();
-            let _ = mailbox.report(Update::Block(
-                Arc::new(block2.clone()),
-                acknowledgement,
-            ));
+            let _ = mailbox.report(Update::Block(Arc::new(block2.clone()), acknowledgement));
             while control.applied.load(Ordering::Relaxed) < 2 {
                 context.sleep(Duration::from_millis(10)).await;
             }
@@ -2781,7 +2779,9 @@ mod tests {
             select! {
                 result = &mut verify => assert!(result),
                 _ = context.sleep(Duration::from_millis(100)) => {
-                    panic!("successor sync stopped polling the verification that owned its read lock");
+                    panic!(
+                        "successor sync stopped polling the verification that owned its read lock"
+                    );
                 },
             }
 

--- a/glue/src/stateful/actor/processor/mod.rs
+++ b/glue/src/stateful/actor/processor/mod.rs
@@ -2906,7 +2906,10 @@ mod tests {
                     result.expect("finalized hook should remain reachable");
                     panic!("finalization reached the application hook before replay completed");
                 },
-                _ = harness.context_cell.as_present().sleep(Duration::from_millis(10)) => {},
+                _ = harness
+                    .context_cell
+                    .as_present()
+                    .sleep(Duration::from_millis(10)) => {},
             }
 
             owner.finish(Ok(()));
@@ -3316,7 +3319,9 @@ mod tests {
                     }),
                 ));
                 select! {
-                    result = &mut first => panic!("first rebuild completed before replay gate: {result:?}"),
+                    result = &mut first => {
+                        panic!("first rebuild completed before replay gate: {result:?}")
+                    },
                     result = first_started => result.expect("first replay should start"),
                 }
 
@@ -3366,10 +3371,18 @@ mod tests {
                         break;
                     }
                     select! {
-                        result = &mut first => panic!("first rebuild completed before cancellation: {result:?}"),
-                        result = &mut second => panic!("second rebuild completed before cancellation: {result:?}"),
-                        result = &mut third => panic!("third rebuild completed before cancellation: {result:?}"),
-                        result = &mut fourth => panic!("fourth rebuild completed before cancellation: {result:?}"),
+                        result = &mut first => {
+                            panic!("first rebuild completed before cancellation: {result:?}")
+                        },
+                        result = &mut second => {
+                            panic!("second rebuild completed before cancellation: {result:?}")
+                        },
+                        result = &mut third => {
+                            panic!("third rebuild completed before cancellation: {result:?}")
+                        },
+                        result = &mut fourth => {
+                            panic!("fourth rebuild completed before cancellation: {result:?}")
+                        },
                         result = &mut duplicate_started => {
                             result.expect("duplicate replay signal should remain available");
                             panic!("overlapping rebuilds executed the same ancestor concurrently");
@@ -3386,9 +3399,15 @@ mod tests {
                 drop(fourth_live);
                 let fourth_result = select! {
                     result = &mut fourth => result,
-                    result = &mut first => panic!("owner completed while cancelling waiter: {result:?}"),
-                    result = &mut second => panic!("live waiter completed while cancelling peer: {result:?}"),
-                    result = &mut third => panic!("live waiter completed while cancelling peer: {result:?}"),
+                    result = &mut first => {
+                        panic!("owner completed while cancelling waiter: {result:?}")
+                    },
+                    result = &mut second => {
+                        panic!("live waiter completed while cancelling peer: {result:?}")
+                    },
+                    result = &mut third => {
+                        panic!("live waiter completed while cancelling peer: {result:?}")
+                    },
                     _ = context.sleep(std::time::Duration::from_secs(1)) => {
                         panic!("cancelled replay waiter did not stop");
                     },
@@ -3411,8 +3430,12 @@ mod tests {
                 drop(first_live);
                 let first_result = select! {
                     result = &mut first => result,
-                    result = &mut second => panic!("waiter completed before owner cancellation: {result:?}"),
-                    result = &mut third => panic!("waiter completed before owner cancellation: {result:?}"),
+                    result = &mut second => {
+                        panic!("waiter completed before owner cancellation: {result:?}")
+                    },
+                    result = &mut third => {
+                        panic!("waiter completed before owner cancellation: {result:?}")
+                    },
                     _ = context.sleep(std::time::Duration::from_secs(1)) => {
                         panic!("cancelled replay owner did not stop");
                     },
@@ -3420,9 +3443,13 @@ mod tests {
                 assert_eq!(first_result, Err(PrepareBatchesError::Cancelled));
                 first_release.closed().await;
                 select! {
-                    result = &mut second => panic!("waiter completed before retry gate: {result:?}"),
+                    result = &mut second => {
+                        panic!("waiter completed before retry gate: {result:?}")
+                    },
                     result = &mut third => panic!("waiter completed before retry gate: {result:?}"),
-                    result = retry_started => result.expect("live waiter should acquire replay ownership"),
+                    result = retry_started => {
+                        result.expect("live waiter should acquire replay ownership")
+                    },
                     result = &mut duplicate_started => {
                         result.expect("duplicate replay signal should remain available");
                         panic!("multiple waiters acquired replay ownership");

--- a/p2p/src/lib.rs
+++ b/p2p/src/lib.rs
@@ -23,8 +23,8 @@ stability_scope!(BETA {
     };
     use std::{error::Error as StdError, fmt::Debug, future::Future, time::SystemTime};
 
-    mod sizing;
     pub mod authenticated;
+    mod sizing;
     pub mod types;
     pub mod utils;
 

--- a/parallel/src/lib.rs
+++ b/parallel/src/lib.rs
@@ -489,9 +489,12 @@ commonware_macros::stability_scope!(BETA {
             F: Fn(I::Item) -> R + Send + Sync,
             R: Send,
         {
-            self.map_init_collect_vec_with_multiplier(iter, multiplier, || (), |_, item| {
-                map_op(item)
-            })
+            self.map_init_collect_vec_with_multiplier(
+                iter,
+                multiplier,
+                || (),
+                |_, item| map_op(item),
+            )
         }
 
         /// Maps each element, filtering out `None` results and tracking their keys.

--- a/runtime/src/iobuf/pool/freelist.rs
+++ b/runtime/src/iobuf/pool/freelist.rs
@@ -84,8 +84,7 @@ cfg_if::cfg_if! {
         use loom::{
             cell::UnsafeCell,
             sync::{
-                Mutex,
-                MutexGuard,
+                Mutex, MutexGuard,
                 atomic::{AtomicBool, AtomicUsize},
             },
             thread,
@@ -150,7 +149,9 @@ impl Stripe {
     fn lock(&self) -> MutexGuard<'_, Vec<u32>> {
         cfg_if::cfg_if! {
             if #[cfg(feature = "loom")] {
-                self.free.lock().expect("freelist mutex must not be poisoned")
+                self.free
+                    .lock()
+                    .expect("freelist mutex must not be poisoned")
             } else {
                 self.free.lock()
             }

--- a/runtime/src/storage/tokio/blob.rs
+++ b/runtime/src/storage/tokio/blob.rs
@@ -193,7 +193,11 @@ impl Blob {
                             io_slices_len as i32,
                             offset.try_into().map_err(|_| Error::OffsetOverflow)?,
                             flags.unwrap_or(0)
-                                | if attempted_dont_cache { libc::RWF_DONTCACHE } else { 0 },
+                                | if attempted_dont_cache {
+                                    libc::RWF_DONTCACHE
+                                } else {
+                                    0
+                                },
                         )
                     };
                 } else {


### PR DESCRIPTION
Formatted with https://github.com/andresilva/rustfmt/commit/b11f2a81cba6de7b53f37a4049ff1f2cdf8da9d1.

I also made some changes in glue to extract some helpers and make two `select_loop!` less ugly, otherwise rustfmt puts some of those giant match blocks inside a new block which adds another level of indentation.