### PR TITLE
[runtime] Model crash shapes for storage fuzzing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1934,7 +1934,6 @@ name = "commonware-runtime-fuzz"
 version = "2026.7.0"
 dependencies = [
  "arbitrary",
- "commonware-cryptography",
  "commonware-runtime",
  "commonware-utils",
  "libfuzzer-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1934,6 +1934,7 @@ name = "commonware-runtime-fuzz"
 version = "2026.7.0"
 dependencies = [
  "arbitrary",
+ "commonware-cryptography",
  "commonware-runtime",
  "commonware-utils",
  "libfuzzer-sys",

--- a/runtime/fuzz/Cargo.toml
+++ b/runtime/fuzz/Cargo.toml
@@ -10,8 +10,7 @@ cargo-fuzz = true
 
 [dependencies]
 arbitrary = { workspace = true, features = ["derive"] }
-commonware-cryptography.workspace = true
-commonware-runtime = { workspace = true, features = ["test-utils"] }
+commonware-runtime = { workspace = true, features = ["arbitrary", "test-utils"] }
 commonware-utils.workspace = true
 libfuzzer-sys.workspace = true
 

--- a/runtime/fuzz/Cargo.toml
+++ b/runtime/fuzz/Cargo.toml
@@ -10,7 +10,8 @@ cargo-fuzz = true
 
 [dependencies]
 arbitrary = { workspace = true, features = ["derive"] }
-commonware-runtime = { workspace = true, features = ["arbitrary", "test-utils"] }
+commonware-cryptography.workspace = true
+commonware-runtime = { workspace = true, features = ["test-utils"] }
 commonware-utils.workspace = true
 libfuzzer-sys.workspace = true
 

--- a/runtime/fuzz/Cargo.toml
+++ b/runtime/fuzz/Cargo.toml
@@ -10,7 +10,7 @@ cargo-fuzz = true
 
 [dependencies]
 arbitrary = { workspace = true, features = ["derive"] }
-commonware-runtime.workspace = true
+commonware-runtime = { workspace = true, features = ["test-utils"] }
 commonware-utils.workspace = true
 libfuzzer-sys.workspace = true
 
@@ -23,5 +23,11 @@ doc = false
 [[bin]]
 name = "blob_integrity"
 path = "fuzz_targets/blob_integrity.rs"
+test = false
+doc = false
+
+[[bin]]
+name = "blob_creation"
+path = "fuzz_targets/blob_creation.rs"
 test = false
 doc = false

--- a/runtime/fuzz/Cargo.toml
+++ b/runtime/fuzz/Cargo.toml
@@ -10,6 +10,7 @@ cargo-fuzz = true
 
 [dependencies]
 arbitrary = { workspace = true, features = ["derive"] }
+commonware-cryptography.workspace = true
 commonware-runtime = { workspace = true, features = ["test-utils"] }
 commonware-utils.workspace = true
 libfuzzer-sys.workspace = true

--- a/runtime/fuzz/fuzz_targets/blob_creation.rs
+++ b/runtime/fuzz/fuzz_targets/blob_creation.rs
@@ -1,123 +1,27 @@
 //! Fuzz blob creation recovery after partial header writes.
 //!
-//! Creation writes one canonical header region over a zero-length file, so a crash leaves a
-//! canonical prefix, a persisted length whose unwritten tail reads as zeros, and possibly zero
-//! holes where device writeback persisted bytes out of order. Every such image is classified
-//! by an oracle derived from the header spec: images matching a torn canonical creation must
-//! heal into an empty usable blob, and everything else must fail loudly without mutation.
+//! A [TornCreation] shape is materialized over the canonical V1 region and installed as the
+//! blob's raw contents, and reopening is held to [creation_outcome]: images classifiable as
+//! a torn canonical creation must heal into an empty usable blob, and everything else must
+//! fail loudly without mutation.
 
 #![no_main]
 
 use arbitrary::Arbitrary;
-use commonware_cryptography::Crc32;
 use commonware_runtime::{
     Blob, BufferPooler, ReadOptions, Runner, Storage, WriteOptions, deterministic,
-    mocks::MemoryStorage,
+    mocks::{CreationOutcome, MemoryStorage, TornCreation, creation_outcome},
 };
 use libfuzzer_sys::fuzz_target;
 
 const PARTITION: &str = "blob_creation";
 const PAYLOAD: &[u8] = b"payload!";
-const V0_NAME: &[u8] = b"v0";
-const V1_NAME: &[u8] = b"v1";
+const NAME: &[u8] = b"blob";
 
 #[derive(Arbitrary, Debug)]
 struct FuzzInput {
     blob_version: u16,
-    retained_prefix: u16,
-    persisted_tail: u16,
-    /// Bit `i` zeroes byte `i` of the installed image: a hole torn by out-of-order writeback.
-    /// The low bits cover the parseable header; higher bits fall on padding or off the image.
-    holes: u16,
-}
-
-/// Model a creation write interrupted mid-flight: a canonical prefix survives, the persisted
-/// file length may extend past it (unwritten bytes read as zeros after `set_len(0)`), and
-/// holes mark bytes writeback never persisted. A hole can only zero a byte, never invent one:
-/// creation starts from an empty file, so unwritten storage reads as zeros.
-fn crash_image(canonical: &[u8], input: &FuzzInput) -> Vec<u8> {
-    let retained = usize::from(input.retained_prefix) % (canonical.len() + 1);
-    let persisted =
-        retained + usize::from(input.persisted_tail) % (canonical.len() - retained + 1);
-    let mut image = vec![0u8; persisted];
-    image[..retained].copy_from_slice(&canonical[..retained]);
-    for bit in 0..u16::BITS as usize {
-        if input.holes & (1 << bit) != 0 {
-            if let Some(byte) = image.get_mut(bit) {
-                *byte = 0;
-            }
-        }
-    }
-    image
-}
-
-/// Expected recovery outcome for an installed creation image, derived from the header spec:
-/// `Some(header)` when reopening must succeed and leave that durable header region, `None`
-/// when it must fail without mutating the image.
-///
-/// Mirrors header resolution for images no longer than their creation region. Parsing
-/// preempts healing: an intact header is honored, and a blob version disagreement or nonzero
-/// padding on an otherwise valid region is genuine corruption. Only failures a torn write can
-/// produce (bad magic, runtime version, checksum, truncation) reach the torn-creation
-/// classifier, which accepts a canonical prefix (with any blob version, the CRC binding the
-/// written prelude) followed by zeros.
-fn expected_recovery<'a>(
-    image: &[u8],
-    version: u16,
-    canonical_v0: &'a [u8],
-    canonical_v1: &'a [u8],
-) -> Option<&'a [u8]> {
-    let prelude = canonical_v0.len();
-    let parse_len = prelude + 4;
-    let region = canonical_v1.len();
-
-    // Too short to hold any header: recreated as new regardless of content.
-    if image.len() < prelude {
-        return Some(canonical_v1);
-    }
-    let stamped = u16::from_be_bytes([image[6], image[7]]);
-
-    // An intact V0 magic and runtime version parse as a legacy blob: the stamped version
-    // decides, and a mismatch is a genuine disagreement that never heals. Creation images
-    // never extend a valid V0 header, so a longer image cannot arise here.
-    if image[..6] == canonical_v0[..6] {
-        return (image.len() == prelude && stamped == version).then_some(canonical_v0);
-    }
-
-    // A CRC-validated full V1 region parses: nonzero padding and a stamped version mismatch
-    // are corruption, not torn writes. A valid CRC over a truncated region still falls
-    // through to the classifier.
-    if image[..6] == canonical_v1[..6]
-        && image.len() >= parse_len
-        && image[prelude..parse_len] == Crc32::checksum(&image[..prelude]).to_be_bytes()
-        && image.len() >= region
-    {
-        if image[parse_len..].iter().any(|&byte| byte != 0) {
-            return None;
-        }
-        return (stamped == version).then_some(canonical_v1);
-    }
-
-    // Torn-creation classifier: the written prefix ends at the last nonzero byte, must match
-    // the canonical V1 region (blob version free, CRC bytes prefixing the CRC over the
-    // written prelude), and everything past it must be zero.
-    if image.len() > region {
-        return None;
-    }
-    let head_len = image.len().min(parse_len);
-    if image[head_len..].iter().any(|&byte| byte != 0) {
-        return None;
-    }
-    let head = &image[..head_len];
-    let written = head.iter().rposition(|&byte| byte != 0).map_or(0, |i| i + 1);
-    let canonical = if written <= prelude {
-        head[..written.min(6)] == canonical_v1[..written.min(6)]
-    } else {
-        head[..6] == canonical_v1[..6]
-            && head[prelude..written]
-                == Crc32::checksum(&head[..prelude]).to_be_bytes()[..written - prelude]
-    };
-    canonical.then_some(canonical_v1)
+    torn: TornCreation,
 }
 
 /// Verify that a recoverable creation crash image heals into an empty, usable blob.
