### PR TITLE
[runtime, storage] Harden recovery fuzz oracles from the final review pass

### DIFF
--- a/runtime/src/utils/buffer/paged/writer.rs
+++ b/runtime/src/utils/buffer/paged/writer.rs
@@ -132,6 +132,11 @@ impl<B: Blob> Writer<B> {
     /// Wrap `blob` in a [Writer]. `blob` must already hold `original_blob_size` physical bytes;
     /// reads are cached through `cache_ref` and appends stage in a write buffer of capacity
     /// `capacity`. Rewinds the blob if necessary so it only contains checksum-validated data.
+    ///
+    /// The blob's tail-page contents must be durable (freshly opened after a crash, or synced
+    /// since the last partial-page rewrite): the discovered checksum slot seeds the writer's
+    /// durable-slot tracking, so wrapping a blob whose tail rewrite is still volatile would
+    /// let a later unsynced flush overwrite the only durable slot.
     pub async fn new(
         blob: B,
         original_blob_size: u64,

--- a/storage/fuzz/fuzz_targets/current_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/current_crash_recovery.rs
@@ -7,7 +7,7 @@
 //! storage faults, crashes again, then recovers cleanly and verifies the DB is usable.
 
 use arbitrary::Arbitrary;
-use commonware_cryptography::Sha256;
+use commonware_cryptography::{Sha256, sha256::Digest};
 use commonware_parallel::Sequential;
 use commonware_runtime::{
     Runner, Supervisor as _,
@@ -137,8 +137,16 @@ fn apply_pending(pending: &mut HashMap<RawKey, Option<RawValue>>, committed: &mu
     }
 }
 
-/// Return the complete snapshots recovery may expose after an errored batch.
-fn failure_states(pending: &HashMap<RawKey, Option<RawValue>>, committed: &State) -> Vec<State> {
+/// Return the complete (state, root) snapshots recovery may expose after an errored batch.
+///
+/// An applied batch can be KV-identical to the committed state while still appending
+/// operations (and changing the root), so entries collapse only when the roots also match.
+fn failure_states(
+    pending: &HashMap<RawKey, Option<RawValue>>,
+    committed: &State,
+    committed_root: Digest,
+    post_root: Digest,
+) -> Vec<(State, Digest)> {
     let mut post = committed.clone();
     for (key, value) in pending {
         match value {
@@ -151,37 +159,59 @@ fn failure_states(pending: &HashMap<RawKey, Option<RawValue>>, committed: &State
         }
     }
 
-    if post == *committed {
-        vec![committed.clone()]
+    if post == *committed && post_root == committed_root {
+        vec![(committed.clone(), committed_root)]
     } else {
-        vec![committed.clone(), post]
+        vec![(committed.clone(), committed_root), (post, post_root)]
     }
 }
 
-/// Commit pending writes, returning the complete snapshots allowed after failure.
+/// Commit pending writes, returning the (state, root) snapshots allowed after failure.
+///
+/// On success, `committed_root` advances to the applied batch's canonical root, which
+/// equals the db's root after `apply_batch` (commit changes durability, not the root).
 async fn commit_pending<F: Graftable>(
     db: Db<F>,
     pending_writes: &mut Vec<(Key, Option<Value>)>,
     pending: &mut HashMap<RawKey, Option<RawValue>>,
     committed: &mut State,
-) -> Result<Db<F>, Vec<State>> {
+    committed_root: &mut Digest,
+) -> Result<Db<F>, Vec<(State, Digest)>> {
     let mut batch = db.new_batch();
     for (k, v) in pending_writes.drain(..) {
         batch = batch.write(k, v);
     }
-    let merkleized = match batch.merkleize(&db, None).await {
-        Ok(m) => m,
-        Err(_) => return Err(vec![committed.clone()]),
-    };
+    // Merkleize only reads and hashes, and reads are never fault-injected, so an
+    // error here is a real bug rather than a legal crash trigger.
+    let merkleized = batch
+        .merkleize(&db, None)
+        .await
+        .expect("merkleize failed without any mutable operation");
+    let post_root = merkleized.root();
     let db = match db.apply_batch(merkleized).await {
         Ok((db, _)) => db,
-        Err(_) => return Err(failure_states(pending, committed)),
+        Err(_) => {
+            return Err(failure_states(
+                pending,
+                committed,
+                *committed_root,
+                post_root,
+            ));
+        }
     };
     let db = match db.commit().await {
         Ok(db) => db,
-        Err(_) => return Err(failure_states(pending, committed)),
+        Err(_) => {
+            return Err(failure_states(
+                pending,
+                committed,
+                *committed_root,
+                post_root,
+            ));
+        }
     };
     apply_pending(pending, committed);
+    *committed_root = post_root;
     Ok(db)
 }
 
@@ -203,7 +233,8 @@ fn fuzz_family<F: Graftable>(input: &FuzzInput, suffix_base: &str) {
     let runner = deterministic::Runner::new(cfg);
 
     // Phase 1: Execute operations with fault injection until crash.
-    // Track committed KV state so we can verify it survives recovery.
+    // Track committed KV state and per-boundary roots so recovery can be
+    // verified against an independently recorded snapshot.
     let ((known_keys, allowed_states), checkpoint) = runner.start_and_recover(|ctx| {
         let suffix = suffix.clone();
         let operations = operations.clone();
@@ -211,6 +242,9 @@ fn fuzz_family<F: Graftable>(input: &FuzzInput, suffix_base: &str) {
             let mut db: Db<F> = Db::init(ctx.child("db"), make_config(&ctx, &suffix, params))
                 .await
                 .unwrap();
+
+            // Root recorded at the last successful commit boundary (initially empty).
+            let mut committed_root = db.root();
 
             let fault_cfg = ctx.storage_fault_config();
             *fault_cfg.write() = deterministic::FaultConfig {
@@ -245,8 +279,14 @@ fn fuzz_family<F: Graftable>(input: &FuzzInput, suffix_base: &str) {
                         db
                     }
                     CurrentOperation::Commit => {
-                        match commit_pending(db, &mut pending_writes, &mut pending, &mut committed)
-                            .await
+                        match commit_pending(
+                            db,
+                            &mut pending_writes,
+                            &mut pending,
+                            &mut committed,
+                            &mut committed_root,
+                        )
+                        .await
                         {
                             Ok(db) => db,
                             Err(states) => {
@@ -261,6 +301,7 @@ fn fuzz_family<F: Graftable>(input: &FuzzInput, suffix_base: &str) {
                             &mut pending_writes,
                             &mut pending,
                             &mut committed,
+                            &mut committed_root,
                         )
                         .await
                         {
@@ -279,10 +320,9 @@ fn fuzz_family<F: Graftable>(input: &FuzzInput, suffix_base: &str) {
                 };
             }
 
-            (
-                known_keys.into_iter().collect::<Vec<_>>(),
-                failure.unwrap_or_else(|| vec![committed]),
-            )
+            // A failed prune leaves both the committed state and the root unchanged.
+            let allowed = failure.unwrap_or_else(|| vec![(committed, committed_root)]);
+            (known_keys.into_iter().collect::<Vec<_>>(), allowed)
         }
     });
 
@@ -306,26 +346,30 @@ fn fuzz_family<F: Graftable>(input: &FuzzInput, suffix_base: &str) {
                 .await
                 .expect("recovery must succeed");
 
-            // Read every observed key in one batch so the result must match one atomic snapshot.
+            // Read every observed key in one batch so the result must match one atomic
+            // snapshot, and require the recovered root to match the root recorded at
+            // that same boundary: the root is a pure function of the log, so accepting
+            // the instance's own root would let a self-consistent rebuild bug pass.
+            let root = db.root();
             let keys = known_keys.iter().copied().map(Key::new).collect::<Vec<_>>();
             let key_refs = keys.iter().collect::<Vec<_>>();
             let recovered = db
                 .get_many(&key_refs)
                 .await
                 .expect("whole-snapshot read should not fail");
-            let matches_allowed = allowed_states.iter().any(|state| {
-                known_keys
-                    .iter()
-                    .map(|key| state.get(key).copied().map(Value::new))
-                    .eq(recovered.iter().cloned())
+            let matches_allowed = allowed_states.iter().any(|(state, expected_root)| {
+                *expected_root == root
+                    && known_keys
+                        .iter()
+                        .map(|key| state.get(key).copied().map(Value::new))
+                        .eq(recovered.iter().cloned())
             });
             assert!(
                 matches_allowed,
-                "recovery exposed a state that was not atomic at a batch boundary"
+                "recovery exposed a (state, root) pair that was not atomic at a batch boundary"
             );
 
-            // Verify all recovered KV pairs are provable.
-            let root = db.root();
+            // Verify all recovered KV pairs are provable against the matched root.
             for (key, value) in keys
                 .into_iter()
                 .zip(recovered)

--- a/storage/fuzz/fuzz_targets/freezer_recovery.rs
+++ b/storage/fuzz/fuzz_targets/freezer_recovery.rs
@@ -36,6 +36,12 @@ struct FuzzInput {
     path: WritePath,
     crash: CrashKind,
     retention: u8,
+    /// Let the first candidate write succeed (volatile) and fail the second,
+    /// so the failed-write cut can land past a pending update.
+    fail_second: bool,
+    /// Deepen the checkpointed baseline with filler puts and syncs that complete
+    /// a table resize and roll past one value section before the crash scenario.
+    deepen: bool,
 }
 
 /// Build the deterministic Freezer configuration used by the recovery scenario.
@@ -92,8 +98,9 @@ async fn assert_values<E: commonware_storage::Context>(
     freezer: &Freezer<E, Key, i32>,
     expected: &[(Key, i32)],
 ) {
-    let mut candidates = (0..3).map(baseline_key).collect::<Vec<_>>();
+    let mut candidates = (0..4).map(baseline_key).collect::<Vec<_>>();
     candidates.extend([candidate_key(), sentinel_key()]);
+    candidates.extend(expected.iter().map(|(key, _)| key.clone()));
     for key in candidates {
         let expected_value = expected
             .iter()
@@ -119,11 +126,36 @@ fn run(input: &FuzzInput, mode: PartialWriteMode) {
                 Freezer::<_, Key, i32>::init(context.child("freezer"), config(&context), None)
                     .await
                     .expect("initial freezer init failed");
-            let baseline_slots: &[u32] = match phase_input.path {
-                WritePath::Put => &[0],
-                WritePath::Resize => &[0, 1, 2],
-            };
             let mut baseline = Vec::new();
+
+            // Deepen the checkpointed state: mark every initial slot, then advance the
+            // bounded resize one chunk per sync until it completes (start plus three more
+            // advances for a four-entry table), doubling the table and resetting every
+            // slot's added count. Eight framed values also roll past one value section,
+            // so restore later trims a multi-section journal against a doubled table.
+            if phase_input.deepen {
+                for round in 0..8u32 {
+                    let key = key_for_slot(round % TABLE_SIZE, 0x30 + round as u8);
+                    let value = 300 + round as i32;
+                    (freezer, _) = freezer
+                        .put(key.clone(), value)
+                        .await
+                        .expect("filler put failed");
+                    baseline.push((key, value));
+                }
+                for _ in 0..4 {
+                    (freezer, _) = freezer.sync().await.expect("filler sync failed");
+                }
+            }
+
+            // A deepened resize scenario marks four slots: after the completed resize the
+            // threshold doubles, and the distinct low residues land in distinct slots of
+            // the doubled table, so the checkpoint sync leaves a fresh resize in progress.
+            let baseline_slots: &[u32] = match (phase_input.path, phase_input.deepen) {
+                (WritePath::Put, _) => &[0],
+                (WritePath::Resize, false) => &[0, 1, 2],
+                (WritePath::Resize, true) => &[0, 1, 2, 3],
+            };
             for &slot in baseline_slots {
                 let key = baseline_key(slot);
                 let value = 100 + slot as i32;
@@ -138,8 +170,14 @@ fn run(input: &FuzzInput, mode: PartialWriteMode) {
 
             // Failed writes retain selected submitted bytes immediately. Successful writes remain
             // unsynced by forcing the next durability operation to fail, after which the instance
-            // is dropped without further use.
+            // is dropped without further use. With `fail_second`, the first candidate write
+            // succeeds (volatile) and the failure is armed just before the second, so the cut
+            // lands past a pending update.
+            let fail_second = matches!(phase_input.path, WritePath::Put)
+                && matches!(phase_input.crash, CrashKind::FailedWrite)
+                && phase_input.fail_second;
             let failure_rate = match phase_input.crash {
+                CrashKind::FailedWrite if fail_second => Probability::new(0, 1).unwrap(),
                 CrashKind::FailedWrite => Probability::new(1, 1).unwrap(),
                 CrashKind::UnsyncedWrite => Probability::new(0, 1).unwrap(),
             };
@@ -147,7 +185,8 @@ fn run(input: &FuzzInput, mode: PartialWriteMode) {
                 CrashKind::FailedWrite => None,
                 CrashKind::UnsyncedWrite => Some(Probability::new(1, 1).unwrap()),
             };
-            *context.storage_fault_config().write() = deterministic::FaultConfig {
+            let fault_config = context.storage_fault_config();
+            *fault_config.write() = deterministic::FaultConfig {
                 write_rate: Some(WriteConfig {
                     failure_rate,
                     retention_rate: Probability::new(u64::from(phase_input.retention % 101), 100)
@@ -164,10 +203,22 @@ fn run(input: &FuzzInput, mode: PartialWriteMode) {
                     let (freezer, updated_cursor) = match updated {
                         Ok(result) => result,
                         Err(_) => {
-                            assert!(matches!(phase_input.crash, CrashKind::FailedWrite));
+                            // With fail_second the failure rate is still zero here, so
+                            // the first put has no legal way to fail.
+                            assert!(
+                                matches!(phase_input.crash, CrashKind::FailedWrite) && !fail_second
+                            );
                             return (freezer_checkpoint, baseline, Vec::new());
                         }
                     };
+                    if fail_second {
+                        fault_config
+                            .write()
+                            .write_rate
+                            .as_mut()
+                            .expect("write faults configured")
+                            .failure_rate = Probability::new(1, 1).unwrap();
+                    }
                     let inserted = freezer.put(candidate_key(), 901).await;
                     let (freezer, inserted_cursor) = match inserted {
                         Ok(result) => result,

--- a/storage/fuzz/fuzz_targets/journal_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/journal_crash_recovery.rs
@@ -40,10 +40,10 @@
 //! # Positions
 //!
 //! Position arguments (`Read`, `Rewind`, `Replay`) come straight from the fuzzer, so a random `u64`
-//! is almost always out of range. Each such op runs twice: once with the value clamped into the
-//! live range, which must take the success path, and once with the raw value, which exercises the
-//! validation path (`ItemPruned` below the start, `ItemOutOfRange` past the end). Clamping
-//! guarantees the success path is covered on every input; the raw value still tests rejection.
+//! is almost always out of range. `Read` and `Replay` run twice (`Read` skips the clamped pass on
+//! an empty journal): once with the value clamped into the live range, which must take the success
+//! path, and once with the raw value, which exercises the validation path (`ItemPruned` below the
+//! start, `ItemOutOfRange` past the end). `Rewind` runs once, usually clamped, occasionally raw.
 
 use arbitrary::{Arbitrary, Unstructured};
 use commonware_runtime::{BufferPooler, ReadOptions, Runner, Supervisor as _, deterministic};
@@ -565,29 +565,22 @@ fn assert_read(result: Result<Item, Error>, pos: u64, bounds: &Range<u64>) {
     );
 }
 
-/// Whether the cycle continues after the raw replay. Validation
-/// precedes any I/O, so an out-of-range start is deterministic: `< start` -> `ItemPruned`,
-/// `> end` -> `ItemOutOfRange` (`== end` is in range). An in-range start succeeds or hits a
-/// tail-repair I/O fault (ends the cycle); any other result is a bug.
-fn should_continue_raw_replay(
-    result: Result<Vec<(u64, Item)>, Error>,
-    start_pos: u64,
-    bounds: &Range<u64>,
-) -> bool {
-    let in_range = start_pos >= bounds.start && start_pos <= bounds.end;
-    match &result {
-        Ok(_) if in_range => true,
-        Err(Error::ItemPruned(_)) if start_pos < bounds.start => true,
-        Err(Error::ItemOutOfRange(_)) if start_pos > bounds.end => true,
-        // An in-range start that failed with a non-validation error is a tail-repair I/O fault.
-        Err(e) if in_range && !matches!(e, Error::ItemPruned(_) | Error::ItemOutOfRange(_)) => {
-            false
-        }
-        _ => panic!(
-            "raw replay at {start_pos} (bounds [{}, {})) returned {result:?}",
-            bounds.start, bounds.end
-        ),
-    }
+/// Check a raw-position replay. Validation precedes any I/O, so an out-of-range start is
+/// deterministic: `< start` -> `ItemPruned`, `> end` -> `ItemOutOfRange` (`== end` is in
+/// range). Replay is a pure read and read faults are never injected, so an in-range start
+/// must succeed and any other result is a real bug.
+fn assert_raw_replay(result: Result<Vec<(u64, Item)>, Error>, start_pos: u64, bounds: &Range<u64>) {
+    let ok = match &result {
+        Ok(_) => start_pos >= bounds.start && start_pos <= bounds.end,
+        Err(Error::ItemPruned(_)) => start_pos < bounds.start,
+        Err(Error::ItemOutOfRange(_)) => start_pos > bounds.end,
+        Err(_) => false,
+    };
+    assert!(
+        ok,
+        "raw replay at {start_pos} (bounds [{}, {})) returned {result:?}",
+        bounds.start, bounds.end
+    );
 }
 
 /// Assert the items from replaying an in-bounds `start` are exactly positions `[start, bounds.end)`,
@@ -609,9 +602,9 @@ fn assert_replay_suffix(items: &[(u64, Item)], start: u64, bounds: &Range<u64>) 
     }
 }
 
-/// Run a cycle's ops under faults, updating `expected`. Stops early on any error that may have left
-/// the journal inconsistent (a mutable-method error or a tail-repair I/O fault); the journal is
-/// then dropped to crash. Reads never fault, so a bad read panics instead of ending the cycle.
+/// Run a cycle's ops under faults, updating `expected`. Stops early on a mutable-method error,
+/// which may have left the journal inconsistent; the journal is then dropped to crash. Reads and
+/// replays never fault, so a bad one panics instead of ending the cycle.
 async fn run_ops<J: FuzzJournal>(
     mut journal: J,
     expected: &mut Expected,
@@ -630,7 +623,11 @@ async fn run_ops<J: FuzzJournal>(
                         expected.appended(item);
                         journal
                     }
-                    Err(_) => {
+                    Err(err) => {
+                        assert!(
+                            !matches!(err, Error::Corruption(_)),
+                            "append reported corruption mid-cycle: {err:?}"
+                        );
                         expected.append_failed(size_before);
                         return;
                     }
@@ -652,7 +649,13 @@ async fn run_ops<J: FuzzJournal>(
                     expected.synced(journal.bounds());
                     journal
                 }
-                Err(_) => return,
+                Err(err) => {
+                    assert!(
+                        !matches!(err, Error::Corruption(_)),
+                        "sync reported corruption mid-cycle: {err:?}"
+                    );
+                    return;
+                }
             },
 
             // A snapshot flushes buffered data without a durability barrier, changing no
@@ -660,7 +663,13 @@ async fn run_ops<J: FuzzJournal>(
             // next crash to cut.
             JournalOperation::Snapshot => match journal.snapshot().await {
                 Ok(journal) => journal,
-                Err(_) => return,
+                Err(err) => {
+                    assert!(
+                        !matches!(err, Error::Corruption(_)),
+                        "snapshot reported corruption mid-cycle: {err:?}"
+                    );
+                    return;
+                }
             },
 
             JournalOperation::Commit => match journal.commit().await {
@@ -668,7 +677,13 @@ async fn run_ops<J: FuzzJournal>(
                     expected.committed(journal.size().await);
                     journal
                 }
-                Err(_) => return,
+                Err(err) => {
+                    assert!(
+                        !matches!(err, Error::Corruption(_)),
+                        "commit reported corruption mid-cycle: {err:?}"
+                    );
+                    return;
+                }
             },
 
             JournalOperation::Rewind { size } => {
@@ -704,7 +719,11 @@ async fn run_ops<J: FuzzJournal>(
                             );
                             return;
                         }
-                        Err(_) => {
+                        Err(err) => {
+                            assert!(
+                                !matches!(err, Error::Corruption(_)),
+                                "rewind reported corruption mid-cycle: {err:?}"
+                            );
                             expected.rewound(target.min(bounds.end), bounds.end);
                             return;
                         }
@@ -720,7 +739,12 @@ async fn run_ops<J: FuzzJournal>(
                         expected.pruned(journal.bounds().start);
                         journal
                     }
-                    Err(_) => {
+                    Err(err) => {
+                        assert!(
+                            !matches!(err, Error::Corruption(_)),
+                            "prune reported corruption mid-cycle: {err:?}"
+                        );
+
                         // A failed prune advances the boundary at most to the section floor.
                         let capped = (*min_pos).min(size);
                         let section_floor =
@@ -732,39 +756,32 @@ async fn run_ops<J: FuzzJournal>(
             }
 
             JournalOperation::Replay { buffer, start_pos } => {
-                // The clamped replay must return the full suffix matching `read()`, or hit a
-                // tail-repair I/O fault.
+                // The clamped replay must return the full suffix matching `read()`. Replay
+                // is a pure read over successfully written data, so any error is a real bug.
                 let bounds = journal.bounds();
                 let clamped = bounds.start + (*start_pos % (bounds.end - bounds.start + 1));
-                let clamped_ok = match journal.replay(clamped, NZUsize!(*buffer)).await {
-                    Ok(items) => {
-                        assert_replay_suffix(&items, clamped, &bounds);
-                        for (pos, item) in &items {
-                            let via_read = journal.read(*pos).await.unwrap_or_else(|e| {
-                                panic!("read({pos}) cross-check during replay: {e:?}")
-                            });
-                            assert_eq!(*item, via_read, "replay/read divergence at {pos}");
-                        }
-                        true
-                    }
-                    // A clamped start is always in bounds, so a validation error is a bug.
-                    Err(e @ (Error::ItemPruned(_) | Error::ItemOutOfRange(_))) => panic!(
-                        "in-bounds replay at {clamped} (bounds [{}, {})) returned {e:?}",
-                        bounds.start, bounds.end
-                    ),
-                    // Tail-repair I/O fault: end the cycle.
-                    Err(_) => false,
-                };
-                if !clamped_ok {
-                    return;
+                let items = journal
+                    .replay(clamped, NZUsize!(*buffer))
+                    .await
+                    .unwrap_or_else(|e| {
+                        panic!(
+                            "in-bounds replay at {clamped} (bounds [{}, {})) returned {e:?}",
+                            bounds.start, bounds.end
+                        )
+                    });
+                assert_replay_suffix(&items, clamped, &bounds);
+                for (pos, item) in &items {
+                    let via_read = journal
+                        .read(*pos)
+                        .await
+                        .unwrap_or_else(|e| panic!("read({pos}) cross-check during replay: {e:?}"));
+                    assert_eq!(*item, via_read, "replay/read divergence at {pos}");
                 }
-                if !should_continue_raw_replay(
+                assert_raw_replay(
                     journal.replay(*start_pos, NZUsize!(*buffer)).await,
                     *start_pos,
                     &bounds,
-                ) {
-                    return;
-                }
+                );
                 journal
             }
 
@@ -805,21 +822,29 @@ where
 }
 
 /// Attempt ordinary journal recovery under storage faults and return its crash checkpoint.
+///
+/// `cycle` varies the fault selectors per restart, so a multi-cycle run can hit a different
+/// mutation class (write, sync, resize, or remove) at each recovery.
 fn faulted_restart<J: FuzzJournal + Send + 'static>(
     checkpoint: deterministic::Checkpoint,
     partition: String,
     params: Params,
+    cycle: u64,
 ) -> deterministic::Checkpoint
 where
     J::Config: Send,
 {
-    faulted_recovery(checkpoint, params.recovery_seed, move |ctx| async move {
-        J::init(
-            ctx.child("faulted_recovery"),
-            J::config(&partition, &ctx, &params),
-        )
-        .await
-    })
+    faulted_recovery(
+        checkpoint,
+        params.recovery_seed ^ cycle,
+        move |ctx| async move {
+            J::init(
+                ctx.child("faulted_recovery"),
+                J::config(&partition, &ctx, &params),
+            )
+            .await
+        },
+    )
 }
 
 /// Split the operation stream into one `ops` list per cycle, cutting at each `Crash` marker. Always
@@ -867,9 +892,9 @@ where
         partition.clone(),
         params,
     );
-    checkpoint = faulted_restart::<J>(checkpoint, partition.clone(), params);
+    checkpoint = faulted_restart::<J>(checkpoint, partition.clone(), params, 0);
 
-    for ops in cycles.iter().skip(1) {
+    for (cycle, ops) in cycles.iter().enumerate().skip(1) {
         let runner = deterministic::Runner::from(checkpoint);
         (expected, checkpoint) = run_cycle::<J>(
             runner,
@@ -878,7 +903,7 @@ where
             partition.clone(),
             params,
         );
-        checkpoint = faulted_restart::<J>(checkpoint, partition.clone(), params);
+        checkpoint = faulted_restart::<J>(checkpoint, partition.clone(), params, cycle as u64);
     }
 
     // Final fault-free phase: verify the last recovery, then append, sync, drop, and reopen a

--- a/storage/fuzz/fuzz_targets/merkle_full_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/merkle_full_crash_recovery.rs
@@ -1,6 +1,6 @@
 #![no_main]
 
-//! Fuzz test for Merkle Merkle crash recovery with fault injection.
+//! Fuzz test for persisted Merkle crash recovery with fault injection.
 //! Tests both MMR and MMB families.
 
 use arbitrary::Arbitrary;
@@ -34,6 +34,10 @@ enum MerkleOperation {
     Add { data: [u8; DATA_SIZE] },
     /// Sync to storage.
     Sync,
+    /// Flush cached nodes to the journal without a durability barrier.
+    Flush,
+    /// Begin a durable sync and abandon its completion handle.
+    StartSync,
     /// Prune leaves up to a location.
     PruneToLoc { loc: u64 },
     /// Prune all nodes.
@@ -142,6 +146,23 @@ async fn run_operations<F: MerkleFamily>(
                 }
             },
 
+            // Flushed nodes reach the journal without a durability barrier, so no
+            // expectation changes: only a completed sync raises the floor.
+            MerkleOperation::Flush => match merkle.flush().await {
+                Err(_) => break,
+                Ok(merkle) => merkle,
+            },
+
+            // The completion handle is dropped unobserved, so nothing is credited as
+            // durable: the abandoned sync may or may not have completed by the crash.
+            MerkleOperation::StartSync => match merkle.start_sync().await {
+                Err(_) => break,
+                Ok((merkle, handle)) => {
+                    drop(handle);
+                    merkle
+                }
+            },
+
             MerkleOperation::PruneToLoc { loc } => {
                 let leaves = *merkle.leaves();
                 let current_pruned = *merkle.bounds().start;
@@ -150,6 +171,9 @@ async fn run_operations<F: MerkleFamily>(
                 if safe_loc > current_pruned {
                     match merkle.prune(Location::new(safe_loc)).await {
                         Err(_) => {
+                            // The error is opaque: the prune may have failed before its
+                            // internal sync proved anything durable, so this ceiling is
+                            // conservative.
                             max_pruned = max_pruned.max(safe_loc);
                             break;
                         }
@@ -157,6 +181,13 @@ async fn run_operations<F: MerkleFamily>(
                             let pruned = merkle.bounds().start.as_u64();
                             min_pruned = pruned;
                             max_pruned = pruned;
+
+                            // Prune completes a full durable sync before touching
+                            // metadata, so it is also a size/leaves barrier.
+                            min_size = merkle.size().as_u64();
+                            min_leaves = merkle.leaves().as_u64();
+                            max_size = max_size.max(min_size);
+                            max_leaves = max_leaves.max(min_leaves);
                             merkle
                         }
                     }
@@ -179,6 +210,13 @@ async fn run_operations<F: MerkleFamily>(
                             let pruned = merkle.bounds().start.as_u64();
                             min_pruned = pruned;
                             max_pruned = pruned;
+
+                            // Prune completes a full durable sync before touching
+                            // metadata, so it is also a size/leaves barrier.
+                            min_size = merkle.size().as_u64();
+                            min_leaves = merkle.leaves().as_u64();
+                            max_size = max_size.max(min_size);
+                            max_leaves = max_leaves.max(min_leaves);
                             merkle
                         }
                     }

--- a/storage/fuzz/fuzz_targets/metadata_recovery.rs
+++ b/storage/fuzz/fuzz_targets/metadata_recovery.rs
@@ -48,21 +48,24 @@ fn config() -> Config<<Vec<u8> as Read>::Cfg> {
 }
 
 fn value(input: &FuzzInput, tag: u8) -> Vec<u8> {
-    let mut value = input.payload.to_vec();
-    value[0] = tag;
+    let mut value = vec![tag];
+    value.extend_from_slice(&input.payload);
     value
 }
 
+/// Snapshot the store's complete key set, so a load that fabricates or misparses
+/// an extra key diverges from the expected map.
 fn snapshot<E: commonware_storage::Context>(
     metadata: &Metadata<E, U64, Vec<u8>>,
 ) -> BTreeMap<u64, Vec<u8>> {
-    [0, 1, 2, SENTINEL_KEY]
-        .into_iter()
-        .filter_map(|key| {
-            metadata
-                .get(&U64::new(key))
-                .cloned()
-                .map(|value| (key, value))
+    metadata
+        .keys()
+        .map(|key| {
+            let value = metadata
+                .get(key)
+                .expect("listed key must be readable")
+                .clone();
+            (u64::from(key), value)
         })
         .collect()
 }
@@ -152,7 +155,10 @@ fn run(input: &FuzzInput, mode: PartialWriteMode) {
         }
     });
 
-    let checkpoint = faulted_recovery(checkpoint, input.seed, |context| async move {
+    // Metadata::init performs no write_at and no remove, so force the faulted pass's
+    // mutation selector to the sync (1) or resize (2) arm it can actually exercise.
+    let fault_seed = (input.seed & !0x03) | (1 + (input.seed & 1));
+    let checkpoint = faulted_recovery(checkpoint, fault_seed, |context| async move {
         Metadata::<_, U64, Vec<u8>>::init(context.child("faulted_recovery"), config()).await
     });
 

--- a/storage/fuzz/fuzz_targets/oversized_recovery.rs
+++ b/storage/fuzz/fuzz_targets/oversized_recovery.rs
@@ -16,7 +16,7 @@ use commonware_storage::journal::{
     Error as JournalError,
     segmented::oversized::{Config, Oversized, Record},
 };
-use commonware_storage_fuzz::faulted_recovery;
+use commonware_storage_fuzz::{faulted_recovery, release_oldest_pending_sync};
 use commonware_utils::{NZU16, NZUsize, Probability};
 use libfuzzer_sys::fuzz_target;
 use std::{
@@ -198,12 +198,16 @@ async fn frame_valid(
 /// through it, adopting earlier records whose frames were damaged (their reads must fail loud).
 /// Maps each section to `(id, value readable)` per retained position, asserting identity against
 /// the intended append stream since an in-model crash cut cannot forge a CRC-valid record.
+///
+/// Also returns each scanned section's terminal value end (zero when nothing is retained),
+/// which repair must truncate the glob to.
 async fn recover_expected(
     context: &deterministic::Context,
     intended: &BTreeMap<u64, Vec<u64>>,
-) -> BTreeMap<u64, Vec<(u64, bool)>> {
+) -> (BTreeMap<u64, Vec<(u64, bool)>>, BTreeMap<u64, u64>) {
     let page_size = usize::from(PAGE_SIZE.get());
     let physical_page_size = page_size + PAGE_CHECKSUM_RECORD_SIZE;
+    let mut value_ends = BTreeMap::new();
     let mut sections: BTreeMap<u64, Vec<(u64, bool)>> =
         (0..SECTIONS).map(|section| (section, Vec::new())).collect();
     for name in context
@@ -257,6 +261,13 @@ async fn recover_expected(
             .iter()
             .rposition(|&valid| valid)
             .map_or(0, |last| last + 1);
+        let value_end = records[..retained].last().map_or(0, |record| {
+            let (offset, size) = record.value_location();
+            offset
+                .checked_add(u64::from(size))
+                .expect("oracle value end overflow")
+        });
+        value_ends.insert(section, value_end);
 
         let intended = intended.get(&section).map_or(&[][..], Vec::as_slice);
         let mut expected = Vec::with_capacity(retained);
@@ -274,7 +285,7 @@ async fn recover_expected(
         }
         sections.insert(section, expected);
     }
-    sections
+    (sections, value_ends)
 }
 
 /// Assert the recovered journal serves exactly the expected view: identity for every retained
@@ -444,33 +455,41 @@ fn fuzz(input: FuzzInput) {
         };
         match first_phase_input.final_op % 3 {
             1 => {
-                // Interrupt a blocking sync of every section mid-flight: poll until it parks on
-                // a held completion, then drop the future, so the crash lands between its
-                // internal barriers with only a prefix of the sections flushed.
+                // Interrupt a blocking sync of every section behind the armed one-shot
+                // gate: the first barrier to arrive parks with its blob's flush left
+                // volatile while every other blob syncs durably. Releasing the gate and
+                // polling again instead completes the sync before the crash.
                 pending.arm();
                 let mut sync = Box::pin(oversized.sync_all());
-                for _ in 0..usize::from(first_phase_input.final_op >> 2) % 8 + 1 {
-                    if futures::future::poll_immediate(sync.as_mut())
-                        .await
-                        .is_some()
-                    {
+                for _ in 0..usize::from(first_phase_input.final_op >> 2) % 2 + 1 {
+                    if let Some(result) = futures::future::poll_immediate(sync.as_mut()).await {
+                        // A sync that ran to completion is an observed barrier: it must
+                        // succeed and every appended entry becomes durable.
+                        drop(result.expect("interrupted sync_all failed"));
+                        durable = counts.clone();
                         break;
                     }
+                    release_oldest_pending_sync(&pending);
                 }
                 drop(sync);
             }
             2 => {
-                // Interrupt a blocking sync of one section mid-flight.
+                // Interrupt a blocking sync of one section behind the armed gate, with
+                // the same parked-or-completed split as above.
                 pending.arm();
                 let section = u64::from(first_phase_input.final_op >> 2) % SECTIONS;
                 let mut sync = Box::pin(oversized.sync(section));
-                for _ in 0..usize::from(first_phase_input.final_op >> 5) % 8 + 1 {
-                    if futures::future::poll_immediate(sync.as_mut())
-                        .await
-                        .is_some()
-                    {
+                for _ in 0..usize::from(first_phase_input.final_op >> 5) % 2 + 1 {
+                    if let Some(result) = futures::future::poll_immediate(sync.as_mut()).await {
+                        // A completed section sync must succeed and makes that section's
+                        // appended entries durable.
+                        drop(result.expect("interrupted section sync failed"));
+                        if let Some(&count) = counts.get(&section) {
+                            durable.insert(section, count);
+                        }
                         break;
                     }
+                    release_oldest_pending_sync(&pending);
                 }
                 drop(sync);
             }
@@ -505,7 +524,7 @@ fn fuzz(input: FuzzInput) {
         .start_and_recover(move |context| async move {
             *context.storage_fault_config().write() = deterministic::FaultConfig::default();
             let cfg = config(&context);
-            let expected = recover_expected(&context, &recovery_appended).await;
+            let (expected, value_ends) = recover_expected(&context, &recovery_appended).await;
             let recovered: Oversized<_, TestEntry, TestValue> =
                 Oversized::init(context.child("recovered"), cfg, None)
                     .await
@@ -537,6 +556,27 @@ fn fuzz(input: FuzzInput) {
             assert_view(&recovered, &expected, true).await;
             drop(recovered);
             let sizes = blob_sizes(&context).await;
+
+            // Repair must pair every index section with a glob truncated to the last
+            // retained entry's end and remove value sections with no index counterpart,
+            // so stale value bytes can never satisfy a later append's range.
+            for (&(is_index, section), &size) in &sizes {
+                if is_index {
+                    assert!(
+                        sizes.contains_key(&(false, section)),
+                        "index section {section} recovered without its value section"
+                    );
+                    continue;
+                }
+                assert!(
+                    sizes.contains_key(&(true, section)),
+                    "recovery kept an orphan value section {section}"
+                );
+                assert_eq!(
+                    size, value_ends[&section],
+                    "recovery left the wrong value size in section {section}"
+                );
+            }
             (expected, sizes)
         });
 

--- a/storage/fuzz/fuzz_targets/prunable_archive_recovery.rs
+++ b/storage/fuzz/fuzz_targets/prunable_archive_recovery.rs
@@ -16,7 +16,7 @@ use commonware_storage::{
     rmap::RMap,
     translator::EightCap,
 };
-use commonware_storage_fuzz::faulted_recovery;
+use commonware_storage_fuzz::{faulted_recovery, release_oldest_pending_sync};
 use commonware_utils::{NZUsize, Probability, sequence::FixedBytes};
 use libfuzzer_sys::fuzz_target;
 use std::{
@@ -147,14 +147,19 @@ async fn read_value(
     let end = record
         .value_offset
         .checked_add(u64::from(record.value_size))?;
-    let (blob, blob_size) = context.open(partition, &section.to_be_bytes()).await.ok()?;
+    // The value blob is created before any index bytes can exist, and reads are never
+    // fault-injected, so open and read failures here are real bugs, not crash shapes.
+    let (blob, blob_size) = context
+        .open(partition, &section.to_be_bytes())
+        .await
+        .expect("oracle value open failed");
     if end > blob_size {
         return None;
     }
     let frame = blob
         .read_at(record.value_offset, size, ReadOptions::default())
         .await
-        .ok()?
+        .expect("oracle value read failed")
         .coalesce();
     let data_len = size - VALUE_CHECKSUM_SIZE;
     let stored = u32::from_be_bytes(frame.as_ref()[data_len..].try_into().ok()?);
@@ -441,6 +446,7 @@ fn fuzz(input: FuzzInput) {
                     .expect("initial archive init failed");
             let mut held: Vec<(usize, Handle<()>)> = Vec::new();
             let mut durable = 0usize;
+            let total = first_phase_entries.len();
             let mut exempt_below = 0u64;
             let mut pruned = false;
             for (offset, entry) in first_phase_entries.into_iter().enumerate() {
@@ -550,39 +556,43 @@ fn fuzz(input: FuzzInput) {
             };
             match first_phase_input.final_op % 3 {
                 1 => {
-                    // Interrupt a blocking sync mid-flight: poll until it parks on a held
-                    // completion, then drop the future (the owner-consuming contract retires the
-                    // instance) so the crash lands between its internal barriers.
+                    // Interrupt a blocking sync mid-flight: each iteration releases the
+                    // oldest parked completion, advancing the sync one durability barrier
+                    // per poll, then drop the future (the owner-consuming contract retires
+                    // the instance) so the crash lands between its internal barriers. A
+                    // sync that runs to completion is an observed barrier: it must succeed
+                    // and every accepted write becomes durable.
                     let mut sync = Box::pin(archive.sync());
                     for _ in 0..usize::from(first_phase_input.final_op >> 2) % 8 + 1 {
-                        if futures::future::poll_immediate(sync.as_mut())
-                            .await
-                            .is_some()
-                        {
+                        if let Some(result) = futures::future::poll_immediate(sync.as_mut()).await {
+                            drop(result.expect("interrupted sync failed"));
+                            durable = durable.max(total);
                             break;
                         }
+                        release_oldest_pending_sync(&pending);
                     }
                     drop(sync);
                 }
                 2 => {
-                    // Interrupt a prune mid-flight: the armed gate parks it at its internal
-                    // durability barriers, starting with the marker-removal metadata sync, so the
-                    // crash lands between marker removal and section deletion. Markers must be
-                    // removed durably before any section storage disappears, so every cut point
-                    // must recover. Only indices below the section-rounded floor can disappear.
+                    // Interrupt a prune mid-flight: the armed gate parks it at the
+                    // marker-removal metadata sync (the only parking point, so a second
+                    // poll after the release runs the prune to completion). Markers must
+                    // be removed durably before any section storage disappears, so both
+                    // cut points must recover. Only indices below the section-rounded
+                    // floor can disappear.
                     let min = u64::from(first_phase_input.final_op >> 2);
                     let floor = (min / items_per_section) * items_per_section.get();
                     pruned |= floor > 0;
                     exempt_below = exempt_below.max(floor);
                     pending.arm();
                     let mut prune = Box::pin(archive.prune(min));
-                    for _ in 0..usize::from(first_phase_input.final_op >> 5) % 8 + 1 {
-                        if futures::future::poll_immediate(prune.as_mut())
-                            .await
-                            .is_some()
+                    for _ in 0..usize::from(first_phase_input.final_op >> 5) % 2 + 1 {
+                        if let Some(result) = futures::future::poll_immediate(prune.as_mut()).await
                         {
+                            drop(result.expect("interrupted prune failed"));
                             break;
                         }
+                        release_oldest_pending_sync(&pending);
                     }
                     drop(prune);
                 }

--- a/storage/fuzz/fuzz_targets/queue_crash_recovery.rs
+++ b/storage/fuzz/fuzz_targets/queue_crash_recovery.rs
@@ -86,9 +86,10 @@ struct RecoveryState {
     /// Items that were successfully enqueued or committed (position -> value).
     committed: BTreeMap<u64, u8>,
 
-    /// Items that were enqueued/appended but the operation may have failed,
-    /// or were appended but not yet committed.
-    pending: Vec<u8>,
+    /// Items whose covering operation failed (position -> value). Every append
+    /// targets the queue size at call time, so a failed operation's bytes can only
+    /// become durable at its predicted position.
+    pending: BTreeMap<u64, u8>,
 
     /// Current in-memory ack floor (lost on crash).
     current_ack_floor: u64,
@@ -96,6 +97,10 @@ struct RecoveryState {
     /// Items that were appended but not yet committed (position -> value).
     /// These may be lost on crash. On commit, they move to `committed`.
     uncommitted: BTreeMap<u64, u8>,
+
+    /// Blob-aligned pruning boundary removed by the last successful Sync.
+    /// Recovery reports this boundary as the ack floor.
+    synced_boundary: u64,
 
     /// Whether we observed a mutable storage error during the operation phase.
     ///
@@ -107,9 +112,10 @@ impl RecoveryState {
     fn new() -> Self {
         Self {
             committed: BTreeMap::new(),
-            pending: Vec::new(),
+            pending: BTreeMap::new(),
             current_ack_floor: 0,
             uncommitted: BTreeMap::new(),
+            synced_boundary: 0,
             saw_mutable_error: false,
         }
     }
@@ -127,10 +133,10 @@ impl RecoveryState {
         self.committed.insert(pos, value);
     }
 
-    fn enqueue_failed(&mut self, value: u8) {
+    fn enqueue_failed(&mut self, pos: u64, value: u8) {
         // Enqueue may have partially succeeded (append but not commit).
         // Track as pending - it may or may not be persisted.
-        self.pending.push(value);
+        self.pending.insert(pos, value);
     }
 
     fn append_succeeded(&mut self, pos: u64, value: u8) {
@@ -138,8 +144,8 @@ impl RecoveryState {
         self.uncommitted.insert(pos, value);
     }
 
-    fn append_failed(&mut self, value: u8) {
-        self.pending.push(value);
+    fn append_failed(&mut self, pos: u64, value: u8) {
+        self.pending.insert(pos, value);
     }
 
     fn commit_succeeded(&mut self) {
@@ -154,13 +160,30 @@ impl RecoveryState {
         // Uncommitted items remain uncommitted; they may or may not be durable.
         // Move them to pending since we can't be sure.
         let uncommitted = std::mem::take(&mut self.uncommitted);
-        for (_pos, value) in uncommitted {
-            self.pending.push(value);
+        for (pos, value) in uncommitted {
+            self.pending.insert(pos, value);
         }
     }
 
     fn update_ack_floor(&mut self, ack_floor: u64) {
         self.current_ack_floor = ack_floor;
+    }
+
+    /// Record the boundary pruned by a successful Sync, mirroring the journal's
+    /// clamp: the target blob is capped to the tail blob, boundaries are
+    /// blob-aligned, and the boundary never regresses.
+    fn sync_succeeded(&mut self, ack_floor: u64, size: u64, items_per_section: u64) {
+        let min_blob = (ack_floor / items_per_section).min(size / items_per_section);
+        self.synced_boundary = self.synced_boundary.max(min_blob * items_per_section);
+    }
+
+    /// Returns the expected item content at a recovered position, if tracked.
+    fn expected_item(&self, pos: u64) -> Option<u8> {
+        self.committed
+            .get(&pos)
+            .or_else(|| self.uncommitted.get(&pos))
+            .or_else(|| self.pending.get(&pos))
+            .copied()
     }
 
     /// Returns the minimum size we expect after recovery.
@@ -172,16 +195,6 @@ impl RecoveryState {
     fn max_recovered_size(&self) -> u64 {
         (self.committed.len() + self.pending.len() + self.uncommitted.len()) as u64
     }
-
-    /// Returns the minimum ack floor we expect after recovery.
-    fn min_recovered_ack_floor(&self) -> u64 {
-        0
-    }
-
-    /// Returns the maximum ack floor we expect after recovery.
-    fn max_recovered_ack_floor(&self) -> u64 {
-        self.current_ack_floor
-    }
 }
 
 fn make_item(value: u8) -> Vec<u8> {
@@ -192,6 +205,7 @@ fn make_item(value: u8) -> Vec<u8> {
 async fn run_operations(
     mut queue: Queue<deterministic::Context, Vec<u8>>,
     operations: &[QueueOperation],
+    items_per_section: u64,
 ) -> RecoveryState {
     let mut state = RecoveryState::new();
 
@@ -199,6 +213,7 @@ async fn run_operations(
         queue = match op {
             QueueOperation::Enqueue { value } => {
                 let item = make_item(*value);
+                let pos = queue.size();
                 match queue.enqueue(item).await {
                     Ok((queue, pos)) => {
                         // enqueue = append + commit, so success means ALL
@@ -208,7 +223,7 @@ async fn run_operations(
                         queue
                     }
                     Err(_) => {
-                        state.enqueue_failed(*value);
+                        state.enqueue_failed(pos, *value);
                         state.mark_mutable_error();
                         return state;
                     }
@@ -217,13 +232,14 @@ async fn run_operations(
 
             QueueOperation::Append { value } => {
                 let item = make_item(*value);
+                let pos = queue.size();
                 match queue.append(item).await {
                     Ok((queue, pos)) => {
                         state.append_succeeded(pos, *value);
                         queue
                     }
                     Err(_) => {
-                        state.append_failed(*value);
+                        state.append_failed(pos, *value);
                         state.mark_mutable_error();
                         return state;
                     }
@@ -243,9 +259,16 @@ async fn run_operations(
             },
 
             QueueOperation::DequeueAndAck => {
-                if let Ok(Some((pos, _item))) = queue.dequeue().await
-                    && queue.ack(pos).is_ok()
-                {
+                // Reads are never fault-injected and every prior mutable op
+                // succeeded, so a dequeue error here can only be a real bug.
+                let dequeued = queue
+                    .dequeue()
+                    .await
+                    .expect("dequeue failed on successfully written data");
+                if let Some((pos, _item)) = dequeued {
+                    // Ack of a just-dequeued position is in-memory bookkeeping on an
+                    // in-range position, so it has no legal way to fail.
+                    queue.ack(pos).expect("ack of dequeued position failed");
                     state.update_ack_floor(queue.ack_floor());
                 }
                 queue
@@ -253,7 +276,10 @@ async fn run_operations(
 
             QueueOperation::DequeueNoAck => {
                 // Dequeue without acking - item should be re-delivered on recovery
-                let _ = queue.dequeue().await;
+                queue
+                    .dequeue()
+                    .await
+                    .expect("dequeue failed on successfully written data");
                 queue
             }
 
@@ -263,15 +289,11 @@ async fn run_operations(
                 if size > ack_floor {
                     let range = size - ack_floor;
                     let pos = ack_floor + (*offset as u64 % range);
-                    match queue.ack(pos) {
-                        Ok(()) => {
-                            state.update_ack_floor(queue.ack_floor());
-                        }
-                        Err(_) => {
-                            state.mark_mutable_error();
-                            return state;
-                        }
-                    }
+
+                    // Ack is in-memory bookkeeping and the position is in range, so an
+                    // error here is a real bug, never an injected fault.
+                    queue.ack(pos).expect("ack of in-range position failed");
+                    state.update_ack_floor(queue.ack_floor());
                 }
                 queue
             }
@@ -279,15 +301,12 @@ async fn run_operations(
             QueueOperation::AckUpToOffset { offset } => {
                 let size = queue.size();
                 let up_to = (*offset as u64) % (size + 1);
-                match queue.ack_up_to(up_to) {
-                    Ok(()) => {
-                        state.update_ack_floor(queue.ack_floor());
-                    }
-                    Err(_) => {
-                        state.mark_mutable_error();
-                        return state;
-                    }
-                }
+
+                // Same as ack: in-memory, in-range, no legal failure.
+                queue
+                    .ack_up_to(up_to)
+                    .expect("ack_up_to of in-range position failed");
+                state.update_ack_floor(queue.ack_floor());
                 queue
             }
 
@@ -297,6 +316,7 @@ async fn run_operations(
                     // previously uncommitted items are now durable too.
                     state.commit_succeeded();
                     state.update_ack_floor(queue.ack_floor());
+                    state.sync_succeeded(queue.ack_floor(), queue.size(), items_per_section);
                     queue
                 }
                 Err(_) => {
@@ -328,13 +348,17 @@ async fn verify_recovered_items(
         match queue.dequeue().await {
             Ok(Some((pos, item))) => {
                 dequeued_count += 1;
-                if let Some(value) = state.committed.get(&pos) {
-                    assert_eq!(
-                        item,
-                        make_item(*value),
-                        "item at position {pos} has wrong content after recovery",
-                    );
-                }
+
+                // Every surviving position was appended by exactly one tracked
+                // operation, so it must be tracked and its content must match.
+                let value = state
+                    .expected_item(pos)
+                    .unwrap_or_else(|| panic!("recovered untracked position {pos}"));
+                assert_eq!(
+                    item,
+                    make_item(value),
+                    "item at position {pos} has wrong content after recovery",
+                );
                 assert!(
                     dequeued_count <= size,
                     "dequeued more items than queue size"
@@ -372,10 +396,26 @@ async fn verify_recovery_after_mutable_error(
         size_before >= durable_end,
         "recovered size {size_before} lost committed positions through {durable_end}",
     );
+
+    // A failed operation can leave at most its own tracked items behind, and the
+    // faulted recovery pass only truncates, so recovery cannot fabricate items.
+    assert!(
+        size_before <= state.max_recovered_size(),
+        "recovered size {size_before} exceeds all tracked appends ({})",
+        state.max_recovered_size(),
+    );
     assert!(
         ack_floor <= state.current_ack_floor,
         "recovered ack floor {ack_floor} exceeds requested floor {}",
         state.current_ack_floor,
+    );
+
+    // Successful prunes remove blobs durably, so the boundary cannot regress even
+    // when a later operation failed.
+    assert!(
+        ack_floor >= state.synced_boundary,
+        "recovered ack floor {ack_floor} regressed below the last synced boundary {}",
+        state.synced_boundary,
     );
     verify_recovered_items(&mut queue, state, size_before, ack_floor).await;
 
@@ -420,19 +460,12 @@ async fn verify_recovery(mut queue: Queue<deterministic::Context, Vec<u8>>, stat
         state.max_recovered_size()
     );
 
-    // Ack floor should be within expected bounds
-    // Note: ack_floor after recovery = journal.bounds().start (pruning boundary)
-    assert!(
-        ack_floor >= state.min_recovered_ack_floor(),
-        "recovered ack_floor {} is less than minimum expected {}",
-        ack_floor,
-        state.min_recovered_ack_floor()
-    );
-    assert!(
-        ack_floor <= state.max_recovered_ack_floor(),
-        "recovered ack_floor {} is greater than maximum expected {}",
-        ack_floor,
-        state.max_recovered_ack_floor()
+    // Recovery reports ack_floor = journal.bounds().start (the pruning boundary),
+    // and with every operation successful the only prunes are from Syncs, so the
+    // recovered floor must equal the boundary the last successful Sync established.
+    assert_eq!(
+        ack_floor, state.synced_boundary,
+        "recovered ack_floor diverged from the boundary pruned by the last successful sync"
     );
 
     verify_recovered_items(&mut queue, state, size, ack_floor).await;
@@ -483,7 +516,7 @@ fn fuzz(input: FuzzInput) {
             let faults = ctx.storage_fault_config();
             *faults.write() = fault_config;
 
-            run_operations(queue, &operations).await
+            run_operations(queue, &operations, items_per_section.get()).await
         }
     });
 

--- a/storage/fuzz/fuzz_targets/queue_operations.rs
+++ b/storage/fuzz/fuzz_targets/queue_operations.rs
@@ -6,6 +6,7 @@ use commonware_storage::queue::{Config, Queue};
 use commonware_storage_fuzz::{
     bounded_buffer, bounded_items, bounded_page_cache_size, bounded_page_size,
 };
+use commonware_utils::NZUsize;
 use libfuzzer_sys::fuzz_target;
 use std::{
     collections::BTreeSet,
@@ -46,8 +47,6 @@ struct FuzzInput {
     /// Write buffer size.
     #[arbitrary(with = bounded_buffer)]
     write_buffer: usize,
-    #[arbitrary(with = bounded_buffer)]
-    replay_buffer: usize,
     /// Sequence of operations to execute.
     operations: Vec<QueueOperation>,
 }
@@ -146,7 +145,6 @@ fn fuzz(input: FuzzInput) {
     let page_cache_size = NonZeroUsize::new(input.page_cache_size).unwrap();
     let items_per_section = NonZeroU64::new(input.items_per_section).unwrap();
     let write_buffer = NonZeroUsize::new(input.write_buffer).unwrap();
-    let replay_buffer = NonZeroUsize::new(input.replay_buffer).unwrap();
 
     runner.start(|context| async move {
         let cfg = Config {
@@ -156,7 +154,9 @@ fn fuzz(input: FuzzInput) {
             codec_config: ((0usize..).into(), ()),
             page_cache: CacheRef::from_pooler(&context, page_size, page_cache_size),
             write_buffer,
-            replay_buffer,
+            // The queue is initialized once on an empty partition and never reopened,
+            // so replay never reads anything: fuzzing this knob adds no coverage.
+            replay_buffer: NZUsize!(1024),
         };
 
         let mut queue = Queue::<_, Vec<u8>>::init(context.child("storage"), cfg)

--- a/storage/fuzz/fuzz_targets/segmented_variable_recovery.rs
+++ b/storage/fuzz/fuzz_targets/segmented_variable_recovery.rs
@@ -17,10 +17,13 @@ use commonware_runtime::{
     mocks::{DelayedSyncContext, PendingSyncs, drive_pending_syncs},
 };
 use commonware_storage::journal::{Error, segmented::variable};
-use commonware_storage_fuzz::faulted_recovery;
+use commonware_storage_fuzz::{faulted_recovery, release_oldest_pending_sync};
 use commonware_utils::{NZUsize, Probability};
 use libfuzzer_sys::fuzz_target;
-use std::{collections::BTreeMap, num::NonZeroU16};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    num::NonZeroU16,
+};
 
 type Journal = variable::Journal<DelayedSyncContext<deterministic::Context>, Vec<u8>>;
 
@@ -37,7 +40,9 @@ struct FuzzInput {
     subset: bool,
     /// Per-item target section selector.
     routes: [u8; 32],
-    /// How far the interrupted final sync is polled before the crash.
+    /// Whether the interrupted final sync is driven through the armed gate to
+    /// completion before the crash, or left parked with one section's flush
+    /// volatile so the crash tears it per the retention policy.
     final_polls: u8,
 }
 
@@ -119,9 +124,10 @@ fn read_varint(bytes: &[u8]) -> Option<(usize, usize)> {
 async fn recover_expected(
     context: &deterministic::Context,
     partition: &str,
-) -> BTreeMap<u64, (u64, Vec<Vec<u8>>)> {
+) -> (BTreeMap<u64, (u64, Vec<Vec<u8>>)>, BTreeSet<u64>) {
     let physical_page_size = PAGE_SIZE + PAGE_CHECKSUM_RECORD_SIZE;
     let mut sections = BTreeMap::new();
+    let mut gated = BTreeSet::new();
     for name in context.scan(partition).await.expect("oracle scan failed") {
         let section = u64::from_be_bytes(name.as_slice().try_into().expect("invalid section name"));
         let (blob, size) = context
@@ -172,9 +178,15 @@ async fn recover_expected(
             frames.push(payload[inner..].to_vec());
             offset = end;
         }
+
+        // Any valid logical prefix (even a partial frame short of a whole one) means the
+        // journal recovers a nonzero size for this section and gates appends on replay.
+        if !logical.is_empty() {
+            gated.insert(section);
+        }
         sections.insert(section, (offset as u64, frames));
     }
-    sections
+    (sections, gated)
 }
 
 /// Drain a full replay, asserting it yields exactly the expected frames in order.
@@ -249,7 +261,10 @@ fn fuzz(input: FuzzInput) {
             .await
             .expect("initial init failed");
         let mut durable: BTreeMap<u64, usize> = BTreeMap::new();
-        for (offset, (section, item)) in phase_script.iter().enumerate() {
+
+        // The extra iteration reaches baseline == script length: everything synced,
+        // with the crash tearing only the no-op final sync.
+        for offset in 0..=phase_script.len() {
             if offset == baseline && baseline > 0 {
                 journal = drive_pending_syncs(&pending, journal.sync_all())
                     .await
@@ -258,11 +273,16 @@ fn fuzz(input: FuzzInput) {
                     *durable.entry(*section).or_default() += 1;
                 }
             }
+            let Some((section, item)) = phase_script.get(offset) else {
+                break;
+            };
             (journal, _, _) = journal.append(*section, item).await.expect("append failed");
         }
 
-        // Flush buffered writes into storage behind held durability barriers, then crash: the
-        // image retains an arbitrary byte subset of everything past the baseline.
+        // Interrupt the final sync behind the armed one-shot gate: the first section's
+        // durability barrier parks with its flush left volatile (every other section
+        // syncs durably), so the crash tears that section's bytes per the retention
+        // policy. Releasing the gate and polling again instead completes the sync.
         *fault_config.write() = deterministic::FaultConfig {
             write_rate: Some(WriteConfig {
                 failure_rate: Probability::new(0, 1).unwrap(),
@@ -276,14 +296,20 @@ fn fuzz(input: FuzzInput) {
             }),
             ..Default::default()
         };
+        pending.arm();
         let mut sync = Box::pin(journal.sync_all());
-        for _ in 0..usize::from(phase_input.final_polls) % 8 + 1 {
-            if futures::future::poll_immediate(sync.as_mut())
-                .await
-                .is_some()
-            {
+        for _ in 0..usize::from(phase_input.final_polls) % 2 + 1 {
+            if let Some(result) = futures::future::poll_immediate(sync.as_mut()).await {
+                // A sync that ran to completion is an observed barrier: it must
+                // succeed and every scripted item becomes durable.
+                drop(result.expect("interrupted sync failed"));
+                durable.clear();
+                for (section, _) in &phase_script {
+                    *durable.entry(*section).or_default() += 1;
+                }
                 break;
             }
+            release_oldest_pending_sync(&pending);
         }
         drop(sync);
         durable
@@ -293,7 +319,27 @@ fn fuzz(input: FuzzInput) {
 
     deterministic::Runner::from(checkpoint).start(move |context| async move {
         *context.storage_fault_config().write() = deterministic::FaultConfig::default();
-        let expected = recover_expected(&context, "segmented-variable-recovery").await;
+        let (expected, gated) = recover_expected(&context, "segmented-variable-recovery").await;
+
+        // Under the crash model every legal image is a per-section prefix of the
+        // scripted items (retention keeps subsets of submitted bytes, and a stale
+        // checksum slot exposes an older prefix), so a flush path that rewrites,
+        // reorders, or fabricates CRC-valid frames must be caught here.
+        for (&section, (_, frames)) in &expected {
+            let scripted: Vec<&Vec<u8>> = script
+                .iter()
+                .filter(|(candidate, _)| *candidate == section)
+                .map(|(_, item)| item)
+                .collect();
+            assert!(
+                frames.len() <= scripted.len()
+                    && frames
+                        .iter()
+                        .zip(&scripted)
+                        .all(|(frame, item)| frame == *item),
+                "crash image diverges from the scripted prefix in section {section}"
+            );
+        }
 
         // Every item covered by the completed baseline sync must survive the crash in order.
         for (section, count) in &durable {
@@ -320,9 +366,10 @@ fn fuzz(input: FuzzInput) {
             pending: pending.clone(),
         };
 
-        // Every section retained from the previous execution rejects appends until replayed.
-        // Each probe consumes its journal (append takes self and returns it only on success).
-        for (&section, _) in expected.iter().filter(|(_, (size, _))| *size > 0) {
+        // Every section retained from the previous execution rejects appends until replayed,
+        // including sections whose valid prefix holds no complete frame. Each probe consumes
+        // its journal (append takes self and returns it only on success).
+        for &section in &gated {
             let journal = Journal::init(context.child("gate"), config(&context))
                 .await
                 .expect("gate init failed");
@@ -339,7 +386,7 @@ fn fuzz(input: FuzzInput) {
             .expect("recovery init failed");
         let mut journal = assert_replay(journal, &expected).await;
         let mut sentinels = expected.clone();
-        for (&section, (size, frames)) in &expected {
+        for (&section, (size, _)) in &expected {
             let offset;
             (journal, offset, _) = journal
                 .append(section, &vec![0xCD; 9])
@@ -351,7 +398,6 @@ fn fuzz(input: FuzzInput) {
             );
             let entry = sentinels.get_mut(&section).unwrap();
             entry.0 = size + 11;
-            entry.1 = frames.clone();
             entry.1.push(vec![0xCD; 9]);
         }
         journal = journal.sync_all().await.expect("sentinel sync failed");

--- a/storage/fuzz/src/lib.rs
+++ b/storage/fuzz/src/lib.rs
@@ -1,9 +1,31 @@
 //! Shared input generators and crash-recovery flows for storage fuzz targets.
 
 use arbitrary::Unstructured;
-use commonware_runtime::deterministic::{self, PartialWriteMode};
+use commonware_runtime::{
+    deterministic::{self, PartialWriteMode},
+    mocks::PendingSyncs,
+};
 use commonware_utils::{Probability, probability};
 use std::future::Future;
+
+/// Complete the oldest parked durability completion, if any.
+///
+/// Interrupted-sync arms call this between polls so each iteration advances the
+/// interrupted future one durability barrier deeper before the crash cuts it. The
+/// final release may stay unobserved, leaving that barrier's data volatile.
+pub fn release_oldest_pending_sync(pending: &PendingSyncs) {
+    let released = {
+        let mut parked = pending.lock();
+        if parked.is_empty() {
+            None
+        } else {
+            Some(parked.remove(0))
+        }
+    };
+    if let Some(sync) = released {
+        let _ = sync.release.send(Ok(()));
+    }
+}
 
 fn recovery_fault_config(seed: u64) -> deterministic::FaultConfig {
     let selectors = seed.to_le_bytes();
@@ -49,7 +71,8 @@ fn recovery_fault_config(seed: u64) -> deterministic::FaultConfig {
 /// `fault_seed` selects the mutation, failure and retention rates, and partial-write mode.
 ///
 /// The recovered object or error is discarded because mutable-operation errors retire the
-/// instance. The returned checkpoint is suitable for a fault-free recovery and verification.
+/// instance. The fault config is cleared before the crash (retention policies bind when a
+/// write is issued), so the returned checkpoint recovers fault-free.
 pub fn faulted_recovery<F, Fut, T, E>(
     checkpoint: deterministic::Checkpoint,
     fault_seed: u64,
@@ -61,8 +84,10 @@ where
 {
     let (_, checkpoint) =
         deterministic::Runner::from(checkpoint).start_and_recover(move |context| async move {
-            *context.storage_fault_config().write() = recovery_fault_config(fault_seed);
+            let config = context.storage_fault_config();
+            *config.write() = recovery_fault_config(fault_seed);
             drop(recover(context).await);
+            *config.write() = deterministic::FaultConfig::default();
         });
     checkpoint
 }
@@ -91,4 +116,61 @@ pub fn bounded_buffer(u: &mut Unstructured<'_>) -> arbitrary::Result<usize> {
 pub fn bounded_nonzero_rate(u: &mut Unstructured<'_>) -> arbitrary::Result<Probability> {
     let percent: u8 = u.int_in_range(1..=100)?;
     Ok(probability!(u64::from(percent), 100))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use commonware_runtime::deterministic::PartialWriteMode;
+
+    /// Build a fault seed from the selector bytes the decoder consumes.
+    fn seed(mutation: u8, failure: u8, retention: u8, partial: u8, mode: u8) -> u64 {
+        u64::from_le_bytes([mutation, failure, retention, partial, mode, 0, 0, 0])
+    }
+
+    /// Pin the seed-to-config decoding: a regression here would silently skew or
+    /// disable fault injection in every recovery target's faulted pass.
+    #[test]
+    fn test_recovery_fault_config_decoding() {
+        // Mutation 0 injects write failures with the selected retention and mode.
+        let config = recovery_fault_config(seed(0, 49, 25, 0, 0));
+        let write = config.write_rate.unwrap();
+        assert_eq!(write.failure_rate, probability!(50, 100));
+        assert_eq!(write.retention_rate, probability!(25, 100));
+        assert_eq!(write.mode, PartialWriteMode::Prefix);
+        assert!(config.sync_rate.is_none());
+        assert!(config.resize_rate.is_none());
+        assert!(config.remove_rate.is_none());
+
+        // Mutations 1..=3 zero the write failure rate but keep crash retention and
+        // mode, routing the failure rate to sync, resize, or remove respectively.
+        let config = recovery_fault_config(seed(1, 99, 100, 0, 1));
+        let write = config.write_rate.unwrap();
+        assert_eq!(write.failure_rate, probability!(0, 1));
+        assert_eq!(write.retention_rate, probability!(100, 100));
+        assert_eq!(write.mode, PartialWriteMode::Subset);
+        assert_eq!(config.sync_rate, Some(probability!(100, 100)));
+        assert!(config.resize_rate.is_none());
+        assert!(config.remove_rate.is_none());
+
+        let config = recovery_fault_config(seed(2, 0, 0, 75, 0));
+        let resize = config.resize_rate.unwrap();
+        assert_eq!(resize.failure_rate, probability!(1, 100));
+        assert_eq!(resize.partial_rate, probability!(75, 100));
+        assert_eq!(config.write_rate.unwrap().failure_rate, probability!(0, 1));
+        assert!(config.sync_rate.is_none());
+        assert!(config.remove_rate.is_none());
+
+        let config = recovery_fault_config(seed(3, 199, 0, 0, 0));
+        assert_eq!(config.remove_rate, Some(probability!(100, 100)));
+        assert!(config.sync_rate.is_none());
+        assert!(config.resize_rate.is_none());
+
+        // Selector bits above the two-bit mutation mask are ignored.
+        let config = recovery_fault_config(seed(0x04, 0, 0, 0, 0));
+        assert_eq!(
+            config.write_rate.unwrap().failure_rate,
+            probability!(1, 100)
+        );
+    }
 }

--- a/storage/src/archive/prunable/mod.rs
+++ b/storage/src/archive/prunable/mod.rs
@@ -486,7 +486,7 @@ mod tests {
             pending.arm();
             let completed = Arc::new(AtomicUsize::new(0));
             let completed_clone = completed.clone();
-            let task = context.inner.child("put_sync").spawn(|_| async move {
+            let task = context.inner.child("put_multi_sync").spawn(|_| async move {
                 let result = archive.put_multi_sync(0, test_key("pruned"), 0).await;
                 completed_clone.store(1, Ordering::Relaxed);
                 result

--- a/storage/src/archive/prunable/storage.rs
+++ b/storage/src/archive/prunable/storage.rs
@@ -223,7 +223,7 @@ impl<T: Translator, E: Context, K: Array, V: CodecShared> Inner<T, E, K, V> {
         let mut intervals = RMap::new();
         debug!("initializing archive from index journal");
         while let Some(result) = replay.next().await {
-            let (_, position, entry) = result?;
+            let (_, position, entry) = result.map_err(map_journal_error)?;
 
             // Index every retained occurrence by position, translated key, and range.
             match indices.entry(entry.index) {

--- a/storage/src/freezer/mod.rs
+++ b/storage/src/freezer/mod.rs
@@ -163,9 +163,10 @@
 //!
 //! [Freezer::sync] and [Freezer::close] return a [Checkpoint] for recovering existing data.
 //! When a checkpoint is provided, [Freezer::init] rewinds the journals to the checkpoint, truncates
-//! a longer table to the checkpointed table size, and clears invalid or newer table entries. A table
-//! shorter than the checkpointed size cannot back the checkpointed entries and fails initialization. Passing `None`
-//! or an empty checkpoint to [Freezer::init] deletes any existing freezer data and starts empty.
+//! a longer table to the checkpointed table size, and clears invalid or newer table entries. A
+//! table shorter than the checkpointed size cannot back the checkpointed entries and fails
+//! initialization. Passing `None` or an empty checkpoint to [Freezer::init] deletes any existing
+//! freezer data and starts empty.
 //!
 //! # Example
 //!

--- a/storage/src/journal/durability.rs
+++ b/storage/src/journal/durability.rs
@@ -59,14 +59,11 @@ impl Barrier {
         }
     }
 
-    /// Track a sync started at `boundary`, returning the proof established without observing its
-    /// completion.
-    pub(crate) fn record(&mut self, boundary: u64, completion: SyncCompletion) -> u64 {
+    /// Track a sync started at `boundary`.
+    pub(crate) fn record(&mut self, boundary: u64, completion: SyncCompletion) {
         // Preserve a completed prior proof before replacing its observer.
         self.observe();
-        let previous = self.boundary;
         self.pending = Some((boundary, completion));
-        previous
     }
 
     /// Lower the proven boundary after storage moves backward.

--- a/storage/src/journal/segmented/fixed.rs
+++ b/storage/src/journal/segmented/fixed.rs
@@ -268,10 +268,13 @@ impl<E: Storage + Metrics, A: CodecFixedShared> Inner<E, A> {
     }
 
     /// Classify an invalid or missing boundary as committed corruption without hiding I/O errors.
-    fn boundary_error(section: u64, required: u64, err: RError) -> Error {
+    ///
+    /// `searched` is the extent the boundary read covered: the current section's logical
+    /// boundary size, or an earlier section's physical blob size.
+    fn boundary_error(section: u64, searched: u64, err: RError) -> Error {
         match err {
             RError::InvalidChecksum | RError::BlobInsufficientLength => Error::Corruption(format!(
-                "section {section} does not retain its {required}-byte durable boundary"
+                "section {section} does not retain a valid durable boundary within {searched} bytes"
             )),
             err => Error::Runtime(err),
         }

--- a/storage/src/journal/segmented/oversized.rs
+++ b/storage/src/journal/segmented/oversized.rs
@@ -1145,8 +1145,10 @@ impl<E: Context, I: Record + Send + Sync, V: CodecShared> Replay<E, I, V> {
     /// Returns the next `(section, position, entry)`, or `None` once every section is
     /// exhausted.
     ///
-    /// An error ends the section that produced it, and iteration continues with the
-    /// next section. Errors while mutating storage to repair a section, and
+    /// An index error ends the section that produced it, and iteration continues with
+    /// the next section. A value-verification error is returned without ending its
+    /// section and dooms the tracked replay: finishing it fails with
+    /// [Error::ReplayFailed]. Errors while mutating storage to repair a section, and
     /// [Error::ReplayInterrupted], end the replay.
     pub async fn next(&mut self) -> Option<Result<(u64, u64, I), Error>> {
         loop {

--- a/storage/src/journal/utils.rs
+++ b/storage/src/journal/utils.rs
@@ -17,9 +17,13 @@ pub(crate) async fn corrupt_page(
     let physical_page_size = logical_page_size + CHECKSUM_SIZE;
     let offset = page * physical_page_size;
     let (blob, size) = context.open(partition, &blob.to_be_bytes()).await.unwrap();
+
+    // A complete physical page must follow the target: a trailing partial page can never
+    // validate, so a target followed only by one would be the last validatable page.
     assert!(
-        size.checked_sub(physical_page_size)
-            .is_some_and(|remaining| offset < remaining),
+        offset
+            .checked_add(physical_page_size * 2)
+            .is_some_and(|end| end <= size),
         "corruption target must be an interior page"
     );
     let byte = blob


### PR DESCRIPTION
**Stack 4/4** splitting #4546. Top of the stack: this tree is byte-identical to `v1-fuzzing` (c81001ed6).

Closes every confirmed finding from the adversarial review of the recovery harnesses, validated empirically by mutation testing (10 deliberate recovery-path breakages: 8 caught, 2 survivors are documented coverage boundaries — orphan value sections are unreachable without a prune op, and the untruncated trailing table region is invisible to mask-based reads):

- `current_crash_recovery` records a root per commit boundary and requires the recovered (state, root) pair to jointly match one, closing the circular authenticated oracle. The self-consistent bitmap-flip mutation is caught by exactly this assert; the previous oracle was blind to it.
- `queue_crash_recovery` pins the recovered ack floor to the modeled prune-clamp boundary, bounds recovered size above, verifies content at every tracked position, and panics on impossible-in-model errors (dequeue/ack).
- Interrupted final syncs park behind the armed one-shot gate (segmented/oversized/prunable), assert success and credit full durability when they run to completion, with poll knobs reduced to their real cut granularity.
- `oversized_recovery` asserts glob truncation to the last retained entry's end and index/value section pairing; `segmented_variable_recovery` asserts every crash image is a per-section prefix of the scripted appends and probes the append gate for any valid-prefix section; merkle gains `Flush`/`StartSync` ops and prune durability credits; freezer gains the fail-second cut and a deepened completed-resize baseline; metadata snapshots the full key set and routes its faulted pass to mutation arms it can exercise.
- `faulted_recovery` clears the fault config before its crash (its fault-free-checkpoint doc is now true) and the seed decoder gains a pinning unit test. Small production fixes: `Barrier::record` returns nothing again, prunable replay errors keep the archive error taxonomy, `corrupt_page` rejects the last validatable page, and `Writer::new` documents its wrap contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)