### PR TITLE
[storage] Recover archives from partial writes

### DIFF
--- a/consensus/conformance.toml
+++ b/consensus/conformance.toml
@@ -24,11 +24,11 @@ hash = "ec3dc188f84f7b163c59e15d21ec9a7c5c2ea1f3f12c3098de52ee57a9c2b70e"
 
 ["commonware_consensus::marshal::conformance::CodingStorageConformance"]
 n_cases = 32
-hash = "8335cf7b198c4889b83633b066ec23aeecd67ce9c568d4741640beb39a024d8a"
+hash = "2ff334d822ff93d08ce5af50daca1478a71389c52973beac7dd3090a1e8659b6"
 
 ["commonware_consensus::marshal::conformance::StandardStorageConformance"]
 n_cases = 32
-hash = "5a263f4dbf20f9ebc64a81bc0dfbf487055b136074809d8c01aa725e28b86f17"
+hash = "75a29a836c5cb2ff9e1801e75851561e061d0d5d44043608cde7b66e443003df"
 
 ["commonware_consensus::marshal::resolver::handler::tests::conformance::CodecConformance<Key<D>>"]
 n_cases = 65536
@@ -130,10 +130,6 @@ hash = "b9fbf2cfcbc37c87cb7aa8ede95c4ddf93c8bbd9f1a01e86ed72ba14bed920fa"
 n_cases = 65536
 hash = "01cc3b0d41d0ef29f02de2729d51b1b31bb96f00c6390e56aadd0fb5117cc7b1"
 
-["commonware_consensus::types::tests::conformance::CodecConformance<TestCommitment>"]
-n_cases = 65536
-hash = "2ce8beed4a11c22fcb65c614f250f5758d71229a729a2fef13faf765b2d9a5ea"
-
 ["commonware_consensus::types::tests::conformance::CodecConformance<Epoch>"]
 n_cases = 65536
 hash = "56ab85978136cb50f12ea89c8d25ce24451788172fe9d3d3c063f7ae6342d279"
@@ -145,6 +141,10 @@ hash = "56ab85978136cb50f12ea89c8d25ce24451788172fe9d3d3c063f7ae6342d279"
 ["commonware_consensus::types::tests::conformance::CodecConformance<Round>"]
 n_cases = 65536
 hash = "d8ccba2653a5a2e5e317f0f365edbfc4845e3dc4325daefe0b43ca75920a654c"
+
+["commonware_consensus::types::tests::conformance::CodecConformance<TestCommitment>"]
+n_cases = 65536
+hash = "2ce8beed4a11c22fcb65c614f250f5758d71229a729a2fef13faf765b2d9a5ea"
 
 ["commonware_consensus::types::tests::conformance::CodecConformance<View>"]
 n_cases = 65536