@@ -184,34 +88,28 @@ fn fuzz(input: FuzzInput) {
 
         // Create the canonical V1 region through the same storage path used in production.
         let (blob, size, version) = storage
-            .open_versioned(PARTITION, V1_NAME, versions.clone())
+            .open_versioned(PARTITION, NAME, versions)
             .await
             .expect("initial blob creation failed");
         assert_eq!(size, 0);
         assert_eq!(version, input.blob_version);
         drop(blob);
-        let canonical_v1 = storage
-            .raw_blob(PARTITION, V1_NAME)
+        let canonical = storage
+            .raw_blob(PARTITION, NAME)
             .expect("created blob has no durable image");
 
-        // Create a canonical V0 region through the pre-V1 storage path.
-        let (blob, size, version) = storage
-            .open_versioned_v0(PARTITION, V0_NAME, versions)
-            .expect("legacy blob creation failed");
-        assert_eq!(size, 0);
-        assert_eq!(version, input.blob_version);
-        drop(blob);
-        let canonical_v0 = storage
-            .raw_blob(PARTITION, V0_NAME)
-            .expect("created legacy blob has no durable image");
-
-        // Install a crash image over each canonical blob and hold recovery to the oracle.
-        for (name, canonical) in [(V1_NAME, &canonical_v1), (V0_NAME, &canonical_v0)] {
-            let image = crash_image(canonical, &input);
-            storage.set_raw_blob(PARTITION, name, image.clone());
-            match expected_recovery(&image, input.blob_version, &canonical_v0, &canonical_v1) {
-                Some(header) => assert_recovers(&storage, name, input.blob_version, header).await,
-                None => assert_rejects(&storage, name, input.blob_version, &image).await,
+        // Install a crash image over the canonical blob and hold recovery to the oracle.
+        let image = input.torn.image(&canonical);
+        storage.set_raw_blob(PARTITION, NAME, image.clone());
+        match creation_outcome(&image, input.blob_version) {
+            CreationOutcome::Recreated => {
+                assert_recovers(&storage, NAME, input.blob_version, &canonical).await
+            }
+            CreationOutcome::Kept => {
+                assert_recovers(&storage, NAME, input.blob_version, &image).await
+            }
+            CreationOutcome::Rejected => {
+                assert_rejects(&storage, NAME, input.blob_version, &image).await
             }
         }
     });

--- a/runtime/fuzz/fuzz_targets/blob_creation.rs
+++ b/runtime/fuzz/fuzz_targets/blob_creation.rs
@@ -1,0 +1,117 @@
+//! Fuzz blob creation recovery after partial header writes.
+
+#![no_main]
+
+use arbitrary::Arbitrary;
+use commonware_runtime::{
+    Blob, BufferPooler, ReadOptions, Runner, Storage, WriteOptions, deterministic,
+    mocks::MemoryStorage,
+};
+use libfuzzer_sys::fuzz_target;
+
+const PARTITION: &str = "blob_creation";
+const PAYLOAD: &[u8] = b"payload!";
+const V0_NAME: &[u8] = b"v0";
+const V1_NAME: &[u8] = b"v1";
+
+#[derive(Arbitrary, Debug)]
+struct FuzzInput {
+    blob_version: u16,
+    retained_prefix: u16,
+    persisted_tail: u16,
+}
+
+/// Verify that a recoverable creation crash image heals into an empty, usable blob.
+async fn assert_recovers(
+    storage: &MemoryStorage,
+    name: &[u8],
+    blob_version: u16,
+    expected_header: &[u8],
+) {
+    let versions = blob_version..=blob_version;
+
+    // Reopen the installed crash image and verify recovery restored its logical metadata.
+    let (blob, size, version) = storage
+        .open_versioned(PARTITION, name, versions.clone())
+        .await
+        .expect("partial blob creation did not recover");
+    assert_eq!(size, 0);
+    assert_eq!(version, blob_version);
+
+    // Inspect durable bytes before writing payload data so only header recovery shaped the image.
+    let healed = storage
+        .raw_blob(PARTITION, name)
+        .expect("recovered blob has no durable image");
+    assert_eq!(healed, expected_header);
+
+    // A synced logical-offset-zero write and another reopen verify the recovered data offset.
+    blob.write_at(0, PAYLOAD, WriteOptions::SYNC)
+        .await
+        .expect("write after creation recovery failed");
+    drop(blob);
+    let (blob, size, version) = storage
+        .open_versioned(PARTITION, name, versions)
+        .await
+        .expect("reopening healed blob failed");
+    assert_eq!(size, PAYLOAD.len() as u64);
+    assert_eq!(version, blob_version);
+    let read = blob
+        .read_at(0, PAYLOAD.len(), ReadOptions::default())
+        .await
+        .expect("reading healed blob failed");
+    assert_eq!(read.coalesce().as_ref(), PAYLOAD);
+}
+
+fn fuzz(input: FuzzInput) {
+    deterministic::Runner::default().start(|context| async move {
+        let storage = MemoryStorage::new(context.storage_buffer_pool().clone());
+        let versions = input.blob_version..=input.blob_version;
+
+        // Create the canonical V1 region through the same storage path used in production.
+        let (blob, size, version) = storage
+            .open_versioned(PARTITION, V1_NAME, versions.clone())
+            .await
+            .expect("initial blob creation failed");
+        assert_eq!(size, 0);
+        assert_eq!(version, input.blob_version);
+        drop(blob);
+        let canonical_v1 = storage
+            .raw_blob(PARTITION, V1_NAME)
+            .expect("created blob has no durable image");
+
+        // Model a partial V1 creation write as a retained canonical prefix. The file length may
+        // stop at that prefix or persist farther, in which case the unwritten tail reads as zeros.
+        let retained = usize::from(input.retained_prefix) % (canonical_v1.len() + 1);
+        let persisted =
+            retained + usize::from(input.persisted_tail) % (canonical_v1.len() - retained + 1);
+        let mut interrupted = vec![0u8; persisted];
+        interrupted[..retained].copy_from_slice(&canonical_v1[..retained]);
+        storage.set_raw_blob(PARTITION, V1_NAME, interrupted);
+        assert_recovers(&storage, V1_NAME, input.blob_version, &canonical_v1).await;
+
+        // Create a canonical V0 region through the pre-V1 storage path, then model a writer that
+        // left only a prefix of its prelude. A complete prelude remains V0; every shorter prefix
+        // is treated as a new blob and recreated V1.
+        let (blob, size, version) = storage
+            .open_versioned_v0(PARTITION, V0_NAME, versions)
+            .expect("legacy blob creation failed");
+        assert_eq!(size, 0);
+        assert_eq!(version, input.blob_version);
+        drop(blob);
+        let canonical_v0 = storage
+            .raw_blob(PARTITION, V0_NAME)
+            .expect("created legacy blob has no durable image");
+        let retained = usize::from(input.retained_prefix) % (canonical_v0.len() + 1);
+        storage.set_raw_blob(PARTITION, V0_NAME, canonical_v0[..retained].to_vec());
+        let expected_header = if retained == canonical_v0.len() {
+            canonical_v0.as_slice()
+        } else {
+            canonical_v1.as_slice()
+        };
+        assert_recovers(&storage, V0_NAME, input.blob_version, expected_header).await;
+    });
+}
+
+fuzz_target!(|input: FuzzInput| {
+    fuzz(input);
+});

--- a/runtime/fuzz/fuzz_targets/blob_creation.rs
+++ b/runtime/fuzz/fuzz_targets/blob_creation.rs
@@ -1,16 +1,12 @@
-//! Fuzz blob creation recovery after partial header writes.
-//!
-//! A [TornCreation] shape is materialized over the canonical V1 region and installed as the
-//! blob's raw contents, and reopening is held to [creation_outcome]: images classifiable as
-//! a torn canonical creation must heal into an empty usable blob, and everything else must
-//! fail loudly without mutation.
+//! Fuzz blob recovery from arbitrary durable images.
 
 #![no_main]
 
-use arbitrary::Arbitrary;
+use arbitrary::{Arbitrary, Result, Unstructured};
+use commonware_cryptography::Crc32;
 use commonware_runtime::{
     Blob, BufferPooler, ReadOptions, Runner, Storage, WriteOptions, deterministic,
-    mocks::{CreationOutcome, MemoryStorage, TornCreation, creation_outcome},
+    mocks::MemoryStorage,
 };
 use libfuzzer_sys::fuzz_target;
 
@@ -18,10 +14,113 @@ const PARTITION: &str = "blob_creation";
 const PAYLOAD: &[u8] = b"payload!";
 const NAME: &[u8] = b"blob";
 
+/// Header spec constants (see runtime/src/storage/header.rs): the prelude, the prelude plus
+/// its V1 CRC, the V1 region size, and each layout's magic plus runtime version bytes. The
+/// V1 values are asserted against a real creation before every image is classified.
+const PRELUDE: usize = 8;
+const PARSE_LEN: usize = 12;
+const REGION: usize = 4096;
+const V0_PREFIX: [u8; 6] = *b"CWIC\x00\x00";
+const V1_PREFIX: [u8; 6] = *b"CWIK\x00\x01";
+
+/// Bound the image to the sizes recovery distinguishes: everything past the region plus a
+/// small payload margin behaves identically.
+fn bounded_image(u: &mut Unstructured<'_>) -> Result<Vec<u8>> {
+    let len = u.int_in_range(0..=REGION + PRELUDE)?;
+    Ok(u.bytes(len.min(u.len()))?.to_vec())
+}
+
 #[derive(Arbitrary, Debug)]
 struct FuzzInput {
     blob_version: u16,
-    torn: TornCreation,
+    /// Raw durable contents installed as the blob's crash image.
+    #[arbitrary(with = bounded_image)]
+    image: Vec<u8>,
+}
+
+/// Required recovery outcome when a blob's raw contents are an arbitrary image.
+enum CreationOutcome {
+    /// The open succeeds and recreates the canonical V1 region for the requested version.
+    Recreated,
+    /// The open succeeds against the intact header, leaving the contents unchanged, with
+    /// the given logical size.
+    Kept { size: u64 },
+    /// The open fails without mutating the contents.
+    Rejected,
+}
+
+/// Classify the required recovery outcome for an installed image, per the header spec: a
+/// sub-prelude file is always recreated, a parseable header is honored before healing is
+/// considered (a blob version disagreement or nonzero padding on an intact region never
+/// heals), and only failures a torn write can produce fall through to the torn-creation
+/// classifier, which accepts a canonical prefix (with any blob version, the CRC binding the
+/// written prelude) followed by zeros.
+fn creation_outcome(image: &[u8], version: u16) -> CreationOutcome {
+    // Too short to hold any header: recreated as new regardless of content.
+    if image.len() < PRELUDE {
+        return CreationOutcome::Recreated;
+    }
+    let stamped = u16::from_be_bytes([image[6], image[7]]);
+
+    // An intact V0 magic and runtime version parse as a legacy blob: the stamped version
+    // decides, and a mismatch is a genuine disagreement that never heals.
+    if image[..6] == V0_PREFIX {
+        return if stamped == version {
+            CreationOutcome::Kept {
+                size: (image.len() - PRELUDE) as u64,
+            }
+        } else {
+            CreationOutcome::Rejected
+        };
+    }
+
+    // A CRC-validated full V1 region parses: nonzero padding and a stamped version mismatch
+    // are corruption, not torn writes. A valid CRC over a truncated region still falls
+    // through to the torn-creation classifier.
+    if image[..6] == V1_PREFIX
+        && image.len() >= PARSE_LEN
+        && image[PRELUDE..PARSE_LEN] == Crc32::checksum(&image[..PRELUDE]).to_be_bytes()
+        && image.len() >= REGION
+    {
+        if image[PARSE_LEN..REGION].iter().any(|&byte| byte != 0) {
+            return CreationOutcome::Rejected;
+        }
+        return if stamped == version {
+            CreationOutcome::Kept {
+                size: (image.len() - REGION) as u64,
+            }
+        } else {
+            CreationOutcome::Rejected
+        };
+    }
+
+    // Torn-creation classifier: the written prefix ends at the last nonzero byte, must match
+    // a canonical V1 region (blob version free, CRC bytes prefixing the CRC over the written
+    // prelude), and everything past it must be zero.
+    if image.len() > REGION {
+        return CreationOutcome::Rejected;
+    }
+    let head_len = image.len().min(PARSE_LEN);
+    if image[head_len..].iter().any(|&byte| byte != 0) {
+        return CreationOutcome::Rejected;
+    }
+    let head = &image[..head_len];
+    let written = head
+        .iter()
+        .rposition(|&byte| byte != 0)
+        .map_or(0, |i| i + 1);
+    let canonical = if written <= PRELUDE {
+        head[..written.min(6)] == V1_PREFIX[..written.min(6)]
+    } else {
+        head[..6] == V1_PREFIX
+            && head[PRELUDE..written]
+                == Crc32::checksum(&head[..PRELUDE]).to_be_bytes()[..written - PRELUDE]
+    };
+    if canonical {
+        CreationOutcome::Recreated
+    } else {
+        CreationOutcome::Rejected
+    }
 }
 
 /// Verify that a recoverable creation crash image heals into an empty, usable blob.
@@ -65,6 +164,27 @@ async fn assert_recovers(
     assert_eq!(read.coalesce().as_ref(), PAYLOAD);
 }
 
+/// Verify that an intact non-empty blob image opens unchanged at its logical size.
+async fn assert_kept(
+    storage: &MemoryStorage,
+    name: &[u8],
+    blob_version: u16,
+    image: &[u8],
+    size: u64,
+) {
+    let versions = blob_version..=blob_version;
+    let (_, opened, version) = storage
+        .open_versioned(PARTITION, name, versions)
+        .await
+        .expect("intact image did not open");
+    assert_eq!(opened, size);
+    assert_eq!(version, blob_version);
+    let raw = storage
+        .raw_blob(PARTITION, name)
+        .expect("opened blob lost its image");
+    assert_eq!(raw, image, "open mutated an intact image");
+}
+
 /// Verify that an unclassifiable crash image fails loudly without being mutated.
 async fn assert_rejects(storage: &MemoryStorage, name: &[u8], blob_version: u16, image: &[u8]) {
     let versions = blob_version..=blob_version;
@@ -86,7 +206,8 @@ fn fuzz(input: FuzzInput) {
         let storage = MemoryStorage::new(context.storage_buffer_pool().clone());
         let versions = input.blob_version..=input.blob_version;
 
-        // Create the canonical V1 region through the same storage path used in production.
+        // Create the canonical V1 region through the same storage path used in production: a
+        // healed image must recreate exactly this, and it anchors the spec constants.
         let (blob, size, version) = storage
             .open_versioned(PARTITION, NAME, versions)
             .await
@@ -97,19 +218,23 @@ fn fuzz(input: FuzzInput) {
         let canonical = storage
             .raw_blob(PARTITION, NAME)
             .expect("created blob has no durable image");
+        assert_eq!(canonical.len(), REGION);
+        assert_eq!(canonical[..6], V1_PREFIX);
 
-        // Install a crash image over the canonical blob and hold recovery to the oracle.
-        let image = input.torn.image(&canonical);
-        storage.set_raw_blob(PARTITION, NAME, image.clone());
-        match creation_outcome(&image, input.blob_version) {
+        // Install the image and hold recovery to the oracle.
+        storage.set_raw_blob(PARTITION, NAME, input.image.clone());
+        match creation_outcome(&input.image, input.blob_version) {
             CreationOutcome::Recreated => {
                 assert_recovers(&storage, NAME, input.blob_version, &canonical).await
             }
-            CreationOutcome::Kept => {
-                assert_recovers(&storage, NAME, input.blob_version, &image).await
+            CreationOutcome::Kept { size: 0 } => {
+                assert_recovers(&storage, NAME, input.blob_version, &input.image).await
+            }
+            CreationOutcome::Kept { size } => {
+                assert_kept(&storage, NAME, input.blob_version, &input.image, size).await
             }
             CreationOutcome::Rejected => {
-                assert_rejects(&storage, NAME, input.blob_version, &image).await
+                assert_rejects(&storage, NAME, input.blob_version, &input.image).await
             }
         }
     });

--- a/runtime/fuzz/fuzz_targets/blob_creation.rs
+++ b/runtime/fuzz/fuzz_targets/blob_creation.rs
@@ -1,8 +1,15 @@
 //! Fuzz blob creation recovery after partial header writes.
+//!
+//! Creation writes one canonical header region over a zero-length file, so a crash leaves a
+//! canonical prefix, a persisted length whose unwritten tail reads as zeros, and possibly zero
+//! holes where device writeback persisted bytes out of order. Every such image is classified
+//! by an oracle derived from the header spec: images matching a torn canonical creation must
+//! heal into an empty usable blob, and everything else must fail loudly without mutation.
 
 #![no_main]
 
 use arbitrary::Arbitrary;
+use commonware_cryptography::Crc32;
 use commonware_runtime::{
     Blob, BufferPooler, ReadOptions, Runner, Storage, WriteOptions, deterministic,
     mocks::MemoryStorage,
@@ -19,6 +26,98 @@ struct FuzzInput {
     blob_version: u16,
     retained_prefix: u16,
     persisted_tail: u16,
+    /// Bit `i` zeroes byte `i` of the installed image: a hole torn by out-of-order writeback.
+    /// The low bits cover the parseable header; higher bits fall on padding or off the image.
+    holes: u16,
+}
+
+/// Model a creation write interrupted mid-flight: a canonical prefix survives, the persisted
+/// file length may extend past it (unwritten bytes read as zeros after `set_len(0)`), and
+/// holes mark bytes writeback never persisted. A hole can only zero a byte, never invent one:
+/// creation starts from an empty file, so unwritten storage reads as zeros.
+fn crash_image(canonical: &[u8], input: &FuzzInput) -> Vec<u8> {
+    let retained = usize::from(input.retained_prefix) % (canonical.len() + 1);
+    let persisted =
+        retained + usize::from(input.persisted_tail) % (canonical.len() - retained + 1);
+    let mut image = vec![0u8; persisted];
+    image[..retained].copy_from_slice(&canonical[..retained]);
+    for bit in 0..u16::BITS as usize {
+        if input.holes & (1 << bit) != 0 {
+            if let Some(byte) = image.get_mut(bit) {
+                *byte = 0;
+            }
+        }
+    }
+    image
+}
+
+/// Expected recovery outcome for an installed creation image, derived from the header spec:
+/// `Some(header)` when reopening must succeed and leave that durable header region, `None`
+/// when it must fail without mutating the image.
+///
+/// Mirrors header resolution for images no longer than their creation region. Parsing
+/// preempts healing: an intact header is honored, and a blob version disagreement or nonzero
+/// padding on an otherwise valid region is genuine corruption. Only failures a torn write can
+/// produce (bad magic, runtime version, checksum, truncation) reach the torn-creation
+/// classifier, which accepts a canonical prefix (with any blob version, the CRC binding the
+/// written prelude) followed by zeros.
+fn expected_recovery<'a>(
+    image: &[u8],
+    version: u16,
+    canonical_v0: &'a [u8],
+    canonical_v1: &'a [u8],
+) -> Option<&'a [u8]> {
+    let prelude = canonical_v0.len();
+    let parse_len = prelude + 4;
+    let region = canonical_v1.len();
+
+    // Too short to hold any header: recreated as new regardless of content.
+    if image.len() < prelude {
+        return Some(canonical_v1);
+    }
+    let stamped = u16::from_be_bytes([image[6], image[7]]);
+
+    // An intact V0 magic and runtime version parse as a legacy blob: the stamped version
+    // decides, and a mismatch is a genuine disagreement that never heals. Creation images
+    // never extend a valid V0 header, so a longer image cannot arise here.
+    if image[..6] == canonical_v0[..6] {
+        return (image.len() == prelude && stamped == version).then_some(canonical_v0);
+    }
+
+    // A CRC-validated full V1 region parses: nonzero padding and a stamped version mismatch
+    // are corruption, not torn writes. A valid CRC over a truncated region still falls
+    // through to the classifier.
+    if image[..6] == canonical_v1[..6]
+        && image.len() >= parse_len
+        && image[prelude..parse_len] == Crc32::checksum(&image[..prelude]).to_be_bytes()
+        && image.len() >= region
+    {
+        if image[parse_len..].iter().any(|&byte| byte != 0) {
+            return None;
+        }
+        return (stamped == version).then_some(canonical_v1);
+    }
+
+    // Torn-creation classifier: the written prefix ends at the last nonzero byte, must match
+    // the canonical V1 region (blob version free, CRC bytes prefixing the CRC over the
+    // written prelude), and everything past it must be zero.
+    if image.len() > region {
+        return None;
+    }
+    let head_len = image.len().min(parse_len);
+    if image[head_len..].iter().any(|&byte| byte != 0) {
+        return None;
+    }
+    let head = &image[..head_len];
+    let written = head.iter().rposition(|&byte| byte != 0).map_or(0, |i| i + 1);
+    let canonical = if written <= prelude {
+        head[..written.min(6)] == canonical_v1[..written.min(6)]
+    } else {
+        head[..6] == canonical_v1[..6]
+            && head[prelude..written]
+                == Crc32::checksum(&head[..prelude]).to_be_bytes()[..written - prelude]
+    };
+    canonical.then_some(canonical_v1)
 }
 
 /// Verify that a recoverable creation crash image heals into an empty, usable blob.
@@ -62,6 +161,22 @@ async fn assert_recovers(
     assert_eq!(read.coalesce().as_ref(), PAYLOAD);
 }
 
+/// Verify that an unclassifiable crash image fails loudly without being mutated.
+async fn assert_rejects(storage: &MemoryStorage, name: &[u8], blob_version: u16, image: &[u8]) {
+    let versions = blob_version..=blob_version;
+    assert!(
+        storage
+            .open_versioned(PARTITION, name, versions)
+            .await
+            .is_err(),
+        "non-canonical crash image was accepted"
+    );
+    let raw = storage
+        .raw_blob(PARTITION, name)
+        .expect("rejected blob lost its image");
+    assert_eq!(raw, image, "rejected open mutated the image");
+}
+
 fn fuzz(input: FuzzInput) {
     deterministic::Runner::default().start(|context| async move {
         let storage = MemoryStorage::new(context.storage_buffer_pool().clone());
@@ -79,19 +194,7 @@ fn fuzz(input: FuzzInput) {
             .raw_blob(PARTITION, V1_NAME)
             .expect("created blob has no durable image");
 
-        // Model a partial V1 creation write as a retained canonical prefix. The file length may
-        // stop at that prefix or persist farther, in which case the unwritten tail reads as zeros.
-        let retained = usize::from(input.retained_prefix) % (canonical_v1.len() + 1);
-        let persisted =
-            retained + usize::from(input.persisted_tail) % (canonical_v1.len() - retained + 1);
-        let mut interrupted = vec![0u8; persisted];
-        interrupted[..retained].copy_from_slice(&canonical_v1[..retained]);
-        storage.set_raw_blob(PARTITION, V1_NAME, interrupted);
-        assert_recovers(&storage, V1_NAME, input.blob_version, &canonical_v1).await;
-
-        // Create a canonical V0 region through the pre-V1 storage path, then model a writer that
-        // left only a prefix of its prelude. A complete prelude remains V0; every shorter prefix
-        // is treated as a new blob and recreated V1.
+        // Create a canonical V0 region through the pre-V1 storage path.
         let (blob, size, version) = storage
             .open_versioned_v0(PARTITION, V0_NAME, versions)
             .expect("legacy blob creation failed");
@@ -101,14 +204,16 @@ fn fuzz(input: FuzzInput) {
         let canonical_v0 = storage
             .raw_blob(PARTITION, V0_NAME)
             .expect("created legacy blob has no durable image");
-        let retained = usize::from(input.retained_prefix) % (canonical_v0.len() + 1);
-        storage.set_raw_blob(PARTITION, V0_NAME, canonical_v0[..retained].to_vec());
-        let expected_header = if retained == canonical_v0.len() {
-            canonical_v0.as_slice()
-        } else {
-            canonical_v1.as_slice()
-        };
-        assert_recovers(&storage, V0_NAME, input.blob_version, expected_header).await;
+
+        // Install a crash image over each canonical blob and hold recovery to the oracle.
+        for (name, canonical) in [(V1_NAME, &canonical_v1), (V0_NAME, &canonical_v0)] {
+            let image = crash_image(canonical, &input);
+            storage.set_raw_blob(PARTITION, name, image.clone());
+            match expected_recovery(&image, input.blob_version, &canonical_v0, &canonical_v1) {
+                Some(header) => assert_recovers(&storage, name, input.blob_version, header).await,
+                None => assert_rejects(&storage, name, input.blob_version, &image).await,
+            }
+        }
     });
 }
 

--- a/runtime/src/mocks.rs
+++ b/runtime/src/mocks.rs
@@ -1,5 +1,7 @@
 //! Mock implementations of runtime primitives for testing.
 
+#[cfg(any(test, feature = "test-utils"))]
+pub use crate::storage::memory::Storage as MemoryStorage;
 use crate::{
     Blob, BufMut, BufferPool, BufferPooler, Clock, Error, Handle, IoBufs, IoBufsMut, Metrics, Name,
     ReadOptions, Spawner, Storage, Supervisor, WriteOptions,

--- a/runtime/src/mocks.rs
+++ b/runtime/src/mocks.rs
@@ -1,9 +1,7 @@
 //! Mock implementations of runtime primitives for testing.
 
 #[cfg(any(test, feature = "test-utils"))]
-pub use crate::storage::memory::{
-    CreationOutcome, Storage as MemoryStorage, TornCreation, creation_outcome,
-};
+pub use crate::storage::memory::Storage as MemoryStorage;
 use crate::{
     Blob, BufMut, BufferPool, BufferPooler, Clock, Error, Handle, IoBufs, IoBufsMut, Metrics, Name,
     ReadOptions, Spawner, Storage, Supervisor, WriteOptions,

--- a/runtime/src/mocks.rs
+++ b/runtime/src/mocks.rs
@@ -1,7 +1,9 @@
 //! Mock implementations of runtime primitives for testing.
 
 #[cfg(any(test, feature = "test-utils"))]
-pub use crate::storage::memory::Storage as MemoryStorage;
+pub use crate::storage::memory::{
+    CreationOutcome, Storage as MemoryStorage, TornCreation, creation_outcome,
+};
 use crate::{
     Blob, BufMut, BufferPool, BufferPooler, Clock, Error, Handle, IoBufs, IoBufsMut, Metrics, Name,
     ReadOptions, Spawner, Storage, Supervisor, WriteOptions,

--- a/runtime/src/storage/faulty.rs
+++ b/runtime/src/storage/faulty.rs
@@ -55,6 +55,42 @@ pub struct WriteConfig {
     pub mode: PartialWriteMode,
 }
 
+#[cfg(feature = "arbitrary")]
+const WRITE_CONFIG_RATE_STEPS: u16 = 101;
+#[cfg(feature = "arbitrary")]
+const WRITE_CONFIG_RATE_PAIRS: u16 = WRITE_CONFIG_RATE_STEPS * WRITE_CONFIG_RATE_STEPS;
+#[cfg(feature = "arbitrary")]
+const WRITE_CONFIG_CELLS: u16 = WRITE_CONFIG_RATE_PAIRS * 2;
+
+#[cfg(feature = "arbitrary")]
+fn write_config_from_cell(cell: u16) -> WriteConfig {
+    let rates = cell % WRITE_CONFIG_RATE_PAIRS;
+    let failure = rates % WRITE_CONFIG_RATE_STEPS;
+    let retention = rates / WRITE_CONFIG_RATE_STEPS;
+    WriteConfig {
+        failure_rate: Probability::new(u64::from(failure), 100).unwrap(),
+        retention_rate: Probability::new(u64::from(retention), 100).unwrap(),
+        mode: if cell < WRITE_CONFIG_RATE_PAIRS {
+            PartialWriteMode::Prefix
+        } else {
+            PartialWriteMode::Subset
+        },
+    }
+}
+
+#[cfg(feature = "arbitrary")]
+impl<'a> arbitrary::Arbitrary<'a> for WriteConfig {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        Ok(write_config_from_cell(
+            u.int_in_range(0..=WRITE_CONFIG_CELLS - 1)?,
+        ))
+    }
+
+    fn size_hint(_: usize) -> (usize, Option<usize>) {
+        (2, Some(2))
+    }
+}
+
 /// Fault configuration for `resize` operations and partial failure behavior.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct ResizeConfig {
@@ -870,6 +906,38 @@ mod tests {
         sync::atomic::AtomicBool,
         task::{Context, Poll},
     };
+
+    #[cfg(feature = "arbitrary")]
+    #[test]
+    fn test_write_config_arbitrary_is_compact_and_covers_grid() {
+        use arbitrary::{Arbitrary as _, Unstructured};
+
+        assert_eq!(WriteConfig::size_hint(0), (2, Some(2)));
+        let mut input = Unstructured::new(&[0, 0, 0]);
+        WriteConfig::arbitrary(&mut input).unwrap();
+        assert_eq!(input.len(), 1);
+
+        for cell in 0..WRITE_CONFIG_CELLS {
+            let config = write_config_from_cell(cell);
+            let rates = cell % WRITE_CONFIG_RATE_PAIRS;
+            assert_eq!(
+                config.failure_rate,
+                Probability::new(u64::from(rates % WRITE_CONFIG_RATE_STEPS), 100).unwrap()
+            );
+            assert_eq!(
+                config.retention_rate,
+                Probability::new(u64::from(rates / WRITE_CONFIG_RATE_STEPS), 100).unwrap()
+            );
+            assert_eq!(
+                config.mode,
+                if cell < WRITE_CONFIG_RATE_PAIRS {
+                    PartialWriteMode::Prefix
+                } else {
+                    PartialWriteMode::Subset
+                }
+            );
+        }
+    }
 
     #[derive(Clone)]
     struct OperationGate<B> {

--- a/runtime/src/storage/header.rs
+++ b/runtime/src/storage/header.rs
@@ -96,8 +96,8 @@ stability_scope!(BETA {
     /// contents: the application-owned blob version passed to
     /// [crate::Storage::open_versioned] is a separate field and is unaffected by the layout.
     ///
-    /// New blobs are always created with the latest layout. Reopening an existing blob honors
-    /// the layout recorded in its header.
+    /// Production storage creates new blobs with the latest layout. Reopening an existing blob
+    /// honors the layout recorded in its header.
     #[derive(Clone, Copy, Debug, PartialEq, Eq)]
     pub(crate) enum Layout {
         /// An 8-byte header, with data beginning immediately after it.
@@ -318,18 +318,31 @@ stability_scope!(BETA {
         /// a torn write cannot splice old bytes into a fully valid header with a wrong version:
         /// every partial state in the canonical-prefix model then remains classifiable as an
         /// interrupted creation.
+        #[cfg(test)]
         pub(crate) fn create(versions: &RangeInclusive<u16>) -> (Vec<u8>, u16) {
-            let layout = Layout::V1;
+            Self::create_for_layout(Layout::V1, versions)
+        }
+
+        /// Creates a header region in a specific layout for compatibility tests.
+        pub(crate) fn create_for_layout(
+            layout: Layout,
+            versions: &RangeInclusive<u16>,
+        ) -> (Vec<u8>, u16) {
             let blob_version = *versions.end();
             let header = Self {
                 magic: layout.magic(),
                 runtime_version: layout.runtime_version(),
                 blob_version,
             };
-            let mut region = Vec::with_capacity(Layout::V1.data_offset() as usize);
+            let mut region = Vec::with_capacity(layout.data_offset() as usize);
             region.extend_from_slice(&header.encode());
-            let crc = Crc32::checksum(&region);
-            region.extend_from_slice(&crc.to_be_bytes());
+            match layout {
+                Layout::V0 => {}
+                Layout::V1 => {
+                    let crc = Crc32::checksum(&region);
+                    region.extend_from_slice(&crc.to_be_bytes());
+                }
+            }
             region.resize(layout.data_offset() as usize, 0);
             (region, blob_version)
         }
@@ -493,25 +506,42 @@ pub(crate) mod tests {
     /// Raw bytes of a legacy V0 blob: an 8-byte header followed immediately by `payload`, as a
     /// pre-V1 writer laid them out.
     pub(crate) fn v0_blob_bytes(blob_version: u16, payload: &[u8]) -> Vec<u8> {
-        let mut raw = v0_header(blob_version).encode().to_vec();
+        let (mut raw, _) = Header::create_for_layout(Layout::V0, &(blob_version..=blob_version));
         raw.extend_from_slice(payload);
         raw
     }
 
     /// Raw bytes of a V1 blob with the given version, followed by `payload`.
     pub(crate) fn v1_blob_bytes(blob_version: u16, payload: &[u8]) -> Vec<u8> {
-        let header = Header {
-            magic: Layout::V1.magic(),
-            runtime_version: Layout::V1.runtime_version(),
-            blob_version,
-        };
-        let mut raw = Vec::with_capacity(Layout::V1.data_offset() as usize + payload.len());
-        raw.extend_from_slice(&header.encode());
-        let crc = commonware_cryptography::Crc32::checksum(&raw);
-        raw.extend_from_slice(&crc.to_be_bytes());
-        raw.resize(Layout::V1.data_offset() as usize, 0);
+        let (mut raw, _) = Header::create(&(blob_version..=blob_version));
         raw.extend_from_slice(payload);
         raw
+    }
+
+    #[test]
+    fn test_header_create_v0() {
+        let (region, blob_version) = Header::create_for_layout(Layout::V0, &(0..=7));
+        assert_eq!(blob_version, 7);
+        assert_eq!(region.len(), Layout::V0.data_offset() as usize);
+
+        let (size, parsed_blob_version, data_offset) =
+            Header::parse(&region, Layout::V0.data_offset(), &(0..=7)).unwrap();
+        assert_eq!(size, 0);
+        assert_eq!(parsed_blob_version, 7);
+        assert_eq!(data_offset, Layout::V0.data_offset());
+    }
+
+    #[test]
+    fn test_header_v0_fixture_bytes() {
+        let (region, _) = Header::create_for_layout(Layout::V0, &(3..=3));
+        assert_eq!(
+            region,
+            [
+                b'C', b'W', b'I', b'C', // V0 magic
+                0x00, 0x00, // runtime version 0
+                0x00, 0x03, // blob version 3
+            ]
+        );
     }
 
     #[test]
@@ -793,7 +823,7 @@ pub(crate) mod tests {
         }
     }
 
-    /// This runtime never creates V0 blobs, so no contents qualify as an interrupted V0
+    /// Production storage never creates V0 blobs, so no contents qualify as an interrupted V0
     /// creation, including ones that heal under V1.
     #[test]
     fn test_layout_v0_interrupted_creation_rejects_all() {

--- a/runtime/src/storage/header.rs
+++ b/runtime/src/storage/header.rs
@@ -193,8 +193,8 @@ stability_scope!(BETA {
         /// Returns true if a blob's raw contents are consistent with the creation of a
         /// blob with this layout that was interrupted before its header became durable.
         ///
-        /// This runtime never creates [Layout::V0] blobs, so no contents qualify for V0 (a
-        /// pre-V1 writer's torn creation is a sub-prelude file, healed as new before any
+        /// Production storage never creates [Layout::V0] blobs, so no contents qualify for V0
+        /// (a pre-V1 writer's torn creation is a sub-prelude file, healed as new before any
         /// parsing).
         ///
         /// [Layout::V1] creation writes the region with set_len(0) -> write -> sync, and
@@ -310,21 +310,16 @@ stability_scope!(BETA {
             }
         }
 
-        /// Creates the header region for a new blob using the latest version from the range and
-        /// the latest header layout. Returns (encoded header region, blob version); the data
-        /// offset is the region's length.
+        /// Creates the header region for a new blob in the given layout using the latest version
+        /// from the range. Returns (encoded header region, blob version); the data offset is the
+        /// region's length. Production storage creates [Layout::V1] regions; other layouts exist
+        /// for compatibility tests.
         ///
         /// Callers writing this region over an existing blob must truncate it to zero first, so
         /// a torn write cannot splice old bytes into a fully valid header with a wrong version:
         /// every partial state in the canonical-prefix model then remains classifiable as an
         /// interrupted creation.
-        #[cfg(test)]
-        pub(crate) fn create(versions: &RangeInclusive<u16>) -> (Vec<u8>, u16) {
-            Self::create_for_layout(Layout::V1, versions)
-        }
-
-        /// Creates a header region in a specific layout for compatibility tests.
-        pub(crate) fn create_for_layout(
+        pub(crate) fn create(
             layout: Layout,
             versions: &RangeInclusive<u16>,
         ) -> (Vec<u8>, u16) {
@@ -506,21 +501,21 @@ pub(crate) mod tests {
     /// Raw bytes of a legacy V0 blob: an 8-byte header followed immediately by `payload`, as a
     /// pre-V1 writer laid them out.
     pub(crate) fn v0_blob_bytes(blob_version: u16, payload: &[u8]) -> Vec<u8> {
-        let (mut raw, _) = Header::create_for_layout(Layout::V0, &(blob_version..=blob_version));
+        let (mut raw, _) = Header::create(Layout::V0, &(blob_version..=blob_version));
         raw.extend_from_slice(payload);
         raw
     }
 
     /// Raw bytes of a V1 blob with the given version, followed by `payload`.
     pub(crate) fn v1_blob_bytes(blob_version: u16, payload: &[u8]) -> Vec<u8> {
-        let (mut raw, _) = Header::create(&(blob_version..=blob_version));
+        let (mut raw, _) = Header::create(Layout::V1, &(blob_version..=blob_version));
         raw.extend_from_slice(payload);
         raw
     }
 
     #[test]
     fn test_header_create_v0() {
-        let (region, blob_version) = Header::create_for_layout(Layout::V0, &(0..=7));
+        let (region, blob_version) = Header::create(Layout::V0, &(0..=7));
         assert_eq!(blob_version, 7);
         assert_eq!(region.len(), Layout::V0.data_offset() as usize);
 
@@ -533,7 +528,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_header_v0_fixture_bytes() {
-        let (region, _) = Header::create_for_layout(Layout::V0, &(3..=3));
+        let (region, _) = Header::create(Layout::V0, &(3..=3));
         assert_eq!(
             region,
             [
@@ -546,7 +541,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_header_create_v1() {
-        let (region, blob_version) = Header::create(&(0..=7));
+        let (region, blob_version) = Header::create(Layout::V1, &(0..=7));
         assert_eq!(blob_version, 7);
         assert_eq!(region.len(), Layout::V1.data_offset() as usize);
 
@@ -565,7 +560,7 @@ pub(crate) mod tests {
     /// (the padding is asserted zero in [test_header_create_v1]).
     #[test]
     fn test_header_v1_fixture_bytes() {
-        let (region, _) = Header::create(&(3..=3));
+        let (region, _) = Header::create(Layout::V1, &(3..=3));
         let expected = [
             b'C', b'W', b'I', b'K', // V1 magic
             0x00, 0x01, // runtime version 1
@@ -579,7 +574,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_header_extension_rejects_bad_crc() {
-        let (mut region, _) = Header::create(&(0..=0));
+        let (mut region, _) = Header::create(Layout::V1, &(0..=0));
         region[Header::PARSE_LEN - 1] ^= 0x01;
         let result = Header::parse(&region, Layout::V1.data_offset(), &(0..=0));
         assert!(matches!(result, Err(HeaderError::InvalidChecksum)));
@@ -587,7 +582,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_header_extension_rejects_truncated_region() {
-        let (region, _) = Header::create(&(0..=0));
+        let (region, _) = Header::create(Layout::V1, &(0..=0));
         let result = Header::parse(
             &region[..Layout::V1.data_offset() as usize - 1],
             Layout::V1.data_offset() - 1,
@@ -602,7 +597,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_header_v1_rejects_nonzero_padding() {
-        let (mut region, _) = Header::create(&(0..=0));
+        let (mut region, _) = Header::create(Layout::V1, &(0..=0));
         region[Header::PARSE_LEN] = 0x01;
         let result = Header::parse(&region, Layout::V1.data_offset(), &(0..=0));
         assert!(matches!(result, Err(HeaderError::InvalidPadding)));
@@ -827,7 +822,7 @@ pub(crate) mod tests {
     /// creation, including ones that heal under V1.
     #[test]
     fn test_layout_v0_interrupted_creation_rejects_all() {
-        let (region, _) = Header::create(&(0..=0));
+        let (region, _) = Header::create(Layout::V1, &(0..=0));
         assert!(Layout::V1.interrupted_creation(&region[..10]));
         assert!(!Layout::V0.interrupted_creation(&region[..10]));
         assert!(!Layout::V0.interrupted_creation(&[]));

--- a/runtime/src/storage/iouring.rs
+++ b/runtime/src/storage/iouring.rs
@@ -168,8 +168,7 @@ impl crate::Storage for Storage {
                 sync_dir(&self.storage_directory)?;
 
                 // Truncate to zero before writing, per the [Header::create] contract.
-                let (region, blob_version) =
-                    Header::create_for_layout(crate::storage::Layout::V1, &versions);
+                let (region, blob_version) = Header::create(crate::storage::Layout::V1, &versions);
                 let data_offset = region.len() as u64;
                 file.set_len(0)
                     .map_err(|e| Error::BlobResizeFailed(partition.into(), hex(name), e.into()))?;

--- a/runtime/src/storage/iouring.rs
+++ b/runtime/src/storage/iouring.rs
@@ -168,7 +168,8 @@ impl crate::Storage for Storage {
                 sync_dir(&self.storage_directory)?;
 
                 // Truncate to zero before writing, per the [Header::create] contract.
-                let (region, blob_version) = Header::create(&versions);
+                let (region, blob_version) =
+                    Header::create_for_layout(crate::storage::Layout::V1, &versions);
                 let data_offset = region.len() as u64;
                 file.set_len(0)
                     .map_err(|e| Error::BlobResizeFailed(partition.into(), hex(name), e.into()))?;

--- a/runtime/src/storage/memory.rs
+++ b/runtime/src/storage/memory.rs
@@ -1,4 +1,4 @@
-use super::Header;
+use super::{Header, Layout};
 use crate::{
     Buf, BufferPool, Handle, IoBufs, IoBufsMut, ReadOptions, WriteOptions,
     deterministic::AuditHasher,
@@ -84,6 +84,55 @@ impl Storage {
     pub(crate) fn from_snapshot(snapshot: Snapshot, pool: BufferPool) -> Self {
         Self::with_partitions(snapshot.0, pool)
     }
+
+    fn open_versioned_with_layout(
+        &self,
+        partition: &str,
+        name: &[u8],
+        layout: Layout,
+        versions: RangeInclusive<u16>,
+    ) -> Result<(Blob, u64, u16), crate::Error> {
+        super::validate_partition_name(partition)?;
+
+        let key = (partition.to_string(), name.to_vec());
+        let mut generations = self.generations.lock();
+        let mut partitions = self.partitions.lock();
+        let partition_entry = partitions.entry(partition.into()).or_default();
+        let content = partition_entry.entry(name.into()).or_default();
+
+        // Handle header: existing blobs have their header read; new blobs and blobs left torn
+        // by an interrupted creation get a fresh header written.
+        let existing = resolve_header(content, &versions, partition, name)?;
+        let (logical_size, blob_version, data_offset, generation) = match existing {
+            Some((logical_size, blob_version, data_offset)) => (
+                logical_size,
+                blob_version,
+                data_offset,
+                generations.get_or_insert(&key),
+            ),
+            None => {
+                let (region, blob_version) = Header::create_for_layout(layout, &versions);
+                let data_offset = region.len() as u64;
+                content.clear();
+                content.extend_from_slice(&region);
+                (0, blob_version, data_offset, generations.rotate(&key))
+            }
+        };
+
+        Ok((
+            Blob::new(
+                self.partitions.clone(),
+                self.generations.clone(),
+                key,
+                content.clone(),
+                self.pool.clone(),
+                data_offset,
+                generation,
+            ),
+            logical_size,
+            blob_version,
+        ))
+    }
 }
 
 impl Storage {
@@ -106,6 +155,36 @@ impl Storage {
 
         hasher.finalize()
     }
+
+    /// Return a copy of a blob's durable raw contents without interpreting its container header.
+    #[cfg(any(test, feature = "test-utils"))]
+    pub fn raw_blob(&self, partition: &str, name: &[u8]) -> Option<Vec<u8>> {
+        self.partitions.lock().get(partition)?.get(name).cloned()
+    }
+
+    /// Install durable raw contents without validating the blob's container header.
+    #[cfg(any(test, feature = "test-utils"))]
+    pub fn set_raw_blob(&self, partition: &str, name: &[u8], content: Vec<u8>) {
+        let key = (partition.to_string(), name.to_vec());
+        let mut generations = self.generations.lock();
+        let mut partitions = self.partitions.lock();
+        generations.current.remove(&key);
+        partitions
+            .entry(partition.into())
+            .or_default()
+            .insert(name.into(), content);
+    }
+
+    /// Open a blob, creating missing or recoverable content with the legacy V0 layout.
+    #[cfg(any(test, feature = "test-utils"))]
+    pub fn open_versioned_v0(
+        &self,
+        partition: &str,
+        name: &[u8],
+        versions: RangeInclusive<u16>,
+    ) -> Result<(Blob, u64, u16), crate::Error> {
+        self.open_versioned_with_layout(partition, name, Layout::V0, versions)
+    }
 }
 
 impl crate::Storage for Storage {
@@ -117,46 +196,7 @@ impl crate::Storage for Storage {
         name: &[u8],
         versions: RangeInclusive<u16>,
     ) -> Result<(Self::Blob, u64, u16), crate::Error> {
-        super::validate_partition_name(partition)?;
-
-        let key = (partition.to_string(), name.to_vec());
-        let mut generations = self.generations.lock();
-        let mut partitions = self.partitions.lock();
-        let partition_entry = partitions.entry(partition.into()).or_default();
-        let content = partition_entry.entry(name.into()).or_default();
-
-        // Handle header: existing blobs have their header read; new blobs and blobs left torn
-        // by an interrupted creation get a fresh header written.
-        let existing = resolve_header(content, &versions, partition, name)?;
-        let (logical_size, blob_version, data_offset, generation) = match existing {
-            Some((logical_size, blob_version, data_offset)) => (
-                logical_size,
-                blob_version,
-                data_offset,
-                generations.get_or_insert(&key),
-            ),
-            None => {
-                let (region, blob_version) = Header::create(&versions);
-                let data_offset = region.len() as u64;
-                content.clear();
-                content.extend_from_slice(&region);
-                (0, blob_version, data_offset, generations.rotate(&key))
-            }
-        };
-
-        Ok((
-            Blob::new(
-                self.partitions.clone(),
-                self.generations.clone(),
-                key,
-                content.clone(),
-                self.pool.clone(),
-                data_offset,
-                generation,
-            ),
-            logical_size,
-            blob_version,
-        ))
+        self.open_versioned_with_layout(partition, name, Layout::V1, versions)
     }
 
     async fn remove(&self, partition: &str, name: Option<&[u8]>) -> Result<(), crate::Error> {
@@ -464,9 +504,17 @@ mod tests {
     use super::{Header, *};
     use crate::{
         Blob, BufferPoolConfig, Storage as _,
-        storage::{Layout, tests::run_storage_tests},
+        deterministic::BoxDynRng,
+        storage::{
+            Layout,
+            faulty::{
+                Config as FaultConfig, PartialWriteMode, Storage as FaultyStorage, WriteConfig,
+            },
+            tests::run_storage_tests,
+        },
         telemetry::metrics::Registry,
     };
+    use commonware_utils::{ScriptedRng, probability};
 
     fn test_pool() -> BufferPool {
         let mut registry = Registry::default();
@@ -500,6 +548,47 @@ mod tests {
         drop(sync);
         let (_, sync_len) = storage.open("partition", b"sync").await.unwrap();
         assert_eq!(sync_len, 0);
+    }
+
+    #[tokio::test]
+    async fn test_set_raw_blob_retires_live_generation() {
+        const PARTITION: &str = "partition";
+        const NAME: &[u8] = b"blob";
+        const INSTALLED: &[u8] = b"current";
+
+        let storage = Storage::new(test_pool());
+        let (stale, _) = storage.open(PARTITION, NAME).await.unwrap();
+        stale
+            .write_at(0, b"stale", WriteOptions::default())
+            .await
+            .unwrap();
+
+        let installed = crate::storage::header::tests::v1_blob_bytes(0, INSTALLED);
+        storage.set_raw_blob(PARTITION, NAME, installed.clone());
+
+        assert!(matches!(
+            stale.sync().await,
+            Err(crate::Error::BlobMissing(_, _))
+        ));
+        assert_eq!(
+            storage.raw_blob(PARTITION, NAME).as_deref(),
+            Some(installed.as_slice())
+        );
+
+        let (fresh, size, version) = storage
+            .open_versioned(PARTITION, NAME, 0..=0)
+            .await
+            .unwrap();
+        assert_eq!(size, INSTALLED.len() as u64);
+        assert_eq!(version, 0);
+        assert_eq!(
+            fresh
+                .read_at(0, INSTALLED.len(), ReadOptions::default())
+                .await
+                .unwrap()
+                .coalesce(),
+            INSTALLED
+        );
     }
 
     #[tokio::test]
@@ -571,6 +660,162 @@ mod tests {
                 .unwrap()
                 .coalesce(),
             b"new!"
+        );
+    }
+
+    #[derive(Clone, Copy, Debug)]
+    enum SubsetWriteCut {
+        FailedWrite,
+        Crash,
+    }
+
+    async fn assert_subset_write_preserves_header(layout: Layout, cut: SubsetWriteCut) {
+        // Alternating case makes a retained subset distinguishable from a contiguous prefix.
+        const ORIGINAL: &[u8] = b"abcdefghijklmnop";
+        const REPLACEMENT: &[u8] = b"ABCDEFGHIJKLMNOP";
+        const RETAINED: &[u8] = b"AbCdEfGhIjKlMnOp";
+        const PARTITION: &str = "partition";
+        const NAME: &[u8] = b"blob";
+
+        // Seed a canonical image so both layouts enter the same logical blob interface.
+        let inner = Storage::new(test_pool());
+        let raw = match layout {
+            Layout::V0 => crate::storage::header::tests::v0_blob_bytes(0, ORIGINAL),
+            Layout::V1 => crate::storage::header::tests::v1_blob_bytes(0, ORIGINAL),
+        };
+        let data_offset = layout.data_offset() as usize;
+        let expected_header = raw[..data_offset].to_vec();
+        inner.set_raw_blob(PARTITION, NAME, raw);
+
+        // Select whether the subset is retained by a failed write or by a later crash, and script
+        // alternating per-byte retention decisions for an exact expected image.
+        let failure_rate = match cut {
+            SubsetWriteCut::FailedWrite => probability!(1.0),
+            SubsetWriteCut::Crash => probability!(0.0),
+        };
+        let rng: BoxDynRng = Box::new(ScriptedRng::new(
+            (0..REPLACEMENT.len()).map(|index| if index % 2 == 0 { 0 } else { u64::MAX }),
+        ));
+        let faulty = FaultyStorage::new(
+            inner.clone(),
+            Arc::new(Mutex::new(rng)),
+            Arc::new(RwLock::new(FaultConfig::default().write(WriteConfig {
+                failure_rate,
+                retention_rate: probability!(0.5),
+                mode: PartialWriteMode::Subset,
+            }))),
+        );
+
+        // Apply the overwrite through the faulty wrapper and assert the selected write boundary.
+        let (blob, size, version) = faulty.open_versioned(PARTITION, NAME, 0..=0).await.unwrap();
+        assert_eq!(size, ORIGINAL.len() as u64);
+        assert_eq!(version, 0);
+        let result = blob.write_at(0, REPLACEMENT, WriteOptions::default()).await;
+        match cut {
+            SubsetWriteCut::FailedWrite => {
+                assert!(matches!(result, Err(crate::Error::Io(_))));
+            }
+            SubsetWriteCut::Crash => result.unwrap(),
+        }
+        drop(blob);
+
+        // Failed writes retain their subset immediately, while successful unsynchronized writes
+        // remain volatile. Neither path may address bytes in the container header.
+        let raw = inner.raw_blob(PARTITION, NAME).unwrap();
+        assert_eq!(&raw[..data_offset], expected_header);
+        let expected_payload = match cut {
+            SubsetWriteCut::FailedWrite => RETAINED,
+            SubsetWriteCut::Crash => ORIGINAL,
+        };
+        assert_eq!(&raw[data_offset..], expected_payload);
+
+        // Simulating a crash applies the snapshotted retention policy to the durable payload while
+        // leaving the complete container header unchanged.
+        faulty.crash().unwrap();
+        drop(faulty);
+        let recovered = Storage::from_snapshot(inner.take_snapshot(), test_pool());
+        let raw = recovered.raw_blob(PARTITION, NAME).unwrap();
+        assert_eq!(&raw[..data_offset], expected_header);
+        assert_eq!(&raw[data_offset..], RETAINED);
+
+        // Reopen the crashed image through the versioned API to prove the retained subset remains
+        // a valid logical blob under both layouts.
+        let (blob, size, version) = recovered
+            .open_versioned(PARTITION, NAME, 0..=0)
+            .await
+            .unwrap();
+        assert_eq!(size, ORIGINAL.len() as u64);
+        assert_eq!(version, 0);
+        assert_eq!(
+            blob.read_at(0, ORIGINAL.len(), ReadOptions::default())
+                .await
+                .unwrap()
+                .coalesce(),
+            RETAINED
+        );
+    }
+
+    #[tokio::test]
+    async fn test_subset_write_preserves_v0_and_v1_headers() {
+        for layout in [Layout::V0, Layout::V1] {
+            for cut in [SubsetWriteCut::FailedWrite, SubsetWriteCut::Crash] {
+                assert_subset_write_preserves_header(layout, cut).await;
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_v0_writer_reopens_with_current_layout() {
+        const PARTITION: &str = "legacy";
+        const NAME: &[u8] = b"blob";
+        const PAYLOAD: &[u8] = b"payload";
+        const VERSION: u16 = 7;
+
+        let legacy_writer = Storage::new(test_pool());
+        let (blob, size, version) = legacy_writer
+            .open_versioned_v0(PARTITION, NAME, VERSION..=VERSION)
+            .unwrap();
+        assert_eq!(size, 0);
+        assert_eq!(version, VERSION);
+        blob.write_at(0, PAYLOAD, WriteOptions::SYNC).await.unwrap();
+        drop(blob);
+
+        let data_offset = Layout::V0.data_offset() as usize;
+        let raw = legacy_writer.raw_blob(PARTITION, NAME).unwrap();
+        assert_eq!(&raw[..Header::MAGIC_LENGTH], &Layout::V0.magic());
+        assert_eq!(&raw[data_offset..], PAYLOAD);
+
+        let current = Storage::from_snapshot(legacy_writer.take_snapshot(), test_pool());
+        let (blob, size, version) = current
+            .open_versioned(PARTITION, NAME, VERSION..=VERSION)
+            .await
+            .unwrap();
+        assert_eq!(size, PAYLOAD.len() as u64);
+        assert_eq!(version, VERSION);
+        assert_eq!(
+            blob.read_at(0, PAYLOAD.len(), ReadOptions::default())
+                .await
+                .unwrap()
+                .coalesce(),
+            PAYLOAD
+        );
+
+        blob.write_at(PAYLOAD.len() as u64, b"!", WriteOptions::SYNC)
+            .await
+            .unwrap();
+        drop(blob);
+        let (blob, size, version) = current
+            .open_versioned(PARTITION, NAME, VERSION..=VERSION)
+            .await
+            .unwrap();
+        assert_eq!(size, (PAYLOAD.len() + 1) as u64);
+        assert_eq!(version, VERSION);
+        assert_eq!(
+            blob.read_at(0, PAYLOAD.len() + 1, ReadOptions::default())
+                .await
+                .unwrap()
+                .coalesce(),
+            b"payload!"
         );
     }
 

--- a/runtime/src/storage/memory.rs
+++ b/runtime/src/storage/memory.rs
@@ -988,6 +988,7 @@ mod tests {
                             *byte = 0;
                         }
                     }
+
                     // Expected outcome per the header spec: a sub-prelude file is always
                     // recreated, an intact prelude parses (the stamped version decides,
                     // and only the version bytes can differ once the first six match), and
@@ -1009,6 +1010,7 @@ mod tests {
                         Expect::Rejected
                     };
 
+                    // Install the image, reopen, and hold recovery to the expected outcome.
                     storage.set_raw_blob("partition", b"v0", image.clone());
                     let result = storage
                         .open_versioned("partition", b"v0", versions.clone())

--- a/runtime/src/storage/memory.rs
+++ b/runtime/src/storage/memory.rs
@@ -84,6 +84,28 @@ impl Storage {
     pub(crate) fn from_snapshot(snapshot: Snapshot, pool: BufferPool) -> Self {
         Self::with_partitions(snapshot.0, pool)
     }
+}
+
+impl Storage {
+    /// Compute a SHA-256 digest of all blob contents.
+    pub fn audit(&self) -> [u8; 32] {
+        let partitions = self.partitions.lock();
+        let mut hasher = AuditHasher::new();
+        hasher.update(b"commonware-runtime-storage-audit-v1");
+
+        for (partition_name, blobs) in partitions.iter() {
+            for (blob_name, content) in blobs.iter() {
+                hasher.update(b"partition");
+                hasher.update(partition_name.as_bytes());
+                hasher.update(b"blob");
+                hasher.update(blob_name);
+                hasher.update(b"content");
+                hasher.update(content);
+            }
+        }
+
+        hasher.finalize()
+    }
 
     fn open_versioned_with_layout(
         &self,
@@ -111,7 +133,7 @@ impl Storage {
                 generations.get_or_insert(&key),
             ),
             None => {
-                let (region, blob_version) = Header::create_for_layout(layout, &versions);
+                let (region, blob_version) = Header::create(layout, &versions);
                 let data_offset = region.len() as u64;
                 content.clear();
                 content.extend_from_slice(&region);
@@ -132,28 +154,6 @@ impl Storage {
             logical_size,
             blob_version,
         ))
-    }
-}
-
-impl Storage {
-    /// Compute a SHA-256 digest of all blob contents.
-    pub fn audit(&self) -> [u8; 32] {
-        let partitions = self.partitions.lock();
-        let mut hasher = AuditHasher::new();
-        hasher.update(b"commonware-runtime-storage-audit-v1");
-
-        for (partition_name, blobs) in partitions.iter() {
-            for (blob_name, content) in blobs.iter() {
-                hasher.update(b"partition");
-                hasher.update(partition_name.as_bytes());
-                hasher.update(b"blob");
-                hasher.update(blob_name);
-                hasher.update(b"content");
-                hasher.update(content);
-            }
-        }
-
-        hasher.finalize()
     }
 
     /// Return a copy of a blob's durable raw contents without interpreting its container header.
@@ -184,6 +184,156 @@ impl Storage {
         versions: RangeInclusive<u16>,
     ) -> Result<(Blob, u64, u16), crate::Error> {
         self.open_versioned_with_layout(partition, name, Layout::V0, versions)
+    }
+}
+
+/// Shape of a blob creation interrupted mid-write.
+///
+/// Creation writes one canonical header region over an empty file, so a crash leaves a
+/// canonical prefix, a persisted length whose unwritten tail reads as zeros, and possibly
+/// zero holes where device writeback persisted bytes out of order. A hole can only zero a
+/// byte, never invent one: creation starts from an empty file, so unwritten storage reads
+/// as zeros.
+#[cfg(any(test, feature = "test-utils"))]
+#[derive(Clone, Copy, Debug)]
+pub struct TornCreation {
+    /// Length of the canonical prefix that reached the file, reduced modulo the region.
+    retained: u16,
+    /// Zero-filled bytes of persisted file length past the prefix, reduced modulo the region.
+    tail: u16,
+    /// Bit `i` zeroes byte `i` of the image: a hole torn by out-of-order writeback. The low
+    /// bits cover the parseable header; higher bits fall on padding or off the image.
+    holes: u16,
+}
+
+#[cfg(any(test, feature = "test-utils"))]
+impl TornCreation {
+    /// Materialize the crash image this shape leaves over a canonical creation `region`.
+    pub fn image(&self, region: &[u8]) -> Vec<u8> {
+        let retained = usize::from(self.retained) % (region.len() + 1);
+        let persisted = retained + usize::from(self.tail) % (region.len() - retained + 1);
+        let mut image = vec![0u8; persisted];
+        image[..retained].copy_from_slice(&region[..retained]);
+        for bit in 0..u16::BITS as usize {
+            if self.holes & (1 << bit) != 0
+                && let Some(byte) = image.get_mut(bit)
+            {
+                *byte = 0;
+            }
+        }
+        image
+    }
+}
+
+#[cfg(all(any(test, feature = "test-utils"), feature = "arbitrary"))]
+impl<'a> arbitrary::Arbitrary<'a> for TornCreation {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        Ok(Self {
+            retained: u.arbitrary()?,
+            tail: u.arbitrary()?,
+            holes: u.arbitrary()?,
+        })
+    }
+
+    fn size_hint(_: usize) -> (usize, Option<usize>) {
+        (6, Some(6))
+    }
+}
+
+/// Required recovery outcome when a blob's raw contents are a creation crash image.
+#[cfg(any(test, feature = "test-utils"))]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CreationOutcome {
+    /// The open succeeds and recreates the canonical V1 region for the requested version.
+    Recreated,
+    /// The open succeeds against the intact header and leaves the contents unchanged.
+    Kept,
+    /// The open fails without mutating the contents.
+    Rejected,
+}
+
+/// Classify the required recovery outcome for a creation crash image.
+///
+/// Mirrors header resolution: a sub-prelude file is always recreated, a parseable
+/// header is honored before healing is considered (a blob version disagreement or nonzero
+/// padding on an intact region never heals), and only failures a torn write can produce
+/// fall through to the torn-creation classifier, which accepts a canonical prefix (with any
+/// blob version, the CRC binding the written prelude) followed by zeros.
+#[cfg(any(test, feature = "test-utils"))]
+pub fn creation_outcome(image: &[u8], version: u16) -> CreationOutcome {
+    use commonware_cryptography::Crc32;
+
+    fn prefix(layout: Layout) -> [u8; 6] {
+        let mut bytes = [0u8; 6];
+        bytes[..4].copy_from_slice(&layout.magic());
+        bytes[4..6].copy_from_slice(&layout.runtime_version().to_be_bytes());
+        bytes
+    }
+
+    let prelude = Header::PRELUDE_SIZE;
+    let parse_len = Header::PARSE_LEN;
+    let region = Layout::V1.data_offset() as usize;
+
+    // Too short to hold any header: recreated as new regardless of content.
+    if image.len() < prelude {
+        return CreationOutcome::Recreated;
+    }
+    let stamped = u16::from_be_bytes([image[6], image[7]]);
+
+    // An intact V0 magic and runtime version parse as a legacy blob: the stamped version
+    // decides, and a mismatch is a genuine disagreement that never heals.
+    if image[..6] == prefix(Layout::V0) {
+        return if stamped == version {
+            CreationOutcome::Kept
+        } else {
+            CreationOutcome::Rejected
+        };
+    }
+
+    // A CRC-validated full V1 region parses: nonzero padding and a stamped version mismatch
+    // are corruption, not torn writes. A valid CRC over a truncated region still falls
+    // through to the torn-creation classifier.
+    if image[..6] == prefix(Layout::V1)
+        && image.len() >= parse_len
+        && image[prelude..parse_len] == Crc32::checksum(&image[..prelude]).to_be_bytes()
+        && image.len() >= region
+    {
+        if image[parse_len..region].iter().any(|&byte| byte != 0) {
+            return CreationOutcome::Rejected;
+        }
+        return if stamped == version {
+            CreationOutcome::Kept
+        } else {
+            CreationOutcome::Rejected
+        };
+    }
+
+    // Torn-creation classifier: the written prefix ends at the last nonzero byte, must match
+    // a canonical V1 region (blob version free, CRC bytes prefixing the CRC over the written
+    // prelude), and everything past it must be zero.
+    if image.len() > region {
+        return CreationOutcome::Rejected;
+    }
+    let head_len = image.len().min(parse_len);
+    if image[head_len..].iter().any(|&byte| byte != 0) {
+        return CreationOutcome::Rejected;
+    }
+    let head = &image[..head_len];
+    let written = head
+        .iter()
+        .rposition(|&byte| byte != 0)
+        .map_or(0, |i| i + 1);
+    let canonical = if written <= prelude {
+        head[..written.min(6)] == prefix(Layout::V1)[..written.min(6)]
+    } else {
+        head[..6] == prefix(Layout::V1)
+            && head[prelude..written]
+                == Crc32::checksum(&head[..prelude]).to_be_bytes()[..written - prelude]
+    };
+    if canonical {
+        CreationOutcome::Recreated
+    } else {
+        CreationOutcome::Rejected
     }
 }
 
@@ -436,12 +586,14 @@ impl crate::Blob for Blob {
         let offset: usize = offset
             .try_into()
             .map_err(|_| crate::Error::OffsetOverflow)?;
+        let end = offset
+            .checked_add(len)
+            .ok_or(crate::Error::OffsetOverflow)?;
         let content = self.content.read();
-        let content_len = content.len();
-        if offset + len > content_len {
+        if end > content.len() {
             return Err(crate::Error::BlobInsufficientLength);
         }
-        bufs.copy_from_slice(&content[offset..offset + len]);
+        bufs.copy_from_slice(&content[offset..end]);
         Ok(bufs)
     }
 
@@ -959,6 +1111,87 @@ mod tests {
         assert_ne!(storage_a.audit(), storage_b.audit());
     }
 
+    /// Pin one image per [CreationOutcome] arm so the classifier cannot drift from
+    /// [super::super::header::resolve] unnoticed.
+    #[test]
+    fn test_creation_outcome_arms() {
+        use super::{CreationOutcome::*, creation_outcome};
+        let (v1, _) = Header::create(Layout::V1, &(3..=3));
+        let (v0, _) = Header::create(Layout::V0, &(3..=3));
+
+        assert_eq!(creation_outcome(&[], 3), Recreated);
+        assert_eq!(creation_outcome(&v1[..7], 3), Recreated);
+        assert_eq!(creation_outcome(&v1[..100], 3), Recreated);
+        assert_eq!(creation_outcome(&v1, 3), Kept);
+        assert_eq!(creation_outcome(&v1, 4), Rejected);
+        assert_eq!(creation_outcome(&v0, 3), Kept);
+        assert_eq!(creation_outcome(&v0, 4), Rejected);
+
+        // A hole below persisted bytes is not a canonical prefix.
+        let mut holed = v1[..100].to_vec();
+        holed[1] = 0;
+        assert_eq!(creation_outcome(&holed, 3), Rejected);
+    }
+
+    /// Exhaustively verify recovery of every torn V0 creation image against the oracle: the
+    /// V0 prelude is 8 bytes, so the whole crash-image space (every persisted length, every
+    /// zero-hole subset) is enumerable. Recreated images must heal to the canonical V1
+    /// region, kept images must open unchanged, and everything else must fail without
+    /// mutation.
+    #[tokio::test]
+    async fn test_v0_creation_images_exhaustive() {
+        for version in [0u16, 3, 0x0100, 0xFFFF] {
+            let versions = version..=version;
+            let storage = Storage::new(test_pool());
+
+            let (blob, _, _) = storage
+                .open_versioned("partition", b"v1", versions.clone())
+                .await
+                .unwrap();
+            drop(blob);
+            let canonical_v1 = storage.raw_blob("partition", b"v1").unwrap();
+            let (blob, _, _) = storage
+                .open_versioned_v0("partition", b"v0", versions.clone())
+                .unwrap();
+            drop(blob);
+            let canonical_v0 = storage.raw_blob("partition", b"v0").unwrap();
+
+            for len in 0..=canonical_v0.len() {
+                for mask in 0u16..1 << len {
+                    let mut image = canonical_v0[..len].to_vec();
+                    for (bit, byte) in image.iter_mut().enumerate() {
+                        if mask & (1 << bit) != 0 {
+                            *byte = 0;
+                        }
+                    }
+                    storage.set_raw_blob("partition", b"v0", image.clone());
+                    let result = storage
+                        .open_versioned("partition", b"v0", versions.clone())
+                        .await;
+                    match creation_outcome(&image, version) {
+                        CreationOutcome::Recreated => {
+                            let (_, size, opened) =
+                                result.expect("torn creation image did not recover");
+                            assert_eq!(size, 0);
+                            assert_eq!(opened, version);
+                            assert_eq!(storage.raw_blob("partition", b"v0").unwrap(), canonical_v1);
+                        }
+                        CreationOutcome::Kept => {
+                            let (_, size, opened) = result.expect("intact image did not open");
+                            assert_eq!(size, 0);
+                            assert_eq!(opened, version);
+                            assert_eq!(storage.raw_blob("partition", b"v0").unwrap(), image);
+                        }
+                        CreationOutcome::Rejected => {
+                            assert!(result.is_err(), "non-canonical image was accepted");
+                            assert_eq!(storage.raw_blob("partition", b"v0").unwrap(), image);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     #[tokio::test]
     async fn test_blob_torn_creation_recovers() {
         let storage = Storage::new(test_pool());
@@ -966,7 +1199,7 @@ mod tests {
         // Manually insert a torn-creation leftover: a prefix of a canonical V1 header
         // region (the full state enumeration lives in the Layout::interrupted_creation
         // unit tables)
-        let (region, _) = Header::create(&(0..=0));
+        let (region, _) = Header::create(Layout::V1, &(0..=0));
         let states = [region[..10].to_vec()];
         for (i, state) in states.into_iter().enumerate() {
             let name = format!("torn_{i}").into_bytes();

--- a/runtime/src/storage/memory.rs
+++ b/runtime/src/storage/memory.rs
@@ -107,7 +107,7 @@ impl Storage {
         hasher.finalize()
     }
 
-    fn open_versioned_with_layout(
+    fn open_inner(
         &self,
         partition: &str,
         name: &[u8],
@@ -174,167 +174,6 @@ impl Storage {
             .or_default()
             .insert(name.into(), content);
     }
-
-    /// Open a blob, creating missing or recoverable content with the legacy V0 layout.
-    #[cfg(any(test, feature = "test-utils"))]
-    pub fn open_versioned_v0(
-        &self,
-        partition: &str,
-        name: &[u8],
-        versions: RangeInclusive<u16>,
-    ) -> Result<(Blob, u64, u16), crate::Error> {
-        self.open_versioned_with_layout(partition, name, Layout::V0, versions)
-    }
-}
-
-/// Shape of a blob creation interrupted mid-write.
-///
-/// Creation writes one canonical header region over an empty file, so a crash leaves a
-/// canonical prefix, a persisted length whose unwritten tail reads as zeros, and possibly
-/// zero holes where device writeback persisted bytes out of order. A hole can only zero a
-/// byte, never invent one: creation starts from an empty file, so unwritten storage reads
-/// as zeros.
-#[cfg(any(test, feature = "test-utils"))]
-#[derive(Clone, Copy, Debug)]
-pub struct TornCreation {
-    /// Length of the canonical prefix that reached the file, reduced modulo the region.
-    retained: u16,
-    /// Zero-filled bytes of persisted file length past the prefix, reduced modulo the region.
-    tail: u16,
-    /// Bit `i` zeroes byte `i` of the image: a hole torn by out-of-order writeback. The low
-    /// bits cover the parseable header; higher bits fall on padding or off the image.
-    holes: u16,
-}
-
-#[cfg(any(test, feature = "test-utils"))]
-impl TornCreation {
-    /// Materialize the crash image this shape leaves over a canonical creation `region`.
-    pub fn image(&self, region: &[u8]) -> Vec<u8> {
-        let retained = usize::from(self.retained) % (region.len() + 1);
-        let persisted = retained + usize::from(self.tail) % (region.len() - retained + 1);
-        let mut image = vec![0u8; persisted];
-        image[..retained].copy_from_slice(&region[..retained]);
-        for bit in 0..u16::BITS as usize {
-            if self.holes & (1 << bit) != 0
-                && let Some(byte) = image.get_mut(bit)
-            {
-                *byte = 0;
-            }
-        }
-        image
-    }
-}
-
-#[cfg(all(any(test, feature = "test-utils"), feature = "arbitrary"))]
-impl<'a> arbitrary::Arbitrary<'a> for TornCreation {
-    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
-        Ok(Self {
-            retained: u.arbitrary()?,
-            tail: u.arbitrary()?,
-            holes: u.arbitrary()?,
-        })
-    }
-
-    fn size_hint(_: usize) -> (usize, Option<usize>) {
-        (6, Some(6))
-    }
-}
-
-/// Required recovery outcome when a blob's raw contents are a creation crash image.
-#[cfg(any(test, feature = "test-utils"))]
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum CreationOutcome {
-    /// The open succeeds and recreates the canonical V1 region for the requested version.
-    Recreated,
-    /// The open succeeds against the intact header and leaves the contents unchanged.
-    Kept,
-    /// The open fails without mutating the contents.
-    Rejected,
-}
-
-/// Classify the required recovery outcome for a creation crash image.
-///
-/// Mirrors header resolution: a sub-prelude file is always recreated, a parseable
-/// header is honored before healing is considered (a blob version disagreement or nonzero
-/// padding on an intact region never heals), and only failures a torn write can produce
-/// fall through to the torn-creation classifier, which accepts a canonical prefix (with any
-/// blob version, the CRC binding the written prelude) followed by zeros.
-#[cfg(any(test, feature = "test-utils"))]
-pub fn creation_outcome(image: &[u8], version: u16) -> CreationOutcome {
-    use commonware_cryptography::Crc32;
-
-    fn prefix(layout: Layout) -> [u8; 6] {
-        let mut bytes = [0u8; 6];
-        bytes[..4].copy_from_slice(&layout.magic());
-        bytes[4..6].copy_from_slice(&layout.runtime_version().to_be_bytes());
-        bytes
-    }
-
-    let prelude = Header::PRELUDE_SIZE;
-    let parse_len = Header::PARSE_LEN;
-    let region = Layout::V1.data_offset() as usize;
-
-    // Too short to hold any header: recreated as new regardless of content.
-    if image.len() < prelude {
-        return CreationOutcome::Recreated;
-    }
-    let stamped = u16::from_be_bytes([image[6], image[7]]);
-
-    // An intact V0 magic and runtime version parse as a legacy blob: the stamped version
-    // decides, and a mismatch is a genuine disagreement that never heals.
-    if image[..6] == prefix(Layout::V0) {
-        return if stamped == version {
-            CreationOutcome::Kept
-        } else {
-            CreationOutcome::Rejected
-        };
-    }
-
-    // A CRC-validated full V1 region parses: nonzero padding and a stamped version mismatch
-    // are corruption, not torn writes. A valid CRC over a truncated region still falls
-    // through to the torn-creation classifier.
-    if image[..6] == prefix(Layout::V1)
-        && image.len() >= parse_len
-        && image[prelude..parse_len] == Crc32::checksum(&image[..prelude]).to_be_bytes()
-        && image.len() >= region
-    {
-        if image[parse_len..region].iter().any(|&byte| byte != 0) {
-            return CreationOutcome::Rejected;
-        }
-        return if stamped == version {
-            CreationOutcome::Kept
-        } else {
-            CreationOutcome::Rejected
-        };
-    }
-
-    // Torn-creation classifier: the written prefix ends at the last nonzero byte, must match
-    // a canonical V1 region (blob version free, CRC bytes prefixing the CRC over the written
-    // prelude), and everything past it must be zero.
-    if image.len() > region {
-        return CreationOutcome::Rejected;
-    }
-    let head_len = image.len().min(parse_len);
-    if image[head_len..].iter().any(|&byte| byte != 0) {
-        return CreationOutcome::Rejected;
-    }
-    let head = &image[..head_len];
-    let written = head
-        .iter()
-        .rposition(|&byte| byte != 0)
-        .map_or(0, |i| i + 1);
-    let canonical = if written <= prelude {
-        head[..written.min(6)] == prefix(Layout::V1)[..written.min(6)]
-    } else {
-        head[..6] == prefix(Layout::V1)
-            && head[prelude..written]
-                == Crc32::checksum(&head[..prelude]).to_be_bytes()[..written - prelude]
-    };
-    if canonical {
-        CreationOutcome::Recreated
-    } else {
-        CreationOutcome::Rejected
-    }
 }
 
 impl crate::Storage for Storage {
@@ -346,7 +185,7 @@ impl crate::Storage for Storage {
         name: &[u8],
         versions: RangeInclusive<u16>,
     ) -> Result<(Self::Blob, u64, u16), crate::Error> {
-        self.open_versioned_with_layout(partition, name, Layout::V1, versions)
+        self.open_inner(partition, name, Layout::V1, versions)
     }
 
     async fn remove(&self, partition: &str, name: Option<&[u8]>) -> Result<(), crate::Error> {
@@ -925,7 +764,7 @@ mod tests {
 
         let legacy_writer = Storage::new(test_pool());
         let (blob, size, version) = legacy_writer
-            .open_versioned_v0(PARTITION, NAME, VERSION..=VERSION)
+            .open_inner(PARTITION, NAME, Layout::V0, VERSION..=VERSION)
             .unwrap();
         assert_eq!(size, 0);
         assert_eq!(version, VERSION);
@@ -1111,26 +950,11 @@ mod tests {
         assert_ne!(storage_a.audit(), storage_b.audit());
     }
 
-    /// Pin one image per [CreationOutcome] arm so the classifier cannot drift from
-    /// [super::super::header::resolve] unnoticed.
-    #[test]
-    fn test_creation_outcome_arms() {
-        use super::{CreationOutcome::*, creation_outcome};
-        let (v1, _) = Header::create(Layout::V1, &(3..=3));
-        let (v0, _) = Header::create(Layout::V0, &(3..=3));
-
-        assert_eq!(creation_outcome(&[], 3), Recreated);
-        assert_eq!(creation_outcome(&v1[..7], 3), Recreated);
-        assert_eq!(creation_outcome(&v1[..100], 3), Recreated);
-        assert_eq!(creation_outcome(&v1, 3), Kept);
-        assert_eq!(creation_outcome(&v1, 4), Rejected);
-        assert_eq!(creation_outcome(&v0, 3), Kept);
-        assert_eq!(creation_outcome(&v0, 4), Rejected);
-
-        // A hole below persisted bytes is not a canonical prefix.
-        let mut holed = v1[..100].to_vec();
-        holed[1] = 0;
-        assert_eq!(creation_outcome(&holed, 3), Rejected);
+    /// Required recovery outcome for an installed V0 crash image.
+    enum Expect {
+        Recreated,
+        Kept,
+        Rejected,
     }
 
     /// Exhaustively verify recovery of every torn V0 creation image against the oracle: the
@@ -1151,7 +975,7 @@ mod tests {
             drop(blob);
             let canonical_v1 = storage.raw_blob("partition", b"v1").unwrap();
             let (blob, _, _) = storage
-                .open_versioned_v0("partition", b"v0", versions.clone())
+                .open_inner("partition", b"v0", Layout::V0, versions.clone())
                 .unwrap();
             drop(blob);
             let canonical_v0 = storage.raw_blob("partition", b"v0").unwrap();
@@ -1164,25 +988,46 @@ mod tests {
                             *byte = 0;
                         }
                     }
+                    // Expected outcome per the header spec: a sub-prelude file is always
+                    // recreated, an intact prelude parses (the stamped version decides,
+                    // and only the version bytes can differ once the first six match), and
+                    // anything else heals only as a canonical V1 creation prefix, which a
+                    // V0 image can satisfy just through the shared "CWI" brand.
+                    let written = image
+                        .iter()
+                        .rposition(|&byte| byte != 0)
+                        .map_or(0, |i| i + 1);
+                    let expected = if image.len() < canonical_v0.len() {
+                        Expect::Recreated
+                    } else if image == canonical_v0 {
+                        Expect::Kept
+                    } else if image[..6] == canonical_v0[..6] {
+                        Expect::Rejected
+                    } else if written <= 3 && image[..written] == canonical_v0[..written] {
+                        Expect::Recreated
+                    } else {
+                        Expect::Rejected
+                    };
+
                     storage.set_raw_blob("partition", b"v0", image.clone());
                     let result = storage
                         .open_versioned("partition", b"v0", versions.clone())
                         .await;
-                    match creation_outcome(&image, version) {
-                        CreationOutcome::Recreated => {
+                    match expected {
+                        Expect::Recreated => {
                             let (_, size, opened) =
                                 result.expect("torn creation image did not recover");
                             assert_eq!(size, 0);
                             assert_eq!(opened, version);
                             assert_eq!(storage.raw_blob("partition", b"v0").unwrap(), canonical_v1);
                         }
-                        CreationOutcome::Kept => {
+                        Expect::Kept => {
                             let (_, size, opened) = result.expect("intact image did not open");
                             assert_eq!(size, 0);
                             assert_eq!(opened, version);
                             assert_eq!(storage.raw_blob("partition", b"v0").unwrap(), image);
                         }
-                        CreationOutcome::Rejected => {
+                        Expect::Rejected => {
                             assert!(result.is_err(), "non-canonical image was accepted");
                             assert_eq!(storage.raw_blob("partition", b"v0").unwrap(), image);
                         }

--- a/runtime/src/storage/tokio/mod.rs
+++ b/runtime/src/storage/tokio/mod.rs
@@ -149,7 +149,8 @@ impl crate::Storage for Storage {
                     sync_dir(&storage_directory).await?;
 
                     // Truncate to zero before writing, per the [Header::create] contract.
-                    let (region, blob_version) = Header::create(&versions);
+                    let (region, blob_version) =
+                        Header::create_for_layout(crate::storage::Layout::V1, &versions);
                     let data_offset = region.len() as u64;
                     file.set_len(0).await.map_err(|e| {
                         Error::BlobResizeFailed(err_partition.clone(), err_name.clone(), e.into())

--- a/runtime/src/storage/tokio/mod.rs
+++ b/runtime/src/storage/tokio/mod.rs
@@ -150,7 +150,7 @@ impl crate::Storage for Storage {
 
                     // Truncate to zero before writing, per the [Header::create] contract.
                     let (region, blob_version) =
-                        Header::create_for_layout(crate::storage::Layout::V1, &versions);
+                        Header::create(crate::storage::Layout::V1, &versions);
                     let data_offset = region.len() as u64;
                     file.set_len(0).await.map_err(|e| {
                         Error::BlobResizeFailed(err_partition.clone(), err_name.clone(), e.into())

--- a/runtime/src/utils/buffer/mod.rs
+++ b/runtime/src/utils/buffer/mod.rs
@@ -58,6 +58,11 @@ enum SyncState {
 }
 
 impl SyncState {
+    /// Whether no mutation still needs a sync.
+    const fn is_clean(&self) -> bool {
+        matches!(self, Self::Clean)
+    }
+
     /// Mark a new unsynced mutation.
     fn mark_dirty(&mut self) {
         assert!(

--- a/runtime/src/utils/buffer/paged/mod.rs
+++ b/runtime/src/utils/buffer/paged/mod.rs
@@ -27,19 +27,19 @@
 //! physical pages that straddle storage-page boundaries amplify cold random reads.
 //!
 //! Two checksums are stored so that re-writing a partial page cannot destroy the valid checksum
-//! for its previously committed contents. Each rewrite covers the whole physical page: the new
-//! checksum lands in the alternate slot, while the committed prefix and its protected checksum
-//! are resubmitted byte-identically, leaving their durable bytes unchanged even if the write
-//! tears. A checksum over a page is computed over the first [0,len) bytes in the page, with all
-//! other bytes in the page ignored. Ordinary partial-page payload writes 0-pad the range
-//! [len, page_size), but recovery does not depend on bytes outside [0,len). A checksum with
-//! length 0 is never considered valid. If both checksums are valid for the page, the one with the
-//! larger `len` is considered authoritative. Partial-page shrink first makes the shorter checksum
-//! durable in the alternate slot, then invalidates the old longer checksum.
+//! for its last durable contents. Each rewrite covers the whole physical page: the new checksum
+//! lands in the slot not protecting the durable contents, while the durable prefix and its
+//! protected checksum are resubmitted byte-identically, leaving their durable bytes unchanged
+//! even if the write tears. A checksum over a page is computed over the first [0,len) bytes in
+//! the page, with all other bytes in the page ignored. Ordinary partial-page payload writes
+//! 0-pad the range [len, page_size), but recovery does not depend on bytes outside [0,len). A
+//! checksum with length 0 is never considered valid. If both checksums are valid for the page,
+//! the one with the larger `len` is considered authoritative. Partial-page shrink first makes
+//! the shorter checksum durable in the alternate slot, then invalidates the old longer checksum.
 //!
 //! A _full_ page is one whose crc stores a len equal to the logical page size. Otherwise the page
 //! is called _partial_. All pages in a blob are full except for the very last page, which can be
-//! full or partial. A partial page's committed prefix remains recoverable while it is rewritten.
+//! full or partial. A partial page's durable prefix remains recoverable while it is rewritten.
 
 use crate::{Blob, Buf, BufMut, Error, IoBuf, ReadOptions};
 use commonware_codec::{EncodeFixed, FixedSize, Read as CodecRead, ReadExt, Write};
@@ -58,8 +58,8 @@ pub use sealed::Sealed;
 use tracing::{debug, error};
 pub use writer::Writer;
 
-// A checksum record contains two slots. Each slot stores one u16 length and one CRC.
-const CHECKSUM_SIZE: u64 = Checksum::SIZE as u64;
+/// Size in bytes of the checksum record appended to each logical page.
+pub const CHECKSUM_SIZE: u64 = Checksum::SIZE as u64;
 
 /// The storage-page granularity physical pages should align to (see the module docs).
 pub(crate) const STORAGE_PAGE_SIZE: u64 = 4096;

--- a/runtime/src/utils/buffer/paged/mod.rs
+++ b/runtime/src/utils/buffer/paged/mod.rs
@@ -401,9 +401,10 @@ impl Checksum {
     /// Encode just a slot's leading `len` field (the first [`CHECKSUM_SLOT_LEN_SIZE`] bytes of
     /// [`Self::slot_bytes`]).
     ///
-    /// Because `len` decides which slot is authoritative, rewriting only this field flips a slot's
-    /// authority without disturbing its already-durable CRC: writing a non-zero `len` commits a
-    /// previously staged slot, while writing 0 retires one.
+    /// Because `len` decides which slot is authoritative, rewriting only this field commits a
+    /// previously staged slot without disturbing its already-durable CRC. Retiring a slot must
+    /// instead zero it entirely with [`Self::slot_bytes`]: a zero length with a durable CRC left
+    /// behind could be reassembled into the retired checksum by a later torn rewrite.
     fn slot_len_bytes(len: u16) -> [u8; CHECKSUM_SLOT_LEN_SIZE] {
         let mut bytes = [0; CHECKSUM_SLOT_LEN_SIZE];
         let mut buf = bytes.as_mut_slice();

--- a/runtime/src/utils/buffer/paged/writer.rs
+++ b/runtime/src/utils/buffer/paged/writer.rs
@@ -811,9 +811,10 @@ impl<B: Blob> Writer<B> {
             )
             .await?;
 
-        // Clear only the old slot's length bytes. Rewriting the whole footer here could tear across
-        // both slots and lose the already-durable shorter checksum. Once this lands, length 0 is
-        // never authoritative, so the shrunken slot wins.
+        // Clear the old slot entirely. The write stays within the old slot, so it cannot damage
+        // the already-durable shorter checksum, and zeroing the CRC alongside the length keeps a
+        // later torn rewrite of this page from reassembling the retired longer checksum over the
+        // pre-shrink bytes still on the page. Once this lands, the shrunken slot wins.
         let old_slot_offset = crc_start
             .checked_add(old_slot.offset() as u64)
             .ok_or(Error::OffsetOverflow)?;
@@ -821,7 +822,7 @@ impl<B: Blob> Writer<B> {
             .write_at(
                 &self.blob,
                 old_slot_offset,
-                Checksum::slot_len_bytes(0).to_vec(),
+                Checksum::slot_bytes(0, 0).to_vec(),
                 WriteOptions::SYNC | WriteOptions::DONT_CACHE,
             )
             .await?;
@@ -1321,10 +1322,7 @@ mod tests {
     use crate::{
         Buf, BufferPool, BufferPoolConfig, Handle, IoBufsMut, Runner as _, Spawner as _,
         Storage as _, Supervisor as _,
-        buffer::{
-            paged::{CHECKSUM_SLOT_LEN_SIZE, CHECKSUM_SLOT_SIZE},
-            tests::SyncTrackingBlob,
-        },
+        buffer::{paged::CHECKSUM_SLOT_SIZE, tests::SyncTrackingBlob},
         deterministic,
         mocks::{DelayedSyncBlob, RecordingContext, next_pending_sync},
         telemetry::metrics::Registry,
@@ -5095,6 +5093,55 @@ mod tests {
         });
     }
 
+    /// A torn tail-page rewrite after a durable shrink must not resurrect the retired slot:
+    /// the shrink zeroes the whole slot, so stale length bytes alone cannot reassemble a valid
+    /// checksum over the pre-shrink bytes still on the page.
+    #[test_traced("DEBUG")]
+    fn test_shrink_then_torn_rewrite_does_not_resurrect() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context: deterministic::Context| async move {
+            let (blob, blob_size) = context
+                .open("test_partition", b"shrink_torn")
+                .await
+                .unwrap();
+            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
+            let mut writer = Writer::new(blob.clone(), blob_size, BUFFER_SIZE, cache_ref)
+                .await
+                .unwrap();
+
+            // Commit 80 bytes into the first slot, then durably shrink the tail page to 50.
+            let data: Vec<u8> = (1u8..=80).collect();
+            writer.append(&data).await.unwrap();
+            writer.sync().await.unwrap();
+            writer.resize(50).await.unwrap();
+            drop(writer);
+
+            // Model a rewrite of the tail page back to 80 bytes torn down to only the retired
+            // slot's length bytes: the pre-shrink data still on the page must not revalidate.
+            let page_size = u64::from(PAGE_SIZE.get());
+            blob.write_at(
+                page_size,
+                80u16.to_be_bytes().to_vec(),
+                WriteOptions::default(),
+            )
+            .await
+            .unwrap();
+            blob.sync().await.unwrap();
+
+            let (blob, blob_size) = context
+                .open("test_partition", b"shrink_torn")
+                .await
+                .unwrap();
+            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
+            let recovered = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref)
+                .await
+                .unwrap();
+            assert_eq!(recovered.size(), 50);
+            let read = recovered.read_at(0, 50).await.unwrap().coalesce();
+            assert_eq!(read.as_ref(), &data[..50]);
+        });
+    }
+
     #[test]
     fn test_resize_same_page_shrink_survives_interrupted_crc_stage() {
         let executor = deterministic::Runner::default();
@@ -5408,10 +5455,7 @@ mod tests {
                 "old-slot length invalidation should fail"
             );
             assert_eq!(write_count.load(Ordering::SeqCst), 3);
-            assert_eq!(
-                failed_write_len.load(Ordering::SeqCst),
-                CHECKSUM_SLOT_LEN_SIZE
-            );
+            assert_eq!(failed_write_len.load(Ordering::SeqCst), CHECKSUM_SLOT_SIZE);
             drop(append);
 
             let (blob, size) = context

--- a/runtime/src/utils/buffer/paged/writer.rs
+++ b/runtime/src/utils/buffer/paged/writer.rs
@@ -941,7 +941,8 @@ impl<B: Blob> Writer<B> {
     ///
     /// `proven` is a logical byte offset already known valid (a durability watermark or a
     /// replay-validated prefix). Pages wholly below it are accepted without reading, and the
-    /// scan starts at the page containing it.
+    /// scan starts at the page containing it. A proof past the blob's content clamps to the
+    /// full pages that exist, so a partial tail is still read rather than credited as full.
     pub async fn recoverable_prefix_len(
         &self,
         proven: u64,
@@ -950,16 +951,57 @@ impl<B: Blob> Writer<B> {
     ) -> Result<u64, Error> {
         let logical_page_size = self.cache_ref.page_size();
         let total_pages = self.current_page + u64::from(self.partial_page_state.is_some());
-        let (recoverable, _) = Self::recoverable_prefix_len_from_pages(
-            &self.blob,
-            logical_page_size,
-            total_pages,
-            proven / logical_page_size,
-            buffer_size,
-            read_options,
-        )
-        .await?;
-        Ok(recoverable)
+        let physical_page_size = logical_page_size
+            .checked_add(CHECKSUM_SIZE)
+            .ok_or(Error::OffsetOverflow)?;
+        let physical_page_size_usize =
+            usize::try_from(physical_page_size).map_err(|_| Error::OffsetOverflow)?;
+        let max_batch_pages = u64::try_from((buffer_size.get() / physical_page_size_usize).max(1))
+            .map_err(|_| Error::OffsetOverflow)?;
+
+        // Pages below the proof are accepted without reading. An overshooting proof clamps to
+        // the full pages: a partial tail backs fewer logical bytes than a skipped page would
+        // credit, so it must always be read.
+        let start_page = (proven / logical_page_size).min(self.current_page);
+        let mut valid_len = start_page
+            .checked_mul(logical_page_size)
+            .ok_or(Error::OffsetOverflow)?;
+        let mut page = start_page;
+        while page < total_pages {
+            // Bound each read while deriving its physical range with checked arithmetic.
+            let batch_pages = max_batch_pages.min(total_pages - page);
+            let batch_end = page.checked_add(batch_pages).ok_or(Error::OffsetOverflow)?;
+            let physical_offset = page
+                .checked_mul(physical_page_size)
+                .ok_or(Error::OffsetOverflow)?;
+            let physical_len = batch_pages
+                .checked_mul(physical_page_size)
+                .ok_or(Error::OffsetOverflow)?;
+            let physical_len = usize::try_from(physical_len).map_err(|_| Error::OffsetOverflow)?;
+
+            // Coalesce once so each physical page can be checksum-validated in place.
+            let physical = self
+                .blob
+                .read_at(physical_offset, physical_len, read_options)
+                .await?
+                .coalesce();
+
+            // The first invalid page terminates the only recoverable contiguous prefix.
+            for physical_page in physical.as_ref().chunks_exact(physical_page_size_usize) {
+                let Some(checksum) = Checksum::validate_page(physical_page) else {
+                    return Ok(valid_len);
+                };
+                let len = u64::from(checksum.len);
+                valid_len = valid_len.checked_add(len).ok_or(Error::OffsetOverflow)?;
+
+                // A valid partial logical page ends the contiguous prefix wherever it appears.
+                if len < logical_page_size {
+                    return Ok(valid_len);
+                }
+            }
+            page = batch_end;
+        }
+        Ok(valid_len)
     }
 
     /// Read a logical range directly from a raw paged blob, validating every page it spans.
@@ -1081,112 +1123,6 @@ impl<B: Blob> Writer<B> {
         out.append(tail.slice(tail_start..));
         assert_eq!(out.len(), len);
         Ok((logical_size, out))
-    }
-
-    /// Return the contiguous recoverable prefix of a raw paged blob without mutating it.
-    ///
-    /// `physical_size` must be the blob's current size, and the blob must remain unchanged while
-    /// the scan runs.
-    ///
-    /// The boolean is true only when every physical byte belongs to a valid page in that prefix.
-    /// It is false when the scan stops at a short or invalid page, at a partial physical page, or
-    /// before a later physical page. `buffer_size` bounds each read with the same one-page minimum
-    /// as replay.
-    pub async fn recoverable_prefix_len_from_blob(
-        blob: &B,
-        physical_size: u64,
-        logical_page_size: NonZeroU16,
-        buffer_size: NonZeroUsize,
-        read_options: ReadOptions,
-    ) -> Result<(u64, bool), Error> {
-        let logical_page_size = u64::from(logical_page_size.get());
-        let physical_page_size = logical_page_size
-            .checked_add(CHECKSUM_SIZE)
-            .ok_or(Error::OffsetOverflow)?;
-        let total_pages = physical_size / physical_page_size;
-        let (recoverable, complete) = Self::recoverable_prefix_len_from_pages(
-            blob,
-            logical_page_size,
-            total_pages,
-            0,
-            buffer_size,
-            read_options,
-        )
-        .await?;
-        Ok((
-            recoverable,
-            complete && physical_size.is_multiple_of(physical_page_size),
-        ))
-    }
-
-    /// Scan complete physical pages in bounded batches and return their contiguous logical prefix.
-    ///
-    /// The boolean is true only when all requested pages were consumed, including any terminal
-    /// partial logical page.
-    async fn recoverable_prefix_len_from_pages(
-        blob: &B,
-        logical_page_size: u64,
-        total_pages: u64,
-        start_page: u64,
-        buffer_size: NonZeroUsize,
-        read_options: ReadOptions,
-    ) -> Result<(u64, bool), Error> {
-        let physical_page_size = logical_page_size
-            .checked_add(CHECKSUM_SIZE)
-            .ok_or(Error::OffsetOverflow)?;
-        let physical_page_size_usize =
-            usize::try_from(physical_page_size).map_err(|_| Error::OffsetOverflow)?;
-        let max_batch_pages = u64::try_from((buffer_size.get() / physical_page_size_usize).max(1))
-            .map_err(|_| Error::OffsetOverflow)?;
-
-        // Pages below the caller's proven prefix are accepted without reading.
-        let start_page = start_page.min(total_pages);
-        let mut valid_len = start_page
-            .checked_mul(logical_page_size)
-            .ok_or(Error::OffsetOverflow)?;
-        let mut page = start_page;
-        while page < total_pages {
-            // Bound each read while deriving its physical range with checked arithmetic.
-            let batch_pages = max_batch_pages.min(total_pages - page);
-            let batch_end = page.checked_add(batch_pages).ok_or(Error::OffsetOverflow)?;
-            let physical_offset = page
-                .checked_mul(physical_page_size)
-                .ok_or(Error::OffsetOverflow)?;
-            let physical_len = batch_pages
-                .checked_mul(physical_page_size)
-                .ok_or(Error::OffsetOverflow)?;
-            let physical_len = usize::try_from(physical_len).map_err(|_| Error::OffsetOverflow)?;
-
-            // Coalesce once so each physical page can be checksum-validated in place.
-            let physical = blob
-                .read_at(physical_offset, physical_len, read_options)
-                .await?
-                .coalesce();
-
-            // The first invalid page terminates the only recoverable contiguous prefix.
-            for (batch_page, physical_page) in physical
-                .as_ref()
-                .chunks_exact(physical_page_size_usize)
-                .enumerate()
-            {
-                let Some(checksum) = Checksum::validate_page(physical_page) else {
-                    return Ok((valid_len, false));
-                };
-                let len = u64::from(checksum.len);
-                valid_len = valid_len.checked_add(len).ok_or(Error::OffsetOverflow)?;
-
-                // A valid partial logical page is terminal only when it ends the scanned blob.
-                if len < logical_page_size {
-                    let scanned_pages = page
-                        .checked_add(batch_page as u64)
-                        .and_then(|page| page.checked_add(1))
-                        .ok_or(Error::OffsetOverflow)?;
-                    return Ok((valid_len, scanned_pages == total_pages));
-                }
-            }
-            page = batch_end;
-        }
-        Ok((valid_len, true))
     }
 
     /// Wait for any started sync to complete without starting a new sync.
@@ -1678,6 +1614,25 @@ mod tests {
                     .unwrap(),
                 4 * page
             );
+
+            // A partial tail is still read when the proof overshoots the blob: the clamp stops
+            // at the full pages, so the tail contributes its logical length, not a full page.
+            writer.append(&data[..20]).await.unwrap();
+            writer.sync().await.unwrap();
+            for proven in [4 * page + 20, 5 * page, 100 * page] {
+                assert_eq!(
+                    writer
+                        .recoverable_prefix_len(
+                            proven,
+                            NZUsize!(BUFFER_SIZE),
+                            ReadOptions::default()
+                        )
+                        .await
+                        .unwrap(),
+                    4 * page + 20,
+                    "proven {proven}"
+                );
+            }
         });
     }
 
@@ -1752,35 +1707,26 @@ mod tests {
 
             // A sub-page budget falls back to one page per read.
             recordings.clear();
-            let physical_page_size = PAGE_SIZE.get() as usize + CHECKSUM_SIZE as usize;
-            let physical_size = physical_page_size as u64 * 9;
-            let (recoverable, complete) = Writer::<_>::recoverable_prefix_len_from_blob(
-                &blob,
-                physical_size,
-                PAGE_SIZE,
-                NZUsize!(1),
-                ReadOptions::default(),
-            )
-            .await
-            .unwrap();
-            assert_eq!(recoverable, total as u64);
-            assert!(complete);
+            assert_eq!(
+                writer
+                    .recoverable_prefix_len(0, NZUsize!(1), ReadOptions::default())
+                    .await
+                    .unwrap(),
+                total as u64
+            );
             assert_eq!(recordings.snapshot().reads.len(), 9);
 
             // A three-page budget coalesces the same scan into three reads.
             recordings.clear();
+            let physical_page_size = PAGE_SIZE.get() as usize + CHECKSUM_SIZE as usize;
             let scan_buffer = NonZeroUsize::new(physical_page_size * 3).unwrap();
-            let (recoverable, complete) = Writer::<_>::recoverable_prefix_len_from_blob(
-                &blob,
-                physical_size,
-                PAGE_SIZE,
-                scan_buffer,
-                ReadOptions::default(),
-            )
-            .await
-            .unwrap();
-            assert_eq!(recoverable, total as u64);
-            assert!(complete);
+            assert_eq!(
+                writer
+                    .recoverable_prefix_len(0, scan_buffer, ReadOptions::default())
+                    .await
+                    .unwrap(),
+                total as u64
+            );
             assert_eq!(recordings.snapshot().reads.len(), 3);
         });
     }
@@ -3765,20 +3711,6 @@ mod tests {
             assert_eq!(checksum.len1, 3);
             assert_eq!(checksum.len2, 6);
 
-            // The protected slot proves exactly the previously committed boundary: the torn
-            // extension cannot make any later byte part of the recoverable prefix.
-            let (recoverable, complete) = Writer::<_>::recoverable_prefix_len_from_blob(
-                &blob,
-                physical_page_size as u64,
-                PAGE_SIZE,
-                NZUsize!(BUFFER_SIZE),
-                ReadOptions::default(),
-            )
-            .await
-            .unwrap();
-            assert_eq!(recoverable, 3);
-            assert!(complete);
-
             let (blob, blob_size) = context
                 .open("test_partition", b"torn_extension_footer")
                 .await
@@ -3788,6 +3720,16 @@ mod tests {
                 .await
                 .unwrap();
             assert_eq!(recovered.size(), 3);
+
+            // The protected slot proves exactly the previously committed boundary: the torn
+            // extension cannot make any later byte part of the recoverable prefix.
+            assert_eq!(
+                recovered
+                    .recoverable_prefix_len(0, NZUsize!(BUFFER_SIZE), ReadOptions::default())
+                    .await
+                    .unwrap(),
+                3
+            );
             let data = recovered.read_at(0, 3).await.unwrap().coalesce();
             assert_eq!(data.as_ref(), b"abc");
         });

--- a/runtime/src/utils/buffer/paged/writer.rs
+++ b/runtime/src/utils/buffer/paged/writer.rs
@@ -25,9 +25,9 @@
 //! # Checksums
 //!
 //! Each physical page ends in a two-slot CRC record. The slots let a partial page be rewritten
-//! without clobbering its previously committed contents, so an interrupted write loses at most
-//! the bytes it was writing. [Writer::new] backs up over any trailing bytes not covered by a
-//! valid checksum, treating them as an incomplete write.
+//! without clobbering its last durable contents, so an interrupted write loses at most unsynced
+//! bytes. [Writer::new] backs up over any trailing bytes not covered by a valid checksum,
+//! treating them as an incomplete write.
 //!
 //! # Raw [Blob] handles
 //!
@@ -105,6 +105,15 @@ pub struct Writer<B: Blob> {
     /// The active checksum of the partial page in the blob, if any.
     partial_page_state: Option<ActiveChecksum>,
 
+    /// The durable checksum of the page a partial-page flush would rewrite, if any.
+    ///
+    /// Rewrites preserve this slot byte-identically so a torn rewrite can never lose the page's
+    /// last durable contents. It trails [Self::partial_page_state] until a completed sync proves
+    /// the flushed state durable: an unsynced flush ([Self::replay], [Self::snapshot]) must not
+    /// advance it, or a later rewrite would evict the durable checksum and a crash cutting both
+    /// writes could leave no slot covering the synced prefix.
+    durable_page_state: Option<ActiveChecksum>,
+
     /// Durability state for plain writes, resizes, and range-sync writes.
     sync_state: SyncState,
 
@@ -161,6 +170,7 @@ impl<B: Blob> Writer<B> {
             blob,
             current_page,
             partial_page_state,
+            durable_page_state: partial_page_state,
             sync_state: if needs_sync {
                 SyncState::Dirty
             } else {
@@ -368,14 +378,34 @@ impl<B: Blob> Writer<B> {
         Ok(offset)
     }
 
+    /// Whether a flush would emit any physical page write. Mirrors the emptiness rules of
+    /// [Self::to_physical_pages]: full buffered pages always flush, and a partial page flushes
+    /// only when its length differs from the last flushed partial state.
+    fn has_flush_work(&self, write_partial_page: bool) -> bool {
+        let page_size = self.cache_ref.page_size() as usize;
+        if self.buffer.len() / page_size > 0 {
+            return true;
+        }
+        if !write_partial_page {
+            return false;
+        }
+        let partial_len = self.buffer.len() % page_size;
+        if partial_len == 0 {
+            return false;
+        }
+        self.partial_page_state
+            .as_ref()
+            .is_none_or(|state| state.len as usize != partial_len)
+    }
+
     /// Flush all full pages from the buffer to disk, resetting the buffer to contain only the bytes
     /// in any final partial page.
     ///
     /// If `write_partial_page` is true, the partial page will be written to the blob as well along
     /// with a CRC record.
     ///
-    /// A flush emits one write covering whole physical pages. A previously committed partial page
-    /// is rewritten in full, preserving its committed bytes and protected checksum slot.
+    /// A flush emits one write covering whole physical pages. A previously written partial page
+    /// is rewritten in full, preserving its durable bytes and protected checksum slot.
     ///
     /// If `sync` is true, the emitted write is made durable immediately. When an earlier mutation
     /// is pending, the write is followed by a blob sync instead of relying on per-write durability.
@@ -386,21 +416,34 @@ impl<B: Blob> Writer<B> {
         write_partial_page: bool,
         sync: bool,
     ) -> Result<bool, Error> {
-        // Prepare the *physical* pages corresponding to the data in the buffer.
-        // Pass the old partial page state so the CRC record is constructed correctly.
+        // If there's nothing to write, return early without observing any pending barrier (an
+        // empty start_sync must remain a cheap re-observation of the in-flight sync).
+        if !self.has_flush_work(write_partial_page) {
+            return Ok(false);
+        }
+
+        // A flush mutates the blob, so first resolve any outstanding start_sync barrier. Once
+        // no unsynced mutation remains, the last flushed partial state is durable and becomes
+        // the checksum the rewrite below must preserve.
+        self.sync_state.wait_for_pending().await?;
+        if self.sync_state.is_clean() {
+            self.durable_page_state = self.partial_page_state;
+        }
+
+        // Prepare the *physical* pages corresponding to the data in the buffer. Rewrites
+        // preserve the durable checksum, not merely the last flushed one: an unsynced flush
+        // (replay, snapshot) may have rewritten the partial page with no barrier, and a torn
+        // later rewrite must still leave the durable contents recoverable.
         let (physical_pages, partial_page_state) = self.to_physical_pages(
             &self.buffer,
             write_partial_page,
             self.partial_page_state.as_ref(),
+            self.durable_page_state.as_ref(),
         );
-
-        // If there's nothing to write, return early.
-        if physical_pages.is_empty() {
-            return Ok(false);
-        }
-
-        // A flush mutates the blob, so first resolve any outstanding start_sync barrier.
-        self.sync_state.wait_for_pending().await?;
+        assert!(
+            !physical_pages.is_empty(),
+            "flush work predicate must match physical page construction"
+        );
 
         // Split buffered bytes into full logical pages to hand off now, leaving any trailing
         // partial page in tip for continued buffering.
@@ -443,6 +486,15 @@ impl<B: Blob> Writer<B> {
         // the blob after any mutable method returns an error.
         self.current_page += pages_to_cache as u64;
         self.partial_page_state = partial_page_state;
+        self.durable_page_state = if sync {
+            // The write below is made durable before this flush returns.
+            partial_page_state
+        } else if pages_to_cache > 0 {
+            // The tip moved to a page with no durable contents to preserve yet.
+            None
+        } else {
+            self.durable_page_state
+        };
 
         // Make sure the buffer offset and underlying blob agree on the state of the tip.
         assert_eq!(self.current_page * self.cache_ref.page_size(), new_offset);
@@ -560,17 +612,20 @@ impl<B: Blob> Writer<B> {
     ///
     /// * `buffer` - The buffer containing logical page data
     /// * `include_partial_page` - Whether to include a partial page if one exists
-    /// * `old_checksum` - The active checksum from a previously committed partial page, if any.
-    ///   When present, the first page's CRC record will preserve it in its original slot and place
-    ///   the new checksum in the other slot.
+    /// * `flushed` - The active checksum of the last flushed partial page, if any. Used only to
+    ///   detect a partial page with nothing new to write.
+    /// * `durable` - The durable checksum of the page being rewritten, if any. When present, the
+    ///   first page's CRC record preserves it in its original slot and places the new checksum
+    ///   in the other slot.
     ///
-    /// Returns the physical pages to write and, for any included partial page, the active
-    /// checksum future flushes must protect.
+    /// Returns the physical pages to write and, for any included partial page, its new active
+    /// checksum.
     fn to_physical_pages(
         &self,
         buffer: &Buffer,
         include_partial_page: bool,
-        old_checksum: Option<&ActiveChecksum>,
+        flushed: Option<&ActiveChecksum>,
+        durable: Option<&ActiveChecksum>,
     ) -> (IoBufs, Option<ActiveChecksum>) {
         let page_size = self.cache_ref.page_size() as usize;
         let physical_page_size = page_size + CHECKSUM_SIZE as usize;
@@ -581,7 +636,7 @@ impl<B: Blob> Writer<B> {
         if pages_to_write > 0 {
             self.append_full_pages(
                 &buffer.slice(..pages_to_write * page_size),
-                old_checksum,
+                durable,
                 &mut write_buffer,
             );
         }
@@ -599,23 +654,19 @@ impl<B: Blob> Writer<B> {
         // If there are no full pages and the partial page length matches what was already
         // written, there's nothing new to write.
         if pages_to_write == 0
-            && let Some(old_checksum) = old_checksum
-            && partial_page.len() == old_checksum.len as usize
+            && let Some(flushed) = flushed
+            && partial_page.len() == flushed.len as usize
         {
             return (write_buffer, None);
         }
         let partial_len = partial_page.len();
         let crc = Crc32::checksum(partial_page);
 
-        // For partial pages: if this is the first page and there's an old CRC, preserve it.
+        // For partial pages: if this is the first page and there's a durable CRC, preserve it.
         // Otherwise just use the new CRC in slot 0.
-        let old_checksum = if pages_to_write == 0 {
-            old_checksum
-        } else {
-            None
-        };
+        let durable = if pages_to_write == 0 { durable } else { None };
         let (crc_record, active_checksum) =
-            Self::build_crc_record(partial_len as u16, crc, old_checksum);
+            Self::build_crc_record(partial_len as u16, crc, durable);
 
         // A persisted partial page still occupies one full physical page:
         // [partial logical bytes, zero padding, crc record].
@@ -858,7 +909,10 @@ impl<B: Blob> Writer<B> {
         }
 
         // The flush had nothing to write. Sync only if a durability barrier is still pending.
-        self.sync_state.sync(&self.blob).await
+        // Everything flushed is durable once it completes.
+        self.sync_state.sync(&self.blob).await?;
+        self.durable_page_state = self.partial_page_state;
+        Ok(())
     }
 
     /// Flushes buffered data and begins making all pending mutations durable, returning a
@@ -881,36 +935,258 @@ impl<B: Blob> Writer<B> {
     /// at the first invalid or short page.
     ///
     /// Expects all appended bytes to have reached the blob (as after recovery): a partial page
-    /// still buffered in this writer is unreadable from the blob and fails the scan.
-    pub async fn recoverable_prefix_len(&self) -> Result<u64, Error> {
+    /// still buffered in this writer is unreadable from the blob and fails the scan. `buffer_size`
+    /// bounds each blob read, with a minimum of one physical page. Applies `read_options` to
+    /// every blob read.
+    ///
+    /// `proven` is a logical byte offset already known valid (a durability watermark or a
+    /// replay-validated prefix). Pages wholly below it are accepted without reading, and the
+    /// scan starts at the page containing it.
+    pub async fn recoverable_prefix_len(
+        &self,
+        proven: u64,
+        buffer_size: NonZeroUsize,
+        read_options: ReadOptions,
+    ) -> Result<u64, Error> {
         let logical_page_size = self.cache_ref.page_size();
         let total_pages = self.current_page + u64::from(self.partial_page_state.is_some());
-        let mut valid_len = 0u64;
-        for page in 0..total_pages {
-            // Recovery may replay the validated prefix immediately, so use the
-            // default cache policy.
-            match super::get_page_with_checksum_from_blob(
-                &self.blob,
+        let (recoverable, _) = Self::recoverable_prefix_len_from_pages(
+            &self.blob,
+            logical_page_size,
+            total_pages,
+            proven / logical_page_size,
+            buffer_size,
+            read_options,
+        )
+        .await?;
+        Ok(recoverable)
+    }
+
+    /// Read a logical range directly from a raw paged blob, validating every page it spans.
+    ///
+    /// Returns [Error::BlobInsufficientLength] when valid page contents do not cover the whole
+    /// range, and [Error::OffsetOverflow] when its end or page offsets overflow.
+    pub async fn read_validated_from_blob(
+        blob: &B,
+        logical_page_size: NonZeroU16,
+        offset: u64,
+        len: usize,
+        read_options: ReadOptions,
+    ) -> Result<IoBufs, Error> {
+        // Resolve the requested range before allocating or reading any pages.
+        let len_u64 = u64::try_from(len).map_err(|_| Error::OffsetOverflow)?;
+        let end = offset.checked_add(len_u64).ok_or(Error::OffsetOverflow)?;
+        if len == 0 {
+            return Ok(IoBufs::default());
+        }
+
+        // Identify the inclusive logical page range spanning the requested bytes.
+        let logical_page_size = u64::from(logical_page_size.get());
+        let first_page = offset / logical_page_size;
+        let last_page = (end - 1) / logical_page_size;
+        let mut out = IoBufs::default();
+
+        // Validate every spanning page and append only its intersection with the requested range.
+        for page in first_page..=last_page {
+            let (logical, _) = super::get_page_with_checksum_from_blob(
+                blob,
                 page,
                 logical_page_size,
-                ReadOptions::default(),
+                read_options,
             )
-            .await
-            {
-                Ok((logical, _)) => {
-                    let len = logical.len() as u64;
-                    valid_len += len;
-                    // A partial page can only legitimately be the last one, so stop here.
-                    if len < logical_page_size {
-                        break;
-                    }
-                }
-                // First torn/invalid page: the contiguous valid prefix ends here.
-                Err(Error::InvalidChecksum) => break,
-                Err(err) => return Err(err),
+            .await?;
+            let page_start = page
+                .checked_mul(logical_page_size)
+                .ok_or(Error::OffsetOverflow)?;
+            let logical_len = u64::try_from(logical.len()).map_err(|_| Error::OffsetOverflow)?;
+            let page_end = page_start
+                .checked_add(logical_len)
+                .ok_or(Error::OffsetOverflow)?;
+            let overlap_start = offset.max(page_start);
+            let overlap_end = end.min(page_end);
+            if overlap_start >= overlap_end {
+                return Err(Error::BlobInsufficientLength);
             }
+            let start = (overlap_start - page_start) as usize;
+            let end = (overlap_end - page_start) as usize;
+            out.append(logical.slice(start..end));
         }
-        Ok(valid_len)
+
+        // A short terminal page can leave the requested range only partially covered.
+        if out.len() != len {
+            return Err(Error::BlobInsufficientLength);
+        }
+        Ok(out)
+    }
+
+    /// Read the terminal logical range of a raw paged blob and return its logical size.
+    ///
+    /// The blob must contain only complete physical pages. The last page is validated first to
+    /// determine the logical end. If `len` crosses a page boundary, preceding pages are validated
+    /// with [Self::read_validated_from_blob].
+    pub async fn read_validated_tail_from_blob(
+        blob: &B,
+        physical_size: u64,
+        logical_page_size: NonZeroU16,
+        len: usize,
+        read_options: ReadOptions,
+    ) -> Result<(u64, IoBufs), Error> {
+        if physical_size == 0 {
+            return if len == 0 {
+                Ok((0, IoBufs::default()))
+            } else {
+                Err(Error::BlobInsufficientLength)
+            };
+        }
+
+        let page_size = u64::from(logical_page_size.get());
+        let physical_page_size = page_size
+            .checked_add(CHECKSUM_SIZE)
+            .ok_or(Error::OffsetOverflow)?;
+        if !physical_size.is_multiple_of(physical_page_size) {
+            return Err(Error::BlobInsufficientLength);
+        }
+
+        // The checksum length on the terminal page determines the blob's logical end.
+        let page = physical_size / physical_page_size - 1;
+        let (tail, _) =
+            super::get_page_with_checksum_from_blob(blob, page, page_size, read_options).await?;
+        let page_start = page.checked_mul(page_size).ok_or(Error::OffsetOverflow)?;
+        let logical_size = page_start
+            .checked_add(u64::try_from(tail.len()).map_err(|_| Error::OffsetOverflow)?)
+            .ok_or(Error::OffsetOverflow)?;
+        let len_u64 = u64::try_from(len).map_err(|_| Error::OffsetOverflow)?;
+        let offset = logical_size
+            .checked_sub(len_u64)
+            .ok_or(Error::BlobInsufficientLength)?;
+
+        // Read only the portion preceding the terminal page, then append its already-validated
+        // suffix. This keeps a terminal item wholly within the last page to one blob read.
+        let mut out = if offset < page_start {
+            let prefix_len =
+                usize::try_from(page_start - offset).map_err(|_| Error::OffsetOverflow)?;
+            Self::read_validated_from_blob(
+                blob,
+                logical_page_size,
+                offset,
+                prefix_len,
+                read_options,
+            )
+            .await?
+        } else {
+            IoBufs::default()
+        };
+        let tail_start = usize::try_from(offset.max(page_start) - page_start)
+            .map_err(|_| Error::OffsetOverflow)?;
+        out.append(tail.slice(tail_start..));
+        assert_eq!(out.len(), len);
+        Ok((logical_size, out))
+    }
+
+    /// Return the contiguous recoverable prefix of a raw paged blob without mutating it.
+    ///
+    /// `physical_size` must be the blob's current size, and the blob must remain unchanged while
+    /// the scan runs.
+    ///
+    /// The boolean is true only when every physical byte belongs to a valid page in that prefix.
+    /// It is false when the scan stops at a short or invalid page, at a partial physical page, or
+    /// before a later physical page. `buffer_size` bounds each read with the same one-page minimum
+    /// as replay.
+    pub async fn recoverable_prefix_len_from_blob(
+        blob: &B,
+        physical_size: u64,
+        logical_page_size: NonZeroU16,
+        buffer_size: NonZeroUsize,
+        read_options: ReadOptions,
+    ) -> Result<(u64, bool), Error> {
+        let logical_page_size = u64::from(logical_page_size.get());
+        let physical_page_size = logical_page_size
+            .checked_add(CHECKSUM_SIZE)
+            .ok_or(Error::OffsetOverflow)?;
+        let total_pages = physical_size / physical_page_size;
+        let (recoverable, complete) = Self::recoverable_prefix_len_from_pages(
+            blob,
+            logical_page_size,
+            total_pages,
+            0,
+            buffer_size,
+            read_options,
+        )
+        .await?;
+        Ok((
+            recoverable,
+            complete && physical_size.is_multiple_of(physical_page_size),
+        ))
+    }
+
+    /// Scan complete physical pages in bounded batches and return their contiguous logical prefix.
+    ///
+    /// The boolean is true only when all requested pages were consumed, including any terminal
+    /// partial logical page.
+    async fn recoverable_prefix_len_from_pages(
+        blob: &B,
+        logical_page_size: u64,
+        total_pages: u64,
+        start_page: u64,
+        buffer_size: NonZeroUsize,
+        read_options: ReadOptions,
+    ) -> Result<(u64, bool), Error> {
+        let physical_page_size = logical_page_size
+            .checked_add(CHECKSUM_SIZE)
+            .ok_or(Error::OffsetOverflow)?;
+        let physical_page_size_usize =
+            usize::try_from(physical_page_size).map_err(|_| Error::OffsetOverflow)?;
+        let max_batch_pages = u64::try_from((buffer_size.get() / physical_page_size_usize).max(1))
+            .map_err(|_| Error::OffsetOverflow)?;
+
+        // Pages below the caller's proven prefix are accepted without reading.
+        let start_page = start_page.min(total_pages);
+        let mut valid_len = start_page
+            .checked_mul(logical_page_size)
+            .ok_or(Error::OffsetOverflow)?;
+        let mut page = start_page;
+        while page < total_pages {
+            // Bound each read while deriving its physical range with checked arithmetic.
+            let batch_pages = max_batch_pages.min(total_pages - page);
+            let batch_end = page.checked_add(batch_pages).ok_or(Error::OffsetOverflow)?;
+            let physical_offset = page
+                .checked_mul(physical_page_size)
+                .ok_or(Error::OffsetOverflow)?;
+            let physical_len = batch_pages
+                .checked_mul(physical_page_size)
+                .ok_or(Error::OffsetOverflow)?;
+            let physical_len = usize::try_from(physical_len).map_err(|_| Error::OffsetOverflow)?;
+
+            // Coalesce once so each physical page can be checksum-validated in place.
+            let physical = blob
+                .read_at(physical_offset, physical_len, read_options)
+                .await?
+                .coalesce();
+
+            // The first invalid page terminates the only recoverable contiguous prefix.
+            for (batch_page, physical_page) in physical
+                .as_ref()
+                .chunks_exact(physical_page_size_usize)
+                .enumerate()
+            {
+                let Some(checksum) = Checksum::validate_page(physical_page) else {
+                    return Ok((valid_len, false));
+                };
+                let len = u64::from(checksum.len);
+                valid_len = valid_len.checked_add(len).ok_or(Error::OffsetOverflow)?;
+
+                // A valid partial logical page is terminal only when it ends the scanned blob.
+                if len < logical_page_size {
+                    let scanned_pages = page
+                        .checked_add(batch_page as u64)
+                        .and_then(|page| page.checked_add(1))
+                        .ok_or(Error::OffsetOverflow)?;
+                    return Ok((valid_len, scanned_pages == total_pages));
+                }
+            }
+            page = batch_end;
+        }
+        Ok((valid_len, true))
     }
 
     /// Wait for any started sync to complete without starting a new sync.
@@ -1003,6 +1279,7 @@ impl<B: Blob> Writer<B> {
 
         // Shrink the blob to a page boundary, which requires no CRC-slot rewrite.
         self.partial_page_state = None;
+        self.durable_page_state = None;
         self.current_page = full_pages;
         self.buffer.offset = tail_offset;
         self.buffer.clear();
@@ -1052,7 +1329,10 @@ impl<B: Blob> Writer<B> {
                 &old_checksum,
             )
             .await?;
+
+        // The shrink surgery above made the new record durable.
         self.partial_page_state = Some(final_record);
+        self.durable_page_state = Some(final_record);
 
         Ok(())
     }
@@ -1150,6 +1430,70 @@ mod tests {
         });
     }
 
+    /// Unsynced partial-page flushes ([Writer::snapshot], [Writer::replay]) rewrite the tail
+    /// page without a durability barrier. Every rewrite must keep the page's durable checksum
+    /// slot byte-identical: a crash can cut the unsynced rewrites per byte, and whichever bytes
+    /// land, the footer must still validate the synced prefix.
+    #[test_traced("DEBUG")]
+    fn test_unsynced_flushes_preserve_durable_checksum_slot() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context: deterministic::Context| async move {
+            let page_size = PAGE_SIZE.get() as usize;
+            let physical_page = page_size + CHECKSUM_SIZE as usize;
+            let (blob, blob_size) = context
+                .open("test_partition", b"snapshot_torn")
+                .await
+                .unwrap();
+            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
+            let mut writer = Writer::new(blob.clone(), blob_size, BUFFER_SIZE, cache_ref.clone())
+                .await
+                .unwrap();
+
+            // Make a mid-page prefix durable and capture the page's durable image.
+            let synced: Vec<u8> = (1u8..=24).collect();
+            writer.append(&synced).await.unwrap();
+            writer.sync().await.unwrap();
+            let durable_image = blob
+                .read_at(0, physical_page, ReadOptions::default())
+                .await
+                .unwrap()
+                .coalesce();
+
+            // Two unsynced rewrites of the same page.
+            writer.append(&[25u8; 8]).await.unwrap();
+            drop(writer.snapshot().await.unwrap());
+            writer.append(&[26u8; 8]).await.unwrap();
+            drop(writer.snapshot().await.unwrap());
+            let torn_image = blob
+                .read_at(0, physical_page, ReadOptions::default())
+                .await
+                .unwrap()
+                .coalesce();
+
+            // Crash: of the unsynced rewrites, only the final one's footer bytes land, while
+            // the logical region keeps its durable bytes.
+            let mut crash = durable_image.as_ref().to_vec();
+            crash[page_size..].copy_from_slice(&torn_image.as_ref()[page_size..]);
+            let (crashed, _) = context
+                .open("test_partition", b"snapshot_crash")
+                .await
+                .unwrap();
+            crashed
+                .write_at(0, crash, WriteOptions::default())
+                .await
+                .unwrap();
+            crashed.sync().await.unwrap();
+
+            // The synced prefix must recover through the preserved durable slot.
+            let recovered = Writer::new(crashed, physical_page as u64, BUFFER_SIZE, cache_ref)
+                .await
+                .unwrap();
+            assert_eq!(recovered.size(), synced.len() as u64);
+            let read = recovered.read_at(0, synced.len()).await.unwrap().coalesce();
+            assert_eq!(read.as_ref(), synced.as_slice());
+        });
+    }
+
     /// `recoverable_prefix_len` returns the full logical size when every page is well-formed.
     #[test_traced("DEBUG")]
     fn test_recoverable_prefix_len_clean() {
@@ -1164,7 +1508,13 @@ mod tests {
             let mut writer = Writer::new(blob, blob_size, BUFFER_SIZE, cache_ref.clone())
                 .await
                 .unwrap();
-            assert_eq!(writer.recoverable_prefix_len().await.unwrap(), 0);
+            assert_eq!(
+                writer
+                    .recoverable_prefix_len(0, NZUsize!(BUFFER_SIZE), ReadOptions::default())
+                    .await
+                    .unwrap(),
+                0
+            );
 
             let total = PAGE_SIZE.get() as usize * 2 + 50;
             let data: Vec<u8> = (0u8..=255).cycle().take(total).collect();
@@ -1173,7 +1523,13 @@ mod tests {
 
             // Prefix validation uses the default options so recovery can reuse the validated pages.
             recordings.clear();
-            assert_eq!(writer.recoverable_prefix_len().await.unwrap(), total as u64);
+            assert_eq!(
+                writer
+                    .recoverable_prefix_len(0, NZUsize!(BUFFER_SIZE), ReadOptions::default())
+                    .await
+                    .unwrap(),
+                total as u64
+            );
             let reads = recordings.snapshot().reads;
             assert!(!reads.is_empty());
             assert!(
@@ -1240,8 +1596,87 @@ mod tests {
             blob.sync().await.unwrap();
 
             assert_eq!(
-                writer.recoverable_prefix_len().await.unwrap(),
+                writer
+                    .recoverable_prefix_len(0, NZUsize!(BUFFER_SIZE), ReadOptions::default())
+                    .await
+                    .unwrap(),
                 PAGE_SIZE.get() as u64
+            );
+        });
+    }
+
+    /// A proven prefix skips its pages without reading them: a scan started past a torn page
+    /// accepts the caller's proof, and a proof past the blob's end clamps without panicking.
+    #[test_traced("DEBUG")]
+    fn test_recoverable_prefix_len_proven_prefix() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context: deterministic::Context| async move {
+            let (blob, blob_size) = context
+                .open("test_partition", b"prefix_proven")
+                .await
+                .unwrap();
+            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
+            let mut writer = Writer::new(blob.clone(), blob_size, BUFFER_SIZE, cache_ref)
+                .await
+                .unwrap();
+            let total = PAGE_SIZE.get() as usize * 4;
+            let data: Vec<u8> = (0u8..=255).cycle().take(total).collect();
+            writer.append(&data).await.unwrap();
+            writer.sync().await.unwrap();
+
+            // Tear page 1, leaving pages 0 and 2+ valid.
+            let physical_page_size = PAGE_SIZE.get() as u64 + CHECKSUM_SIZE;
+            let offset = physical_page_size + 7;
+            let byte = blob
+                .read_at(offset, 1, ReadOptions::default())
+                .await
+                .unwrap()
+                .coalesce();
+            blob.write_at(
+                offset,
+                vec![byte.as_ref()[0] ^ 0xFF],
+                WriteOptions::default(),
+            )
+            .await
+            .unwrap();
+            blob.sync().await.unwrap();
+
+            // An unproven scan stops at the torn page. A proof past it skips the damage and
+            // scans the remainder, and a mid-page proof rescans the page containing it.
+            let page = u64::from(PAGE_SIZE.get());
+            for (proven, expected) in [
+                (0, page),
+                (page, page),
+                (2 * page, 4 * page),
+                (2 * page + 3, 4 * page),
+                (total as u64, 4 * page),
+            ] {
+                assert_eq!(
+                    writer
+                        .recoverable_prefix_len(
+                            proven,
+                            NZUsize!(BUFFER_SIZE),
+                            ReadOptions::default()
+                        )
+                        .await
+                        .unwrap(),
+                    expected,
+                    "proven {proven}"
+                );
+            }
+
+            // A proof past the blob clamps to the pages that exist. Callers only pass proven
+            // prefixes, and storage-level guards reject a prefix the blob cannot back.
+            assert_eq!(
+                writer
+                    .recoverable_prefix_len(
+                        100 * page,
+                        NZUsize!(BUFFER_SIZE),
+                        ReadOptions::default()
+                    )
+                    .await
+                    .unwrap(),
+                4 * page
             );
         });
     }
@@ -1283,7 +1718,70 @@ mod tests {
                 .unwrap();
             blob.sync().await.unwrap();
 
-            assert_eq!(writer.recoverable_prefix_len().await.unwrap(), 20);
+            assert_eq!(
+                writer
+                    .recoverable_prefix_len(0, NZUsize!(BUFFER_SIZE), ReadOptions::default())
+                    .await
+                    .unwrap(),
+                20
+            );
+        });
+    }
+
+    /// A clean scan derives its read batches from the supplied byte budget while always making
+    /// progress by at least one page.
+    #[test_traced("DEBUG")]
+    fn test_recoverable_prefix_len_batches_reads() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context: deterministic::Context| async move {
+            let (context, recordings) = RecordingContext::new(context);
+            let (blob, blob_size) = context
+                .open("test_partition", b"prefix_batches")
+                .await
+                .unwrap();
+            let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(BUFFER_SIZE));
+            let mut writer = Writer::new(blob.clone(), blob_size, BUFFER_SIZE, cache_ref)
+                .await
+                .unwrap();
+
+            // Eight full pages plus a partial tail span three batches under a three-page budget.
+            let total = PAGE_SIZE.get() as usize * 8 + 10;
+            let data: Vec<u8> = (0u8..=255).cycle().take(total).collect();
+            writer.append(&data).await.unwrap();
+            writer.sync().await.unwrap();
+
+            // A sub-page budget falls back to one page per read.
+            recordings.clear();
+            let physical_page_size = PAGE_SIZE.get() as usize + CHECKSUM_SIZE as usize;
+            let physical_size = physical_page_size as u64 * 9;
+            let (recoverable, complete) = Writer::<_>::recoverable_prefix_len_from_blob(
+                &blob,
+                physical_size,
+                PAGE_SIZE,
+                NZUsize!(1),
+                ReadOptions::default(),
+            )
+            .await
+            .unwrap();
+            assert_eq!(recoverable, total as u64);
+            assert!(complete);
+            assert_eq!(recordings.snapshot().reads.len(), 9);
+
+            // A three-page budget coalesces the same scan into three reads.
+            recordings.clear();
+            let scan_buffer = NonZeroUsize::new(physical_page_size * 3).unwrap();
+            let (recoverable, complete) = Writer::<_>::recoverable_prefix_len_from_blob(
+                &blob,
+                physical_size,
+                PAGE_SIZE,
+                scan_buffer,
+                ReadOptions::default(),
+            )
+            .await
+            .unwrap();
+            assert_eq!(recoverable, total as u64);
+            assert!(complete);
+            assert_eq!(recordings.snapshot().reads.len(), 3);
         });
     }
 
@@ -3267,6 +3765,20 @@ mod tests {
             assert_eq!(checksum.len1, 3);
             assert_eq!(checksum.len2, 6);
 
+            // The protected slot proves exactly the previously committed boundary: the torn
+            // extension cannot make any later byte part of the recoverable prefix.
+            let (recoverable, complete) = Writer::<_>::recoverable_prefix_len_from_blob(
+                &blob,
+                physical_page_size as u64,
+                PAGE_SIZE,
+                NZUsize!(BUFFER_SIZE),
+                ReadOptions::default(),
+            )
+            .await
+            .unwrap();
+            assert_eq!(recoverable, 3);
+            assert!(complete);
+
             let (blob, blob_size) = context
                 .open("test_partition", b"torn_extension_footer")
                 .await
@@ -3445,7 +3957,7 @@ mod tests {
 
             // Convert buffered logical bytes into physical-page writes.
             let (physical_pages, partial_page_state) =
-                append.to_physical_pages(&buffer, true, None);
+                append.to_physical_pages(&buffer, true, None, None);
 
             // Two full pages should each contribute a logical slice and a CRC slice, and the
             // trailing partial page should contribute one materialized padded physical page.

--- a/runtime/src/utils/buffer/paged/writer.rs
+++ b/runtime/src/utils/buffer/paged/writer.rs
@@ -132,6 +132,11 @@ impl<B: Blob> Writer<B> {
     /// Wrap `blob` in a [Writer]. `blob` must already hold `original_blob_size` physical bytes;
     /// reads are cached through `cache_ref` and appends stage in a write buffer of capacity
     /// `capacity`. Rewinds the blob if necessary so it only contains checksum-validated data.
+    ///
+    /// The blob's tail-page contents must be durable (freshly opened after a crash, or synced
+    /// since the last partial-page rewrite): the discovered checksum slot seeds the writer's
+    /// durable-slot tracking, so wrapping a blob whose tail rewrite is still volatile would
+    /// let a later unsynced flush overwrite the only durable slot.
     pub async fn new(
         blob: B,
         original_blob_size: u64,
@@ -378,24 +383,32 @@ impl<B: Blob> Writer<B> {
         Ok(offset)
     }
 
-    /// Whether a flush would emit any physical page write. Mirrors the emptiness rules of
-    /// [Self::to_physical_pages]: full buffered pages always flush, and a partial page flushes
-    /// only when its length differs from the last flushed partial state.
+    /// Whether a partial page of `partial_len` bytes needs a write when `full_pages` full
+    /// pages precede it in the same flush and `flushed` is the last flushed partial state: an
+    /// empty tip never writes, a moved tip always writes, and an unmoved tip writes only when
+    /// its length changed.
+    fn partial_page_dirty(
+        full_pages: usize,
+        partial_len: usize,
+        flushed: Option<&ActiveChecksum>,
+    ) -> bool {
+        partial_len != 0
+            && (full_pages > 0 || flushed.is_none_or(|state| state.len as usize != partial_len))
+    }
+
+    /// Whether a flush would emit any physical page write.
     fn has_flush_work(&self, write_partial_page: bool) -> bool {
         let page_size = self.cache_ref.page_size() as usize;
-        if self.buffer.len() / page_size > 0 {
+        let full_pages = self.buffer.len() / page_size;
+        if full_pages > 0 {
             return true;
         }
-        if !write_partial_page {
-            return false;
-        }
-        let partial_len = self.buffer.len() % page_size;
-        if partial_len == 0 {
-            return false;
-        }
-        self.partial_page_state
-            .as_ref()
-            .is_none_or(|state| state.len as usize != partial_len)
+        write_partial_page
+            && Self::partial_page_dirty(
+                full_pages,
+                self.buffer.len() % page_size,
+                self.partial_page_state.as_ref(),
+            )
     }
 
     /// Flush all full pages from the buffer to disk, resetting the buffer to contain only the bytes
@@ -646,17 +659,7 @@ impl<B: Blob> Writer<B> {
         }
 
         let partial_page = &buffer_data[pages_to_write * page_size..];
-        if partial_page.is_empty() {
-            // No partial page data to write.
-            return (write_buffer, None);
-        }
-
-        // If there are no full pages and the partial page length matches what was already
-        // written, there's nothing new to write.
-        if pages_to_write == 0
-            && let Some(flushed) = flushed
-            && partial_page.len() == flushed.len as usize
-        {
+        if !Self::partial_page_dirty(pages_to_write, partial_page.len(), flushed) {
             return (write_buffer, None);
         }
         let partial_len = partial_page.len();
@@ -1003,127 +1006,6 @@ impl<B: Blob> Writer<B> {
             page = batch_end;
         }
         Ok(valid_len)
-    }
-
-    /// Read a logical range directly from a raw paged blob, validating every page it spans.
-    ///
-    /// Returns [Error::BlobInsufficientLength] when valid page contents do not cover the whole
-    /// range, and [Error::OffsetOverflow] when its end or page offsets overflow.
-    pub async fn read_validated_from_blob(
-        blob: &B,
-        logical_page_size: NonZeroU16,
-        offset: u64,
-        len: usize,
-        read_options: ReadOptions,
-    ) -> Result<IoBufs, Error> {
-        // Resolve the requested range before allocating or reading any pages.
-        let len_u64 = u64::try_from(len).map_err(|_| Error::OffsetOverflow)?;
-        let end = offset.checked_add(len_u64).ok_or(Error::OffsetOverflow)?;
-        if len == 0 {
-            return Ok(IoBufs::default());
-        }
-
-        // Identify the inclusive logical page range spanning the requested bytes.
-        let logical_page_size = u64::from(logical_page_size.get());
-        let first_page = offset / logical_page_size;
-        let last_page = (end - 1) / logical_page_size;
-        let mut out = IoBufs::default();
-
-        // Validate every spanning page and append only its intersection with the requested range.
-        for page in first_page..=last_page {
-            let (logical, _) = super::get_page_with_checksum_from_blob(
-                blob,
-                page,
-                logical_page_size,
-                read_options,
-            )
-            .await?;
-            let page_start = page
-                .checked_mul(logical_page_size)
-                .ok_or(Error::OffsetOverflow)?;
-            let logical_len = u64::try_from(logical.len()).map_err(|_| Error::OffsetOverflow)?;
-            let page_end = page_start
-                .checked_add(logical_len)
-                .ok_or(Error::OffsetOverflow)?;
-            let overlap_start = offset.max(page_start);
-            let overlap_end = end.min(page_end);
-            if overlap_start >= overlap_end {
-                return Err(Error::BlobInsufficientLength);
-            }
-            let start = (overlap_start - page_start) as usize;
-            let end = (overlap_end - page_start) as usize;
-            out.append(logical.slice(start..end));
-        }
-
-        // A short terminal page can leave the requested range only partially covered.
-        if out.len() != len {
-            return Err(Error::BlobInsufficientLength);
-        }
-        Ok(out)
-    }
-
-    /// Read the terminal logical range of a raw paged blob and return its logical size.
-    ///
-    /// The blob must contain only complete physical pages. The last page is validated first to
-    /// determine the logical end. If `len` crosses a page boundary, preceding pages are validated
-    /// with [Self::read_validated_from_blob].
-    pub async fn read_validated_tail_from_blob(
-        blob: &B,
-        physical_size: u64,
-        logical_page_size: NonZeroU16,
-        len: usize,
-        read_options: ReadOptions,
-    ) -> Result<(u64, IoBufs), Error> {
-        if physical_size == 0 {
-            return if len == 0 {
-                Ok((0, IoBufs::default()))
-            } else {
-                Err(Error::BlobInsufficientLength)
-            };
-        }
-
-        let page_size = u64::from(logical_page_size.get());
-        let physical_page_size = page_size
-            .checked_add(CHECKSUM_SIZE)
-            .ok_or(Error::OffsetOverflow)?;
-        if !physical_size.is_multiple_of(physical_page_size) {
-            return Err(Error::BlobInsufficientLength);
-        }
-
-        // The checksum length on the terminal page determines the blob's logical end.
-        let page = physical_size / physical_page_size - 1;
-        let (tail, _) =
-            super::get_page_with_checksum_from_blob(blob, page, page_size, read_options).await?;
-        let page_start = page.checked_mul(page_size).ok_or(Error::OffsetOverflow)?;
-        let logical_size = page_start
-            .checked_add(u64::try_from(tail.len()).map_err(|_| Error::OffsetOverflow)?)
-            .ok_or(Error::OffsetOverflow)?;
-        let len_u64 = u64::try_from(len).map_err(|_| Error::OffsetOverflow)?;
-        let offset = logical_size
-            .checked_sub(len_u64)
-            .ok_or(Error::BlobInsufficientLength)?;
-
-        // Read only the portion preceding the terminal page, then append its already-validated
-        // suffix. This keeps a terminal item wholly within the last page to one blob read.
-        let mut out = if offset < page_start {
-            let prefix_len =
-                usize::try_from(page_start - offset).map_err(|_| Error::OffsetOverflow)?;
-            Self::read_validated_from_blob(
-                blob,
-                logical_page_size,
-                offset,
-                prefix_len,
-                read_options,
-            )
-            .await?
-        } else {
-            IoBufs::default()
-        };
-        let tail_start = usize::try_from(offset.max(page_start) - page_start)
-            .map_err(|_| Error::OffsetOverflow)?;
-        out.append(tail.slice(tail_start..));
-        assert_eq!(out.len(), len);
-        Ok((logical_size, out))
     }
 
     /// Wait for any started sync to complete without starting a new sync.

--- a/runtime/src/utils/buffer/paged/writer.rs
+++ b/runtime/src/utils/buffer/paged/writer.rs
@@ -512,8 +512,8 @@ impl<B: Blob> Writer<B> {
         // Make sure the buffer offset and underlying blob agree on the state of the tip.
         assert_eq!(self.current_page * self.cache_ref.page_size(), new_offset);
 
-        // Rewriting a physical page resubmits its committed bytes and protected checksum
-        // unchanged, so a torn write leaves the previous state recoverable.
+        // Rewriting a physical page resubmits its durable bytes and protected checksum
+        // unchanged, so a torn write leaves the durable state recoverable.
         if sync {
             self.sync_state
                 .write_at(

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -476,7 +476,7 @@ impl<E: Context, A: CodecFixedShared> Inner<E, A> {
             let valid = writer
                 .recoverable_prefix_len(
                     0,
-                    commonware_utils::NZUsize!(4096),
+                    super::RECOVERY_BUFFER,
                     commonware_runtime::ReadOptions::default(),
                 )
                 .await?;

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -473,7 +473,13 @@ impl<E: Context, A: CodecFixedShared> Inner<E, A> {
         let suspects: Vec<u64> = pending.keys().rev().take(2).copied().collect();
         for blob in suspects {
             let writer = pending.get_mut(&blob).expect("suspect blob is present");
-            let valid = writer.recoverable_prefix_len().await?;
+            let valid = writer
+                .recoverable_prefix_len(
+                    0,
+                    commonware_utils::NZUsize!(4096),
+                    commonware_runtime::ReadOptions::default(),
+                )
+                .await?;
             let valid = Self::items_to_bytes(valid / Self::CHUNK_SIZE_U64)?;
             if valid == writer.size() {
                 continue;

--- a/storage/src/journal/contiguous/mod.rs
+++ b/storage/src/journal/contiguous/mod.rs
@@ -27,6 +27,10 @@ pub mod variable;
 #[cfg(test)]
 mod tests;
 
+/// Read-buffer size for recovery scans of suspect blobs.
+// TODO (#4615): replace with replay_buffer
+const RECOVERY_BUFFER: NonZeroUsize = commonware_utils::NZUsize!(4096);
+
 /// Return the number of items that can be written before crossing the current blob boundary.
 ///
 /// `position` is the next logical item position and `remaining` is the number of items left in the

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -1105,7 +1105,13 @@ impl<E: Context, V: CodecShared> Inner<E, V> {
         let suspects: Vec<u64> = pending.keys().rev().take(2).copied().collect();
         for blob in suspects {
             let writer = pending.get_mut(&blob).expect("suspect blob is present");
-            let valid = writer.recoverable_prefix_len().await?;
+            let valid = writer
+                .recoverable_prefix_len(
+                    0,
+                    commonware_utils::NZUsize!(4096),
+                    commonware_runtime::ReadOptions::default(),
+                )
+                .await?;
             if valid == writer.size() {
                 continue;
             }

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -1108,7 +1108,7 @@ impl<E: Context, V: CodecShared> Inner<E, V> {
             let valid = writer
                 .recoverable_prefix_len(
                     0,
-                    commonware_utils::NZUsize!(4096),
+                    super::RECOVERY_BUFFER,
                     commonware_runtime::ReadOptions::default(),
                 )
                 .await?;


### PR DESCRIPTION
Extends the simulated crash model so recovery fuzzers can generate every supported partial-write shape:

- `faulty::WriteConfig` gains an `Arbitrary` grid over (failure rate, retention rate, prefix/subset mode), with a unit test pinning the cell decoding.
- The memory storage gains test-utils raw blob access (`raw_blob`/`set_raw_blob`) and legacy V0-layout opens, with crash tests proving subset writes preserve container headers under both layouts.
- The paged writer tracks its durable checksum slot (`durable_page_state`) so a partial tail-page rewrite can never evict the slot covering the synced prefix, and exposes forward-scanning recovery helpers (`recoverable_prefix_len` takes a proven floor, read buffer, and read options; the two storage call sites are updated mechanically here and reworked in stack 2/4).
- New `blob_creation` fuzz target over versioned header creation, torn-creation recovery, and V0→V1 reopen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



