### PR TITLE
docs: fix typos in algebra.rs, FUZZING.md, and futures.rs

### DIFF
--- a/FUZZING.md
+++ b/FUZZING.md
@@ -21,7 +21,7 @@ $ cargo +nightly fuzz run roundtrip --help
 ```
 
 > [!NOTE]
-> If using the [`justfile`](./justfile), all fuzz tests for a given directory can be ran using 
+> If using the [`justfile`](./justfile), all fuzz tests for a given directory can be run using 
 > `just fuzz <dir> <max_time>`.
 
 ### Coverage

--- a/math/src/algebra.rs
+++ b/math/src/algebra.rs
@@ -136,7 +136,7 @@ pub trait Additive:
     ///
     /// This has a default implementation involving a clone.
     ///
-    /// This can be overriden if a more efficient implementation is available.
+    /// This can be overridden if a more efficient implementation is available.
     fn double(&mut self) {
         *self += &self.clone();
     }
@@ -190,7 +190,7 @@ pub trait Multiplicative:
     ///
     /// This has a default implementation involving a clone.
     ///
-    /// This can be overriden for a specific type that's better.
+    /// This can be overridden for a specific type that's better.
     fn square(&mut self) {
         *self *= &self.clone();
     }

--- a/utils/src/futures.rs
+++ b/utils/src/futures.rs
@@ -51,7 +51,7 @@ impl<'a, T: Send> Pool<'a, T> {
         self.pool.push(Box::pin(future));
     }
 
-    /// Returns a futures that resolves to the next future in the pool that resolves.
+    /// Returns a future that resolves to the next future in the pool that resolves.
     ///
     /// If the pool is empty, the future will never resolve.
     pub fn next_completed(&mut self) -> SelectNextSome<'_, FuturesUnordered<PooledFuture<'a, T>>> {


### PR DESCRIPTION
## Summary
- `math/src/algebra.rs`: "overriden" → "overridden" (lines 139, 193)
- `FUZZING.md`: "can be ran" → "can be run" (line 24)
- `utils/src/futures.rs`: "Returns a futures" → "Returns a future" (line 54)

Fixes #4607