### PR TITLE
[parallel] Inline spawned jobs measured cheaper than the offload round trip

### DIFF
--- a/p2p/Cargo.toml
+++ b/p2p/Cargo.toml
@@ -38,6 +38,7 @@ tracing.workspace = true
 [dev-dependencies]
 commonware-conformance.workspace = true
 commonware-math.workspace = true
+commonware-parallel = { workspace = true, features = ["test-utils"] }
 commonware-runtime = { workspace = true, features = ["test-utils"] }
 tracing-subscriber.workspace = true
 

--- a/p2p/src/utils/codec.rs
+++ b/p2p/src/utils/codec.rs
@@ -299,12 +299,12 @@ mod tests {
         ed25519::{PrivateKey, PublicKey},
     };
     use commonware_macros::test_traced;
-    use commonware_parallel::{Manual, Sequential, Strategy};
+    use commonware_parallel::{Sequential, mocks};
     use commonware_runtime::{Clock as _, IoBuf, Quota, Runner, Supervisor as _, deterministic};
     use commonware_utils::{NZUsize, Probability, channel::mpsc, ordered::Set};
     use std::{
         io,
-        num::{NonZeroU32, NonZeroUsize},
+        num::NonZeroU32,
         sync::{
             Arc,
             atomic::{AtomicUsize, Ordering},
@@ -398,128 +398,6 @@ mod tests {
 
         fn block(&mut self, _peer: Self::PublicKey) -> Feedback {
             Feedback::Ok
-        }
-    }
-
-    #[derive(Clone, Debug)]
-    struct TestStrategy {
-        parallelism: NonZeroUsize,
-        pending: bool,
-    }
-
-    impl TestStrategy {
-        const fn complete(parallelism: NonZeroUsize) -> Self {
-            Self {
-                parallelism,
-                pending: false,
-            }
-        }
-
-        const fn pending(parallelism: NonZeroUsize) -> Self {
-            Self {
-                parallelism,
-                pending: true,
-            }
-        }
-    }
-
-    impl Strategy for TestStrategy {
-        fn manual(&self) -> Manual<Self> {
-            Manual::new(self.clone(), self.parallelism)
-        }
-
-        fn spawn<F, T>(
-            &self,
-            _len: usize,
-            f: F,
-        ) -> impl core::future::Future<Output = T> + Send + 'static
-        where
-            F: FnOnce(Self) -> T + Send + 'static,
-            T: Send + 'static,
-        {
-            let pending = self.pending;
-            let s = self.clone();
-            async move {
-                if pending {
-                    futures::future::pending::<()>().await;
-                }
-                f(s)
-            }
-        }
-
-        fn fold_init<I, INIT, T, R, ID, F, RD>(
-            &self,
-            iter: I,
-            init: INIT,
-            identity: ID,
-            fold_op: F,
-            reduce_op: RD,
-        ) -> R
-        where
-            I: IntoIterator<IntoIter: Send, Item: Send> + Send,
-            INIT: Fn() -> T + Send + Sync,
-            T: Send,
-            R: Send,
-            ID: Fn() -> R + Send + Sync,
-            F: Fn(R, &mut T, I::Item) -> R + Send + Sync,
-            RD: Fn(R, R) -> R + Send + Sync,
-        {
-            Sequential.fold_init(iter, init, identity, fold_op, reduce_op)
-        }
-
-        fn try_fold<I, R, E, ID, F, RD>(
-            &self,
-            iter: I,
-            identity: ID,
-            fold_op: F,
-            reduce_op: RD,
-        ) -> Result<R, E>
-        where
-            I: IntoIterator<IntoIter: Send, Item: Send> + Send,
-            R: Send,
-            E: Send,
-            ID: Fn() -> R + Send + Sync,
-            F: Fn(R, I::Item) -> Result<R, E> + Send + Sync,
-            RD: Fn(R, R) -> R + Send + Sync,
-        {
-            Sequential.try_fold(iter, identity, fold_op, reduce_op)
-        }
-
-        fn run<R, SEQ, PAR>(&self, len: usize, serial: SEQ, parallel: PAR) -> R
-        where
-            R: Send,
-            SEQ: FnOnce() -> R + Send,
-            PAR: FnOnce() -> R + Send,
-        {
-            Sequential.run(len, serial, parallel)
-        }
-
-        fn try_run<R, E, SEQ, PAR>(&self, len: usize, serial: SEQ, parallel: PAR) -> Result<R, E>
-        where
-            R: Send,
-            E: Send,
-            SEQ: FnOnce() -> Result<R, E> + Send,
-            PAR: FnOnce() -> Result<R, E> + Send,
-        {
-            Sequential.try_run(len, serial, parallel)
-        }
-
-        fn join<A, B, RA, RB>(&self, a: A, b: B) -> (RA, RB)
-        where
-            A: FnOnce() -> RA + Send,
-            B: FnOnce() -> RB + Send,
-            RA: Send,
-            RB: Send,
-        {
-            Sequential.join(a, b)
-        }
-
-        fn sort_by<T, C>(&self, items: &mut [T], compare: C)
-        where
-            T: Send,
-            C: Fn(&T, &T) -> std::cmp::Ordering + Send + Sync,
-        {
-            Sequential.sort_by(items, compare);
         }
     }
 
@@ -682,7 +560,7 @@ mod tests {
                 (),
                 control2.clone(),
                 NZUsize!(50),
-                TestStrategy::complete(NZUsize!(4)),
+                mocks::inline(NZUsize!(4)),
             );
             let _handle = bg.start();
 
@@ -816,7 +694,7 @@ mod tests {
                 (),
                 NoopBlocker,
                 NZUsize!(16),
-                TestStrategy::pending(NZUsize!(2)),
+                mocks::pending(NZUsize!(2)),
             );
             let handle = bg.start();
 

--- a/parallel/Cargo.toml
+++ b/parallel/Cargo.toml
@@ -28,3 +28,4 @@ rayon.workspace = true
 [features]
 default = [ "std" ]
 std = [ "commonware-macros/std", "dep:dashmap", "dep:futures", "dep:rayon" ]
+test-utils = [ "std" ]

--- a/parallel/src/lib.rs
+++ b/parallel/src/lib.rs
@@ -1060,22 +1060,17 @@ commonware_macros::stability_scope!(BETA, cfg(any(feature = "std", test)) {
             // One worker cannot overlap a hand-off (always inline, untimed); a manual strategy
             // has no policy (keep spawn's unconditional hand-off). Otherwise the policy decides
             // from the measured hand-off and job costs.
-            let (decision, policy) = if threads <= 1 {
-                (
-                    policy::SpawnDecision::Inline {
-                        measure: false,
-                    },
-                    None,
-                )
+            let ((execution, measure), policy) = if threads <= 1 {
+                ((policy::SpawnExecution::Inline, false), None)
             } else {
                 self.policy.as_ref().map_or(
-                    (policy::SpawnDecision::Offload { measure: false }, None),
+                    ((policy::SpawnExecution::Offload, false), None),
                     |policy| (policy.choose_spawn(caller, len, threads), Some(policy)),
                 )
             };
 
-            match decision {
-                policy::SpawnDecision::Inline { measure } => {
+            match execution {
+                policy::SpawnExecution::Inline => {
                     // Inline: run on the calling task and hand back a ready future.
                     let start = measure.then(Instant::now);
                     let result = f(self.clone());
@@ -1084,7 +1079,7 @@ commonware_macros::stability_scope!(BETA, cfg(any(feature = "std", test)) {
                     }
                     Either::Left(future::ready(result))
                 }
-                policy::SpawnDecision::Offload { measure } => {
+                policy::SpawnExecution::Offload => {
                     // Offload: hand the job to the pool. The worker records the sample before
                     // sending the result, so measurement is independent of how (or whether) the
                     // caller polls the returned future.

--- a/parallel/src/lib.rs
+++ b/parallel/src/lib.rs
@@ -1075,10 +1075,9 @@ commonware_macros::stability_scope!(BETA, cfg(any(feature = "std", test)) {
                     Either::Left(future::ready(result))
                 }
                 policy::SpawnExecution::Offload => {
-                    // Offload: hand the job to the pool. The worker records the job wall before
-                    // sending the result (so job estimates survive a dropped future), and the
-                    // awaiting future records the round-trip overhead when it observes the
-                    // result.
+                    // Offload: hand the job to the pool. The worker records the job wall (so
+                    // job estimates survive a dropped future), and the awaiting future records
+                    // the round-trip overhead when it observes the result.
                     let spawn_start = measure.then(Instant::now);
                     let (tx, mut rx) = oneshot::channel();
                     let s = self.clone();
@@ -1097,16 +1096,18 @@ commonware_macros::stability_scope!(BETA, cfg(any(feature = "std", test)) {
                         // a spawned job).
                         let result = panic::catch_unwind(AssertUnwindSafe(|| f(s)));
                         let job = job_start.map(|start| start.elapsed());
+                        let ok = result.is_ok();
+                        let _ = tx.send((result, job));
 
                         // Record successful runs only, matching the inline arm: a panicked job's
-                        // wall time says nothing about the job size.
-                        if result.is_ok()
+                        // wall time says nothing about the job size. Recording after the send
+                        // keeps the bookkeeping off the caller's wake path.
+                        if ok
                             && let (Some((policy, caller, len, threads)), Some(job)) =
                                 (worker_recorder, job)
                         {
                             policy.record_spawn_job(caller, len, threads, job);
                         }
-                        let _ = tx.send((result, job));
                     });
                     Either::Right(async move {
                         // When the polling thread is itself a member of the pool, waiting on the

--- a/parallel/src/lib.rs
+++ b/parallel/src/lib.rs
@@ -1075,7 +1075,7 @@ commonware_macros::stability_scope!(BETA, cfg(any(feature = "std", test)) {
                     let start = measure.then(Instant::now);
                     let result = f(self.clone());
                     if let (Some(start), Some(policy)) = (start, policy) {
-                        policy.record_spawn_job(caller, len, threads, start.elapsed());
+                        policy.record_spawn_inline(caller, len, threads, start.elapsed());
                     }
                     Either::Left(future::ready(result))
                 }

--- a/parallel/src/lib.rs
+++ b/parallel/src/lib.rs
@@ -98,7 +98,8 @@ commonware_macros::stability_scope!(BETA {
     /// A strategy wrapper for manually partitioned work.
     ///
     /// Built via [`Strategy::manual`], this disables adaptive policy decisions (including spawn
-    /// placement) for operations that callers have already split into partitions.
+    /// placement) for operations that callers have already split into partitions, and carries
+    /// the parallelism used to plan those partitions.
     #[derive(Clone, Debug)]
     pub struct Manual<S> {
         strategy: S,
@@ -106,14 +107,6 @@ commonware_macros::stability_scope!(BETA {
     }
 
     impl<S> Manual<S> {
-        /// Creates a strategy wrapper for manually partitioned work.
-        pub const fn new(strategy: S, parallelism: NonZeroUsize) -> Self {
-            Self {
-                strategy,
-                parallelism: parallelism.get(),
-            }
-        }
-
         /// Returns the parallelism to use for manually partitioned work.
         pub const fn parallelism(&self) -> usize {
             self.parallelism
@@ -132,14 +125,12 @@ commonware_macros::stability_scope!(BETA {
             Self: Sized;
 
         /// Submit one CPU-bound job to this strategy, running it inline on the calling task when
-        /// it is measured cheaper than the pool hand-off itself and offloading it to the pool
-        /// otherwise.
+        /// it is measured cheaper than the round trip of offloading it to the pool.
         ///
         /// `len` groups calls at a call site into size classes for those measurements, so similar
         /// `len` must mean comparable cost. An inline job runs to completion before `spawn`
-        /// returns and is capped by a small time budget, so big jobs always offload. To force a
-        /// hand-off, submit through [`manual`](Self::manual) (a single-worker pool always runs
-        /// jobs inline).
+        /// returns, and jobs whose measured cost exceeds a small time budget offload. To force a
+        /// hand-off on a multi-worker pool, submit through [`manual`](Self::manual).
         ///
         /// The returned future resolves when the job completes. Blocking on external
         /// synchronization or I/O inside the job can occupy execution capacity until it returns.
@@ -812,7 +803,10 @@ commonware_macros::stability_scope!(BETA {
 
     impl Strategy for Sequential {
         fn manual(&self) -> Manual<Self> {
-            Manual::new(Self, NonZeroUsize::new(1).unwrap())
+            Manual {
+                strategy: Self,
+                parallelism: 1,
+            }
         }
 
         fn spawn<F, T>(
@@ -1349,6 +1343,9 @@ commonware_macros::stability_scope!(BETA, cfg(any(feature = "std", test)) {
             });
         }
     }
+});
+commonware_macros::stability_scope!(ALPHA, cfg(feature = "test-utils") {
+    pub mod mocks;
 });
 
 #[cfg(test)]

--- a/parallel/src/lib.rs
+++ b/parallel/src/lib.rs
@@ -85,7 +85,7 @@ commonware_macros::stability_scope!(BETA {
             use std::{
                 panic::{self, AssertUnwindSafe, Location},
                 sync::Arc,
-                time::{Duration, Instant},
+                time::Instant,
             };
 
             mod policy;
@@ -97,8 +97,8 @@ commonware_macros::stability_scope!(BETA {
 
     /// A strategy wrapper for manually partitioned work.
     ///
-    /// This disables adaptive serial-vs-parallel policy decisions for operations that callers have
-    /// already split into partitions.
+    /// Built via [`Strategy::manual`], this disables adaptive policy decisions (including spawn
+    /// placement) for operations that callers have already split into partitions.
     #[derive(Clone, Debug)]
     pub struct Manual<S> {
         strategy: S,
@@ -107,6 +107,10 @@ commonware_macros::stability_scope!(BETA {
 
     impl<S> Manual<S> {
         /// Creates a strategy wrapper for manually partitioned work.
+        ///
+        /// Unlike [`Strategy::manual`], this wraps `strategy` as-is: an adaptive strategy keeps
+        /// its policy, spawn placement included. Use [`Strategy::manual`] to disable adaptive
+        /// decisions.
         pub const fn new(strategy: S, parallelism: NonZeroUsize) -> Self {
             Self {
                 strategy,
@@ -131,12 +135,17 @@ commonware_macros::stability_scope!(BETA {
         where
             Self: Sized;
 
-        /// Submit one CPU-bound job to this strategy, running it inline on the calling task or
-        /// offloading it to the pool based on the measured cost of each path.
+        /// Submit one CPU-bound job to this strategy, running it inline on the calling task when
+        /// it is measured cheaper than the pool hand-off itself and offloading it to the pool
+        /// otherwise.
         ///
-        /// `len` is a size hint used only to group similar calls. It has no ordering or
-        /// correctness meaning. Jobs too small to amortize the pool hand-off run inline. To force
-        /// an unconditional hand-off, submit through [`manual`](Self::manual).
+        /// `len` groups calls into per-callsite size classes for those measurements: calls from
+        /// one call site with similar `len` must have comparable cost, or the learned inline
+        /// bound weakens. It has no ordering meaning. An inline job runs to completion before
+        /// `spawn` returns, and inline placement is reserved for jobs whose measured cost sits
+        /// under a small time budget, so big jobs always offload. To force a hand-off on a pool
+        /// with more than one worker, submit through [`manual`](Self::manual) (a single-worker
+        /// pool always runs jobs inline).
         ///
         /// The returned future resolves when the job completes. Blocking on external
         /// synchronization or I/O inside the job can occupy execution capacity until it returns.
@@ -1048,92 +1057,99 @@ commonware_macros::stability_scope!(BETA, cfg(any(feature = "std", test)) {
             let threads = self.thread_pool.current_num_threads();
             let caller = Location::caller();
 
-            // One worker cannot overlap (always inline); a manual strategy has no policy (keep
-            // spawn's unconditional offload). Otherwise let the policy decide.
-            let (offload_it, measure) = if threads <= 1 {
-                (false, false)
+            // One worker cannot overlap a hand-off (always inline, untimed); a manual strategy
+            // has no policy (keep spawn's unconditional hand-off). Otherwise the policy decides
+            // from the measured hand-off and job costs.
+            let (decision, policy) = if threads <= 1 {
+                (
+                    policy::SpawnDecision::Inline {
+                        measure: false,
+                    },
+                    None,
+                )
             } else {
-                self.policy.as_ref().map_or((true, false), |policy| {
-                    match policy.choose_spawn(caller, len, threads) {
-                        (policy::SpawnExecution::Inline, measure) => (false, measure),
-                        (policy::SpawnExecution::Offload, measure) => (true, measure),
-                    }
-                })
+                self.policy.as_ref().map_or(
+                    (policy::SpawnDecision::Offload { measure: false }, None),
+                    |policy| (policy.choose_spawn(caller, len, threads), Some(policy)),
+                )
             };
 
-            if !offload_it {
-                // Inline: run on the calling task and hand back a ready future.
-                let start = measure.then(Instant::now);
-                let result = f(self.clone());
-                if let (Some(start), Some(policy)) = (start, self.policy.as_ref()) {
-                    policy.record_spawn(
-                        caller,
-                        len,
-                        threads,
-                        policy::SpawnExecution::Inline,
-                        start.elapsed(),
-                        None,
-                    );
+            match decision {
+                policy::SpawnDecision::Inline { measure } => {
+                    // Inline: run on the calling task and hand back a ready future.
+                    let start = measure.then(Instant::now);
+                    let result = f(self.clone());
+                    if let (Some(start), Some(policy)) = (start, policy) {
+                        policy.record_spawn_inline(caller, len, threads, start.elapsed());
+                    }
+                    Either::Left(future::ready(result))
                 }
-                return Either::Left(future::ready(result));
-            }
+                policy::SpawnDecision::Offload { measure } => {
+                    // Offload: hand the job to the pool. The worker records the sample before
+                    // sending the result, so measurement is independent of how (or whether) the
+                    // caller polls the returned future.
+                    let handoff_start = measure.then(Instant::now);
+                    let (tx, mut rx) = oneshot::channel();
+                    let s = self.clone();
+                    let pool = self.thread_pool.clone();
+                    let recorder = if measure {
+                        policy.cloned().map(|policy| (policy, caller, len, threads))
+                    } else {
+                        None
+                    };
+                    self.thread_pool.spawn(move || {
+                        // The hand-off ends when the job starts here: channel setup, clones,
+                        // enqueue, queue wait, and worker wake. `Instant` is monotonic across
+                        // threads, so the caller-captured start is valid on this one.
+                        let handoff = handoff_start.map(|start| start.elapsed());
+                        let job_start = handoff.is_some().then(Instant::now);
 
-            // Offload: hand the job to the pool. The worker times the job's own wall so we can
-            // estimate the inline cost; the returned future times the residual wait once joined.
-            let setup_start = measure.then(Instant::now);
-            let (tx, mut rx) = oneshot::channel();
-            let s = self.clone();
-            let pool = self.thread_pool.clone();
-            self.thread_pool.spawn(move || {
-                let job_start = measure.then(Instant::now);
-                let result = panic::catch_unwind(AssertUnwindSafe(|| f(s)));
-                let job_wall = job_start.map(|start| start.elapsed());
-                let _ = tx.send((result, job_wall));
-            });
-            let recorder = measure.then(|| {
-                (
-                    self.policy.clone(),
-                    caller,
-                    len,
-                    threads,
-                    setup_start.map_or(Duration::ZERO, |start| start.elapsed()),
-                )
-            });
-            Either::Right(async move {
-                // Time from the caller's first poll (when it joins) to the result: the part of the
-                // job not hidden behind the caller's interleaved work.
-                let poll_start = Instant::now();
-                let (result, job_wall) = loop {
-                    if let Ok(Some(payload)) = rx.try_recv() {
-                        break payload;
-                    }
+                        // Catch the panic so a panicking job propagates to the awaiting task
+                        // rather than aborting the process (rayon aborts on an uncaught panic in
+                        // a spawned job).
+                        let result = panic::catch_unwind(AssertUnwindSafe(|| f(s)));
 
-                    // If the polling thread is a pool member, run pending pool work inline rather
-                    // than parking the only worker able to finish the job.
-                    if !matches!(pool.yield_now(), Some(Yield::Executed)) {
-                        break rx.await
-                            .unwrap_or_else(|_| panic!("strategy job dropped before completion"));
-                    }
-                };
-                match result {
-                    Ok(value) => {
-                        // Record successful runs only, matching the inline arm: a panicked
-                        // job's wall time says nothing about the job size.
-                        if let Some((Some(policy), caller, len, threads, setup)) = recorder {
-                            policy.record_spawn(
+                        // Record successful runs only, matching the inline arm: a panicked job's
+                        // wall time says nothing about the job size.
+                        if result.is_ok()
+                            && let (Some((policy, caller, len, threads)), Some(handoff), Some(start)) =
+                                (recorder, handoff, job_start)
+                        {
+                            policy.record_spawn_offload(
                                 caller,
                                 len,
                                 threads,
-                                policy::SpawnExecution::Offload,
-                                setup.saturating_add(poll_start.elapsed()),
-                                job_wall,
+                                handoff,
+                                start.elapsed(),
                             );
                         }
-                        value
-                    }
-                    Err(payload) => panic::resume_unwind(payload),
+                        let _ = tx.send(result);
+                    });
+                    Either::Right(async move {
+                        // When the polling thread is itself a member of the pool, waiting on the
+                        // channel could park the only worker able to run the job. Execute pending
+                        // pool work inline until the job completes or another worker takes over.
+                        // `yield_now` returns `None` when this thread is not a pool member, so
+                        // external callers fall through to the channel immediately.
+                        loop {
+                            if let Ok(Some(result)) = rx.try_recv() {
+                                return match result {
+                                    Ok(value) => value,
+                                    Err(payload) => panic::resume_unwind(payload),
+                                };
+                            }
+                            if !matches!(pool.yield_now(), Some(Yield::Executed)) {
+                                break;
+                            }
+                        }
+                        match rx.await {
+                            Ok(Ok(value)) => value,
+                            Ok(Err(payload)) => panic::resume_unwind(payload),
+                            Err(_) => panic!("strategy job dropped before completion"),
+                        }
+                    })
                 }
-            })
+            }
         }
 
         #[track_caller]
@@ -1394,6 +1410,41 @@ mod test {
         let (loc, job) = spawn_flagged(&strategy, false);
         assert_eq!(futures::executor::block_on(job), 7);
         assert!(spawn_recorded(&strategy, loc));
+    }
+
+    /// Once the seed and boundary runs measure a trivial job cheaper than the pool hand-off,
+    /// spawn places it inline on the calling (non-pool) thread.
+    #[test]
+    fn spawn_converges_inline_for_tiny_jobs() {
+        let strategy = parallel_strategy();
+
+        for _ in 0..100 {
+            let on_pool = futures::executor::block_on(
+                strategy.spawn(64, |_| rayon::current_thread_index().is_some()),
+            );
+            if !on_pool {
+                return;
+            }
+        }
+        panic!("a trivial job never converged to inline placement");
+    }
+
+    /// A job measured over the inline budget keeps offloading: the calling task is never blocked
+    /// on a big job even when the hand-off looks expensive.
+    #[test]
+    fn spawn_keeps_offloading_big_jobs() {
+        let strategy = parallel_strategy();
+
+        for _ in 0..20 {
+            let on_pool = futures::executor::block_on(strategy.spawn(64, |_| {
+                std::thread::sleep(std::time::Duration::from_millis(2));
+                rayon::current_thread_index().is_some()
+            }));
+            assert!(
+                on_pool,
+                "a job over the inline budget ran on the calling task"
+            );
+        }
     }
 
     fn policy_len(strategy: &Rayon) -> usize {

--- a/parallel/src/lib.rs
+++ b/parallel/src/lib.rs
@@ -1001,7 +1001,7 @@ commonware_macros::stability_scope!(BETA, cfg(any(feature = "std", test)) {
             &self,
             len: usize,
             multiplier: usize,
-            run: impl FnOnce(policy::Execution) -> R,
+            run: impl FnOnce(policy::RunExecution) -> R,
         ) -> R {
             match self.try_execute(len, multiplier, |execution| {
                 Ok::<_, Infallible>(run(execution))
@@ -1016,13 +1016,13 @@ commonware_macros::stability_scope!(BETA, cfg(any(feature = "std", test)) {
             &self,
             len: usize,
             multiplier: usize,
-            run: impl FnOnce(policy::Execution) -> Result<R, E>,
+            run: impl FnOnce(policy::RunExecution) -> Result<R, E>,
         ) -> Result<R, E> {
             let Some(policy) = &self.policy else {
                 let execution = if self.parallelism <= 1 {
-                    policy::Execution::Serial
+                    policy::RunExecution::Serial
                 } else {
-                    policy::Execution::Parallel
+                    policy::RunExecution::Parallel
                 };
                 return run(execution);
             };
@@ -1166,8 +1166,8 @@ commonware_macros::stability_scope!(BETA, cfg(any(feature = "std", test)) {
             PAR: FnOnce() -> R + Send,
         {
             self.execute(len, 1, |execution| match execution {
-                policy::Execution::Serial => serial(),
-                policy::Execution::Parallel => parallel(),
+                policy::RunExecution::Serial => serial(),
+                policy::RunExecution::Parallel => parallel(),
             })
         }
 
@@ -1180,8 +1180,8 @@ commonware_macros::stability_scope!(BETA, cfg(any(feature = "std", test)) {
             PAR: FnOnce() -> Result<R, E> + Send,
         {
             self.try_execute(len, 1, |execution| match execution {
-                policy::Execution::Serial => serial(),
-                policy::Execution::Parallel => parallel(),
+                policy::RunExecution::Serial => serial(),
+                policy::RunExecution::Parallel => parallel(),
             })
         }
 
@@ -1205,10 +1205,10 @@ commonware_macros::stability_scope!(BETA, cfg(any(feature = "std", test)) {
         {
             let items: Vec<I::Item> = iter.into_iter().collect();
             self.execute(items.len(), 1, |execution| match execution {
-                policy::Execution::Serial => {
+                policy::RunExecution::Serial => {
                     Sequential.fold_init(items, init, identity, fold_op, reduce_op)
                 }
-                policy::Execution::Parallel => self.thread_pool.install(|| {
+                policy::RunExecution::Parallel => self.thread_pool.install(|| {
                     items
                         .into_par_iter()
                         .fold(
@@ -1233,8 +1233,8 @@ commonware_macros::stability_scope!(BETA, cfg(any(feature = "std", test)) {
         {
             let items: Vec<I::Item> = iter.into_iter().collect();
             self.execute(items.len(), 1, |execution| match execution {
-                policy::Execution::Serial => Sequential.map_collect_vec(items, map_op),
-                policy::Execution::Parallel => self
+                policy::RunExecution::Serial => Sequential.map_collect_vec(items, map_op),
+                policy::RunExecution::Parallel => self
                     .thread_pool
                     .install(|| items.into_par_iter().map(map_op).collect()),
             })
@@ -1250,8 +1250,8 @@ commonware_macros::stability_scope!(BETA, cfg(any(feature = "std", test)) {
         {
             let items: Vec<I::Item> = iter.into_iter().collect();
             self.try_execute(items.len(), 1, |execution| match execution {
-                policy::Execution::Serial => Sequential.try_map_collect_vec(items, map_op),
-                policy::Execution::Parallel => self
+                policy::RunExecution::Serial => Sequential.try_map_collect_vec(items, map_op),
+                policy::RunExecution::Parallel => self
                     .thread_pool
                     .install(|| items.into_par_iter().map(map_op).collect()),
             })
@@ -1268,8 +1268,8 @@ commonware_macros::stability_scope!(BETA, cfg(any(feature = "std", test)) {
         {
             let items: Vec<I::Item> = iter.into_iter().collect();
             self.execute(items.len(), 1, |execution| match execution {
-                policy::Execution::Serial => Sequential.map_init_collect_vec(items, init, map_op),
-                policy::Execution::Parallel => self
+                policy::RunExecution::Serial => Sequential.map_init_collect_vec(items, init, map_op),
+                policy::RunExecution::Parallel => self
                     .thread_pool
                     .install(|| items.into_par_iter().map_init(init, map_op).collect()),
             })
@@ -1292,8 +1292,8 @@ commonware_macros::stability_scope!(BETA, cfg(any(feature = "std", test)) {
         {
             let items: Vec<I::Item> = iter.into_iter().collect();
             self.execute(items.len(), multiplier, |execution| match execution {
-                policy::Execution::Serial => Sequential.map_init_collect_vec(items, init, map_op),
-                policy::Execution::Parallel => self
+                policy::RunExecution::Serial => Sequential.map_init_collect_vec(items, init, map_op),
+                policy::RunExecution::Parallel => self
                     .thread_pool
                     .install(|| items.into_par_iter().map_init(init, map_op).collect()),
             })
@@ -1317,10 +1317,10 @@ commonware_macros::stability_scope!(BETA, cfg(any(feature = "std", test)) {
         {
             let items: Vec<I::Item> = iter.into_iter().collect();
             self.try_execute(items.len(), 1, |execution| match execution {
-                policy::Execution::Serial => {
+                policy::RunExecution::Serial => {
                     Sequential.try_fold(items, identity, fold_op, reduce_op)
                 }
-                policy::Execution::Parallel => self.thread_pool.install(|| {
+                policy::RunExecution::Parallel => self.thread_pool.install(|| {
                     items
                         .into_par_iter()
                         .try_fold(&identity, &fold_op)
@@ -1346,8 +1346,8 @@ commonware_macros::stability_scope!(BETA, cfg(any(feature = "std", test)) {
             C: Fn(&T, &T) -> Ordering + Send + Sync,
         {
             self.execute(items.len(), 1, |execution| match execution {
-                policy::Execution::Serial => Sequential.sort_by(items, compare),
-                policy::Execution::Parallel => {
+                policy::RunExecution::Serial => Sequential.sort_by(items, compare),
+                policy::RunExecution::Parallel => {
                     self.thread_pool.install(|| items.par_sort_by(compare))
                 }
             });

--- a/parallel/src/lib.rs
+++ b/parallel/src/lib.rs
@@ -1051,9 +1051,10 @@ commonware_macros::stability_scope!(BETA, cfg(any(feature = "std", test)) {
             let threads = self.thread_pool.current_num_threads();
             let caller = Location::caller();
 
-            // One worker cannot overlap a hand-off (always inline, untimed); a manual strategy
-            // has no policy (keep spawn's unconditional hand-off). Otherwise the policy decides
-            // from the measured job cost and offload round trip.
+            // A single-worker pool cannot overlap a hand-off, so the job always runs inline,
+            // untimed. A manual strategy has no policy and keeps spawn's unconditional
+            // hand-off. Otherwise the policy weighs the measured job cost against the offload
+            // round trip.
             let ((execution, measure), policy) = if threads <= 1 {
                 ((policy::SpawnExecution::Inline, false), None)
             } else {

--- a/parallel/src/lib.rs
+++ b/parallel/src/lib.rs
@@ -1344,7 +1344,7 @@ commonware_macros::stability_scope!(BETA, cfg(any(feature = "std", test)) {
         }
     }
 });
-commonware_macros::stability_scope!(ALPHA, cfg(feature = "test-utils") {
+commonware_macros::stability_scope!(ALPHA, cfg(any(feature = "test-utils", test)) {
     pub mod mocks;
 });
 

--- a/parallel/src/lib.rs
+++ b/parallel/src/lib.rs
@@ -135,13 +135,11 @@ commonware_macros::stability_scope!(BETA {
         /// it is measured cheaper than the pool hand-off itself and offloading it to the pool
         /// otherwise.
         ///
-        /// `len` groups calls into per-callsite size classes for those measurements: calls from
-        /// one call site with similar `len` must have comparable cost, or the learned inline
-        /// bound weakens. It has no ordering meaning. An inline job runs to completion before
-        /// `spawn` returns, and inline placement is reserved for jobs whose measured cost sits
-        /// under a small time budget, so big jobs always offload. To force a hand-off on a pool
-        /// with more than one worker, submit through [`manual`](Self::manual) (a single-worker
-        /// pool always runs jobs inline).
+        /// `len` groups calls at a call site into size classes for those measurements, so similar
+        /// `len` must mean comparable cost. An inline job runs to completion before `spawn`
+        /// returns and is capped by a small time budget, so big jobs always offload. To force a
+        /// hand-off, submit through [`manual`](Self::manual) (a single-worker pool always runs
+        /// jobs inline).
         ///
         /// The returned future resolves when the job completes. Blocking on external
         /// synchronization or I/O inside the job can occupy execution capacity until it returns.

--- a/parallel/src/lib.rs
+++ b/parallel/src/lib.rs
@@ -1059,7 +1059,7 @@ commonware_macros::stability_scope!(BETA, cfg(any(feature = "std", test)) {
 
             // One worker cannot overlap a hand-off (always inline, untimed); a manual strategy
             // has no policy (keep spawn's unconditional hand-off). Otherwise the policy decides
-            // from the measured hand-off and job costs.
+            // from the measured job cost and offload round trip.
             let ((execution, measure), policy) = if threads <= 1 {
                 ((policy::SpawnExecution::Inline, false), None)
             } else {
@@ -1075,15 +1075,16 @@ commonware_macros::stability_scope!(BETA, cfg(any(feature = "std", test)) {
                     let start = measure.then(Instant::now);
                     let result = f(self.clone());
                     if let (Some(start), Some(policy)) = (start, policy) {
-                        policy.record_spawn_inline(caller, len, threads, start.elapsed());
+                        policy.record_spawn_job(caller, len, threads, start.elapsed());
                     }
                     Either::Left(future::ready(result))
                 }
                 policy::SpawnExecution::Offload => {
-                    // Offload: hand the job to the pool. The worker records the sample before
-                    // sending the result, so measurement is independent of how (or whether) the
-                    // caller polls the returned future.
-                    let handoff_start = measure.then(Instant::now);
+                    // Offload: hand the job to the pool. The worker records the job wall before
+                    // sending the result (so job estimates survive a dropped future), and the
+                    // awaiting future records the round-trip overhead when it observes the
+                    // result.
+                    let spawn_start = measure.then(Instant::now);
                     let (tx, mut rx) = oneshot::channel();
                     let s = self.clone();
                     let pool = self.thread_pool.clone();
@@ -1092,33 +1093,25 @@ commonware_macros::stability_scope!(BETA, cfg(any(feature = "std", test)) {
                     } else {
                         None
                     };
+                    let worker_recorder = recorder.clone();
                     self.thread_pool.spawn(move || {
-                        // The hand-off ends when the job starts here: channel setup, clones,
-                        // enqueue, queue wait, and worker wake. `Instant` is monotonic across
-                        // threads, so the caller-captured start is valid on this one.
-                        let handoff = handoff_start.map(|start| start.elapsed());
-                        let job_start = handoff.is_some().then(Instant::now);
+                        let job_start = worker_recorder.is_some().then(Instant::now);
 
                         // Catch the panic so a panicking job propagates to the awaiting task
                         // rather than aborting the process (rayon aborts on an uncaught panic in
                         // a spawned job).
                         let result = panic::catch_unwind(AssertUnwindSafe(|| f(s)));
+                        let job = job_start.map(|start| start.elapsed());
 
                         // Record successful runs only, matching the inline arm: a panicked job's
                         // wall time says nothing about the job size.
                         if result.is_ok()
-                            && let (Some((policy, caller, len, threads)), Some(handoff), Some(start)) =
-                                (recorder, handoff, job_start)
+                            && let (Some((policy, caller, len, threads)), Some(job)) =
+                                (worker_recorder, job)
                         {
-                            policy.record_spawn_offload(
-                                caller,
-                                len,
-                                threads,
-                                handoff,
-                                start.elapsed(),
-                            );
+                            policy.record_spawn_job(caller, len, threads, job);
                         }
-                        let _ = tx.send(result);
+                        let _ = tx.send((result, job));
                     });
                     Either::Right(async move {
                         // When the polling thread is itself a member of the pool, waiting on the
@@ -1126,21 +1119,39 @@ commonware_macros::stability_scope!(BETA, cfg(any(feature = "std", test)) {
                         // pool work inline until the job completes or another worker takes over.
                         // `yield_now` returns `None` when this thread is not a pool member, so
                         // external callers fall through to the channel immediately.
-                        loop {
-                            if let Ok(Some(result)) = rx.try_recv() {
-                                return match result {
-                                    Ok(value) => value,
-                                    Err(payload) => panic::resume_unwind(payload),
-                                };
+                        let (result, job) = loop {
+                            if let Ok(Some(payload)) = rx.try_recv() {
+                                break payload;
                             }
                             if !matches!(pool.yield_now(), Some(Yield::Executed)) {
-                                break;
+                                break rx.await.unwrap_or_else(|_| {
+                                    panic!("strategy job dropped before completion")
+                                });
                             }
-                        }
-                        match rx.await {
-                            Ok(Ok(value)) => value,
-                            Ok(Err(payload)) => panic::resume_unwind(payload),
-                            Err(_) => panic!("strategy job dropped before completion"),
+                        };
+                        match result {
+                            Ok(value) => {
+                                // The round trip is everything around the job itself: hand-off
+                                // setup, queueing, worker wake, result send, task wake, and this
+                                // poll. A late poll inflates the sample with overlap slack, which
+                                // only ever biases toward inline, and the policy's budget caps
+                                // what that bias can buy.
+                                if let (
+                                    Some((policy, caller, len, threads)),
+                                    Some(job),
+                                    Some(start),
+                                ) = (recorder, job, spawn_start)
+                                {
+                                    policy.record_spawn_overhead(
+                                        caller,
+                                        len,
+                                        threads,
+                                        start.elapsed().saturating_sub(job),
+                                    );
+                                }
+                                value
+                            }
+                            Err(payload) => panic::resume_unwind(payload),
                         }
                     })
                 }

--- a/parallel/src/lib.rs
+++ b/parallel/src/lib.rs
@@ -107,10 +107,6 @@ commonware_macros::stability_scope!(BETA {
 
     impl<S> Manual<S> {
         /// Creates a strategy wrapper for manually partitioned work.
-        ///
-        /// Unlike [`Strategy::manual`], this wraps `strategy` as-is: an adaptive strategy keeps
-        /// its policy, spawn placement included. Use [`Strategy::manual`] to disable adaptive
-        /// decisions.
         pub const fn new(strategy: S, parallelism: NonZeroUsize) -> Self {
             Self {
                 strategy,

--- a/parallel/src/lib.rs
+++ b/parallel/src/lib.rs
@@ -68,11 +68,11 @@
 
 commonware_macros::stability_scope!(BETA {
     use cfg_if::cfg_if;
-    use core::{cmp::Ordering, fmt, num::NonZeroUsize};
+    use core::{cmp::Ordering, fmt};
 
     cfg_if! {
         if #[cfg(any(feature = "std", test))] {
-            use core::convert::Infallible;
+            use core::{convert::Infallible, num::NonZeroUsize};
             use futures::{
                 channel::oneshot,
                 future::{self, Either},

--- a/parallel/src/mocks.rs
+++ b/parallel/src/mocks.rs
@@ -1,0 +1,27 @@
+//! Mock strategy configurations for testing.
+
+use crate::{Rayon, ThreadPool};
+use core::num::NonZeroUsize;
+use rayon::ThreadPoolBuilder;
+use std::sync::Arc;
+
+/// Returns a strategy whose spawned jobs run inline at submission: a single-worker pool with the
+/// manual parallelism overridden to `parallelism`.
+pub fn inline(parallelism: NonZeroUsize) -> Rayon {
+    Rayon::new(NonZeroUsize::MIN)
+        .unwrap()
+        .with_parallelism(parallelism)
+}
+
+/// Returns a strategy whose spawned jobs never run: `workers` workers are registered but never
+/// started, so offloaded jobs queue forever.
+pub fn pending(workers: NonZeroUsize) -> Rayon {
+    let pool: ThreadPool = Arc::new(
+        ThreadPoolBuilder::new()
+            .num_threads(workers.get())
+            .spawn_handler(|_| Ok(()))
+            .build()
+            .unwrap(),
+    );
+    Rayon::with_pool(pool)
+}

--- a/parallel/src/mocks.rs
+++ b/parallel/src/mocks.rs
@@ -25,3 +25,27 @@ pub fn pending(workers: NonZeroUsize) -> Rayon {
     );
     Rayon::with_pool(pool)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Strategy;
+    use futures::FutureExt;
+
+    #[test]
+    fn inline_runs_spawned_jobs_at_submission() {
+        let strategy = inline(NonZeroUsize::new(4).unwrap());
+
+        assert_eq!(strategy.manual().parallelism(), 4);
+        assert_eq!(strategy.spawn(1, |_| 7).now_or_never(), Some(7));
+    }
+
+    /// Construction must return (rayon's `build` does not wait for workers to prime) and the
+    /// spawned job must stay queued forever.
+    #[test]
+    fn pending_never_completes_spawned_jobs() {
+        let strategy = pending(NonZeroUsize::new(2).unwrap());
+
+        assert!(strategy.spawn(1, |_| 7).now_or_never().is_none());
+    }
+}

--- a/parallel/src/policy.rs
+++ b/parallel/src/policy.rs
@@ -66,12 +66,12 @@ const EWMA_PREVIOUS_WEIGHT: u64 = 4;
 const EWMA_NEXT_WEIGHT: u64 = 1;
 const EWMA_WEIGHT: u64 = EWMA_PREVIOUS_WEIGHT + EWMA_NEXT_WEIGHT;
 
-type Entries = DashMap<Key, Entry>;
+type RunEntries = DashMap<Key, RunEntry>;
 type SpawnEntries = DashMap<Key, SpawnEntry>;
 
 /// The path the policy chose for a call: the strategy runs the matching serial or parallel body.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(super) enum Execution {
+pub(super) enum RunExecution {
     Serial,
     Parallel,
 }
@@ -84,10 +84,11 @@ pub(super) enum SpawnExecution {
     Offload,
 }
 
-/// Adaptive serial-vs-parallel decisions, shared cheaply across [`super::Rayon`] clones.
+/// Adaptive execution decisions (serial vs parallel for collection operations, inline vs
+/// offload for spawned jobs), shared cheaply across [`super::Rayon`] clones.
 #[derive(Clone, Debug, Default)]
 pub(super) struct Policy {
-    entries: Arc<Entries>,
+    run_entries: Arc<RunEntries>,
     spawn_entries: Arc<SpawnEntries>,
 }
 
@@ -105,20 +106,20 @@ impl Policy {
         len: usize,
         work: usize,
         parallelism: usize,
-        run: impl FnOnce(Execution) -> Result<R, E>,
+        run: impl FnOnce(RunExecution) -> Result<R, E>,
     ) -> Result<R, E> {
         // A strategy configured for serial execution cannot benefit from rayon scheduling, so
         // always run serial and never spend a measurement on it.
         if parallelism <= 1 {
-            return run(Execution::Serial);
+            return run(RunExecution::Serial);
         }
 
         let key = Key::new(caller, len, work, parallelism);
-        let (execution, measure) = self.entries.entry(key).or_default().choose(parallelism);
+        let (execution, measure) = self.run_entries.entry(key).or_default().choose(parallelism);
         let start = measure.then(Instant::now);
         let result = run(execution);
         if let (Some(start), Ok(_)) = (start, &result) {
-            let mut entry = self.entries.entry(key).or_default();
+            let mut entry = self.run_entries.entry(key).or_default();
             entry.record(execution, start.elapsed());
         }
         result
@@ -210,7 +211,7 @@ impl Policy {
 
     #[cfg(test)]
     pub(super) fn len(&self) -> usize {
-        self.entries.len()
+        self.run_entries.len()
     }
 
     /// Whether the spawn entry for this call site has recorded at least one sample
@@ -237,7 +238,7 @@ impl Policy {
         parallelism: usize,
     ) -> Option<(Option<u64>, Option<u64>)> {
         let key = Key::new(caller, len, work, parallelism);
-        self.entries
+        self.run_entries
             .get(&key)
             .map(|e| (e.serial_ns.get(), e.parallel_ns.get()))
     }
@@ -345,13 +346,13 @@ impl Cadence {
 
 /// Timing state for one [`Key`].
 #[derive(Clone, Copy, Debug, Default)]
-struct Entry {
+struct RunEntry {
     serial_ns: Estimate,
     parallel_ns: Estimate,
     cadence: Cadence,
 }
 
-impl Entry {
+impl RunEntry {
     // A serial pass of work that parallel finishes in `parallel_ns` can take up to
     // `parallel_ns * parallelism`.
     fn projected_serial(parallel_ns: u64, parallelism: usize) -> u64 {
@@ -361,26 +362,26 @@ impl Entry {
     // Returns the path to prefer: the faster estimate, provided both the projected and
     // measured serial cost fit under the budget (the tuner only arbitrates small cases).
     // Ties go to serial (equal wall time for fewer busy workers).
-    fn preferred(serial_ns: u64, parallel_ns: u64, parallelism: usize) -> Execution {
+    fn preferred(serial_ns: u64, parallel_ns: u64, parallelism: usize) -> RunExecution {
         if Self::projected_serial(parallel_ns, parallelism) >= SERIAL_SAMPLE_BUDGET_NS
             || serial_ns >= SERIAL_SAMPLE_BUDGET_NS
             || parallel_ns < serial_ns
         {
-            Execution::Parallel
+            RunExecution::Parallel
         } else {
-            Execution::Serial
+            RunExecution::Serial
         }
     }
 
     // Returns the path to run and whether the caller should time it and feed the elapsed duration
     // back to [`record`](Self::record).
-    fn choose(&mut self, parallelism: usize) -> (Execution, bool) {
+    fn choose(&mut self, parallelism: usize) -> (RunExecution, bool) {
         // Seed the parallel estimate with the first call. Saturating the cadence keeps the
         // entry due for an immediate boundary, so the serial seed is offered as soon as the
         // parallel estimate lands (when the projection allows).
         let Some(parallel_ns) = self.parallel_ns.get() else {
             self.cadence.saturate();
-            return (Execution::Parallel, true);
+            return (RunExecution::Parallel, true);
         };
 
         // The projection gates serial in both sampling and preference: a case whose projection
@@ -392,10 +393,10 @@ impl Entry {
         // Until serial is sampled, parallel is preferred by default (winner and loser tie, so
         // the cadence runs at its base interval) and the boundary doubles as the seed slot.
         let (preferred, winner_ns, loser_ns) = self.serial_ns.get().map_or(
-            (Execution::Parallel, parallel_ns, parallel_ns),
+            (RunExecution::Parallel, parallel_ns, parallel_ns),
             |serial_ns| match Self::preferred(serial_ns, parallel_ns, parallelism) {
-                Execution::Serial => (Execution::Serial, serial_ns, parallel_ns),
-                Execution::Parallel => (Execution::Parallel, parallel_ns, serial_ns),
+                RunExecution::Serial => (RunExecution::Serial, serial_ns, parallel_ns),
+                RunExecution::Parallel => (RunExecution::Parallel, parallel_ns, serial_ns),
             },
         );
 
@@ -406,9 +407,9 @@ impl Entry {
         let tick = self.cadence.tick(winner_ns, loser_ns);
         if tick.boundary {
             let probe = match preferred {
-                Execution::Serial => Execution::Parallel,
-                Execution::Parallel if can_sample_serial => Execution::Serial,
-                Execution::Parallel => Execution::Parallel,
+                RunExecution::Serial => RunExecution::Parallel,
+                RunExecution::Parallel if can_sample_serial => RunExecution::Serial,
+                RunExecution::Parallel => RunExecution::Parallel,
             };
             return (probe, true);
         }
@@ -416,11 +417,11 @@ impl Entry {
         (preferred, tick.measure)
     }
 
-    fn record(&mut self, execution: Execution, elapsed: Duration) {
+    fn record(&mut self, execution: RunExecution, elapsed: Duration) {
         let elapsed_ns = u64::try_from(elapsed.as_nanos()).unwrap_or(u64::MAX);
         match execution {
-            Execution::Serial => self.serial_ns.record(elapsed_ns),
-            Execution::Parallel => self.parallel_ns.record(elapsed_ns),
+            RunExecution::Serial => self.serial_ns.record(elapsed_ns),
+            RunExecution::Parallel => self.parallel_ns.record(elapsed_ns),
         }
     }
 }
@@ -508,54 +509,54 @@ const fn len_bucket(len: usize) -> u8 {
 #[cfg(test)]
 mod tests {
     use super::{
-        Entry, Execution, MAX_RESAMPLE_SHIFT, PREFERRED_SAMPLE_INTERVAL, Policy, RESAMPLE_INTERVAL,
-        SPAWN_INLINE_BUDGET_NS, SpawnEntry, SpawnExecution,
+        MAX_RESAMPLE_SHIFT, PREFERRED_SAMPLE_INTERVAL, Policy, RESAMPLE_INTERVAL, RunEntry,
+        RunExecution, SPAWN_INLINE_BUDGET_NS, SpawnEntry, SpawnExecution,
     };
     use std::{panic::Location, time::Duration};
 
     const PARALLELISM: usize = 4;
 
-    fn choose(entry: &mut Entry) -> (Execution, bool) {
+    fn choose(entry: &mut RunEntry) -> (RunExecution, bool) {
         entry.choose(PARALLELISM)
     }
 
     #[test]
     fn starts_parallel_then_seeds_serial_immediately() {
-        let mut entry = Entry::default();
+        let mut entry = RunEntry::default();
 
-        assert_eq!(choose(&mut entry), (Execution::Parallel, true));
-        entry.record(Execution::Parallel, Duration::from_micros(100));
+        assert_eq!(choose(&mut entry), (RunExecution::Parallel, true));
+        entry.record(RunExecution::Parallel, Duration::from_micros(100));
 
         // The projection fits the budget, so the serial seed is offered on the very next
         // call rather than after a full interval.
-        assert_eq!(choose(&mut entry), (Execution::Serial, true));
-        entry.record(Execution::Serial, Duration::from_micros(95));
+        assert_eq!(choose(&mut entry), (RunExecution::Serial, true));
+        entry.record(RunExecution::Serial, Duration::from_micros(95));
 
         // With both estimates seeded, the boundary resumes its normal cadence.
         for i in 1..RESAMPLE_INTERVAL {
             assert_eq!(
                 choose(&mut entry),
-                (Execution::Serial, i % PREFERRED_SAMPLE_INTERVAL == 0)
+                (RunExecution::Serial, i % PREFERRED_SAMPLE_INTERVAL == 0)
             );
         }
-        assert_eq!(choose(&mut entry), (Execution::Parallel, true));
+        assert_eq!(choose(&mut entry), (RunExecution::Parallel, true));
     }
 
     #[test]
     fn defers_serial_seed_when_projection_exceeds_budget() {
-        let mut entry = Entry::default();
+        let mut entry = RunEntry::default();
 
-        assert_eq!(choose(&mut entry), (Execution::Parallel, true));
-        entry.record(Execution::Parallel, Duration::from_millis(10));
+        assert_eq!(choose(&mut entry), (RunExecution::Parallel, true));
+        entry.record(RunExecution::Parallel, Duration::from_millis(10));
 
         // The projection (10ms x 4) is over budget, so the immediate boundary refreshes
         // parallel instead of seeding serial and the cadence resets to a full interval.
-        assert_eq!(choose(&mut entry), (Execution::Parallel, true));
+        assert_eq!(choose(&mut entry), (RunExecution::Parallel, true));
         assert!(entry.serial_ns.get().is_none());
         for i in 1..RESAMPLE_INTERVAL {
             assert_eq!(
                 choose(&mut entry),
-                (Execution::Parallel, i % PREFERRED_SAMPLE_INTERVAL == 0)
+                (RunExecution::Parallel, i % PREFERRED_SAMPLE_INTERVAL == 0)
             );
         }
     }
@@ -564,14 +565,14 @@ mod tests {
     fn never_seeds_serial_when_projection_exceeds_budget() {
         // A serial pass could cost up to parallel * parallelism. When that projection exceeds
         // the budget, the tuner biases to parallel without ever paying a serial sample.
-        let mut entry = Entry::default();
+        let mut entry = RunEntry::default();
 
-        entry.record(Execution::Parallel, Duration::from_millis(10));
+        entry.record(RunExecution::Parallel, Duration::from_millis(10));
 
         for i in 1..=(2 * RESAMPLE_INTERVAL) {
             assert_eq!(
                 choose(&mut entry),
-                (Execution::Parallel, i % PREFERRED_SAMPLE_INTERVAL == 0)
+                (RunExecution::Parallel, i % PREFERRED_SAMPLE_INTERVAL == 0)
             );
         }
         assert!(entry.serial_ns.get().is_none());
@@ -581,14 +582,14 @@ mod tests {
     fn never_runs_serial_on_big_work() {
         // The production profile of a large signature batch: parallel wall of 25ms on a
         // 12-thread pool. Serial must never run, no matter how many calls arrive.
-        let mut entry = Entry::default();
-        entry.record(Execution::Parallel, Duration::from_millis(25));
+        let mut entry = RunEntry::default();
+        entry.record(RunExecution::Parallel, Duration::from_millis(25));
 
         for _ in 0..10_000 {
             let (execution, measure) = entry.choose(12);
-            assert_eq!(execution, Execution::Parallel);
+            assert_eq!(execution, RunExecution::Parallel);
             if measure {
-                entry.record(Execution::Parallel, Duration::from_millis(25));
+                entry.record(RunExecution::Parallel, Duration::from_millis(25));
             }
         }
         assert!(entry.serial_ns.get().is_none());
@@ -599,13 +600,13 @@ mod tests {
         // Both estimates exceed the budget and serial nominally wins the comparison, but the
         // tuner only arbitrates small cases: big work runs parallel outright, and the serial
         // probe stays suppressed because the projection is over budget too.
-        let mut entry = Entry::default();
-        entry.record(Execution::Parallel, Duration::from_millis(30));
-        entry.record(Execution::Serial, Duration::from_millis(12));
+        let mut entry = RunEntry::default();
+        entry.record(RunExecution::Parallel, Duration::from_millis(30));
+        entry.record(RunExecution::Serial, Duration::from_millis(12));
 
         for _ in 0..(2 * RESAMPLE_INTERVAL) {
             let (execution, _) = choose(&mut entry);
-            assert_eq!(execution, Execution::Parallel);
+            assert_eq!(execution, RunExecution::Parallel);
         }
     }
 
@@ -614,44 +615,44 @@ mod tests {
         // A workload grew within its bucket: parallel is now 25ms on a 12-thread pool
         // (projection 300ms, well over budget), but a stale serial estimate from a smaller
         // input claims 8ms. The live projection must keep serial from running.
-        let mut entry = Entry::default();
-        entry.record(Execution::Parallel, Duration::from_millis(25));
-        entry.record(Execution::Serial, Duration::from_millis(8));
+        let mut entry = RunEntry::default();
+        entry.record(RunExecution::Parallel, Duration::from_millis(25));
+        entry.record(RunExecution::Serial, Duration::from_millis(8));
 
         for _ in 0..(2 * RESAMPLE_INTERVAL) {
             let (execution, _) = entry.choose(12);
-            assert_eq!(execution, Execution::Parallel);
+            assert_eq!(execution, RunExecution::Parallel);
         }
     }
 
     #[test]
     fn prefers_serial_when_faster() {
-        let mut entry = Entry::default();
-        entry.record(Execution::Parallel, Duration::from_micros(100));
-        entry.record(Execution::Serial, Duration::from_micros(95));
+        let mut entry = RunEntry::default();
+        entry.record(RunExecution::Parallel, Duration::from_micros(100));
+        entry.record(RunExecution::Serial, Duration::from_micros(95));
 
-        assert_eq!(choose(&mut entry), (Execution::Serial, false));
+        assert_eq!(choose(&mut entry), (RunExecution::Serial, false));
     }
 
     #[test]
     fn prefers_parallel_when_it_wins_wall_time() {
         // Serial is only 2x slower in wall time (cheaper in worker time on a 4-thread pool),
         // but the policy optimizes latency: parallel wins.
-        let mut entry = Entry::default();
-        entry.record(Execution::Parallel, Duration::from_micros(100));
-        entry.record(Execution::Serial, Duration::from_micros(200));
+        let mut entry = RunEntry::default();
+        entry.record(RunExecution::Parallel, Duration::from_micros(100));
+        entry.record(RunExecution::Serial, Duration::from_micros(200));
 
-        assert_eq!(choose(&mut entry), (Execution::Parallel, false));
+        assert_eq!(choose(&mut entry), (RunExecution::Parallel, false));
     }
 
     #[test]
     fn prefers_serial_on_tie() {
         // Equal wall time: serial occupies one worker instead of the whole pool.
-        let mut entry = Entry::default();
-        entry.record(Execution::Parallel, Duration::from_micros(100));
-        entry.record(Execution::Serial, Duration::from_micros(100));
+        let mut entry = RunEntry::default();
+        entry.record(RunExecution::Parallel, Duration::from_micros(100));
+        entry.record(RunExecution::Serial, Duration::from_micros(100));
 
-        assert_eq!(choose(&mut entry), (Execution::Serial, false));
+        assert_eq!(choose(&mut entry), (RunExecution::Serial, false));
     }
 
     #[test]
@@ -659,33 +660,33 @@ mod tests {
         // Before serial is seeded there is no loser: parallel samples smooth into the EWMA,
         // so a single outlier (a contended call) cannot swing the projection that gates
         // serial sampling.
-        let mut entry = Entry::default();
-        entry.record(Execution::Parallel, Duration::from_millis(10));
-        entry.record(Execution::Parallel, Duration::from_millis(20));
+        let mut entry = RunEntry::default();
+        entry.record(RunExecution::Parallel, Duration::from_millis(10));
+        entry.record(RunExecution::Parallel, Duration::from_millis(20));
 
         assert_eq!(entry.parallel_ns.get(), Some(12_000_000));
     }
 
     #[test]
     fn blends_preferred_samples_with_integer_math() {
-        let mut entry = Entry::default();
-        entry.record(Execution::Parallel, Duration::from_nanos(1000));
-        entry.record(Execution::Serial, Duration::from_nanos(100));
+        let mut entry = RunEntry::default();
+        entry.record(RunExecution::Parallel, Duration::from_nanos(1000));
+        entry.record(RunExecution::Serial, Duration::from_nanos(100));
 
         // Serial is preferred, so further serial samples blend 4:1.
-        entry.record(Execution::Serial, Duration::from_nanos(200));
+        entry.record(RunExecution::Serial, Duration::from_nanos(200));
 
         assert_eq!(entry.serial_ns.get(), Some(120));
     }
 
     #[test]
     fn blends_preferred_parallel_samples() {
-        let mut entry = Entry::default();
-        entry.record(Execution::Parallel, Duration::from_nanos(100));
-        entry.record(Execution::Serial, Duration::from_nanos(1000));
+        let mut entry = RunEntry::default();
+        entry.record(RunExecution::Parallel, Duration::from_nanos(100));
+        entry.record(RunExecution::Serial, Duration::from_nanos(1000));
 
         // Parallel is preferred, so further parallel samples blend 4:1.
-        entry.record(Execution::Parallel, Duration::from_nanos(200));
+        entry.record(RunExecution::Parallel, Duration::from_nanos(200));
 
         assert_eq!(entry.parallel_ns.get(), Some(120));
     }
@@ -694,20 +695,20 @@ mod tests {
     fn probes_blend_into_stale_estimates() {
         // A probe's sample blends like any other, so one probe moves a stale estimate by a
         // fifth of the gap rather than trusting a single measurement outright.
-        let mut entry = Entry::default();
-        entry.record(Execution::Parallel, Duration::from_millis(25));
-        entry.record(Execution::Serial, Duration::from_millis(100));
+        let mut entry = RunEntry::default();
+        entry.record(RunExecution::Parallel, Duration::from_millis(25));
+        entry.record(RunExecution::Serial, Duration::from_millis(100));
 
-        entry.record(Execution::Serial, Duration::from_millis(5));
+        entry.record(RunExecution::Serial, Duration::from_millis(5));
 
         assert_eq!(entry.serial_ns.get(), Some(81_000_000));
         assert_eq!(
-            Entry::preferred(
+            RunEntry::preferred(
                 entry.serial_ns.get().unwrap(),
                 entry.parallel_ns.get().unwrap(),
                 PARALLELISM
             ),
-            Execution::Parallel
+            RunExecution::Parallel
         );
     }
 
@@ -715,80 +716,80 @@ mod tests {
     fn seeds_serial_once_projection_shrinks_into_budget() {
         // The projection is live: a key that starts over budget seeds serial at the first
         // boundary after refreshes shrink the parallel estimate into the budget.
-        let mut entry = Entry::default();
-        entry.record(Execution::Parallel, Duration::from_millis(10));
+        let mut entry = RunEntry::default();
+        entry.record(RunExecution::Parallel, Duration::from_millis(10));
 
         for _ in 1..RESAMPLE_INTERVAL {
             let (execution, measure) = choose(&mut entry);
-            assert_eq!(execution, Execution::Parallel);
+            assert_eq!(execution, RunExecution::Parallel);
             if measure {
-                entry.record(Execution::Parallel, Duration::from_micros(100));
+                entry.record(RunExecution::Parallel, Duration::from_micros(100));
             }
         }
-        assert_eq!(choose(&mut entry), (Execution::Serial, true));
+        assert_eq!(choose(&mut entry), (RunExecution::Serial, true));
     }
 
     #[test]
     fn resamples_other_execution() {
-        let mut entry = Entry::default();
-        entry.record(Execution::Parallel, Duration::from_micros(100));
-        entry.record(Execution::Serial, Duration::from_micros(80));
+        let mut entry = RunEntry::default();
+        entry.record(RunExecution::Parallel, Duration::from_micros(100));
+        entry.record(RunExecution::Serial, Duration::from_micros(80));
 
         for i in 1..RESAMPLE_INTERVAL {
             assert_eq!(
                 choose(&mut entry),
-                (Execution::Serial, i % PREFERRED_SAMPLE_INTERVAL == 0)
+                (RunExecution::Serial, i % PREFERRED_SAMPLE_INTERVAL == 0)
             );
         }
-        assert_eq!(choose(&mut entry), (Execution::Parallel, true));
+        assert_eq!(choose(&mut entry), (RunExecution::Parallel, true));
     }
 
     #[test]
     fn resamples_serial_when_parallel_wins() {
-        let mut entry = Entry::default();
-        entry.record(Execution::Parallel, Duration::from_micros(100));
-        entry.record(Execution::Serial, Duration::from_micros(150));
+        let mut entry = RunEntry::default();
+        entry.record(RunExecution::Parallel, Duration::from_micros(100));
+        entry.record(RunExecution::Serial, Duration::from_micros(150));
 
         for i in 1..RESAMPLE_INTERVAL {
             assert_eq!(
                 choose(&mut entry),
-                (Execution::Parallel, i % PREFERRED_SAMPLE_INTERVAL == 0)
+                (RunExecution::Parallel, i % PREFERRED_SAMPLE_INTERVAL == 0)
             );
         }
-        assert_eq!(choose(&mut entry), (Execution::Serial, true));
+        assert_eq!(choose(&mut entry), (RunExecution::Serial, true));
     }
 
     #[test]
     fn resample_interval_doubles_per_slowdown_multiple() {
         // Parallel lost by 2x-3x, so the probe interval doubles once.
-        let mut entry = Entry::default();
-        entry.record(Execution::Parallel, Duration::from_micros(250));
-        entry.record(Execution::Serial, Duration::from_micros(100));
+        let mut entry = RunEntry::default();
+        entry.record(RunExecution::Parallel, Duration::from_micros(250));
+        entry.record(RunExecution::Serial, Duration::from_micros(100));
 
         for i in 1..(2 * RESAMPLE_INTERVAL) {
             assert_eq!(
                 choose(&mut entry),
-                (Execution::Serial, i % PREFERRED_SAMPLE_INTERVAL == 0)
+                (RunExecution::Serial, i % PREFERRED_SAMPLE_INTERVAL == 0)
             );
         }
-        assert_eq!(choose(&mut entry), (Execution::Parallel, true));
+        assert_eq!(choose(&mut entry), (RunExecution::Parallel, true));
     }
 
     #[test]
     fn resample_interval_is_capped() {
         // Serial lost by 9x, so the interval shift is capped and the probe still happens.
-        let mut entry = Entry::default();
-        entry.record(Execution::Parallel, Duration::from_micros(100));
-        entry.record(Execution::Serial, Duration::from_micros(900));
+        let mut entry = RunEntry::default();
+        entry.record(RunExecution::Parallel, Duration::from_micros(100));
+        entry.record(RunExecution::Serial, Duration::from_micros(900));
 
         let interval = RESAMPLE_INTERVAL << MAX_RESAMPLE_SHIFT;
         for i in 1..interval {
             assert_eq!(
                 choose(&mut entry),
-                (Execution::Parallel, i % PREFERRED_SAMPLE_INTERVAL == 0)
+                (RunExecution::Parallel, i % PREFERRED_SAMPLE_INTERVAL == 0)
             );
         }
-        assert_eq!(choose(&mut entry), (Execution::Serial, true));
+        assert_eq!(choose(&mut entry), (RunExecution::Serial, true));
     }
 
     #[test]
@@ -797,40 +798,40 @@ mod tests {
         // is preferred. The projection is still under budget (2ms x 4 = 8ms). The true
         // parallel cost is 0.5ms: probes blend the estimate down geometrically until the
         // preference flips.
-        let mut entry = Entry::default();
-        entry.record(Execution::Parallel, Duration::from_millis(2));
-        entry.record(Execution::Serial, Duration::from_millis(1));
+        let mut entry = RunEntry::default();
+        entry.record(RunExecution::Parallel, Duration::from_millis(2));
+        entry.record(RunExecution::Serial, Duration::from_millis(1));
         assert_eq!(
-            Entry::preferred(
+            RunEntry::preferred(
                 entry.serial_ns.get().unwrap(),
                 entry.parallel_ns.get().unwrap(),
                 PARALLELISM
             ),
-            Execution::Serial
+            RunExecution::Serial
         );
 
         let mut probes = 0;
         let mut flipped_at = None;
         for i in 1..=1_000 {
-            if Entry::preferred(
+            if RunEntry::preferred(
                 entry.serial_ns.get().unwrap(),
                 entry.parallel_ns.get().unwrap(),
                 PARALLELISM,
-            ) == Execution::Parallel
+            ) == RunExecution::Parallel
             {
                 flipped_at = Some(i - 1);
                 break;
             }
             let (execution, measure) = choose(&mut entry);
             match execution {
-                Execution::Parallel => {
+                RunExecution::Parallel => {
                     assert!(measure);
                     probes += 1;
-                    entry.record(Execution::Parallel, Duration::from_micros(500));
+                    entry.record(RunExecution::Parallel, Duration::from_micros(500));
                 }
-                Execution::Serial => {
+                RunExecution::Serial => {
                     if measure {
-                        entry.record(Execution::Serial, Duration::from_millis(1));
+                        entry.record(RunExecution::Serial, Duration::from_millis(1));
                     }
                 }
             }
@@ -848,22 +849,22 @@ mod tests {
         // Exactly one caller crosses the probe boundary and receives the serial seed, so
         // concurrent callers cannot herd onto serial. A seed whose sample never lands (the
         // call panicked) is offered again one interval later instead of wedging the key.
-        let mut entry = Entry::default();
-        entry.record(Execution::Parallel, Duration::from_micros(250));
+        let mut entry = RunEntry::default();
+        entry.record(RunExecution::Parallel, Duration::from_micros(250));
 
         for round in 0..2 {
             for i in 1..RESAMPLE_INTERVAL {
                 assert_eq!(
                     choose(&mut entry),
-                    (Execution::Parallel, i % PREFERRED_SAMPLE_INTERVAL == 0),
+                    (RunExecution::Parallel, i % PREFERRED_SAMPLE_INTERVAL == 0),
                     "round {round}"
                 );
             }
-            assert_eq!(choose(&mut entry), (Execution::Serial, true));
+            assert_eq!(choose(&mut entry), (RunExecution::Serial, true));
         }
 
-        entry.record(Execution::Serial, Duration::from_millis(1));
-        assert_eq!(choose(&mut entry).0, Execution::Parallel);
+        entry.record(RunExecution::Serial, Duration::from_millis(1));
+        assert_eq!(choose(&mut entry).0, RunExecution::Parallel);
     }
 
     #[test]
@@ -871,16 +872,16 @@ mod tests {
         // A serial estimate poisoned over the budget (e.g. one contended stall) must not
         // lock serial out forever: the probe gate reads the live projection, not the stale
         // estimate.
-        let mut entry = Entry::default();
-        entry.record(Execution::Parallel, Duration::from_micros(500));
-        entry.record(Execution::Serial, Duration::from_millis(15));
+        let mut entry = RunEntry::default();
+        entry.record(RunExecution::Parallel, Duration::from_micros(500));
+        entry.record(RunExecution::Serial, Duration::from_millis(15));
         assert_eq!(
-            Entry::preferred(
+            RunEntry::preferred(
                 entry.serial_ns.get().unwrap(),
                 entry.parallel_ns.get().unwrap(),
                 PARALLELISM
             ),
-            Execution::Parallel
+            RunExecution::Parallel
         );
 
         // Slowdown 15ms / 500us = 30 caps the shift, so the probe fires at 100 << 5 calls.
@@ -888,12 +889,12 @@ mod tests {
         for i in 1..interval {
             assert_eq!(
                 choose(&mut entry),
-                (Execution::Parallel, i % PREFERRED_SAMPLE_INTERVAL == 0)
+                (RunExecution::Parallel, i % PREFERRED_SAMPLE_INTERVAL == 0)
             );
         }
-        assert_eq!(choose(&mut entry), (Execution::Serial, true));
+        assert_eq!(choose(&mut entry), (RunExecution::Serial, true));
 
-        entry.record(Execution::Serial, Duration::from_micros(300));
+        entry.record(RunExecution::Serial, Duration::from_micros(300));
         assert_eq!(entry.serial_ns.get(), Some(12_060_000));
     }
 
@@ -901,44 +902,44 @@ mod tests {
     fn poisoned_probe_cannot_flip_preference() {
         // A spuriously fast serial sample (e.g. from a contended probe) blends into the EWMA
         // and cannot flip the preference on its own.
-        let mut entry = Entry::default();
-        entry.record(Execution::Parallel, Duration::from_micros(800));
-        entry.record(Execution::Serial, Duration::from_millis(3));
+        let mut entry = RunEntry::default();
+        entry.record(RunExecution::Parallel, Duration::from_micros(800));
+        entry.record(RunExecution::Serial, Duration::from_millis(3));
         assert_eq!(
-            Entry::preferred(
+            RunEntry::preferred(
                 entry.serial_ns.get().unwrap(),
                 entry.parallel_ns.get().unwrap(),
                 PARALLELISM
             ),
-            Execution::Parallel
+            RunExecution::Parallel
         );
 
-        entry.record(Execution::Serial, Duration::from_micros(20));
+        entry.record(RunExecution::Serial, Duration::from_micros(20));
 
         assert_eq!(entry.serial_ns.get(), Some(2_404_000));
         assert_eq!(
-            Entry::preferred(
+            RunEntry::preferred(
                 entry.serial_ns.get().unwrap(),
                 entry.parallel_ns.get().unwrap(),
                 PARALLELISM
             ),
-            Execution::Parallel
+            RunExecution::Parallel
         );
     }
 
     #[test]
     fn refreshes_preferred_parallel_sample() {
-        let mut entry = Entry::default();
-        entry.record(Execution::Parallel, Duration::from_micros(100));
-        entry.record(Execution::Serial, Duration::from_micros(410));
+        let mut entry = RunEntry::default();
+        entry.record(RunExecution::Parallel, Duration::from_micros(100));
+        entry.record(RunExecution::Serial, Duration::from_micros(410));
 
         for i in 1..PREFERRED_SAMPLE_INTERVAL {
             assert_eq!(
                 choose(&mut entry),
-                (Execution::Parallel, i % PREFERRED_SAMPLE_INTERVAL == 0)
+                (RunExecution::Parallel, i % PREFERRED_SAMPLE_INTERVAL == 0)
             );
         }
-        assert_eq!(choose(&mut entry), (Execution::Parallel, true));
+        assert_eq!(choose(&mut entry), (RunExecution::Parallel, true));
     }
 
     #[test]
@@ -971,8 +972,8 @@ mod tests {
                     work,
                     PARALLELISM,
                     |execution| match execution {
-                        Execution::Parallel => Err(()),
-                        Execution::Serial => Ok(()),
+                        RunExecution::Parallel => Err(()),
+                        RunExecution::Serial => Ok(()),
                     },
                 );
         }

--- a/parallel/src/policy.rs
+++ b/parallel/src/policy.rs
@@ -1,4 +1,4 @@
-//! Adaptive execution policy for collection operations.
+//! Adaptive execution policies for collection operations and spawned jobs.
 //!
 //! Entries are keyed by callsite, input-size bucket, work-size bucket, and planning parallelism
 //! so a decision learned for one workload does not leak into another. The policy compares recent
@@ -59,6 +59,8 @@ const MAX_RESAMPLE_SHIFT: u32 = 5;
 // The tuner only arbitrates cases where a serial run is provably cheap: serial is seeded,
 // probed, or preferred only when its projected and measured costs fit this budget.
 const SERIAL_SAMPLE_BUDGET_NS: u64 = 10_000_000;
+// Only jobs measured below this executor-friendly budget are eligible to run inline.
+const SPAWN_INLINE_BUDGET_NS: u64 = 1_000_000;
 // Track a short EWMA so recent measurements outweigh old startup noise.
 const EWMA_PREVIOUS_WEIGHT: u64 = 4;
 const EWMA_NEXT_WEIGHT: u64 = 1;
@@ -74,12 +76,13 @@ pub(super) enum Execution {
     Parallel,
 }
 
-/// The path the spawn policy chose: run the job inline on the calling task, or offload it to the
-/// pool, which overlaps it with the caller's other work at the cost of a hand-off.
+/// The placement the spawn policy chose for one call.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(super) enum SpawnExecution {
-    Inline,
-    Offload,
+pub(super) enum SpawnDecision {
+    /// Run the job inline on the calling task, timing it when `measure` is set.
+    Inline { measure: bool },
+    /// Hand the job to the pool, timing the hand-off and the job wall when `measure` is set.
+    Offload { measure: bool },
 }
 
 /// Adaptive serial-vs-parallel decisions, shared cheaply across [`super::Rayon`] clones.
@@ -122,50 +125,61 @@ impl Policy {
         result
     }
 
-    /// Chooses whether to run a spawned job inline on the calling task or offload it to the pool,
-    /// and whether the caller should time this run and feed the result back via
-    /// [`record_spawn`](Self::record_spawn).
+    /// Chooses where to run a spawned job: inline on the calling task when the job is measured
+    /// cheaper than the pool hand-off itself, offloaded to the pool otherwise.
     pub(super) fn choose_spawn(
         &self,
         caller: &'static Location<'static>,
         len: usize,
         parallelism: usize,
-    ) -> (SpawnExecution, bool) {
-        // A single worker cannot overlap a hand-off, so always inline.
+    ) -> SpawnDecision {
+        // A single worker cannot overlap a hand-off, so always inline (nothing to measure).
         if parallelism <= 1 {
-            return (SpawnExecution::Inline, false);
+            return SpawnDecision::Inline { measure: false };
         }
         let key = Key::new(caller, len, len, parallelism);
         self.spawn_entries
             .entry(key)
             .or_default()
-            .choose(SERIAL_SAMPLE_BUDGET_NS)
+            .choose(SPAWN_INLINE_BUDGET_NS)
     }
 
-    /// Records the caller-visible cost of a spawned job. `caller_ns` is the marginal latency the
-    /// chosen path added to the caller. For inline it is the job's wall time. For offload it is
-    /// the hand-off setup plus the residual wait once the caller joined. `job_wall_ns` is the
-    /// job's measured wall time on the pool (offload only). It estimates the inline cost and
-    /// bounds inlining so a long job never blocks the calling task.
-    pub(super) fn record_spawn(
+    /// Records the wall time of a spawned job that ran inline on the calling task.
+    pub(super) fn record_spawn_inline(
         &self,
         caller: &'static Location<'static>,
         len: usize,
         parallelism: usize,
-        execution: SpawnExecution,
-        caller_ns: Duration,
-        job_wall_ns: Option<Duration>,
+        job: Duration,
     ) {
         if parallelism <= 1 {
             return;
         }
         let key = Key::new(caller, len, len, parallelism);
-        let caller_ns = u64::try_from(caller_ns.as_nanos()).unwrap_or(u64::MAX);
-        let job_wall_ns = job_wall_ns.map(|d| u64::try_from(d.as_nanos()).unwrap_or(u64::MAX));
+        let job = u64::try_from(job.as_nanos()).unwrap_or(u64::MAX);
+        self.spawn_entries.entry(key).or_default().record_job(job);
+    }
+
+    /// Records one offloaded spawn: `handoff` spans spawn entry to job start on the worker
+    /// (setup, enqueue, queue wait, and worker wake) and `job` is the job's own wall time there.
+    pub(super) fn record_spawn_offload(
+        &self,
+        caller: &'static Location<'static>,
+        len: usize,
+        parallelism: usize,
+        handoff: Duration,
+        job: Duration,
+    ) {
+        if parallelism <= 1 {
+            return;
+        }
+        let key = Key::new(caller, len, len, parallelism);
+        let handoff = u64::try_from(handoff.as_nanos()).unwrap_or(u64::MAX);
+        let job = u64::try_from(job.as_nanos()).unwrap_or(u64::MAX);
         self.spawn_entries
             .entry(key)
             .or_default()
-            .record(execution, caller_ns, job_wall_ns);
+            .record_offload(handoff, job);
     }
 
     #[cfg(test)]
@@ -185,7 +199,7 @@ impl Policy {
         let key = Key::new(caller, len, len, parallelism);
         self.spawn_entries
             .get(&key)
-            .is_some_and(|entry| entry.offload_ns.is_some() || entry.inline_ns.is_some())
+            .is_some_and(|entry| entry.handoff_ns.get().is_some() || entry.job_ns.get().is_some())
     }
 
     #[cfg(test)]
@@ -197,7 +211,9 @@ impl Policy {
         parallelism: usize,
     ) -> Option<(Option<u64>, Option<u64>)> {
         let key = Key::new(caller, len, work, parallelism);
-        self.entries.get(&key).map(|e| (e.serial_ns, e.parallel_ns))
+        self.entries
+            .get(&key)
+            .map(|e| (e.serial_ns.get(), e.parallel_ns.get()))
     }
 }
 
@@ -230,12 +246,83 @@ impl Key {
     }
 }
 
+/// An EWMA-smoothed wall-clock estimate in nanoseconds.
+///
+/// The first sample initializes the estimate, and every later sample blends into the EWMA, so a
+/// single outlier (a contended pool) moves an established estimate by at most a fifth of the gap.
+#[derive(Clone, Copy, Debug, Default)]
+struct Estimate(Option<u64>);
+
+impl Estimate {
+    const fn get(&self) -> Option<u64> {
+        self.0
+    }
+
+    fn record(&mut self, sample_ns: u64) {
+        self.0 = Some(
+            self.0
+                .map_or(sample_ns, |current| update_ewma(current, sample_ns)),
+        );
+    }
+}
+
+/// One [`Cadence::tick`] outcome.
+struct Tick {
+    /// This call crosses the probe boundary.
+    boundary: bool,
+    /// This call should be measured to refresh the preferred path's estimate.
+    measure: bool,
+}
+
+/// Paces measurement and probing for one policy entry.
+///
+/// Between boundaries the preferred path is measured every [`PREFERRED_SAMPLE_INTERVAL`] calls so
+/// its estimate stays live. The boundary recurs every `RESAMPLE_INTERVAL << shift` calls, where
+/// the shift grows with how badly the losing path lost (one doubling per multiple of the winner's
+/// wall time, capped at [`MAX_RESAMPLE_SHIFT`]), so a close race is re-checked often while a
+/// blowout is re-checked rarely yet remains discoverable.
+#[derive(Clone, Copy, Debug, Default)]
+struct Cadence {
+    since_probe: u32,
+}
+
+impl Cadence {
+    // Saturate the counter so the next call lands on a boundary (used at seed time so a freshly
+    // seeded entry is re-examined immediately instead of waiting a full interval that a
+    // low-frequency callsite may never reach).
+    const fn saturate(&mut self) {
+        self.since_probe = u32::MAX;
+    }
+
+    // Advances one call for an entry whose winning path is estimated at `winner_ns` and losing
+    // path at `loser_ns`.
+    fn tick(&mut self, winner_ns: u64, loser_ns: u64) -> Tick {
+        let slowdown = loser_ns / winner_ns.max(1);
+        let shift = slowdown
+            .saturating_sub(1)
+            .min(u64::from(MAX_RESAMPLE_SHIFT)) as u32;
+        let interval = RESAMPLE_INTERVAL << shift;
+        self.since_probe = self.since_probe.saturating_add(1);
+        if self.since_probe >= interval {
+            self.since_probe = 0;
+            return Tick {
+                boundary: true,
+                measure: true,
+            };
+        }
+        Tick {
+            boundary: false,
+            measure: self.since_probe.is_multiple_of(PREFERRED_SAMPLE_INTERVAL),
+        }
+    }
+}
+
 /// Timing state for one [`Key`].
 #[derive(Clone, Copy, Debug, Default)]
 struct Entry {
-    serial_ns: Option<u64>,
-    parallel_ns: Option<u64>,
-    since_probe: u32,
+    serial_ns: Estimate,
+    parallel_ns: Estimate,
+    cadence: Cadence,
 }
 
 impl Entry {
@@ -262,12 +349,11 @@ impl Entry {
     // Returns the path to run and whether the caller should time it and feed the elapsed duration
     // back to [`record`](Self::record).
     fn choose(&mut self, parallelism: usize) -> (Execution, bool) {
-        // Seed the parallel estimate with the first call. Saturating the probe counter keeps
-        // the entry due for an immediate boundary, so the serial seed is offered as soon as
-        // the parallel estimate lands (when the projection allows) instead of waiting a full
-        // interval that a low-frequency callsite may never reach.
-        let Some(parallel_ns) = self.parallel_ns else {
-            self.since_probe = u32::MAX;
+        // Seed the parallel estimate with the first call. Saturating the cadence keeps the
+        // entry due for an immediate boundary, so the serial seed is offered as soon as the
+        // parallel estimate lands (when the projection allows).
+        let Some(parallel_ns) = self.parallel_ns.get() else {
+            self.cadence.saturate();
             return (Execution::Parallel, true);
         };
 
@@ -277,32 +363,22 @@ impl Entry {
         let can_sample_serial =
             Self::projected_serial(parallel_ns, parallelism) < SERIAL_SAMPLE_BUDGET_NS;
 
-        // Until serial is sampled, parallel is preferred by default and the boundary doubles
-        // as the seed slot. Once both estimates exist, the boundary probes the losing path on
-        // an interval that doubles for each multiple of the winner's wall time it is behind,
-        // so a close race is re-checked often while a blowout is re-checked rarely.
-        let (preferred, interval) =
-            self.serial_ns
-                .map_or((Execution::Parallel, RESAMPLE_INTERVAL), |serial_ns| {
-                    let preferred = Self::preferred(serial_ns, parallel_ns, parallelism);
-                    let (winner_ns, loser_ns) = match preferred {
-                        Execution::Serial => (serial_ns, parallel_ns),
-                        Execution::Parallel => (parallel_ns, serial_ns),
-                    };
-                    let slowdown = loser_ns / winner_ns.max(1);
-                    let shift = slowdown
-                        .saturating_sub(1)
-                        .min(u64::from(MAX_RESAMPLE_SHIFT)) as u32;
-                    (preferred, RESAMPLE_INTERVAL << shift)
-                });
+        // Until serial is sampled, parallel is preferred by default (winner and loser tie, so
+        // the cadence runs at its base interval) and the boundary doubles as the seed slot.
+        let (preferred, winner_ns, loser_ns) = self.serial_ns.get().map_or(
+            (Execution::Parallel, parallel_ns, parallel_ns),
+            |serial_ns| match Self::preferred(serial_ns, parallel_ns, parallelism) {
+                Execution::Serial => (Execution::Serial, serial_ns, parallel_ns),
+                Execution::Parallel => (Execution::Parallel, parallel_ns, serial_ns),
+            },
+        );
 
         // Exactly one caller crosses the boundary, and a serial seed whose sample never lands
         // is simply offered again at the next boundary. A serial seed or probe must fit the
         // live projection. A parallel probe is always allowed: it pays the true parallel wall
         // (including any pool queueing), which the capped interval amortizes.
-        self.since_probe = self.since_probe.saturating_add(1);
-        if self.since_probe >= interval {
-            self.since_probe = 0;
+        let tick = self.cadence.tick(winner_ns, loser_ns);
+        if tick.boundary {
             let probe = match preferred {
                 Execution::Serial => Execution::Parallel,
                 Execution::Parallel if can_sample_serial => Execution::Serial,
@@ -311,121 +387,75 @@ impl Entry {
             return (probe, true);
         }
 
-        (
-            preferred,
-            self.since_probe.is_multiple_of(PREFERRED_SAMPLE_INTERVAL),
-        )
+        (preferred, tick.measure)
     }
 
-    // The first sample of each path initializes its estimate, and every later sample blends
-    // into the EWMA, so a single outlier (a contended pool) moves an established estimate by
-    // at most a fifth of the gap.
     fn record(&mut self, execution: Execution, elapsed: Duration) {
         let elapsed_ns = u64::try_from(elapsed.as_nanos()).unwrap_or(u64::MAX);
-        let estimate = match execution {
-            Execution::Serial => &mut self.serial_ns,
-            Execution::Parallel => &mut self.parallel_ns,
-        };
-        *estimate = Some(estimate.map_or(elapsed_ns, |current| update_ewma(current, elapsed_ns)));
+        match execution {
+            Execution::Serial => self.serial_ns.record(elapsed_ns),
+            Execution::Parallel => self.parallel_ns.record(elapsed_ns),
+        }
     }
 }
 
 /// Timing state for one spawn [`Key`].
 ///
-/// Offloading never makes the job itself run faster. What it buys is overlap: the calling task can
-/// do other work while the job runs on the pool, so the caller waits only for whatever is left when
-/// it finally awaits the result. `choose` therefore compares the caller's *wait*, not the job's
-/// runtime: the whole job if inlined, versus the hand-off plus that leftover if offloaded (measured
-/// in [`crate::Strategy::spawn`]). Offloading wins when the caller has enough of its own work to
-/// overlap the job behind.
+/// Since caller overlap cannot be observed, the policy inlines only when the job EWMA is no greater
+/// than both the hand-off EWMA and [`SPAWN_INLINE_BUDGET_NS`]. Hand-off samples include setup,
+/// queueing, and worker wake.
 #[derive(Clone, Copy, Debug, Default)]
 struct SpawnEntry {
-    inline_ns: Option<u64>,
-    offload_ns: Option<u64>,
-    job_wall_ns: Option<u64>,
-    // The most recent inline measurement, kept raw (not blended into `inline_ns`) so the
-    // executor-block gate reacts to a single over-budget run instead of waiting for the EWMA.
-    last_inline_ns: Option<u64>,
-    since_probe: u32,
+    // Spawn entry to job start on a worker: setup, enqueue, queue wait, and worker wake.
+    handoff_ns: Estimate,
+    // The job's own wall time, fed by offload and inline runs alike.
+    job_ns: Estimate,
+    cadence: Cadence,
 }
 
 impl SpawnEntry {
-    // Decides whether this call runs inline or offloads, and whether the caller should time the run.
-    // `budget` bounds how long an inline run may occupy the calling task.
-    fn choose(&mut self, budget: u64) -> (SpawnExecution, bool) {
-        let Some(offload_ns) = self.offload_ns else {
-            self.since_probe = u32::MAX;
-            return (SpawnExecution::Offload, true);
+    // Decides where this call runs. `budget` caps the job EWMA eligible for inlining.
+    fn choose(&mut self, budget: u64) -> SpawnDecision {
+        // Seed both estimates from an offloaded run before ever inlining.
+        let (Some(handoff_ns), Some(job_ns)) = (self.handoff_ns.get(), self.job_ns.get()) else {
+            self.cadence.saturate();
+            return SpawnDecision::Offload { measure: true };
         };
-        let job_wall = self.job_wall_ns.unwrap_or(offload_ns);
-        // `inline_est` (an EWMA) drives the cheaper-path preference. The safety gate instead uses
-        // the latest raw inline sample, so a single over-budget run offloads immediately rather
-        // than after the EWMA slowly crosses `budget`. Before any inline sample both fall back to
-        // the offload-measured pool wall, which is also stale once the policy converges to inline.
-        let inline_est = self.inline_ns.unwrap_or(job_wall);
-        let inline_gate = self.last_inline_ns.unwrap_or(job_wall);
-        let inline_safe = inline_gate < budget;
-        let preferred = if inline_safe && inline_est <= offload_ns {
-            SpawnExecution::Inline
-        } else {
-            SpawnExecution::Offload
-        };
-        let (winner_ns, loser_ns) = match preferred {
-            SpawnExecution::Inline => (inline_est, offload_ns),
-            SpawnExecution::Offload => (offload_ns, inline_est),
-        };
-        let slowdown = loser_ns / winner_ns.max(1);
-        let shift = slowdown
-            .saturating_sub(1)
-            .min(u64::from(MAX_RESAMPLE_SHIFT)) as u32;
-        let interval = RESAMPLE_INTERVAL << shift;
 
-        self.since_probe = self.since_probe.saturating_add(1);
-        if self.since_probe >= interval {
-            self.since_probe = 0;
-            let probe = match preferred {
-                SpawnExecution::Inline => SpawnExecution::Offload,
-                // Probe inline whenever fresh offload evidence (`job_wall`, refreshed by the
-                // offloads we are running) says the job is small enough to try safely, even if the
-                // last inline sample was over budget. This lets a transient slow run recover once
-                // the job shrinks again instead of offloading forever.
-                SpawnExecution::Offload if job_wall < budget => SpawnExecution::Inline,
-                SpawnExecution::Offload => SpawnExecution::Offload,
+        // Ties go to inline: equal cost for one fewer pool wake.
+        let threshold = handoff_ns.min(budget);
+        if job_ns > threshold {
+            // Offload steady state. Measured runs keep both estimates live, so the entry flips
+            // to inline on its own once the evidence clears the threshold: no inline probe is
+            // needed because an inline run measures nothing an offloaded run does not.
+            let tick = self.cadence.tick(threshold, job_ns);
+            return SpawnDecision::Offload {
+                measure: tick.boundary || tick.measure,
             };
-            return (probe, true);
         }
-        (
-            preferred,
-            self.since_probe.is_multiple_of(PREFERRED_SAMPLE_INTERVAL),
-        )
+
+        // Inline steady state: the boundary hands one call back to the pool so the hand-off
+        // estimate tracks the live pool.
+        let tick = self.cadence.tick(job_ns, threshold);
+        if tick.boundary {
+            return SpawnDecision::Offload { measure: true };
+        }
+        SpawnDecision::Inline {
+            measure: tick.measure,
+        }
     }
 
-    // Folds one timing sample into this entry: `caller_ns` is the caller-visible wait for
-    // `execution`, and `job_wall_ns` is the job's own pool wall (present only for offload runs).
-    fn record(&mut self, execution: SpawnExecution, caller_ns: u64, job_wall_ns: Option<u64>) {
-        match execution {
-            SpawnExecution::Inline => {
-                self.inline_ns = Some(
-                    self.inline_ns
-                        .map_or(caller_ns, |current| update_ewma(current, caller_ns)),
-                );
-                // Keep the raw sample for the safety gate, unblended, so an over-budget run is
-                // seen immediately rather than smoothed away by the EWMA above.
-                self.last_inline_ns = Some(caller_ns);
-            }
-            SpawnExecution::Offload => {
-                self.offload_ns = Some(
-                    self.offload_ns
-                        .map_or(caller_ns, |current| update_ewma(current, caller_ns)),
-                );
-                if let Some(job_wall_ns) = job_wall_ns {
-                    self.job_wall_ns = Some(
-                        self.job_wall_ns
-                            .map_or(job_wall_ns, |current| update_ewma(current, job_wall_ns)),
-                    );
-                }
-            }
-        }
+    // Folds one job-wall sample into this entry (measured on the caller for inline runs and on
+    // the worker for offloaded runs).
+    fn record_job(&mut self, job_ns: u64) {
+        self.job_ns.record(job_ns);
+    }
+
+    // Folds one offloaded run into this entry: the hand-off (spawn entry to job start on the
+    // worker) and the job's own wall time there.
+    fn record_offload(&mut self, handoff_ns: u64, job_ns: u64) {
+        self.handoff_ns.record(handoff_ns);
+        self.job_ns.record(job_ns);
     }
 }
 
@@ -451,7 +481,7 @@ const fn len_bucket(len: usize) -> u8 {
 mod tests {
     use super::{
         Entry, Execution, MAX_RESAMPLE_SHIFT, PREFERRED_SAMPLE_INTERVAL, Policy, RESAMPLE_INTERVAL,
-        SERIAL_SAMPLE_BUDGET_NS, SpawnEntry, SpawnExecution,
+        SPAWN_INLINE_BUDGET_NS, SpawnDecision, SpawnEntry,
     };
     use std::{panic::Location, time::Duration};
 
@@ -493,7 +523,7 @@ mod tests {
         // The projection (10ms x 4) is over budget, so the immediate boundary refreshes
         // parallel instead of seeding serial and the cadence resets to a full interval.
         assert_eq!(choose(&mut entry), (Execution::Parallel, true));
-        assert!(entry.serial_ns.is_none());
+        assert!(entry.serial_ns.get().is_none());
         for i in 1..RESAMPLE_INTERVAL {
             assert_eq!(
                 choose(&mut entry),
@@ -516,7 +546,7 @@ mod tests {
                 (Execution::Parallel, i % PREFERRED_SAMPLE_INTERVAL == 0)
             );
         }
-        assert!(entry.serial_ns.is_none());
+        assert!(entry.serial_ns.get().is_none());
     }
 
     #[test]
@@ -533,7 +563,7 @@ mod tests {
                 entry.record(Execution::Parallel, Duration::from_millis(25));
             }
         }
-        assert!(entry.serial_ns.is_none());
+        assert!(entry.serial_ns.get().is_none());
     }
 
     #[test]
@@ -605,7 +635,7 @@ mod tests {
         entry.record(Execution::Parallel, Duration::from_millis(10));
         entry.record(Execution::Parallel, Duration::from_millis(20));
 
-        assert_eq!(entry.parallel_ns, Some(12_000_000));
+        assert_eq!(entry.parallel_ns.get(), Some(12_000_000));
     }
 
     #[test]
@@ -617,7 +647,7 @@ mod tests {
         // Serial is preferred, so further serial samples blend 4:1.
         entry.record(Execution::Serial, Duration::from_nanos(200));
 
-        assert_eq!(entry.serial_ns, Some(120));
+        assert_eq!(entry.serial_ns.get(), Some(120));
     }
 
     #[test]
@@ -629,7 +659,7 @@ mod tests {
         // Parallel is preferred, so further parallel samples blend 4:1.
         entry.record(Execution::Parallel, Duration::from_nanos(200));
 
-        assert_eq!(entry.parallel_ns, Some(120));
+        assert_eq!(entry.parallel_ns.get(), Some(120));
     }
 
     #[test]
@@ -642,11 +672,11 @@ mod tests {
 
         entry.record(Execution::Serial, Duration::from_millis(5));
 
-        assert_eq!(entry.serial_ns, Some(81_000_000));
+        assert_eq!(entry.serial_ns.get(), Some(81_000_000));
         assert_eq!(
             Entry::preferred(
-                entry.serial_ns.unwrap(),
-                entry.parallel_ns.unwrap(),
+                entry.serial_ns.get().unwrap(),
+                entry.parallel_ns.get().unwrap(),
                 PARALLELISM
             ),
             Execution::Parallel
@@ -744,8 +774,8 @@ mod tests {
         entry.record(Execution::Serial, Duration::from_millis(1));
         assert_eq!(
             Entry::preferred(
-                entry.serial_ns.unwrap(),
-                entry.parallel_ns.unwrap(),
+                entry.serial_ns.get().unwrap(),
+                entry.parallel_ns.get().unwrap(),
                 PARALLELISM
             ),
             Execution::Serial
@@ -755,8 +785,8 @@ mod tests {
         let mut flipped_at = None;
         for i in 1..=1_000 {
             if Entry::preferred(
-                entry.serial_ns.unwrap(),
-                entry.parallel_ns.unwrap(),
+                entry.serial_ns.get().unwrap(),
+                entry.parallel_ns.get().unwrap(),
                 PARALLELISM,
             ) == Execution::Parallel
             {
@@ -818,8 +848,8 @@ mod tests {
         entry.record(Execution::Serial, Duration::from_millis(15));
         assert_eq!(
             Entry::preferred(
-                entry.serial_ns.unwrap(),
-                entry.parallel_ns.unwrap(),
+                entry.serial_ns.get().unwrap(),
+                entry.parallel_ns.get().unwrap(),
                 PARALLELISM
             ),
             Execution::Parallel
@@ -836,7 +866,7 @@ mod tests {
         assert_eq!(choose(&mut entry), (Execution::Serial, true));
 
         entry.record(Execution::Serial, Duration::from_micros(300));
-        assert_eq!(entry.serial_ns, Some(12_060_000));
+        assert_eq!(entry.serial_ns.get(), Some(12_060_000));
     }
 
     #[test]
@@ -848,8 +878,8 @@ mod tests {
         entry.record(Execution::Serial, Duration::from_millis(3));
         assert_eq!(
             Entry::preferred(
-                entry.serial_ns.unwrap(),
-                entry.parallel_ns.unwrap(),
+                entry.serial_ns.get().unwrap(),
+                entry.parallel_ns.get().unwrap(),
                 PARALLELISM
             ),
             Execution::Parallel
@@ -857,11 +887,11 @@ mod tests {
 
         entry.record(Execution::Serial, Duration::from_micros(20));
 
-        assert_eq!(entry.serial_ns, Some(2_404_000));
+        assert_eq!(entry.serial_ns.get(), Some(2_404_000));
         assert_eq!(
             Entry::preferred(
-                entry.serial_ns.unwrap(),
-                entry.parallel_ns.unwrap(),
+                entry.serial_ns.get().unwrap(),
+                entry.parallel_ns.get().unwrap(),
                 PARALLELISM
             ),
             Execution::Parallel
@@ -923,75 +953,74 @@ mod tests {
     }
 
     #[test]
-    fn spawn_seeds_offload_then_inlines_a_tiny_poorly_overlapped_job() {
+    fn spawn_seeds_offload_then_inlines_a_sub_handoff_job() {
         let mut entry = SpawnEntry::default();
 
-        // The first call seeds the offload estimate (and the job's own wall time).
+        // The first call seeds both estimates from an offloaded run.
         assert_eq!(
-            entry.choose(SERIAL_SAMPLE_BUDGET_NS),
-            (SpawnExecution::Offload, true)
+            entry.choose(SPAWN_INLINE_BUDGET_NS),
+            SpawnDecision::Offload { measure: true }
         );
-        // A 2us job whose caller-visible cost was 50us: the overlap did not hide it.
-        entry.record(SpawnExecution::Offload, 50_000, Some(2_000));
+        // A 2us job behind a 50us hand-off.
+        entry.record_offload(50_000, 2_000);
 
-        // The seed leaves the entry due for an immediate boundary, which re-probes offload.
+        // The seed leaves the entry due for an immediate boundary, which re-measures offload.
         assert_eq!(
-            entry.choose(SERIAL_SAMPLE_BUDGET_NS),
-            (SpawnExecution::Offload, true)
+            entry.choose(SPAWN_INLINE_BUDGET_NS),
+            SpawnDecision::Offload { measure: true }
         );
-        entry.record(SpawnExecution::Offload, 50_000, Some(2_000));
+        entry.record_offload(50_000, 2_000);
 
-        // The job (2us) fits the budget and beats its 50us offload cost, so inline wins.
+        // The job costs less than the hand-off and fits the budget, so it runs inline.
         assert_eq!(
-            entry.choose(SERIAL_SAMPLE_BUDGET_NS),
-            (SpawnExecution::Inline, false)
+            entry.choose(SPAWN_INLINE_BUDGET_NS),
+            SpawnDecision::Inline { measure: false }
         );
     }
 
     #[test]
-    fn spawn_keeps_offloading_a_well_overlapped_job() {
+    fn spawn_keeps_offloading_a_job_bigger_than_the_handoff() {
+        // A 50us job behind a 5us hand-off: inline must never fire even though the job is far
+        // under the budget, because offloading is cheaper for the caller under any polling.
         let mut entry = SpawnEntry::default();
-
         assert_eq!(
-            entry.choose(SERIAL_SAMPLE_BUDGET_NS),
-            (SpawnExecution::Offload, true)
+            entry.choose(SPAWN_INLINE_BUDGET_NS),
+            SpawnDecision::Offload { measure: true }
         );
-        // A 50us job whose caller-visible cost was only 3us: the overlap hid almost all of it.
-        entry.record(SpawnExecution::Offload, 3_000, Some(50_000));
-
-        // Offload is preferred (3us beats a 50us inline), so the boundary probes the inline loser.
-        assert_eq!(
-            entry.choose(SERIAL_SAMPLE_BUDGET_NS),
-            (SpawnExecution::Inline, true)
-        );
-        entry.record(SpawnExecution::Inline, 50_000, None);
-
-        // With both estimates known, offload still wins because the overlap makes it cheaper.
-        assert_eq!(
-            entry.choose(SERIAL_SAMPLE_BUDGET_NS).0,
-            SpawnExecution::Offload
-        );
-    }
-
-    #[test]
-    fn spawn_never_inlines_a_job_over_the_executor_block_budget() {
-        let mut entry = SpawnEntry::default();
-
-        assert_eq!(
-            entry.choose(SERIAL_SAMPLE_BUDGET_NS),
-            (SpawnExecution::Offload, true)
-        );
-        // A job whose measured wall exceeds the budget must never run inline (it would stall the
-        // async executor), no matter how the caller-visible cost compares.
-        let over_budget = SERIAL_SAMPLE_BUDGET_NS * 2;
-        entry.record(SpawnExecution::Offload, over_budget, Some(over_budget));
+        entry.record_offload(5_000, 50_000);
 
         for _ in 0..(2 * RESAMPLE_INTERVAL) {
-            assert_eq!(
-                entry.choose(SERIAL_SAMPLE_BUDGET_NS).0,
-                SpawnExecution::Offload
-            );
-            entry.record(SpawnExecution::Offload, over_budget, Some(over_budget));
+            match entry.choose(SPAWN_INLINE_BUDGET_NS) {
+                SpawnDecision::Offload { measure } => {
+                    if measure {
+                        entry.record_offload(5_000, 50_000);
+                    }
+                }
+                inline => panic!("expected offload, got {inline:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn spawn_budget_caps_inline_when_the_handoff_is_inflated() {
+        // A contended pool measured the hand-off at 50ms. The 2ms job is cheaper than that, but its
+        // EWMA exceeds the inline budget, so it remains offloaded.
+        let mut entry = SpawnEntry::default();
+        assert_eq!(
+            entry.choose(SPAWN_INLINE_BUDGET_NS),
+            SpawnDecision::Offload { measure: true }
+        );
+        entry.record_offload(50_000_000, 2_000_000);
+
+        for _ in 0..(2 * RESAMPLE_INTERVAL) {
+            match entry.choose(SPAWN_INLINE_BUDGET_NS) {
+                SpawnDecision::Offload { measure } => {
+                    if measure {
+                        entry.record_offload(50_000_000, 2_000_000);
+                    }
+                }
+                inline => panic!("expected offload, got {inline:?}"),
+            }
         }
     }
 
@@ -1002,52 +1031,94 @@ mod tests {
         let location = Location::caller();
         assert_eq!(
             policy.choose_spawn(location, 64, 1),
-            (SpawnExecution::Inline, false)
+            SpawnDecision::Inline { measure: false }
         );
     }
 
     #[test]
-    fn spawn_offloads_after_a_single_over_budget_inline_sample() {
-        // Start from a cheap, converged inline estimate: offload is expensive, inline is cheap, and
-        // both sit well under the budget.
-        let mut entry = SpawnEntry {
-            offload_ns: Some(30_000_000), // offloading measured at 30ms
-            inline_ns: Some(2_000),       // established cheap inline EWMA (2us)
-            last_inline_ns: Some(2_000),
-            job_wall_ns: Some(2_000),
-            ..Default::default()
-        };
-        // One inline run now measures 15ms, over the 10ms budget. The blended `inline_ns` stays
-        // ~3ms (still "safe" on its own), but the raw safety gate must offload on this single
-        // sample rather than wait for the EWMA to cross the budget.
-        entry.record(SpawnExecution::Inline, 15_000_000, None);
+    fn spawn_uses_job_ewma() {
+        // A converged-inline entry: cheap job, expensive hand-off.
+        let mut entry = SpawnEntry::default();
+        entry.record_offload(50_000, 2_000);
+
+        // The latest sample exceeds the hand-off, but the EWMA remains below it.
+        entry.record_job(100_000);
+        assert_eq!(entry.job_ns.get(), Some(21_600));
+        assert!(matches!(
+            entry.choose(SPAWN_INLINE_BUDGET_NS),
+            SpawnDecision::Inline { .. }
+        ));
+    }
+
+    #[test]
+    fn spawn_recovers_after_a_transient_slow_run() {
+        // A spike revoked inline placement. Offloaded runs keep measuring the job small, so the
+        // estimates decay and inline returns without any dedicated probe.
+        let mut entry = SpawnEntry::default();
+        entry.record_offload(50_000, 2_000);
+        entry.record_job(15_000_000);
+
+        let mut calls = 0;
+        loop {
+            match entry.choose(SPAWN_INLINE_BUDGET_NS) {
+                SpawnDecision::Inline { .. } => break,
+                SpawnDecision::Offload { measure } => {
+                    if measure {
+                        entry.record_offload(50_000, 2_000);
+                    }
+                }
+            }
+            calls += 1;
+            assert!(
+                calls <= 10 * RESAMPLE_INTERVAL,
+                "inline placement never recovered"
+            );
+        }
+    }
+
+    #[test]
+    fn spawn_inline_records_on_cadence_and_probes_offload() {
+        // The hand-off is within 2x of the job, so the shared cadence probes at its base
+        // interval.
+        let mut entry = SpawnEntry::default();
+        entry.record_offload(50_000, 30_000);
+
+        for i in 1..RESAMPLE_INTERVAL {
+            assert_eq!(
+                entry.choose(SPAWN_INLINE_BUDGET_NS),
+                SpawnDecision::Inline {
+                    measure: i.is_multiple_of(PREFERRED_SAMPLE_INTERVAL)
+                },
+                "call {i}"
+            );
+        }
+        // The boundary hands one call back to the pool so the hand-off estimate stays live.
         assert_eq!(
-            entry.choose(SERIAL_SAMPLE_BUDGET_NS).0,
-            SpawnExecution::Offload
+            entry.choose(SPAWN_INLINE_BUDGET_NS),
+            SpawnDecision::Offload { measure: true }
         );
     }
 
     #[test]
-    fn spawn_probes_inline_to_recover_after_a_transient_slow_run() {
-        // A transient slow inline left `last_inline_ns` over budget, so the gate is unsafe and the
-        // entry is offloading. Fresh offloads now show the job is small again (`job_wall` under
-        // budget), and the entry is due for a boundary.
-        let mut entry = SpawnEntry {
-            offload_ns: Some(5_000),          // 5us
-            job_wall_ns: Some(2_000),         // 2us: fresh offload evidence, the job is small
-            inline_ns: Some(3_000_000),       // stale 3ms EWMA from the slow run
-            last_inline_ns: Some(15_000_000), // 15ms: over budget, currently locks out inline
-            since_probe: u32::MAX,
-        };
-        // Rather than offload forever, the boundary schedules a controlled inline probe because the
-        // offload evidence is under budget.
+    fn spawn_probe_interval_is_capped() {
+        // Inline wins by 25x, so the offload probe backs off to the capped interval while the
+        // measure cadence continues, matching the serial-vs-parallel entries.
+        let mut entry = SpawnEntry::default();
+        entry.record_offload(50_000, 2_000);
+
+        let interval = RESAMPLE_INTERVAL << MAX_RESAMPLE_SHIFT;
+        for i in 1..interval {
+            assert_eq!(
+                entry.choose(SPAWN_INLINE_BUDGET_NS),
+                SpawnDecision::Inline {
+                    measure: i.is_multiple_of(PREFERRED_SAMPLE_INTERVAL)
+                },
+                "call {i}"
+            );
+        }
         assert_eq!(
-            entry.choose(SERIAL_SAMPLE_BUDGET_NS),
-            (SpawnExecution::Inline, true)
+            entry.choose(SPAWN_INLINE_BUDGET_NS),
+            SpawnDecision::Offload { measure: true }
         );
-        // The probe measures the now-tiny job, clearing the raw over-budget gate so the entry can
-        // inline again.
-        entry.record(SpawnExecution::Inline, 2_000, None);
-        assert!(entry.last_inline_ns.unwrap() < SERIAL_SAMPLE_BUDGET_NS);
     }
 }

--- a/parallel/src/policy.rs
+++ b/parallel/src/policy.rs
@@ -156,16 +156,7 @@ impl Policy {
         parallelism: usize,
         job: Duration,
     ) {
-        if parallelism <= 1 {
-            return;
-        }
-        let key = Key::new(caller, len, len, parallelism);
-        let job = u64::try_from(job.as_nanos()).unwrap_or(u64::MAX);
-        self.spawn_entries
-            .entry(key)
-            .or_default()
-            .inline_ns
-            .record(job);
+        self.record_spawn(caller, len, parallelism, job, |entry| &mut entry.inline_ns);
     }
 
     /// Records the wall time of a spawned job that ran on a pool worker.
@@ -176,16 +167,7 @@ impl Policy {
         parallelism: usize,
         job: Duration,
     ) {
-        if parallelism <= 1 {
-            return;
-        }
-        let key = Key::new(caller, len, len, parallelism);
-        let job = u64::try_from(job.as_nanos()).unwrap_or(u64::MAX);
-        self.spawn_entries
-            .entry(key)
-            .or_default()
-            .job_ns
-            .record(job);
+        self.record_spawn(caller, len, parallelism, job, |entry| &mut entry.job_ns);
     }
 
     /// Records one offloaded spawn's round-trip overhead: the elapsed time from spawn entry to
@@ -197,16 +179,26 @@ impl Policy {
         parallelism: usize,
         overhead: Duration,
     ) {
+        self.record_spawn(caller, len, parallelism, overhead, |entry| {
+            &mut entry.overhead_ns
+        });
+    }
+
+    /// Folds one spawn timing sample into the selected estimate.
+    fn record_spawn(
+        &self,
+        caller: &'static Location<'static>,
+        len: usize,
+        parallelism: usize,
+        sample: Duration,
+        estimate: impl FnOnce(&mut SpawnEntry) -> &mut Estimate,
+    ) {
         if parallelism <= 1 {
             return;
         }
         let key = Key::new(caller, len, len, parallelism);
-        let overhead = u64::try_from(overhead.as_nanos()).unwrap_or(u64::MAX);
-        self.spawn_entries
-            .entry(key)
-            .or_default()
-            .overhead_ns
-            .record(overhead);
+        let mut entry = self.spawn_entries.entry(key).or_default();
+        estimate(&mut entry).record(nanos(sample));
     }
 
     #[cfg(test)]
@@ -293,14 +285,6 @@ impl Estimate {
     }
 }
 
-/// One [`Cadence::tick`] outcome.
-struct Tick {
-    /// This call crosses the probe boundary.
-    boundary: bool,
-    /// This call should be measured to refresh the preferred path's estimate.
-    measure: bool,
-}
-
 /// Paces measurement and probing for one policy entry.
 ///
 /// Between boundaries the preferred path is measured every [`PREFERRED_SAMPLE_INTERVAL`] calls so
@@ -321,9 +305,17 @@ impl Cadence {
         self.since_probe = u32::MAX;
     }
 
-    // Advances one call for an entry whose winning path is estimated at `winner_ns` and losing
-    // path at `loser_ns`.
-    fn tick(&mut self, winner_ns: u64, loser_ns: u64) -> Tick {
+    // Arbitrates one call between a `preferred` and a `loser` path, returning the path to run
+    // and whether the caller should time it. The loser runs at an allowed probe boundary, and a
+    // disallowed boundary still measures the preferred path and resets the counter.
+    fn arbitrate<P: Copy>(
+        &mut self,
+        preferred: P,
+        loser: P,
+        winner_ns: u64,
+        loser_ns: u64,
+        probe_allowed: bool,
+    ) -> (P, bool) {
         let slowdown = loser_ns / winner_ns.max(1);
         let shift = slowdown
             .saturating_sub(1)
@@ -332,15 +324,15 @@ impl Cadence {
         self.since_probe = self.since_probe.saturating_add(1);
         if self.since_probe >= interval {
             self.since_probe = 0;
-            return Tick {
-                boundary: true,
-                measure: true,
-            };
+            if probe_allowed {
+                return (loser, true);
+            }
+            return (preferred, true);
         }
-        Tick {
-            boundary: false,
-            measure: self.since_probe.is_multiple_of(PREFERRED_SAMPLE_INTERVAL),
-        }
+        (
+            preferred,
+            self.since_probe.is_multiple_of(PREFERRED_SAMPLE_INTERVAL),
+        )
     }
 }
 
@@ -392,11 +384,26 @@ impl RunEntry {
 
         // Until serial is sampled, parallel is preferred by default (winner and loser tie, so
         // the cadence runs at its base interval) and the boundary doubles as the seed slot.
-        let (preferred, winner_ns, loser_ns) = self.serial_ns.get().map_or(
-            (RunExecution::Parallel, parallel_ns, parallel_ns),
+        let (preferred, loser, winner_ns, loser_ns) = self.serial_ns.get().map_or(
+            (
+                RunExecution::Parallel,
+                RunExecution::Serial,
+                parallel_ns,
+                parallel_ns,
+            ),
             |serial_ns| match Self::preferred(serial_ns, parallel_ns, parallelism) {
-                RunExecution::Serial => (RunExecution::Serial, serial_ns, parallel_ns),
-                RunExecution::Parallel => (RunExecution::Parallel, parallel_ns, serial_ns),
+                RunExecution::Serial => (
+                    RunExecution::Serial,
+                    RunExecution::Parallel,
+                    serial_ns,
+                    parallel_ns,
+                ),
+                RunExecution::Parallel => (
+                    RunExecution::Parallel,
+                    RunExecution::Serial,
+                    parallel_ns,
+                    serial_ns,
+                ),
             },
         );
 
@@ -404,21 +411,13 @@ impl RunEntry {
         // is simply offered again at the next boundary. A serial seed or probe must fit the
         // live projection. A parallel probe is always allowed: it pays the true parallel wall
         // (including any pool queueing), which the capped interval amortizes.
-        let tick = self.cadence.tick(winner_ns, loser_ns);
-        if tick.boundary {
-            let probe = match preferred {
-                RunExecution::Serial => RunExecution::Parallel,
-                RunExecution::Parallel if can_sample_serial => RunExecution::Serial,
-                RunExecution::Parallel => RunExecution::Parallel,
-            };
-            return (probe, true);
-        }
-
-        (preferred, tick.measure)
+        let probe_allowed = preferred == RunExecution::Serial || can_sample_serial;
+        self.cadence
+            .arbitrate(preferred, loser, winner_ns, loser_ns, probe_allowed)
     }
 
     fn record(&mut self, execution: RunExecution, elapsed: Duration) {
-        let elapsed_ns = u64::try_from(elapsed.as_nanos()).unwrap_or(u64::MAX);
+        let elapsed_ns = nanos(elapsed);
         match execution {
             RunExecution::Serial => self.serial_ns.record(elapsed_ns),
             RunExecution::Parallel => self.parallel_ns.record(elapsed_ns),
@@ -461,31 +460,39 @@ impl SpawnEntry {
             return (SpawnExecution::Offload, true);
         };
 
-        // Ties go to inline: equal cost for one fewer pool wake.
+        // Ties go to inline: equal cost for one fewer pool wake. An inline probe is gated on
+        // the live worker wall fitting the budget: the inline wall is only observable by
+        // inlining, so without the probe an entry seeded into offload could never learn it,
+        // and gating on the live worker wall (not the stale inline estimate) lets a poisoned
+        // inline estimate recover. An offload probe is always allowed, since it keeps the
+        // offload estimates tracking the live pool.
         let bound = self.inline_ns.get().unwrap_or(job_ns);
         let threshold = overhead_ns.min(budget);
-        if bound > threshold {
-            // Offload steady state. Measured runs keep the offload estimates live, and the
-            // boundary probes inline when the live worker wall fits the budget: the inline
-            // wall is only observable by inlining, so without the probe an entry seeded into
-            // offload could never learn it. Gating the probe on the live worker wall (not the
-            // stale inline estimate) lets a poisoned inline estimate recover, and a probe
-            // never stalls the calling task beyond the budget.
-            let tick = self.cadence.tick(threshold, bound);
-            if tick.boundary && job_ns < budget {
-                return (SpawnExecution::Inline, true);
-            }
-            return (SpawnExecution::Offload, tick.boundary || tick.measure);
-        }
-
-        // Inline steady state: the boundary hands one call back to the pool so the offload
-        // estimates track the live pool.
-        let tick = self.cadence.tick(bound, threshold);
-        if tick.boundary {
-            return (SpawnExecution::Offload, true);
-        }
-        (SpawnExecution::Inline, tick.measure)
+        let (preferred, loser, winner_ns, loser_ns, probe_allowed) = if bound > threshold {
+            (
+                SpawnExecution::Offload,
+                SpawnExecution::Inline,
+                threshold,
+                bound,
+                job_ns < budget,
+            )
+        } else {
+            (
+                SpawnExecution::Inline,
+                SpawnExecution::Offload,
+                bound,
+                threshold,
+                true,
+            )
+        };
+        self.cadence
+            .arbitrate(preferred, loser, winner_ns, loser_ns, probe_allowed)
     }
+}
+
+// Saturating nanosecond conversion for timing samples.
+fn nanos(duration: Duration) -> u64 {
+    u64::try_from(duration.as_nanos()).unwrap_or(u64::MAX)
 }
 
 fn update_ewma(current: u64, next: u64) -> u64 {

--- a/parallel/src/policy.rs
+++ b/parallel/src/policy.rs
@@ -125,10 +125,10 @@ impl Policy {
     }
 
     /// Chooses where to run a spawned job (inline on the calling task when the job is measured
-    /// cheaper than the pool hand-off itself, offloaded to the pool otherwise) and whether the
-    /// caller should time the run and feed the sample back via
-    /// [`record_spawn_inline`](Self::record_spawn_inline) or
-    /// [`record_spawn_offload`](Self::record_spawn_offload).
+    /// cheaper than the round trip of offloading it, offloaded to the pool otherwise) and whether
+    /// the caller should time the run and feed the samples back via
+    /// [`record_spawn_job`](Self::record_spawn_job) and
+    /// [`record_spawn_overhead`](Self::record_spawn_overhead).
     pub(super) fn choose_spawn(
         &self,
         caller: &'static Location<'static>,
@@ -146,8 +146,9 @@ impl Policy {
             .choose(SPAWN_INLINE_BUDGET_NS)
     }
 
-    /// Records the wall time of a spawned job that ran inline on the calling task.
-    pub(super) fn record_spawn_inline(
+    /// Records a spawned job's own wall time, measured on the caller for inline runs and on the
+    /// worker for offloaded runs.
+    pub(super) fn record_spawn_job(
         &self,
         caller: &'static Location<'static>,
         len: usize,
@@ -158,30 +159,33 @@ impl Policy {
             return;
         }
         let key = Key::new(caller, len, len, parallelism);
-        let job = u64::try_from(job.as_nanos()).unwrap_or(u64::MAX);
-        self.spawn_entries.entry(key).or_default().record_job(job);
-    }
-
-    /// Records one offloaded spawn: `handoff` spans spawn entry to job start on the worker
-    /// (setup, enqueue, queue wait, and worker wake) and `job` is the job's own wall time there.
-    pub(super) fn record_spawn_offload(
-        &self,
-        caller: &'static Location<'static>,
-        len: usize,
-        parallelism: usize,
-        handoff: Duration,
-        job: Duration,
-    ) {
-        if parallelism <= 1 {
-            return;
-        }
-        let key = Key::new(caller, len, len, parallelism);
-        let handoff = u64::try_from(handoff.as_nanos()).unwrap_or(u64::MAX);
         let job = u64::try_from(job.as_nanos()).unwrap_or(u64::MAX);
         self.spawn_entries
             .entry(key)
             .or_default()
-            .record_offload(handoff, job);
+            .job_ns
+            .record(job);
+    }
+
+    /// Records one offloaded spawn's round-trip overhead: the elapsed time from spawn entry to
+    /// the result being observed by the awaiting future, minus the job's own wall time.
+    pub(super) fn record_spawn_overhead(
+        &self,
+        caller: &'static Location<'static>,
+        len: usize,
+        parallelism: usize,
+        overhead: Duration,
+    ) {
+        if parallelism <= 1 {
+            return;
+        }
+        let key = Key::new(caller, len, len, parallelism);
+        let overhead = u64::try_from(overhead.as_nanos()).unwrap_or(u64::MAX);
+        self.spawn_entries
+            .entry(key)
+            .or_default()
+            .overhead_ns
+            .record(overhead);
     }
 
     #[cfg(test)]
@@ -201,7 +205,7 @@ impl Policy {
         let key = Key::new(caller, len, len, parallelism);
         self.spawn_entries
             .get(&key)
-            .is_some_and(|entry| entry.handoff_ns.get().is_some() || entry.job_ns.get().is_some())
+            .is_some_and(|entry| entry.overhead_ns.get().is_some() || entry.job_ns.get().is_some())
     }
 
     #[cfg(test)]
@@ -403,13 +407,17 @@ impl Entry {
 
 /// Timing state for one spawn [`Key`].
 ///
-/// Since caller overlap cannot be observed, the policy inlines only when the job EWMA is no greater
-/// than both the hand-off EWMA and [`SPAWN_INLINE_BUDGET_NS`]. Hand-off samples include setup,
-/// queueing, and worker wake.
+/// Since caller overlap cannot be observed, the policy inlines only when the job EWMA is no
+/// greater than both the offload round-trip overhead EWMA and [`SPAWN_INLINE_BUDGET_NS`]. The
+/// overhead is everything an offloaded run costs around the job itself (hand-off setup, queueing,
+/// worker wake, result send, task wake, and the observing poll), so a caller that waits on the
+/// result inlines whenever that is measured cheaper. A caller that polls late inflates its
+/// overhead samples with overlap slack, which biases toward inline, and the budget bounds what
+/// that bias can place on the calling task.
 #[derive(Clone, Copy, Debug, Default)]
 struct SpawnEntry {
-    // Spawn entry to job start on a worker: setup, enqueue, queue wait, and worker wake.
-    handoff_ns: Estimate,
+    // Spawn entry to result observed, minus the job's own wall time, from offloaded runs.
+    overhead_ns: Estimate,
     // The job's own wall time, fed by offload and inline runs alike.
     job_ns: Estimate,
     cadence: Cadence,
@@ -420,13 +428,13 @@ impl SpawnEntry {
     // EWMA eligible for inlining.
     fn choose(&mut self, budget: u64) -> (SpawnExecution, bool) {
         // Seed both estimates from an offloaded run before ever inlining.
-        let (Some(handoff_ns), Some(job_ns)) = (self.handoff_ns.get(), self.job_ns.get()) else {
+        let (Some(overhead_ns), Some(job_ns)) = (self.overhead_ns.get(), self.job_ns.get()) else {
             self.cadence.saturate();
             return (SpawnExecution::Offload, true);
         };
 
         // Ties go to inline: equal cost for one fewer pool wake.
-        let threshold = handoff_ns.min(budget);
+        let threshold = overhead_ns.min(budget);
         if job_ns > threshold {
             // Offload steady state. Measured runs keep both estimates live, so the entry flips
             // to inline on its own once the evidence clears the threshold: no inline probe is
@@ -435,26 +443,13 @@ impl SpawnEntry {
             return (SpawnExecution::Offload, tick.boundary || tick.measure);
         }
 
-        // Inline steady state: the boundary hands one call back to the pool so the hand-off
+        // Inline steady state: the boundary hands one call back to the pool so the overhead
         // estimate tracks the live pool.
         let tick = self.cadence.tick(job_ns, threshold);
         if tick.boundary {
             return (SpawnExecution::Offload, true);
         }
         (SpawnExecution::Inline, tick.measure)
-    }
-
-    // Folds one job-wall sample into this entry (measured on the caller for inline runs and on
-    // the worker for offloaded runs).
-    fn record_job(&mut self, job_ns: u64) {
-        self.job_ns.record(job_ns);
-    }
-
-    // Folds one offloaded run into this entry: the hand-off (spawn entry to job start on the
-    // worker) and the job's own wall time there.
-    fn record_offload(&mut self, handoff_ns: u64, job_ns: u64) {
-        self.handoff_ns.record(handoff_ns);
-        self.job_ns.record(job_ns);
     }
 }
 
@@ -952,7 +947,7 @@ mod tests {
     }
 
     #[test]
-    fn spawn_seeds_offload_then_inlines_a_sub_handoff_job() {
+    fn spawn_seeds_offload_then_inlines_a_sub_overhead_job() {
         let mut entry = SpawnEntry::default();
 
         // The first call seeds both estimates from an offloaded run.
@@ -960,17 +955,19 @@ mod tests {
             entry.choose(SPAWN_INLINE_BUDGET_NS),
             (SpawnExecution::Offload, true)
         );
-        // A 2us job behind a 50us hand-off.
-        entry.record_offload(50_000, 2_000);
+        // A 2us job behind a 50us round-trip overhead.
+        entry.job_ns.record(2_000);
+        entry.overhead_ns.record(50_000);
 
         // The seed leaves the entry due for an immediate boundary, which re-measures offload.
         assert_eq!(
             entry.choose(SPAWN_INLINE_BUDGET_NS),
             (SpawnExecution::Offload, true)
         );
-        entry.record_offload(50_000, 2_000);
+        entry.job_ns.record(2_000);
+        entry.overhead_ns.record(50_000);
 
-        // The job costs less than the hand-off and fits the budget, so it runs inline.
+        // The job costs less than the overhead and fits the budget, so it runs inline.
         assert_eq!(
             entry.choose(SPAWN_INLINE_BUDGET_NS),
             (SpawnExecution::Inline, false)
@@ -978,21 +975,23 @@ mod tests {
     }
 
     #[test]
-    fn spawn_keeps_offloading_a_job_bigger_than_the_handoff() {
-        // A 50us job behind a 5us hand-off: inline must never fire even though the job is far
-        // under the budget, because offloading is cheaper for the caller under any polling.
+    fn spawn_keeps_offloading_a_job_bigger_than_the_overhead() {
+        // A 50us job behind a 5us round-trip overhead: inline must never fire even though the job
+        // is far under the budget, because offloading is cheaper under any polling.
         let mut entry = SpawnEntry::default();
         assert_eq!(
             entry.choose(SPAWN_INLINE_BUDGET_NS),
             (SpawnExecution::Offload, true)
         );
-        entry.record_offload(5_000, 50_000);
+        entry.job_ns.record(50_000);
+        entry.overhead_ns.record(5_000);
 
         for _ in 0..(2 * RESAMPLE_INTERVAL) {
             match entry.choose(SPAWN_INLINE_BUDGET_NS) {
                 (SpawnExecution::Offload, measure) => {
                     if measure {
-                        entry.record_offload(5_000, 50_000);
+                        entry.job_ns.record(50_000);
+                        entry.overhead_ns.record(5_000);
                     }
                 }
                 (execution, _) => panic!("expected offload, got {execution:?}"),
@@ -1001,21 +1000,23 @@ mod tests {
     }
 
     #[test]
-    fn spawn_budget_caps_inline_when_the_handoff_is_inflated() {
-        // A contended pool measured the hand-off at 50ms. The 2ms job is cheaper than that, but its
+    fn spawn_budget_caps_inline_when_the_overhead_is_inflated() {
+        // A contended pool measured the round-trip overhead at 50ms. The 2ms job is cheaper, but its
         // EWMA exceeds the inline budget, so it remains offloaded.
         let mut entry = SpawnEntry::default();
         assert_eq!(
             entry.choose(SPAWN_INLINE_BUDGET_NS),
             (SpawnExecution::Offload, true)
         );
-        entry.record_offload(50_000_000, 2_000_000);
+        entry.job_ns.record(2_000_000);
+        entry.overhead_ns.record(50_000_000);
 
         for _ in 0..(2 * RESAMPLE_INTERVAL) {
             match entry.choose(SPAWN_INLINE_BUDGET_NS) {
                 (SpawnExecution::Offload, measure) => {
                     if measure {
-                        entry.record_offload(50_000_000, 2_000_000);
+                        entry.job_ns.record(2_000_000);
+                        entry.overhead_ns.record(50_000_000);
                     }
                 }
                 (execution, _) => panic!("expected offload, got {execution:?}"),
@@ -1036,12 +1037,13 @@ mod tests {
 
     #[test]
     fn spawn_uses_job_ewma() {
-        // A converged-inline entry: cheap job, expensive hand-off.
+        // A converged-inline entry: cheap job, expensive round trip.
         let mut entry = SpawnEntry::default();
-        entry.record_offload(50_000, 2_000);
+        entry.job_ns.record(2_000);
+        entry.overhead_ns.record(50_000);
 
-        // The latest sample exceeds the hand-off, but the EWMA remains below it.
-        entry.record_job(100_000);
+        // The latest sample exceeds the overhead, but the EWMA remains below it.
+        entry.job_ns.record(100_000);
         assert_eq!(entry.job_ns.get(), Some(21_600));
         assert!(matches!(
             entry.choose(SPAWN_INLINE_BUDGET_NS),
@@ -1054,8 +1056,9 @@ mod tests {
         // A spike revoked inline placement. Offloaded runs keep measuring the job small, so the
         // estimates decay and inline returns without any dedicated probe.
         let mut entry = SpawnEntry::default();
-        entry.record_offload(50_000, 2_000);
-        entry.record_job(15_000_000);
+        entry.job_ns.record(2_000);
+        entry.overhead_ns.record(50_000);
+        entry.job_ns.record(15_000_000);
 
         let mut calls = 0;
         loop {
@@ -1063,7 +1066,8 @@ mod tests {
                 (SpawnExecution::Inline, _) => break,
                 (SpawnExecution::Offload, measure) => {
                     if measure {
-                        entry.record_offload(50_000, 2_000);
+                        entry.job_ns.record(2_000);
+                        entry.overhead_ns.record(50_000);
                     }
                 }
             }
@@ -1077,10 +1081,11 @@ mod tests {
 
     #[test]
     fn spawn_inline_records_on_cadence_and_probes_offload() {
-        // The hand-off is within 2x of the job, so the shared cadence probes at its base
+        // The overhead is within 2x of the job, so the shared cadence probes at its base
         // interval.
         let mut entry = SpawnEntry::default();
-        entry.record_offload(50_000, 30_000);
+        entry.job_ns.record(30_000);
+        entry.overhead_ns.record(50_000);
 
         for i in 1..RESAMPLE_INTERVAL {
             assert_eq!(
@@ -1092,7 +1097,7 @@ mod tests {
                 "call {i}"
             );
         }
-        // The boundary hands one call back to the pool so the hand-off estimate stays live.
+        // The boundary hands one call back to the pool so the overhead estimate stays live.
         assert_eq!(
             entry.choose(SPAWN_INLINE_BUDGET_NS),
             (SpawnExecution::Offload, true)
@@ -1104,7 +1109,8 @@ mod tests {
         // Inline wins by 25x, so the offload probe backs off to the capped interval while the
         // measure cadence continues, matching the serial-vs-parallel entries.
         let mut entry = SpawnEntry::default();
-        entry.record_offload(50_000, 2_000);
+        entry.job_ns.record(2_000);
+        entry.overhead_ns.record(50_000);
 
         let interval = RESAMPLE_INTERVAL << MAX_RESAMPLE_SHIFT;
         for i in 1..interval {

--- a/parallel/src/policy.rs
+++ b/parallel/src/policy.rs
@@ -76,13 +76,12 @@ pub(super) enum Execution {
     Parallel,
 }
 
-/// The placement the spawn policy chose for one call.
+/// The placement the spawn policy chose: run the job inline on the calling task, or hand it off
+/// to the pool.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(super) enum SpawnDecision {
-    /// Run the job inline on the calling task, timing it when `measure` is set.
-    Inline { measure: bool },
-    /// Hand the job to the pool, timing the hand-off and the job wall when `measure` is set.
-    Offload { measure: bool },
+pub(super) enum SpawnExecution {
+    Inline,
+    Offload,
 }
 
 /// Adaptive serial-vs-parallel decisions, shared cheaply across [`super::Rayon`] clones.
@@ -125,17 +124,20 @@ impl Policy {
         result
     }
 
-    /// Chooses where to run a spawned job: inline on the calling task when the job is measured
-    /// cheaper than the pool hand-off itself, offloaded to the pool otherwise.
+    /// Chooses where to run a spawned job (inline on the calling task when the job is measured
+    /// cheaper than the pool hand-off itself, offloaded to the pool otherwise) and whether the
+    /// caller should time the run and feed the sample back via
+    /// [`record_spawn_inline`](Self::record_spawn_inline) or
+    /// [`record_spawn_offload`](Self::record_spawn_offload).
     pub(super) fn choose_spawn(
         &self,
         caller: &'static Location<'static>,
         len: usize,
         parallelism: usize,
-    ) -> SpawnDecision {
+    ) -> (SpawnExecution, bool) {
         // A single worker cannot overlap a hand-off, so always inline (nothing to measure).
         if parallelism <= 1 {
-            return SpawnDecision::Inline { measure: false };
+            return (SpawnExecution::Inline, false);
         }
         let key = Key::new(caller, len, len, parallelism);
         self.spawn_entries
@@ -414,12 +416,13 @@ struct SpawnEntry {
 }
 
 impl SpawnEntry {
-    // Decides where this call runs. `budget` caps the job EWMA eligible for inlining.
-    fn choose(&mut self, budget: u64) -> SpawnDecision {
+    // Decides where this call runs and whether the caller should time it. `budget` caps the job
+    // EWMA eligible for inlining.
+    fn choose(&mut self, budget: u64) -> (SpawnExecution, bool) {
         // Seed both estimates from an offloaded run before ever inlining.
         let (Some(handoff_ns), Some(job_ns)) = (self.handoff_ns.get(), self.job_ns.get()) else {
             self.cadence.saturate();
-            return SpawnDecision::Offload { measure: true };
+            return (SpawnExecution::Offload, true);
         };
 
         // Ties go to inline: equal cost for one fewer pool wake.
@@ -429,20 +432,16 @@ impl SpawnEntry {
             // to inline on its own once the evidence clears the threshold: no inline probe is
             // needed because an inline run measures nothing an offloaded run does not.
             let tick = self.cadence.tick(threshold, job_ns);
-            return SpawnDecision::Offload {
-                measure: tick.boundary || tick.measure,
-            };
+            return (SpawnExecution::Offload, tick.boundary || tick.measure);
         }
 
         // Inline steady state: the boundary hands one call back to the pool so the hand-off
         // estimate tracks the live pool.
         let tick = self.cadence.tick(job_ns, threshold);
         if tick.boundary {
-            return SpawnDecision::Offload { measure: true };
+            return (SpawnExecution::Offload, true);
         }
-        SpawnDecision::Inline {
-            measure: tick.measure,
-        }
+        (SpawnExecution::Inline, tick.measure)
     }
 
     // Folds one job-wall sample into this entry (measured on the caller for inline runs and on
@@ -481,7 +480,7 @@ const fn len_bucket(len: usize) -> u8 {
 mod tests {
     use super::{
         Entry, Execution, MAX_RESAMPLE_SHIFT, PREFERRED_SAMPLE_INTERVAL, Policy, RESAMPLE_INTERVAL,
-        SPAWN_INLINE_BUDGET_NS, SpawnDecision, SpawnEntry,
+        SPAWN_INLINE_BUDGET_NS, SpawnEntry, SpawnExecution,
     };
     use std::{panic::Location, time::Duration};
 
@@ -959,7 +958,7 @@ mod tests {
         // The first call seeds both estimates from an offloaded run.
         assert_eq!(
             entry.choose(SPAWN_INLINE_BUDGET_NS),
-            SpawnDecision::Offload { measure: true }
+            (SpawnExecution::Offload, true)
         );
         // A 2us job behind a 50us hand-off.
         entry.record_offload(50_000, 2_000);
@@ -967,14 +966,14 @@ mod tests {
         // The seed leaves the entry due for an immediate boundary, which re-measures offload.
         assert_eq!(
             entry.choose(SPAWN_INLINE_BUDGET_NS),
-            SpawnDecision::Offload { measure: true }
+            (SpawnExecution::Offload, true)
         );
         entry.record_offload(50_000, 2_000);
 
         // The job costs less than the hand-off and fits the budget, so it runs inline.
         assert_eq!(
             entry.choose(SPAWN_INLINE_BUDGET_NS),
-            SpawnDecision::Inline { measure: false }
+            (SpawnExecution::Inline, false)
         );
     }
 
@@ -985,18 +984,18 @@ mod tests {
         let mut entry = SpawnEntry::default();
         assert_eq!(
             entry.choose(SPAWN_INLINE_BUDGET_NS),
-            SpawnDecision::Offload { measure: true }
+            (SpawnExecution::Offload, true)
         );
         entry.record_offload(5_000, 50_000);
 
         for _ in 0..(2 * RESAMPLE_INTERVAL) {
             match entry.choose(SPAWN_INLINE_BUDGET_NS) {
-                SpawnDecision::Offload { measure } => {
+                (SpawnExecution::Offload, measure) => {
                     if measure {
                         entry.record_offload(5_000, 50_000);
                     }
                 }
-                inline => panic!("expected offload, got {inline:?}"),
+                (execution, _) => panic!("expected offload, got {execution:?}"),
             }
         }
     }
@@ -1008,18 +1007,18 @@ mod tests {
         let mut entry = SpawnEntry::default();
         assert_eq!(
             entry.choose(SPAWN_INLINE_BUDGET_NS),
-            SpawnDecision::Offload { measure: true }
+            (SpawnExecution::Offload, true)
         );
         entry.record_offload(50_000_000, 2_000_000);
 
         for _ in 0..(2 * RESAMPLE_INTERVAL) {
             match entry.choose(SPAWN_INLINE_BUDGET_NS) {
-                SpawnDecision::Offload { measure } => {
+                (SpawnExecution::Offload, measure) => {
                     if measure {
                         entry.record_offload(50_000_000, 2_000_000);
                     }
                 }
-                inline => panic!("expected offload, got {inline:?}"),
+                (execution, _) => panic!("expected offload, got {execution:?}"),
             }
         }
     }
@@ -1031,7 +1030,7 @@ mod tests {
         let location = Location::caller();
         assert_eq!(
             policy.choose_spawn(location, 64, 1),
-            SpawnDecision::Inline { measure: false }
+            (SpawnExecution::Inline, false)
         );
     }
 
@@ -1046,7 +1045,7 @@ mod tests {
         assert_eq!(entry.job_ns.get(), Some(21_600));
         assert!(matches!(
             entry.choose(SPAWN_INLINE_BUDGET_NS),
-            SpawnDecision::Inline { .. }
+            (SpawnExecution::Inline, _)
         ));
     }
 
@@ -1061,8 +1060,8 @@ mod tests {
         let mut calls = 0;
         loop {
             match entry.choose(SPAWN_INLINE_BUDGET_NS) {
-                SpawnDecision::Inline { .. } => break,
-                SpawnDecision::Offload { measure } => {
+                (SpawnExecution::Inline, _) => break,
+                (SpawnExecution::Offload, measure) => {
                     if measure {
                         entry.record_offload(50_000, 2_000);
                     }
@@ -1086,16 +1085,17 @@ mod tests {
         for i in 1..RESAMPLE_INTERVAL {
             assert_eq!(
                 entry.choose(SPAWN_INLINE_BUDGET_NS),
-                SpawnDecision::Inline {
-                    measure: i.is_multiple_of(PREFERRED_SAMPLE_INTERVAL)
-                },
+                (
+                    SpawnExecution::Inline,
+                    i.is_multiple_of(PREFERRED_SAMPLE_INTERVAL)
+                ),
                 "call {i}"
             );
         }
         // The boundary hands one call back to the pool so the hand-off estimate stays live.
         assert_eq!(
             entry.choose(SPAWN_INLINE_BUDGET_NS),
-            SpawnDecision::Offload { measure: true }
+            (SpawnExecution::Offload, true)
         );
     }
 
@@ -1110,15 +1110,16 @@ mod tests {
         for i in 1..interval {
             assert_eq!(
                 entry.choose(SPAWN_INLINE_BUDGET_NS),
-                SpawnDecision::Inline {
-                    measure: i.is_multiple_of(PREFERRED_SAMPLE_INTERVAL)
-                },
+                (
+                    SpawnExecution::Inline,
+                    i.is_multiple_of(PREFERRED_SAMPLE_INTERVAL)
+                ),
                 "call {i}"
             );
         }
         assert_eq!(
             entry.choose(SPAWN_INLINE_BUDGET_NS),
-            SpawnDecision::Offload { measure: true }
+            (SpawnExecution::Offload, true)
         );
     }
 }

--- a/parallel/src/policy.rs
+++ b/parallel/src/policy.rs
@@ -1113,6 +1113,58 @@ mod tests {
     }
 
     #[test]
+    fn spawn_inline_ewma_crossing_the_overhead_revokes_inline() {
+        // A converged-inline entry whose inline wall grows: the flip must come from the inline
+        // EWMA while the worker wall stays low, pinning that the decision prefers the inline
+        // wall once one exists.
+        let mut entry = SpawnEntry::default();
+        entry.job_ns.record(2_000);
+        entry.overhead_ns.record(50_000);
+        entry.inline_ns.record(2_000);
+        assert!(matches!(
+            entry.choose(SPAWN_INLINE_BUDGET_NS),
+            (SpawnExecution::Inline, _)
+        ));
+
+        // One grown sample blends the inline EWMA over the 50us overhead.
+        entry.inline_ns.record(500_000);
+        assert_eq!(entry.inline_ns.get(), Some(101_600));
+        assert!(matches!(
+            entry.choose(SPAWN_INLINE_BUDGET_NS),
+            (SpawnExecution::Offload, _)
+        ));
+    }
+
+    #[test]
+    fn spawn_records_feed_choose() {
+        // Policy-level wiring for the three spawn record paths: the worker and future samples
+        // seed the entry, and the probe's inline sample drives the flip.
+        let policy = Policy::default();
+        let location = Location::caller();
+
+        assert_eq!(
+            policy.choose_spawn(location, 64, PARALLELISM),
+            (SpawnExecution::Offload, true)
+        );
+        policy.record_spawn_job(location, 64, PARALLELISM, Duration::from_micros(25));
+        policy.record_spawn_overhead(location, 64, PARALLELISM, Duration::from_micros(10));
+
+        // The boundary probes inline (the worker wall fits the budget).
+        assert_eq!(
+            policy.choose_spawn(location, 64, PARALLELISM),
+            (SpawnExecution::Inline, true)
+        );
+
+        // The probe's inline wall beats the overhead, so the entry flips inline: recording it
+        // anywhere but the inline estimate would leave the entry offloaded.
+        policy.record_spawn_inline(location, 64, PARALLELISM, Duration::from_micros(8));
+        assert_eq!(
+            policy.choose_spawn(location, 64, PARALLELISM),
+            (SpawnExecution::Inline, false)
+        );
+    }
+
+    #[test]
     fn spawn_uses_job_ewma() {
         // A converged-inline entry: cheap job, expensive round trip.
         let mut entry = SpawnEntry::default();

--- a/parallel/src/policy.rs
+++ b/parallel/src/policy.rs
@@ -127,7 +127,8 @@ impl Policy {
     /// Chooses where to run a spawned job (inline on the calling task when the job is measured
     /// cheaper than the round trip of offloading it, offloaded to the pool otherwise) and whether
     /// the caller should time the run and feed the samples back via
-    /// [`record_spawn_job`](Self::record_spawn_job) and
+    /// [`record_spawn_inline`](Self::record_spawn_inline),
+    /// [`record_spawn_job`](Self::record_spawn_job), and
     /// [`record_spawn_overhead`](Self::record_spawn_overhead).
     pub(super) fn choose_spawn(
         &self,
@@ -146,8 +147,27 @@ impl Policy {
             .choose(SPAWN_INLINE_BUDGET_NS)
     }
 
-    /// Records a spawned job's own wall time, measured on the caller for inline runs and on the
-    /// worker for offloaded runs.
+    /// Records the wall time of a spawned job that ran inline on the calling task.
+    pub(super) fn record_spawn_inline(
+        &self,
+        caller: &'static Location<'static>,
+        len: usize,
+        parallelism: usize,
+        job: Duration,
+    ) {
+        if parallelism <= 1 {
+            return;
+        }
+        let key = Key::new(caller, len, len, parallelism);
+        let job = u64::try_from(job.as_nanos()).unwrap_or(u64::MAX);
+        self.spawn_entries
+            .entry(key)
+            .or_default()
+            .inline_ns
+            .record(job);
+    }
+
+    /// Records the wall time of a spawned job that ran on a pool worker.
     pub(super) fn record_spawn_job(
         &self,
         caller: &'static Location<'static>,
@@ -407,45 +427,59 @@ impl Entry {
 
 /// Timing state for one spawn [`Key`].
 ///
-/// Since caller overlap cannot be observed, the policy inlines only when the job EWMA is no
+/// Since caller overlap cannot be observed, the policy inlines only when the job wall is no
 /// greater than both the offload round-trip overhead EWMA and [`SPAWN_INLINE_BUDGET_NS`]. The
 /// overhead is everything an offloaded run costs around the job itself (hand-off setup, queueing,
 /// worker wake, result send, task wake, and the observing poll), so a caller that waits on the
 /// result inlines whenever that is measured cheaper. A caller that polls late inflates its
 /// overhead samples with overlap slack, which biases toward inline, and the budget bounds what
 /// that bias can place on the calling task.
+///
+/// The job wall is tracked per placement: the worker-measured wall carries the penalty of
+/// migrating the job to another core, so the decision prefers the inline-measured wall once one
+/// exists, and the offload-state boundary probes inline (when the live worker wall fits the
+/// budget) so that estimate is observable from an entry seeded into offload.
 #[derive(Clone, Copy, Debug, Default)]
 struct SpawnEntry {
     // Spawn entry to result observed, minus the job's own wall time, from offloaded runs.
     overhead_ns: Estimate,
-    // The job's own wall time, fed by offload and inline runs alike.
+    // The job's own wall time on a pool worker.
     job_ns: Estimate,
+    // The job's own wall time inline on the calling task.
+    inline_ns: Estimate,
     cadence: Cadence,
 }
 
 impl SpawnEntry {
     // Decides where this call runs and whether the caller should time it. `budget` caps the job
-    // EWMA eligible for inlining.
+    // wall eligible for inlining.
     fn choose(&mut self, budget: u64) -> (SpawnExecution, bool) {
-        // Seed both estimates from an offloaded run before ever inlining.
+        // Seed both offload estimates before ever inlining.
         let (Some(overhead_ns), Some(job_ns)) = (self.overhead_ns.get(), self.job_ns.get()) else {
             self.cadence.saturate();
             return (SpawnExecution::Offload, true);
         };
 
         // Ties go to inline: equal cost for one fewer pool wake.
+        let bound = self.inline_ns.get().unwrap_or(job_ns);
         let threshold = overhead_ns.min(budget);
-        if job_ns > threshold {
-            // Offload steady state. Measured runs keep both estimates live, so the entry flips
-            // to inline on its own once the evidence clears the threshold: no inline probe is
-            // needed because an inline run measures nothing an offloaded run does not.
-            let tick = self.cadence.tick(threshold, job_ns);
+        if bound > threshold {
+            // Offload steady state. Measured runs keep the offload estimates live, and the
+            // boundary probes inline when the live worker wall fits the budget: the inline
+            // wall is only observable by inlining, so without the probe an entry seeded into
+            // offload could never learn it. Gating the probe on the live worker wall (not the
+            // stale inline estimate) lets a poisoned inline estimate recover, and a probe
+            // never stalls the calling task beyond the budget.
+            let tick = self.cadence.tick(threshold, bound);
+            if tick.boundary && job_ns < budget {
+                return (SpawnExecution::Inline, true);
+            }
             return (SpawnExecution::Offload, tick.boundary || tick.measure);
         }
 
-        // Inline steady state: the boundary hands one call back to the pool so the overhead
-        // estimate tracks the live pool.
-        let tick = self.cadence.tick(job_ns, threshold);
+        // Inline steady state: the boundary hands one call back to the pool so the offload
+        // estimates track the live pool.
+        let tick = self.cadence.tick(bound, threshold);
         if tick.boundary {
             return (SpawnExecution::Offload, true);
         }
@@ -976,8 +1010,7 @@ mod tests {
 
     #[test]
     fn spawn_keeps_offloading_a_job_bigger_than_the_overhead() {
-        // A 50us job behind a 5us round-trip overhead: inline must never fire even though the job
-        // is far under the budget, because offloading is cheaper under any polling.
+        // A 50us job behind a 5us round-trip overhead: offloading is cheaper under any polling.
         let mut entry = SpawnEntry::default();
         assert_eq!(
             entry.choose(SPAWN_INLINE_BUDGET_NS),
@@ -986,6 +1019,16 @@ mod tests {
         entry.job_ns.record(50_000);
         entry.overhead_ns.record(5_000);
 
+        // The seed leaves the entry due for a boundary, which probes inline (the worker wall
+        // fits the budget) to observe the inline wall.
+        assert_eq!(
+            entry.choose(SPAWN_INLINE_BUDGET_NS),
+            (SpawnExecution::Inline, true)
+        );
+        entry.inline_ns.record(50_000);
+
+        // The inline wall confirms the job is bigger than the overhead, so offload holds until
+        // the next (backed-off) boundary.
         for _ in 0..(2 * RESAMPLE_INTERVAL) {
             match entry.choose(SPAWN_INLINE_BUDGET_NS) {
                 (SpawnExecution::Offload, measure) => {
@@ -997,6 +1040,32 @@ mod tests {
                 (execution, _) => panic!("expected offload, got {execution:?}"),
             }
         }
+    }
+
+    #[test]
+    fn spawn_probe_learns_the_inline_wall() {
+        // The worker-measured wall (25us, migrated to another core) exceeds the 10us overhead,
+        // so the entry seeds into offload. The boundary probe runs the job inline, the inline
+        // wall (8us) comes in under the overhead, and the entry flips: without the probe this
+        // state is unlearnable.
+        let mut entry = SpawnEntry::default();
+        assert_eq!(
+            entry.choose(SPAWN_INLINE_BUDGET_NS),
+            (SpawnExecution::Offload, true)
+        );
+        entry.job_ns.record(25_000);
+        entry.overhead_ns.record(10_000);
+
+        assert_eq!(
+            entry.choose(SPAWN_INLINE_BUDGET_NS),
+            (SpawnExecution::Inline, true)
+        );
+        entry.inline_ns.record(8_000);
+
+        assert_eq!(
+            entry.choose(SPAWN_INLINE_BUDGET_NS),
+            (SpawnExecution::Inline, false)
+        );
     }
 
     #[test]
@@ -1041,10 +1110,11 @@ mod tests {
         let mut entry = SpawnEntry::default();
         entry.job_ns.record(2_000);
         entry.overhead_ns.record(50_000);
+        entry.inline_ns.record(2_000);
 
-        // The latest sample exceeds the overhead, but the EWMA remains below it.
-        entry.job_ns.record(100_000);
-        assert_eq!(entry.job_ns.get(), Some(21_600));
+        // The latest inline sample exceeds the overhead, but the EWMA remains below it.
+        entry.inline_ns.record(100_000);
+        assert_eq!(entry.inline_ns.get(), Some(21_600));
         assert!(matches!(
             entry.choose(SPAWN_INLINE_BUDGET_NS),
             (SpawnExecution::Inline, _)
@@ -1053,17 +1123,25 @@ mod tests {
 
     #[test]
     fn spawn_recovers_after_a_transient_slow_run() {
-        // A spike revoked inline placement. Offloaded runs keep measuring the job small, so the
-        // estimates decay and inline returns without any dedicated probe.
+        // A spike poisoned the inline estimate. Boundary probes are gated on the live worker
+        // wall rather than the stale inline estimate, so probe samples blend the estimate back
+        // down and inline placement returns.
         let mut entry = SpawnEntry::default();
         entry.job_ns.record(2_000);
         entry.overhead_ns.record(50_000);
-        entry.job_ns.record(15_000_000);
+        entry.inline_ns.record(15_000_000);
 
-        let mut calls = 0;
+        let mut calls: u32 = 0;
         loop {
             match entry.choose(SPAWN_INLINE_BUDGET_NS) {
-                (SpawnExecution::Inline, _) => break,
+                (SpawnExecution::Inline, measure) => {
+                    if measure {
+                        entry.inline_ns.record(2_000);
+                    }
+                    if entry.inline_ns.get().unwrap() <= 50_000 {
+                        break;
+                    }
+                }
                 (SpawnExecution::Offload, measure) => {
                     if measure {
                         entry.job_ns.record(2_000);
@@ -1072,10 +1150,7 @@ mod tests {
                 }
             }
             calls += 1;
-            assert!(
-                calls <= 10 * RESAMPLE_INTERVAL,
-                "inline placement never recovered"
-            );
+            assert!(calls <= 100_000, "inline placement never recovered");
         }
     }
 

--- a/runtime/src/tokio/runtime.rs
+++ b/runtime/src/tokio/runtime.rs
@@ -1036,7 +1036,7 @@ mod tests {
         let runner = std::thread::spawn(move || {
             let strategy = Runner::new(cfg).start(move |context| async move {
                 let strategy = context.strategy(NZUsize!(2));
-                strategy.spawn(|_| ()).await;
+                strategy.spawn(1, |_| ()).await;
                 retain.then_some(strategy)
             });
             strategy_tx.send(strategy).unwrap();
@@ -1155,7 +1155,7 @@ mod tests {
         assert!(run_with_returned_strategy(false).is_none());
 
         let strategy = run_with_returned_strategy(true).unwrap();
-        assert_eq!(futures::executor::block_on(strategy.spawn(|_| 42)), 42);
+        assert_eq!(futures::executor::block_on(strategy.spawn(1, |_| 42)), 42);
     }
 
     #[test]
@@ -1168,7 +1168,7 @@ mod tests {
                 std::panic::catch_unwind(AssertUnwindSafe(|| {
                     Runner::new(cfg).start(move |context| async move {
                         let strategy = context.strategy(NZUsize!(2));
-                        strategy.spawn(|_| ()).await;
+                        strategy.spawn(1, |_| ()).await;
                         std::panic::panic_any(strategy);
                     });
                 }));
@@ -1184,7 +1184,7 @@ mod tests {
             .expect("Runner::start did not resume the strategy panic payload");
         runner.join().unwrap();
         let _ = std::fs::remove_dir_all(storage_directory);
-        assert_eq!(futures::executor::block_on(strategy.spawn(|_| 42)), 42);
+        assert_eq!(futures::executor::block_on(strategy.spawn(1, |_| 42)), 42);
     }
 
     #[test]

--- a/storage/src/qmdb/current/batch.rs
+++ b/storage/src/qmdb/current/batch.rs
@@ -1394,7 +1394,10 @@ mod tests {
         let _ = futures::executor::block_on(merkleize);
         assert!(ancestor.upgrade().is_none());
 
-        // Drop the waiter while the worker is queued to prove the guard moved with it.
+        // Drop the waiter while the worker is queued to prove the guard moved with it. A fresh
+        // strategy makes this spawn the policy's seed, which always offloads (the completed
+        // first scenario could otherwise train the shared entry into an inline probe).
+        let strategy = Rayon::new(NZUsize!(2)).unwrap();
         let (a, b) = grafted_chain(&strategy, &mem);
         let ancestor = Arc::downgrade(&a);
         let release = block_strategy(&strategy, 2);

--- a/storage/src/qmdb/current/batch.rs
+++ b/storage/src/qmdb/current/batch.rs
@@ -1327,7 +1327,7 @@ mod tests {
     use crate::{mmb, mmr, utils::detached::block_strategy};
     use commonware_cryptography::Sha256;
     use commonware_macros::test_traced;
-    use commonware_parallel::Rayon;
+    use commonware_parallel::{Manual, Rayon};
     use commonware_utils::{NZUsize, bitmap::Prunable as BitMap};
     use std::{
         future::Future as _,
@@ -1338,7 +1338,8 @@ mod tests {
     // N=4 -> CHUNK_SIZE_BITS = 32
     const N: usize = 4;
     type Bm = BitMap<N>;
-    type GraftedBatch = Arc<GenericMerkleizedBatch<mmb::Family, <Sha256 as Hasher>::Digest, Rayon>>;
+    type GraftedBatch =
+        Arc<GenericMerkleizedBatch<mmb::Family, <Sha256 as Hasher>::Digest, Manual<Rayon>>>;
     type Location = mmr::Location;
 
     fn make_bitmap(bits: &[bool]) -> Bm {
@@ -1350,7 +1351,7 @@ mod tests {
     }
 
     fn grafted_chain(
-        strategy: &Rayon,
+        strategy: &Manual<Rayon>,
         mem: &Arc<Mem<mmb::Family, <Sha256 as Hasher>::Digest>>,
     ) -> (GraftedBatch, GraftedBatch) {
         let hasher = grafting::hasher::<mmb::Family, Sha256>(grafting::height::<1>());
@@ -1370,6 +1371,7 @@ mod tests {
     #[test_traced]
     fn test_grafted_merkleize_retains_ancestors_after_cancellation() {
         let strategy = Rayon::new(NZUsize!(2)).unwrap();
+        let manual = strategy.manual();
         let mem = Arc::new(Mem::<mmb::Family, <Sha256 as Hasher>::Digest>::new());
         let grafting_height = grafting::height::<1>();
         let graft_inputs = || vec![(0, Sha256::hash(&[b"replacement"]), [1u8; 1])];
@@ -1377,11 +1379,11 @@ mod tests {
         let mut context = TaskContext::from_waker(&waker);
 
         // Observe the worker result so a missing grandparent fails the test directly.
-        let (a, b) = grafted_chain(&strategy, &mem);
+        let (a, b) = grafted_chain(&manual, &mem);
         let ancestor = Arc::downgrade(&a);
         let release = block_strategy(&strategy, 2);
         let mut merkleize = Box::pin(merkleize_grafted_batch::<mmb::Family, Sha256, _, 1>(
-            &strategy,
+            &manual,
             Arc::clone(&b),
             &mem,
             graft_inputs(),
@@ -1394,15 +1396,12 @@ mod tests {
         let _ = futures::executor::block_on(merkleize);
         assert!(ancestor.upgrade().is_none());
 
-        // Drop the waiter while the worker is queued to prove the guard moved with it. A fresh
-        // strategy makes this spawn the policy's seed, which always offloads (the completed
-        // first scenario could otherwise train the shared entry into an inline probe).
-        let strategy = Rayon::new(NZUsize!(2)).unwrap();
-        let (a, b) = grafted_chain(&strategy, &mem);
+        // Drop the waiter while the worker is queued to prove the guard moved with it.
+        let (a, b) = grafted_chain(&manual, &mem);
         let ancestor = Arc::downgrade(&a);
         let release = block_strategy(&strategy, 2);
         let mut merkleize = Box::pin(merkleize_grafted_batch::<mmb::Family, Sha256, _, 1>(
-            &strategy,
+            &manual,
             Arc::clone(&b),
             &mem,
             graft_inputs(),

--- a/storage/src/utils/detached.rs
+++ b/storage/src/utils/detached.rs
@@ -12,14 +12,20 @@ use std::{
 
 /// Occupy `workers` Rayon workers until the returned sender is dropped.
 pub(crate) fn block_strategy(strategy: &Rayon, workers: usize) -> mpsc::Sender<()> {
+    // The jobs block until released, so they must never run inline on the calling task:
+    // `manual()` disables the spawn policy, and the assert rejects the remaining inline path
+    // (spawn always inlines on a single-worker pool; the parallelism plan mirrors the pool
+    // size for strategies built with `Rayon::new`).
+    assert!(
+        strategy.manual().parallelism() >= 2,
+        "block_strategy requires a multi-worker pool"
+    );
     let (started_tx, started_rx) = mpsc::channel();
     let (release_tx, release_rx) = mpsc::channel();
     let release_rx = Arc::new(Mutex::new(release_rx));
     for _ in 0..workers {
         let started_tx = started_tx.clone();
         let release_rx = Arc::clone(&release_rx);
-        // The job blocks until released, so it must never run inline on the calling
-        // task: submit through `manual()` for an unconditional hand-off.
         drop(strategy.manual().spawn(1, move |_| {
             started_tx.send(()).unwrap();
             let _ = release_rx.lock().recv();

--- a/storage/src/utils/detached.rs
+++ b/storage/src/utils/detached.rs
@@ -16,8 +16,9 @@ pub(crate) fn block_strategy(strategy: &Rayon, workers: usize) -> mpsc::Sender<(
     // `manual()` disables the spawn policy, and the assert rejects the remaining inline path
     // (spawn always inlines on a single-worker pool; the parallelism plan mirrors the pool
     // size for strategies built with `Rayon::new`).
+    let manual = strategy.manual();
     assert!(
-        strategy.manual().parallelism() >= 2,
+        manual.parallelism() >= 2,
         "block_strategy requires a multi-worker pool"
     );
     let (started_tx, started_rx) = mpsc::channel();
@@ -26,7 +27,7 @@ pub(crate) fn block_strategy(strategy: &Rayon, workers: usize) -> mpsc::Sender<(
     for _ in 0..workers {
         let started_tx = started_tx.clone();
         let release_rx = Arc::clone(&release_rx);
-        drop(strategy.manual().spawn(1, move |_| {
+        drop(manual.spawn(1, move |_| {
             started_tx.send(()).unwrap();
             let _ = release_rx.lock().recv();
         }));

--- a/storage/src/utils/detached.rs
+++ b/storage/src/utils/detached.rs
@@ -12,10 +12,7 @@ use std::{
 
 /// Occupy `workers` Rayon workers until the returned sender is dropped.
 pub(crate) fn block_strategy(strategy: &Rayon, workers: usize) -> mpsc::Sender<()> {
-    // The jobs block until released, so they must never run inline on the calling task:
-    // `manual()` disables the spawn policy, and the assert rejects the remaining inline path
-    // (spawn always inlines on a single-worker pool; the parallelism plan mirrors the pool
-    // size for strategies built with `Rayon::new`).
+    // The jobs block until released, so they must never run inline on the calling task.
     let manual = strategy.manual();
     assert!(
         manual.parallelism() >= 2,


### PR DESCRIPTION
Targets #4423's branch.

## Problem

#4423 prices the offload path by hand-off setup plus the elapsed time from the returned future's first poll to the result. First poll is not the join, so the signal depends on how the caller polls: a `FuturesUnordered` consumer like the p2p background decoder polls immediately and charges its fully overlapped decode wall to offload (converging every sub-budget decode inline and serializing the receive loop the wrapper exists to keep clear), while immediate-await callers measure offload as setup plus the whole job (degenerating the comparison to "inline everything under the 10ms budget").

Benchmarks on the QMDB follower write path drove out two successor measurements:

- Timing only the forward leg (spawn entry to job start on the worker) reads a few microseconds on a spin-warm pool, missing the return leg (result send, task wake, executor re-poll). The follower's 5-25us waiting jobs never inlined and the negative scaling returned (t8 wall 27.4s vs 13.0s base).
- Pricing offload as the full round trip minus the job recovered that (t8 13.8-14.5s) but left merkleize 7-14% over base: the worker-measured job wall carries the penalty of migrating the job to another core, so entries whose measured overhead sat below that inflated wall seeded into offload and could never learn the cheaper inline wall.

## Fix

Each spawn entry (callsite, size bucket, parallelism) learns three signals:

- **overhead**: spawn entry to result observed, minus the job's own wall, from offloaded runs. Everything an offloaded run costs around the job itself.
- **job wall, per placement**: measured on the worker for offloaded runs and on the caller for inline runs. The decision prefers the inline wall once one exists, since the worker wall includes the migration penalty.

A job runs inline iff its wall is no greater than both the overhead estimate and a 1ms budget, with ties to inline (equal cost for one fewer pool wake). Entries seed by offloading. The offload-state cadence boundary probes inline when the live worker wall fits the budget, so the inline wall is learnable from an entry seeded into offload and a poisoned inline estimate recovers. The inline-state boundary hands one call back to the pool so the offload estimates track the live pool. Estimates and pacing share the `Estimate`/`Cadence` machinery with the collection-op tuner (renamed `RunEntry`/`RunExecution` for naming symmetry), including the proportional, capped probe interval.

The worker records its wall before sending the result, so job estimates survive dropped futures, and panicked jobs record nothing. The overhead sample is recorded by the future that observes the result, which is the one deliberate polling dependence left: a late poll inflates overhead with overlap slack, which only ever biases toward inline, and the budget caps what that bias can place on the calling task (a persistently late-harvesting caller can at worst inline sub-budget jobs).

Also fixes the missed `Strategy::spawn` migration in the tokio runtime tests, documents that `manual()` forces a hand-off only on multi-worker pools (a single-worker pool always runs jobs inline), makes `block_strategy` assert a multi-worker pool since its jobs block until released, and gives the grafted-cancellation test's queued-worker scenario a fresh strategy so it relies on seed semantics instead of policy internals.

## Tests

New `SpawnEntry` unit tests: seed then inline for sub-overhead jobs, offload for jobs bigger than the overhead, the budget cap under an inflated overhead estimate, the probe learning the inline wall from a cold-seeded entry, EWMA-paced revocation and recovery through the probe, the measure cadence, and the capped probe interval. `Rayon::spawn` integration tests: tiny jobs converge inline on the calling thread, over-budget jobs never leave the pool. `just test -p commonware-parallel` green (64 tests). Pending before merge: the QMDB follower re-bench at this head (expected to close the 7-14% residual) and a loaded-p2p run to size the overlap-slack bias.