--- a/consensus/src/marshal/core/cache.rs
+++ b/consensus/src/marshal/core/cache.rs
@@ -296,6 +296,7 @@ where
         let start = ctx.current();
         let archive_cfg = prunable::Config {
             translator: TwoCap,
+            metadata_partition: format!("{}-cache-{epoch}-{name}-metadata", cfg.partition_prefix),
             key_partition: format!("{}-cache-{epoch}-{name}-key", cfg.partition_prefix),
             key_page_cache: cfg.key_page_cache.clone(),
             value_partition: format!("{}-cache-{epoch}-{name}-value", cfg.partition_prefix),

--- a/consensus/src/marshal/mocks/harness.rs
+++ b/consensus/src/marshal/mocks/harness.rs
@@ -2155,6 +2155,10 @@ impl TestHarness for StandardHarness {
             context.child("finalizations_by_height"),
             prunable::Config {
                 translator: EightCap,
+                metadata_partition: format!(
+                    "{}-finalizations-by-height-metadata",
+                    partition_prefix
+                ),
                 key_partition: format!("{}-finalizations-by-height-key", partition_prefix),
                 key_page_cache: page_cache.clone(),
                 value_partition: format!("{}-finalizations-by-height-value", partition_prefix),
@@ -2173,6 +2177,7 @@ impl TestHarness for StandardHarness {
             context.child("finalized_blocks"),
             prunable::Config {
                 translator: EightCap,
+                metadata_partition: format!("{}-finalized-blocks-metadata", partition_prefix),
                 key_partition: format!("{}-finalized-blocks-key", partition_prefix),
                 key_page_cache: page_cache.clone(),
                 value_partition: format!("{}-finalized-blocks-value", partition_prefix),
@@ -2987,6 +2992,10 @@ impl TestHarness for CodingHarness {
             context.child("finalizations_by_height"),
             prunable::Config {
                 translator: EightCap,
+                metadata_partition: format!(
+                    "{}-finalizations-by-height-metadata",
+                    partition_prefix
+                ),
                 key_partition: format!("{}-finalizations-by-height-key", partition_prefix),
                 key_page_cache: page_cache.clone(),
                 value_partition: format!("{}-finalizations-by-height-value", partition_prefix),
@@ -3005,6 +3014,7 @@ impl TestHarness for CodingHarness {
             context.child("finalized_blocks"),
             prunable::Config {
                 translator: EightCap,
+                metadata_partition: format!("{}-finalized-blocks-metadata", partition_prefix),
                 key_partition: format!("{}-finalized-blocks-key", partition_prefix),
                 key_page_cache: page_cache.clone(),
                 value_partition: format!("{}-finalized-blocks-value", partition_prefix),

--- a/consensus/src/marshal/standard/mod.rs
+++ b/consensus/src/marshal/standard/mod.rs
@@ -543,6 +543,7 @@ mod tests {
                 context.child("seed_notarized"),
                 prunable::Config {
                     translator: TwoCap,
+                    metadata_partition: format!("{cache_prefix}-cache-{epoch}-notarized-metadata"),
                     key_partition: format!("{cache_prefix}-cache-{epoch}-notarized-key"),
                     key_page_cache: page_cache,
                     value_partition: format!("{cache_prefix}-cache-{epoch}-notarized-value"),
@@ -6263,8 +6264,10 @@ mod tests {
 
     #[test_traced("WARN")]
     fn test_standard_finalized_delivery_verifies_with_verify_only_scope() {
+        const PARTITION_PREFIX: &str = "finalized-delivery-verify-only";
+
         let runner = deterministic::Runner::timed(Duration::from_secs(30));
-        runner.start(|mut context| async move {
+        let (fixture, checkpoint) = runner.start_and_recover(|mut context| async move {
             let Fixture { schemes, .. } =
                 bls12381_threshold_vrf::fixture::<V, _>(&mut context, NAMESPACE, NUM_VALIDATORS);
 
@@ -6273,12 +6276,14 @@ mod tests {
             let block = make_raw_block(Sha256::hash(&[b""]), height, 100);
             let proposal = Proposal::new(round, View::zero(), StandardHarness::commitment(&block));
             let finalization = StandardHarness::make_finalization(proposal, &schemes, QUORUM);
+            let verifier = schemes[0].clone();
+            let application = Application::<B>::manual_ack();
 
-            let (_mailbox, _buffer, resolver, _actor_handle) = start_standard_actor(
+            let (mailbox, _buffer, resolver, actor_handle) = start_standard_actor(
                 context.child("validator"),
-                "finalized-delivery-verify-only",
-                VerifierProvider::new(schemes[0].clone()),
-                Application::<B>::default(),
+                PARTITION_PREFIX,
+                VerifierProvider::new(verifier.clone()),
+                application.clone(),
                 Some(RecordingBuffer::default()),
                 Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16)),
             )
@@ -6297,7 +6302,7 @@ mod tests {
                                 tracing::Span::none(),
                             )),
                         },
-                        value: (finalization, block).encode(),
+                        value: (finalization.clone(), block.clone()).encode(),
                         response,
                     })
                     .accepted()
@@ -6306,6 +6311,40 @@ mod tests {
                 response_rx.await.expect("delivery response missing"),
                 "finalization verified through a verify-only scope should be accepted"
             );
+            assert_eq!(application.acknowledged().await, Height::zero());
+            assert_eq!(application.acknowledged().await, height);
+            assert_eq!(
+                application.blocks().get(&height).unwrap().digest(),
+                block.digest()
+            );
+
+            actor_handle.abort();
+            drop(mailbox);
+            (verifier, block, finalization)
+        });
+
+        deterministic::Runner::from(checkpoint).start(|context| async move {
+            let (verifier, block, finalization) = fixture;
+            let (mailbox, _buffer, _resolver, _actor_handle) = start_standard_actor(
+                context.child("recovered"),
+                PARTITION_PREFIX,
+                VerifierProvider::new(verifier),
+                Application::<B>::default(),
+                Some(RecordingBuffer::default()),
+                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16)),
+            )
+            .await;
+
+            let recovered_block = mailbox
+                .get_block(Height::new(1))
+                .await
+                .expect("delivered finalized block must be durable");
+            assert_eq!(recovered_block.digest(), block.digest());
+            let recovered_finalization = mailbox
+                .get_finalization(Height::new(1))
+                .await
+                .expect("delivered finalization must be durable");
+            assert_eq!(recovered_finalization.proposal, finalization.proposal);
         });
     }
 
@@ -6955,6 +6994,7 @@ mod tests {
                 context.child("finalizations_by_height"),
                 prunable::Config {
                     translator: EightCap,
+                    metadata_partition: format!("{partition_prefix}-fbh-metadata"),
                     key_partition: format!("{partition_prefix}-fbh-key"),
                     key_page_cache: page_cache.clone(),
                     value_partition: format!("{partition_prefix}-fbh-value"),
@@ -6972,6 +7012,7 @@ mod tests {
                 context.child("finalized_blocks"),
                 prunable::Config {
                     translator: EightCap,
+                    metadata_partition: format!("{partition_prefix}-fb-metadata"),
                     key_partition: format!("{partition_prefix}-fb-key"),
                     key_page_cache: page_cache,
                     value_partition: format!("{partition_prefix}-fb-value"),
@@ -7298,6 +7339,7 @@ mod tests {
             context.child("finalizations_by_height"),
             prunable::Config {
                 translator: EightCap,
+                metadata_partition: format!("{partition_prefix}-fbh-metadata"),
                 key_partition: format!("{partition_prefix}-fbh-key"),
                 key_page_cache: page_cache.clone(),
                 value_partition: format!("{partition_prefix}-fbh-value"),
@@ -7315,6 +7357,7 @@ mod tests {
             context.child("finalized_blocks"),
             prunable::Config {
                 translator: EightCap,
+                metadata_partition: format!("{partition_prefix}-fb-metadata"),
                 key_partition: format!("{partition_prefix}-fb-key"),
                 key_page_cache: page_cache,
                 value_partition: format!("{partition_prefix}-fb-value"),

--- a/examples/reshare/src/validator.rs
+++ b/examples/reshare/src/validator.rs
@@ -400,6 +400,7 @@ fn archive_config<C>(
 ) -> prunable::Config<TwoCap, C> {
     prunable::Config {
         translator: TwoCap,
+        metadata_partition: format!("{prefix}-{name}-metadata"),
         key_partition: format!("{prefix}-{name}-key"),
         key_page_cache: page_cache,
         value_partition: format!("{prefix}-{name}-value"),

--- a/glue/src/dkg/bootstrap/mod.rs
+++ b/glue/src/dkg/bootstrap/mod.rs
@@ -642,6 +642,7 @@ fn archive_config<C>(
 ) -> prunable::Config<TwoCap, C> {
     prunable::Config {
         translator: TwoCap,
+        metadata_partition: format!("{prefix}-{name}-metadata"),
         key_partition: format!("{prefix}-{name}-key"),
         key_page_cache: page_cache,
         value_partition: format!("{prefix}-{name}-value"),

--- a/glue/src/dkg/tests/reshare/harness.rs
+++ b/glue/src/dkg/tests/reshare/harness.rs
@@ -1326,6 +1326,7 @@ fn archive_config<C>(
 ) -> prunable::Config<TwoCap, C> {
     prunable::Config {
         translator: TwoCap,
+        metadata_partition: format!("{prefix}-{name}-metadata"),
         key_partition: format!("{prefix}-{name}-key"),
         key_page_cache: page_cache,
         value_partition: format!("{prefix}-{name}-value"),

--- a/glue/src/stateful/tests/common.rs
+++ b/glue/src/stateful/tests/common.rs
@@ -55,6 +55,7 @@ pub(super) fn archive_config<C>(
 ) -> prunable::Config<TwoCap, C> {
     prunable::Config {
         translator: TwoCap,
+        metadata_partition: format!("{prefix}-{name}-metadata"),
         key_partition: format!("{prefix}-{name}-key"),
         key_page_cache: page_cache,
         value_partition: format!("{prefix}-{name}-value"),

--- a/glue/src/stateful/tests/fixtures.rs
+++ b/glue/src/stateful/tests/fixtures.rs
@@ -169,6 +169,7 @@ fn archive_config(page_cache: CacheRef, partition: &str) -> immutable::Config<()
 fn prunable_archive_config(page_cache: CacheRef, partition: &str) -> prunable::Config<TwoCap, ()> {
     prunable::Config {
         translator: TwoCap,
+        metadata_partition: format!("{partition}-metadata"),
         key_partition: format!("{partition}-key"),
         key_page_cache: page_cache,
         value_partition: format!("{partition}-value"),

--- a/storage/conformance.toml
+++ b/storage/conformance.toml
@@ -4,7 +4,7 @@ hash = "836f71ea345dc8707105fee756c04b1f2edb8a5e54c38b23282b53998244dd12"
 
 ["commonware_storage::archive::conformance::StorageConformance<ArchivePrunableWorkload>"]
 n_cases = 128
-hash = "c42202186ded174cd23871b6728b23a2284f7146c7acdaf1dbff61fa9bd666ea"
+hash = "2827ffcac98c552c1673bc7fd15cb8c8399c6ac6cd8f0b971329c027c7bd8ca0"
 
 ["commonware_storage::archive::immutable::storage::conformance::CodecConformance<Record>"]
 n_cases = 65536

--- a/storage/fuzz/fuzz_targets/archive_operations.rs
+++ b/storage/fuzz/fuzz_targets/archive_operations.rs
@@ -49,6 +49,7 @@ fn fuzz(data: FuzzInput) {
     runner.start(|context| async move {
         let cfg = Config {
             translator: EightCap,
+            metadata_partition: "test-metadata".into(),
             key_partition: "test-key".into(),
             key_page_cache: CacheRef::from_pooler(
                 &context,

--- a/storage/src/archive/benches/utils.rs
+++ b/storage/src/archive/benches/utils.rs
@@ -84,6 +84,7 @@ impl Archive {
             Variant::Prunable => {
                 let cfg = prunable::Config {
                     translator: TwoCap,
+                    metadata_partition: "archive-bench-metadata".into(),
                     key_partition: "archive-bench-key".into(),
                     key_page_cache: CacheRef::from_pooler(&ctx, PAGE_SIZE, PAGE_CACHE_SIZE),
                     value_partition: "archive-bench-value".into(),

--- a/storage/src/archive/conformance.rs
+++ b/storage/src/archive/conformance.rs
@@ -16,6 +16,7 @@ use core::num::{NonZeroU16, NonZeroU64, NonZeroUsize};
 use rand::RngExt as _;
 
 const WRITE_BUFFER: NonZeroUsize = NZUsize!(1024);
+const REPLAY_BUFFER: NonZeroUsize = NZUsize!(1024);
 const ITEMS_PER_SECTION: NonZeroU64 = NZU64!(1024);
 const PAGE_SIZE: NonZeroU16 = NZU16!(1024);
 const PAGE_CACHE_SIZE: NonZeroUsize = NZUsize!(10);
@@ -31,6 +32,7 @@ impl StorageWorkload for ArchivePrunableWorkload {
     ) -> Result<(), Self::Error> {
         let config = prunable::Config {
             translator: TwoCap,
+            metadata_partition: format!("archive-prunable-metadata-{seed}"),
             key_partition: format!("archive-prunable-key-{seed}"),
             key_page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
             value_partition: format!("archive-prunable-value-{seed}"),
@@ -39,7 +41,7 @@ impl StorageWorkload for ArchivePrunableWorkload {
             items_per_section: ITEMS_PER_SECTION,
             key_write_buffer: WRITE_BUFFER,
             value_write_buffer: WRITE_BUFFER,
-            replay_buffer: WRITE_BUFFER,
+            replay_buffer: REPLAY_BUFFER,
         };
         let mut archive =
             prunable::Archive::<_, _, FixedBytes<64>, i32>::init(context.child("archive"), config)
@@ -83,7 +85,7 @@ impl StorageWorkload for ArchiveImmutableWorkload {
             freezer_key_write_buffer: WRITE_BUFFER,
             freezer_value_write_buffer: WRITE_BUFFER,
             ordinal_write_buffer: WRITE_BUFFER,
-            replay_buffer: WRITE_BUFFER,
+            replay_buffer: REPLAY_BUFFER,
             codec_config: (),
         };
         let mut archive =

--- a/storage/src/archive/immutable/mod.rs
+++ b/storage/src/archive/immutable/mod.rs
@@ -82,7 +82,8 @@ pub use storage::Archive;
 /// Configuration for [Archive] storage.
 #[derive(Clone)]
 pub struct Config<C> {
-    /// The partition to use for the archive's metadata.
+    /// The partition to use for the archive's commit records: the freezer checkpoint and
+    /// ordinal bitmaps that recovery uses to keep both stores consistent.
     pub metadata_partition: String,
 
     /// The partition to use for the archive's freezer table.

--- a/storage/src/archive/mod.rs
+++ b/storage/src/archive/mod.rs
@@ -28,7 +28,7 @@ pub enum Identifier<'a, K: Array> {
 #[derive(Debug, Error)]
 pub enum Error {
     #[error("journal error: {0}")]
-    Journal(#[from] crate::journal::Error),
+    Journal(crate::journal::Error),
     #[error("ordinal error: {0}")]
     Ordinal(#[from] crate::ordinal::Error),
     #[error("metadata error: {0}")]
@@ -39,6 +39,16 @@ pub enum Error {
     RecordCorrupted,
     #[error("record too large")]
     RecordTooLarge,
+}
+
+// Preserve the archive's error classification for journal-owned metadata operations.
+impl From<crate::journal::Error> for Error {
+    fn from(error: crate::journal::Error) -> Self {
+        match error {
+            crate::journal::Error::Metadata(error) => Self::Metadata(error),
+            error => Self::Journal(error),
+        }
+    }
 }
 
 /// A write-once key-value store addressed by both an index and a key.

--- a/storage/src/archive/mod.rs
+++ b/storage/src/archive/mod.rs
@@ -250,6 +250,7 @@ mod tests {
     ) -> impl MultiArchive<Key = FixedBytes<64>, Value = i32> {
         let cfg = prunable::Config {
             translator: TwoCap,
+            metadata_partition: "test-metadata".into(),
             key_partition: "test-key".into(),
             key_page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
             value_partition: "test-value".into(),

--- a/storage/src/archive/prunable/mod.rs
+++ b/storage/src/archive/prunable/mod.rs
@@ -183,7 +183,8 @@ pub struct Config<T: Translator, C> {
     /// If that is not the case, lookups may be O(n) instead of O(1).
     pub translator: T,
 
-    /// The partition to use for durable value-validation boundaries.
+    /// The partition to use for per-section validation markers. Recovery adopts entries
+    /// below a section's marker without re-validating their values.
     pub metadata_partition: String,
 
     /// The partition to use for the key journal (stores index+key metadata).

--- a/storage/src/archive/prunable/mod.rs
+++ b/storage/src/archive/prunable/mod.rs
@@ -146,6 +146,7 @@
 //!     // Create an archive
 //!     let cfg = Config {
 //!         translator: FourCap,
+//!         metadata_partition: "demo-metadata".into(),
 //!         key_partition: "demo-index".into(),
 //!         key_page_cache: CacheRef::from_pooler(&context, NZU16!(1024), NZUsize!(10)),
 //!         value_partition: "demo-value".into(),
@@ -181,6 +182,9 @@ pub struct Config<T: Translator, C> {
     /// [Archive] assumes that all internal keys are spread uniformly across the key space.
     /// If that is not the case, lookups may be O(n) instead of O(1).
     pub translator: T,
+
+    /// The partition to use for durable value-validation boundaries.
+    pub metadata_partition: String,
 
     /// The partition to use for the key journal (stores index+key metadata).
     pub key_partition: String,
@@ -220,14 +224,15 @@ mod tests {
         journal::Error as JournalError,
         translator::{FourCap, TwoCap},
     };
-    use commonware_codec::{DecodeExt, Error as CodecError};
+    use commonware_codec::{DecodeExt, Error as CodecError, FixedSize};
+    use commonware_cryptography::Crc32;
     use commonware_macros::{test_group, test_traced};
     use commonware_runtime::{
-        BufferPooler, Error as RError, Metrics as _, Runner, Spawner as _, Supervisor as _,
-        deterministic,
+        Blob as _, BufferPooler, Error as RError, Metrics as _, ReadOptions, Runner, Spawner as _,
+        Storage as _, Supervisor as _, WriteOptions, deterministic,
         mocks::{
-            DelayedSyncContext, PendingSyncs, fail_pending_syncs, release_next_pending_syncs,
-            release_pending_syncs,
+            DelayedSyncContext, PendingSyncs, drive_pending_syncs, fail_pending_syncs,
+            release_next_pending_syncs, release_pending_syncs,
         },
         telemetry::metrics::has_metric_value,
     };
@@ -258,13 +263,15 @@ mod tests {
 
     fn test_config<E: BufferPooler>(
         context: &E,
+        partition_prefix: &str,
         items_per_section: NonZeroU64,
     ) -> Config<FourCap, ()> {
         Config {
             translator: FourCap,
-            key_partition: "test-index".into(),
+            metadata_partition: format!("{partition_prefix}-metadata"),
+            key_partition: format!("{partition_prefix}-index"),
             key_page_cache: CacheRef::from_pooler(context, PAGE_SIZE, PAGE_CACHE_SIZE),
-            value_partition: "test-value".into(),
+            value_partition: format!("{partition_prefix}-value"),
             codec_config: (),
             compression: None,
             key_write_buffer: NZUsize!(DEFAULT_WRITE_BUFFER),
@@ -272,6 +279,30 @@ mod tests {
             replay_buffer: NZUsize!(DEFAULT_REPLAY_BUFFER),
             items_per_section,
         }
+    }
+
+    const I32_VALUE_FRAME_SIZE: u64 = 8;
+
+    async fn corrupt_value_frame(
+        context: &deterministic::Context,
+        partition: &str,
+        section: u64,
+        position: u64,
+    ) {
+        let offset = position * I32_VALUE_FRAME_SIZE;
+        let (blob, size) = context
+            .open(partition, &section.to_be_bytes())
+            .await
+            .unwrap();
+        assert!(offset < size);
+        let byte = blob
+            .read_at(offset, 1, ReadOptions::default())
+            .await
+            .unwrap()
+            .coalesce();
+        blob.write_at(offset, vec![byte.as_ref()[0] ^ 0xFF], WriteOptions::SYNC)
+            .await
+            .unwrap();
     }
 
     #[test_traced]
@@ -283,7 +314,7 @@ mod tests {
                 inner: context,
                 pending: pending.clone(),
             };
-            let cfg = test_config(&context, NZU64!(DEFAULT_ITEMS_PER_SECTION));
+            let cfg = test_config(&context, "test", NZU64!(DEFAULT_ITEMS_PER_SECTION));
             let archive = Archive::init(context.child("storage"), cfg)
                 .await
                 .expect("Failed to initialize archive");
@@ -325,7 +356,7 @@ mod tests {
         });
 
         deterministic::Runner::from(checkpoint).start(|context| async move {
-            let cfg = test_config(&context, NZU64!(DEFAULT_ITEMS_PER_SECTION));
+            let cfg = test_config(&context, "test", NZU64!(DEFAULT_ITEMS_PER_SECTION));
             let archive = Archive::<_, _, FixedBytes<64>, i32>::init(context.child("reopen"), cfg)
                 .await
                 .expect("Failed to reopen archive");
@@ -344,7 +375,7 @@ mod tests {
                 inner: context,
                 pending: pending.clone(),
             };
-            let cfg = test_config(&context, NZU64!(DEFAULT_ITEMS_PER_SECTION));
+            let cfg = test_config(&context, "test", NZU64!(DEFAULT_ITEMS_PER_SECTION));
             let archive = Archive::init(context.child("storage"), cfg)
                 .await
                 .expect("Failed to initialize archive");
@@ -397,6 +428,90 @@ mod tests {
     }
 
     #[test_traced]
+    fn test_below_floor_put_start_sync_covers_prior_pending_write() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let pending = PendingSyncs::default();
+            let context = DelayedSyncContext {
+                inner: context,
+                pending: pending.clone(),
+            };
+            let cfg = test_config(&context, "test", NZU64!(1));
+            let archive = Archive::init(context.child("storage"), cfg)
+                .await
+                .expect("Failed to initialize archive");
+            let archive = archive.prune(1).await.expect("Failed to set prune floor");
+            let archive = archive
+                .put(2, test_key("pending"), 20)
+                .await
+                .expect("Failed to buffer retained write");
+
+            assert!(pending.lock().is_empty());
+            let (archive, handle) = archive
+                .put_start_sync(0, test_key("pruned"), 0)
+                .await
+                .expect("Failed to request sync through below-floor put");
+            assert_eq!(
+                pending.lock().len(),
+                2,
+                "the sync combinator must cover writes accepted before its below-floor put"
+            );
+
+            release_pending_syncs(&pending);
+            handle.await.expect("covering sync should complete");
+            assert_eq!(archive.get(Identifier::Index(2)).await.unwrap(), Some(20));
+            assert_eq!(archive.get(Identifier::Index(0)).await.unwrap(), None);
+        });
+    }
+
+    #[test_traced]
+    fn test_below_floor_put_multi_sync_covers_prior_pending_write() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let pending = PendingSyncs::default();
+            let context = DelayedSyncContext {
+                inner: context,
+                pending: pending.clone(),
+            };
+            let cfg = test_config(&context, "test", NZU64!(1));
+            let archive = Archive::init(context.child("storage"), cfg)
+                .await
+                .expect("Failed to initialize archive");
+            let archive = archive.prune(1).await.expect("Failed to set prune floor");
+            let archive = archive
+                .put_multi(2, test_key("pending"), 20)
+                .await
+                .expect("Failed to buffer retained write");
+
+            pending.arm();
+            let completed = Arc::new(AtomicUsize::new(0));
+            let completed_clone = completed.clone();
+            let task = context.inner.child("put_sync").spawn(|_| async move {
+                let result = archive.put_multi_sync(0, test_key("pruned"), 0).await;
+                completed_clone.store(1, Ordering::Relaxed);
+                result
+            });
+            while pending.calls() == 0 && completed.load(Ordering::Relaxed) == 0 {
+                commonware_runtime::reschedule().await;
+            }
+
+            assert_eq!(
+                completed.load(Ordering::Relaxed),
+                0,
+                "put_multi_sync must wait for writes accepted before its below-floor put"
+            );
+            assert!(pending.calls() > 0);
+            release_pending_syncs(&pending);
+            let archive = task
+                .await
+                .expect("put_multi_sync task failed")
+                .expect("put_multi_sync failed");
+            assert_eq!(archive.get_all(2).await.unwrap(), Some(vec![20]));
+            assert_eq!(archive.get_all(0).await.unwrap(), None);
+        });
+    }
+
+    #[test_traced]
     fn test_overlapping_put_start_sync_waits_for_in_flight_sync() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
@@ -405,7 +520,7 @@ mod tests {
                 inner: context,
                 pending: pending.clone(),
             };
-            let cfg = test_config(&context, NZU64!(DEFAULT_ITEMS_PER_SECTION));
+            let cfg = test_config(&context, "test", NZU64!(DEFAULT_ITEMS_PER_SECTION));
             let archive = Archive::init(context.child("storage"), cfg)
                 .await
                 .expect("Failed to initialize archive");
@@ -466,7 +581,7 @@ mod tests {
                 inner: context,
                 pending: pending.clone(),
             };
-            let cfg = test_config(&context, NZU64!(DEFAULT_ITEMS_PER_SECTION));
+            let cfg = test_config(&context, "test", NZU64!(DEFAULT_ITEMS_PER_SECTION));
             let archive = Archive::init(context.child("storage"), cfg)
                 .await
                 .expect("Failed to initialize archive");
@@ -517,7 +632,7 @@ mod tests {
                 inner: context,
                 pending: pending.clone(),
             };
-            let cfg = test_config(&context, NZU64!(DEFAULT_ITEMS_PER_SECTION));
+            let cfg = test_config(&context, "test", NZU64!(DEFAULT_ITEMS_PER_SECTION));
             let archive = Archive::<_, _, FixedBytes<64>, i32>::init(context.child("storage"), cfg)
                 .await
                 .expect("Failed to initialize archive");
@@ -566,7 +681,7 @@ mod tests {
                 inner: context,
                 pending: pending.clone(),
             };
-            let cfg = test_config(&context, NZU64!(1));
+            let cfg = test_config(&context, "test", NZU64!(1));
             let archive = Archive::<_, _, FixedBytes<64>, i32>::init(context.child("storage"), cfg)
                 .await
                 .expect("Failed to initialize archive");
@@ -619,7 +734,7 @@ mod tests {
                 inner: context,
                 pending: pending.clone(),
             };
-            let cfg = test_config(&context, NZU64!(1));
+            let cfg = test_config(&context, "test", NZU64!(1));
             let archive = Archive::<_, _, FixedBytes<64>, i32>::init(context.child("storage"), cfg)
                 .await
                 .expect("Failed to initialize archive");
@@ -653,7 +768,7 @@ mod tests {
                 inner: context,
                 pending: pending.clone(),
             };
-            let cfg = test_config(&context, NZU64!(1));
+            let cfg = test_config(&context, "test", NZU64!(1));
             let archive = Archive::<_, _, FixedBytes<64>, i32>::init(context.child("storage"), cfg)
                 .await
                 .expect("Failed to initialize archive");
@@ -675,8 +790,7 @@ mod tests {
                 .expect("put_start_sync after prune should succeed");
             release_pending_syncs(&pending);
             second.await.expect("second sync handle should complete");
-            let archive = archive
-                .sync()
+            let archive = drive_pending_syncs(&pending, archive.sync())
                 .await
                 .expect("sync after prune should succeed");
 
@@ -694,7 +808,7 @@ mod tests {
                 inner: context,
                 pending: pending.clone(),
             };
-            let cfg = test_config(&context, NZU64!(1));
+            let cfg = test_config(&context, "test", NZU64!(1));
             let archive = Archive::<_, _, FixedBytes<64>, i32>::init(context.child("storage"), cfg)
                 .await
                 .expect("Failed to initialize archive");
@@ -721,7 +835,7 @@ mod tests {
         });
 
         deterministic::Runner::from(checkpoint).start(|context| async move {
-            let cfg = test_config(&context, NZU64!(1));
+            let cfg = test_config(&context, "test", NZU64!(1));
             let archive = Archive::<_, _, FixedBytes<64>, i32>::init(context.child("reopen"), cfg)
                 .await
                 .expect("Failed to reopen archive");
@@ -740,7 +854,7 @@ mod tests {
                 inner: context,
                 pending: pending.clone(),
             };
-            let cfg = test_config(&context, NZU64!(1));
+            let cfg = test_config(&context, "test", NZU64!(1));
             let archive = Archive::<_, _, FixedBytes<64>, i32>::init(context.child("storage"), cfg)
                 .await
                 .expect("Failed to initialize archive");
@@ -763,7 +877,7 @@ mod tests {
         });
 
         deterministic::Runner::from(checkpoint).start(|context| async move {
-            let cfg = test_config(&context, NZU64!(1));
+            let cfg = test_config(&context, "test", NZU64!(1));
             let archive = Archive::<_, _, FixedBytes<64>, i32>::init(context.child("reopen"), cfg)
                 .await
                 .expect("Failed to reopen archive");
@@ -782,7 +896,7 @@ mod tests {
                 inner: context,
                 pending: pending.clone(),
             };
-            let cfg = test_config(&context, NZU64!(DEFAULT_ITEMS_PER_SECTION));
+            let cfg = test_config(&context, "test", NZU64!(DEFAULT_ITEMS_PER_SECTION));
             let archive = Archive::<_, _, FixedBytes<64>, i32>::init(context.child("storage"), cfg)
                 .await
                 .expect("Failed to initialize archive");
@@ -814,6 +928,1131 @@ mod tests {
     }
 
     #[test_traced]
+    fn test_archive_truncates_at_first_invalid_value() {
+        deterministic::Runner::default().start(|context| async move {
+            for (name, bad_position, retained) in [("first", 0, 0), ("middle", 1, 1)] {
+                let cfg = test_config(&context, &format!("invalid-{name}"), NZU64!(4));
+
+                let mut archive = Archive::init(context.child(name), cfg.clone())
+                    .await
+                    .unwrap();
+                for (index, value) in [10, 20, 30].into_iter().enumerate() {
+                    archive = archive
+                        .put(index as u64, test_key(&format!("key-{index}")), value)
+                        .await
+                        .unwrap();
+                }
+                archive = archive.sync().await.unwrap();
+                drop(archive);
+
+                corrupt_value_frame(&context, &cfg.value_partition, 0, bad_position).await;
+
+                // Every frame after the first invalid one belongs to the same uncommitted suffix,
+                // even if its own CRC is valid:
+                //
+                // first:  [bad]              [valid] [valid] -> []
+                // middle: [valid, retained]  [bad]   [valid] -> [valid]
+                let archive =
+                    Archive::<_, _, FixedBytes<64>, i32>::init(context.child(name), cfg.clone())
+                        .await
+                        .unwrap();
+                assert_eq!(
+                    archive.ranges().collect::<Vec<_>>(),
+                    if retained == 0 {
+                        Vec::new()
+                    } else {
+                        vec![(0, retained - 1)]
+                    }
+                );
+                for (index, value) in [10, 20, 30].into_iter().enumerate() {
+                    let expected = (index < retained as usize).then_some(value);
+                    assert_eq!(
+                        archive.get(Identifier::Index(index as u64)).await.unwrap(),
+                        expected
+                    );
+                }
+                drop(archive);
+
+                let archive = Archive::<_, _, FixedBytes<64>, i32>::init(context.child(name), cfg)
+                    .await
+                    .unwrap();
+                assert_eq!(archive.last_index(), retained.checked_sub(1));
+                archive.destroy().await.unwrap();
+            }
+        });
+    }
+
+    #[test_traced]
+    fn test_archive_completes_interrupted_rewind_to_empty_section() {
+        deterministic::Runner::default().start(|context| async move {
+            let cfg = test_config(&context, "empty-rewind", NZU64!(4));
+
+            let archive = Archive::init(context.child("seed"), cfg.clone())
+                .await
+                .unwrap();
+            let archive = archive.put(0, test_key("zero"), 10).await.unwrap();
+            let archive = archive.sync().await.unwrap();
+            drop(archive);
+            context.remove(&cfg.metadata_partition, None).await.unwrap();
+
+            // Model a crash between Archive's two durable section truncations:
+            //
+            //     before: index [A] -> values [A]
+            //     crash:  index [ ]    values [A]
+            //
+            // Archive owns both journals, so startup must finish removing the unindexed value.
+            let (index, _) = context
+                .open(&cfg.key_partition, &0u64.to_be_bytes())
+                .await
+                .unwrap();
+            index.resize(0).await.unwrap();
+            index.sync().await.unwrap();
+            drop(index);
+            let (_, value_size) = context
+                .open(&cfg.value_partition, &0u64.to_be_bytes())
+                .await
+                .unwrap();
+            assert_eq!(value_size, I32_VALUE_FRAME_SIZE);
+
+            let archive =
+                Archive::<_, _, FixedBytes<64>, i32>::init(context.child("repair"), cfg.clone())
+                    .await
+                    .unwrap();
+            assert_eq!(archive.last_index(), None);
+            drop(archive);
+            let (_, value_size) = context
+                .open(&cfg.value_partition, &0u64.to_be_bytes())
+                .await
+                .unwrap();
+            assert_eq!(value_size, 0, "startup must finish the value truncation");
+            context.remove(&cfg.metadata_partition, None).await.unwrap();
+
+            // Once both halves of the rewind are empty, missing derived metadata does not require
+            // durability work:
+            //
+            //     index [ ]    values [ ]    metadata [ ] -> no rewind, no sync
+            //
+            // This keeps the recovery write bounded to the restart that actually finds the
+            // orphaned value bytes.
+            let pending = PendingSyncs::default();
+            let delayed = DelayedSyncContext {
+                inner: context.child("clean_restart"),
+                pending: pending.clone(),
+            };
+            pending.arm();
+            let completed = Arc::new(AtomicUsize::new(0));
+            let completed_clone = completed.clone();
+            let cfg_clone = cfg.clone();
+            let task = context.child("clean_restart_task").spawn(|_| async move {
+                let result = Archive::init(delayed.child("archive"), cfg_clone).await;
+                completed_clone.store(1, Ordering::Relaxed);
+                result
+            });
+            while pending.calls() == 0 && completed.load(Ordering::Relaxed) == 0 {
+                commonware_runtime::reschedule().await;
+            }
+            if pending.calls() != 0 {
+                pending.unblock();
+                let _ = task.await;
+                panic!("clean empty-section restart must not issue durability operations");
+            }
+            pending.unblock();
+            let archive = task.await.unwrap().unwrap();
+            let archive = archive.put(0, test_key("new"), 20).await.unwrap();
+            let archive = archive.sync().await.unwrap();
+            drop(archive);
+            let (_, value_size) = context
+                .open(&cfg.value_partition, &0u64.to_be_bytes())
+                .await
+                .unwrap();
+            assert_eq!(value_size, I32_VALUE_FRAME_SIZE);
+
+            let archive = Archive::<_, _, FixedBytes<64>, i32>::init(context.child("reopen"), cfg)
+                .await
+                .unwrap();
+            assert_eq!(archive.get(Identifier::Index(0)).await.unwrap(), Some(20));
+            archive.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced]
+    fn test_validation_marker_skips_previously_validated_values() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = test_config(&context, "marker-skip", NZU64!(4));
+
+            let mut archive = Archive::init(context.child("seed"), cfg.clone())
+                .await
+                .unwrap();
+            archive = archive.put(0, test_key("zero"), 10).await.unwrap();
+            archive = archive.put(1, test_key("one"), 20).await.unwrap();
+            archive = archive.sync().await.unwrap();
+            drop(archive);
+
+            // Simulate an archive created before validation markers existed. The first open
+            // scans every retained value and writes the additive sidecar:
+            //
+            // first open:  [value 0] [value 1] -> validate 2
+            // second open: [marker covers both] -> validate 0
+            context.remove(&cfg.metadata_partition, None).await.unwrap();
+            let archive = Archive::<_, _, FixedBytes<64>, i32>::init(
+                context.child("first_open"),
+                cfg.clone(),
+            )
+            .await
+            .unwrap();
+            assert_eq!(archive.ranges().collect::<Vec<_>>(), vec![(0, 1)]);
+            drop(archive);
+
+            let archive = Archive::<_, _, FixedBytes<64>, i32>::init(
+                context.child("second_open"),
+                cfg.clone(),
+            )
+            .await
+            .unwrap();
+            assert_eq!(archive.get(Identifier::Index(0)).await.unwrap(), Some(10));
+            assert_eq!(archive.get(Identifier::Index(1)).await.unwrap(), Some(20));
+
+            let archive = archive.put(2, test_key("two"), 30).await.unwrap();
+            let archive = archive.sync().await.unwrap();
+            drop(archive);
+
+            let archive =
+                Archive::<_, _, FixedBytes<64>, i32>::init(context.child("third_open"), cfg)
+                    .await
+                    .unwrap();
+            assert_eq!(archive.ranges().collect::<Vec<_>>(), vec![(0, 2)]);
+            assert_eq!(archive.get(Identifier::Index(0)).await.unwrap(), Some(10));
+            assert_eq!(archive.get(Identifier::Index(1)).await.unwrap(), Some(20));
+            assert_eq!(archive.get(Identifier::Index(2)).await.unwrap(), Some(30));
+        });
+    }
+
+    #[test_traced]
+    fn test_validation_marker_skips_covered_interior_values() {
+        deterministic::Runner::default().start(|context| async move {
+            let cfg = test_config(&context, "marker-covered-interior", NZU64!(4));
+
+            // Publish a boundary covering both values. The terminal value remains the floor's
+            // cross-journal proof. The earlier value must not be revisited during startup.
+            let archive = Archive::init(context.child("seed"), cfg.clone())
+                .await
+                .unwrap();
+            let archive = archive.put(0, test_key("zero"), 10).await.unwrap();
+            let archive = archive.put(1, test_key("one"), 20).await.unwrap();
+            let archive = archive.sync().await.unwrap();
+            let archive = archive.sync().await.unwrap();
+            drop(archive);
+
+            // Damage only the covered interior frame. Initialization succeeds because the marker
+            // skips it, while a direct read still exposes its invalid checksum.
+            corrupt_value_frame(&context, &cfg.value_partition, 0, 0).await;
+            let archive = Archive::<_, _, FixedBytes<64>, i32>::init(context.child("reopen"), cfg)
+                .await
+                .unwrap();
+            assert!(archive.get(Identifier::Index(0)).await.is_err());
+            assert_eq!(archive.get(Identifier::Index(1)).await.unwrap(), Some(20));
+        });
+    }
+
+    #[test_traced]
+    fn test_validation_marker_damage_never_mutates() {
+        #[derive(Clone, Copy)]
+        enum Damage {
+            MissingIndex,
+            MissingValues,
+            TruncatedIndex,
+            TruncatedValues,
+            CorruptIndex,
+            CorruptValues,
+        }
+
+        deterministic::Runner::default().start(|context| async move {
+            for (name, damage) in [
+                ("missing_index", Damage::MissingIndex),
+                ("missing_values", Damage::MissingValues),
+                ("truncated_index", Damage::TruncatedIndex),
+                ("truncated_values", Damage::TruncatedValues),
+                ("corrupt_index", Damage::CorruptIndex),
+                ("corrupt_values", Damage::CorruptValues),
+            ] {
+                let case = context.child(name);
+                let cfg = test_config(&case, name, NZU64!(4));
+
+                let archive = Archive::init(case.child("seed"), cfg.clone())
+                    .await
+                    .unwrap();
+                let archive = archive.put_sync(0, test_key("zero"), 10).await.unwrap();
+                let archive = archive.sync().await.unwrap();
+                drop(archive);
+
+                // The marker proves that both journals contained one durable validated item:
+                //
+                // metadata: section 0 -> 1
+                // index:    section 0 -> [record]
+                // values:   section 0 -> [frame]
+                //
+                // Prune removes the marker durably before either journal, so missing or truncated
+                // marked data is corruption, not an interrupted prune.
+                let (_, index_size) = context
+                    .open(&cfg.key_partition, &0u64.to_be_bytes())
+                    .await
+                    .unwrap();
+                let (_, value_size) = context
+                    .open(&cfg.value_partition, &0u64.to_be_bytes())
+                    .await
+                    .unwrap();
+                let damage_index = matches!(
+                    damage,
+                    Damage::MissingIndex | Damage::TruncatedIndex | Damage::CorruptIndex
+                );
+                let damaged_partition = if damage_index {
+                    &cfg.key_partition
+                } else {
+                    &cfg.value_partition
+                };
+                let damaged_size = match damage {
+                    Damage::MissingIndex | Damage::MissingValues => {
+                        context
+                            .remove(damaged_partition, Some(&0u64.to_be_bytes()))
+                            .await
+                            .unwrap();
+                        None
+                    }
+                    Damage::TruncatedIndex | Damage::TruncatedValues => {
+                        let (blob, size) = context
+                            .open(damaged_partition, &0u64.to_be_bytes())
+                            .await
+                            .unwrap();
+                        let size = if damage_index { size - 1 } else { 0 };
+                        blob.resize(size).await.unwrap();
+                        blob.sync().await.unwrap();
+                        Some(size)
+                    }
+                    Damage::CorruptIndex | Damage::CorruptValues => {
+                        let (blob, size) = context
+                            .open(damaged_partition, &0u64.to_be_bytes())
+                            .await
+                            .unwrap();
+                        let byte = blob
+                            .read_at(0, 1, ReadOptions::default())
+                            .await
+                            .unwrap()
+                            .coalesce();
+                        let byte = byte.as_ref()[0];
+                        blob.write_at(0, vec![byte ^ 0xFF], WriteOptions::SYNC)
+                            .await
+                            .unwrap();
+                        Some(size)
+                    }
+                };
+
+                // Marked values are never re-read at startup: value damage that preserves the
+                // floor's byte range surfaces lazily at get, like covered interior values.
+                if matches!(damage, Damage::CorruptValues) {
+                    for child in ["first", "second"] {
+                        let archive = Archive::<_, _, FixedBytes<64>, i32>::init(
+                            case.child(child),
+                            cfg.clone(),
+                        )
+                        .await
+                        .expect("marked value damage must not fail startup");
+                        assert!(archive.get(Identifier::Index(0)).await.is_err());
+                        drop(archive);
+                        let (_, size) = context
+                            .open(&cfg.value_partition, &0u64.to_be_bytes())
+                            .await
+                            .unwrap();
+                        assert_eq!(size, value_size, "adoption must preserve the damaged frame");
+                    }
+                    continue;
+                }
+
+                for child in ["first", "second"] {
+                    let result =
+                        Archive::<_, _, FixedBytes<64>, i32>::init(case.child(child), cfg.clone())
+                            .await;
+                    assert!(
+                        matches!(result, Err(Error::Journal(JournalError::Corruption(_)))),
+                        "damaged marked section must remain visible as corruption"
+                    );
+
+                    let (surviving_partition, surviving_size) = if damage_index {
+                        (&cfg.value_partition, value_size)
+                    } else {
+                        (&cfg.key_partition, index_size)
+                    };
+                    let (_, size) = context
+                        .open(surviving_partition, &0u64.to_be_bytes())
+                        .await
+                        .unwrap();
+                    assert_eq!(
+                        size, surviving_size,
+                        "failed startup must preserve the surviving journal section"
+                    );
+                    if let Some(damaged_size) = damaged_size {
+                        let (_, size) = context
+                            .open(damaged_partition, &0u64.to_be_bytes())
+                            .await
+                            .unwrap();
+                        assert_eq!(
+                            size, damaged_size,
+                            "failed startup must not normalize the damaged journal section"
+                        );
+                    }
+                }
+            }
+        });
+    }
+
+    #[test_traced]
+    fn test_validation_floor_rejection_precedes_index_suffix_repair() {
+        deterministic::Runner::default().start(|context| async move {
+            let cfg = test_config(&context, "floor-order", NZU64!(4));
+
+            let archive =
+                Archive::<_, _, FixedBytes<64>, i32>::init(context.child("seed"), cfg.clone())
+                    .await
+                    .unwrap();
+            let archive = archive.put_sync(0, test_key("zero"), 10).await.unwrap();
+            let archive = archive.sync().await.unwrap();
+            drop(archive);
+
+            let (index, index_size) = context
+                .open(&cfg.key_partition, &0u64.to_be_bytes())
+                .await
+                .unwrap();
+            index
+                .write_at(index_size, vec![0xA5; 7], WriteOptions::SYNC)
+                .await
+                .unwrap();
+            let expected_size = index_size + 7;
+
+            // Break the floor's terminal index page so preflight rejects the section before
+            // the repairable trailing junk can be truncated.
+            let byte = index
+                .read_at(0, 1, ReadOptions::default())
+                .await
+                .unwrap()
+                .coalesce();
+            index
+                .write_at(0, vec![byte.as_ref()[0] ^ 0xFF], WriteOptions::SYNC)
+                .await
+                .unwrap();
+            let expected = index
+                .read_at(0, expected_size as usize, ReadOptions::default())
+                .await
+                .unwrap()
+                .coalesce();
+            drop(index);
+
+            for child in ["first", "second"] {
+                let result =
+                    Archive::<_, _, FixedBytes<64>, i32>::init(context.child(child), cfg.clone())
+                        .await;
+                assert!(matches!(
+                    result,
+                    Err(Error::Journal(JournalError::Corruption(_)))
+                ));
+
+                let (index, actual_size) = context
+                    .open(&cfg.key_partition, &0u64.to_be_bytes())
+                    .await
+                    .unwrap();
+                assert_eq!(actual_size, expected_size);
+                let actual = index
+                    .read_at(0, actual_size as usize, ReadOptions::default())
+                    .await
+                    .unwrap()
+                    .coalesce();
+                assert_eq!(actual.as_ref(), expected.as_ref());
+            }
+        });
+    }
+
+    #[test_traced]
+    fn test_validation_marker_survives_torn_index_tail_rewrite() {
+        let executor = deterministic::Runner::default();
+        let (_, checkpoint) = executor.start_and_recover(|context| async move {
+            let cfg = test_config(&context, "marker-torn-tail", NZU64!(4));
+            let archive = Archive::init(context.child("seed"), cfg.clone())
+                .await
+                .unwrap();
+
+            // Publish a marker for one record while its index occupies only part of the first page.
+            let archive = archive.put_sync(0, test_key("zero"), 10).await.unwrap();
+            let archive = archive.sync().await.unwrap();
+            let page_size = usize::from(PAGE_SIZE.get());
+            let physical_page_size = page_size + 12;
+            let record_size = u64::SIZE + FixedBytes::<64>::SIZE + u64::SIZE + u32::SIZE;
+            assert!(record_size < page_size);
+            let (index, size) = context
+                .open(&cfg.key_partition, &0u64.to_be_bytes())
+                .await
+                .unwrap();
+            assert_eq!(size, physical_page_size as u64);
+            let old_page = index
+                .read_at(0, physical_page_size, ReadOptions::default())
+                .await
+                .unwrap()
+                .coalesce();
+            let old_page = old_page.as_ref().to_vec();
+            drop(index);
+            let old_len =
+                u16::from_be_bytes(old_page[page_size..page_size + 2].try_into().unwrap()) as usize;
+            let old_crc =
+                u32::from_be_bytes(old_page[page_size + 2..page_size + 6].try_into().unwrap());
+            assert_eq!(old_len, record_size);
+            assert_eq!(old_crc, Crc32::checksum(&old_page[..old_len]));
+
+            // Capture Archive's same-page extension, then persist only the prefix through the new
+            // slot's length. This is the exact Prefix fault cut: the old slot remains valid while
+            // the new slot's checksum retains its prior zero bytes.
+            let archive = archive.put_sync(1, test_key("one"), 20).await.unwrap();
+            drop(archive);
+            let (index, size) = context
+                .open(&cfg.key_partition, &0u64.to_be_bytes())
+                .await
+                .unwrap();
+            assert_eq!(size, physical_page_size as u64);
+            let new_page = index
+                .read_at(0, physical_page_size, ReadOptions::default())
+                .await
+                .unwrap()
+                .coalesce();
+            let new_page = new_page.as_ref().to_vec();
+            assert_eq!(
+                &new_page[page_size..page_size + 6],
+                &old_page[page_size..page_size + 6],
+            );
+            let new_len =
+                u16::from_be_bytes(new_page[page_size + 6..page_size + 8].try_into().unwrap())
+                    as usize;
+            let new_crc =
+                u32::from_be_bytes(new_page[page_size + 8..page_size + 12].try_into().unwrap());
+            assert_eq!(new_len, 2 * record_size);
+            assert_eq!(new_crc, Crc32::checksum(&new_page[..new_len]));
+
+            index
+                .write_at(0, old_page.clone(), WriteOptions::SYNC)
+                .await
+                .unwrap();
+            let torn_prefix = page_size + 6 + 2;
+            index
+                .write_at(0, new_page[..torn_prefix].to_vec(), WriteOptions::SYNC)
+                .await
+                .unwrap();
+            let torn_page = index
+                .read_at(0, physical_page_size, ReadOptions::default())
+                .await
+                .unwrap()
+                .coalesce();
+            let torn_page = torn_page.as_ref();
+            assert_eq!(
+                &torn_page[page_size..page_size + 6],
+                &old_page[page_size..page_size + 6],
+            );
+            assert_eq!(
+                u16::from_be_bytes(torn_page[page_size + 6..page_size + 8].try_into().unwrap(),)
+                    as usize,
+                new_len,
+            );
+            let torn_crc =
+                u32::from_be_bytes(torn_page[page_size + 8..page_size + 12].try_into().unwrap());
+            assert_ne!(torn_crc, Crc32::checksum(&torn_page[..new_len]));
+            drop(index);
+
+            let (_, value_size) = context
+                .open(&cfg.value_partition, &0u64.to_be_bytes())
+                .await
+                .unwrap();
+            assert_eq!(value_size, 2 * I32_VALUE_FRAME_SIZE);
+        });
+
+        deterministic::Runner::from(checkpoint).start(|context| async move {
+            let pending = PendingSyncs::default();
+            let delayed = DelayedSyncContext {
+                inner: context.child("delayed"),
+                pending: pending.clone(),
+            };
+            pending.arm();
+            let cfg = test_config(&delayed, "marker-torn-tail", NZU64!(4));
+
+            // Recovery must trust the marker-covered record, select the older checksum slot, and
+            // durably remove only the orphaned value suffix.
+            let archive = drive_pending_syncs(
+                &pending,
+                Archive::<_, _, FixedBytes<64>, i32>::init(delayed.child("reopen"), cfg.clone()),
+            )
+            .await
+            .unwrap();
+            assert_eq!(pending.calls(), 1);
+            assert_eq!(archive.last_index(), Some(0));
+            assert_eq!(archive.ranges().collect::<Vec<_>>(), vec![(0, 0)]);
+            assert_eq!(archive.get(Identifier::Index(0)).await.unwrap(), Some(10));
+            assert_eq!(archive.get(Identifier::Index(1)).await.unwrap(), None);
+            drop(archive);
+
+            let (_, value_size) = context
+                .open(&cfg.value_partition, &0u64.to_be_bytes())
+                .await
+                .unwrap();
+            assert_eq!(value_size, I32_VALUE_FRAME_SIZE);
+        });
+    }
+
+    #[test_traced]
+    fn test_startup_publishes_validated_marker_without_data_resync() {
+        deterministic::Runner::default().start(|context| async move {
+            let cfg = test_config(&context, "startup-order", NZU64!(4));
+
+            let archive = Archive::init(context.child("seed"), cfg.clone())
+                .await
+                .unwrap();
+            let archive = archive.put(0, test_key("zero"), 10).await.unwrap();
+            let archive = archive.sync().await.unwrap();
+            drop(archive);
+
+            let pending = PendingSyncs::default();
+            let delayed = DelayedSyncContext {
+                inner: context.child("delayed"),
+                pending: pending.clone(),
+            };
+            pending.arm();
+            let completed = Arc::new(AtomicUsize::new(0));
+            let completed_clone = completed.clone();
+            let reopen_cfg = cfg.clone();
+            let task = context.child("startup").spawn(|_| async move {
+                let result =
+                    Archive::<_, _, FixedBytes<64>, i32>::init(delayed.child("reopen"), reopen_cfg)
+                        .await;
+                completed_clone.store(1, Ordering::Relaxed);
+                result
+            });
+
+            while pending.calls() == 0 && completed.load(Ordering::Relaxed) == 0 {
+                commonware_runtime::reschedule().await;
+            }
+            commonware_runtime::reschedule().await;
+
+            // Startup-readable bytes are already durable. A clean reopen should start only the
+            // derived marker and return while that metadata sync drives itself in the background.
+            let calls = pending.calls();
+            let finished = completed.load(Ordering::Relaxed);
+            if calls != 1 || finished != 1 {
+                pending.unblock();
+                let _ = task.await;
+                panic!(
+                    "clean startup must return after starting one marker sync, calls={calls}, \
+                     finished={finished}"
+                );
+            }
+
+            pending.unblock();
+            let archive = task.await.unwrap().unwrap().sync().await.unwrap();
+            assert_eq!(archive.get(Identifier::Index(0)).await.unwrap(), Some(10));
+            drop(archive);
+
+            Archive::<_, _, FixedBytes<64>, i32>::init(context.child("marker_reopen"), cfg)
+                .await
+                .unwrap()
+                .destroy()
+                .await
+                .unwrap();
+        });
+    }
+
+    #[test_traced]
+    fn test_startup_marker_failure_fails_next_sync() {
+        deterministic::Runner::default().start(|context| async move {
+            let cfg = test_config(&context, "startup-marker-failure", NZU64!(4));
+
+            let archive = Archive::init(context.child("seed"), cfg.clone())
+                .await
+                .unwrap();
+            let archive = archive.put(0, test_key("zero"), 10).await.unwrap();
+            let archive = archive.sync().await.unwrap();
+            drop(archive);
+
+            let pending = PendingSyncs::default();
+            let delayed = DelayedSyncContext {
+                inner: context.child("delayed"),
+                pending: pending.clone(),
+            };
+            pending.arm();
+            let archive = Archive::<_, _, FixedBytes<64>, i32>::init(delayed.child("reopen"), cfg)
+                .await
+                .unwrap();
+            assert_eq!(pending.lock().len(), 1);
+
+            fail_pending_syncs(&pending);
+            assert!(matches!(archive.sync().await, Err(Error::Metadata(_))));
+        });
+    }
+
+    #[test_traced]
+    fn test_start_sync_publishes_closed_section_boundary() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = test_config(&context, "marker-lag", NZU64!(4));
+
+            let pending = PendingSyncs::default();
+            let delayed = DelayedSyncContext {
+                inner: context.child("delayed"),
+                pending: pending.clone(),
+            };
+            let archive = Archive::init(delayed.child("archive"), cfg.clone())
+                .await
+                .unwrap();
+
+            // The first call has no prior durability proof, so it starts only the index and value
+            // syncs. Moving to section 4 closes section 0 and publishes its completed boundary
+            // alongside the new section's data syncs:
+            //
+            // call 1: section 0 data durable, marker absent
+            // call 2: section 4 data pending, section 0 marker pending
+            let (archive, first) = archive
+                .put_start_sync(0, test_key("zero"), 10)
+                .await
+                .unwrap();
+            assert_eq!(pending.lock().len(), 2);
+            release_pending_syncs(&pending);
+            first.await.unwrap();
+
+            let archive = archive.put(4, test_key("four"), 40).await.unwrap();
+            let (archive, second) = archive.start_sync().await.unwrap();
+            assert_eq!(pending.lock().len(), 3);
+            release_pending_syncs(&pending);
+            second.await.unwrap();
+            drop(archive);
+
+            let archive = Archive::<_, _, FixedBytes<64>, i32>::init(
+                context.child("first_reopen"),
+                cfg.clone(),
+            )
+            .await
+            .unwrap();
+            assert_eq!(archive.ranges().collect::<Vec<_>>(), vec![(0, 0), (4, 4)]);
+            drop(archive);
+
+            Archive::<_, _, FixedBytes<64>, i32>::init(context.child("second_reopen"), cfg)
+                .await
+                .unwrap()
+                .destroy()
+                .await
+                .unwrap();
+        });
+    }
+
+    #[test_traced]
+    fn test_sync_publishes_closed_section_boundary() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = test_config(&context, "blocking-marker-lag", NZU64!(4));
+
+            let pending = PendingSyncs::default();
+            let delayed = DelayedSyncContext {
+                inner: context.child("delayed"),
+                pending: pending.clone(),
+            };
+            let archive = Archive::init(delayed.child("archive"), cfg.clone())
+                .await
+                .unwrap();
+
+            let (archive, first) = archive
+                .put_start_sync(0, test_key("zero"), 10)
+                .await
+                .unwrap();
+            assert_eq!(pending.lock().len(), 2);
+            release_pending_syncs(&pending);
+            first.await.unwrap();
+
+            let archive = archive.put(4, test_key("four"), 40).await.unwrap();
+            pending.arm();
+            let completed = Arc::new(AtomicUsize::new(0));
+            let completed_clone = completed.clone();
+            let task = delayed.inner.child("sync").spawn(|_| async move {
+                let archive = archive.sync().await.unwrap();
+                completed_clone.store(1, Ordering::Relaxed);
+                archive
+            });
+
+            while pending.calls() < 2 {
+                commonware_runtime::reschedule().await;
+            }
+            commonware_runtime::reschedule().await;
+
+            // The marker for closed section 0 must start alongside section 4's data sync, rather
+            // than after it:
+            //
+            // data:   section 4 [0 -------- 1)  <- current sync, two journals
+            // marker: section 0 [0 -------- 1)  <- previous durable boundary
+            let parked_syncs = pending.lock().len();
+            if parked_syncs != 3 {
+                // Let the spawned operation unwind before reporting the regression. Otherwise the
+                // deterministic runner would correctly keep waiting for its parked durability work.
+                pending.unblock();
+                let _ = task.await;
+                panic!(
+                    "blocking sync must not serialize the derived marker behind data: \
+                     parked {parked_syncs} durability operations"
+                );
+            }
+
+            // The two data journals enqueue first. Release only the metadata operation to prove
+            // that publishing the older boundary cannot satisfy the blocking data contract. The
+            // marker future is polled only when a later request observes it, so this test
+            // cannot wait for it to park before releasing it.
+            let metadata = pending.lock().remove(2);
+            metadata.release.send(Ok(())).unwrap();
+            commonware_runtime::reschedule().await;
+            assert_eq!(
+                completed.load(Ordering::Relaxed),
+                0,
+                "publishing the previous marker must not complete the current data sync"
+            );
+
+            release_pending_syncs(&pending);
+            let archive = task.await.unwrap();
+            drop(archive);
+
+            let archive = Archive::<_, _, FixedBytes<64>, i32>::init(
+                delayed.inner.child("first_reopen"),
+                cfg.clone(),
+            )
+            .await
+            .unwrap();
+            assert_eq!(archive.get(Identifier::Index(0)).await.unwrap(), Some(10));
+            assert_eq!(archive.get(Identifier::Index(4)).await.unwrap(), Some(40));
+            drop(archive);
+
+            Archive::<_, _, FixedBytes<64>, i32>::init(delayed.inner.child("second_reopen"), cfg)
+                .await
+                .unwrap()
+                .destroy()
+                .await
+                .unwrap();
+        });
+    }
+
+    #[test_traced]
+    fn test_sync_delays_immediately_ready_durable_boundary() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let pending = PendingSyncs::default();
+            pending.unblock();
+            let immediate = DelayedSyncContext {
+                inner: context,
+                pending: pending.clone(),
+            };
+            let cfg = test_config(&immediate, "ready-marker-lag", NZU64!(4));
+
+            let archive = Archive::init(immediate.child("archive"), cfg)
+                .await
+                .unwrap();
+            let initial_starts = pending.starts();
+            let archive = archive.put_sync(0, test_key("zero"), 10).await.unwrap();
+
+            // The unblocked wrapper returns immediately-ready data-sync handles while retaining
+            // the number of durability operations. The current boundary must still become
+            // publication debt for the next sync, rather than making this call synchronously
+            // persist a marker after its data:
+            //
+            // call 1: two data syncs, marker absent
+            // call 2: no new data, one marker sync
+            assert_eq!(pending.starts() - initial_starts, 2);
+
+            let archive = archive.sync().await.unwrap();
+            assert_eq!(pending.starts() - initial_starts, 3);
+            archive.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced]
+    fn test_sync_batches_markers_by_active_section() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let pending = PendingSyncs::default();
+            pending.unblock();
+            let immediate = DelayedSyncContext {
+                inner: context,
+                pending: pending.clone(),
+            };
+            let cfg = test_config(&immediate, "section-marker-batch", NZU64!(4));
+            let archive = Archive::init(immediate.child("archive"), cfg)
+                .await
+                .unwrap();
+            let initial_starts = pending.starts();
+
+            // Repeated writes in one active section start only the index and value durability
+            // operations. Its marker remains debt until writes move to another section.
+            let archive = archive.put_sync(0, test_key("zero"), 10).await.unwrap();
+            let archive = archive.put_sync(1, test_key("one"), 20).await.unwrap();
+            assert_eq!(pending.starts() - initial_starts, 4);
+
+            // Moving to section 4 publishes section 0's completed boundary alongside the two data
+            // operations for section 4. An explicit empty sync then flushes the final partial
+            // section once. Another empty sync has no durability work.
+            let archive = archive.put_sync(4, test_key("four"), 40).await.unwrap();
+            assert_eq!(pending.starts() - initial_starts, 7);
+            let archive = archive.sync().await.unwrap();
+            assert_eq!(pending.starts() - initial_starts, 8);
+            let archive = archive.sync().await.unwrap();
+            assert_eq!(pending.starts() - initial_starts, 8);
+            archive.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced]
+    fn test_start_sync_withholds_marker_for_unproven_boundary() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = test_config(&context, "marker-unproven-boundary", NZU64!(4));
+
+            let pending = PendingSyncs::default();
+            let delayed = DelayedSyncContext {
+                inner: context.child("delayed"),
+                pending: pending.clone(),
+            };
+            let archive = Archive::init(delayed.child("archive"), cfg.clone())
+                .await
+                .unwrap();
+
+            // Prove section 0's single item so it owns publishable marker debt.
+            let (archive, first) = archive
+                .put_start_sync(0, test_key("zero"), 10)
+                .await
+                .unwrap();
+            release_pending_syncs(&pending);
+            first.await.unwrap();
+
+            // Moving to section 4 starts its data syncs and publishes section 0's boundary.
+            let archive = archive.put(4, test_key("four"), 40).await.unwrap();
+            let (archive, second) = archive.start_sync().await.unwrap();
+            assert_eq!(pending.lock().len(), 3);
+
+            // Complete only the marker generation, which parked last. Section 4's data syncs
+            // stay in flight, so nothing beyond its published floor is proven. Sync futures
+            // are lazy, so the released marker resolves when the next request polls it.
+            let marker = pending.lock().pop().expect("marker sync parked");
+            marker
+                .release
+                .send(Ok(()))
+                .expect("marker sync receiver dropped");
+
+            // The next request observes the completed marker generation and retires caught-up
+            // barriers. It must not manufacture a durability proof for section 4: publishing
+            // its unproven length as a marker would let a crash that keeps the marker but
+            // loses the in-flight items make every reopen fail.
+            let archive = archive.put(8, test_key("eight"), 80).await.unwrap();
+            let before = pending.starts();
+            let (archive, third) = archive.start_sync().await.unwrap();
+            assert_eq!(pending.starts() - before, 2);
+
+            release_pending_syncs(&pending);
+            second.await.unwrap();
+            third.await.unwrap();
+
+            // Every boundary publishes once proven. A blocking sync flushes the remaining
+            // debt and a reopen sees all three sections.
+            let archive = drive_pending_syncs(&pending, archive.sync()).await.unwrap();
+            drop(archive);
+            let archive = Archive::<_, _, FixedBytes<64>, i32>::init(context.child("reopen"), cfg)
+                .await
+                .unwrap();
+            assert_eq!(
+                archive.ranges().collect::<Vec<_>>(),
+                vec![(0, 0), (4, 4), (8, 8)]
+            );
+            archive.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced]
+    fn test_sync_publishes_previous_durable_sections_across_section_changes() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = test_config(&context, "cross-section-marker-lag", NZU64!(1));
+
+            let pending = PendingSyncs::default();
+            let delayed = DelayedSyncContext {
+                inner: context.child("delayed"),
+                pending: pending.clone(),
+            };
+            let archive = Archive::init(delayed.child("archive"), cfg.clone())
+                .await
+                .unwrap();
+            let archive = drive_pending_syncs(&pending, archive.put_sync(0, test_key("zero"), 10))
+                .await
+                .unwrap();
+            let archive = drive_pending_syncs(&pending, archive.put_sync(1, test_key("one"), 20))
+                .await
+                .unwrap();
+            let archive = drive_pending_syncs(&pending, archive.put_sync(2, test_key("two"), 30))
+                .await
+                .unwrap();
+            drop(archive);
+
+            // Every item occupies its own section. Each blocking sync publishes the preceding
+            // call's completed section while synchronizing the current section:
+            //
+            // call 1: data section 0, marker absent
+            // call 2: data section 1, marker section 0
+            // call 3: data section 2, marker section 1
+            //
+            // Markers may trail durable data, but changing sections must not strand every earlier
+            // proof and turn startup validation into an unbounded full-archive scan.
+            let archive = Archive::<_, _, FixedBytes<64>, i32>::init(
+                context.child("first_reopen"),
+                cfg.clone(),
+            )
+            .await
+            .unwrap();
+            assert_eq!(archive.get(Identifier::Index(0)).await.unwrap(), Some(10));
+            assert_eq!(archive.get(Identifier::Index(1)).await.unwrap(), Some(20));
+            assert_eq!(archive.get(Identifier::Index(2)).await.unwrap(), Some(30));
+            drop(archive);
+
+            Archive::<_, _, FixedBytes<64>, i32>::init(context.child("second_reopen"), cfg)
+                .await
+                .unwrap()
+                .destroy()
+                .await
+                .unwrap();
+        });
+    }
+
+    #[test_traced]
+    fn test_empty_sync_publishes_final_durable_boundary() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = test_config(&context, "empty-sync-marker", NZU64!(1));
+
+            let pending = PendingSyncs::default();
+            let delayed = DelayedSyncContext {
+                inner: context.child("delayed"),
+                pending: pending.clone(),
+            };
+            let archive = Archive::init(delayed.child("archive"), cfg.clone())
+                .await
+                .unwrap();
+            let archive = drive_pending_syncs(&pending, archive.put_sync(0, test_key("zero"), 10))
+                .await
+                .unwrap();
+            assert_eq!(pending.starts(), 2);
+
+            // A blocking sync with no new data flushes the final lagging marker without
+            // re-synchronizing the already durable section:
+            //
+            // call 1: data section 0, marker absent
+            // call 2: data absent,    marker section 0
+            let archive = drive_pending_syncs(&pending, archive.sync()).await.unwrap();
+            assert_eq!(pending.starts(), 3);
+
+            // Once the marker completes, another empty sync has no durability work.
+            let archive = drive_pending_syncs(&pending, archive.sync()).await.unwrap();
+            assert_eq!(pending.starts(), 3);
+            drop(archive);
+
+            let archive = Archive::<_, _, FixedBytes<64>, i32>::init(context.child("reopen"), cfg)
+                .await
+                .unwrap();
+            assert_eq!(archive.get(Identifier::Index(0)).await.unwrap(), Some(10));
+        });
+    }
+
+    #[test_traced]
+    fn test_sync_recreates_settled_section_barrier() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = test_config(&context, "marker-recreate", NZU64!(2));
+
+            let pending = PendingSyncs::default();
+            let delayed = DelayedSyncContext {
+                inner: context.child("delayed"),
+                pending: pending.clone(),
+            };
+            let archive = Archive::init(delayed.child("archive"), cfg.clone())
+                .await
+                .unwrap();
+
+            // Each successful call publishes the preceding section and retains the current one as
+            // marker debt. Returning to section 0 must start its new barrier at the retained
+            // one-item prefix rather than at zero.
+            let archive = drive_pending_syncs(&pending, archive.put_sync(0, test_key("zero"), 10))
+                .await
+                .unwrap();
+            assert_eq!(pending.starts(), 2);
+            let archive = drive_pending_syncs(&pending, archive.put_sync(2, test_key("two"), 30))
+                .await
+                .unwrap();
+            assert_eq!(pending.starts(), 5);
+            let archive = drive_pending_syncs(&pending, archive.put_sync(1, test_key("one"), 20))
+                .await
+                .unwrap();
+            assert_eq!(pending.starts(), 8);
+
+            // Flush the final marker, then prove another empty sync has no retained work.
+            let archive = drive_pending_syncs(&pending, archive.sync()).await.unwrap();
+            assert_eq!(pending.starts(), 9);
+            let archive = drive_pending_syncs(&pending, archive.sync()).await.unwrap();
+            assert_eq!(pending.starts(), 9);
+            drop(archive);
+
+            let archive = Archive::<_, _, FixedBytes<64>, i32>::init(context.child("reopen"), cfg)
+                .await
+                .unwrap();
+            assert_eq!(archive.get(Identifier::Index(0)).await.unwrap(), Some(10));
+            assert_eq!(archive.get(Identifier::Index(1)).await.unwrap(), Some(20));
+            assert_eq!(archive.get(Identifier::Index(2)).await.unwrap(), Some(30));
+        });
+    }
+
+    #[test_traced]
+    fn test_prune_clears_validation_marker_before_section_reuse() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = test_config(&context, "marker-reuse", NZU64!(2));
+
+            let archive = Archive::init(context.child("seed"), cfg.clone())
+                .await
+                .unwrap();
+            let archive = archive.put_sync(0, test_key("old"), 10).await.unwrap();
+            let archive = archive.sync().await.unwrap();
+            let archive = archive.prune(2).await.unwrap();
+            drop(archive);
+
+            // Reinitialization resets the in-memory prune floor, so section 0 can be created again
+            // if the application does not reapply its durable floor. Make the replacement bytes
+            // durable without a second sync call that could publish their new marker:
+            //
+            // old section 0: [position 0 -> 10] --prune--> absent
+            // new section 0: [position 0 -> 20] --sync data only--> validate on reopen
+            //
+            // A stale marker from the old incarnation would incorrectly skip that validation.
+            let pending = PendingSyncs::default();
+            let delayed = DelayedSyncContext {
+                inner: context.child("delayed"),
+                pending: pending.clone(),
+            };
+            let archive = Archive::init(delayed.child("reuse"), cfg.clone())
+                .await
+                .unwrap();
+            let archive = archive.put(0, test_key("new"), 20).await.unwrap();
+            let (archive, handle) = archive.start_sync().await.unwrap();
+            assert_eq!(pending.lock().len(), 2);
+            release_pending_syncs(&pending);
+            handle.await.unwrap();
+            drop(archive);
+
+            let archive = Archive::<_, _, FixedBytes<64>, i32>::init(context.child("reopen"), cfg)
+                .await
+                .unwrap();
+            assert_eq!(archive.get(Identifier::Index(0)).await.unwrap(), Some(20));
+        });
+    }
+
+    #[test_traced]
     fn test_archive_compression_then_none() {
         // Initialize the deterministic context
         let executor = deterministic::Runner::default();
@@ -821,6 +2060,7 @@ mod tests {
             // Initialize the archive
             let cfg = Config {
                 translator: FourCap,
+                metadata_partition: "test-metadata".into(),
                 key_partition: "test-index".into(),
                 key_page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                 value_partition: "test-value".into(),
@@ -852,6 +2092,7 @@ mod tests {
             // Index journal replay succeeds (no compression), but value reads will fail.
             let cfg = Config {
                 translator: FourCap,
+                metadata_partition: "test-metadata".into(),
                 key_partition: "test-index".into(),
                 key_page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                 value_partition: "test-value".into(),
@@ -888,6 +2129,7 @@ mod tests {
             // Initialize the archive
             let cfg = Config {
                 translator: FourCap,
+                metadata_partition: "test-metadata".into(),
                 key_partition: "test-index".into(),
                 key_page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                 value_partition: "test-value".into(),
@@ -953,6 +2195,7 @@ mod tests {
             // Initialize the archive
             let cfg = Config {
                 translator: FourCap,
+                metadata_partition: "test-metadata".into(),
                 key_partition: "test-index".into(),
                 key_page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                 value_partition: "test-value".into(),
@@ -1012,6 +2255,7 @@ mod tests {
             // Initialize the archive
             let cfg = Config {
                 translator: FourCap,
+                metadata_partition: "test-metadata".into(),
                 key_partition: "test-index".into(),
                 key_page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                 value_partition: "test-value".into(),
@@ -1099,8 +2343,8 @@ mod tests {
                 None
             );
 
-            // The sync combinators skip the sync for a satisfied below-floor put
-            // and return a ready handle
+            // With no earlier pending writes, the below-floor sync combinators complete without
+            // storing the pruned item.
             let (archive, handle) = archive
                 .put_start_sync(1, test_key("key1-blah"), 1)
                 .await
@@ -1123,6 +2367,7 @@ mod tests {
             let items_per_section = 256u64;
             let cfg = Config {
                 translator: TwoCap,
+                metadata_partition: "test-metadata".into(),
                 key_partition: "test-index".into(),
                 key_page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                 value_partition: "test-value".into(),
@@ -1186,6 +2431,7 @@ mod tests {
             // Reinitialize the archive
             let cfg = Config {
                 translator: TwoCap,
+                metadata_partition: "test-metadata".into(),
                 key_partition: "test-index".into(),
                 key_page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                 value_partition: "test-value".into(),
@@ -1294,6 +2540,7 @@ mod tests {
         executor.start(|context| async move {
             let cfg = Config {
                 translator: FourCap,
+                metadata_partition: "test-metadata".into(),
                 key_partition: "test-index".into(),
                 key_page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                 value_partition: "test-value".into(),
@@ -1345,6 +2592,7 @@ mod tests {
         executor.start(|context| async move {
             let cfg = Config {
                 translator: FourCap,
+                metadata_partition: "test-metadata".into(),
                 key_partition: "test-index".into(),
                 key_page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                 value_partition: "test-value".into(),
@@ -1380,7 +2628,7 @@ mod tests {
     fn test_has_at() {
         let executor = deterministic::Runner::default();
         let (_, checkpoint) = executor.start_and_recover(|context| async move {
-            let cfg = test_config(&context, NZU64!(2));
+            let cfg = test_config(&context, "test", NZU64!(2));
             let mut archive = Archive::init(context.child("storage"), cfg)
                 .await
                 .expect("Failed to initialize archive");
@@ -1412,7 +2660,7 @@ mod tests {
         });
 
         deterministic::Runner::from(checkpoint).start(|context| async move {
-            let cfg = test_config(&context, NZU64!(2));
+            let cfg = test_config(&context, "test", NZU64!(2));
             let archive = Archive::<_, _, FixedBytes<64>, i32>::init(context.child("reopen"), cfg)
                 .await
                 .expect("Failed to reopen archive");
@@ -1436,7 +2684,7 @@ mod tests {
     fn test_has_key() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let cfg = test_config(&context, NZU64!(2));
+            let cfg = test_config(&context, "test", NZU64!(2));
             let mut archive = Archive::init(context.child("storage"), cfg)
                 .await
                 .expect("Failed to initialize archive");
@@ -1480,6 +2728,7 @@ mod tests {
         executor.start(|context| async move {
             let cfg = Config {
                 translator: FourCap,
+                metadata_partition: "test-metadata".into(),
                 key_partition: "test-index".into(),
                 key_page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
                 value_partition: "test-value".into(),
@@ -1547,8 +2796,8 @@ mod tests {
                 None
             );
 
-            // put_multi_start_sync below the prune floor skips the sync and
-            // returns a ready handle
+            // With no earlier pending writes, put_multi_start_sync below the prune floor returns
+            // a ready handle without storing the pruned item.
             let (archive, handle) = archive
                 .put_multi_start_sync(2, test_key("ddd"), 41)
                 .await
@@ -1556,7 +2805,7 @@ mod tests {
             handle.await.expect("handle must resolve");
             assert_eq!(archive.get_all(2).await.expect("Failed to get data"), None);
 
-            // put_multi_sync below the prune floor skips the sync
+            // put_multi_sync below the prune floor stores nothing.
             let archive = archive
                 .put_multi_sync(2, test_key("ddd"), 42)
                 .await

--- a/storage/src/archive/prunable/mod.rs
+++ b/storage/src/archive/prunable/mod.rs
@@ -221,7 +221,7 @@ mod tests {
     use super::*;
     use crate::{
         archive::{Archive as _, Error, Identifier, MultiArchive as _},
-        journal::Error as JournalError,
+        journal::{Error as JournalError, segmented::glob::corrupt_frame},
         translator::{FourCap, TwoCap},
     };
     use commonware_codec::{DecodeExt, Error as CodecError, FixedSize};
@@ -281,29 +281,10 @@ mod tests {
         }
     }
 
-    const I32_VALUE_FRAME_SIZE: u64 = 8;
-
-    async fn corrupt_value_frame(
-        context: &deterministic::Context,
-        partition: &str,
-        section: u64,
-        position: u64,
-    ) {
-        let offset = position * I32_VALUE_FRAME_SIZE;
-        let (blob, size) = context
-            .open(partition, &section.to_be_bytes())
-            .await
-            .unwrap();
-        assert!(offset < size);
-        let byte = blob
-            .read_at(offset, 1, ReadOptions::default())
-            .await
-            .unwrap()
-            .coalesce();
-        blob.write_at(offset, vec![byte.as_ref()[0] ^ 0xFF], WriteOptions::SYNC)
-            .await
-            .unwrap();
-    }
+    /// Physical size of one uncompressed i32 value frame in the value journal, per the
+    /// glob's frame layout (encoded value followed by its CRC32).
+    const I32_VALUE_FRAME_SIZE: u64 =
+        (i32::SIZE + crate::journal::segmented::glob::CHECKSUM_SIZE) as u64;
 
     #[test_traced]
     fn test_put_after_start_sync_is_accepted_before_handle_completes() {
@@ -440,12 +421,18 @@ mod tests {
             let archive = Archive::init(context.child("storage"), cfg)
                 .await
                 .expect("Failed to initialize archive");
+
+            // Raise the prune floor above index 0, then buffer an unsynced write to retained
+            // section 2.
             let archive = archive.prune(1).await.expect("Failed to set prune floor");
             let archive = archive
                 .put(2, test_key("pending"), 20)
                 .await
                 .expect("Failed to buffer retained write");
 
+            // The below-floor put stores nothing, yet the returned handle must cover every
+            // previously accepted write. The two parked operations are section 2's index and
+            // value syncs.
             assert!(pending.lock().is_empty());
             let (archive, handle) = archive
                 .put_start_sync(0, test_key("pruned"), 0)
@@ -457,6 +444,8 @@ mod tests {
                 "the sync combinator must cover writes accepted before its below-floor put"
             );
 
+            // Releasing the parked syncs completes the handle, proving the covered write
+            // durable while the below-floor index stays absent.
             release_pending_syncs(&pending);
             handle.await.expect("covering sync should complete");
             assert_eq!(archive.get(Identifier::Index(2)).await.unwrap(), Some(20));
@@ -477,12 +466,17 @@ mod tests {
             let archive = Archive::init(context.child("storage"), cfg)
                 .await
                 .expect("Failed to initialize archive");
+
+            // Raise the prune floor above index 0, then buffer an unsynced write to retained
+            // section 2.
             let archive = archive.prune(1).await.expect("Failed to set prune floor");
             let archive = archive
                 .put_multi(2, test_key("pending"), 20)
                 .await
                 .expect("Failed to buffer retained write");
 
+            // Run the blocking combinator in a spawned task so the test can observe whether it
+            // returns while the covering sync is still parked.
             pending.arm();
             let completed = Arc::new(AtomicUsize::new(0));
             let completed_clone = completed.clone();
@@ -495,6 +489,8 @@ mod tests {
                 commonware_runtime::reschedule().await;
             }
 
+            // The below-floor put stores nothing, yet the blocking call must not return before
+            // the previously buffered write is durable.
             assert_eq!(
                 completed.load(Ordering::Relaxed),
                 0,
@@ -506,6 +502,8 @@ mod tests {
                 .await
                 .expect("put_multi_sync task failed")
                 .expect("put_multi_sync failed");
+
+            // The covered write survives while the below-floor index stays absent.
             assert_eq!(archive.get_all(2).await.unwrap(), Some(vec![20]));
             assert_eq!(archive.get_all(0).await.unwrap(), None);
         });
@@ -933,6 +931,9 @@ mod tests {
             for (name, bad_position, retained) in [("first", 0, 0), ("middle", 1, 1)] {
                 let cfg = test_config(&context, &format!("invalid-{name}"), NZU64!(4));
 
+                // Seed three values in one section. The sync leaves them durable with no marker
+                // (the active section's boundary stays debt), so reopen must CRC-validate every
+                // frame from position 0.
                 let mut archive = Archive::init(context.child(name), cfg.clone())
                     .await
                     .unwrap();
@@ -945,7 +946,14 @@ mod tests {
                 archive = archive.sync().await.unwrap();
                 drop(archive);
 
-                corrupt_value_frame(&context, &cfg.value_partition, 0, bad_position).await;
+                corrupt_frame(
+                    &context,
+                    &cfg.value_partition,
+                    &0u64.to_be_bytes(),
+                    bad_position,
+                    I32_VALUE_FRAME_SIZE,
+                )
+                .await;
 
                 // Every frame after the first invalid one belongs to the same uncommitted suffix,
                 // even if its own CRC is valid:
@@ -973,6 +981,8 @@ mod tests {
                 }
                 drop(archive);
 
+                // The truncation was made durable before the first reopen returned: a second
+                // reopen observes the same retained prefix.
                 let archive = Archive::<_, _, FixedBytes<64>, i32>::init(context.child(name), cfg)
                     .await
                     .unwrap();
@@ -987,6 +997,8 @@ mod tests {
         deterministic::Runner::default().start(|context| async move {
             let cfg = test_config(&context, "empty-rewind", NZU64!(4));
 
+            // Seed one durable value, then drop the sidecar so startup cannot consult markers
+            // and must reconcile the journals alone.
             let archive = Archive::init(context.child("seed"), cfg.clone())
                 .await
                 .unwrap();
@@ -1058,6 +1070,9 @@ mod tests {
             }
             pending.unblock();
             let archive = task.await.unwrap().unwrap();
+
+            // The repaired empty section accepts a fresh write at the reclaimed offsets, and
+            // the write survives reopen.
             let archive = archive.put(0, test_key("new"), 20).await.unwrap();
             let archive = archive.sync().await.unwrap();
             drop(archive);
@@ -1081,6 +1096,7 @@ mod tests {
         executor.start(|context| async move {
             let cfg = test_config(&context, "marker-skip", NZU64!(4));
 
+            // Seed two durable values with no published marker.
             let mut archive = Archive::init(context.child("seed"), cfg.clone())
                 .await
                 .unwrap();
@@ -1113,6 +1129,8 @@ mod tests {
             assert_eq!(archive.get(Identifier::Index(0)).await.unwrap(), Some(10));
             assert_eq!(archive.get(Identifier::Index(1)).await.unwrap(), Some(20));
 
+            // Append a third value above the marker. Its boundary stays debt, so the third open
+            // must validate the suffix and adopt the covered pair into one contiguous range.
             let archive = archive.put(2, test_key("two"), 30).await.unwrap();
             let archive = archive.sync().await.unwrap();
             drop(archive);
@@ -1140,13 +1158,22 @@ mod tests {
                 .unwrap();
             let archive = archive.put(0, test_key("zero"), 10).await.unwrap();
             let archive = archive.put(1, test_key("one"), 20).await.unwrap();
+
+            // The first sync proves the data durable. The second publishes the resulting marker.
             let archive = archive.sync().await.unwrap();
             let archive = archive.sync().await.unwrap();
             drop(archive);
 
             // Damage only the covered interior frame. Initialization succeeds because the marker
             // skips it, while a direct read still exposes its invalid checksum.
-            corrupt_value_frame(&context, &cfg.value_partition, 0, 0).await;
+            corrupt_frame(
+                &context,
+                &cfg.value_partition,
+                &0u64.to_be_bytes(),
+                0,
+                I32_VALUE_FRAME_SIZE,
+            )
+            .await;
             let archive = Archive::<_, _, FixedBytes<64>, i32>::init(context.child("reopen"), cfg)
                 .await
                 .unwrap();
@@ -1168,6 +1195,9 @@ mod tests {
         }
 
         deterministic::Runner::default().start(|context| async move {
+            // Every shape damages data at or below a published marker. Marked bytes were proven
+            // durable before publication, so startup must treat their loss as corruption (or
+            // leave it to lazy reads) without mutating either journal.
             for (name, damage) in [
                 ("missing_index", Damage::MissingIndex),
                 ("missing_values", Damage::MissingValues),
@@ -1179,6 +1209,8 @@ mod tests {
                 let case = context.child(name);
                 let cfg = test_config(&case, name, NZU64!(4));
 
+                // Seed one marked item: the blocking put proves it durable and the trailing
+                // sync publishes its marker.
                 let archive = Archive::init(case.child("seed"), cfg.clone())
                     .await
                     .unwrap();
@@ -1268,6 +1300,8 @@ mod tests {
                     continue;
                 }
 
+                // Failed startups must be byte-stable across repeated opens: rejection happens
+                // before any repair could mutate the marked section.
                 for child in ["first", "second"] {
                     let result =
                         Archive::<_, _, FixedBytes<64>, i32>::init(case.child(child), cfg.clone())
@@ -1310,6 +1344,8 @@ mod tests {
         deterministic::Runner::default().start(|context| async move {
             let cfg = test_config(&context, "floor-order", NZU64!(4));
 
+            // Seed one marked item: the blocking put proves it durable and the trailing sync
+            // publishes its marker.
             let archive =
                 Archive::<_, _, FixedBytes<64>, i32>::init(context.child("seed"), cfg.clone())
                     .await
@@ -1318,6 +1354,8 @@ mod tests {
             let archive = archive.sync().await.unwrap();
             drop(archive);
 
+            // Append trailing junk past the index tail. Alone, this is repairable damage that
+            // suffix repair would truncate on the next open.
             let (index, index_size) = context
                 .open(&cfg.key_partition, &0u64.to_be_bytes())
                 .await
@@ -1346,6 +1384,8 @@ mod tests {
                 .coalesce();
             drop(index);
 
+            // Repeated failed opens must leave the section byte-identical, junk included: the
+            // floor check rejects the section before suffix repair can truncate anything.
             for child in ["first", "second"] {
                 let result =
                     Archive::<_, _, FixedBytes<64>, i32>::init(context.child(child), cfg.clone())
@@ -1382,6 +1422,14 @@ mod tests {
             // Publish a marker for one record while its index occupies only part of the first page.
             let archive = archive.put_sync(0, test_key("zero"), 10).await.unwrap();
             let archive = archive.sync().await.unwrap();
+
+            // A physical page is the logical page plus a two-slot trailer, where each slot is a
+            // two-byte length and a four-byte checksum over that length's prefix of the page:
+            //
+            //   [ records ... pad ......][len0 crc0][len1 crc1]
+            //   0               page_size         +6        +12
+            //
+            // The first write filled slot 0 for one record and left slot 1 zeroed.
             let page_size = usize::from(PAGE_SIZE.get());
             let physical_page_size = page_size + 12;
             let record_size = u64::SIZE + FixedBytes::<64>::SIZE + u64::SIZE + u32::SIZE;
@@ -1433,6 +1481,12 @@ mod tests {
             assert_eq!(new_len, 2 * record_size);
             assert_eq!(new_crc, Crc32::checksum(&new_page[..new_len]));
 
+            // Restore the one-record image, then replay the extended image only through slot
+            // 1's length. The stored page now holds both records' data, a valid slot 0 covering
+            // one record, and a slot 1 that advertises two records with a stale zero checksum:
+            //
+            //   [ record 0 | record 1 | pad ][len0 crc0][len1 crc1]
+            //     persisted prefix ends after len1 --------------^
             index
                 .write_at(0, old_page.clone(), WriteOptions::SYNC)
                 .await
@@ -1462,6 +1516,8 @@ mod tests {
             assert_ne!(torn_crc, Crc32::checksum(&torn_page[..new_len]));
             drop(index);
 
+            // Both value frames survive the torn index write, leaving recovery to decide which
+            // bytes are orphaned.
             let (_, value_size) = context
                 .open(&cfg.value_partition, &0u64.to_be_bytes())
                 .await
@@ -1506,6 +1562,8 @@ mod tests {
         deterministic::Runner::default().start(|context| async move {
             let cfg = test_config(&context, "startup-order", NZU64!(4));
 
+            // Seed one durable value with no published marker, so the next startup must
+            // validate it and derive the marker itself.
             let archive = Archive::init(context.child("seed"), cfg.clone())
                 .await
                 .unwrap();
@@ -1513,6 +1571,8 @@ mod tests {
             let archive = archive.sync().await.unwrap();
             drop(archive);
 
+            // Reopen through the armed wrapper to count every durability operation startup
+            // issues.
             let pending = PendingSyncs::default();
             let delayed = DelayedSyncContext {
                 inner: context.child("delayed"),
@@ -1553,6 +1613,7 @@ mod tests {
             assert_eq!(archive.get(Identifier::Index(0)).await.unwrap(), Some(10));
             drop(archive);
 
+            // The published marker must leave a reopenable archive.
             Archive::<_, _, FixedBytes<64>, i32>::init(context.child("marker_reopen"), cfg)
                 .await
                 .unwrap()
@@ -1567,6 +1628,7 @@ mod tests {
         deterministic::Runner::default().start(|context| async move {
             let cfg = test_config(&context, "startup-marker-failure", NZU64!(4));
 
+            // Seed one durable value with no published marker, so reopen must derive one.
             let archive = Archive::init(context.child("seed"), cfg.clone())
                 .await
                 .unwrap();
@@ -1574,6 +1636,8 @@ mod tests {
             let archive = archive.sync().await.unwrap();
             drop(archive);
 
+            // Reopen with the armed wrapper. The only durability operation startup issues is
+            // the derived marker sync, left parked.
             let pending = PendingSyncs::default();
             let delayed = DelayedSyncContext {
                 inner: context.child("delayed"),
@@ -1585,6 +1649,8 @@ mod tests {
                 .unwrap();
             assert_eq!(pending.lock().len(), 1);
 
+            // A marker sync failure must not vanish: the next sync call observes the completed
+            // generation and surfaces the failure as a metadata error.
             fail_pending_syncs(&pending);
             assert!(matches!(archive.sync().await, Err(Error::Metadata(_))));
         });
@@ -1626,6 +1692,8 @@ mod tests {
             second.await.unwrap();
             drop(archive);
 
+            // Reopen adopts section 0 through its published marker and validates section 4
+            // above its absent one. Both items must survive.
             let archive = Archive::<_, _, FixedBytes<64>, i32>::init(
                 context.child("first_reopen"),
                 cfg.clone(),
@@ -1659,6 +1727,7 @@ mod tests {
                 .await
                 .unwrap();
 
+            // Prove section 0's single item durable so its boundary becomes publishable debt.
             let (archive, first) = archive
                 .put_start_sync(0, test_key("zero"), 10)
                 .await
@@ -1667,6 +1736,7 @@ mod tests {
             release_pending_syncs(&pending);
             first.await.unwrap();
 
+            // Buffer section 4 and park its blocking sync behind the armed gate.
             let archive = archive.put(4, test_key("four"), 40).await.unwrap();
             pending.arm();
             let completed = Arc::new(AtomicUsize::new(0));
@@ -1716,6 +1786,8 @@ mod tests {
             let archive = task.await.unwrap();
             drop(archive);
 
+            // Both items survive reopen: the published marker adopts section 0 and validation
+            // covers section 4.
             let archive = Archive::<_, _, FixedBytes<64>, i32>::init(
                 delayed.inner.child("first_reopen"),
                 cfg.clone(),
@@ -1739,6 +1811,7 @@ mod tests {
     fn test_sync_delays_immediately_ready_durable_boundary() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
+            // Started durability operations complete immediately and are only counted.
             let pending = PendingSyncs::default();
             pending.unblock();
             let immediate = DelayedSyncContext {
@@ -1772,6 +1845,7 @@ mod tests {
     fn test_sync_batches_markers_by_active_section() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
+            // Started durability operations complete immediately and are only counted.
             let pending = PendingSyncs::default();
             pending.unblock();
             let immediate = DelayedSyncContext {
@@ -1843,7 +1917,8 @@ mod tests {
             // The next request observes the completed marker generation and retires caught-up
             // barriers. It must not manufacture a durability proof for section 4: publishing
             // its unproven length as a marker would let a crash that keeps the marker but
-            // loses the in-flight items make every reopen fail.
+            // loses the in-flight items make every reopen fail. The two operations started
+            // here are section 8's index and value syncs.
             let archive = archive.put(8, test_key("eight"), 80).await.unwrap();
             let before = pending.starts();
             let (archive, third) = archive.start_sync().await.unwrap();
@@ -1882,6 +1957,9 @@ mod tests {
             let archive = Archive::init(delayed.child("archive"), cfg.clone())
                 .await
                 .unwrap();
+
+            // Three items land in three single-item sections, each through its own blocking
+            // sync.
             let archive = drive_pending_syncs(&pending, archive.put_sync(0, test_key("zero"), 10))
                 .await
                 .unwrap();
@@ -1936,6 +2014,8 @@ mod tests {
             let archive = Archive::init(delayed.child("archive"), cfg.clone())
                 .await
                 .unwrap();
+
+            // Seed one durable item. The two starts are section 0's index and value syncs.
             let archive = drive_pending_syncs(&pending, archive.put_sync(0, test_key("zero"), 10))
                 .await
                 .unwrap();
@@ -1999,6 +2079,8 @@ mod tests {
             assert_eq!(pending.starts(), 9);
             drop(archive);
 
+            // The recreated barrier's final marker covers section 0's full two-item prefix, so
+            // a reopen sees every value.
             let archive = Archive::<_, _, FixedBytes<64>, i32>::init(context.child("reopen"), cfg)
                 .await
                 .unwrap();
@@ -2014,6 +2096,10 @@ mod tests {
         executor.start(|context| async move {
             let cfg = test_config(&context, "marker-reuse", NZU64!(2));
 
+            // Seed one marked item in section 0 (the trailing sync publishes its marker), then
+            // prune the section away. Prune must remove the durable marker along with the data:
+            // a surviving marker would make the next init fail by claiming a marked section
+            // with no journals.
             let archive = Archive::init(context.child("seed"), cfg.clone())
                 .await
                 .unwrap();

--- a/storage/src/archive/prunable/storage.rs
+++ b/storage/src/archive/prunable/storage.rs
@@ -193,8 +193,8 @@ impl<T: Translator, E: Context, K: Array, V: CodecShared> Inner<T, E, K, V> {
         )
         .await?;
 
-        // Rebuild every lookup view from the single retained prefix selected by oversized
-        // recovery.
+        // Rebuild the in-memory indexes from the replay. It yields exactly the entries
+        // recovery retained, so one scan serves both recovery and indexing.
         let mut indices: BTreeMap<u64, u64> = BTreeMap::new();
         let mut extra_indices: BTreeMap<u64, Vec<u64>> = BTreeMap::new();
         let mut keys = Index::new(context.child("index"), cfg.translator);

--- a/storage/src/archive/prunable/storage.rs
+++ b/storage/src/archive/prunable/storage.rs
@@ -17,14 +17,6 @@ use commonware_utils::Array;
 use std::collections::{BTreeMap, BTreeSet, btree_map};
 use tracing::debug;
 
-/// Preserve the archive's error classification for journal-owned metadata operations.
-fn map_journal_error(error: crate::journal::Error) -> Error {
-    match error {
-        crate::journal::Error::Metadata(error) => Error::Metadata(error),
-        error => Error::Journal(error),
-    }
-}
-
 /// Index entry for the archive.
 #[derive(Debug, Clone, PartialEq)]
 struct Record<K: Array> {
@@ -212,8 +204,7 @@ impl<T: Translator, E: Context, K: Array, V: CodecShared> Inner<T, E, K, V> {
             metadata_partition,
             commonware_runtime::ReadOptions::default(),
         )
-        .await
-        .map_err(map_journal_error)?;
+        .await?;
 
         // Rebuild every lookup view from the single retained prefix selected by oversized
         // recovery.
@@ -237,7 +228,7 @@ impl<T: Translator, E: Context, K: Array, V: CodecShared> Inner<T, E, K, V> {
             keys.insert(&entry.key, entry.index);
             intervals.insert(entry.index);
         }
-        let oversized = replay.finish_tracked().await.map_err(map_journal_error)?;
+        let oversized = replay.finish_tracked().await?;
         debug!("archive initialized");
 
         // Initialize metrics
@@ -392,11 +383,7 @@ impl<T: Translator, E: Context, K: Array, V: CodecShared> Inner<T, E, K, V> {
         let section = self.section(index);
         let entry = Record::new(index, key.clone(), 0, 0);
         let position;
-        (self.oversized, position, _, _) = self
-            .oversized
-            .append(section, entry, &data)
-            .await
-            .map_err(map_journal_error)?;
+        (self.oversized, position, _, _) = self.oversized.append(section, entry, &data).await?;
 
         // Store index location
         match self.indices.entry(index) {
@@ -439,7 +426,7 @@ impl<T: Translator, E: Context, K: Array, V: CodecShared> Inner<T, E, K, V> {
         debug!(min, "pruning archive");
 
         // Prune the section's index, values, and recovery markers together.
-        (self.oversized, _) = self.oversized.prune(min).await.map_err(map_journal_error)?;
+        (self.oversized, _) = self.oversized.prune(min).await?;
 
         // Discard synchronization state owned by pruned sections.
         self.pending = self.pending.split_off(&min);
@@ -494,8 +481,7 @@ impl<T: Translator, E: Context, K: Array, V: CodecShared> Inner<T, E, K, V> {
         self.oversized = self
             .oversized
             .sync_tracked(&self.requested, &active)
-            .await
-            .map_err(map_journal_error)?;
+            .await?;
         self.requested.clear();
         Ok(self)
     }
@@ -513,8 +499,7 @@ impl<T: Translator, E: Context, K: Array, V: CodecShared> Inner<T, E, K, V> {
         (self.oversized, handle) = self
             .oversized
             .start_sync_tracked(&self.requested, &active)
-            .await
-            .map_err(map_journal_error)?;
+            .await?;
         Ok((self, handle))
     }
 
@@ -550,8 +535,7 @@ impl<T: Translator, E: Context, K: Array, V: CodecShared> Inner<T, E, K, V> {
 
     /// See [crate::archive::Archive::destroy].
     async fn destroy(self) -> Result<(), Error> {
-        self.oversized.destroy().await.map_err(map_journal_error)?;
-        Ok(())
+        Ok(self.oversized.destroy().await?)
     }
 
     /// See [crate::archive::MultiArchive::get_all].
@@ -631,11 +615,8 @@ impl<T: Translator, E: Context, K: Array, V: CodecShared> std::fmt::Debug for Ar
 impl<T: Translator, E: Context, K: Array, V: CodecShared> Archive<T, E, K, V> {
     /// Initialize a new `Archive` instance.
     ///
-    /// The in-memory index is populated by replaying the index journal. Value frames not covered by
-    /// a durable validation marker are CRC-validated before this returns.
-    ///
-    /// Recovery relies on the runtime's startup durability guarantee. Before reopening the same
-    /// storage within a running process, synchronize the previous owner before dropping it.
+    /// Replays the index journal to rebuild the in-memory index, CRC-validating every value
+    /// above its section's durable marker.
     pub async fn init(context: E, cfg: Config<T, V::Cfg>) -> Result<Self, Error> {
         Ok(Self(Box::new(Inner::init(context, cfg).await?)))
     }

--- a/storage/src/archive/prunable/storage.rs
+++ b/storage/src/archive/prunable/storage.rs
@@ -17,6 +17,14 @@ use commonware_utils::Array;
 use std::collections::{BTreeMap, BTreeSet, btree_map};
 use tracing::debug;
 
+/// Preserve the archive's error classification for journal-owned metadata operations.
+fn map_journal_error(error: crate::journal::Error) -> Error {
+    match error {
+        crate::journal::Error::Metadata(error) => Error::Metadata(error),
+        error => Error::Journal(error),
+    }
+}
+
 /// Index entry for the archive.
 #[derive(Debug, Clone, PartialEq)]
 struct Record<K: Array> {
@@ -174,59 +182,63 @@ impl<T: Translator, E: Context, K: Array, V: CodecShared> Inner<T, E, K, V> {
 
     /// See [Archive::init].
     async fn init(context: E, cfg: Config<T, V::Cfg>) -> Result<Self, Error> {
-        // Initialize oversized journal
+        let Config {
+            translator,
+            metadata_partition,
+            key_partition,
+            key_page_cache,
+            value_partition,
+            compression,
+            codec_config,
+            items_per_section,
+            key_write_buffer,
+            value_write_buffer,
+            replay_buffer,
+        } = cfg;
+        let items_per_section = items_per_section.get();
         let oversized_cfg = OversizedConfig {
-            index_partition: cfg.key_partition,
-            value_partition: cfg.value_partition,
-            index_page_cache: cfg.key_page_cache,
-            index_write_buffer: cfg.key_write_buffer,
-            replay_buffer: cfg.replay_buffer,
-            value_write_buffer: cfg.value_write_buffer,
-            compression: cfg.compression,
-            codec_config: cfg.codec_config,
+            index_partition: key_partition,
+            value_partition,
+            index_page_cache: key_page_cache,
+            index_write_buffer: key_write_buffer,
+            value_write_buffer,
+            replay_buffer,
+            compression,
+            codec_config,
         };
-        // TODO (#4610): fuse this init's recovery drain with the replay below via tracked
-        // replay, restoring single-scan startup
-        let oversized: Oversized<E, Record<K>, V> =
-            Oversized::init(context.child("oversized"), oversized_cfg).await?;
+        let mut replay = Oversized::<E, Record<K>, V>::init_with_metadata(
+            &context,
+            oversized_cfg,
+            metadata_partition,
+            commonware_runtime::ReadOptions::default(),
+        )
+        .await
+        .map_err(map_journal_error)?;
 
-        // Initialize keys and replay index journal (no values read!)
+        // Rebuild every lookup view from the single retained prefix selected by oversized
+        // recovery.
         let mut indices: BTreeMap<u64, u64> = BTreeMap::new();
         let mut extra_indices: BTreeMap<u64, Vec<u64>> = BTreeMap::new();
-        let mut keys = Index::new(context.child("index"), cfg.translator.clone());
+        let mut keys = Index::new(context.child("index"), translator);
         let mut intervals = RMap::new();
-        let oversized = {
-            debug!("initializing archive from index journal");
-            let mut replay = oversized
-                .replay(
-                    0,
-                    0,
-                    cfg.replay_buffer,
-                    commonware_runtime::ReadOptions::default(),
-                )
-                .await?;
-            while let Some(result) = replay.next().await {
-                let (_section, position, entry) = result?;
+        debug!("initializing archive from index journal");
+        while let Some(result) = replay.next().await {
+            let (_, position, entry) = result?;
 
-                // Store index location (position in index journal)
-                match indices.entry(entry.index) {
-                    btree_map::Entry::Vacant(e) => {
-                        e.insert(position);
-                    }
-                    btree_map::Entry::Occupied(_) => {
-                        extra_indices.entry(entry.index).or_default().push(position);
-                    }
+            // Index every retained occurrence by position, translated key, and range.
+            match indices.entry(entry.index) {
+                btree_map::Entry::Vacant(e) => {
+                    e.insert(position);
                 }
-
-                // Store index in keys
-                keys.insert(&entry.key, entry.index);
-
-                // Store index in intervals
-                intervals.insert(entry.index);
+                btree_map::Entry::Occupied(_) => {
+                    extra_indices.entry(entry.index).or_default().push(position);
+                }
             }
-            debug!("archive initialized");
-            replay.finish()?
-        };
+            keys.insert(&entry.key, entry.index);
+            intervals.insert(entry.index);
+        }
+        let oversized = replay.finish_tracked().await.map_err(map_journal_error)?;
+        debug!("archive initialized");
 
         // Initialize metrics
         let items_tracked = context.gauge("items_tracked", "Number of items tracked");
@@ -242,7 +254,7 @@ impl<T: Translator, E: Context, K: Array, V: CodecShared> Inner<T, E, K, V> {
 
         // Return populated archive
         Ok(Self {
-            items_per_section: cfg.items_per_section.get(),
+            items_per_section,
             oversized,
             pending: BTreeSet::new(),
             requested: BTreeSet::new(),
@@ -363,24 +375,28 @@ impl<T: Translator, E: Context, K: Array, V: CodecShared> Inner<T, E, K, V> {
         key: K,
         data: V,
         skip_if_index_exists: bool,
-    ) -> Result<(Box<Self>, bool), Error> {
+    ) -> Result<Box<Self>, Error> {
         // A put below the prune floor is satisfied without storing
         let oldest_allowed = self.oldest_allowed.unwrap_or(0);
         if index < oldest_allowed {
             debug!(index, oldest_allowed, "ignoring put below prune floor");
-            return Ok((self, false));
+            return Ok(self);
         }
 
         // Check for existing index when enforcing single-item semantics.
         if skip_if_index_exists && self.indices.contains_key(&index) {
-            return Ok((self, true));
+            return Ok(self);
         }
 
         // Write value and index entry atomically (glob first, then index)
         let section = self.section(index);
         let entry = Record::new(index, key.clone(), 0, 0);
         let position;
-        (self.oversized, position, _, _) = self.oversized.append(section, entry, &data).await?;
+        (self.oversized, position, _, _) = self
+            .oversized
+            .append(section, entry, &data)
+            .await
+            .map_err(map_journal_error)?;
 
         // Store index location
         match self.indices.entry(index) {
@@ -399,12 +415,12 @@ impl<T: Translator, E: Context, K: Array, V: CodecShared> Inner<T, E, K, V> {
         self.keys
             .insert_and_retain(&key, index, |v| *v >= oldest_allowed);
 
-        // Add section to pending
+        // Include this section in the next sync request.
         self.pending.insert(section);
 
         // Update metrics
         let _ = self.items_tracked.try_set(self.indices.len());
-        Ok((self, true))
+        Ok(self)
     }
 
     /// See [Archive::prune].
@@ -422,10 +438,10 @@ impl<T: Translator, E: Context, K: Array, V: CodecShared> Inner<T, E, K, V> {
         }
         debug!(min, "pruning archive");
 
-        // Prune oversized journal (handles both index and values)
-        (self.oversized, _) = self.oversized.prune(min).await?;
+        // Prune the section's index, values, and recovery markers together.
+        (self.oversized, _) = self.oversized.prune(min).await.map_err(map_journal_error)?;
 
-        // Remove pending and requested sync work (no need to call `sync` as we are pruning)
+        // Discard synchronization state owned by pruned sections.
         self.pending = self.pending.split_off(&min);
         self.requested = self.requested.split_off(&min);
 
@@ -440,7 +456,7 @@ impl<T: Translator, E: Context, K: Array, V: CodecShared> Inner<T, E, K, V> {
             self.indices_pruned.inc();
         }
 
-        // Remove all keys from interval tree less than min
+        // Remove pruned indices from the retained range view.
         if min > 0 {
             self.intervals.remove(0, min - 1);
         }
@@ -470,14 +486,16 @@ impl<T: Translator, E: Context, K: Array, V: CodecShared> Inner<T, E, K, V> {
 
     /// See [crate::archive::Archive::sync].
     async fn sync(mut self: Box<Self>) -> Result<Box<Self>, Error> {
-        // Update metrics (`requested` sections were already counted by `start_sync`)
+        // Include each section once in the sync metric and retain prior pipelined requests until
+        // this blocking call observes their completion.
         self.syncs.inc_by(self.pending.len() as u64);
+        let active = self.pending.clone();
         self.requested.append(&mut self.pending);
-
-        // Sync oversized journal (handles both index and values). Re-syncing `requested` sections
-        // also waits for any of their syncs still in flight.
-        self.oversized = self.oversized.sync(&self.requested).await?;
-
+        self.oversized = self
+            .oversized
+            .sync_tracked(&self.requested, &active)
+            .await
+            .map_err(map_journal_error)?;
         self.requested.clear();
         Ok(self)
     }
@@ -487,12 +505,16 @@ impl<T: Translator, E: Context, K: Array, V: CodecShared> Inner<T, E, K, V> {
         // Update metrics
         self.syncs.inc_by(self.pending.len() as u64);
 
-        // Move sections into `requested` rather than dropping them: section buffers reuse
-        // in-flight syncs, so re-requesting a section makes this handle observe outstanding work
-        // without issuing a new sync.
+        // Retain requested sections until a blocking sync observes their outstanding work.
+        let active = self.pending.clone();
         self.requested.append(&mut self.pending);
+
         let handle;
-        (self.oversized, handle) = self.oversized.start_sync(&self.requested).await?;
+        (self.oversized, handle) = self
+            .oversized
+            .start_sync_tracked(&self.requested, &active)
+            .await
+            .map_err(map_journal_error)?;
         Ok((self, handle))
     }
 
@@ -528,7 +550,8 @@ impl<T: Translator, E: Context, K: Array, V: CodecShared> Inner<T, E, K, V> {
 
     /// See [crate::archive::Archive::destroy].
     async fn destroy(self) -> Result<(), Error> {
-        Ok(self.oversized.destroy().await?)
+        self.oversized.destroy().await.map_err(map_journal_error)?;
+        Ok(())
     }
 
     /// See [crate::archive::MultiArchive::get_all].
@@ -608,8 +631,11 @@ impl<T: Translator, E: Context, K: Array, V: CodecShared> std::fmt::Debug for Ar
 impl<T: Translator, E: Context, K: Array, V: CodecShared> Archive<T, E, K, V> {
     /// Initialize a new `Archive` instance.
     ///
-    /// The in-memory index for `Archive` is populated during this call
-    /// by replaying only the index journal (no values are read).
+    /// The in-memory index is populated by replaying the index journal. Value frames not covered by
+    /// a durable validation marker are CRC-validated before this returns.
+    ///
+    /// Recovery relies on the runtime's startup durability guarantee. Before reopening the same
+    /// storage within a running process, synchronize the previous owner before dropping it.
     pub async fn init(context: E, cfg: Config<T, V::Cfg>) -> Result<Self, Error> {
         Ok(Self(Box::new(Inner::init(context, cfg).await?)))
     }
@@ -632,33 +658,8 @@ impl<T: Translator, E: Context, K: Array, V: CodecShared> crate::archive::Archiv
     type Value = V;
 
     async fn put(mut self, index: u64, key: K, data: V) -> Result<Self, Error> {
-        (self.0, _) = self.0.put_internal(index, key, data, true).await?;
+        self.0 = self.0.put_internal(index, key, data, true).await?;
         Ok(self)
-    }
-
-    async fn put_sync(mut self, index: u64, key: K, data: V) -> Result<Self, Error> {
-        // A put satisfied below the prune floor stored nothing, so skip the sync.
-        let stored;
-        (self.0, stored) = self.0.put_internal(index, key, data, true).await?;
-        if !stored {
-            return Ok(self);
-        }
-        self.sync().await
-    }
-
-    async fn put_start_sync(
-        mut self,
-        index: u64,
-        key: K,
-        data: V,
-    ) -> Result<(Self, Handle<()>), Error> {
-        // A put satisfied below the prune floor stored nothing, so skip the sync.
-        let stored;
-        (self.0, stored) = self.0.put_internal(index, key, data, true).await?;
-        if !stored {
-            return Ok((self, Handle::ready(Ok(()))));
-        }
-        self.start_sync().await
     }
 
     async fn get(&self, identifier: Identifier<'_, K>) -> Result<Option<V>, Error> {
@@ -717,33 +718,8 @@ impl<T: Translator, E: Context, K: Array, V: CodecShared> crate::archive::MultiA
     }
 
     async fn put_multi(mut self, index: u64, key: K, data: V) -> Result<Self, Error> {
-        (self.0, _) = self.0.put_internal(index, key, data, false).await?;
+        self.0 = self.0.put_internal(index, key, data, false).await?;
         Ok(self)
-    }
-
-    async fn put_multi_sync(mut self, index: u64, key: K, data: V) -> Result<Self, Error> {
-        // A put satisfied below the prune floor stored nothing, so skip the sync.
-        let stored;
-        (self.0, stored) = self.0.put_internal(index, key, data, false).await?;
-        if !stored {
-            return Ok(self);
-        }
-        crate::archive::Archive::sync(self).await
-    }
-
-    async fn put_multi_start_sync(
-        mut self,
-        index: u64,
-        key: K,
-        data: V,
-    ) -> Result<(Self, Handle<()>), Error> {
-        // A put satisfied below the prune floor stored nothing, so skip the sync.
-        let stored;
-        (self.0, stored) = self.0.put_internal(index, key, data, false).await?;
-        if !stored {
-            return Ok((self, Handle::ready(Ok(()))));
-        }
-        crate::archive::Archive::start_sync(self).await
     }
 
     async fn has_at(&self, index: u64, key: &K) -> Result<bool, Error> {

--- a/storage/src/archive/prunable/storage.rs
+++ b/storage/src/archive/prunable/storage.rs
@@ -174,34 +174,21 @@ impl<T: Translator, E: Context, K: Array, V: CodecShared> Inner<T, E, K, V> {
 
     /// See [Archive::init].
     async fn init(context: E, cfg: Config<T, V::Cfg>) -> Result<Self, Error> {
-        let Config {
-            translator,
-            metadata_partition,
-            key_partition,
-            key_page_cache,
-            value_partition,
-            compression,
-            codec_config,
-            items_per_section,
-            key_write_buffer,
-            value_write_buffer,
-            replay_buffer,
-        } = cfg;
-        let items_per_section = items_per_section.get();
+        let items_per_section = cfg.items_per_section.get();
         let oversized_cfg = OversizedConfig {
-            index_partition: key_partition,
-            value_partition,
-            index_page_cache: key_page_cache,
-            index_write_buffer: key_write_buffer,
-            value_write_buffer,
-            replay_buffer,
-            compression,
-            codec_config,
+            index_partition: cfg.key_partition,
+            value_partition: cfg.value_partition,
+            index_page_cache: cfg.key_page_cache,
+            index_write_buffer: cfg.key_write_buffer,
+            value_write_buffer: cfg.value_write_buffer,
+            replay_buffer: cfg.replay_buffer,
+            compression: cfg.compression,
+            codec_config: cfg.codec_config,
         };
         let mut replay = Oversized::<E, Record<K>, V>::init_with_metadata(
             &context,
             oversized_cfg,
-            metadata_partition,
+            cfg.metadata_partition,
             commonware_runtime::ReadOptions::default(),
         )
         .await?;
@@ -210,7 +197,7 @@ impl<T: Translator, E: Context, K: Array, V: CodecShared> Inner<T, E, K, V> {
         // recovery.
         let mut indices: BTreeMap<u64, u64> = BTreeMap::new();
         let mut extra_indices: BTreeMap<u64, Vec<u64>> = BTreeMap::new();
-        let mut keys = Index::new(context.child("index"), translator);
+        let mut keys = Index::new(context.child("index"), cfg.translator);
         let mut intervals = RMap::new();
         debug!("initializing archive from index journal");
         while let Some(result) = replay.next().await {

--- a/storage/src/cache/mod.rs
+++ b/storage/src/cache/mod.rs
@@ -129,7 +129,8 @@ mod tests {
     use crate::journal::Error as JournalError;
     use commonware_macros::{test_group, test_traced};
     use commonware_runtime::{
-        Metrics as _, Runner, Supervisor as _, deterministic, telemetry::metrics::has_metric_value,
+        Metrics as _, Runner, Supervisor as _, deterministic, mocks::RecordingContext,
+        telemetry::metrics::has_metric_value,
     };
     use commonware_utils::{NZU16, NZU64, NZUsize};
     use rand::RngExt as _;
@@ -365,6 +366,43 @@ mod tests {
 
             context.auditor().state()
         })
+    }
+
+    #[test_traced]
+    fn test_cache_clean_restart_reads_journal_once() {
+        deterministic::Runner::default().start(|context| async move {
+            let (context, recordings) = RecordingContext::new(context);
+            let config = |context: &RecordingContext<_>| Config {
+                partition: "clean-restart-single-pass".into(),
+                codec_config: (),
+                compression: None,
+                write_buffer: NZUsize!(256),
+                replay_buffer: NZUsize!(1024),
+                items_per_blob: NZU64!(64),
+                page_cache: CacheRef::from_pooler(context, NZU16!(64), NZUsize!(10)),
+            };
+
+            let mut cache = Cache::<_, u64>::init(context.child("seed"), config(&context))
+                .await
+                .expect("failed to initialize cache");
+            for index in 0..15 {
+                cache = cache.put(index, index).await.expect("failed to put");
+            }
+            cache = cache.sync().await.expect("failed to sync");
+            drop(cache);
+
+            recordings.clear();
+            let cache = Cache::<_, u64>::init(context.child("reopen"), config(&context))
+                .await
+                .expect("failed to reopen cache");
+            for index in 0..15 {
+                assert!(cache.has(index));
+            }
+
+            // The 150 logical bytes occupy three pages. Writer construction reads the tail page,
+            // then one replay prefetch validates and decodes all three pages.
+            assert_eq!(recordings.snapshot().reads.len(), 2);
+        });
     }
 
     #[test_group("slow")]

--- a/storage/src/journal/segmented/glob.rs
+++ b/storage/src/journal/segmented/glob.rs
@@ -30,9 +30,14 @@ use super::manager::{Config as ManagerConfig, Manager, WriteFactory};
 use crate::{Context, journal::Error};
 use commonware_codec::{Codec, CodecShared, FixedSize};
 use commonware_cryptography::{Crc32, crc32};
+#[cfg(any(test, feature = "test-utils"))]
+use commonware_runtime::{Blob as _, ReadOptions, Storage, WriteOptions};
 use commonware_runtime::{BufMut, Error as RError, Handle};
 use std::{io::Cursor, num::NonZeroUsize};
 use zstd::{bulk::compress, decode_all};
+
+/// Physical overhead appended to every frame: the CRC32 of the frame's data.
+pub(crate) const CHECKSUM_SIZE: usize = crc32::Digest::SIZE;
 
 /// Configuration for blob storage.
 #[derive(Clone)]
@@ -93,7 +98,7 @@ impl<E: Context, V: CodecShared> Inner<E, V> {
             compressed
         } else {
             // Uncompressed: pre-allocate exact size to avoid copying
-            let entry_size = value.encode_size() + crc32::Digest::SIZE;
+            let entry_size = value.encode_size() + CHECKSUM_SIZE;
             let mut buf = Vec::with_capacity(entry_size);
             value.write(&mut buf);
             let checksum = Crc32::checksum(&buf);
@@ -121,11 +126,11 @@ impl<E: Context, V: CodecShared> Inner<E, V> {
         let buf = writer.read_at(offset, size as usize).await?.coalesce();
 
         // Entry format: [compressed_data] [crc32 (4 bytes)]
-        if buf.len() < crc32::Digest::SIZE {
+        if buf.len() < CHECKSUM_SIZE {
             return Err(Error::Runtime(RError::BlobInsufficientLength));
         }
 
-        let data_len = buf.len() - crc32::Digest::SIZE;
+        let data_len = buf.len() - CHECKSUM_SIZE;
         let compressed_data = &buf.as_ref()[..data_len];
         let stored_checksum = u32::from_be_bytes(
             buf.as_ref()[data_len..]
@@ -154,7 +159,7 @@ impl<E: Context, V: CodecShared> Inner<E, V> {
     /// See [Glob::verify].
     async fn verify(&self, section: u64, offset: u64, size: u32) -> Result<bool, Error> {
         // A frame is at least its checksum trailer.
-        if (size as usize) < crc32::Digest::SIZE {
+        if (size as usize) < CHECKSUM_SIZE {
             return Ok(false);
         }
         let Some(writer) = self.manager.get(section)? else {
@@ -166,7 +171,7 @@ impl<E: Context, V: CodecShared> Inner<E, V> {
             Err(RError::BlobInsufficientLength | RError::OffsetOverflow) => return Ok(false),
             Err(err) => return Err(Error::Runtime(err)),
         };
-        let data_len = buf.len() - crc32::Digest::SIZE;
+        let data_len = buf.len() - CHECKSUM_SIZE;
         let stored_checksum = u32::from_be_bytes(
             buf.as_ref()[data_len..]
                 .try_into()
@@ -397,6 +402,31 @@ impl<E: Context, V: CodecShared> Glob<E, V> {
     pub async fn destroy(self) -> Result<(), Error> {
         self.0.destroy().await
     }
+}
+
+/// Flip one byte inside value frame `frame` of the blob at `name`, breaking that frame's CRC
+/// while leaving every other frame valid. Models a value torn by a crash after its index entry
+/// became durable. Addresses uncompressed fixed-size frames: `frame_size` is the encoded value
+/// size plus its CRC32.
+#[cfg(any(test, feature = "test-utils"))]
+pub async fn corrupt_frame(
+    storage: &impl Storage,
+    partition: &str,
+    name: &[u8],
+    frame: u64,
+    frame_size: u64,
+) {
+    let offset = frame * frame_size;
+    let (blob, size) = storage.open(partition, name).await.unwrap();
+    assert!(offset < size, "corruption target must be inside the blob");
+    let byte = blob
+        .read_at(offset, 1, ReadOptions::default())
+        .await
+        .unwrap()
+        .coalesce();
+    blob.write_at(offset, vec![byte.as_ref()[0] ^ 0xFF], WriteOptions::SYNC)
+        .await
+        .unwrap();
 }
 
 #[cfg(test)]

--- a/storage/src/journal/segmented/oversized.rs
+++ b/storage/src/journal/segmented/oversized.rs
@@ -125,12 +125,7 @@ pub struct Config<C> {
 /// `Floors` preserves per-section validated prefixes while repairing any suffix, and `Infer`
 /// derives the boundary entirely from journal contents.
 enum Recovery<'a> {
-    Restore {
-        section: u64,
-        index_size: u64,
-    },
-    // TODO (#4610): migrate the prunable archive to tracked replay
-    #[allow(dead_code)]
+    Restore { section: u64, index_size: u64 },
     Floors(&'a BTreeMap<u64, u64>),
     Infer,
 }
@@ -218,8 +213,6 @@ struct Validation {
 }
 
 impl Validation {
-    // TODO (#4610): migrate the prunable archive to tracked replay
-    #[allow(dead_code)]
     const fn new() -> Self {
         Self {
             current_section: None,
@@ -300,8 +293,6 @@ impl<E: Context, I: Record + Send + Sync, V: CodecShared> Oversized<E, I, V> {
     /// The caller must drain the replay and call [Replay::finish_tracked]. Entries below each
     /// durable marker are retained after their cross-journal boundary is proven. Entries above it
     /// are value-validated in order and the first invalid entry truncates its section.
-    // TODO (#4610): migrate the prunable archive to tracked replay
-    #[allow(dead_code)]
     pub(crate) async fn init_with_metadata(
         context: &E,
         cfg: Config<V::Cfg>,
@@ -1183,8 +1174,6 @@ impl<E: Context, I: Record + Send + Sync, V: CodecShared> Replay<E, I, V> {
     }
 
     /// Finish marker-aware startup recovery and return the tracked journal.
-    // TODO (#4610): migrate the prunable archive to tracked replay
-    #[allow(dead_code)]
     pub(crate) async fn finish_tracked(self) -> Result<Oversized<E, I, V>, Error> {
         let Some(validation) = self.validation else {
             return Err(Error::ReplayFailed);

--- a/storage/src/metadata/mod.rs
+++ b/storage/src/metadata/mod.rs
@@ -74,6 +74,8 @@ use thiserror::Error;
 pub enum Error {
     #[error("runtime error: {0}")]
     Runtime(#[from] commonware_runtime::Error),
+    #[error("corruption: {0}")]
+    Corruption(String),
 }
 
 /// Configuration for [Metadata] storage.
@@ -776,6 +778,50 @@ mod tests {
     }
 
     #[test_traced]
+    fn test_recovered_mirror_supports_shrinking_rewrite() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "test".into(),
+                codec_config: ((0..).into(), ()),
+            };
+            let mut metadata =
+                Metadata::<_, U64, Vec<u8>>::init(context.child("first"), cfg.clone())
+                    .await
+                    .unwrap();
+            let key = U64::new(42);
+            let hello = b"hello".to_vec();
+            metadata.put(key.clone(), hello.clone());
+            metadata = metadata.sync().await.unwrap();
+            metadata.put(key.clone(), b"world".to_vec());
+            metadata.put(U64::new(43), b"foo".to_vec());
+            metadata.sync().await.unwrap();
+
+            // Corrupt the newer copy so the next initialization must repair it.
+            let (blob, _) = context.open("test", b"left").await.unwrap();
+            blob.write_at(0, b"corrupted".to_vec(), WriteOptions::SYNC)
+                .await
+                .unwrap();
+
+            // The repaired copy must support a shrinking rewrite: a stale tail left behind by
+            // recovery would survive the smaller write and poison the next reopen.
+            let mut metadata =
+                Metadata::<_, U64, Vec<u8>>::init(context.child("second"), cfg.clone())
+                    .await
+                    .unwrap();
+            assert_eq!(metadata.get(&key).unwrap(), &hello);
+            metadata.clear();
+            metadata.sync().await.unwrap();
+
+            let metadata = Metadata::<_, U64, Vec<u8>>::init(context.child("third"), cfg)
+                .await
+                .unwrap();
+            assert!(metadata.get(&key).is_none());
+            metadata.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced]
     fn test_recover_corrupted_both() {
         // Initialize the deterministic context
         let executor = deterministic::Runner::default();
@@ -817,26 +863,16 @@ mod tests {
                 .await
                 .unwrap();
 
-            // Reopen the metadata store
-            let cfg = Config {
-                partition: "test".into(),
-                codec_config: ((0..).into(), ()),
-            };
-            let metadata = Metadata::<_, U64, Vec<u8>>::init(context.child("second"), cfg)
-                .await
-                .unwrap();
-
-            // Get the key (falls back to non-corrupt)
-            let value = metadata.get(&key);
-            assert!(value.is_none());
-
-            // Check metrics
-            let buffer = context.encode();
-            assert!(buffer.contains("second_sync_rewrites_total 0"));
-            assert!(buffer.contains("second_sync_overwrites_total 0"));
-            assert!(buffer.contains("second_keys 0"));
-
-            metadata.destroy().await.unwrap();
+            // Both copies failing validation is impossible under a crash (syncs alternate and
+            // drain), so reopening must fail loudly rather than adopt a fresh store.
+            for child in ["second", "third"] {
+                let cfg = Config {
+                    partition: "test".into(),
+                    codec_config: ((0..).into(), ()),
+                };
+                let result = Metadata::<_, U64, Vec<u8>>::init(context.child(child), cfg).await;
+                assert!(matches!(result, Err(Error::Corruption(_))));
+            }
         });
     }
 

--- a/storage/src/metadata/storage.rs
+++ b/storage/src/metadata/storage.rs
@@ -86,6 +86,14 @@ struct Inner<E: Context, K: Span, V: Codec> {
     keys: Gauge,
 }
 
+/// One copy of the store, as loaded at startup.
+enum Loaded<B: Blob, K: Span, V> {
+    /// The copy decoded cleanly (an empty blob decodes to an empty map).
+    Valid(BTreeMap<K, V>, Wrapper<B, K>),
+    /// The copy holds bytes that fail validation.
+    Invalid(B),
+}
+
 impl<E: Context, K: Span, V: Codec> Inner<E, K, V> {
     /// See [Metadata::init].
     async fn init(context: E, cfg: Config<V::Cfg>) -> Result<Self, Error> {
@@ -93,11 +101,18 @@ impl<E: Context, K: Span, V: Codec> Inner<E, K, V> {
         let (left_blob, left_len) = context.open(&cfg.partition, BLOB_NAMES[0]).await?;
         let (right_blob, right_len) = context.open(&cfg.partition, BLOB_NAMES[1]).await?;
 
-        // Find latest blob (check which includes a hash of the other)
-        let (left_map, left_wrapper) =
-            Self::load(&context, &cfg.codec_config, 0, left_blob, left_len).await?;
-        let (right_map, right_wrapper) =
-            Self::load(&context, &cfg.codec_config, 1, right_blob, right_len).await?;
+        // Find latest blob (check which includes a hash of the other). Syncs alternate copies
+        // and drain the previous sync first, so at most one copy is ever mid-write: both copies
+        // failing validation is corruption, and adopting a fresh store would mask it.
+        let left = Self::load(&context, &cfg.codec_config, 0, left_blob, left_len).await?;
+        let right = Self::load(&context, &cfg.codec_config, 1, right_blob, right_len).await?;
+        if matches!((&left, &right), (Loaded::Invalid(_), Loaded::Invalid(_))) {
+            return Err(Error::Corruption(
+                "both metadata copies failed validation".into(),
+            ));
+        }
+        let (left_map, left_wrapper) = Self::normalize(left).await?;
+        let (right_map, right_wrapper) = Self::normalize(right).await?;
 
         // Choose latest blob
         let mut map = left_map;
@@ -146,11 +161,11 @@ impl<E: Context, K: Span, V: Codec> Inner<E, K, V> {
         index: usize,
         blob: E::Blob,
         len: u64,
-    ) -> Result<(BTreeMap<K, V>, Wrapper<E::Blob, K>), Error> {
+    ) -> Result<Loaded<E::Blob, K, V>, Error> {
         // Get blob length
         if len == 0 {
             // Empty blob
-            return Ok((BTreeMap::new(), Wrapper::empty(blob)));
+            return Ok(Loaded::Valid(BTreeMap::new(), Wrapper::empty(blob)));
         }
 
         // The full encoded blob remains in the in-memory mirror after decoding, so request that
@@ -165,15 +180,8 @@ impl<E: Context, K: Span, V: Codec> Inner<E, K, V> {
         //
         // 8 bytes for version + 4 bytes for checksum.
         if buf.len() < 8 + crc32::Digest::SIZE {
-            // Truncate and return none
-            warn!(
-                blob = index,
-                len = buf.len(),
-                "blob is too short: truncating"
-            );
-            blob.resize(0).await?;
-            blob.sync().await?;
-            return Ok((BTreeMap::new(), Wrapper::empty(blob)));
+            warn!(blob = index, len = buf.len(), "blob is too short");
+            return Ok(Loaded::Invalid(blob));
         }
 
         // Extract checksum
@@ -182,16 +190,13 @@ impl<E: Context, K: Span, V: Codec> Inner<E, K, V> {
             u32::from_be_bytes(buf.as_ref()[checksum_index..].try_into().unwrap());
         let computed_checksum = Crc32::checksum(&buf.as_ref()[..checksum_index]);
         if stored_checksum != computed_checksum {
-            // Truncate and return none
             warn!(
                 blob = index,
                 stored = stored_checksum,
                 computed = computed_checksum,
-                "checksum mismatch: truncating"
+                "checksum mismatch"
             );
-            blob.resize(0).await?;
-            blob.sync().await?;
-            return Ok((BTreeMap::new(), Wrapper::empty(blob)));
+            return Ok(Loaded::Invalid(blob));
         }
 
         // Get parent
@@ -219,7 +224,24 @@ impl<E: Context, K: Span, V: Codec> Inner<E, K, V> {
         }
 
         // Return info
-        Ok((data, Wrapper::new(blob, version, lengths, buf)))
+        Ok(Loaded::Valid(
+            data,
+            Wrapper::new(blob, version, lengths, buf),
+        ))
+    }
+
+    /// Adopt a valid copy, or durably reset the one copy a crash left mid-write.
+    async fn normalize(
+        copy: Loaded<E::Blob, K, V>,
+    ) -> Result<(BTreeMap<K, V>, Wrapper<E::Blob, K>), Error> {
+        match copy {
+            Loaded::Valid(map, wrapper) => Ok((map, wrapper)),
+            Loaded::Invalid(blob) => {
+                blob.resize(0).await?;
+                blob.sync().await?;
+                Ok((BTreeMap::new(), Wrapper::empty(blob)))
+            }
+        }
     }
 
     /// See [Metadata::get].

--- a/storage/src/ordinal/mod.rs
+++ b/storage/src/ordinal/mod.rs
@@ -54,11 +54,13 @@
 //! # Recovery
 //!
 //! To recover existing data, pass `Some(bits)` to [Ordinal::init]. The bits identify which records
-//! were durably committed by the caller. [Ordinal] validates required records using their CRC32 and
-//! rebuilds the in-memory [crate::rmap::RMap]. Stored sections omitted from `bits` are removed, and
-//! stored records whose bits are unset are cleared before replay. Missing or invalid required records
-//! fail initialization. Passing `Some(BTreeMap::new())` or `None` removes all stored sections and
-//! starts empty.
+//! were durably committed by the caller and rebuild the in-memory [crate::rmap::RMap] without
+//! re-reading the records they mark (a damaged marked record surfaces at [Ordinal::get]). Records in
+//! sections listed with no bitmap are instead validated using their CRC32. Stored sections omitted
+//! from `bits` are removed, and stored records whose bits are unset are cleared before replay.
+//! Records missing from stored sections, and CRC-invalid records in sections listed with no
+//! bitmap, fail initialization. Passing `Some(BTreeMap::new())` or `None` removes all stored
+//! sections and starts empty.
 //!
 //! # Example
 //!
@@ -1834,20 +1836,24 @@ mod tests {
                 );
             }
 
-            // Unselected records in a retained section are physically cleared.
+            // Unselected records in a retained section are physically cleared. A later
+            // bitmap claiming a cleared record is trusted at init (the bitmap proves
+            // membership), so the damage surfaces at get.
             {
                 let mut bitmap = BitMap::zeroes(10);
                 bitmap.set(0, true); // Index 10
                 let bitmap_option = Some(bitmap);
                 let mut bits_map: BTreeMap<u64, &Option<BitMap>> = BTreeMap::new();
                 bits_map.insert(1, &bitmap_option);
-                let result = Ordinal::<_, FixedBytes<32>>::init(
+                let store = Ordinal::<_, FixedBytes<32>>::init(
                     context.child("third"),
                     cfg.clone(),
                     Some(bits_map),
                 )
-                .await;
-                assert!(matches!(result, Err(Error::MissingRecord(10))));
+                .await
+                .expect("Failed to initialize store with bits");
+                assert!(store.has(10));
+                assert!(matches!(store.get(10).await, Err(Error::InvalidRecord(10))));
             }
         });
     }
@@ -2041,8 +2047,7 @@ mod tests {
     }
 
     #[test_traced]
-    #[should_panic(expected = "Failed to initialize store with bits: MissingRecord(2)")]
-    fn test_init_corrupted_records() {
+    fn test_marked_record_damage_surfaces_at_get() {
         // Initialize the deterministic context
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
@@ -2085,21 +2090,32 @@ mod tests {
             {
                 let mut bits_map: BTreeMap<u64, &Option<BitMap>> = BTreeMap::new();
 
-                // Create a BitMap that includes the corrupted record
+                // Create a BitMap that includes the corrupted record. The bitmap proves
+                // membership, so the record is not re-read at startup and the damage
+                // surfaces at get.
                 let mut bitmap = BitMap::zeroes(5);
                 bitmap.set(0, true); // Index 0
-                bitmap.set(2, true); // Index 2 (corrupted) - this will cause a panic
+                bitmap.set(2, true); // Index 2 (corrupted)
                 bitmap.set(4, true); // Index 4
                 let bitmap_option = Some(bitmap);
                 bits_map.insert(0, &bitmap_option);
 
-                let _store = Ordinal::<_, FixedBytes<32>>::init(
+                let store = Ordinal::<_, FixedBytes<32>>::init(
                     context.child("second"),
                     cfg.clone(),
                     Some(bits_map),
                 )
                 .await
                 .expect("Failed to initialize store with bits");
+                assert_eq!(
+                    store.get(0).await.unwrap(),
+                    Some(FixedBytes::new([0u8; 32]))
+                );
+                assert!(store.get(2).await.is_err());
+                assert_eq!(
+                    store.get(4).await.unwrap(),
+                    Some(FixedBytes::new([4u8; 32]))
+                );
             }
         });
     }

--- a/storage/src/ordinal/storage.rs
+++ b/storage/src/ordinal/storage.rs
@@ -219,8 +219,13 @@ impl<E: Context, V: CodecFixed<Cfg = ()>> Inner<E, V> {
                 // to the records it marks
                 let mut set_indices = bits.as_ref().map(|bits| bits.ones_iter());
                 let mut all_indices = 0..items_per_blob;
-                let mut replay_blob =
-                    ReadBuffer::from_pooler(&context, blob.clone(), *size, config.replay_buffer);
+
+                // A committed bitmap already proves membership, so marked records are not
+                // re-read and damage surfaces at get. Membership of an unmarked section
+                // comes from record validity, so its records must be read.
+                let mut replay_blob = bits.is_none().then(|| {
+                    ReadBuffer::from_pooler(&context, blob.clone(), *size, config.replay_buffer)
+                });
                 while let Some(bit_index) = set_indices
                     .as_mut()
                     .map_or_else(|| all_indices.next(), |indices| indices.next())
@@ -235,10 +240,12 @@ impl<E: Context, V: CodecFixed<Cfg = ()>> Inner<E, V> {
                     }
 
                     // A committed record that is missing or invalid cannot be recovered
-                    replay_blob.seek_to(offset)?;
-                    let record_buf = replay_blob.read(Record::<V>::SIZE).await?.coalesce();
-                    if Record::<V>::decode_valid(record_buf.as_ref()).is_none() {
-                        return Err(Error::MissingRecord(index));
+                    if let Some(replay_blob) = replay_blob.as_mut() {
+                        replay_blob.seek_to(offset)?;
+                        let record_buf = replay_blob.read(Record::<V>::SIZE).await?.coalesce();
+                        if Record::<V>::decode_valid(record_buf.as_ref()).is_none() {
+                            return Err(Error::MissingRecord(index));
+                        }
                     }
                     items += 1;
                     intervals.insert(index);


### PR DESCRIPTION
The archive and store consumers of the reworked journals: prunable archive init routes through the oversized journal's tracked recovery with per-section validation floors (new `metadata_partition` config), proven boundaries of closed sections publish on `sync`/`start_sync` while the active section's marker deliberately trails its data, and markers are removed durably before section names can be reused (also removes the prunable `put_sync`/`put_start_sync` overrides that returned ready handles while earlier accepted writes were still unsynced). Metadata turns both-copies-invalid into a loud `Corruption` instead of silently adopting a fresh store. Ordinal trusts bitmap-marked records at init and surfaces damage at `get`. Downstream `metadata_partition` plumbing lands in marshal, glue, examples, and the conformance fixtures. Removes the staging `#[allow(dead_code)]` markers from the PR below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
