### PR TITLE
[storage] Recover segmented journals from partial writes

### DIFF
--- a/runtime/fuzz/fuzz_targets/buffer.rs
+++ b/runtime/fuzz/fuzz_targets/buffer.rs
@@ -9,7 +9,7 @@ use commonware_runtime::{
     },
     deterministic,
 };
-use commonware_utils::{NZU16, NZU32, NZUsize};
+use commonware_utils::{NZU16, NZU32, NZUsize, Widen};
 use libfuzzer_sys::fuzz_target;
 
 const MAX_SIZE: usize = 1024 * 1024;
@@ -314,8 +314,9 @@ fn fuzz(input: FuzzInput) {
                 } => {
                     if let Some(ref cache) = cache_ref {
                         let offset = offset as u64;
-                        if data.len() >= cache.page_size() as usize {
-                            let data = &data[..cache.page_size() as usize];
+                        let page_size: usize = cache.page_size().widen();
+                        if data.len() >= page_size {
+                            let data = &data[..page_size];
                             if let Some(cache_page_size) = cache_page_size_ref {
                                 let aligned_offset =
                                     (offset / cache_page_size as u64) * cache_page_size as u64;

--- a/runtime/src/utils/buffer/paged/cache.rs
+++ b/runtime/src/utils/buffer/paged/cache.rs
@@ -511,15 +511,13 @@ impl Cache {
     /// page boundary, so multiple reads may be required even if all data in the desired range is
     /// buffered.
     fn read_at(&self, blob_id: u64, buf: &mut [u8], logical_offset: u64) -> usize {
-        let (page_num, offset_in_page) = Self::offset_to_page(self.page_size, logical_offset);
+        let (page_num, offset_in_page, remaining) = Self::locate(self.page_size, logical_offset);
         let Some(page) = self.get_page(blob_id, page_num) else {
             return 0;
         };
         let page = page.as_ref();
 
-        let offset_in_page = offset_in_page as usize;
-        let width: usize = self.page_size.widen();
-        let bytes_to_copy = std::cmp::min(buf.len(), width - offset_in_page);
+        let bytes_to_copy = std::cmp::min(buf.len(), remaining);
         buf[..bytes_to_copy].copy_from_slice(&page[offset_in_page..offset_in_page + bytes_to_copy]);
 
         bytes_to_copy

--- a/runtime/src/utils/buffer/paged/cache.rs
+++ b/runtime/src/utils/buffer/paged/cache.rs
@@ -4,7 +4,7 @@
 use super::{CHECKSUM_SIZE, STORAGE_PAGE_SIZE, get_page_from_blob};
 use crate::{Blob, BufferPool, BufferPooler, Error, IoBuf, IoBufMut, ReadOptions};
 use ahash::AHashMap;
-use commonware_utils::{cache::Clock, sync::RwLock};
+use commonware_utils::{Widen, cache::Clock, sync::RwLock};
 use futures::{FutureExt, future::Shared};
 use std::{
     collections::hash_map::Entry,
@@ -121,7 +121,7 @@ struct Cache {
 
     /// Logical size of each page in bytes (the payload stored per page, excluding the CRC
     /// record appended on disk).
-    page_size: usize,
+    page_size: NonZeroU16,
 
     /// Pool the page buffers were allocated from.
     pool: BufferPool,
@@ -146,7 +146,7 @@ pub struct CacheRef {
     /// blob for writing treats the mismatched pages as invalid trailing data and silently truncates
     /// the blob (potentially to empty). Changing an existing store's page size is a destructive
     /// format migration, not a configuration change.
-    page_size: u64,
+    page_size: NonZeroU16,
 
     /// The next id to assign to a blob that will be managed by this cache.
     next_id: Arc<AtomicU64>,
@@ -169,7 +169,7 @@ impl CacheRef {
     /// the module docs) amplify cold random reads. Use [super::page_size] to pick an aligned value.
     /// Cache misses request [ReadOptions::DONT_CACHE] because the fetched page is retained here.
     pub fn new(pool: BufferPool, page_size: NonZeroU16, capacity: NonZeroUsize) -> Self {
-        let page_size_u64 = page_size.get() as u64;
+        let page_size_u64: u64 = page_size.widen();
         let physical_page_size = page_size_u64 + CHECKSUM_SIZE;
         if !physical_page_size.is_multiple_of(STORAGE_PAGE_SIZE)
             && !STORAGE_PAGE_SIZE.is_multiple_of(physical_page_size)
@@ -181,7 +181,7 @@ impl CacheRef {
         }
 
         Self {
-            page_size: page_size_u64,
+            page_size,
             next_id: Arc::new(AtomicU64::new(0)),
             cache: Arc::new(RwLock::new(Cache::new(pool.clone(), page_size, capacity))),
             pool,
@@ -201,7 +201,7 @@ impl CacheRef {
     /// The page size used by this page cache: the logical payload bytes stored per page. Each
     /// page occupies `page_size() + CHECKSUM_SIZE` bytes on disk (its physical size).
     #[inline]
-    pub const fn page_size(&self) -> u64 {
+    pub const fn page_size(&self) -> NonZeroU16 {
         self.page_size
     }
 
@@ -218,7 +218,7 @@ impl CacheRef {
 
     /// Convert a logical offset into the number of the page it belongs to and the offset within
     /// that page.
-    pub const fn offset_to_page(&self, offset: u64) -> (u64, u64) {
+    pub fn offset_to_page(&self, offset: u64) -> (u64, u64) {
         Cache::offset_to_page(self.page_size, offset)
     }
 
@@ -259,9 +259,8 @@ impl CacheRef {
         // stalling each lookup behind the previous range's copy.
         let mut srcs: Vec<Option<&[u8]>> = Vec::with_capacity(ranges.len());
         for (buf, offset) in ranges.iter() {
-            let (page_num, offset_in_page) = Cache::offset_to_page(page_size as u64, *offset);
-            let offset_in_page = offset_in_page as usize;
-            let seg = std::cmp::min(buf.len(), page_size - offset_in_page);
+            let (page_num, offset_in_page, remaining) = Cache::locate(page_size, *offset);
+            let seg = std::cmp::min(buf.len(), remaining);
             srcs.push(
                 page_cache
                     .get_page(blob_id, page_num)
@@ -341,8 +340,7 @@ impl CacheRef {
     ) -> Result<usize, Error> {
         assert!(!buf.is_empty());
 
-        let (page_num, offset_in_page) = Cache::offset_to_page(self.page_size, offset);
-        let offset_in_page = offset_in_page as usize;
+        let (page_num, offset_in_page, _) = Cache::locate(self.page_size, offset);
         trace!(page_num, blob_id, "page fault");
 
         // Create or clone a future that retrieves the desired page from the underlying blob. This
@@ -442,7 +440,7 @@ impl CacheRef {
         assert_eq!(offset_in_page, 0);
         {
             // Write lock the page cache.
-            let page_size = self.page_size as usize;
+            let page_size: usize = self.page_size.widen();
             let mut page_cache = self.cache.write();
             while buf.len() >= page_size {
                 page_cache.cache(blob_id, &buf[..page_size], page_num);
@@ -477,9 +475,9 @@ impl Cache {
     /// Return a new empty page cache with a max cache capacity of `capacity` pages, each of size
     /// `page_size` bytes.
     pub fn new(pool: BufferPool, page_size: NonZeroU16, capacity: NonZeroUsize) -> Self {
-        let page_size = page_size.get() as usize;
+        let slot_size: usize = page_size.widen();
         let mut cache = Clock::new(capacity);
-        cache.prefill(|| pool.alloc_zeroed(page_size));
+        cache.prefill(|| pool.alloc_zeroed(slot_size));
         let hints = capacity.get().saturating_mul(2).next_power_of_two();
         Self {
             cache,
@@ -492,8 +490,19 @@ impl Cache {
 
     /// Convert a logical offset into the number of the page it belongs to and the offset within
     /// that page.
-    const fn offset_to_page(page_size: u64, offset: u64) -> (u64, u64) {
+    fn offset_to_page(page_size: NonZeroU16, offset: u64) -> (u64, u64) {
+        let page_size: u64 = page_size.widen();
         (offset / page_size, offset % page_size)
+    }
+
+    /// Locate `offset` within its page: the page number, the offset inside that page, and the
+    /// bytes remaining in the page at that offset.
+    fn locate(page_size: NonZeroU16, offset: u64) -> (u64, usize, usize) {
+        let (page_num, offset_in_page) = Self::offset_to_page(page_size, offset);
+        let offset_in_page = offset_in_page as usize;
+        let width: usize = page_size.widen();
+        let remaining = width - offset_in_page;
+        (page_num, offset_in_page, remaining)
     }
 
     /// Attempt to fetch blob data starting at `offset` from the page cache. Returns the number of
@@ -502,15 +511,15 @@ impl Cache {
     /// page boundary, so multiple reads may be required even if all data in the desired range is
     /// buffered.
     fn read_at(&self, blob_id: u64, buf: &mut [u8], logical_offset: u64) -> usize {
-        let (page_num, offset_in_page) =
-            Self::offset_to_page(self.page_size as u64, logical_offset);
+        let (page_num, offset_in_page) = Self::offset_to_page(self.page_size, logical_offset);
         let Some(page) = self.get_page(blob_id, page_num) else {
             return 0;
         };
         let page = page.as_ref();
 
         let offset_in_page = offset_in_page as usize;
-        let bytes_to_copy = std::cmp::min(buf.len(), self.page_size - offset_in_page);
+        let width: usize = self.page_size.widen();
+        let bytes_to_copy = std::cmp::min(buf.len(), width - offset_in_page);
         buf[..bytes_to_copy].copy_from_slice(&page[offset_in_page..offset_in_page + bytes_to_copy]);
 
         bytes_to_copy
@@ -518,9 +527,9 @@ impl Cache {
 
     /// Put the given `page` into the page cache and record its slot hint.
     fn cache(&mut self, blob_id: u64, page: &[u8], page_num: u64) {
-        assert_eq!(page.len(), self.page_size);
+        let page_size: usize = self.page_size.widen();
+        assert_eq!(page.len(), page_size);
         let pool = &self.pool;
-        let page_size = self.page_size;
         let (slot, buf) = self
             .cache
             .get_or_insert_mut((blob_id, page_num), || pool.alloc_zeroed(page_size));
@@ -573,17 +582,19 @@ impl Cache {
 async fn fetch_cacheable_page(
     blob: &impl Blob,
     page_num: u64,
-    page_size: u64,
+    page_size: NonZeroU16,
 ) -> Result<IoBuf, Arc<Error>> {
     // CacheRef retains the page, so the source page need not remain in the OS page cache.
-    let page = get_page_from_blob(blob, page_num, page_size, ReadOptions::DONT_CACHE)
+    let width: u64 = page_size.widen();
+    let page = get_page_from_blob(blob, page_num, width, ReadOptions::DONT_CACHE)
         .await
         .map_err(Arc::new)?;
 
     // We should never be fetching partial pages through the page cache. This can happen if a
     // non-last page is corrupted and falls back to a partial CRC.
     let len = page.len();
-    if len != page_size as usize {
+    let expected: usize = page_size.widen();
+    if len != expected {
         error!(
             page_num,
             expected = page_size,

--- a/runtime/src/utils/buffer/paged/sealed.rs
+++ b/runtime/src/utils/buffer/paged/sealed.rs
@@ -15,10 +15,7 @@
 use super::{CHECKSUM_SIZE, CacheRef, Replay, read::PageReader, view::View};
 use crate::{Blob, Error, IoBuf, IoBufMut, IoBufs, ReadOptions};
 use commonware_utils::Widen;
-use std::{
-    num::{NonZeroU16, NonZeroUsize},
-    sync::Arc,
-};
+use std::{num::NonZeroUsize, sync::Arc};
 
 /// An immutable, page-cache-backed read handle for a [Blob]. The read-only counterpart to
 /// [`super::Writer`].
@@ -180,8 +177,8 @@ impl<B: Blob> Sealed<B> {
         buffer_size: NonZeroUsize,
         read_options: ReadOptions,
     ) -> Result<Replay<B>, Error> {
-        let page_size: u64 = self.inner.cache_ref.page_size().widen();
-        let page_size_nz = NonZeroU16::new(page_size as u16).expect("page_size is non-zero");
+        let page_size_nz = self.inner.cache_ref.page_size();
+        let page_size: u64 = page_size_nz.widen();
         let physical_page_size = page_size
             .checked_add(CHECKSUM_SIZE)
             .ok_or(Error::OffsetOverflow)?;
@@ -229,6 +226,7 @@ mod tests {
     };
     use commonware_macros::test_traced;
     use commonware_utils::{NZU16, NZUsize};
+    use std::num::NonZeroU16;
 
     const PAGE_SIZE: NonZeroU16 = NZU16!(103); // janky page size to test alignment
     const BUFFER_SIZE: usize = PAGE_SIZE.get() as usize * 2;

--- a/runtime/src/utils/buffer/paged/sealed.rs
+++ b/runtime/src/utils/buffer/paged/sealed.rs
@@ -14,6 +14,7 @@
 
 use super::{CHECKSUM_SIZE, CacheRef, Replay, read::PageReader, view::View};
 use crate::{Blob, Error, IoBuf, IoBufMut, IoBufs, ReadOptions};
+use commonware_utils::Widen;
 use std::{
     num::{NonZeroU16, NonZeroUsize},
     sync::Arc,
@@ -179,7 +180,7 @@ impl<B: Blob> Sealed<B> {
         buffer_size: NonZeroUsize,
         read_options: ReadOptions,
     ) -> Result<Replay<B>, Error> {
-        let page_size = self.inner.cache_ref.page_size();
+        let page_size: u64 = self.inner.cache_ref.page_size().widen();
         let page_size_nz = NonZeroU16::new(page_size as u16).expect("page_size is non-zero");
         let physical_page_size = page_size
             .checked_add(CHECKSUM_SIZE)

--- a/runtime/src/utils/buffer/paged/writer.rs
+++ b/runtime/src/utils/buffer/paged/writer.rs
@@ -848,8 +848,8 @@ impl<B: Blob> Writer<B> {
         buffer_size: NonZeroUsize,
         read_options: ReadOptions,
     ) -> Result<Replay<B>, Error> {
-        let page_size: u64 = self.cache_ref.page_size().widen();
-        let page_size_nz = NonZeroU16::new(page_size as u16).expect("page_size is non-zero");
+        let page_size_nz = self.cache_ref.page_size();
+        let page_size: u64 = page_size_nz.widen();
 
         // Flush any buffered data (without fsync) so the reader sees all written data.
         self.flush_internal(true, false).await?;
@@ -1009,6 +1009,21 @@ impl<B: Blob> Writer<B> {
         Ok(valid_len)
     }
 
+    /// Read and validate one page, returning its logical bytes and the range they cover.
+    async fn read_page(
+        blob: &B,
+        page: u64,
+        page_size: u64,
+        read_options: ReadOptions,
+    ) -> Result<(IoBuf, u64, u64), Error> {
+        let (logical, _) =
+            super::get_page_with_checksum_from_blob(blob, page, page_size, read_options).await?;
+        let start = page.checked_mul(page_size).ok_or(Error::OffsetOverflow)?;
+        let len = u64::try_from(logical.len()).map_err(|_| Error::OffsetOverflow)?;
+        let end = start.checked_add(len).ok_or(Error::OffsetOverflow)?;
+        Ok((logical, start, end))
+    }
+
     /// Read a logical range directly from a raw paged blob, validating every page it spans.
     ///
     /// Returns [Error::BlobInsufficientLength] when valid page contents do not cover the whole
@@ -1035,20 +1050,8 @@ impl<B: Blob> Writer<B> {
 
         // Validate every spanning page and append only its intersection with the requested range.
         for page in first_page..=last_page {
-            let (logical, _) = super::get_page_with_checksum_from_blob(
-                blob,
-                page,
-                logical_page_size,
-                read_options,
-            )
-            .await?;
-            let page_start = page
-                .checked_mul(logical_page_size)
-                .ok_or(Error::OffsetOverflow)?;
-            let logical_len = u64::try_from(logical.len()).map_err(|_| Error::OffsetOverflow)?;
-            let page_end = page_start
-                .checked_add(logical_len)
-                .ok_or(Error::OffsetOverflow)?;
+            let (logical, page_start, page_end) =
+                Self::read_page(blob, page, logical_page_size, read_options).await?;
             let overlap_start = offset.max(page_start);
             let overlap_end = end.min(page_end);
             if overlap_start >= overlap_end {
@@ -1096,12 +1099,8 @@ impl<B: Blob> Writer<B> {
 
         // The checksum length on the terminal page determines the blob's logical end.
         let page = physical_size / physical_page_size - 1;
-        let (tail, _) =
-            super::get_page_with_checksum_from_blob(blob, page, page_size, read_options).await?;
-        let page_start = page.checked_mul(page_size).ok_or(Error::OffsetOverflow)?;
-        let logical_size = page_start
-            .checked_add(u64::try_from(tail.len()).map_err(|_| Error::OffsetOverflow)?)
-            .ok_or(Error::OffsetOverflow)?;
+        let (tail, page_start, logical_size) =
+            Self::read_page(blob, page, page_size, read_options).await?;
         let len_u64 = u64::try_from(len).map_err(|_| Error::OffsetOverflow)?;
         let offset = logical_size
             .checked_sub(len_u64)

--- a/runtime/src/utils/buffer/paged/writer.rs
+++ b/runtime/src/utils/buffer/paged/writer.rs
@@ -51,6 +51,7 @@ use crate::{
 };
 use bytes::BufMut;
 use commonware_cryptography::Crc32;
+use commonware_utils::Widen;
 use std::num::{NonZeroU16, NonZeroUsize};
 use tracing::warn;
 
@@ -143,11 +144,12 @@ impl<B: Blob> Writer<B> {
         capacity: usize,
         cache_ref: CacheRef,
     ) -> Result<Self, Error> {
+        let page_size: u64 = cache_ref.page_size().widen();
         let (partial_page_state, pages, invalid_data_found) =
-            Self::read_last_valid_page(&blob, original_blob_size, cache_ref.page_size()).await?;
+            Self::read_last_valid_page(&blob, original_blob_size, page_size).await?;
         if invalid_data_found {
             // Invalid data was detected, trim it from the blob.
-            let new_blob_size = pages * (cache_ref.page_size() + CHECKSUM_SIZE);
+            let new_blob_size = pages * (page_size + CHECKSUM_SIZE);
             warn!(
                 original_blob_size,
                 new_blob_size, "truncating blob to remove invalid data"
@@ -156,7 +158,7 @@ impl<B: Blob> Writer<B> {
             blob.sync().await?;
         }
 
-        let capacity = adjusted_capacity(capacity, cache_ref.page_size());
+        let capacity = adjusted_capacity(capacity, page_size);
         let needs_sync = !invalid_data_found; // ensure pending writes on the wrapped blob are synced
 
         let (current_page, partial_page_state, partial_data) = match partial_page_state {
@@ -165,7 +167,7 @@ impl<B: Blob> Writer<B> {
         };
 
         let buffer = Buffer::from(
-            current_page * cache_ref.page_size(),
+            current_page * page_size,
             partial_data.unwrap_or_default(),
             capacity,
             cache_ref.pool().clone(),
@@ -263,7 +265,7 @@ impl<B: Blob> Writer<B> {
     /// Append all bytes in `buf` to the tip of the blob, returning the logical offset at which
     /// the first byte was written.
     pub async fn append(&mut self, buf: &[u8]) -> Result<u64, Error> {
-        let page_size = self.cache_ref.page_size() as usize;
+        let page_size: usize = self.cache_ref.page_size().widen();
 
         // Bypass the write buffer and write whole pages directly when `buf` is large.
         if too_big_for_buffer(
@@ -288,7 +290,7 @@ impl<B: Blob> Writer<B> {
     /// blob, and leave only a sub-page suffix in the write buffer. This avoids copying full-page
     /// payloads while preserving the invariant that the buffer starts at `current_page`.
     pub async fn append_owned(&mut self, buf: IoBuf) -> Result<u64, Error> {
-        let page_size = self.cache_ref.page_size() as usize;
+        let page_size: usize = self.cache_ref.page_size().widen();
         let offset = self.buffer.size();
 
         // Buffer the append unless `buf` is too big for the buffer.
@@ -364,13 +366,11 @@ impl<B: Blob> Writer<B> {
         self.buffer.replace(boundary + bulk_len as u64, suffix);
 
         // Make sure the buffer offset and underlying blob agree on the state of the tip.
-        assert_eq!(
-            self.current_page * self.cache_ref.page_size(),
-            self.buffer.offset
-        );
+        let page_size: u64 = self.cache_ref.page_size().widen();
+        assert_eq!(self.current_page * page_size, self.buffer.offset);
 
-        let physical_page_size = page_size as u64 + CHECKSUM_SIZE;
-        let write_at_offset = boundary / page_size as u64 * physical_page_size;
+        let physical_page_size = page_size + CHECKSUM_SIZE;
+        let write_at_offset = boundary / page_size * physical_page_size;
         self.sync_state
             .write_at(
                 &self.blob,
@@ -398,7 +398,7 @@ impl<B: Blob> Writer<B> {
 
     /// Whether a flush would emit any physical page write.
     fn has_flush_work(&self, write_partial_page: bool) -> bool {
-        let page_size = self.cache_ref.page_size() as usize;
+        let page_size: usize = self.cache_ref.page_size().widen();
         let full_pages = self.buffer.len() / page_size;
         if full_pages > 0 {
             return true;
@@ -460,7 +460,7 @@ impl<B: Blob> Writer<B> {
 
         // Split buffered bytes into full logical pages to hand off now, leaving any trailing
         // partial page in tip for continued buffering.
-        let page_size = self.cache_ref.page_size() as usize;
+        let page_size: usize = self.cache_ref.page_size().widen();
         let pages_to_cache = self.buffer.len() / page_size;
         let bytes_to_drain = pages_to_cache * page_size;
 
@@ -510,7 +510,8 @@ impl<B: Blob> Writer<B> {
         };
 
         // Make sure the buffer offset and underlying blob agree on the state of the tip.
-        assert_eq!(self.current_page * self.cache_ref.page_size(), new_offset);
+        let page_size: u64 = self.cache_ref.page_size().widen();
+        assert_eq!(self.current_page * page_size, new_offset);
 
         // Rewriting a physical page resubmits its durable bytes and protected checksum
         // unchanged, so a torn write leaves the durable state recoverable.
@@ -640,7 +641,7 @@ impl<B: Blob> Writer<B> {
         flushed: Option<&ActiveChecksum>,
         durable: Option<&ActiveChecksum>,
     ) -> (IoBufs, Option<ActiveChecksum>) {
-        let page_size = self.cache_ref.page_size() as usize;
+        let page_size: usize = self.cache_ref.page_size().widen();
         let physical_page_size = page_size + CHECKSUM_SIZE as usize;
         let pages_to_write = buffer.len() / page_size;
         let mut write_buffer = IoBufs::default();
@@ -696,7 +697,7 @@ impl<B: Blob> Writer<B> {
         old_checksum: Option<&ActiveChecksum>,
         write_buffer: &mut IoBufs,
     ) {
-        let page_size = self.cache_ref.page_size() as usize;
+        let page_size: usize = self.cache_ref.page_size().widen();
         let pages = data.len() / page_size;
         debug_assert!(pages > 0);
         debug_assert_eq!(data.len() % page_size, 0);
@@ -847,7 +848,7 @@ impl<B: Blob> Writer<B> {
         buffer_size: NonZeroUsize,
         read_options: ReadOptions,
     ) -> Result<Replay<B>, Error> {
-        let page_size = self.cache_ref.page_size();
+        let page_size: u64 = self.cache_ref.page_size().widen();
         let page_size_nz = NonZeroU16::new(page_size as u16).expect("page_size is non-zero");
 
         // Flush any buffered data (without fsync) so the reader sees all written data.
@@ -953,7 +954,7 @@ impl<B: Blob> Writer<B> {
         buffer_size: NonZeroUsize,
         read_options: ReadOptions,
     ) -> Result<u64, Error> {
-        let logical_page_size = self.cache_ref.page_size();
+        let logical_page_size: u64 = self.cache_ref.page_size().widen();
         let total_pages = self.current_page + u64::from(self.partial_page_state.is_some());
         let physical_page_size = logical_page_size
             .checked_add(CHECKSUM_SIZE)
@@ -1027,7 +1028,7 @@ impl<B: Blob> Writer<B> {
         }
 
         // Identify the inclusive logical page range spanning the requested bytes.
-        let logical_page_size = u64::from(logical_page_size.get());
+        let logical_page_size: u64 = logical_page_size.widen();
         let first_page = offset / logical_page_size;
         let last_page = (end - 1) / logical_page_size;
         let mut out = IoBufs::default();
@@ -1085,7 +1086,7 @@ impl<B: Blob> Writer<B> {
             };
         }
 
-        let page_size = u64::from(logical_page_size.get());
+        let page_size: u64 = logical_page_size.widen();
         let physical_page_size = page_size
             .checked_add(CHECKSUM_SIZE)
             .ok_or(Error::OffsetOverflow)?;
@@ -1157,7 +1158,7 @@ impl<B: Blob> Writer<B> {
 
     /// Coordinate the dispatch logic for shrinking the blob.
     async fn shrink(&mut self, target_size: u64) -> Result<(), Error> {
-        let page_size = self.cache_ref.page_size();
+        let page_size: u64 = self.cache_ref.page_size().widen();
         let physical_page_size = page_size
             .checked_add(CHECKSUM_SIZE)
             .ok_or(Error::OffsetOverflow)?;
@@ -1278,7 +1279,7 @@ impl<B: Blob> Writer<B> {
 
     /// Construct an immutable read handle for the current blob state.
     fn sealed_handle(&self, id: u64) -> super::Sealed<B> {
-        let page_size = self.cache_ref.page_size();
+        let page_size: u64 = self.cache_ref.page_size().widen();
         let full_pages = self.current_page;
         assert_eq!(
             full_pages.checked_mul(page_size),

--- a/runtime/src/utils/buffer/paged/writer.rs
+++ b/runtime/src/utils/buffer/paged/writer.rs
@@ -1008,6 +1008,120 @@ impl<B: Blob> Writer<B> {
         Ok(valid_len)
     }
 
+    /// Read a logical range directly from a raw paged blob, validating every page it spans.
+    ///
+    /// Returns [Error::BlobInsufficientLength] when valid page contents do not cover the whole
+    /// range, and [Error::OffsetOverflow] when its end or page offsets overflow.
+    pub async fn read_validated(
+        blob: &B,
+        logical_page_size: NonZeroU16,
+        offset: u64,
+        len: usize,
+        read_options: ReadOptions,
+    ) -> Result<IoBufs, Error> {
+        // Resolve the requested range before allocating or reading any pages.
+        let len_u64 = u64::try_from(len).map_err(|_| Error::OffsetOverflow)?;
+        let end = offset.checked_add(len_u64).ok_or(Error::OffsetOverflow)?;
+        if len == 0 {
+            return Ok(IoBufs::default());
+        }
+
+        // Identify the inclusive logical page range spanning the requested bytes.
+        let logical_page_size = u64::from(logical_page_size.get());
+        let first_page = offset / logical_page_size;
+        let last_page = (end - 1) / logical_page_size;
+        let mut out = IoBufs::default();
+
+        // Validate every spanning page and append only its intersection with the requested range.
+        for page in first_page..=last_page {
+            let (logical, _) = super::get_page_with_checksum_from_blob(
+                blob,
+                page,
+                logical_page_size,
+                read_options,
+            )
+            .await?;
+            let page_start = page
+                .checked_mul(logical_page_size)
+                .ok_or(Error::OffsetOverflow)?;
+            let logical_len = u64::try_from(logical.len()).map_err(|_| Error::OffsetOverflow)?;
+            let page_end = page_start
+                .checked_add(logical_len)
+                .ok_or(Error::OffsetOverflow)?;
+            let overlap_start = offset.max(page_start);
+            let overlap_end = end.min(page_end);
+            if overlap_start >= overlap_end {
+                return Err(Error::BlobInsufficientLength);
+            }
+            let start = (overlap_start - page_start) as usize;
+            let end = (overlap_end - page_start) as usize;
+            out.append(logical.slice(start..end));
+        }
+
+        // A short terminal page can leave the requested range only partially covered.
+        if out.len() != len {
+            return Err(Error::BlobInsufficientLength);
+        }
+        Ok(out)
+    }
+
+    /// Read the terminal logical range of a raw paged blob and return its logical size.
+    ///
+    /// The blob must contain only complete physical pages. The last page is validated first to
+    /// determine the logical end. If `len` crosses a page boundary, preceding pages are validated
+    /// with [Self::read_validated].
+    pub async fn read_validated_tail(
+        blob: &B,
+        physical_size: u64,
+        logical_page_size: NonZeroU16,
+        len: usize,
+        read_options: ReadOptions,
+    ) -> Result<(u64, IoBufs), Error> {
+        if physical_size == 0 {
+            return if len == 0 {
+                Ok((0, IoBufs::default()))
+            } else {
+                Err(Error::BlobInsufficientLength)
+            };
+        }
+
+        let page_size = u64::from(logical_page_size.get());
+        let physical_page_size = page_size
+            .checked_add(CHECKSUM_SIZE)
+            .ok_or(Error::OffsetOverflow)?;
+        if !physical_size.is_multiple_of(physical_page_size) {
+            return Err(Error::BlobInsufficientLength);
+        }
+
+        // The checksum length on the terminal page determines the blob's logical end.
+        let page = physical_size / physical_page_size - 1;
+        let (tail, _) =
+            super::get_page_with_checksum_from_blob(blob, page, page_size, read_options).await?;
+        let page_start = page.checked_mul(page_size).ok_or(Error::OffsetOverflow)?;
+        let logical_size = page_start
+            .checked_add(u64::try_from(tail.len()).map_err(|_| Error::OffsetOverflow)?)
+            .ok_or(Error::OffsetOverflow)?;
+        let len_u64 = u64::try_from(len).map_err(|_| Error::OffsetOverflow)?;
+        let offset = logical_size
+            .checked_sub(len_u64)
+            .ok_or(Error::BlobInsufficientLength)?;
+
+        // Read only the portion preceding the terminal page, then append its already-validated
+        // suffix. This keeps a terminal item wholly within the last page to one blob read.
+        let mut out = if offset < page_start {
+            let prefix_len =
+                usize::try_from(page_start - offset).map_err(|_| Error::OffsetOverflow)?;
+            Self::read_validated(blob, logical_page_size, offset, prefix_len, read_options).await?
+        } else {
+            IoBufs::default()
+        };
+        let tail_start = usize::try_from(offset.max(page_start) - page_start)
+            .map_err(|_| Error::OffsetOverflow)?;
+        out.append(tail.slice(tail_start..));
+        assert_eq!(out.len(), len);
+        Ok((logical_size, out))
+    }
+
     /// Wait for any started sync to complete without starting a new sync.
     pub async fn wait_for_sync(&mut self) -> Result<(), Error> {
         self.sync_state.wait_for_pending().await

--- a/runtime/src/utils/buffer/paged/writer.rs
+++ b/runtime/src/utils/buffer/paged/writer.rs
@@ -1089,6 +1089,8 @@ impl<B: Blob> Writer<B> {
             };
         }
 
+        // A trailing partial page means the caller did not size the blob to complete physical
+        // pages, so there is no trusted terminal page to read the logical end from.
         let page_size: u64 = logical_page_size.widen();
         let physical_page_size = page_size
             .checked_add(CHECKSUM_SIZE)

--- a/runtime/src/utils/buffer/paged/writer.rs
+++ b/runtime/src/utils/buffer/paged/writer.rs
@@ -1028,7 +1028,7 @@ impl<B: Blob> Writer<B> {
     ///
     /// Returns [Error::BlobInsufficientLength] when valid page contents do not cover the whole
     /// range, and [Error::OffsetOverflow] when its end or page offsets overflow.
-    pub async fn read(
+    pub async fn read_range(
         blob: &B,
         logical_page_size: NonZeroU16,
         offset: u64,
@@ -1073,7 +1073,7 @@ impl<B: Blob> Writer<B> {
     ///
     /// The blob must contain only complete physical pages. The last page is validated first to
     /// determine the logical end. If `len` crosses a page boundary, preceding pages are validated
-    /// with [Self::read].
+    /// with [Self::read_range].
     pub async fn read_tail(
         blob: &B,
         physical_size: u64,
@@ -1113,7 +1113,7 @@ impl<B: Blob> Writer<B> {
         let mut out = if offset < page_start {
             let prefix_len =
                 usize::try_from(page_start - offset).map_err(|_| Error::OffsetOverflow)?;
-            Self::read(blob, logical_page_size, offset, prefix_len, read_options).await?
+            Self::read_range(blob, logical_page_size, offset, prefix_len, read_options).await?
         } else {
             IoBufs::default()
         };

--- a/runtime/src/utils/buffer/paged/writer.rs
+++ b/runtime/src/utils/buffer/paged/writer.rs
@@ -1028,7 +1028,7 @@ impl<B: Blob> Writer<B> {
     ///
     /// Returns [Error::BlobInsufficientLength] when valid page contents do not cover the whole
     /// range, and [Error::OffsetOverflow] when its end or page offsets overflow.
-    pub async fn read_validated(
+    pub async fn read(
         blob: &B,
         logical_page_size: NonZeroU16,
         offset: u64,
@@ -1073,8 +1073,8 @@ impl<B: Blob> Writer<B> {
     ///
     /// The blob must contain only complete physical pages. The last page is validated first to
     /// determine the logical end. If `len` crosses a page boundary, preceding pages are validated
-    /// with [Self::read_validated].
-    pub async fn read_validated_tail(
+    /// with [Self::read].
+    pub async fn read_tail(
         blob: &B,
         physical_size: u64,
         logical_page_size: NonZeroU16,
@@ -1113,7 +1113,7 @@ impl<B: Blob> Writer<B> {
         let mut out = if offset < page_start {
             let prefix_len =
                 usize::try_from(page_start - offset).map_err(|_| Error::OffsetOverflow)?;
-            Self::read_validated(blob, logical_page_size, offset, prefix_len, read_options).await?
+            Self::read(blob, logical_page_size, offset, prefix_len, read_options).await?
         } else {
             IoBufs::default()
         };

--- a/storage/fuzz/fuzz_targets/oversized_recovery.rs
+++ b/storage/fuzz/fuzz_targets/oversized_recovery.rs
@@ -190,7 +190,7 @@ fn fuzz(input: FuzzInput) {
 
         // Phase 1: Create valid data
         let mut oversized: Oversized<_, TestEntry, TestValue> =
-            Oversized::init(context.child("initial"), cfg.clone(), None)
+            Oversized::init(context.child("initial"), cfg.clone())
                 .await
                 .expect("Failed to init");
 
@@ -314,7 +314,7 @@ fn fuzz(input: FuzzInput) {
 
         // Phase 3: Recovery - this should not panic
         let mut recovered: Oversized<_, TestEntry, TestValue> =
-            match Oversized::init(context.child("recovered"), cfg.clone(), None).await {
+            match Oversized::init(context.child("recovered"), cfg.clone()).await {
                 Ok(recovered) => recovered,
                 // Existing-byte overwrites in the paged index can invalidate fixed-journal
                 // integrity checks before oversized recovery has a chance to inspect entries.

--- a/storage/fuzz/fuzz_targets/oversized_recovery.rs
+++ b/storage/fuzz/fuzz_targets/oversized_recovery.rs
@@ -174,7 +174,7 @@ fn test_cfg(pooler: &impl BufferPooler) -> Config<()> {
         index_partition: INDEX_PARTITION.into(),
         value_partition: VALUE_PARTITION.into(),
         index_page_cache: CacheRef::from_pooler(pooler, PAGE_SIZE, PAGE_CACHE_SIZE),
-        replay_buffer: commonware_utils::NZUsize!(4096),
+        replay_buffer: NZUsize!(4096),
         index_write_buffer: NZUsize!(512),
         value_write_buffer: NZUsize!(512),
         compression: None,

--- a/storage/fuzz/fuzz_targets/oversized_recovery.rs
+++ b/storage/fuzz/fuzz_targets/oversized_recovery.rs
@@ -174,6 +174,7 @@ fn test_cfg(pooler: &impl BufferPooler) -> Config<()> {
         index_partition: INDEX_PARTITION.into(),
         value_partition: VALUE_PARTITION.into(),
         index_page_cache: CacheRef::from_pooler(pooler, PAGE_SIZE, PAGE_CACHE_SIZE),
+        replay_buffer: commonware_utils::NZUsize!(4096),
         index_write_buffer: NZUsize!(512),
         value_write_buffer: NZUsize!(512),
         compression: None,

--- a/storage/src/archive/prunable/storage.rs
+++ b/storage/src/archive/prunable/storage.rs
@@ -180,6 +180,7 @@ impl<T: Translator, E: Context, K: Array, V: CodecShared> Inner<T, E, K, V> {
             value_partition: cfg.value_partition,
             index_page_cache: cfg.key_page_cache,
             index_write_buffer: cfg.key_write_buffer,
+            replay_buffer: cfg.replay_buffer,
             value_write_buffer: cfg.value_write_buffer,
             compression: cfg.compression,
             codec_config: cfg.codec_config,

--- a/storage/src/archive/prunable/storage.rs
+++ b/storage/src/archive/prunable/storage.rs
@@ -185,6 +185,8 @@ impl<T: Translator, E: Context, K: Array, V: CodecShared> Inner<T, E, K, V> {
             compression: cfg.compression,
             codec_config: cfg.codec_config,
         };
+        // TODO (#4610): fuse this init's recovery drain with the replay below via tracked
+        // replay, restoring single-scan startup
         let oversized: Oversized<E, Record<K>, V> =
             Oversized::init(context.child("oversized"), oversized_cfg, None).await?;
 

--- a/storage/src/archive/prunable/storage.rs
+++ b/storage/src/archive/prunable/storage.rs
@@ -188,7 +188,7 @@ impl<T: Translator, E: Context, K: Array, V: CodecShared> Inner<T, E, K, V> {
         // TODO (#4610): fuse this init's recovery drain with the replay below via tracked
         // replay, restoring single-scan startup
         let oversized: Oversized<E, Record<K>, V> =
-            Oversized::init(context.child("oversized"), oversized_cfg, None).await?;
+            Oversized::init(context.child("oversized"), oversized_cfg).await?;
 
         // Initialize keys and replay index journal (no values read!)
         let mut indices: BTreeMap<u64, u64> = BTreeMap::new();

--- a/storage/src/freezer/conformance.rs
+++ b/storage/src/freezer/conformance.rs
@@ -12,6 +12,7 @@ use core::num::{NonZeroU16, NonZeroUsize};
 use rand::RngExt as _;
 
 const WRITE_BUFFER: NonZeroUsize = NZUsize!(1024);
+const REPLAY_BUFFER: NonZeroUsize = NZUsize!(1024);
 const PAGE_SIZE: NonZeroU16 = NZU16!(1024);
 const PAGE_CACHE_SIZE: NonZeroUsize = NZUsize!(10);
 
@@ -36,7 +37,7 @@ impl StorageWorkload for FreezerWorkload {
             table_initial_size: 4,
             table_resize_frequency: 1,
             table_resize_chunk_size: 4,
-            table_replay_buffer: WRITE_BUFFER,
+            table_replay_buffer: REPLAY_BUFFER,
             codec_config: (),
         };
         let mut freezer =

--- a/storage/src/freezer/mod.rs
+++ b/storage/src/freezer/mod.rs
@@ -162,8 +162,9 @@
 //! # Recovery
 //!
 //! [Freezer::sync] and [Freezer::close] return a [Checkpoint] for recovering existing data.
-//! When a checkpoint is provided, [Freezer::init] rewinds the journals to the checkpoint, resizes the
-//! table to the checkpointed table size, and clears invalid or newer table entries. Passing `None`
+//! When a checkpoint is provided, [Freezer::init] rewinds the journals to the checkpoint, truncates
+//! a longer table to the checkpointed table size, and clears invalid or newer table entries. A table
+//! shorter than the checkpointed size cannot back the checkpointed entries and fails initialization. Passing `None`
 //! or an empty checkpoint to [Freezer::init] deletes any existing freezer data and starts empty.
 //!
 //! # Example

--- a/storage/src/freezer/storage.rs
+++ b/storage/src/freezer/storage.rs
@@ -671,6 +671,7 @@ impl<E: Context, K: Array, V: CodecShared> Inner<E, K, V> {
             index_page_cache: config.key_page_cache.clone(),
             index_write_buffer: config.key_write_buffer,
             value_write_buffer: config.value_write_buffer,
+            replay_buffer: config.table_replay_buffer,
             compression: config.value_compression,
             codec_config: config.codec_config,
         };
@@ -701,8 +702,13 @@ impl<E: Context, K: Array, V: CodecShared> Inner<E, K, V> {
                     "table_size must be a power of 2"
                 );
 
-                // Resize table if needed
+                // Resize the table if needed. Growing is never valid: the checkpoint publishes
+                // only after the table sync completes, so a shorter table cannot back the
+                // checkpointed entries, and zero-extending would fabricate empty heads.
                 let expected_table_len = Self::table_offset(checkpoint.table_size);
+                if table_len < expected_table_len {
+                    return Err(Error::CheckpointMismatch);
+                }
                 let mut modified = if table_len != expected_table_len {
                     table.resize(expected_table_len).await?;
                     true
@@ -1702,6 +1708,63 @@ mod tests {
             )
             .await;
             assert!(matches!(result, Err(Error::CheckpointMismatch)));
+        });
+    }
+
+    /// A durable checkpoint's table fsync completed at the checkpointed size, so a shorter
+    /// (but non-empty) table is corruption. Initialization must reject it rather than grow the
+    /// table with fabricated empty entries, and retries must fail identically.
+    #[test_traced]
+    fn non_empty_checkpoint_against_short_table_errors() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = super::super::Config {
+                key_partition: "test-key-index".into(),
+                key_write_buffer: NZUsize!(1024),
+                key_page_cache: CacheRef::from_pooler(&context, NZU16!(1024), NZUsize!(10)),
+                value_partition: "test-value-journal".into(),
+                value_compression: None,
+                value_write_buffer: NZUsize!(1024),
+                value_target_size: 10 * 1024 * 1024,
+                table_partition: "test-table".into(),
+                table_initial_size: 2,
+                table_resize_frequency: 1,
+                table_resize_chunk_size: 1,
+                table_replay_buffer: NZUsize!(64 * 1024),
+                codec_config: (),
+            };
+
+            let short_len = Entry::FULL_SIZE as u64;
+            let (table, _) = context
+                .open(&cfg.table_partition, TABLE_BLOB_NAME)
+                .await
+                .unwrap();
+            table.resize(short_len).await.unwrap();
+            table.sync().await.unwrap();
+            drop(table);
+
+            let checkpoint = Checkpoint {
+                epoch: 1,
+                section: 0,
+                oversized_size: 0,
+                table_size: 2,
+            };
+            for child in ["first", "retry"] {
+                let result = Freezer::<_, FixedBytes<64>, i32>::init(
+                    context.child(child),
+                    cfg.clone(),
+                    Some(checkpoint),
+                )
+                .await;
+                assert!(matches!(result, Err(Error::CheckpointMismatch)));
+            }
+
+            // The rejection must not resize the table.
+            let (_, size) = context
+                .open(&cfg.table_partition, TABLE_BLOB_NAME)
+                .await
+                .unwrap();
+            assert_eq!(size, short_len);
         });
     }
 

--- a/storage/src/freezer/storage.rs
+++ b/storage/src/freezer/storage.rs
@@ -675,14 +675,17 @@ impl<E: Context, K: Array, V: CodecShared> Inner<E, K, V> {
             compression: config.value_compression,
             codec_config: config.codec_config,
         };
-        let oversized: Oversized<E, Record<K>, V> = Oversized::init(
-            context.child("oversized"),
-            oversized_cfg,
-            checkpoint
-                .filter(|checkpoint| !checkpoint.is_empty())
-                .map(|checkpoint| (checkpoint.section, checkpoint.oversized_size)),
-        )
-        .await?;
+        let oversized_context = context.child("oversized");
+        let oversized: Oversized<E, Record<K>, V> = match checkpoint
+            .filter(|checkpoint| !checkpoint.is_empty())
+            .map(|checkpoint| (checkpoint.section, checkpoint.oversized_size))
+        {
+            Some(checkpoint) => {
+                Oversized::init_with_checkpoint(oversized_context, oversized_cfg, checkpoint)
+                    .await?
+            }
+            None => Oversized::init(oversized_context, oversized_cfg).await?,
+        };
 
         // Open table blob
         let (table, table_len) = context

--- a/storage/src/journal/conformance.rs
+++ b/storage/src/journal/conformance.rs
@@ -323,12 +323,9 @@ impl StorageWorkload for SegmentedOversizedWorkload {
             compression: None,
             codec_config: (RangeCfg::new(0..256), ()),
         };
-        let mut journal = oversized::Oversized::<_, TestEntry, Vec<u8>>::init(
-            context.child("journal"),
-            config,
-            None,
-        )
-        .await?;
+        let mut journal =
+            oversized::Oversized::<_, TestEntry, Vec<u8>>::init(context.child("journal"), config)
+                .await?;
 
         let items_count = context.random_range(0..(ITEMS_PER_BLOB.get() as usize) * 4);
         let mut data_to_write = vec![Vec::new(); items_count];

--- a/storage/src/journal/conformance.rs
+++ b/storage/src/journal/conformance.rs
@@ -319,6 +319,7 @@ impl StorageWorkload for SegmentedOversizedWorkload {
             index_page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
             index_write_buffer: WRITE_BUFFER,
             value_write_buffer: WRITE_BUFFER,
+            replay_buffer: REPLAY_BUFFER,
             compression: None,
             codec_config: (RangeCfg::new(0..256), ()),
         };

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -6298,7 +6298,7 @@ mod tests {
     /// appending and rolling.
     #[test_traced]
     fn test_snapshots_readable_during_concurrent_appends() {
-        let executor = deterministic::Runner::seeded(7);
+        let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let cfg = test_cfg(&context, NZU64!(5));
             let mut journal = Journal::<_, Digest>::init(context.child("j"), cfg)

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -8132,7 +8132,7 @@ mod tests {
 
     #[test_traced]
     fn test_variable_snapshots_readable_during_concurrent_appends() {
-        let executor = deterministic::Runner::seeded(7);
+        let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let cfg = Config {
                 partition: "snapshot-concurrent".into(),

--- a/storage/src/journal/durability.rs
+++ b/storage/src/journal/durability.rs
@@ -29,10 +29,10 @@ impl Barrier {
 
     /// Observe the outcome of the last started sync without blocking.
     fn observe(&mut self) {
-        let Some((boundary, completion)) = &self.pending else {
+        let Some((boundary, completion)) = &mut self.pending else {
             return;
         };
-        let Some(result) = completion.clone().now_or_never() else {
+        let Some(result) = completion.now_or_never() else {
             return;
         };
         if result.is_ok() {

--- a/storage/src/journal/durability.rs
+++ b/storage/src/journal/durability.rs
@@ -44,6 +44,13 @@ impl Barrier {
         self.pending = None;
     }
 
+    /// Whether no recorded sync remains unobserved.
+    ///
+    /// Call [Self::boundary] first to observe a completion that already resolved.
+    pub(crate) const fn settled(&self) -> bool {
+        self.pending.is_none()
+    }
+
     /// Record that everything below `boundary` was proven durable.
     pub(crate) fn mark_durable(&mut self, boundary: u64) {
         self.boundary = self.boundary.max(boundary);

--- a/storage/src/journal/mod.rs
+++ b/storage/src/journal/mod.rs
@@ -45,8 +45,6 @@ pub enum Error {
     ReplayInterrupted,
     #[error("replay failed")]
     ReplayFailed,
-    #[error("section must be replayed before append: {0}")]
-    ReplayRequired(u64),
     #[error("size overflow")]
     SizeOverflow,
     #[error("missing blob: {0}")]

--- a/storage/src/journal/mod.rs
+++ b/storage/src/journal/mod.rs
@@ -45,6 +45,8 @@ pub enum Error {
     ReplayInterrupted,
     #[error("replay failed")]
     ReplayFailed,
+    #[error("section must be replayed before append: {0}")]
+    ReplayRequired(u64),
     #[error("size overflow")]
     SizeOverflow,
     #[error("missing blob: {0}")]

--- a/storage/src/journal/segmented/fixed.rs
+++ b/storage/src/journal/segmented/fixed.rs
@@ -218,7 +218,7 @@ impl<E: Storage + Metrics, A: CodecFixedShared> Inner<E, A> {
             } else if physical_size == 0 {
                 None
             } else {
-                let (logical_size, entry) = Writer::<E::Blob>::read_validated_tail(
+                let (logical_size, entry) = Writer::<E::Blob>::read_tail(
                     &blob,
                     physical_size,
                     page_size,
@@ -253,7 +253,7 @@ impl<E: Storage + Metrics, A: CodecFixedShared> Inner<E, A> {
         section: u64,
         size: u64,
     ) -> Result<A, Error> {
-        let entry = Writer::<E::Blob>::read_validated(
+        let entry = Writer::<E::Blob>::read(
             blob,
             page_size,
             size - Self::CHUNK_SIZE_U64,

--- a/storage/src/journal/segmented/fixed.rs
+++ b/storage/src/journal/segmented/fixed.rs
@@ -835,7 +835,7 @@ pub struct Replay<E: Storage + Metrics, A: CodecFixed> {
 impl<E: Storage + Metrics, A: CodecFixedShared> Replay<E, A> {
     /// Validate that the front section's checksum failure is a repairable torn page, returning
     /// the item-aligned truncation target and the validated replay prefix.
-    async fn plan_front_repair(&mut self, source: RError) -> Result<(u64, u64), Error> {
+    async fn plan_repair(&mut self, source: RError) -> Result<(u64, u64), Error> {
         // Only a checksum failure is repairable: it marks a torn write, while any other error
         // is an I/O failure this repair must not mask.
         if !matches!(source, RError::InvalidChecksum) {
@@ -877,9 +877,9 @@ impl<E: Storage + Metrics, A: CodecFixedShared> Replay<E, A> {
     }
 
     /// Repair a torn page discovered by ordered replay and resume at the last complete item.
-    async fn repair_torn_front(&mut self, source: RError) -> Result<(), Error> {
+    async fn repair(&mut self, source: RError) -> Result<(), Error> {
         // A rejected plan mutates nothing: drop the damaged section and surface its error.
-        let (valid_size, target) = match self.plan_front_repair(source).await {
+        let (valid_size, target) = match self.plan_repair(source).await {
             Ok(plan) => plan,
             Err(err) => {
                 self.sections.pop_front();
@@ -981,7 +981,7 @@ impl<E: Storage + Metrics, A: CodecFixedShared> Replay<E, A> {
                     continue;
                 }
                 Err(err) => {
-                    if let Err(err) = self.repair_torn_front(err).await {
+                    if let Err(err) = self.repair(err).await {
                         return self.fail(err);
                     }
                     continue;

--- a/storage/src/journal/segmented/fixed.rs
+++ b/storage/src/journal/segmented/fixed.rs
@@ -20,15 +20,21 @@
 //! All data must be assigned to a `section`. This allows pruning entire sections
 //! (and their corresponding blobs) independently.
 
-use super::manager::{AppendFactory, Config as ManagerConfig, Manager};
+use super::manager::{
+    AppendFactory, Config as ManagerConfig, Manager, section_from_name, stored_names,
+};
 use crate::journal::Error;
 use commonware_codec::{CodecFixed, CodecFixedShared, DecodeExt as _, ReadExt as _};
 use commonware_runtime::{
-    Blob, Handle, Metrics, ReadOptions, Storage,
-    buffer::paged::{CacheRef, Replay as BlobReplay},
+    Blob, Error as RError, Handle, Metrics, ReadOptions, Storage,
+    buffer::paged::{CacheRef, Replay as BlobReplay, Writer},
 };
 use commonware_utils::NZUsize;
-use std::{collections::VecDeque, marker::PhantomData, num::NonZeroUsize};
+use std::{
+    collections::{BTreeMap, BTreeSet, VecDeque},
+    marker::PhantomData,
+    num::{NonZeroU16, NonZeroUsize},
+};
 use tracing::{trace, warn};
 
 /// State for replaying a single section's blob.
@@ -54,7 +60,52 @@ pub struct Config {
 /// The journal's state, boxed so the public [Journal] handle stays pointer-sized.
 struct Inner<E: Storage + Metrics, A: CodecFixed> {
     manager: Manager<E, AppendFactory>,
+
+    /// Nonempty sections opened at initialization that have not been replayed from position zero.
+    unrecovered: BTreeSet<u64>,
+
+    /// Logical byte prefixes protected by durable validation markers.
+    floors: BTreeMap<u64, u64>,
+
     _array: PhantomData<A>,
+}
+
+/// Recovery mutations authorized by a completed non-mutating preflight.
+enum PreflightMode {
+    /// Preserve each durable validation floor while replay repairs its suffix.
+    Floors(BTreeMap<u64, u64>),
+    /// Restore one checkpoint section and discard every later section.
+    Restore {
+        /// The checkpoint section remains explicit because an empty checkpoint has no floor.
+        section: u64,
+        floors: BTreeMap<u64, u64>,
+    },
+}
+
+/// Non-mutating recovery evidence and authorized work bound to the storage that produced it.
+pub(crate) struct RecoveryPreflight<E: Storage + Metrics, A: CodecFixed> {
+    context: E,
+    cfg: Config,
+
+    /// Terminal entry at each validated logical boundary.
+    boundaries: BTreeMap<u64, Option<A>>,
+
+    /// Mutations permitted after sibling storage validates these boundaries.
+    mode: PreflightMode,
+}
+
+impl<E: Storage + Metrics, A: CodecFixedShared> RecoveryPreflight<E, A> {
+    /// Terminal entries captured at each validated boundary.
+    pub(crate) const fn boundaries(&self) -> &BTreeMap<u64, Option<A>> {
+        &self.boundaries
+    }
+
+    /// Apply the preflighted recovery work and open the journal writer.
+    pub(crate) async fn finish(self) -> Result<Journal<E, A>, Error> {
+        Ok(Journal(Box::new(
+            Inner::init(self.context, self.cfg, Some(self.mode)).await?,
+        )))
+    }
 }
 
 impl<E: Storage + Metrics, A: CodecFixedShared> Inner<E, A> {
@@ -62,8 +113,181 @@ impl<E: Storage + Metrics, A: CodecFixedShared> Inner<E, A> {
     const CHUNK_SIZE: usize = A::SIZE;
     const CHUNK_SIZE_U64: u64 = Self::CHUNK_SIZE as u64;
 
+    /// Logical page size shared by all index blobs in this journal.
+    fn page_size(cfg: &Config) -> NonZeroU16 {
+        NonZeroU16::new(
+            cfg.page_cache
+                .page_size()
+                .try_into()
+                .expect("page cache size must fit in u16"),
+        )
+        .expect("page cache size must be non-zero")
+    }
+
+    /// Return canonical section names in numeric order without opening writers.
+    async fn stored(context: &E, cfg: &Config) -> Result<BTreeMap<u64, Vec<u8>>, Error> {
+        // Recovery relies on numeric section order for checkpoint coverage and reverse deletion.
+        let mut stored = BTreeMap::new();
+        for name in stored_names(context, &cfg.partition).await? {
+            let section = section_from_name(&name)?;
+            stored.insert(section, name);
+        }
+        Ok(stored)
+    }
+
+    /// Prove each validation floor and capture its terminal entry without mutating storage.
+    async fn preflight_floors(
+        context: E,
+        cfg: Config,
+        minimum_items: &BTreeMap<u64, u64>,
+    ) -> Result<RecoveryPreflight<E, A>, Error> {
+        let stored = Self::stored(&context, &cfg).await?;
+        let page_size = Self::page_size(&cfg);
+        let mut floor_sizes = BTreeMap::new();
+        let mut boundaries = BTreeMap::new();
+
+        for (&section, &items) in minimum_items {
+            // Every advertised floor must name a retained, representable byte prefix.
+            let Some(name) = stored.get(&section) else {
+                return Err(Error::Corruption(format!(
+                    "section {section} has a validation floor but no blob"
+                )));
+            };
+            let required = items.checked_mul(Self::CHUNK_SIZE_U64).ok_or_else(|| {
+                Error::Corruption(format!(
+                    "section {section} validation floor {items} overflows its byte size"
+                ))
+            })?;
+            if required == 0 {
+                boundaries.insert(section, None);
+                continue;
+            }
+
+            // A published marker follows a completed index/value sync, so its earlier pages are
+            // already durable. Validate the terminal index page that binds the two journals.
+            let entry_offset = required - Self::CHUNK_SIZE_U64;
+            let (blob, _) = context.open(&cfg.partition, name).await?;
+            let entry = Writer::<E::Blob>::read_validated(
+                &blob,
+                page_size,
+                entry_offset,
+                Self::CHUNK_SIZE,
+                ReadOptions::default(),
+            )
+            .await
+            .map_err(|err| Self::boundary_error(section, required, err))?;
+
+            let entry = A::decode(entry.coalesce()).map_err(Error::Codec)?;
+            floor_sizes.insert(section, required);
+            boundaries.insert(section, Some(entry));
+        }
+
+        Ok(RecoveryPreflight {
+            context,
+            cfg,
+            boundaries,
+            mode: PreflightMode::Floors(floor_sizes),
+        })
+    }
+
+    /// Prove every checkpoint-covered index boundary without mutating damaged storage.
+    async fn preflight_restore(
+        context: E,
+        cfg: Config,
+        section: u64,
+        size: u64,
+    ) -> Result<RecoveryPreflight<E, A>, Error> {
+        // The checkpoint can only identify a boundary between fixed-size items.
+        if !size.is_multiple_of(Self::CHUNK_SIZE_U64) {
+            return Err(Error::Corruption(format!(
+                "section {section} checkpoint size {size} is not item-aligned"
+            )));
+        }
+
+        // A non-empty current checkpoint requires its section blob to exist.
+        let stored = Self::stored(&context, &cfg).await?;
+        if size > 0 && !stored.contains_key(&section) {
+            return Err(Error::Corruption(format!(
+                "section {section} has a checkpoint but no blob"
+            )));
+        }
+
+        let page_size = Self::page_size(&cfg);
+        let mut boundaries = BTreeMap::new();
+        let mut floors = BTreeMap::new();
+
+        for (&candidate, name) in stored.range(..=section) {
+            // Earlier sections end at their retained terminal page. The checkpoint supplies the
+            // current section's exact logical boundary, which may precede an uncommitted suffix.
+            let (blob, physical_size) = context.open(&cfg.partition, name).await?;
+            let entry = if candidate == section {
+                if size == 0 {
+                    None
+                } else {
+                    let entry = Writer::<E::Blob>::read_validated(
+                        &blob,
+                        page_size,
+                        size - Self::CHUNK_SIZE_U64,
+                        Self::CHUNK_SIZE,
+                        ReadOptions::default(),
+                    )
+                    .await
+                    .map_err(|err| Self::boundary_error(section, size, err))?;
+                    floors.insert(section, size);
+                    Some(A::decode(entry.coalesce()).map_err(Error::Codec)?)
+                }
+            } else if physical_size == 0 {
+                None
+            } else {
+                let (logical_size, entry) = Writer::<E::Blob>::read_validated_tail(
+                    &blob,
+                    physical_size,
+                    page_size,
+                    Self::CHUNK_SIZE,
+                    ReadOptions::default(),
+                )
+                .await
+                .map_err(|err| Self::boundary_error(candidate, physical_size, err))?;
+                if !logical_size.is_multiple_of(Self::CHUNK_SIZE_U64) {
+                    return Err(Error::Corruption(format!(
+                        "section {candidate} is not a complete checkpoint-covered index"
+                    )));
+                }
+                floors.insert(candidate, logical_size);
+                Some(A::decode(entry.coalesce()).map_err(Error::Codec)?)
+            };
+            boundaries.insert(candidate, entry);
+        }
+        boundaries.entry(section).or_insert(None);
+        Ok(RecoveryPreflight {
+            context,
+            cfg,
+            boundaries,
+            mode: PreflightMode::Restore { section, floors },
+        })
+    }
+
+    /// Classify an invalid or missing boundary as committed corruption without hiding I/O errors.
+    fn boundary_error(section: u64, required: u64, err: RError) -> Error {
+        match err {
+            RError::InvalidChecksum | RError::BlobInsufficientLength => Error::Corruption(format!(
+                "section {section} does not retain its {required}-byte durable boundary"
+            )),
+            err => Error::Runtime(err),
+        }
+    }
+
     /// See [Journal::init].
-    async fn init(context: E, cfg: Config) -> Result<Self, Error> {
+    async fn init(context: E, cfg: Config, mode: Option<PreflightMode>) -> Result<Self, Error> {
+        let (floors, restore) = match mode {
+            None => (BTreeMap::new(), None),
+            Some(PreflightMode::Floors(floors)) => (floors, None),
+            Some(PreflightMode::Restore { section, floors }) => {
+                let size = floors.get(&section).copied().unwrap_or(0);
+                (floors, Some((section, size)))
+            }
+        };
+
         let manager_cfg = ManagerConfig {
             partition: cfg.partition,
             factory: AppendFactory {
@@ -72,34 +296,46 @@ impl<E: Storage + Metrics, A: CodecFixedShared> Inner<E, A> {
             },
         };
         let mut manager = Manager::init(context, manager_cfg).await?;
+        if let Some((section, size)) = restore {
+            // The checkpoint preflight authorized this exact truncation. Make it durable before
+            // the paired value journal can release any corresponding bytes.
+            manager.rewind(section, size).await?;
+            manager.sync(section).await?;
+            return Ok(Self {
+                manager,
+                unrecovered: BTreeSet::new(),
+                floors,
+                _array: PhantomData,
+            });
+        }
 
-        // Repair any blobs with trailing bytes (incomplete items from crash)
-        let sections: Vec<_> = manager.sections().collect();
-        for section in sections {
+        let mut unrecovered = BTreeSet::new();
+        for section in manager.sections() {
             let size = manager.size(section)?;
-            if !size.is_multiple_of(Self::CHUNK_SIZE_U64) {
-                let valid_size = size - (size % Self::CHUNK_SIZE_U64);
-                warn!(
-                    section,
-                    invalid_size = size,
-                    new_size = valid_size,
-                    "trailing bytes detected: truncating"
-                );
-                manager.rewind_section(section, valid_size).await?;
-                // Startup repair is exceptional; make it durable immediately so callers do not
-                // need to track repaired sections separately.
-                manager.sync(section).await?;
+            let floor = floors.get(&section).copied().unwrap_or(0);
+            if size < floor {
+                return Err(Error::Corruption(format!(
+                    "section {section} retains {size} of its {floor}-byte validation floor"
+                )));
+            }
+            if size > floor {
+                unrecovered.insert(section);
             }
         }
 
         Ok(Self {
             manager,
+            unrecovered,
+            floors,
             _array: PhantomData,
         })
     }
 
     /// See [Journal::append].
     async fn append(&mut self, section: u64, item: &A) -> Result<u64, Error> {
+        if self.unrecovered.contains(&section) {
+            return Err(Error::ReplayRequired(section));
+        }
         let blob = self.manager.get_or_create(section).await?;
 
         // Encode the item
@@ -231,7 +467,12 @@ impl<E: Storage + Metrics, A: CodecFixedShared> Inner<E, A> {
 
     /// See [Journal::prune].
     async fn prune(&mut self, min: u64) -> Result<bool, Error> {
-        self.manager.prune(min).await
+        let pruned = self.manager.prune(min).await?;
+        if pruned {
+            self.unrecovered.retain(|section| *section >= min);
+            self.floors.retain(|section, _| *section >= min);
+        }
+        Ok(pruned)
     }
 
     /// See [Journal::pruned].
@@ -267,12 +508,28 @@ impl<E: Storage + Metrics, A: CodecFixedShared> Inner<E, A> {
 
     /// See [Journal::rewind].
     async fn rewind(&mut self, section: u64, offset: u64) -> Result<(), Error> {
-        self.manager.rewind(section, offset).await
+        self.manager.rewind(section, offset).await?;
+        self.unrecovered.retain(|candidate| *candidate <= section);
+        self.floors.retain(|candidate, _| *candidate <= section);
+        if offset == 0 {
+            self.unrecovered.remove(&section);
+        }
+        if let Some(floor) = self.floors.get_mut(&section) {
+            *floor = (*floor).min(offset);
+        }
+        Ok(())
     }
 
     /// See [Journal::rewind_section].
     async fn rewind_section(&mut self, section: u64, size: u64) -> Result<(), Error> {
-        self.manager.rewind_section(section, size).await
+        self.manager.rewind_section(section, size).await?;
+        if size == 0 {
+            self.unrecovered.remove(&section);
+        }
+        if let Some(floor) = self.floors.get_mut(&section) {
+            *floor = (*floor).min(size);
+        }
+        Ok(())
     }
 
     /// See [Journal::destroy].
@@ -282,7 +539,10 @@ impl<E: Storage + Metrics, A: CodecFixedShared> Inner<E, A> {
 
     /// See [Journal::clear].
     async fn clear(&mut self) -> Result<(), Error> {
-        self.manager.clear().await
+        self.manager.clear().await?;
+        self.unrecovered.clear();
+        self.floors.clear();
+        Ok(())
     }
 }
 
@@ -298,7 +558,8 @@ impl<E: Storage + Metrics, A: CodecFixedShared> Inner<E, A> {
 /// [rocksdb](https://github.com/facebook/rocksdb/blob/0c533e61bc6d89fdf1295e8e0bcee4edb3aef401/include/rocksdb/options.h#L441-L445),
 /// the first invalid data read will be considered the new end of the journal (and the
 /// underlying [Blob] will be truncated to the last valid item). Repair occurs during
-/// init by checking each blob's size.
+/// replay so clean initialization reads only each blob's terminal page. A nonempty section opened
+/// during initialization must be replayed from position zero before it accepts new appends.
 ///
 /// Mutating functions consume the journal and return it only on success: an error (or a dropped
 /// future) destroys the handle. [Journal::replay] consumes the journal into an owned [Replay]
@@ -322,15 +583,36 @@ impl<E: Storage + Metrics, A: CodecFixedShared> Journal<E, A> {
 
     /// Initialize a new `Journal` instance.
     ///
-    /// All backing blobs are opened but not read during initialization. Use `replay`
-    /// to iterate over all items.
+    /// Backing blobs are opened without scanning their full page prefixes. Use `replay` to validate
+    /// and iterate over all items before appending to a retained section.
     pub async fn init(context: E, cfg: Config) -> Result<Self, Error> {
-        Ok(Self(Box::new(Inner::init(context, cfg).await?)))
+        Ok(Self(Box::new(Inner::init(context, cfg, None).await?)))
+    }
+
+    /// Prove validation floors without opening a writer or mutating their blobs.
+    pub(crate) async fn preflight_floors(
+        context: E,
+        cfg: Config,
+        minimum_items: &BTreeMap<u64, u64>,
+    ) -> Result<RecoveryPreflight<E, A>, Error> {
+        Inner::preflight_floors(context, cfg, minimum_items).await
+    }
+
+    /// Prove every checkpoint-covered index byte without mutating damage.
+    pub(crate) async fn preflight_restore(
+        context: E,
+        cfg: Config,
+        section: u64,
+        size: u64,
+    ) -> Result<RecoveryPreflight<E, A>, Error> {
+        Inner::preflight_restore(context, cfg, section, size).await
     }
 
     /// Append a new item to the journal in the given section.
     ///
     /// Returns the position of the item within the section (0-indexed).
+    /// Returns [Error::ReplayRequired] when `section` contained an unvalidated suffix at
+    /// initialization and has not completed a replay from position zero.
     pub async fn append(mut self, section: u64, item: &A) -> Result<(Self, u64), Error> {
         let position = self.0.append(section, item).await?;
         Ok((self, position))
@@ -388,6 +670,9 @@ impl<E: Storage + Metrics, A: CodecFixedShared> Journal<E, A> {
     /// are allocated lazily as the reader advances. Every backing blob read performed by
     /// the returned replay uses `read_options`, including reads after advancing to
     /// another section.
+    ///
+    /// A nonzero start must be a boundary already validated by a prior replay or a durable
+    /// marker: torn-page repair treats everything below it as proven.
     pub async fn replay(
         mut self,
         start_section: u64,
@@ -422,8 +707,16 @@ impl<E: Storage + Metrics, A: CodecFixedShared> Journal<E, A> {
         Ok(Replay {
             journal: self,
             sections,
+            fully_replayed_from: if start_position == 0 {
+                Some(start_section)
+            } else {
+                start_section.checked_add(1)
+            },
+            buffer,
+            read_options,
             finished,
             errored: false,
+            repairing: false,
         })
     }
 
@@ -529,29 +822,158 @@ impl<E: Storage + Metrics, A: CodecFixedShared> Journal<E, A> {
 pub struct Replay<E: Storage + Metrics, A: CodecFixed> {
     journal: Journal<E, A>,
     sections: VecDeque<SectionReplay<E::Blob>>,
+    fully_replayed_from: Option<u64>,
+    buffer: NonZeroUsize,
+    read_options: ReadOptions,
     finished: bool,
     errored: bool,
+    repairing: bool,
 }
 
 impl<E: Storage + Metrics, A: CodecFixedShared> Replay<E, A> {
+    /// Repair a torn page discovered by ordered replay and resume at the last complete item.
+    async fn repair_torn_front(&mut self, source: RError) -> Result<(), Error> {
+        if !matches!(source, RError::InvalidChecksum) {
+            self.sections.pop_front();
+            return Err(source.into());
+        }
+
+        let current = self.sections.front().expect("replayed section is present");
+        let section = current.section;
+        let position = current.position;
+        let size = current.reader.blob_size();
+        let Some(valid_size) = position.checked_mul(Inner::<E, A>::CHUNK_SIZE_U64) else {
+            self.sections.pop_front();
+            return Err(Error::OffsetOverflow);
+        };
+        let recoverable = match self
+            .journal
+            .0
+            .manager
+            .get_mut(section)
+            .expect("replayed section is present")
+            .recoverable_prefix_len(valid_size, self.buffer, self.read_options)
+            .await
+        {
+            Ok(recoverable) => recoverable,
+            Err(err) => {
+                self.sections.pop_front();
+                return Err(err.into());
+            }
+        };
+        if recoverable >= size {
+            self.sections.pop_front();
+            return Err(source.into());
+        }
+        let target = recoverable - recoverable % Inner::<E, A>::CHUNK_SIZE_U64;
+        if target < valid_size {
+            self.sections.pop_front();
+            return Err(Error::ItemOutOfRange(position));
+        }
+        if let Err(err) = self.ensure_above_floor(section, target) {
+            self.sections.pop_front();
+            return Err(err);
+        }
+
+        warn!(
+            section,
+            invalid_size = size,
+            recoverable_size = recoverable,
+            new_size = target,
+            "torn page detected: truncating"
+        );
+
+        // Keep the interruption guard set until a new reader has replaced the stale view.
+        self.repairing = true;
+        let current = self
+            .sections
+            .pop_front()
+            .expect("repaired section is present");
+        drop(current.reader);
+        repair_blob(&mut self.journal, section, target).await?;
+        let mut reader = self
+            .journal
+            .0
+            .manager
+            .get_mut(section)
+            .expect("repaired section is present")
+            .replay(self.buffer, self.read_options)
+            .await?;
+        reader.seek_to(valid_size)?;
+        self.sections.push_front(SectionReplay {
+            section,
+            reader,
+            position,
+        });
+        self.repairing = false;
+        Ok(())
+    }
+
+    /// Reject a repair that would remove any marker-protected item.
+    fn ensure_above_floor(&self, section: u64, target: u64) -> Result<(), Error> {
+        let floor = self.journal.0.floors.get(&section).copied().unwrap_or(0);
+        if target < floor {
+            return Err(Error::Corruption(format!(
+                "section {section} recovery target {target} is below its {floor}-byte validation floor"
+            )));
+        }
+        Ok(())
+    }
+
     /// Returns the next `(section, position, item)`, or `None` once every section is
     /// exhausted.
     ///
     /// An error ends the section that produced it, and iteration continues with the
-    /// next section.
+    /// next section. Errors while mutating storage to repair a section, and
+    /// [Error::ReplayInterrupted], end the replay.
     pub async fn next(&mut self) -> Option<Result<(u64, u64, A), Error>> {
+        // A cancelled repair leaves the section's writer unusable.
+        if self.repairing {
+            self.repairing = false;
+            self.sections.clear();
+            if !self.errored {
+                return self.fail(Error::ReplayInterrupted);
+            }
+        }
         while let Some(current) = self.sections.front_mut() {
             // Ensure we have enough data for one item
             match current.reader.ensure(Inner::<E, A>::CHUNK_SIZE).await {
                 Ok(true) => {}
                 Ok(false) => {
-                    // Reader exhausted, move to the next section
+                    let valid_size =
+                        match current.position.checked_mul(Inner::<E, A>::CHUNK_SIZE_U64) {
+                            Some(size) => size,
+                            None => return self.fail(Error::OffsetOverflow),
+                        };
+                    let blob_size = current.reader.blob_size();
+                    if valid_size < blob_size {
+                        let section = current.section;
+                        if let Err(err) = self.ensure_above_floor(section, valid_size) {
+                            self.sections.pop_front();
+                            return self.fail(err);
+                        }
+                        warn!(
+                            section,
+                            invalid_size = blob_size,
+                            new_size = valid_size,
+                            "incomplete item detected: truncating"
+                        );
+                        self.repairing = true;
+                        if let Err(err) = repair_blob(&mut self.journal, section, valid_size).await
+                        {
+                            self.sections.pop_front();
+                            return self.fail(err);
+                        }
+                        self.repairing = false;
+                    }
                     self.sections.pop_front();
                     continue;
                 }
                 Err(err) => {
-                    self.sections.pop_front();
-                    return self.fail(Error::Runtime(err));
+                    if let Err(err) = self.repair_torn_front(err).await {
+                        return self.fail(err);
+                    }
+                    continue;
                 }
             }
 
@@ -582,29 +1004,52 @@ impl<E: Storage + Metrics, A: CodecFixedShared> Replay<E, A> {
     ///
     /// Fails when the reader was not fully drained or yielded an error: the journal is
     /// destroyed and recovery is re-initialization.
-    pub fn finish(self) -> Result<Journal<E, A>, Error> {
+    pub fn finish(mut self) -> Result<Journal<E, A>, Error> {
         if self.errored || !self.finished {
             return Err(Error::ReplayFailed);
+        }
+        if let Some(start) = self.fully_replayed_from {
+            self.journal
+                .0
+                .unrecovered
+                .retain(|section| *section < start);
         }
         Ok(self.journal)
     }
 }
 
+/// Truncate a replayed section and make the repair durable before allowing new appends.
+async fn repair_blob<E: Storage + Metrics, A: CodecFixed>(
+    journal: &mut Journal<E, A>,
+    section: u64,
+    size: u64,
+) -> Result<(), Error> {
+    let blob = journal
+        .0
+        .manager
+        .get_mut(section)
+        .expect("replayed section must exist");
+    blob.resize(size).await?;
+    blob.sync().await?;
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use commonware_codec::FixedSize;
     use commonware_cryptography::{Hasher as _, Sha256, sha256::Digest};
     use commonware_macros::test_traced;
     use commonware_runtime::{
         BufferPooler, Error as RError, Runner, Spawner as _, Supervisor as _,
-        buffer::paged::CacheRef,
+        buffer::paged::{CacheRef, Writer, corrupt_page},
         deterministic,
         mocks::{
             DelayedSyncContext, PendingSyncs, RecordingContext, fail_pending_syncs,
             release_pending_syncs,
         },
     };
-    use commonware_utils::{NZU16, NZUsize};
+    use commonware_utils::{NZU16, NZUsize, probability};
     use core::num::NonZeroU16;
     use std::sync::{
         Arc,
@@ -624,6 +1069,37 @@ mod tests {
             page_cache: CacheRef::from_pooler(pooler, PAGE_SIZE, PAGE_CACHE_SIZE),
             write_buffer: NZUsize!(2048),
         }
+    }
+
+    fn aligned_subset_cfg(pooler: &impl BufferPooler) -> Config {
+        Config {
+            partition: "segmented-fixed-aligned-subset".into(),
+            page_cache: CacheRef::from_pooler(pooler, NZU16!(16), NZUsize!(4)),
+            write_buffer: NZUsize!(128),
+        }
+    }
+
+    fn lazy_recovery_cfg(pooler: &impl BufferPooler, partition: &str) -> Config {
+        Config {
+            partition: partition.into(),
+            page_cache: CacheRef::from_pooler(pooler, NZU16!(16), NZUsize!(4)),
+            write_buffer: NZUsize!(1),
+        }
+    }
+
+    async fn replay_all<E, A>(journal: Journal<E, A>) -> Journal<E, A>
+    where
+        E: Storage + Metrics,
+        A: CodecFixedShared,
+    {
+        let mut replay = journal
+            .replay(0, 0, NZUsize!(1024), ReadOptions::default())
+            .await
+            .expect("failed to start recovery replay");
+        while let Some(item) = replay.next().await {
+            item.expect("failed to recover journal");
+        }
+        replay.finish().expect("failed to finish recovery replay")
     }
 
     #[test_traced]
@@ -750,6 +1226,286 @@ mod tests {
             assert!(replay.next().await.is_none());
 
             let journal = replay.finish().expect("failed to finish replay");
+            journal.destroy().await.expect("failed to destroy");
+        });
+    }
+
+    #[test_traced]
+    fn test_segmented_fixed_clean_recovery_uses_replay_buffer() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let (context, recordings) = RecordingContext::new(context);
+            let cfg = lazy_recovery_cfg(&context, "segmented-fixed-lazy-recovery");
+
+            // Sixteen u64s occupy eight physical pages. Persist a clean journal whose tiny write
+            // buffer would force an eager recovery scan to issue one read per page.
+            let mut journal = Journal::init(context.child("seed"), cfg.clone())
+                .await
+                .expect("failed to init");
+            for value in 0..16u64 {
+                (journal, _) = journal.append(1, &value).await.expect("failed to append");
+            }
+            journal = journal.sync_all().await.expect("failed to sync");
+            drop(journal);
+
+            // Initialization needs only the terminal page used to open Writer. Recovery belongs to
+            // replay, whose 112-byte budget batches four 28-byte physical pages per read.
+            recordings.clear();
+            let journal = Journal::<_, u64>::init(context.child("reopen"), cfg)
+                .await
+                .expect("failed to reopen");
+            assert_eq!(recordings.snapshot().reads.len(), 1);
+
+            let mut replay = journal
+                .replay(0, 0, NZUsize!(112), ReadOptions::default())
+                .await
+                .expect("failed to replay");
+            while let Some(item) = replay.next().await {
+                item.expect("failed to read replay item");
+            }
+            assert_eq!(recordings.snapshot().reads.len(), 3);
+            replay
+                .finish()
+                .expect("failed to finish replay")
+                .destroy()
+                .await
+                .expect("failed to destroy");
+        });
+    }
+
+    #[test_traced]
+    fn test_segmented_fixed_append_requires_replay_after_reopen() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = test_cfg(&context);
+            let mut journal = Journal::init(context.child("seed"), cfg.clone())
+                .await
+                .expect("failed to init");
+            (journal, _) = journal
+                .append(1, &test_digest(0))
+                .await
+                .expect("failed to append");
+            journal = journal.sync_all().await.expect("failed to sync");
+            drop(journal);
+
+            // A tail page can hide an earlier torn page. Reopened sections remain append-locked
+            // until ordered replay has validated their full retained prefix.
+            let journal = Journal::init(context.child("reopen"), cfg)
+                .await
+                .expect("failed to reopen");
+            assert!(matches!(
+                journal.append(1, &test_digest(1)).await,
+                Err(Error::ReplayRequired(1))
+            ));
+        });
+    }
+
+    #[test_traced]
+    fn test_segmented_fixed_floor_preflight_reads_boundary_only() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let (context, recordings) = RecordingContext::new(context);
+            let cfg = lazy_recovery_cfg(&context, "segmented-fixed-floor-boundary");
+            let mut journal = Journal::init(context.child("seed"), cfg.clone())
+                .await
+                .expect("failed to init");
+            for value in 0..16u64 {
+                (journal, _) = journal.append(1, &value).await.expect("failed to append");
+            }
+            journal = journal.sync_all().await.expect("failed to sync");
+            drop(journal);
+
+            // A durable floor proves its prefix. Preflight reads only the page containing the
+            // terminal entry and leaves the ordinary replay pass to inspect the suffix.
+            recordings.clear();
+            let floors = BTreeMap::from([(1, 16)]);
+            let preflight =
+                Journal::<_, u64>::preflight_floors(context.child("preflight"), cfg, &floors)
+                    .await
+                    .expect("failed to preflight");
+            assert_eq!(recordings.snapshot().reads.len(), 1);
+            preflight
+                .finish()
+                .await
+                .expect("failed to finish preflight")
+                .destroy()
+                .await
+                .expect("failed to destroy");
+        });
+    }
+
+    #[test_traced]
+    fn test_segmented_fixed_restore_reads_boundaries_only() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let (context, recordings) = RecordingContext::new(context);
+            let cfg = lazy_recovery_cfg(&context, "segmented-fixed-restore-boundaries");
+            let mut journal = Journal::init(context.child("seed"), cfg.clone())
+                .await
+                .expect("failed to init");
+            for section in 0..=1 {
+                for value in 0..16u64 {
+                    (journal, _) = journal
+                        .append(section, &value)
+                        .await
+                        .expect("failed to append");
+                }
+            }
+            journal = journal.sync_all().await.expect("failed to sync");
+            drop(journal);
+
+            // The checkpoint makes both retained sections durable. Restore needs one terminal
+            // boundary read per section, independent of the eight pages stored in each.
+            recordings.clear();
+            let preflight = Journal::<_, u64>::preflight_restore(
+                context.child("preflight"),
+                cfg,
+                1,
+                16 * u64::SIZE as u64,
+            )
+            .await
+            .expect("failed to preflight");
+            assert_eq!(recordings.snapshot().reads.len(), 2);
+            preflight
+                .finish()
+                .await
+                .expect("failed to finish preflight")
+                .destroy()
+                .await
+                .expect("failed to destroy");
+        });
+    }
+
+    #[test_traced]
+    fn test_segmented_fixed_restore_retains_empty_checkpoint_section() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = lazy_recovery_cfg(&context, "segmented-fixed-empty-restore");
+            let mut journal = Journal::init(context.child("seed"), cfg.clone())
+                .await
+                .expect("failed to init");
+            for section in 0..=2 {
+                (journal, _) = journal
+                    .append(section, &section)
+                    .await
+                    .expect("failed to append");
+            }
+            journal = journal.sync_all().await.expect("failed to sync");
+            journal = journal
+                .rewind_section(1, 0)
+                .await
+                .expect("failed to empty checkpoint section");
+            journal = journal.sync(1).await.expect("failed to sync empty section");
+            drop(journal);
+
+            let journal = Journal::<_, u64>::preflight_restore(context.child("restore"), cfg, 1, 0)
+                .await
+                .expect("failed to preflight")
+                .finish()
+                .await
+                .expect("failed to finish preflight");
+
+            assert_eq!(journal.sections().collect::<Vec<_>>(), vec![0, 1]);
+            assert_eq!(journal.size(1).expect("missing checkpoint section"), 0);
+            journal.destroy().await.expect("failed to destroy");
+        });
+    }
+
+    #[test_traced]
+    fn test_segmented_fixed_restore_floors_block_below_checkpoint_repair() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = lazy_recovery_cfg(&context, "segmented-fixed-restore-floors");
+            let mut journal = Journal::init(context.child("seed"), cfg.clone())
+                .await
+                .expect("failed to init");
+            for section in 0..=1 {
+                for value in 0..16u64 {
+                    (journal, _) = journal
+                        .append(section, &value)
+                        .await
+                        .expect("failed to append");
+                }
+            }
+            journal = journal.sync_all().await.expect("failed to sync");
+            drop(journal);
+
+            // Tear an interior page below the checkpoint boundary. The preflight reads only the
+            // terminal boundary page, so restore succeeds and must arm the proven floor.
+            corrupt_page(&context, &cfg.partition, &1u64.to_be_bytes(), 2, 16).await;
+            let size = 16 * u64::SIZE as u64;
+            let journal = Journal::<_, u64>::preflight_restore(
+                context.child("restore"),
+                cfg.clone(),
+                1,
+                size,
+            )
+            .await
+            .expect("failed to preflight")
+            .finish()
+            .await
+            .expect("failed to finish preflight");
+
+            // Replay repair may not truncate checkpoint-proven bytes: the torn page sits below
+            // the restore floor, so recovery fails loud instead of mutating.
+            let mut replay = journal
+                .replay(0, 0, NZUsize!(1024), ReadOptions::default())
+                .await
+                .expect("failed to start replay");
+            let mut outcome = None;
+            while let Some(item) = replay.next().await {
+                if let Err(err) = item {
+                    outcome = Some(err);
+                    break;
+                }
+            }
+            assert!(matches!(
+                outcome,
+                Some(Error::Corruption(ref message))
+                    if message.contains("below its 128-byte validation floor")
+            ));
+            drop(replay);
+
+            // The checkpoint-proven bytes stay untouched: eight 28-byte physical pages.
+            let (_, blob_size) = context
+                .open(&cfg.partition, &1u64.to_be_bytes())
+                .await
+                .expect("failed to open");
+            assert_eq!(blob_size, 8 * 28);
+        });
+    }
+
+    #[test_traced]
+    fn test_segmented_fixed_floor_preflight_reads_terminal_entry_only() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let (context, recordings) = RecordingContext::new(context);
+            let cfg = aligned_subset_cfg(&context);
+            let mut journal = Journal::init(context.child("seed"), cfg.clone())
+                .await
+                .expect("failed to init");
+            for value in 0..2 {
+                (journal, _) = journal
+                    .append(1, &test_digest(value))
+                    .await
+                    .expect("failed to append");
+            }
+            journal = journal.sync(1).await.expect("failed to sync");
+            drop(journal);
+
+            recordings.clear();
+            let floors = BTreeMap::from([(1, 2)]);
+            let journal =
+                Journal::<_, Digest>::preflight_floors(context.child("reopen"), cfg, &floors)
+                    .await
+                    .expect("failed to preflight")
+                    .finish()
+                    .await
+                    .expect("failed to reopen");
+
+            // Two 32-byte items occupy four 16-byte pages. The terminal entry spans two pages, and
+            // Writer reads the tail once when opening. No earlier entry page is scanned.
+            assert_eq!(recordings.snapshot().reads.len(), 3);
             journal.destroy().await.expect("failed to destroy");
         });
     }
@@ -1554,6 +2310,150 @@ mod tests {
     }
 
     #[test_traced]
+    fn test_segmented_fixed_validates_pages_before_trailing_bytes() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            const LOGICAL_PAGE_SIZE: u64 = 5;
+            const SECTION: u64 = 0;
+
+            let cfg = Config {
+                partition: "segmented-fixed-validate-before-tail-trim".into(),
+                page_cache: CacheRef::from_pooler(
+                    &context,
+                    NZU16!(LOGICAL_PAGE_SIZE as u16),
+                    NZUsize!(4),
+                ),
+                write_buffer: NZUsize!(128),
+            };
+            let mut journal = Journal::<_, u64>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            for value in [11u64, 22, 33, 44] {
+                (journal, _) = journal.append(SECTION, &value).await.unwrap();
+            }
+            journal = journal.sync_all().await.unwrap();
+            drop(journal);
+
+            let (blob, size) = context
+                .open(&cfg.partition, &SECTION.to_be_bytes())
+                .await
+                .unwrap();
+            let mut writer = Writer::new(blob, size, 128, cfg.page_cache.clone())
+                .await
+                .unwrap();
+            writer.resize(30).await.unwrap();
+            writer.sync().await.unwrap();
+            drop(writer);
+
+            // Five-byte integrity pages crossed by eight-byte journal items:
+            //
+            // pages: [0..5) [5..10) [10..15) [15..20) [20..25) [25..30)
+            // state:    ok      ok       ok       ok       torn      ok
+            // items: [0......8) [8.......16) [16......24) [24..30 tail)
+            //
+            // Backward sizing stops at valid page 5 and reports 30 logical bytes. Item alignment
+            // alone selects 24, inside torn page 4, which `Writer::resize` cannot preserve.
+            // Forward page validation finds 20 contiguous bytes and selects safe item boundary 16.
+            corrupt_page(
+                &context,
+                &cfg.partition,
+                &SECTION.to_be_bytes(),
+                4,
+                LOGICAL_PAGE_SIZE,
+            )
+            .await;
+
+            let journal = Journal::<_, u64>::init(context.child("recover"), cfg)
+                .await
+                .unwrap();
+            let journal = replay_all(journal).await;
+            assert_eq!(journal.section_len(SECTION).unwrap(), 2);
+            assert_eq!(journal.get(SECTION, 0).await.unwrap(), 11);
+            assert_eq!(journal.get(SECTION, 1).await.unwrap(), 22);
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced]
+    fn test_segmented_fixed_repairs_aligned_subset_crash() {
+        const SECTION: u64 = 0;
+
+        let executor = deterministic::Runner::new(deterministic::Config::default().with_seed(4));
+        let (_, checkpoint) = executor.start_and_recover(|context| async move {
+            let fault_config = context.storage_fault_config();
+            let pending = PendingSyncs::default();
+            let context = DelayedSyncContext {
+                inner: context,
+                pending: pending.clone(),
+            };
+            let cfg = aligned_subset_cfg(&context);
+            let mut journal = Journal::<_, u64>::init(context.child("first"), cfg)
+                .await
+                .unwrap();
+            for value in 0..6 {
+                (journal, _) = journal.append(SECTION, &value).await.unwrap();
+            }
+
+            // The three 16-byte logical pages each contain two complete u64 items. This seed
+            // retains pages 0 and 2 but tears page 1 while the durability barrier is pending:
+            //
+            // pages: [0........16) [16.......32) [32.......48)
+            // state:     valid          torn          valid
+            // items: [0.......1]    [2.......3]    [4.......5]
+            //
+            // Backward sizing sees valid page 2 and reports the item-aligned length 48. Recovery
+            // must still scan forward, truncate to page 0's 16-byte prefix, and discard items 2-5.
+            *fault_config.write() = deterministic::FaultConfig {
+                write_rate: Some(deterministic::WriteConfig {
+                    failure_rate: probability!(0.0),
+                    retention_rate: probability!(0.99),
+                    mode: deterministic::PartialWriteMode::Subset,
+                }),
+                ..Default::default()
+            };
+            let (journal, handle) = journal.start_sync(SECTION).await.unwrap();
+            assert_eq!(pending.lock().len(), 1);
+            drop(handle);
+            drop(journal);
+        });
+
+        let (_, checkpoint) =
+            deterministic::Runner::from(checkpoint).start_and_recover(|context| async move {
+                *context.storage_fault_config().write() = deterministic::FaultConfig::default();
+                let cfg = aligned_subset_cfg(&context);
+                let mut journal = Journal::<_, u64>::init(context.child("recover"), cfg)
+                    .await
+                    .unwrap();
+                journal = replay_all(journal).await;
+                assert_eq!(journal.section_len(SECTION).unwrap(), 2);
+                assert_eq!(journal.get(SECTION, 0).await.unwrap(), 0);
+                assert_eq!(journal.get(SECTION, 1).await.unwrap(), 1);
+                assert!(matches!(
+                    journal.get(SECTION, 2).await,
+                    Err(Error::ItemOutOfRange(2))
+                ));
+
+                let position;
+                (journal, position) = journal.append(SECTION, &99).await.unwrap();
+                assert_eq!(position, 2);
+                journal.sync_all().await.unwrap();
+            });
+
+        deterministic::Runner::from(checkpoint).start(|context| async move {
+            *context.storage_fault_config().write() = deterministic::FaultConfig::default();
+            let cfg = aligned_subset_cfg(&context);
+            let journal = Journal::<_, u64>::init(context.child("reopen"), cfg)
+                .await
+                .unwrap();
+            assert_eq!(journal.section_len(SECTION).unwrap(), 3);
+            assert_eq!(journal.get(SECTION, 0).await.unwrap(), 0);
+            assert_eq!(journal.get(SECTION, 1).await.unwrap(), 1);
+            assert_eq!(journal.get(SECTION, 2).await.unwrap(), 99);
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced]
     fn test_segmented_fixed_truncation_recovery_across_page_boundary() {
         // Test that truncating a single byte from a blob that has items straddling a page boundary
         // correctly recovers by removing the incomplete item.
@@ -1598,11 +2498,12 @@ mod tests {
             blob.sync().await.expect("failed to sync");
             drop(blob);
 
-            // Reopen journal - should recover by truncating last page due to failed checksum, and
-            // end up with a correct blob size due to partial-item trimming.
+            // Reopen and drain recovery. Writer removes the torn physical tail while replay rounds
+            // the remaining logical prefix down to complete items.
             let journal = Journal::<_, Digest>::init(context.child("second"), cfg.clone())
                 .await
                 .expect("failed to re-init");
+            let journal = replay_all(journal).await;
 
             // Verify section now has only 2 items
             assert_eq!(journal.section_len(1).unwrap(), 2);

--- a/storage/src/journal/segmented/fixed.rs
+++ b/storage/src/journal/segmented/fixed.rs
@@ -253,7 +253,7 @@ impl<E: Storage + Metrics, A: CodecFixedShared> Inner<E, A> {
         section: u64,
         size: u64,
     ) -> Result<A, Error> {
-        let entry = Writer::<E::Blob>::read(
+        let entry = Writer::<E::Blob>::read_range(
             blob,
             page_size,
             size - Self::CHUNK_SIZE_U64,

--- a/storage/src/journal/segmented/fixed.rs
+++ b/storage/src/journal/segmented/fixed.rs
@@ -33,7 +33,7 @@ use commonware_utils::NZUsize;
 use std::{
     collections::{BTreeMap, BTreeSet, VecDeque},
     marker::PhantomData,
-    num::{NonZeroU16, NonZeroUsize},
+    num::NonZeroUsize,
 };
 use tracing::{trace, warn};
 
@@ -113,17 +113,6 @@ impl<E: Storage + Metrics, A: CodecFixedShared> Inner<E, A> {
     const CHUNK_SIZE: usize = A::SIZE;
     const CHUNK_SIZE_U64: u64 = Self::CHUNK_SIZE as u64;
 
-    /// Logical page size shared by all index blobs in this journal.
-    fn page_size(cfg: &Config) -> NonZeroU16 {
-        NonZeroU16::new(
-            cfg.page_cache
-                .page_size()
-                .try_into()
-                .expect("page cache size must fit in u16"),
-        )
-        .expect("page cache size must be non-zero")
-    }
-
     /// Return canonical section names in numeric order without opening writers.
     async fn stored(context: &E, cfg: &Config) -> Result<BTreeMap<u64, Vec<u8>>, Error> {
         // Recovery relies on numeric section order for checkpoint coverage and reverse deletion.
@@ -142,7 +131,7 @@ impl<E: Storage + Metrics, A: CodecFixedShared> Inner<E, A> {
         minimum_items: &BTreeMap<u64, u64>,
     ) -> Result<RecoveryPreflight<E, A>, Error> {
         let stored = Self::stored(&context, &cfg).await?;
-        let page_size = Self::page_size(&cfg);
+        let page_size = cfg.page_cache.page_size();
         let mut floor_sizes = BTreeMap::new();
         let mut boundaries = BTreeMap::new();
 
@@ -212,7 +201,7 @@ impl<E: Storage + Metrics, A: CodecFixedShared> Inner<E, A> {
             )));
         }
 
-        let page_size = Self::page_size(&cfg);
+        let page_size = cfg.page_cache.page_size();
         let mut boundaries = BTreeMap::new();
         let mut floors = BTreeMap::new();
 

--- a/storage/src/journal/segmented/fixed.rs
+++ b/storage/src/journal/segmented/fixed.rs
@@ -33,7 +33,7 @@ use commonware_utils::NZUsize;
 use std::{
     collections::{BTreeMap, BTreeSet, VecDeque},
     marker::PhantomData,
-    num::NonZeroUsize,
+    num::{NonZeroU16, NonZeroUsize},
 };
 use tracing::{trace, warn};
 
@@ -108,6 +108,15 @@ impl<E: Storage + Metrics, A: CodecFixedShared> RecoveryPreflight<E, A> {
     }
 }
 
+impl<E: Storage + Metrics, A: CodecFixed> Inner<E, A> {
+    /// The section's writer. A replayed section cannot be removed while the replay owns the journal.
+    fn writer(&mut self, section: u64) -> &mut Writer<E::Blob> {
+        self.manager
+            .get_mut(section)
+            .expect("replayed section is present")
+    }
+}
+
 impl<E: Storage + Metrics, A: CodecFixedShared> Inner<E, A> {
     /// Size of each entry.
     const CHUNK_SIZE: usize = A::SIZE;
@@ -154,19 +163,8 @@ impl<E: Storage + Metrics, A: CodecFixedShared> Inner<E, A> {
 
             // A published marker follows a completed index/value sync, so its earlier pages are
             // already durable. Validate the terminal index page that binds the two journals.
-            let entry_offset = required - Self::CHUNK_SIZE_U64;
             let (blob, _) = context.open(&cfg.partition, name).await?;
-            let entry = Writer::<E::Blob>::read_validated(
-                &blob,
-                page_size,
-                entry_offset,
-                Self::CHUNK_SIZE,
-                ReadOptions::default(),
-            )
-            .await
-            .map_err(|err| Self::boundary_error(section, required, err))?;
-
-            let entry = A::decode(entry.coalesce()).map_err(Error::Codec)?;
+            let entry = Self::boundary(&blob, page_size, section, required).await?;
             floor_sizes.insert(section, required);
             boundaries.insert(section, Some(entry));
         }
@@ -213,17 +211,9 @@ impl<E: Storage + Metrics, A: CodecFixedShared> Inner<E, A> {
                 if size == 0 {
                     None
                 } else {
-                    let entry = Writer::<E::Blob>::read_validated(
-                        &blob,
-                        page_size,
-                        size - Self::CHUNK_SIZE_U64,
-                        Self::CHUNK_SIZE,
-                        ReadOptions::default(),
-                    )
-                    .await
-                    .map_err(|err| Self::boundary_error(section, size, err))?;
+                    let entry = Self::boundary(&blob, page_size, section, size).await?;
                     floors.insert(section, size);
-                    Some(A::decode(entry.coalesce()).map_err(Error::Codec)?)
+                    Some(entry)
                 }
             } else if physical_size == 0 {
                 None
@@ -254,6 +244,25 @@ impl<E: Storage + Metrics, A: CodecFixedShared> Inner<E, A> {
             boundaries,
             mode: PreflightMode::Restore { section, floors },
         })
+    }
+
+    /// Read and decode the terminal entry of a validated `size`-byte prefix.
+    async fn boundary(
+        blob: &E::Blob,
+        page_size: NonZeroU16,
+        section: u64,
+        size: u64,
+    ) -> Result<A, Error> {
+        let entry = Writer::<E::Blob>::read_validated(
+            blob,
+            page_size,
+            size - Self::CHUNK_SIZE_U64,
+            Self::CHUNK_SIZE,
+            ReadOptions::default(),
+        )
+        .await
+        .map_err(|err| Self::boundary_error(section, size, err))?;
+        A::decode(entry.coalesce()).map_err(Error::Codec)
     }
 
     /// Classify an invalid or missing boundary as committed corruption without hiding I/O errors.
@@ -824,12 +833,12 @@ pub struct Replay<E: Storage + Metrics, A: CodecFixed> {
 }
 
 impl<E: Storage + Metrics, A: CodecFixedShared> Replay<E, A> {
-    /// Repair a torn page discovered by ordered replay and resume at the last complete item.
-    async fn repair_torn_front(&mut self, source: RError) -> Result<(), Error> {
+    /// Validate that the front section's checksum failure is a repairable torn page, returning
+    /// the item-aligned truncation target and the validated replay prefix.
+    async fn plan_front_repair(&mut self, source: RError) -> Result<(u64, u64), Error> {
         // Only a checksum failure is repairable: it marks a torn write, while any other error
         // is an I/O failure this repair must not mask.
         if !matches!(source, RError::InvalidChecksum) {
-            self.sections.pop_front();
             return Err(source.into());
         }
 
@@ -838,32 +847,21 @@ impl<E: Storage + Metrics, A: CodecFixedShared> Replay<E, A> {
         let section = current.section;
         let position = current.position;
         let size = current.reader.blob_size();
-        let Some(valid_size) = position.checked_mul(Inner::<E, A>::CHUNK_SIZE_U64) else {
-            self.sections.pop_front();
-            return Err(Error::OffsetOverflow);
-        };
+        let valid_size = position
+            .checked_mul(Inner::<E, A>::CHUNK_SIZE_U64)
+            .ok_or(Error::OffsetOverflow)?;
 
         // Forward-validate from the replayed prefix to find where well-formed pages end.
-        let recoverable = match self
+        let recoverable = self
             .journal
             .0
-            .manager
-            .get_mut(section)
-            .expect("replayed section is present")
+            .writer(section)
             .recoverable_prefix_len(valid_size, self.buffer, self.read_options)
-            .await
-        {
-            Ok(recoverable) => recoverable,
-            Err(err) => {
-                self.sections.pop_front();
-                return Err(err.into());
-            }
-        };
+            .await?;
 
         // A whole-blob recoverable prefix means the checksum failure did not come from a torn
         // page: surface the original error instead of truncating valid data.
         if recoverable >= size {
-            self.sections.pop_front();
             return Err(source.into());
         }
 
@@ -871,18 +869,29 @@ impl<E: Storage + Metrics, A: CodecFixedShared> Replay<E, A> {
         // floor: a cut inside either lost acknowledged data.
         let target = recoverable - recoverable % Inner::<E, A>::CHUNK_SIZE_U64;
         if target < valid_size {
-            self.sections.pop_front();
             return Err(Error::ItemOutOfRange(position));
         }
-        if let Err(err) = self.ensure_above_floor(section, target) {
-            self.sections.pop_front();
-            return Err(err);
-        }
+        self.ensure_above_floor(section, target)?;
 
+        Ok((valid_size, target))
+    }
+
+    /// Repair a torn page discovered by ordered replay and resume at the last complete item.
+    async fn repair_torn_front(&mut self, source: RError) -> Result<(), Error> {
+        // A rejected plan mutates nothing: drop the damaged section and surface its error.
+        let (valid_size, target) = match self.plan_front_repair(source).await {
+            Ok(plan) => plan,
+            Err(err) => {
+                self.sections.pop_front();
+                return Err(err);
+            }
+        };
+
+        let current = self.sections.front().expect("replayed section is present");
+        let (section, position) = (current.section, current.position);
         warn!(
             section,
-            invalid_size = size,
-            recoverable_size = recoverable,
+            invalid_size = current.reader.blob_size(),
             new_size = target,
             "torn page detected: truncating"
         );
@@ -898,9 +907,7 @@ impl<E: Storage + Metrics, A: CodecFixedShared> Replay<E, A> {
         let mut reader = self
             .journal
             .0
-            .manager
-            .get_mut(section)
-            .expect("repaired section is present")
+            .writer(section)
             .replay(self.buffer, self.read_options)
             .await?;
         reader.seek_to(valid_size)?;
@@ -1028,11 +1035,7 @@ async fn repair_blob<E: Storage + Metrics, A: CodecFixed>(
     section: u64,
     size: u64,
 ) -> Result<(), Error> {
-    let blob = journal
-        .0
-        .manager
-        .get_mut(section)
-        .expect("replayed section must exist");
+    let blob = journal.0.writer(section);
     blob.resize(size).await?;
     blob.sync().await?;
     Ok(())
@@ -1055,9 +1058,12 @@ mod tests {
     };
     use commonware_utils::{NZU16, NZUsize, probability};
     use core::num::NonZeroU16;
-    use std::sync::{
-        Arc,
-        atomic::{AtomicUsize, Ordering},
+    use std::{
+        ops::RangeInclusive,
+        sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        },
     };
 
     const PAGE_SIZE: NonZeroU16 = NZU16!(44);
@@ -1104,6 +1110,22 @@ mod tests {
             item.expect("failed to recover journal");
         }
         replay.finish().expect("failed to finish recovery replay")
+    }
+
+    /// Seed each section with sixteen durable u64 items.
+    async fn seed<E: Storage + Metrics>(context: &E, cfg: &Config, sections: RangeInclusive<u64>) {
+        let mut journal = Journal::init(context.child("seed"), cfg.clone())
+            .await
+            .expect("failed to init");
+        for section in sections {
+            for value in 0..16u64 {
+                (journal, _) = journal
+                    .append(section, &value)
+                    .await
+                    .expect("failed to append");
+            }
+        }
+        journal.sync_all().await.expect("failed to sync");
     }
 
     #[test_traced]
@@ -1243,14 +1265,7 @@ mod tests {
 
             // Sixteen u64s occupy eight physical pages. Persist a clean journal whose tiny write
             // buffer would force an eager recovery scan to issue one read per page.
-            let mut journal = Journal::init(context.child("seed"), cfg.clone())
-                .await
-                .expect("failed to init");
-            for value in 0..16u64 {
-                (journal, _) = journal.append(1, &value).await.expect("failed to append");
-            }
-            journal = journal.sync_all().await.expect("failed to sync");
-            drop(journal);
+            seed(&context, &cfg, 1..=1).await;
 
             // Initialization needs only the terminal page used to open Writer. Recovery belongs to
             // replay, whose 112-byte budget batches four 28-byte physical pages per read.
@@ -1308,14 +1323,7 @@ mod tests {
         executor.start(|context| async move {
             let (context, recordings) = RecordingContext::new(context);
             let cfg = lazy_recovery_cfg(&context, "segmented-fixed-floor-boundary");
-            let mut journal = Journal::init(context.child("seed"), cfg.clone())
-                .await
-                .expect("failed to init");
-            for value in 0..16u64 {
-                (journal, _) = journal.append(1, &value).await.expect("failed to append");
-            }
-            journal = journal.sync_all().await.expect("failed to sync");
-            drop(journal);
+            seed(&context, &cfg, 1..=1).await;
 
             // A durable floor proves its prefix. Preflight reads only the page containing the
             // terminal entry and leaves the ordinary replay pass to inspect the suffix.
@@ -1342,19 +1350,7 @@ mod tests {
         executor.start(|context| async move {
             let (context, recordings) = RecordingContext::new(context);
             let cfg = lazy_recovery_cfg(&context, "segmented-fixed-restore-boundaries");
-            let mut journal = Journal::init(context.child("seed"), cfg.clone())
-                .await
-                .expect("failed to init");
-            for section in 0..=1 {
-                for value in 0..16u64 {
-                    (journal, _) = journal
-                        .append(section, &value)
-                        .await
-                        .expect("failed to append");
-                }
-            }
-            journal = journal.sync_all().await.expect("failed to sync");
-            drop(journal);
+            seed(&context, &cfg, 0..=1).await;
 
             // The checkpoint makes both retained sections durable. Restore needs one terminal
             // boundary read per section, independent of the eight pages stored in each.
@@ -1418,19 +1414,7 @@ mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let cfg = lazy_recovery_cfg(&context, "segmented-fixed-restore-floors");
-            let mut journal = Journal::init(context.child("seed"), cfg.clone())
-                .await
-                .expect("failed to init");
-            for section in 0..=1 {
-                for value in 0..16u64 {
-                    (journal, _) = journal
-                        .append(section, &value)
-                        .await
-                        .expect("failed to append");
-                }
-            }
-            journal = journal.sync_all().await.expect("failed to sync");
-            drop(journal);
+            seed(&context, &cfg, 0..=1).await;
 
             // Tear an interior page below the checkpoint boundary. The preflight reads only the
             // terminal boundary page, so restore succeeds and must arm the proven floor.

--- a/storage/src/journal/segmented/fixed.rs
+++ b/storage/src/journal/segmented/fixed.rs
@@ -262,7 +262,7 @@ impl<E: Storage + Metrics, A: CodecFixedShared> Inner<E, A> {
             RError::InvalidChecksum | RError::BlobInsufficientLength => Error::Corruption(format!(
                 "section {section} does not retain its {required}-byte durable boundary"
             )),
-            err => Error::Runtime(err),
+            err => err.into(),
         }
     }
 
@@ -826,11 +826,14 @@ pub struct Replay<E: Storage + Metrics, A: CodecFixed> {
 impl<E: Storage + Metrics, A: CodecFixedShared> Replay<E, A> {
     /// Repair a torn page discovered by ordered replay and resume at the last complete item.
     async fn repair_torn_front(&mut self, source: RError) -> Result<(), Error> {
+        // Only a checksum failure is repairable: it marks a torn write, while any other error
+        // is an I/O failure this repair must not mask.
         if !matches!(source, RError::InvalidChecksum) {
             self.sections.pop_front();
             return Err(source.into());
         }
 
+        // The bytes already replayed are validated: they bound the truncation from below.
         let current = self.sections.front().expect("replayed section is present");
         let section = current.section;
         let position = current.position;
@@ -839,6 +842,8 @@ impl<E: Storage + Metrics, A: CodecFixedShared> Replay<E, A> {
             self.sections.pop_front();
             return Err(Error::OffsetOverflow);
         };
+
+        // Forward-validate from the replayed prefix to find where well-formed pages end.
         let recoverable = match self
             .journal
             .0
@@ -854,10 +859,16 @@ impl<E: Storage + Metrics, A: CodecFixedShared> Replay<E, A> {
                 return Err(err.into());
             }
         };
+
+        // A whole-blob recoverable prefix means the checksum failure did not come from a torn
+        // page: surface the original error instead of truncating valid data.
         if recoverable >= size {
             self.sections.pop_front();
             return Err(source.into());
         }
+
+        // Truncate to whole items, never below the validated replay prefix or the durability
+        // floor: a cut inside either lost acknowledged data.
         let target = recoverable - recoverable % Inner::<E, A>::CHUNK_SIZE_U64;
         if target < valid_size {
             self.sections.pop_front();

--- a/storage/src/journal/segmented/fixed.rs
+++ b/storage/src/journal/segmented/fixed.rs
@@ -709,7 +709,7 @@ impl<E: Storage + Metrics, A: CodecFixedShared> Journal<E, A> {
         Ok(Replay {
             journal: self,
             sections,
-            fully_replayed_from: if start_position == 0 {
+            recovered_from: if start_position == 0 {
                 Some(start_section)
             } else {
                 start_section.checked_add(1)
@@ -824,7 +824,9 @@ impl<E: Storage + Metrics, A: CodecFixedShared> Journal<E, A> {
 pub struct Replay<E: Storage + Metrics, A: CodecFixed> {
     journal: Journal<E, A>,
     sections: VecDeque<SectionReplay<E::Blob>>,
-    fully_replayed_from: Option<u64>,
+    /// The first section this replay fully covers: [Replay::finish] marks it and every
+    /// later section recovered.
+    recovered_from: Option<u64>,
     buffer: NonZeroUsize,
     read_options: ReadOptions,
     finished: bool,
@@ -1019,7 +1021,7 @@ impl<E: Storage + Metrics, A: CodecFixedShared> Replay<E, A> {
         if self.errored || !self.finished {
             return Err(Error::ReplayFailed);
         }
-        if let Some(start) = self.fully_replayed_from {
+        if let Some(start) = self.recovered_from {
             self.journal
                 .0
                 .unrecovered

--- a/storage/src/journal/segmented/fixed.rs
+++ b/storage/src/journal/segmented/fixed.rs
@@ -1058,7 +1058,7 @@ mod tests {
             release_pending_syncs,
         },
     };
-    use commonware_utils::{NZU16, NZUsize, probability};
+    use commonware_utils::{NZU16, NZUsize};
     use core::num::NonZeroU16;
     use std::{
         ops::RangeInclusive,
@@ -1083,9 +1083,9 @@ mod tests {
         }
     }
 
-    fn aligned_subset_cfg(pooler: &impl BufferPooler) -> Config {
+    fn aligned_cfg(pooler: &impl BufferPooler) -> Config {
         Config {
-            partition: "segmented-fixed-aligned-subset".into(),
+            partition: "segmented-fixed-aligned".into(),
             page_cache: CacheRef::from_pooler(pooler, NZU16!(16), NZUsize!(4)),
             write_buffer: NZUsize!(128),
         }
@@ -1468,7 +1468,7 @@ mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let (context, recordings) = RecordingContext::new(context);
-            let cfg = aligned_subset_cfg(&context);
+            let cfg = aligned_cfg(&context);
             let mut journal = Journal::init(context.child("seed"), cfg.clone())
                 .await
                 .expect("failed to init");
@@ -2363,27 +2363,23 @@ mod tests {
     }
 
     #[test_traced]
-    fn test_segmented_fixed_repairs_aligned_subset_crash() {
+    fn test_segmented_fixed_repairs_torn_interior_page() {
         const SECTION: u64 = 0;
 
-        let executor = deterministic::Runner::new(deterministic::Config::default().with_seed(4));
-        let (_, checkpoint) = executor.start_and_recover(|context| async move {
-            let fault_config = context.storage_fault_config();
-            let pending = PendingSyncs::default();
-            let context = DelayedSyncContext {
-                inner: context,
-                pending: pending.clone(),
-            };
-            let cfg = aligned_subset_cfg(&context);
-            let mut journal = Journal::<_, u64>::init(context.child("first"), cfg)
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = aligned_cfg(&context);
+            let mut journal = Journal::<_, u64>::init(context.child("first"), cfg.clone())
                 .await
                 .unwrap();
             for value in 0..6 {
                 (journal, _) = journal.append(SECTION, &value).await.unwrap();
             }
+            journal = journal.sync_all().await.unwrap();
+            drop(journal);
 
-            // The three 16-byte logical pages each contain two complete u64 items. This seed
-            // retains pages 0 and 2 but tears page 1 while the durability barrier is pending:
+            // The three 16-byte logical pages each contain two complete u64 items. Tear the
+            // interior page while its neighbors stay valid:
             //
             // pages: [0........16) [16.......32) [32.......48)
             // state:     valid          torn          valid
@@ -2391,45 +2387,27 @@ mod tests {
             //
             // Backward sizing sees valid page 2 and reports the item-aligned length 48. Recovery
             // must still scan forward, truncate to page 0's 16-byte prefix, and discard items 2-5.
-            *fault_config.write() = deterministic::FaultConfig {
-                write_rate: Some(deterministic::WriteConfig {
-                    failure_rate: probability!(0.0),
-                    retention_rate: probability!(0.99),
-                    mode: deterministic::PartialWriteMode::Subset,
-                }),
-                ..Default::default()
-            };
-            let (journal, handle) = journal.start_sync(SECTION).await.unwrap();
-            assert_eq!(pending.lock().len(), 1);
-            drop(handle);
-            drop(journal);
-        });
+            corrupt_page(&context, &cfg.partition, &SECTION.to_be_bytes(), 1, 16).await;
 
-        let (_, checkpoint) =
-            deterministic::Runner::from(checkpoint).start_and_recover(|context| async move {
-                *context.storage_fault_config().write() = deterministic::FaultConfig::default();
-                let cfg = aligned_subset_cfg(&context);
-                let mut journal = Journal::<_, u64>::init(context.child("recover"), cfg)
-                    .await
-                    .unwrap();
-                journal = replay_all(journal).await;
-                assert_eq!(journal.section_len(SECTION).unwrap(), 2);
-                assert_eq!(journal.get(SECTION, 0).await.unwrap(), 0);
-                assert_eq!(journal.get(SECTION, 1).await.unwrap(), 1);
-                assert!(matches!(
-                    journal.get(SECTION, 2).await,
-                    Err(Error::ItemOutOfRange(2))
-                ));
+            let mut journal = Journal::<_, u64>::init(context.child("recover"), cfg.clone())
+                .await
+                .unwrap();
+            journal = replay_all(journal).await;
+            assert_eq!(journal.section_len(SECTION).unwrap(), 2);
+            assert_eq!(journal.get(SECTION, 0).await.unwrap(), 0);
+            assert_eq!(journal.get(SECTION, 1).await.unwrap(), 1);
+            assert!(matches!(
+                journal.get(SECTION, 2).await,
+                Err(Error::ItemOutOfRange(2))
+            ));
 
-                let position;
-                (journal, position) = journal.append(SECTION, &99).await.unwrap();
-                assert_eq!(position, 2);
-                journal.sync_all().await.unwrap();
-            });
+            // The repair truncation is durable: appends resume at the repaired boundary and
+            // survive reopen.
+            let position;
+            (journal, position) = journal.append(SECTION, &99).await.unwrap();
+            assert_eq!(position, 2);
+            journal.sync_all().await.unwrap();
 
-        deterministic::Runner::from(checkpoint).start(|context| async move {
-            *context.storage_fault_config().write() = deterministic::FaultConfig::default();
-            let cfg = aligned_subset_cfg(&context);
             let journal = Journal::<_, u64>::init(context.child("reopen"), cfg)
                 .await
                 .unwrap();

--- a/storage/src/journal/segmented/fixed.rs
+++ b/storage/src/journal/segmented/fixed.rs
@@ -333,9 +333,10 @@ impl<E: Storage + Metrics, A: CodecFixedShared> Inner<E, A> {
 
     /// See [Journal::append].
     async fn append(&mut self, section: u64, item: &A) -> Result<u64, Error> {
-        if self.unrecovered.contains(&section) {
-            return Err(Error::ReplayRequired(section));
-        }
+        assert!(
+            !self.unrecovered.contains(&section),
+            "section {section} must be replayed before append"
+        );
         let blob = self.manager.get_or_create(section).await?;
 
         // Encode the item
@@ -611,8 +612,11 @@ impl<E: Storage + Metrics, A: CodecFixedShared> Journal<E, A> {
     /// Append a new item to the journal in the given section.
     ///
     /// Returns the position of the item within the section (0-indexed).
-    /// Returns [Error::ReplayRequired] when `section` contained an unvalidated suffix at
-    /// initialization and has not completed a replay from position zero.
+    ///
+    /// # Panics
+    ///
+    /// Panics when `section` contained an unvalidated suffix at initialization and has not
+    /// completed a replay from position zero.
     pub async fn append(mut self, section: u64, item: &A) -> Result<(Self, u64), Error> {
         let position = self.0.append(section, item).await?;
         Ok((self, position))
@@ -1274,6 +1278,7 @@ mod tests {
     }
 
     #[test_traced]
+    #[should_panic(expected = "must be replayed before append")]
     fn test_segmented_fixed_append_requires_replay_after_reopen() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
@@ -1293,10 +1298,7 @@ mod tests {
             let journal = Journal::init(context.child("reopen"), cfg)
                 .await
                 .expect("failed to reopen");
-            assert!(matches!(
-                journal.append(1, &test_digest(1)).await,
-                Err(Error::ReplayRequired(1))
-            ));
+            journal.append(1, &test_digest(1)).await.unwrap();
         });
     }
 

--- a/storage/src/journal/segmented/manager.rs
+++ b/storage/src/journal/segmented/manager.rs
@@ -22,6 +22,26 @@ use std::{
 };
 use tracing::debug;
 
+/// List stored blob names, treating a missing partition as an empty journal.
+pub(super) async fn stored_names<E: Storage>(
+    context: &E,
+    partition: &str,
+) -> Result<Vec<Vec<u8>>, Error> {
+    match context.scan(partition).await {
+        Ok(names) => Ok(names),
+        Err(RError::PartitionMissing(_)) => Ok(Vec::new()),
+        Err(err) => Err(Error::Runtime(err)),
+    }
+}
+
+/// Decode the canonical big-endian section number stored in a blob name.
+pub(super) fn section_from_name(name: &[u8]) -> Result<u64, Error> {
+    let section = name
+        .try_into()
+        .map_err(|_| Error::InvalidBlobName(hex(name)))?;
+    Ok(u64::from_be_bytes(section))
+}
+
 /// A minimal [`Blob`] wrapper for [`Manager`].
 pub trait SectionBuffer: Send + Sync {
     /// Returns the current logical size of the buffer including any buffered data.
@@ -199,22 +219,14 @@ impl<E: Storage + Metrics, F: BufferFactory<E::Blob>> Manager<E, F> {
     ///
     /// Scans the partition for existing blobs and opens them.
     pub async fn init(context: E, cfg: Config<F>) -> Result<Self, Error> {
-        // Iterate over blobs in partition
+        // Open each canonical section in storage order.
         let mut blobs = BTreeMap::new();
-        let stored_blobs = match context.scan(&cfg.partition).await {
-            Ok(blobs) => blobs,
-            Err(RError::PartitionMissing(_)) => Vec::new(),
-            Err(err) => return Err(Error::Runtime(err)),
-        };
+        let stored_blobs = stored_names(&context, &cfg.partition).await?;
 
         for name in stored_blobs {
             let (blob, size) = context.open(&cfg.partition, &name).await?;
-            let hex_name = hex(&name);
-            let section = match name.try_into() {
-                Ok(section) => u64::from_be_bytes(section),
-                Err(_) => return Err(Error::InvalidBlobName(hex_name)),
-            };
-            debug!(section, blob = hex_name, size, "loaded section");
+            let section = section_from_name(&name)?;
+            debug!(section, blob = hex(&name), size, "loaded section");
             let buffer = cfg.factory.create(blob, size).await?;
             blobs.insert(section, buffer);
         }

--- a/storage/src/journal/segmented/oversized.rs
+++ b/storage/src/journal/segmented/oversized.rs
@@ -45,22 +45,38 @@
 //! crash once later appends may reuse the freed offsets.
 //!
 //! When a checkpoint is provided at init, recovery restores exactly the checkpointed
-//! state instead of inferring one: sections below the checkpoint are verified complete
-//! (their last entry must end exactly at the glob's size, without reading values) and
-//! adopted unchanged, the checkpointed section is durably truncated to the committed
-//! size, and everything after it is removed. Committed damage the checkpoint covers
-//! fails init rather than being repaired, and value checksums below the checkpoint are
-//! still verified lazily at read.
+//! state instead of inferring one: each section below the checkpoint is adopted at its
+//! validated terminal boundary (without reading values), the checkpointed section is
+//! durably truncated to the committed size, and everything after it is removed. A
+//! missing or damaged durable boundary fails init rather than being repaired. Other
+//! committed damage the checkpoint covers surfaces lazily as read errors.
+//!
+//! Tracked recovery maintains a per-section committed item count for owners that must validate
+//! every newly recovered value. The covered index/value prefix is proven before repair, replay
+//! verifies values above it in order, and the first invalid value truncates the rest of that
+//! section. Marker publication conservatively trails proven data syncs: a section's boundary
+//! is published once it is proven durable and the section is no longer receiving writes, or on
+//! an empty flush.
 
 use super::{
-    fixed::{Config as FixedConfig, Journal as FixedJournal, Replay as FixedReplay},
+    fixed::{
+        Config as FixedConfig, Journal as FixedJournal, RecoveryPreflight, Replay as FixedReplay,
+    },
     glob::{Config as GlobConfig, Glob},
 };
-use crate::{Context, journal::Error};
+use crate::{
+    Context, SyncCompletion,
+    journal::{Error, durability::Barrier},
+    metadata::{Config as MetadataConfig, Metadata},
+};
 use commonware_codec::{Codec, CodecFixed, CodecShared};
 use commonware_runtime::{Error as RError, Handle, ReadOptions};
-use futures::future::try_join;
-use std::{collections::HashSet, num::NonZeroUsize};
+use commonware_utils::sequence::U64 as SectionKey;
+use futures::{FutureExt as _, future::try_join};
+use std::{
+    collections::{BTreeMap, BTreeSet, HashSet},
+    num::NonZeroUsize,
+};
 use tracing::{debug, warn};
 
 /// Trait for index entries that reference oversized values in glob storage.
@@ -95,11 +111,124 @@ pub struct Config<C> {
     /// Write buffer size for the value journal.
     pub value_write_buffer: NonZeroUsize,
 
+    /// Buffer size for sequential index recovery.
+    pub replay_buffer: NonZeroUsize,
+
     /// Optional compression level for values (using zstd).
     pub compression: Option<u8>,
 
     /// Codec configuration for values.
     pub codec_config: C,
+}
+
+/// Recovery contract applied while opening the index and value journals.
+///
+/// Exactly one mode establishes their shared boundary: `Restore` uses an explicit checkpoint,
+/// `Floors` preserves per-section validated prefixes while repairing any suffix, and `Infer`
+/// derives the boundary entirely from journal contents.
+enum Recovery<'a> {
+    Restore {
+        section: u64,
+        index_size: u64,
+    },
+    // Staging: consumed by the prunable archive in the next PR of this stack.
+    #[allow(dead_code)]
+    Floors(&'a BTreeMap<u64, u64>),
+    Infer,
+}
+
+/// Durable recovery state for a journal that validates every uncommitted value during replay.
+struct Tracking<E: Context> {
+    /// Durable committed item count for each retained section.
+    metadata: Metadata<E, SectionKey, u64>,
+
+    /// Completion of the marker generation currently being persisted.
+    marker_sync_pending: Option<SyncCompletion>,
+
+    /// Joint index/value durability proofs not yet fully published as markers.
+    barriers: BTreeMap<u64, Barrier>,
+}
+
+impl<E: Context> Tracking<E> {
+    /// Stage a changed marker while preserving absence as the canonical zero boundary.
+    fn stage_marker(&mut self, section: u64, floor: u64) -> bool {
+        let key = SectionKey::new(section);
+        match self.metadata.get(&key) {
+            None if floor == 0 => false,
+            Some(stored) if *stored == floor => false,
+            _ => {
+                self.metadata.put(key, floor);
+                true
+            }
+        }
+    }
+
+    /// Return the section's barrier, seeding a replacement at its staged floor.
+    ///
+    /// A staged floor never exceeds durably synced data, so it is the newest boundary a
+    /// replacement barrier may claim without observing a completed sync.
+    fn barrier(&mut self, section: u64) -> &mut Barrier {
+        let floor = self
+            .metadata
+            .get(&SectionKey::new(section))
+            .copied()
+            .unwrap_or(0);
+        self.barriers
+            .entry(section)
+            .or_insert_with(|| Barrier::new(floor))
+    }
+
+    /// Observe an in-flight marker without blocking and discard proofs it published.
+    fn observe_marker_sync(&mut self) -> Result<Option<SyncCompletion>, Error> {
+        let Some(completion) = self.marker_sync_pending.clone() else {
+            return Ok(None);
+        };
+        let Some(result) = completion.clone().now_or_never() else {
+            return Ok(Some(completion));
+        };
+        result.map_err(|err| Error::Metadata(crate::metadata::Error::Runtime(err)))?;
+        self.marker_sync_pending = None;
+
+        // Retire only barriers whose proof is fully published. A barrier still awaiting a
+        // sync outcome protects a boundary beyond its marker and must survive to observe it.
+        let metadata = &self.metadata;
+        self.barriers.retain(|section, barrier| {
+            let published = metadata
+                .get(&SectionKey::new(*section))
+                .copied()
+                .unwrap_or(0);
+            barrier.boundary() > published || !barrier.settled()
+        });
+        Ok(None)
+    }
+}
+
+/// State for the one marker-aware replay performed while opening a tracked journal.
+struct Validation {
+    /// Cursor state for the section currently being replayed.
+    current_section: Option<u64>,
+    floor: u64,
+    truncated: bool,
+
+    /// First invalid position in each section, applied after replay releases the index journal.
+    rewinds: Vec<(u64, u64)>,
+
+    /// Whether replay yielded an error that makes the journal unavailable.
+    failed: bool,
+}
+
+impl Validation {
+    // Staging: consumed by the prunable archive in the next PR of this stack.
+    #[allow(dead_code)]
+    const fn new() -> Self {
+        Self {
+            current_section: None,
+            floor: 0,
+            truncated: false,
+            rewinds: Vec::new(),
+            failed: false,
+        }
+    }
 }
 
 /// Segmented journal for entries with oversized values.
@@ -115,6 +244,7 @@ pub struct Config<C> {
 pub struct Oversized<E: Context, I: Record, V: Codec> {
     index: FixedJournal<E, I>,
     values: Glob<E, V>,
+    tracking: Option<Tracking<E>>,
 }
 
 impl<E: Context, I: Record + Send + Sync, V: CodecShared> std::fmt::Debug for Oversized<E, I, V> {
@@ -130,11 +260,12 @@ impl<E: Context, I: Record + Send + Sync, V: CodecShared> Oversized<E, I, V> {
     /// Initialize with crash recovery.
     ///
     /// `checkpoint` is the durable state recovery restores, as `(section, index size)`.
-    /// When set, recovery keeps exactly this state: sections below `section` are
-    /// verified complete and adopted unchanged, `section` is truncated to `index size`,
-    /// and everything after it is removed. Anything the checkpoint covers that is
-    /// missing or inconsistent fails init with [Error::Corruption]. Callers must only
-    /// provide a checkpoint that was durably synced before it was published (see
+    /// When set, recovery keeps exactly this state: each section below `section` is
+    /// adopted at its validated terminal boundary, `section` is truncated to `index
+    /// size`, and everything after it is removed. A missing or damaged boundary the
+    /// checkpoint covers fails init with [Error::Corruption], while interior damage
+    /// below a boundary surfaces lazily as read errors. Callers must only provide a
+    /// checkpoint that was durably synced before it was published (see
     /// [crate::freezer::Freezer]).
     ///
     /// When `None`, recovery infers the durable state instead: it finds each section's
@@ -145,31 +276,168 @@ impl<E: Context, I: Record + Send + Sync, V: CodecShared> Oversized<E, I, V> {
         cfg: Config<V::Cfg>,
         checkpoint: Option<(u64, u64)>,
     ) -> Result<Self, Error> {
-        // Initialize both journals
+        let recovery_buffer = cfg.replay_buffer;
+        let recovery = match checkpoint {
+            Some((section, index_size)) => Recovery::Restore {
+                section,
+                index_size,
+            },
+            None => Recovery::Infer,
+        };
+        let journal = Self::init_inner(context, cfg, recovery).await?;
+        if checkpoint.is_none() {
+            journal.recover_inferred(recovery_buffer).await
+        } else {
+            Ok(journal)
+        }
+    }
+
+    /// Initialize tracked recovery and return its required full replay.
+    ///
+    /// The caller must drain the replay and call [Replay::finish_tracked]. Entries below each
+    /// durable marker are retained after their cross-journal boundary is proven. Entries above it
+    /// are value-validated in order and the first invalid entry truncates its section.
+    // Staging: consumed by the prunable archive in the next PR of this stack.
+    #[allow(dead_code)]
+    pub(crate) async fn init_tracked(
+        context: &E,
+        cfg: Config<V::Cfg>,
+        metadata_partition: String,
+        read_options: ReadOptions,
+    ) -> Result<Replay<E, I, V>, Error> {
+        let buffer = cfg.replay_buffer;
+
+        // Open the commit markers before the data they constrain.
+        let metadata = Metadata::init(
+            context.child("metadata"),
+            MetadataConfig {
+                partition: metadata_partition,
+                codec_config: (),
+            },
+        )
+        .await?;
+        let floors = metadata
+            .keys()
+            .map(|key| {
+                (
+                    u64::from(key),
+                    *metadata.get(key).expect("metadata key must have a value"),
+                )
+            })
+            .collect::<BTreeMap<_, _>>();
+
+        // Every advertised prefix is proven before ordinary suffix repair may mutate either
+        // journal. An empty sidecar retains the legacy inferred-recovery behavior.
+        let recovery = if floors.is_empty() {
+            Recovery::Infer
+        } else {
+            Recovery::Floors(&floors)
+        };
+        let mut journal = Self::init_inner(context.child("oversized"), cfg, recovery).await?;
+        journal.tracking = Some(Tracking {
+            metadata,
+            marker_sync_pending: None,
+            barriers: BTreeMap::new(),
+        });
+        let mut replay = journal.replay(0, 0, buffer, read_options).await?;
+        replay.validation = Some(Validation::new());
+        Ok(replay)
+    }
+
+    async fn init_inner(
+        context: E,
+        cfg: Config<V::Cfg>,
+        recovery: Recovery<'_>,
+    ) -> Result<Self, Error> {
         let index_cfg = FixedConfig {
             partition: cfg.index_partition,
             page_cache: cfg.index_page_cache,
             write_buffer: cfg.index_write_buffer,
         };
-        let index = FixedJournal::init(context.child("index"), index_cfg).await?;
-
         let value_cfg = GlobConfig {
             partition: cfg.value_partition,
             compression: cfg.compression,
             codec_config: cfg.codec_config,
             write_buffer: cfg.value_write_buffer,
         };
-        let values = Glob::init(context.child("values"), value_cfg).await?;
+        let index_context = context.child("index");
+        let value_context = context.child("values");
 
-        let oversized = Self { index, values };
+        match recovery {
+            Recovery::Infer => {
+                let index = FixedJournal::init(index_context, index_cfg).await?;
+                let values = Glob::init(value_context, value_cfg).await?;
+                Ok(Self {
+                    index,
+                    values,
+                    tracking: None,
+                })
+            }
+            Recovery::Floors(minimum_items) => {
+                let preflight =
+                    FixedJournal::preflight_floors(index_context, index_cfg, minimum_items).await?;
+                let values = Glob::init(value_context, value_cfg).await?;
+                Self::validate_value_floors(&values, &preflight)?;
+                let index = preflight.finish().await?;
+                Ok(Self {
+                    index,
+                    values,
+                    tracking: None,
+                })
+            }
+            Recovery::Restore {
+                section,
+                index_size,
+            } => {
+                let preflight =
+                    FixedJournal::preflight_restore(index_context, index_cfg, section, index_size)
+                        .await?;
+                let values = Glob::init(value_context, value_cfg).await?;
+                Self::validate_restore_values(&values, &preflight, section)?;
+                let value_size = Self::boundary_value_end(
+                    section,
+                    preflight
+                        .boundaries()
+                        .get(&section)
+                        .expect("restore preflight includes its current section"),
+                )?;
+                let index = preflight.finish().await?;
 
-        // Perform crash recovery
-        let oversized = match checkpoint {
-            Some((section, index_size)) => oversized.restore(section, index_size).await?,
-            None => oversized.repair().await?,
+                // The index truncation is already durable. Release its unreferenced values only
+                // after that proof, preserving the index-first crash-recovery order.
+                let mut journal = Self {
+                    index,
+                    values,
+                    tracking: None,
+                };
+                journal.values = journal.values.rewind(section, value_size).await?;
+                journal.values = journal.values.sync(section).await?;
+                Ok(journal)
+            }
+        }
+    }
+
+    /// Drain the fixed journal's ordered recovery pass, then reconcile the value tail of each
+    /// section. The replay buffer controls every forward index read.
+    async fn recover_inferred(self, buffer: NonZeroUsize) -> Result<Self, Error> {
+        let mut replay = self.replay(0, 0, buffer, ReadOptions::default()).await?;
+        while let Some(result) = replay.next().await {
+            result?;
+        }
+        replay.finish()?.repair().await
+    }
+
+    /// Return the value boundary owned by an optional terminal index entry.
+    fn boundary_value_end(section: u64, entry: &Option<I>) -> Result<u64, Error> {
+        let Some(entry) = entry else {
+            return Ok(0);
         };
-
-        Ok(oversized)
+        let (offset, size) = entry.value_location();
+        offset.checked_add(u64::from(size)).ok_or_else(|| {
+            Error::Corruption(format!(
+                "section {section} has an overflowing terminal value range"
+            ))
+        })
     }
 
     /// Perform crash recovery by validating index entries against glob contents.
@@ -186,10 +454,6 @@ impl<E: Context, I: Record + Send + Sync, V: CodecShared> Oversized<E, I, V> {
         let mut rewound_values = Vec::new();
         for section in sections {
             let index_size = self.index.size(section)?;
-            if index_size == 0 {
-                continue;
-            }
-
             let glob_size = match self.values.size(section) {
                 Ok(size) => size,
                 Err(Error::AlreadyPrunedToSection(oldest)) => {
@@ -218,14 +482,11 @@ impl<E: Context, I: Record + Send + Sync, V: CodecShared> Oversized<E, I, V> {
                 rewound_index.push(section);
             }
 
-            // If there is nothing, we can exit early and rewind values to 0
+            // Values are reachable only through index entries.
             if entry_count == 0 {
-                warn!(
-                    section,
-                    index_size, "trailing bytes detected: truncating to 0"
-                );
-                self.values = self.values.rewind_section(section, 0).await?;
                 if glob_size > 0 {
+                    debug!(section, glob_size, "truncating orphaned value bytes");
+                    self.values = self.values.rewind_section(section, 0).await?;
                     rewound_values.push(section);
                 }
                 continue;
@@ -268,89 +529,84 @@ impl<E: Context, I: Record + Send + Sync, V: CodecShared> Oversized<E, I, V> {
         self.cleanup_orphan_value_sections().await
     }
 
-    /// Restore the journals to exactly the durable state `(section, index_size)`
-    /// describes (see [Self::init]).
-    async fn restore(mut self, section: u64, index_size: u64) -> Result<Self, Error> {
-        // Sections below the checkpoint were durable when it was published and never
-        // appended to again, so anything but a fully consistent section is
-        // unrecoverable loss, never crash debris. Adopt them unchanged.
-        let below: Vec<u64> = self
-            .index
-            .sections()
-            .take_while(|candidate| *candidate < section)
-            .collect();
-        for candidate in below {
-            let index_size = self.index.size(candidate)?;
-            let glob_size = self.values.size(candidate)?;
-            self.verify_complete(candidate, index_size, glob_size)
-                .await?;
+    /// Verify every floor's terminal value extent before repair can mutate either journal.
+    fn validate_value_floors(
+        values: &Glob<E, V>,
+        preflight: &RecoveryPreflight<E, I>,
+    ) -> Result<(), Error> {
+        for (&section, entry) in preflight.boundaries() {
+            let Some(entry) = entry else {
+                continue;
+            };
+            let (offset, size) = entry.value_location();
+            let required = offset.checked_add(u64::from(size)).ok_or_else(|| {
+                Error::Corruption(format!(
+                    "section {section} validation floor has an overflowing value range"
+                ))
+            })?;
+            let retained = values.size(section)?;
+            if retained < required {
+                return Err(Error::Corruption(format!(
+                    "section {section} retains {retained} value bytes, below the validation \
+                     floor of {required}"
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    /// Verify checkpoint-covered value extents against preflighted index boundaries.
+    fn validate_restore_values(
+        values: &Glob<E, V>,
+        preflight: &RecoveryPreflight<E, I>,
+        section: u64,
+    ) -> Result<(), Error> {
+        // Every earlier section is immutable under the checkpoint, so its terminal index entry
+        // must end exactly at the retained value length.
+        for (&candidate, entry) in preflight.boundaries().range(..section) {
+            let required = match entry {
+                None => 0,
+                Some(entry) => {
+                    let (offset, size) = entry.value_location();
+                    offset.checked_add(u64::from(size)).ok_or_else(|| {
+                        Error::Corruption(format!(
+                            "section {candidate} has an overflowing committed value range"
+                        ))
+                    })?
+                }
+            };
+            let retained = values.size(candidate)?;
+            if retained != required {
+                return Err(Error::Corruption(format!(
+                    "section {candidate} index ends at value byte {required}, but its glob size is {retained}"
+                )));
+            }
         }
 
-        // A value section below the checkpoint without an index counterpart lost its
-        // index, and the checkpointed section must retain at least the committed size.
-        let index_sections: HashSet<u64> = self.index.sections().collect();
-        if let Some(orphan) = self
-            .values
-            .sections()
-            .find(|candidate| *candidate < section && !index_sections.contains(candidate))
-        {
+        // A value-only section below the checkpoint proves that covered index data was lost.
+        if let Some(orphan) = values.sections().find(|candidate| {
+            *candidate < section && !preflight.boundaries().contains_key(candidate)
+        }) {
             return Err(Error::Corruption(format!(
                 "section {orphan} has values but no index"
             )));
         }
-        let retained = self.index.size(section)?;
-        if retained < index_size {
-            return Err(Error::Corruption(format!(
-                "section {section} retains {retained} of committed {index_size}"
-            )));
-        }
 
-        // Truncate to the checkpoint and remove everything after it, durably (see
-        // Self::rewind). Later appends can only reuse the freed offsets once the
-        // truncations are durable.
-        self = self.rewind(section, index_size).await?;
-
-        // The retained glob must cover exactly the committed values.
-        let glob_size = self.values.size(section)?;
-        self.verify_complete(section, index_size, glob_size).await?;
-
-        Ok(self)
-    }
-
-    /// Verify a section's journals agree: the last entry's value range must end exactly
-    /// at the glob's size.
-    async fn verify_complete(
-        &self,
-        section: u64,
-        index_size: u64,
-        glob_size: u64,
-    ) -> Result<(), Error> {
-        if index_size == 0 {
-            if glob_size != 0 {
+        // The current section may retain a suffix, but it must cover its committed terminal value.
+        let entry = &preflight.boundaries()[&section];
+        if let Some(entry) = entry {
+            let (offset, size) = entry.value_location();
+            let required = offset.checked_add(u64::from(size)).ok_or_else(|| {
+                Error::Corruption(format!(
+                    "section {section} checkpoint has an overflowing value range"
+                ))
+            })?;
+            let retained = values.size(section)?;
+            if retained < required {
                 return Err(Error::Corruption(format!(
-                    "section {section} has values but no entries: glob size {glob_size}"
+                    "section {section} retains {retained} of {required} committed value bytes"
                 )));
             }
-            return Ok(());
-        }
-
-        let entry_count = index_size / FixedJournal::<E, I>::CHUNK_SIZE as u64;
-        let entry_end = match self.index.get(section, entry_count - 1).await {
-            Ok(entry) => {
-                let (offset, size) = entry.value_location();
-                offset.saturating_add(u64::from(size))
-            }
-            Err(Error::ItemOutOfRange(_) | Error::Runtime(RError::InvalidChecksum)) => {
-                return Err(Error::Corruption(format!(
-                    "section {section} last entry is unreadable"
-                )));
-            }
-            Err(err) => return Err(err),
-        };
-        if entry_end != glob_size {
-            return Err(Error::Corruption(format!(
-                "section {section} last entry ends at {entry_end}, glob size is {glob_size}"
-            )));
         }
 
         Ok(())
@@ -380,6 +636,27 @@ impl<E: Context, I: Record + Send + Sync, V: CodecShared> Oversized<E, I, V> {
         }
 
         Ok(self)
+    }
+
+    /// Truncate value suffixes that became unreachable while fixed replay repaired index pages.
+    async fn align_values_to_index(mut self) -> Result<Self, Error> {
+        let sections = self.index.sections().collect::<Vec<_>>();
+        let mut rewound = Vec::new();
+        for section in sections {
+            let target = Self::boundary_value_end(section, &self.index.last(section).await?)?;
+            let retained = self.values.size(section)?;
+            if retained < target {
+                return Err(Error::Corruption(format!(
+                    "section {section} retains {retained} of {target} indexed value bytes"
+                )));
+            }
+            if retained > target {
+                self.values = self.values.rewind_section(section, target).await?;
+                rewound.push(section);
+            }
+        }
+        self.values = self.values.sync(&rewound).await?;
+        self.cleanup_orphan_value_sections().await
     }
 
     /// Find the number of valid entries and the corresponding glob target size.
@@ -420,6 +697,73 @@ impl<E: Context, I: Record + Send + Sync, V: CodecShared> Oversized<E, I, V> {
         Ok((0, 0))
     }
 
+    /// Reconcile durable markers with the retained state after tracked startup recovery.
+    async fn reconcile_markers(mut self) -> Result<Self, Error> {
+        let mut tracking = self
+            .tracking
+            .take()
+            .expect("tracked replay preserves its recovery state");
+
+        let mut dirty = false;
+        for section in self.index.sections() {
+            let items = self.index.section_len(section)?;
+            dirty |= tracking.stage_marker(section, items);
+        }
+        if dirty {
+            let marker;
+            (tracking.metadata, marker) = tracking.metadata.start_sync().await?;
+            tracking.marker_sync_pending = Some(marker.boxed().shared());
+        }
+        self.tracking = Some(tracking);
+        Ok(self)
+    }
+
+    /// Lower tracked floors before an operation can free any bytes they authorize.
+    async fn prepare_rewind(
+        &mut self,
+        section: u64,
+        index_size: u64,
+        remove_later: bool,
+    ) -> Result<(), Error> {
+        let Some(mut tracking) = self.tracking.take() else {
+            return Ok(());
+        };
+        let items = index_size / FixedJournal::<E, I>::CHUNK_SIZE as u64;
+        let mut dirty = false;
+
+        if remove_later {
+            tracking.metadata.retain(|key, _| {
+                let keep = u64::from(key) <= section;
+                dirty |= !keep;
+                keep
+            });
+        }
+        let key = SectionKey::new(section);
+        if tracking
+            .metadata
+            .get(&key)
+            .is_some_and(|floor| *floor > items)
+        {
+            tracking.metadata.put(key, items);
+            dirty = true;
+        }
+        if dirty {
+            tracking.metadata = tracking.metadata.sync().await?;
+            tracking.marker_sync_pending = None;
+        }
+
+        if remove_later {
+            tracking
+                .barriers
+                .retain(|candidate, _| *candidate <= section);
+        }
+        if let Some(barrier) = tracking.barriers.get_mut(&section) {
+            barrier.truncate(items);
+        }
+        self.tracking = Some(tracking);
+        Ok(())
+    }
+
     /// Append entry + value.
     ///
     /// Writes value to glob first, then writes index entry with the value location.
@@ -443,6 +787,12 @@ impl<E: Context, I: Record + Send + Sync, V: CodecShared> Oversized<E, I, V> {
         let entry_with_location = entry.with_location(offset, size);
         let position;
         (self.index, position) = self.index.append(section, &entry_with_location).await?;
+
+        // Track this section so a later sync can prove and publish its new length. A fresh
+        // barrier claims only the staged floor, never the unproven pre-append prefix.
+        if let Some(tracking) = &mut self.tracking {
+            tracking.barrier(section);
+        }
 
         Ok((self, position, offset, size))
     }
@@ -485,18 +835,107 @@ impl<E: Context, I: Record + Send + Sync, V: CodecShared> Oversized<E, I, V> {
         buffer: NonZeroUsize,
         read_options: ReadOptions,
     ) -> Result<Replay<E, I, V>, Error> {
-        let index = self
-            .index
+        let Self {
+            index,
+            values,
+            tracking,
+        } = self;
+        let index = index
             .replay(start_section, start_position, buffer, read_options)
             .await?;
         Ok(Replay {
             index,
-            values: self.values,
+            values,
+            tracking,
+            validation: None,
         })
+    }
+
+    /// Start a joint data sync and publish only previously completed tracked boundaries.
+    ///
+    /// The returned handle covers only the requested data syncs. Marker generations trail
+    /// data durability by design, and a marker failure surfaces as [Error::Metadata] when a
+    /// later request observes it.
+    pub(crate) async fn start_sync_tracked(
+        mut self,
+        sections: &BTreeSet<u64>,
+        active: &BTreeSet<u64>,
+    ) -> Result<(Self, Handle<()>), Error> {
+        let mut tracking = self
+            .tracking
+            .take()
+            .expect("tracked sync preserves its recovery state");
+        let pending_marker = tracking.observe_marker_sync()?;
+        let lengths = sections
+            .iter()
+            .map(|&section| Ok((section, self.index.section_len(section)?)))
+            .collect::<Result<Vec<_>, Error>>()?;
+        let ((index, index_handle), (values, values_handle)) = try_join(
+            self.index.start_sync(sections),
+            self.values.start_sync(sections),
+        )
+        .await?;
+        self.index = index;
+        self.values = values;
+        let completion: SyncCompletion =
+            async move { try_join(index_handle, values_handle).await.map(|_| ()) }
+                .boxed()
+                .shared();
+
+        // Bind every selected target to the new joint completion. The recorded length becomes
+        // publishable only once this completion is observed to have succeeded.
+        for (section, length) in lengths {
+            tracking.barrier(section).record(length, completion.clone());
+        }
+
+        // Do not mutate Metadata while its prior generation is in flight. Completed barriers stay
+        // as debt and are published when their section is no longer active, or on an empty flush.
+        if pending_marker.is_none() {
+            let publish = tracking
+                .barriers
+                .iter_mut()
+                .filter(|(section, _)| !active.contains(section))
+                .map(|(&section, barrier)| (section, barrier.boundary()))
+                .collect::<Vec<_>>();
+            let mut metadata_dirty = false;
+            for (section, floor) in publish {
+                metadata_dirty |= tracking.stage_marker(section, floor);
+            }
+            if metadata_dirty {
+                let handle;
+                (tracking.metadata, handle) = tracking.metadata.start_sync().await?;
+                tracking.marker_sync_pending = Some(handle.boxed().shared());
+            }
+        }
+
+        self.tracking = Some(tracking);
+        Ok((self, Handle::from_future(completion)))
+    }
+
+    /// Block until the selected data syncs are durable, surfacing any marker failure the
+    /// completed generation already exposed.
+    pub(crate) async fn sync_tracked(
+        self,
+        sections: &BTreeSet<u64>,
+        active: &BTreeSet<u64>,
+    ) -> Result<Self, Error> {
+        let (mut journal, handle) = self.start_sync_tracked(sections, active).await?;
+        handle.await?;
+        journal
+            .tracking
+            .as_mut()
+            .expect("tracking mode is preserved")
+            .observe_marker_sync()?;
+        Ok(journal)
     }
 
     /// Sync both journals for the given `sections`.
     pub async fn sync(mut self, sections: impl crate::Sections) -> Result<Self, Error> {
+        if self.tracking.is_some() {
+            let sections = sections.sections().collect::<BTreeSet<_>>();
+            return self.sync_tracked(&sections, &sections).await;
+        }
+
         let sections = sections.sections().collect::<Vec<_>>();
         (self.index, self.values) =
             try_join(self.index.sync(&sections), self.values.sync(&sections)).await?;
@@ -512,6 +951,11 @@ impl<E: Context, I: Record + Send + Sync, V: CodecShared> Oversized<E, I, V> {
         mut self,
         sections: impl crate::Sections,
     ) -> Result<(Self, Handle<()>), Error> {
+        if self.tracking.is_some() {
+            let sections = sections.sections().collect::<BTreeSet<_>>();
+            return self.start_sync_tracked(&sections, &sections).await;
+        }
+
         let sections = sections.sections().collect::<Vec<_>>();
         let ((index, index_handle), (values, values_handle)) = try_join(
             self.index.start_sync(&sections),
@@ -530,6 +974,10 @@ impl<E: Context, I: Record + Send + Sync, V: CodecShared> Oversized<E, I, V> {
 
     /// Sync all sections.
     pub async fn sync_all(mut self) -> Result<Self, Error> {
+        if self.tracking.is_some() {
+            let sections = self.index.sections().collect::<BTreeSet<_>>();
+            return self.sync(sections).await;
+        }
         (self.index, self.values) = try_join(self.index.sync_all(), self.values.sync_all()).await?;
         Ok(self)
     }
@@ -540,6 +988,23 @@ impl<E: Context, I: Record + Send + Sync, V: CodecShared> Oversized<E, I, V> {
     /// - If crash after index prune but before glob: orphan data in glob (acceptable)
     /// - If crash before index prune: no change, retry works
     pub async fn prune(mut self, min: u64) -> Result<(Self, bool), Error> {
+        // Remove and durably sync tracked floors before their section names can be deleted and
+        // later reused.
+        if let Some(mut tracking) = self.tracking.take() {
+            let mut removed = false;
+            tracking.metadata.retain(|key, _| {
+                let keep = u64::from(key) >= min;
+                removed |= !keep;
+                keep
+            });
+            if removed {
+                tracking.metadata = tracking.metadata.sync().await?;
+                tracking.marker_sync_pending = None;
+            }
+            tracking.barriers = tracking.barriers.split_off(&min);
+            self.tracking = Some(tracking);
+        }
+
         let index_pruned;
         (self.index, index_pruned) = self.index.prune(min).await?;
         let value_pruned;
@@ -557,6 +1022,8 @@ impl<E: Context, I: Record + Send + Sync, V: CodecShared> Oversized<E, I, V> {
     /// its later sections (newest first) before truncating `section`, and those removals
     /// carry the storage layer's removal durability.
     pub async fn rewind(mut self, section: u64, index_size: u64) -> Result<Self, Error> {
+        self.prepare_rewind(section, index_size, true).await?;
+
         // Rewind index first (this also removes sections after `section`)
         self.index = self.index.rewind(section, index_size).await?;
 
@@ -592,6 +1059,8 @@ impl<E: Context, I: Record + Send + Sync, V: CodecShared> Oversized<E, I, V> {
     ///
     /// Both truncations are made durable before returning (see [Self::rewind]).
     pub async fn rewind_section(mut self, section: u64, index_size: u64) -> Result<Self, Error> {
+        self.prepare_rewind(section, index_size, false).await?;
+
         // Rewind index first
         self.index = self.index.rewind_section(section, index_size).await?;
 
@@ -657,7 +1126,12 @@ impl<E: Context, I: Record + Send + Sync, V: CodecShared> Oversized<E, I, V> {
     }
 
     /// Destroy all underlying storage.
-    pub async fn destroy(self) -> Result<(), Error> {
+    pub async fn destroy(mut self) -> Result<(), Error> {
+        // Remove tracked floors first so an interrupted destroy can only force conservative
+        // recovery of any pair data left behind.
+        if let Some(tracking) = self.tracking.take() {
+            tracking.metadata.destroy().await?;
+        }
         try_join(self.index.destroy(), self.values.destroy())
             .await
             .map(|_| ())
@@ -672,6 +1146,8 @@ impl<E: Context, I: Record + Send + Sync, V: CodecShared> Oversized<E, I, V> {
 pub struct Replay<E: Context, I: Record, V: Codec> {
     index: FixedReplay<E, I>,
     values: Glob<E, V>,
+    tracking: Option<Tracking<E>>,
+    validation: Option<Validation>,
 }
 
 impl<E: Context, I: Record + Send + Sync, V: CodecShared> Replay<E, I, V> {
@@ -679,9 +1155,53 @@ impl<E: Context, I: Record + Send + Sync, V: CodecShared> Replay<E, I, V> {
     /// exhausted.
     ///
     /// An error ends the section that produced it, and iteration continues with the
-    /// next section.
+    /// next section. Errors while mutating storage to repair a section, and
+    /// [Error::ReplayInterrupted], end the replay.
     pub async fn next(&mut self) -> Option<Result<(u64, u64, I), Error>> {
-        self.index.next().await
+        loop {
+            let result = self.index.next().await?;
+            let (section, position, entry) = match result {
+                Ok(entry) => entry,
+                Err(err) => return Some(Err(err)),
+            };
+            let (tracking, validation) = (&self.tracking, &mut self.validation);
+            let Some(validation) = validation else {
+                return Some(Ok((section, position, entry)));
+            };
+
+            // Each section validates forward from its durable floor. Once one value fails, later
+            // entries in that section are outside the retained prefix and are not yielded.
+            if validation.current_section != Some(section) {
+                validation.current_section = Some(section);
+                validation.floor = tracking
+                    .as_ref()
+                    .expect("tracked replay preserves its recovery state")
+                    .metadata
+                    .get(&SectionKey::new(section))
+                    .copied()
+                    .unwrap_or(0);
+                validation.truncated = false;
+            }
+            if validation.truncated {
+                continue;
+            }
+            if position < validation.floor {
+                return Some(Ok((section, position, entry)));
+            }
+
+            let (offset, size) = entry.value_location();
+            match self.values.verify(section, offset, size).await {
+                Ok(true) => return Some(Ok((section, position, entry))),
+                Ok(false) => {
+                    validation.rewinds.push((section, position));
+                    validation.truncated = true;
+                }
+                Err(err) => {
+                    validation.failed = true;
+                    return Some(Err(err));
+                }
+            }
+        }
     }
 
     /// Returns the journal.
@@ -689,10 +1209,44 @@ impl<E: Context, I: Record + Send + Sync, V: CodecShared> Replay<E, I, V> {
     /// Fails when the reader was not fully drained or yielded an error: the journal is
     /// destroyed and recovery is re-initialization.
     pub fn finish(self) -> Result<Oversized<E, I, V>, Error> {
+        if self.validation.is_some() {
+            return Err(Error::ReplayFailed);
+        }
         Ok(Oversized {
             index: self.index.finish()?,
             values: self.values,
+            tracking: self.tracking,
         })
+    }
+
+    /// Finish marker-aware startup recovery and return the tracked journal.
+    // Staging: consumed by the prunable archive in the next PR of this stack.
+    #[allow(dead_code)]
+    pub(crate) async fn finish_tracked(self) -> Result<Oversized<E, I, V>, Error> {
+        let Some(validation) = self.validation else {
+            return Err(Error::ReplayFailed);
+        };
+        if validation.failed {
+            return Err(Error::ReplayFailed);
+        }
+        let mut journal = Oversized {
+            index: self.index.finish()?,
+            values: self.values,
+            tracking: self.tracking,
+        };
+
+        // Apply each section's first invalid position only after replay releases the index
+        // journal, then publish the exact retained lengths as the next marker generation.
+        let chunk_size = FixedJournal::<E, I>::CHUNK_SIZE as u64;
+        for (section, items) in validation.rewinds {
+            let index_size = items.checked_mul(chunk_size).ok_or(Error::OffsetOverflow)?;
+            journal = journal.rewind_section(section, index_size).await?;
+        }
+        journal
+            .align_values_to_index()
+            .await?
+            .reconcile_markers()
+            .await
     }
 }
 
@@ -704,7 +1258,9 @@ mod tests {
     use commonware_macros::test_traced;
     use commonware_runtime::{
         Blob as _, Buf, BufMut, BufferPooler, Runner, Storage as _, Supervisor as _, WriteOptions,
-        buffer::paged::CacheRef, deterministic, mocks::SyncFaultContext,
+        buffer::paged::{CacheRef, corrupt_page},
+        deterministic,
+        mocks::{DelayedSyncContext, PendingSyncs, SyncFaultContext, drive_pending_syncs},
     };
     use commonware_utils::{NZU16, NZUsize};
 
@@ -777,6 +1333,7 @@ mod tests {
             index_page_cache: CacheRef::from_pooler(pooler, NZU16!(64), NZUsize!(8)),
             index_write_buffer: NZUsize!(1024),
             value_write_buffer: NZUsize!(1024),
+            replay_buffer: NZUsize!(4096),
             compression: None,
             codec_config: (),
         }
@@ -1460,6 +2017,7 @@ mod tests {
                 ),
                 index_write_buffer: NZUsize!(1024),
                 value_write_buffer: NZUsize!(1024),
+                replay_buffer: NZUsize!(4096),
                 compression: None,
                 codec_config: (),
             };
@@ -1573,6 +2131,62 @@ mod tests {
     }
 
     #[test_traced]
+    fn test_oversized_restore_does_not_repair_discarded_sections() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let mut cfg = test_cfg(&context);
+            cfg.index_page_cache =
+                CacheRef::from_pooler(&context, NZU16!(TestEntry::SIZE as u16), NZUsize!(8));
+            let mut oversized: Oversized<_, TestEntry, TestValue> =
+                Oversized::init(context.child("seed"), cfg.clone(), None)
+                    .await
+                    .expect("failed to init");
+            (oversized, _, _, _) = oversized
+                .append(1, TestEntry::new(0, 0, 0), &[0; 16])
+                .await
+                .expect("failed to append checkpoint entry");
+            for id in 1..=3 {
+                (oversized, _, _, _) = oversized
+                    .append(2, TestEntry::new(id, 0, 0), &[id as u8; 16])
+                    .await
+                    .expect("failed to append discardable entry");
+            }
+            oversized = oversized.sync_all().await.expect("failed to sync");
+            drop(oversized);
+
+            // The valid final page hides this interior hole from Writer::new. Restore owns no
+            // bytes in section 2 and must remove it without first repairing and syncing it.
+            corrupt_page(
+                &context,
+                &cfg.index_partition,
+                &2u64.to_be_bytes(),
+                1,
+                TestEntry::SIZE as u64,
+            )
+            .await;
+
+            let pending = PendingSyncs::default();
+            pending.arm();
+            let delayed = DelayedSyncContext {
+                inner: context,
+                pending: pending.clone(),
+            };
+            let chunk = TestEntry::SIZE as u64;
+            let oversized: Oversized<_, TestEntry, TestValue> = drive_pending_syncs(
+                &pending,
+                Oversized::init(delayed.child("restore"), cfg, Some((1, chunk))),
+            )
+            .await
+            .expect("checkpoint restore failed");
+
+            // Restoring an already exact checkpoint syncs its index and values once each. Any
+            // additional durability work came from repairing data that restore discards.
+            assert_eq!(pending.calls(), 2);
+            oversized.destroy().await.expect("failed to destroy");
+        });
+    }
+
+    #[test_traced]
     fn test_oversized_restore_incomplete_section_errors() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
@@ -1613,6 +2227,95 @@ mod tests {
                 )
                 .await;
                 assert!(matches!(result, Err(Error::Corruption(_))));
+            }
+        });
+    }
+
+    #[test_traced]
+    fn test_oversized_restore_adopts_interior_index_corruption() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            for (child, seed_child, restore_child, checkpoint) in [
+                (
+                    "checkpoint_section",
+                    "seed_checkpoint_section",
+                    "restore_checkpoint_section",
+                    (1, 3 * TestEntry::SIZE as u64),
+                ),
+                (
+                    "earlier_section",
+                    "seed_earlier_section",
+                    "restore_earlier_section",
+                    (2, TestEntry::SIZE as u64),
+                ),
+            ] {
+                let mut cfg = test_cfg(&context);
+                cfg.index_partition = format!("test-index-{child}");
+                cfg.value_partition = format!("test-values-{child}");
+                cfg.index_page_cache =
+                    CacheRef::from_pooler(&context, NZU16!(TestEntry::SIZE as u16), NZUsize!(8));
+
+                // Persist three entries in section 1 and a later checkpoint candidate. One entry
+                // per integrity page makes the damaged page strictly interior.
+                let mut oversized: Oversized<_, TestEntry, TestValue> =
+                    Oversized::init(context.child(seed_child), cfg.clone(), None)
+                        .await
+                        .expect("failed to init");
+                for id in 0..3 {
+                    (oversized, _, _, _) = oversized
+                        .append(1, TestEntry::new(id, 0, 0), &[id as u8; 16])
+                        .await
+                        .expect("failed to append");
+                }
+                (oversized, _, _, _) = oversized
+                    .append(2, TestEntry::new(3, 0, 0), &[3; 16])
+                    .await
+                    .expect("failed to append later section");
+                oversized = oversized.sync_all().await.expect("failed to sync");
+                drop(oversized);
+
+                // Checkpoint recovery trusts the completed durability boundary and reads only its
+                // terminal entry. Arbitrary post-commit bit rot remains a lazy read error.
+                corrupt_page(
+                    &context,
+                    &cfg.index_partition,
+                    &1u64.to_be_bytes(),
+                    1,
+                    TestEntry::SIZE as u64,
+                )
+                .await;
+                let (blob, expected_size) = context
+                    .open(&cfg.index_partition, &1u64.to_be_bytes())
+                    .await
+                    .expect("failed to open index");
+                let expected = blob
+                    .read_at(0, expected_size as usize, ReadOptions::default())
+                    .await
+                    .expect("failed to snapshot damaged index")
+                    .coalesce();
+                drop(blob);
+
+                let oversized: Oversized<_, TestEntry, TestValue> =
+                    Oversized::init(context.child(restore_child), cfg.clone(), Some(checkpoint))
+                        .await
+                        .expect("checkpoint restore should adopt the covered prefix");
+                assert!(matches!(
+                    oversized.get(1, 1).await,
+                    Err(Error::Runtime(RError::InvalidChecksum))
+                ));
+                drop(oversized);
+
+                let (blob, actual_size) = context
+                    .open(&cfg.index_partition, &1u64.to_be_bytes())
+                    .await
+                    .expect("failed to reopen index");
+                assert_eq!(actual_size, expected_size);
+                let actual = blob
+                    .read_at(0, actual_size as usize, ReadOptions::default())
+                    .await
+                    .expect("failed to read damaged index")
+                    .coalesce();
+                assert_eq!(actual.as_ref(), expected.as_ref());
             }
         });
     }
@@ -2026,6 +2729,7 @@ mod tests {
                 ),
                 index_write_buffer: NZUsize!(1024),
                 value_write_buffer: NZUsize!(1024),
+                replay_buffer: NZUsize!(4096),
                 compression: None,
                 codec_config: (),
             };
@@ -2570,6 +3274,7 @@ mod tests {
                 ),
                 index_write_buffer: NZUsize!(1024),
                 value_write_buffer: NZUsize!(1024),
+                replay_buffer: NZUsize!(4096),
                 compression: None,
                 codec_config: (),
             };
@@ -2859,6 +3564,7 @@ mod tests {
                 ),
                 index_write_buffer: NZUsize!(1024),
                 value_write_buffer: NZUsize!(1024),
+                replay_buffer: NZUsize!(4096),
                 compression: None,
                 codec_config: (),
             };
@@ -3498,6 +4204,104 @@ mod tests {
         });
     }
 
+    /// Bytes appended after an index was truncated or removed cannot replace its authenticated
+    /// prefix.
+    #[test_traced]
+    fn test_recovery_discards_index_extension_after_prefix_loss() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = test_cfg(&context);
+            let mut oversized: Oversized<_, TestEntry, TestValue> =
+                Oversized::init(context.child("first"), cfg.clone(), None)
+                    .await
+                    .expect("Failed to init");
+            for section in 1..=2 {
+                (oversized, _, _, _) = oversized
+                    .append(section, TestEntry::new(section, 0, 0), &[section as u8; 16])
+                    .await
+                    .expect("Failed to append");
+                oversized = oversized.sync(section).await.expect("Failed to sync");
+            }
+            drop(oversized);
+
+            // Keep both value blobs, but erase one index by truncation and the other by removal.
+            // Replace each with two complete pages of bytes that have no valid checksum slots.
+            for section in 1..=2u64 {
+                let (blob, original_size) = context
+                    .open(&cfg.index_partition, &section.to_be_bytes())
+                    .await
+                    .expect("Failed to open index blob");
+                if section == 1 {
+                    blob.resize(0).await.expect("Failed to truncate index");
+                    blob.sync().await.expect("Failed to sync index truncation");
+                } else {
+                    drop(blob);
+                    context
+                        .remove(&cfg.index_partition, Some(&section.to_be_bytes()))
+                        .await
+                        .expect("Failed to remove index");
+                }
+                let (blob, _) = context
+                    .open(&cfg.index_partition, &section.to_be_bytes())
+                    .await
+                    .expect("Failed to recreate index blob");
+                blob.write_at(
+                    0,
+                    vec![0; usize::try_from(original_size * 2).unwrap()],
+                    WriteOptions::SYNC,
+                )
+                .await
+                .expect("Failed to extend index");
+            }
+
+            let mut oversized: Oversized<_, TestEntry, TestValue> =
+                Oversized::init(context.child("second"), cfg.clone(), None)
+                    .await
+                    .expect("Failed to recover extended index");
+            for section in 1..=2u64 {
+                assert!(matches!(
+                    oversized.get(section, 0).await,
+                    Err(Error::ItemOutOfRange(0))
+                ));
+                let (_, recovered_size) = context
+                    .open(&cfg.index_partition, &section.to_be_bytes())
+                    .await
+                    .expect("Failed to reopen index blob");
+                assert_eq!(recovered_size, 0);
+
+                let position;
+                (oversized, position, _, _) = oversized
+                    .append(section, TestEntry::new(section, 0, 0), &[section as u8; 16])
+                    .await
+                    .expect("Failed to append after recovery");
+                assert_eq!(position, 0);
+            }
+            oversized = oversized.sync_all().await.expect("Failed to sync sentinel");
+            drop(oversized);
+
+            let oversized: Oversized<_, TestEntry, TestValue> =
+                Oversized::init(context.child("third"), cfg, None)
+                    .await
+                    .expect("Failed to reopen sentinel");
+            for section in 1..=2u64 {
+                let entry = oversized
+                    .get(section, 0)
+                    .await
+                    .expect("Sentinel index missing");
+                let (offset, size) = entry.value_location();
+                assert_eq!(entry.id, section);
+                assert_eq!(
+                    oversized
+                        .get_value(section, offset, size)
+                        .await
+                        .expect("Sentinel value missing"),
+                    [section as u8; 16]
+                );
+            }
+            oversized.destroy().await.expect("Failed to destroy");
+        });
+    }
+
     #[test_traced]
     fn test_recovery_glob_trailing_garbage_truncated() {
         // Tests the bug fix: when value is written to glob but index entry isn't
@@ -3605,6 +4409,7 @@ mod tests {
                 ),
                 index_write_buffer: NZUsize!(1024),
                 value_write_buffer: NZUsize!(1024),
+                replay_buffer: NZUsize!(4096),
                 compression: None,
                 codec_config: (),
             };
@@ -3745,11 +4550,8 @@ mod tests {
             // Section 1 should still be tracked (blob exists but is empty)
             assert_eq!(oversized.oldest_section(), Some(1));
 
-            // Append to empty section 1
-            // Note: When index is truncated to 0 but the index blob still exists,
-            // the glob is NOT truncated (the section isn't considered an orphan).
-            // The glob still has orphan DATA from the old entries, but this doesn't
-            // affect correctness - new entries simply append after the orphan data.
+            // Values are reachable only through index entries, so recovery removes the orphaned
+            // bytes before the section can be reused.
             let new_value: TestValue = [99; 16];
             let new_entry = TestEntry::new(99, 0, 0);
             let (pos, offset, size);
@@ -3758,11 +4560,10 @@ mod tests {
                 .await
                 .expect("Failed to append to empty section");
             assert_eq!(pos, 0);
-            // Glob offset is non-zero because orphan data wasn't truncated
-            assert!(offset > 0);
+            assert_eq!(offset, 0);
             oversized = oversized.sync(1).await.expect("Failed to sync");
 
-            // Verify the new entry is readable despite orphan data before it
+            // Verify the new entry is readable after reusing the section.
             let entry = oversized.get(1, 0).await.expect("Failed to get");
             assert_eq!(entry.id, 99);
             let value = oversized

--- a/storage/src/journal/segmented/oversized.rs
+++ b/storage/src/journal/segmented/oversized.rs
@@ -356,13 +356,13 @@ impl<E: Context, I: Record + Send + Sync, V: CodecShared> Oversized<E, I, V> {
             page_cache: cfg.index_page_cache,
             write_buffer: cfg.index_write_buffer,
         };
+        let index_context = context.child("index");
         let value_cfg = GlobConfig {
             partition: cfg.value_partition,
             compression: cfg.compression,
             codec_config: cfg.codec_config,
             write_buffer: cfg.value_write_buffer,
         };
-        let index_context = context.child("index");
         let value_context = context.child("values");
 
         let (index, values) = match recovery {

--- a/storage/src/journal/segmented/oversized.rs
+++ b/storage/src/journal/segmented/oversized.rs
@@ -131,7 +131,7 @@ enum Recovery<'a> {
         section: u64,
         index_size: u64,
     },
-    // Staging: consumed by the prunable archive in the next PR of this stack.
+    // TODO (#4610): migrate the prunable archive to tracked replay
     #[allow(dead_code)]
     Floors(&'a BTreeMap<u64, u64>),
     Infer,
@@ -218,7 +218,7 @@ struct Validation {
 }
 
 impl Validation {
-    // Staging: consumed by the prunable archive in the next PR of this stack.
+    // TODO (#4610): migrate the prunable archive to tracked replay
     #[allow(dead_code)]
     const fn new() -> Self {
         Self {
@@ -297,7 +297,7 @@ impl<E: Context, I: Record + Send + Sync, V: CodecShared> Oversized<E, I, V> {
     /// The caller must drain the replay and call [Replay::finish_tracked]. Entries below each
     /// durable marker are retained after their cross-journal boundary is proven. Entries above it
     /// are value-validated in order and the first invalid entry truncates its section.
-    // Staging: consumed by the prunable archive in the next PR of this stack.
+    // TODO (#4610): migrate the prunable archive to tracked replay
     #[allow(dead_code)]
     pub(crate) async fn init_tracked(
         context: &E,
@@ -1220,7 +1220,7 @@ impl<E: Context, I: Record + Send + Sync, V: CodecShared> Replay<E, I, V> {
     }
 
     /// Finish marker-aware startup recovery and return the tracked journal.
-    // Staging: consumed by the prunable archive in the next PR of this stack.
+    // TODO (#4610): migrate the prunable archive to tracked replay
     #[allow(dead_code)]
     pub(crate) async fn finish_tracked(self) -> Result<Oversized<E, I, V>, Error> {
         let Some(validation) = self.validation else {

--- a/storage/src/journal/segmented/oversized.rs
+++ b/storage/src/journal/segmented/oversized.rs
@@ -362,27 +362,17 @@ impl<E: Context, I: Record + Send + Sync, V: CodecShared> Oversized<E, I, V> {
         let index_context = context.child("index");
         let value_context = context.child("values");
 
-        match recovery {
+        let (index, values) = match recovery {
             Recovery::Infer => {
                 let index = FixedJournal::init(index_context, index_cfg).await?;
-                let values = Glob::init(value_context, value_cfg).await?;
-                Ok(Self {
-                    index,
-                    values,
-                    tracking: None,
-                })
+                (index, Glob::init(value_context, value_cfg).await?)
             }
             Recovery::Floors(minimum_items) => {
                 let preflight =
                     FixedJournal::preflight_floors(index_context, index_cfg, minimum_items).await?;
                 let values = Glob::init(value_context, value_cfg).await?;
                 Self::validate_value_floors(&values, &preflight)?;
-                let index = preflight.finish().await?;
-                Ok(Self {
-                    index,
-                    values,
-                    tracking: None,
-                })
+                (preflight.finish().await?, values)
             }
             Recovery::Restore {
                 section,
@@ -392,28 +382,20 @@ impl<E: Context, I: Record + Send + Sync, V: CodecShared> Oversized<E, I, V> {
                     FixedJournal::preflight_restore(index_context, index_cfg, section, index_size)
                         .await?;
                 let values = Glob::init(value_context, value_cfg).await?;
-                Self::validate_restore_values(&values, &preflight, section)?;
-                let value_size = Self::boundary_value_end(
-                    section,
-                    preflight
-                        .boundaries()
-                        .get(&section)
-                        .expect("restore preflight includes its current section"),
-                )?;
+                let value_size = Self::validate_restore_values(&values, &preflight, section)?;
                 let index = preflight.finish().await?;
 
                 // The index truncation is already durable. Release its unreferenced values only
                 // after that proof, preserving the index-first crash-recovery order.
-                let mut journal = Self {
-                    index,
-                    values,
-                    tracking: None,
-                };
-                journal.values = journal.values.rewind(section, value_size).await?;
-                journal.values = journal.values.sync(section).await?;
-                Ok(journal)
+                let values = values.rewind(section, value_size).await?;
+                (index, values.sync(section).await?)
             }
-        }
+        };
+        Ok(Self {
+            index,
+            values,
+            tracking: None,
+        })
     }
 
     /// Drain the fixed journal's ordered recovery pass, then reconcile the value tail of each
@@ -534,15 +516,10 @@ impl<E: Context, I: Record + Send + Sync, V: CodecShared> Oversized<E, I, V> {
         preflight: &RecoveryPreflight<E, I>,
     ) -> Result<(), Error> {
         for (&section, entry) in preflight.boundaries() {
-            let Some(entry) = entry else {
+            let required = Self::boundary_value_end(section, entry)?;
+            if required == 0 {
                 continue;
-            };
-            let (offset, size) = entry.value_location();
-            let required = offset.checked_add(u64::from(size)).ok_or_else(|| {
-                Error::Corruption(format!(
-                    "section {section} validation floor has an overflowing value range"
-                ))
-            })?;
+            }
             let retained = values.size(section)?;
             if retained < required {
                 return Err(Error::Corruption(format!(
@@ -554,26 +531,17 @@ impl<E: Context, I: Record + Send + Sync, V: CodecShared> Oversized<E, I, V> {
         Ok(())
     }
 
-    /// Verify checkpoint-covered value extents against preflighted index boundaries.
+    /// Verify checkpoint-covered value extents against preflighted index boundaries, returning
+    /// the checkpoint section's terminal value end.
     fn validate_restore_values(
         values: &Glob<E, V>,
         preflight: &RecoveryPreflight<E, I>,
         section: u64,
-    ) -> Result<(), Error> {
+    ) -> Result<u64, Error> {
         // Every earlier section is immutable under the checkpoint, so its terminal index entry
         // must end exactly at the retained value length.
         for (&candidate, entry) in preflight.boundaries().range(..section) {
-            let required = match entry {
-                None => 0,
-                Some(entry) => {
-                    let (offset, size) = entry.value_location();
-                    offset.checked_add(u64::from(size)).ok_or_else(|| {
-                        Error::Corruption(format!(
-                            "section {candidate} has an overflowing committed value range"
-                        ))
-                    })?
-                }
-            };
+            let required = Self::boundary_value_end(candidate, entry)?;
             let retained = values.size(candidate)?;
             if retained != required {
                 return Err(Error::Corruption(format!(
@@ -592,14 +560,8 @@ impl<E: Context, I: Record + Send + Sync, V: CodecShared> Oversized<E, I, V> {
         }
 
         // The current section may retain a suffix, but it must cover its committed terminal value.
-        let entry = &preflight.boundaries()[&section];
-        if let Some(entry) = entry {
-            let (offset, size) = entry.value_location();
-            let required = offset.checked_add(u64::from(size)).ok_or_else(|| {
-                Error::Corruption(format!(
-                    "section {section} checkpoint has an overflowing value range"
-                ))
-            })?;
+        let required = Self::boundary_value_end(section, &preflight.boundaries()[&section])?;
+        if required > 0 {
             let retained = values.size(section)?;
             if retained < required {
                 return Err(Error::Corruption(format!(
@@ -608,7 +570,7 @@ impl<E: Context, I: Record + Send + Sync, V: CodecShared> Oversized<E, I, V> {
             }
         }
 
-        Ok(())
+        Ok(required)
     }
 
     /// Remove any value sections that don't have corresponding index sections.
@@ -1011,6 +973,23 @@ impl<E: Context, I: Record + Send + Sync, V: CodecShared> Oversized<E, I, V> {
         Ok((self, index_pruned || value_pruned))
     }
 
+    /// Derive the value boundary owned by `section`'s last entry after an index rewind.
+    ///
+    /// A rewind to zero may leave no section behind, which owns no value bytes.
+    async fn rewound_value_end(&self, section: u64, index_size: u64) -> Result<u64, Error> {
+        match self.index.last(section).await {
+            Ok(Some(entry)) => {
+                let (offset, size) = entry.value_location();
+                offset
+                    .checked_add(u64::from(size))
+                    .ok_or(Error::OffsetOverflow)
+            }
+            Ok(None) => Ok(0),
+            Err(Error::SectionOutOfRange(_)) if index_size == 0 => Ok(0),
+            Err(e) => Err(e),
+        }
+    }
+
     /// Rewind both journals to a specific section and index size.
     ///
     /// This rewinds the section to the given index size and removes all sections
@@ -1027,17 +1006,7 @@ impl<E: Context, I: Record + Send + Sync, V: CodecShared> Oversized<E, I, V> {
         self.index = self.index.rewind(section, index_size).await?;
 
         // Derive value size from last entry (section may not exist if empty)
-        let value_size = match self.index.last(section).await {
-            Ok(Some(entry)) => {
-                let (offset, size) = entry.value_location();
-                offset
-                    .checked_add(u64::from(size))
-                    .ok_or(Error::OffsetOverflow)?
-            }
-            Ok(None) => 0,
-            Err(Error::SectionOutOfRange(_)) if index_size == 0 => 0,
-            Err(e) => return Err(e),
-        };
+        let value_size = self.rewound_value_end(section, index_size).await?;
 
         // Make the index truncation durable before the values are rewound: rewinding the
         // values frees their ranges for reuse by later appends, and a dropped index entry
@@ -1064,17 +1033,7 @@ impl<E: Context, I: Record + Send + Sync, V: CodecShared> Oversized<E, I, V> {
         self.index = self.index.rewind_section(section, index_size).await?;
 
         // Derive value size from last entry (section may not exist if empty)
-        let value_size = match self.index.last(section).await {
-            Ok(Some(entry)) => {
-                let (offset, size) = entry.value_location();
-                offset
-                    .checked_add(u64::from(size))
-                    .ok_or(Error::OffsetOverflow)?
-            }
-            Ok(None) => 0,
-            Err(Error::SectionOutOfRange(_)) if index_size == 0 => 0,
-            Err(e) => return Err(e),
-        };
+        let value_size = self.rewound_value_end(section, index_size).await?;
 
         // Make the index truncation durable before the values are rewound (see Self::rewind).
         self.index = self.index.sync(section).await?;
@@ -1336,6 +1295,14 @@ mod tests {
             compression: None,
             codec_config: (),
         }
+    }
+
+    /// Test configuration sized so each index page holds exactly one entry.
+    fn entry_cfg(pooler: &impl BufferPooler) -> Config<()> {
+        let mut cfg = test_cfg(pooler);
+        cfg.index_page_cache =
+            CacheRef::from_pooler(pooler, NZU16!(TestEntry::SIZE as u16), NZUsize!(8));
+        cfg
     }
 
     /// Simple test value type with unit config.
@@ -2006,20 +1973,7 @@ mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             // Use page size = entry size so each entry is on its own page.
-            let cfg = Config {
-                index_partition: "test-index".into(),
-                value_partition: "test-values".into(),
-                index_page_cache: CacheRef::from_pooler(
-                    &context,
-                    NZU16!(TestEntry::SIZE as u16),
-                    NZUsize!(8),
-                ),
-                index_write_buffer: NZUsize!(1024),
-                value_write_buffer: NZUsize!(1024),
-                replay_buffer: NZUsize!(4096),
-                compression: None,
-                codec_config: (),
-            };
+            let cfg = entry_cfg(&context);
 
             // Create five durable entry/value pairs.
             let mut oversized: Oversized<_, TestEntry, TestValue> =
@@ -2133,9 +2087,7 @@ mod tests {
     fn test_oversized_restore_does_not_repair_discarded_sections() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            let mut cfg = test_cfg(&context);
-            cfg.index_page_cache =
-                CacheRef::from_pooler(&context, NZU16!(TestEntry::SIZE as u16), NZUsize!(8));
+            let cfg = entry_cfg(&context);
             let mut oversized: Oversized<_, TestEntry, TestValue> =
                 Oversized::init(context.child("seed"), cfg.clone(), None)
                     .await
@@ -2248,11 +2200,9 @@ mod tests {
                     (2, TestEntry::SIZE as u64),
                 ),
             ] {
-                let mut cfg = test_cfg(&context);
+                let mut cfg = entry_cfg(&context);
                 cfg.index_partition = format!("test-index-{child}");
                 cfg.value_partition = format!("test-values-{child}");
-                cfg.index_page_cache =
-                    CacheRef::from_pooler(&context, NZU16!(TestEntry::SIZE as u16), NZUsize!(8));
 
                 // Persist three entries in section 1 and a later checkpoint candidate. One entry
                 // per integrity page makes the damaged page strictly interior.
@@ -2718,20 +2668,7 @@ mod tests {
             // Use page size = entry size so each entry is on its own page.
             // This allows corrupting just the last entry's page without affecting others.
             // Physical page size = TestEntry::SIZE (20) + 12 (CRC record) = 32 bytes.
-            let cfg = Config {
-                index_partition: "test-index".into(),
-                value_partition: "test-values".into(),
-                index_page_cache: CacheRef::from_pooler(
-                    &context,
-                    NZU16!(TestEntry::SIZE as u16),
-                    NZUsize!(8),
-                ),
-                index_write_buffer: NZUsize!(1024),
-                value_write_buffer: NZUsize!(1024),
-                replay_buffer: NZUsize!(4096),
-                compression: None,
-                codec_config: (),
-            };
+            let cfg = entry_cfg(&context);
 
             // Create and populate
             let mut oversized: Oversized<_, TestEntry, TestValue> =
@@ -3263,20 +3200,7 @@ mod tests {
             // Use page size = entry size so each entry is exactly one page.
             // This allows truncating by entry count to equal truncating by full pages,
             // maintaining page-level integrity.
-            let cfg = Config {
-                index_partition: "test-index".into(),
-                value_partition: "test-values".into(),
-                index_page_cache: CacheRef::from_pooler(
-                    &context,
-                    NZU16!(TestEntry::SIZE as u16),
-                    NZUsize!(8),
-                ),
-                index_write_buffer: NZUsize!(1024),
-                value_write_buffer: NZUsize!(1024),
-                replay_buffer: NZUsize!(4096),
-                compression: None,
-                codec_config: (),
-            };
+            let cfg = entry_cfg(&context);
 
             // Create and populate
             let mut oversized: Oversized<_, TestEntry, TestValue> =
@@ -3553,20 +3477,7 @@ mod tests {
             // Use page size = entry size so each entry is exactly one page.
             // This allows truncating by entry count to equal truncating by full pages,
             // maintaining page-level integrity.
-            let cfg = Config {
-                index_partition: "test-index".into(),
-                value_partition: "test-values".into(),
-                index_page_cache: CacheRef::from_pooler(
-                    &context,
-                    NZU16!(TestEntry::SIZE as u16),
-                    NZUsize!(8),
-                ),
-                index_write_buffer: NZUsize!(1024),
-                value_write_buffer: NZUsize!(1024),
-                replay_buffer: NZUsize!(4096),
-                compression: None,
-                codec_config: (),
-            };
+            let cfg = entry_cfg(&context);
 
             // Create and populate
             let mut oversized: Oversized<_, TestEntry, TestValue> =
@@ -4404,20 +4315,7 @@ mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             // Use page size = entry size so one entry per page
-            let cfg = Config {
-                index_partition: "test-index".into(),
-                value_partition: "test-values".into(),
-                index_page_cache: CacheRef::from_pooler(
-                    &context,
-                    NZU16!(TestEntry::SIZE as u16),
-                    NZUsize!(8),
-                ),
-                index_write_buffer: NZUsize!(1024),
-                value_write_buffer: NZUsize!(1024),
-                replay_buffer: NZUsize!(4096),
-                compression: None,
-                codec_config: (),
-            };
+            let cfg = entry_cfg(&context);
 
             // Create and populate with valid entry
             let mut oversized: Oversized<_, TestEntry, TestValue> =

--- a/storage/src/journal/segmented/oversized.rs
+++ b/storage/src/journal/segmented/oversized.rs
@@ -177,12 +177,14 @@ impl<E: Context> Tracking<E> {
     }
 
     /// Observe an in-flight marker without blocking and discard proofs it published.
-    fn observe_marker_sync(&mut self) -> Result<Option<SyncCompletion>, Error> {
-        let Some(completion) = self.marker_sync_pending.clone() else {
-            return Ok(None);
+    ///
+    /// Returns whether a marker generation is still in flight.
+    fn observe_marker_sync(&mut self) -> Result<bool, Error> {
+        let Some(completion) = self.marker_sync_pending.as_mut() else {
+            return Ok(false);
         };
-        let Some(result) = completion.clone().now_or_never() else {
-            return Ok(Some(completion));
+        let Some(result) = completion.now_or_never() else {
+            return Ok(true);
         };
         result.map_err(|err| Error::Metadata(crate::metadata::Error::Runtime(err)))?;
         self.marker_sync_pending = None;
@@ -197,7 +199,7 @@ impl<E: Context> Tracking<E> {
                 .unwrap_or(0);
             barrier.boundary() > published || !barrier.settled()
         });
-        Ok(None)
+        Ok(false)
     }
 }
 
@@ -829,7 +831,7 @@ impl<E: Context, I: Record + Send + Sync, V: CodecShared> Oversized<E, I, V> {
             .tracking
             .take()
             .expect("tracked sync preserves its recovery state");
-        let pending_marker = tracking.observe_marker_sync()?;
+        let marker_pending = tracking.observe_marker_sync()?;
         let lengths = sections
             .iter()
             .map(|&section| Ok((section, self.index.section_len(section)?)))
@@ -854,7 +856,7 @@ impl<E: Context, I: Record + Send + Sync, V: CodecShared> Oversized<E, I, V> {
 
         // Do not mutate Metadata while its prior generation is in flight. Completed barriers stay
         // as debt and are published when their section is no longer active, or on an empty flush.
-        if pending_marker.is_none() {
+        if !marker_pending {
             let publish = tracking
                 .barriers
                 .iter_mut()

--- a/storage/src/journal/segmented/oversized.rs
+++ b/storage/src/journal/segmented/oversized.rs
@@ -44,7 +44,7 @@
 //! so neither a dropped index entry nor the stale bytes it referenced can survive a
 //! crash once later appends may reuse the freed offsets.
 //!
-//! When a checkpoint is provided at init, recovery restores exactly the checkpointed
+//! When a checkpoint is provided ([Oversized::init_with_checkpoint]), recovery restores the
 //! state instead of inferring one: each section below the checkpoint is adopted at its
 //! validated terminal boundary (without reading values), the checkpointed section is
 //! durably truncated to the committed size, and everything after it is removed. A
@@ -255,39 +255,42 @@ impl<E: Context, I: Record + Send + Sync, V: CodecShared> std::fmt::Debug for Ov
 }
 
 impl<E: Context, I: Record + Send + Sync, V: CodecShared> Oversized<E, I, V> {
-    /// Initialize with crash recovery.
+    /// Initialize with inferred crash recovery.
     ///
-    /// `checkpoint` is the durable state recovery restores, as `(section, index size)`.
-    /// When set, recovery keeps exactly this state: each section below `section` is
+    /// Recovery infers the durable state: it finds each section's last valid entry (in
+    /// bounds of the glob, checksum-verified) and rewinds the index journal to exclude
+    /// the entries beyond it.
+    pub async fn init(context: E, cfg: Config<V::Cfg>) -> Result<Self, Error> {
+        let replay_buffer = cfg.replay_buffer;
+        let journal = Self::init_inner(context, cfg, Recovery::Infer).await?;
+        journal.recover_inferred(replay_buffer).await
+    }
+
+    /// Initialize with crash recovery restoring a durable checkpoint, as
+    /// `(section, index size)`.
+    ///
+    /// Recovery keeps exactly the checkpointed state: each section below `section` is
     /// adopted at its validated terminal boundary, `section` is truncated to `index
     /// size`, and everything after it is removed. A missing or damaged boundary the
     /// checkpoint covers fails init with [Error::Corruption], while interior damage
     /// below a boundary surfaces lazily as read errors. Callers must only provide a
     /// checkpoint that was durably synced before it was published (see
     /// [crate::freezer::Freezer]).
-    ///
-    /// When `None`, recovery infers the durable state instead: it finds each section's
-    /// last valid entry (in bounds of the glob, checksum-verified) and rewinds the
-    /// index journal to exclude the entries beyond it.
-    pub async fn init(
+    pub async fn init_with_checkpoint(
         context: E,
         cfg: Config<V::Cfg>,
-        checkpoint: Option<(u64, u64)>,
+        checkpoint: (u64, u64),
     ) -> Result<Self, Error> {
-        let replay_buffer = cfg.replay_buffer;
-        let recovery = match checkpoint {
-            Some((section, index_size)) => Recovery::Restore {
+        let (section, index_size) = checkpoint;
+        Self::init_inner(
+            context,
+            cfg,
+            Recovery::Restore {
                 section,
                 index_size,
             },
-            None => Recovery::Infer,
-        };
-        let journal = Self::init_inner(context, cfg, recovery).await?;
-        if checkpoint.is_none() {
-            journal.recover_inferred(replay_buffer).await
-        } else {
-            Ok(journal)
-        }
+        )
+        .await
     }
 
     /// Initialize tracked recovery and return its required full replay.
@@ -297,7 +300,7 @@ impl<E: Context, I: Record + Send + Sync, V: CodecShared> Oversized<E, I, V> {
     /// are value-validated in order and the first invalid entry truncates its section.
     // TODO (#4610): migrate the prunable archive to tracked replay
     #[allow(dead_code)]
-    pub(crate) async fn init_tracked(
+    pub(crate) async fn init_with_metadata(
         context: &E,
         cfg: Config<V::Cfg>,
         metadata_partition: String,
@@ -1314,9 +1317,7 @@ mod tests {
         executor.start(|context| async move {
             let cfg = test_cfg(&context);
             let mut oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context, cfg, None)
-                    .await
-                    .expect("Failed to init");
+                Oversized::init(context, cfg).await.expect("Failed to init");
 
             // Append entry with value
             let value: TestValue = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
@@ -1352,7 +1353,7 @@ mod tests {
 
             // Create and populate oversized journal
             let mut oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("first"), cfg.clone(), None)
+                Oversized::init(context.child("first"), cfg.clone())
                     .await
                     .expect("Failed to init");
 
@@ -1385,7 +1386,7 @@ mod tests {
 
             // Reinitialize - should recover and rewind index
             let oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("second"), cfg.clone(), None)
+                Oversized::init(context.child("second"), cfg.clone())
                     .await
                     .expect("Failed to reinit");
 
@@ -1418,7 +1419,7 @@ mod tests {
 
             // Create and populate
             let mut oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("first"), cfg.clone(), None)
+                Oversized::init(context.child("first"), cfg.clone())
                     .await
                     .expect("Failed to init");
 
@@ -1434,7 +1435,7 @@ mod tests {
 
             // Reopen and verify
             let oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("second"), cfg, None)
+                Oversized::init(context.child("second"), cfg)
                     .await
                     .expect("Failed to reinit");
 
@@ -1458,7 +1459,7 @@ mod tests {
             let cfg = test_cfg(&context);
 
             let mut oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("first"), cfg.clone(), None)
+                Oversized::init(context.child("first"), cfg.clone())
                     .await
                     .expect("Failed to init");
 
@@ -1485,7 +1486,7 @@ mod tests {
 
             // Only the synced sections survive the unclean drop, with both index and value durable.
             let oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("second"), cfg, None)
+                Oversized::init(context.child("second"), cfg)
                     .await
                     .expect("Failed to reinit");
             for &(section, position, offset, size, value) in &located {
@@ -1533,7 +1534,7 @@ mod tests {
         let (_, checkpoint) = executor.start_and_recover(|context| async move {
             // One fully durable entry/value pair.
             let mut oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("first"), test_cfg(&context), None)
+                Oversized::init(context.child("first"), test_cfg(&context))
                     .await
                     .expect("Failed to init");
             (oversized, _, _, _) = oversized
@@ -1561,7 +1562,7 @@ mod tests {
 
         deterministic::Runner::from(checkpoint).start(|context| async move {
             let oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("second"), test_cfg(&context), None)
+                Oversized::init(context.child("second"), test_cfg(&context))
                     .await
                     .expect("Failed to reinit");
             assert_eq!(
@@ -1580,7 +1581,7 @@ mod tests {
         let executor = deterministic::Runner::default();
         let (_, checkpoint) = executor.start_and_recover(|context| async move {
             let mut oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("first"), test_cfg(&context), None)
+                Oversized::init(context.child("first"), test_cfg(&context))
                     .await
                     .expect("Failed to init");
             (oversized, _, _, _) = oversized
@@ -1596,7 +1597,7 @@ mod tests {
         let (_, checkpoint) =
             deterministic::Runner::from(checkpoint).start_and_recover(|context| async move {
                 let mut oversized: Oversized<_, TestEntry, TestValue> =
-                    Oversized::init(context.child("second"), test_cfg(&context), None)
+                    Oversized::init(context.child("second"), test_cfg(&context))
                         .await
                         .expect("Failed to reinit");
                 assert_eq!(
@@ -1619,7 +1620,7 @@ mod tests {
         // entry 1, now range-valid over entry 2's bytes.
         deterministic::Runner::from(checkpoint).start(|context| async move {
             let oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("third"), test_cfg(&context), None)
+                Oversized::init(context.child("third"), test_cfg(&context))
                     .await
                     .expect("Failed to reinit");
             assert_adopted_entries_consistent(&oversized).await;
@@ -1633,7 +1634,7 @@ mod tests {
         let (_, checkpoint) = executor.start_and_recover(|context| async move {
             // One fully durable entry/value pair.
             let mut oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("first"), test_cfg(&context), None)
+                Oversized::init(context.child("first"), test_cfg(&context))
                     .await
                     .expect("Failed to init");
             (oversized, _, _, _) = oversized
@@ -1651,7 +1652,7 @@ mod tests {
                 fail_partition: "test-values".into(),
             };
             let oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(faulty_values, test_cfg(&context), None)
+                Oversized::init(faulty_values, test_cfg(&context))
                     .await
                     .expect("Failed to reinit");
             assert!(
@@ -1664,7 +1665,7 @@ mod tests {
         // must not be adopted at recovery.
         deterministic::Runner::from(checkpoint).start(|context| async move {
             let oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("third"), test_cfg(&context), None)
+                Oversized::init(context.child("third"), test_cfg(&context))
                     .await
                     .expect("Failed to reinit");
             assert_eq!(oversized.size(1).expect("size"), 0);
@@ -1679,7 +1680,7 @@ mod tests {
         let executor = deterministic::Runner::default();
         let (_, checkpoint) = executor.start_and_recover(|context| async move {
             let mut oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("first"), test_cfg(&context), None)
+                Oversized::init(context.child("first"), test_cfg(&context))
                     .await
                     .expect("Failed to init");
             (oversized, _, _, _) = oversized
@@ -1707,7 +1708,7 @@ mod tests {
         let (_, checkpoint) =
             deterministic::Runner::from(checkpoint).start_and_recover(|context| async move {
                 let mut oversized: Oversized<_, TestEntry, TestValue> =
-                    Oversized::init(context.child("second"), test_cfg(&context), None)
+                    Oversized::init(context.child("second"), test_cfg(&context))
                         .await
                         .expect("Failed to reinit");
                 (oversized, _, _, _) = oversized
@@ -1721,7 +1722,7 @@ mod tests {
         // adopted referencing entry 2's still-durable frame.
         deterministic::Runner::from(checkpoint).start(|context| async move {
             let oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("third"), test_cfg(&context), None)
+                Oversized::init(context.child("third"), test_cfg(&context))
                     .await
                     .expect("Failed to reinit");
             assert_adopted_entries_consistent(&oversized).await;
@@ -1735,7 +1736,7 @@ mod tests {
         let (_, checkpoint) = executor.start_and_recover(|context| async move {
             // Two fully durable entry/value pairs.
             let mut oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("first"), test_cfg(&context), None)
+                Oversized::init(context.child("first"), test_cfg(&context))
                     .await
                     .expect("Failed to init");
             (oversized, _, _, _) = oversized
@@ -1763,7 +1764,7 @@ mod tests {
         // state.
         deterministic::Runner::from(checkpoint).start(|context| async move {
             let oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("second"), test_cfg(&context), None)
+                Oversized::init(context.child("second"), test_cfg(&context))
                     .await
                     .expect("Failed to reinit");
             let chunk = FixedJournal::<deterministic::Context, TestEntry>::CHUNK_SIZE as u64;
@@ -1785,7 +1786,7 @@ mod tests {
         let executor = deterministic::Runner::default();
         let (_, checkpoint) = executor.start_and_recover(|context| async move {
             let mut oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("first"), test_cfg(&context), None)
+                Oversized::init(context.child("first"), test_cfg(&context))
                     .await
                     .expect("Failed to init");
             (oversized, _, _, _) = oversized
@@ -1799,7 +1800,7 @@ mod tests {
 
         deterministic::Runner::from(checkpoint).start(|context| async move {
             let oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("second"), test_cfg(&context), None)
+                Oversized::init(context.child("second"), test_cfg(&context))
                     .await
                     .expect("Failed to reinit");
             let chunk = FixedJournal::<deterministic::Context, TestEntry>::CHUNK_SIZE as u64;
@@ -1818,7 +1819,7 @@ mod tests {
                 fail_partition: "test-values".into(),
             };
             let mut oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(faulty_values, test_cfg(&context), None)
+                Oversized::init(faulty_values, test_cfg(&context))
                     .await
                     .expect("Failed to init");
             (oversized, _, _, _) = oversized
@@ -1834,7 +1835,7 @@ mod tests {
 
         deterministic::Runner::from(checkpoint).start(|context| async move {
             let oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("second"), test_cfg(&context), None)
+                Oversized::init(context.child("second"), test_cfg(&context))
                     .await
                     .expect("Failed to reinit");
             assert_eq!(
@@ -1855,7 +1856,7 @@ mod tests {
                 fail_partition: "test-values".into(),
             };
             let mut oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(faulty_values, test_cfg(&context), None)
+                Oversized::init(faulty_values, test_cfg(&context))
                     .await
                     .expect("Failed to init");
             (oversized, _, _, _) = oversized
@@ -1871,7 +1872,7 @@ mod tests {
 
         deterministic::Runner::from(checkpoint).start(|context| async move {
             let oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("second"), test_cfg(&context), None)
+                Oversized::init(context.child("second"), test_cfg(&context))
                     .await
                     .expect("Failed to reinit");
             assert_eq!(
@@ -1888,7 +1889,7 @@ mod tests {
         let executor = deterministic::Runner::default();
         let (_, checkpoint) = executor.start_and_recover(|context| async move {
             let mut oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("first"), test_cfg(&context), None)
+                Oversized::init(context.child("first"), test_cfg(&context))
                     .await
                     .expect("Failed to init");
             (oversized, _, _, _) = oversized
@@ -1905,7 +1906,7 @@ mod tests {
 
         deterministic::Runner::from(checkpoint).start(|context| async move {
             let oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("second"), test_cfg(&context), None)
+                Oversized::init(context.child("second"), test_cfg(&context))
                     .await
                     .expect("Failed to reinit");
             let chunk = FixedJournal::<deterministic::Context, TestEntry>::CHUNK_SIZE as u64;
@@ -1921,7 +1922,7 @@ mod tests {
         let (_, checkpoint) = executor.start_and_recover(|context| async move {
             // One fully durable entry/value pair.
             let mut oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("first"), test_cfg(&context), None)
+                Oversized::init(context.child("first"), test_cfg(&context))
                     .await
                     .expect("Failed to init");
             (oversized, _, _, _) = oversized
@@ -1954,7 +1955,7 @@ mod tests {
         // Entry 2's range fits within the glob, so only the checksum check can reject it.
         deterministic::Runner::from(checkpoint).start(|context| async move {
             let oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("second"), test_cfg(&context), None)
+                Oversized::init(context.child("second"), test_cfg(&context))
                     .await
                     .expect("Failed to reinit");
             let chunk = FixedJournal::<deterministic::Context, TestEntry>::CHUNK_SIZE as u64;
@@ -1977,7 +1978,7 @@ mod tests {
 
             // Create five durable entry/value pairs.
             let mut oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("first"), cfg.clone(), None)
+                Oversized::init(context.child("first"), cfg.clone())
                     .await
                     .expect("Failed to init");
             for i in 1..=5u8 {
@@ -2026,7 +2027,7 @@ mod tests {
             // Recovery scans past the invalid tail values and the torn page (surfaced
             // as a checksum failure, not a generic read error) to the last valid pair.
             let oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("second"), cfg, None)
+                Oversized::init(context.child("second"), cfg)
                     .await
                     .expect("Failed to reinit");
             let chunk = FixedJournal::<deterministic::Context, TestEntry>::CHUNK_SIZE as u64;
@@ -2043,7 +2044,7 @@ mod tests {
             // One committed entry, then torn state beyond the checkpoint: entries in
             // section 1 and 2 whose index becomes durable ahead of their values.
             let mut oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("first"), test_cfg(&context), None)
+                Oversized::init(context.child("first"), test_cfg(&context))
                     .await
                     .expect("Failed to init");
             (oversized, _, _, _) = oversized
@@ -2069,10 +2070,10 @@ mod tests {
         // Restore truncates to the checkpoint without validating the discarded state.
         deterministic::Runner::from(checkpoint).start(|context| async move {
             let chunk = FixedJournal::<deterministic::Context, TestEntry>::CHUNK_SIZE as u64;
-            let oversized: Oversized<_, TestEntry, TestValue> = Oversized::init(
+            let oversized: Oversized<_, TestEntry, TestValue> = Oversized::init_with_checkpoint(
                 context.child("second"),
                 test_cfg(&context),
-                Some((1, chunk)),
+                (1, chunk),
             )
             .await
             .expect("Failed to reinit");
@@ -2089,7 +2090,7 @@ mod tests {
         executor.start(|context| async move {
             let cfg = entry_cfg(&context);
             let mut oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("seed"), cfg.clone(), None)
+                Oversized::init(context.child("seed"), cfg.clone())
                     .await
                     .expect("failed to init");
             (oversized, _, _, _) = oversized
@@ -2125,7 +2126,7 @@ mod tests {
             let chunk = TestEntry::SIZE as u64;
             let oversized: Oversized<_, TestEntry, TestValue> = drive_pending_syncs(
                 &pending,
-                Oversized::init(delayed.child("restore"), cfg, Some((1, chunk))),
+                Oversized::init_with_checkpoint(delayed.child("restore"), cfg, (1, chunk)),
             )
             .await
             .expect("checkpoint restore failed");
@@ -2143,7 +2144,7 @@ mod tests {
         executor.start(|context| async move {
             // Two committed sections
             let mut oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("first"), test_cfg(&context), None)
+                Oversized::init(context.child("first"), test_cfg(&context))
                     .await
                     .expect("Failed to init");
             (oversized, _, _, _) = oversized
@@ -2171,12 +2172,13 @@ mod tests {
             // repaired, so the failure persists across restarts.
             let chunk = FixedJournal::<deterministic::Context, TestEntry>::CHUNK_SIZE as u64;
             for instance in ["second", "third"] {
-                let result: Result<Oversized<_, TestEntry, TestValue>, Error> = Oversized::init(
-                    context.child(instance),
-                    test_cfg(&context),
-                    Some((2, chunk)),
-                )
-                .await;
+                let result: Result<Oversized<_, TestEntry, TestValue>, Error> =
+                    Oversized::init_with_checkpoint(
+                        context.child(instance),
+                        test_cfg(&context),
+                        (2, chunk),
+                    )
+                    .await;
                 assert!(matches!(result, Err(Error::Corruption(_))));
             }
         });
@@ -2207,7 +2209,7 @@ mod tests {
                 // Persist three entries in section 1 and a later checkpoint candidate. One entry
                 // per integrity page makes the damaged page strictly interior.
                 let mut oversized: Oversized<_, TestEntry, TestValue> =
-                    Oversized::init(context.child(seed_child), cfg.clone(), None)
+                    Oversized::init(context.child(seed_child), cfg.clone())
                         .await
                         .expect("failed to init");
                 for id in 0..3 {
@@ -2245,9 +2247,13 @@ mod tests {
                 drop(blob);
 
                 let oversized: Oversized<_, TestEntry, TestValue> =
-                    Oversized::init(context.child(restore_child), cfg.clone(), Some(checkpoint))
-                        .await
-                        .expect("checkpoint restore should adopt the covered prefix");
+                    Oversized::init_with_checkpoint(
+                        context.child(restore_child),
+                        cfg.clone(),
+                        checkpoint,
+                    )
+                    .await
+                    .expect("checkpoint restore should adopt the covered prefix");
                 assert!(matches!(
                     oversized.get(1, 1).await,
                     Err(Error::Runtime(RError::InvalidChecksum))
@@ -2275,7 +2281,7 @@ mod tests {
         executor.start(|context| async move {
             // Two committed sections
             let mut oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("first"), test_cfg(&context), None)
+                Oversized::init(context.child("first"), test_cfg(&context))
                     .await
                     .expect("Failed to init");
             let (offset, size);
@@ -2301,10 +2307,10 @@ mod tests {
             // Restore adopts the section without probing its values: the corruption
             // surfaces at read on exactly the affected entry.
             let chunk = FixedJournal::<deterministic::Context, TestEntry>::CHUNK_SIZE as u64;
-            let oversized: Oversized<_, TestEntry, TestValue> = Oversized::init(
+            let oversized: Oversized<_, TestEntry, TestValue> = Oversized::init_with_checkpoint(
                 context.child("second"),
                 test_cfg(&context),
-                Some((2, chunk)),
+                (2, chunk),
             )
             .await
             .expect("Failed to reinit");
@@ -2330,9 +2336,8 @@ mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let cfg = test_cfg(&context);
-            let oversized: Oversized<_, TestEntry, TestValue> = Oversized::init(context, cfg, None)
-                .await
-                .expect("Failed to init");
+            let oversized: Oversized<_, TestEntry, TestValue> =
+                Oversized::init(context, cfg).await.expect("Failed to init");
 
             // An empty journal's reader is exhausted from the start
             let replay = oversized
@@ -2352,9 +2357,7 @@ mod tests {
             let cfg = test_cfg(&context);
             let page_cache = cfg.index_page_cache.clone();
             let mut oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context, cfg, None)
-                    .await
-                    .expect("Failed to init");
+                Oversized::init(context, cfg).await.expect("Failed to init");
             (oversized, _, _, _) = oversized
                 .append(1, TestEntry::new(1, 0, 0), &[1; 16])
                 .await
@@ -2401,9 +2404,7 @@ mod tests {
         executor.start(|context| async move {
             let cfg = test_cfg(&context);
             let mut oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context, cfg, None)
-                    .await
-                    .expect("Failed to init");
+                Oversized::init(context, cfg).await.expect("Failed to init");
             (oversized, _, _, _) = oversized
                 .append(1, TestEntry::new(1, 0, 0), &[1; 16])
                 .await
@@ -2424,9 +2425,7 @@ mod tests {
         executor.start(|context| async move {
             let cfg = test_cfg(&context);
             let mut oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context, cfg, None)
-                    .await
-                    .expect("Failed to init");
+                Oversized::init(context, cfg).await.expect("Failed to init");
 
             // Append to multiple sections
             for section in 1u64..=5 {
@@ -2468,7 +2467,7 @@ mod tests {
 
             // Create oversized journal
             let mut oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("first"), cfg.clone(), None)
+                Oversized::init(context.child("first"), cfg.clone())
                     .await
                     .expect("Failed to init");
 
@@ -2484,7 +2483,7 @@ mod tests {
 
             // Reinitialize - recovery should handle the empty/non-existent section 1
             let oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("second"), cfg, None)
+                Oversized::init(context.child("second"), cfg)
                     .await
                     .expect("Failed to reinit");
 
@@ -2504,7 +2503,7 @@ mod tests {
 
             // Create and populate
             let mut oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("first"), cfg.clone(), None)
+                Oversized::init(context.child("first"), cfg.clone())
                     .await
                     .expect("Failed to init");
 
@@ -2531,7 +2530,7 @@ mod tests {
 
             // Reinitialize - should recover and rewind index to 0
             let mut oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("second"), cfg, None)
+                Oversized::init(context.child("second"), cfg)
                     .await
                     .expect("Failed to reinit");
 
@@ -2569,7 +2568,7 @@ mod tests {
 
             // Create and populate multiple sections
             let mut oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("first"), cfg.clone(), None)
+                Oversized::init(context.child("first"), cfg.clone())
                     .await
                     .expect("Failed to init");
 
@@ -2637,7 +2636,7 @@ mod tests {
 
             // Reinitialize
             let oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("second"), cfg, None)
+                Oversized::init(context.child("second"), cfg)
                     .await
                     .expect("Failed to reinit");
 
@@ -2672,7 +2671,7 @@ mod tests {
 
             // Create and populate
             let mut oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("first"), cfg.clone(), None)
+                Oversized::init(context.child("first"), cfg.clone())
                     .await
                     .expect("Failed to init");
 
@@ -2706,7 +2705,7 @@ mod tests {
 
             // Reinitialize - should detect page corruption and truncate
             let mut oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("second"), cfg, None)
+                Oversized::init(context.child("second"), cfg)
                     .await
                     .expect("Failed to reinit");
 
@@ -2749,7 +2748,7 @@ mod tests {
 
             // Create and populate
             let mut oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("first"), cfg.clone(), None)
+                Oversized::init(context.child("first"), cfg.clone())
                     .await
                     .expect("Failed to init");
 
@@ -2769,7 +2768,7 @@ mod tests {
 
             // Reinitialize with no corruption - should be fast
             let oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("second"), cfg, None)
+                Oversized::init(context.child("second"), cfg)
                     .await
                     .expect("Failed to reinit");
 
@@ -2796,7 +2795,7 @@ mod tests {
 
             // Create and populate with single entry
             let mut oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("first"), cfg.clone(), None)
+                Oversized::init(context.child("first"), cfg.clone())
                     .await
                     .expect("Failed to init");
 
@@ -2820,7 +2819,7 @@ mod tests {
 
             // Reinitialize
             let oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("second"), cfg, None)
+                Oversized::init(context.child("second"), cfg)
                     .await
                     .expect("Failed to reinit");
 
@@ -2839,7 +2838,7 @@ mod tests {
 
             // Create and populate
             let mut oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("first"), cfg.clone(), None)
+                Oversized::init(context.child("first"), cfg.clone())
                     .await
                     .expect("Failed to init");
 
@@ -2873,7 +2872,7 @@ mod tests {
 
             // Reinitialize
             let mut oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("second"), cfg, None)
+                Oversized::init(context.child("second"), cfg)
                     .await
                     .expect("Failed to reinit");
 
@@ -2914,7 +2913,7 @@ mod tests {
 
             // Create and populate
             let mut oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("first"), cfg.clone(), None)
+                Oversized::init(context.child("first"), cfg.clone())
                     .await
                     .expect("Failed to init");
 
@@ -2937,7 +2936,7 @@ mod tests {
 
             // Reinitialize - glob size will be 0, all entries invalid
             let oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("second"), cfg, None)
+                Oversized::init(context.child("second"), cfg)
                     .await
                     .expect("Failed to reinit");
 
@@ -2958,7 +2957,7 @@ mod tests {
 
             // Create and populate
             let mut oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("first"), cfg.clone(), None)
+                Oversized::init(context.child("first"), cfg.clone())
                     .await
                     .expect("Failed to init");
 
@@ -2988,7 +2987,7 @@ mod tests {
 
             // Reinitialize
             let mut oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("second"), cfg.clone(), None)
+                Oversized::init(context.child("second"), cfg.clone())
                     .await
                     .expect("Failed to reinit");
 
@@ -3029,7 +3028,7 @@ mod tests {
 
             // Create and populate multiple sections
             let mut oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("first"), cfg.clone(), None)
+                Oversized::init(context.child("first"), cfg.clone())
                     .await
                     .expect("Failed to init");
 
@@ -3063,7 +3062,7 @@ mod tests {
             // Reinitialize - should recover gracefully with warning
             // Index section 1 will be rewound to 0 entries
             let oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("second"), cfg.clone(), None)
+                Oversized::init(context.child("second"), cfg.clone())
                     .await
                     .expect("Failed to reinit");
 
@@ -3086,7 +3085,7 @@ mod tests {
 
             // Create and populate multiple sections
             let mut oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("first"), cfg.clone(), None)
+                Oversized::init(context.child("first"), cfg.clone())
                     .await
                     .expect("Failed to init");
 
@@ -3110,7 +3109,7 @@ mod tests {
             // Reinitialize - should handle gracefully
             // Section 2 is gone from index, orphan data in glob is acceptable
             let oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("second"), cfg.clone(), None)
+                Oversized::init(context.child("second"), cfg.clone())
                     .await
                     .expect("Failed to reinit");
 
@@ -3133,7 +3132,7 @@ mod tests {
 
             // Create and populate
             let mut oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("first"), cfg.clone(), None)
+                Oversized::init(context.child("first"), cfg.clone())
                     .await
                     .expect("Failed to init");
 
@@ -3176,7 +3175,7 @@ mod tests {
 
             // Reinitialize - should rewind index to match glob
             let oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("second"), cfg, None)
+                Oversized::init(context.child("second"), cfg)
                     .await
                     .expect("Failed to reinit");
 
@@ -3204,7 +3203,7 @@ mod tests {
 
             // Create and populate
             let mut oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("first"), cfg.clone(), None)
+                Oversized::init(context.child("first"), cfg.clone())
                     .await
                     .expect("Failed to init");
 
@@ -3241,7 +3240,7 @@ mod tests {
 
             // Reinitialize - glob has orphan data from entry 3
             let mut oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("second"), cfg.clone(), None)
+                Oversized::init(context.child("second"), cfg.clone())
                     .await
                     .expect("Failed to reinit");
 
@@ -3293,7 +3292,7 @@ mod tests {
 
             // Reinitialize after adding data on top of orphan glob data
             let oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("third"), cfg, None)
+                Oversized::init(context.child("third"), cfg)
                     .await
                     .expect("Failed to reinit after append");
 
@@ -3342,7 +3341,7 @@ mod tests {
 
             // Create and populate
             let mut oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("first"), cfg.clone(), None)
+                Oversized::init(context.child("first"), cfg.clone())
                     .await
                     .expect("Failed to init");
 
@@ -3372,7 +3371,7 @@ mod tests {
 
             // Reinitialize - should handle partial entry gracefully
             let mut oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("second"), cfg.clone(), None)
+                Oversized::init(context.child("second"), cfg.clone())
                     .await
                     .expect("Failed to reinit");
 
@@ -3416,7 +3415,7 @@ mod tests {
 
             // Create and populate with single entry
             let mut oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("first"), cfg.clone(), None)
+                Oversized::init(context.child("first"), cfg.clone())
                     .await
                     .expect("Failed to init");
 
@@ -3440,7 +3439,7 @@ mod tests {
 
             // Reinitialize - should handle gracefully (rewind to 0)
             let mut oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("second"), cfg.clone(), None)
+                Oversized::init(context.child("second"), cfg.clone())
                     .await
                     .expect("Failed to reinit");
 
@@ -3481,7 +3480,7 @@ mod tests {
 
             // Create and populate
             let mut oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("first"), cfg.clone(), None)
+                Oversized::init(context.child("first"), cfg.clone())
                     .await
                     .expect("Failed to init");
 
@@ -3515,7 +3514,7 @@ mod tests {
 
             // Reinitialize - recovery should succeed (glob has orphan data)
             let mut oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("second"), cfg.clone(), None)
+                Oversized::init(context.child("second"), cfg.clone())
                     .await
                     .expect("Failed to reinit");
 
@@ -3549,7 +3548,7 @@ mod tests {
 
             // Create and populate
             let mut oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("first"), cfg.clone(), None)
+                Oversized::init(context.child("first"), cfg.clone())
                     .await
                     .expect("Failed to init");
 
@@ -3580,7 +3579,7 @@ mod tests {
 
             // Reinitialize - recovery should detect index entries pointing beyond glob
             let mut oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("second"), cfg.clone(), None)
+                Oversized::init(context.child("second"), cfg.clone())
                     .await
                     .expect("Failed to reinit");
 
@@ -3621,9 +3620,7 @@ mod tests {
         executor.start(|context| async move {
             let cfg = test_cfg(&context);
             let mut oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context, cfg, None)
-                    .await
-                    .expect("Failed to init");
+                Oversized::init(context, cfg).await.expect("Failed to init");
 
             let value: TestValue = [42; 16];
             let entry = TestEntry::new(1, 0, 0);
@@ -3663,9 +3660,7 @@ mod tests {
         executor.start(|context| async move {
             let cfg = test_cfg(&context);
             let mut oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context, cfg, None)
-                    .await
-                    .expect("Failed to init");
+                Oversized::init(context, cfg).await.expect("Failed to init");
 
             let value: TestValue = [42; 16];
             let entry = TestEntry::new(1, 0, 0);
@@ -3700,7 +3695,7 @@ mod tests {
 
             // Create and populate with sections 1 and 2
             let mut oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("first"), cfg.clone(), None)
+                Oversized::init(context.child("first"), cfg.clone())
                     .await
                     .expect("Failed to init");
 
@@ -3735,7 +3730,7 @@ mod tests {
 
             // Reinitialize - should detect and remove the orphan section
             let oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("second"), cfg.clone(), None)
+                Oversized::init(context.child("second"), cfg.clone())
                     .await
                     .expect("Failed to reinit");
 
@@ -3758,7 +3753,7 @@ mod tests {
 
             // Create and populate with only section 1
             let mut oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("first"), cfg.clone(), None)
+                Oversized::init(context.child("first"), cfg.clone())
                     .await
                     .expect("Failed to init");
 
@@ -3794,7 +3789,7 @@ mod tests {
 
             // Reinitialize - should detect and remove all orphan sections
             let oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("second"), cfg.clone(), None)
+                Oversized::init(context.child("second"), cfg.clone())
                     .await
                     .expect("Failed to reinit");
 
@@ -3837,7 +3832,7 @@ mod tests {
 
             // Initialize oversized - should remove all orphan value sections
             let oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("first"), cfg.clone(), None)
+                Oversized::init(context.child("first"), cfg.clone())
                     .await
                     .expect("Failed to init");
 
@@ -3857,7 +3852,7 @@ mod tests {
 
             // Create and populate with section 1
             let mut oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("first"), cfg.clone(), None)
+                Oversized::init(context.child("first"), cfg.clone())
                     .await
                     .expect("Failed to init");
 
@@ -3894,7 +3889,7 @@ mod tests {
 
             // Reinitialize - should remove orphan sections
             let mut oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("second"), cfg.clone(), None)
+                Oversized::init(context.child("second"), cfg.clone())
                     .await
                     .expect("Failed to reinit");
 
@@ -3931,7 +3926,7 @@ mod tests {
             drop(oversized);
 
             let oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("third"), cfg, None)
+                Oversized::init(context.child("third"), cfg)
                     .await
                     .expect("Failed to reinit after append");
 
@@ -3952,7 +3947,7 @@ mod tests {
 
             // Create and populate with sections 1, 2, 3 (no orphans)
             let mut oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("first"), cfg.clone(), None)
+                Oversized::init(context.child("first"), cfg.clone())
                     .await
                     .expect("Failed to init");
 
@@ -3969,7 +3964,7 @@ mod tests {
 
             // Reinitialize - no orphan cleanup needed
             let oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("second"), cfg, None)
+                Oversized::init(context.child("second"), cfg)
                     .await
                     .expect("Failed to reinit");
 
@@ -3992,7 +3987,7 @@ mod tests {
 
             // Create and populate section 1 with entries
             let mut oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("first"), cfg.clone(), None)
+                Oversized::init(context.child("first"), cfg.clone())
                     .await
                     .expect("Failed to init");
 
@@ -4034,7 +4029,7 @@ mod tests {
 
             // Reinitialize - should handle empty index section and remove orphan value section
             let oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("second"), cfg, None)
+                Oversized::init(context.child("second"), cfg)
                     .await
                     .expect("Failed to reinit");
 
@@ -4058,7 +4053,7 @@ mod tests {
 
             // Create index with sections 1, 3, 5 (gaps)
             let mut oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("first"), cfg.clone(), None)
+                Oversized::init(context.child("first"), cfg.clone())
                     .await
                     .expect("Failed to init");
 
@@ -4096,7 +4091,7 @@ mod tests {
 
             // Reinitialize - should remove orphan sections 2, 4, 6
             let oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("second"), cfg, None)
+                Oversized::init(context.child("second"), cfg)
                     .await
                     .expect("Failed to reinit");
 
@@ -4123,7 +4118,7 @@ mod tests {
             // Seed two sections with one synced entry each, so both hold durable values.
             let cfg = test_cfg(&context);
             let mut oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("first"), cfg.clone(), None)
+                Oversized::init(context.child("first"), cfg.clone())
                     .await
                     .expect("Failed to init");
             for section in 1..=2 {
@@ -4169,7 +4164,7 @@ mod tests {
             // sections come back empty (the original entries are gone with their prefixes)
             // and the truncation is durable.
             let mut oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("second"), cfg.clone(), None)
+                Oversized::init(context.child("second"), cfg.clone())
                     .await
                     .expect("Failed to recover extended index");
             for section in 1..=2u64 {
@@ -4196,7 +4191,7 @@ mod tests {
 
             // The sentinel entries written after recovery survive a clean reopen.
             let oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("third"), cfg, None)
+                Oversized::init(context.child("third"), cfg)
                     .await
                     .expect("Failed to reopen sentinel");
             for section in 1..=2u64 {
@@ -4229,7 +4224,7 @@ mod tests {
 
             // Create and populate
             let mut oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("first"), cfg.clone(), None)
+                Oversized::init(context.child("first"), cfg.clone())
                     .await
                     .expect("Failed to init");
 
@@ -4275,7 +4270,7 @@ mod tests {
 
             // Reinitialize - should truncate the trailing garbage
             let mut oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("second"), cfg.clone(), None)
+                Oversized::init(context.child("second"), cfg.clone())
                     .await
                     .expect("Failed to reinit");
 
@@ -4319,7 +4314,7 @@ mod tests {
 
             // Create and populate with valid entry
             let mut oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("first"), cfg.clone(), None)
+                Oversized::init(context.child("first"), cfg.clone())
                     .await
                     .expect("Failed to init");
 
@@ -4369,7 +4364,7 @@ mod tests {
             // Reinitialize - recovery should detect the invalid entry
             // (offset + size would overflow, and even with saturating_add it exceeds glob_size)
             let mut oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("second"), cfg.clone(), None)
+                Oversized::init(context.child("second"), cfg.clone())
                     .await
                     .expect("Failed to reinit");
 
@@ -4404,7 +4399,7 @@ mod tests {
 
             // Create and populate section 1 with entries
             let mut oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("first"), cfg.clone(), None)
+                Oversized::init(context.child("first"), cfg.clone())
                     .await
                     .expect("Failed to init");
 
@@ -4439,7 +4434,7 @@ mod tests {
 
             // First restart - recovery should handle empty section 1
             let mut oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("second"), cfg.clone(), None)
+                Oversized::init(context.child("second"), cfg.clone())
                     .await
                     .expect("Failed to reinit");
 
@@ -4479,7 +4474,7 @@ mod tests {
 
             // Second restart - verify persistence
             let oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("third"), cfg.clone(), None)
+                Oversized::init(context.child("third"), cfg.clone())
                     .await
                     .expect("Failed to reinit again");
 
@@ -4503,9 +4498,7 @@ mod tests {
         executor.start(|context| async move {
             let cfg = test_cfg(&context);
             let mut oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context, cfg, None)
-                    .await
-                    .expect("Failed to init");
+                Oversized::init(context, cfg).await.expect("Failed to init");
 
             let value: TestValue = [42; 16];
             let entry = TestEntry::new(1, 0, 0);
@@ -4533,9 +4526,7 @@ mod tests {
         executor.start(|context| async move {
             let cfg = test_cfg(&context);
             let mut oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context, cfg, None)
-                    .await
-                    .expect("Failed to init");
+                Oversized::init(context, cfg).await.expect("Failed to init");
 
             let value: TestValue = [42; 16];
             let entry = TestEntry::new(1, 0, 0);
@@ -4568,7 +4559,7 @@ mod tests {
 
             // Create and populate with large section numbers
             let mut oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("first"), cfg.clone(), None)
+                Oversized::init(context.child("first"), cfg.clone())
                     .await
                     .expect("Failed to init");
 
@@ -4598,7 +4589,7 @@ mod tests {
 
             // Reinitialize - should recover without overflow panics
             let mut oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("second"), cfg.clone(), None)
+                Oversized::init(context.child("second"), cfg.clone())
                     .await
                     .expect("Failed to reinit");
 
@@ -4641,7 +4632,7 @@ mod tests {
 
             // Phase 1: Create valid data with 5 entries
             let mut oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("first"), cfg.clone(), None)
+                Oversized::init(context.child("first"), cfg.clone())
                     .await
                     .expect("Failed to init");
 
@@ -4689,7 +4680,7 @@ mod tests {
             // Phase 4: Second recovery attempt should handle the inconsistent state
             // Index has 4 entries, but glob only supports 3.
             let mut oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("second"), cfg.clone(), None)
+                Oversized::init(context.child("second"), cfg.clone())
                     .await
                     .expect("Failed to reinit after nested crash");
 
@@ -4736,7 +4727,7 @@ mod tests {
 
             // Phase 1: Create valid data in section 1
             let mut oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("first"), cfg.clone(), None)
+                Oversized::init(context.child("first"), cfg.clone())
                     .await
                     .expect("Failed to init");
 
@@ -4780,7 +4771,7 @@ mod tests {
 
             // Phase 4: Recovery should complete the cleanup
             let mut oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context.child("second"), cfg.clone(), None)
+                Oversized::init(context.child("second"), cfg.clone())
                     .await
                     .expect("Failed to reinit");
 
@@ -4817,9 +4808,7 @@ mod tests {
         executor.start(|context| async move {
             let cfg = test_cfg(&context);
             let mut oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context, cfg, None)
-                    .await
-                    .expect("Failed to init");
+                Oversized::init(context, cfg).await.expect("Failed to init");
 
             let value: TestValue = [1; 16];
             let entry = TestEntry::new(1, 0, 0);
@@ -4848,9 +4837,7 @@ mod tests {
         executor.start(|context| async move {
             let cfg = test_cfg(&context);
             let mut oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context, cfg, None)
-                    .await
-                    .expect("Failed to init");
+                Oversized::init(context, cfg).await.expect("Failed to init");
 
             oversized = oversized
                 .rewind(0, 0)
@@ -4872,9 +4859,8 @@ mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let cfg = test_cfg(&context);
-            let oversized: Oversized<_, TestEntry, TestValue> = Oversized::init(context, cfg, None)
-                .await
-                .expect("Failed to init");
+            let oversized: Oversized<_, TestEntry, TestValue> =
+                Oversized::init(context, cfg).await.expect("Failed to init");
 
             let result = oversized.rewind(0, 1).await;
             assert!(
@@ -4889,9 +4875,8 @@ mod tests {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let cfg = test_cfg(&context);
-            let oversized: Oversized<_, TestEntry, TestValue> = Oversized::init(context, cfg, None)
-                .await
-                .expect("Failed to init");
+            let oversized: Oversized<_, TestEntry, TestValue> =
+                Oversized::init(context, cfg).await.expect("Failed to init");
 
             let result = oversized.rewind_section(0, 1).await;
             assert!(
@@ -4907,9 +4892,7 @@ mod tests {
         executor.start(|context| async move {
             let cfg = test_cfg(&context);
             let mut oversized: Oversized<_, TestEntry, TestValue> =
-                Oversized::init(context, cfg, None)
-                    .await
-                    .expect("Failed to init");
+                Oversized::init(context, cfg).await.expect("Failed to init");
 
             let value: TestValue = [1; 16];
             (oversized, _, _, _) = oversized

--- a/storage/src/journal/segmented/oversized.rs
+++ b/storage/src/journal/segmented/oversized.rs
@@ -51,12 +51,10 @@
 //! missing or damaged durable boundary fails init rather than being repaired. Other
 //! committed damage the checkpoint covers surfaces lazily as read errors.
 //!
-//! Tracked recovery maintains a per-section committed item count for owners that must validate
-//! every newly recovered value. The covered index/value prefix is proven before repair, replay
-//! verifies values above it in order, and the first invalid value truncates the rest of that
-//! section. Marker publication conservatively trails proven data syncs: a section's boundary
-//! is published once it is proven durable and the section is no longer receiving writes, or on
-//! an empty flush.
+//! Tracked recovery persists a per-section committed item count. Entries below the marker are
+//! adopted once their index/value boundary is proven, entries above it are value-verified in
+//! order, and the first invalid value truncates the section's remainder. Markers trail proven
+//! syncs, publishing once a section is durable and idle (or on an empty flush).
 
 use super::{
     fixed::{
@@ -276,7 +274,7 @@ impl<E: Context, I: Record + Send + Sync, V: CodecShared> Oversized<E, I, V> {
         cfg: Config<V::Cfg>,
         checkpoint: Option<(u64, u64)>,
     ) -> Result<Self, Error> {
-        let recovery_buffer = cfg.replay_buffer;
+        let replay_buffer = cfg.replay_buffer;
         let recovery = match checkpoint {
             Some((section, index_size)) => Recovery::Restore {
                 section,
@@ -286,7 +284,7 @@ impl<E: Context, I: Record + Send + Sync, V: CodecShared> Oversized<E, I, V> {
         };
         let journal = Self::init_inner(context, cfg, recovery).await?;
         if checkpoint.is_none() {
-            journal.recover_inferred(recovery_buffer).await
+            journal.recover_inferred(replay_buffer).await
         } else {
             Ok(journal)
         }
@@ -305,7 +303,7 @@ impl<E: Context, I: Record + Send + Sync, V: CodecShared> Oversized<E, I, V> {
         metadata_partition: String,
         read_options: ReadOptions,
     ) -> Result<Replay<E, I, V>, Error> {
-        let buffer = cfg.replay_buffer;
+        let replay_buffer = cfg.replay_buffer;
 
         // Open the commit markers before the data they constrain.
         let metadata = Metadata::init(
@@ -339,11 +337,12 @@ impl<E: Context, I: Record + Send + Sync, V: CodecShared> Oversized<E, I, V> {
             marker_sync_pending: None,
             barriers: BTreeMap::new(),
         });
-        let mut replay = journal.replay(0, 0, buffer, read_options).await?;
+        let mut replay = journal.replay(0, 0, replay_buffer, read_options).await?;
         replay.validation = Some(Validation::new());
         Ok(replay)
     }
 
+    /// Open the index and value journals, reconciling them per the selected [Recovery] mode.
     async fn init_inner(
         context: E,
         cfg: Config<V::Cfg>,
@@ -4210,6 +4209,7 @@ mod tests {
     fn test_recovery_discards_index_extension_after_prefix_loss() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
+            // Seed two sections with one synced entry each, so both hold durable values.
             let cfg = test_cfg(&context);
             let mut oversized: Oversized<_, TestEntry, TestValue> =
                 Oversized::init(context.child("first"), cfg.clone(), None)
@@ -4254,6 +4254,9 @@ mod tests {
                 .expect("Failed to extend index");
             }
 
+            // Recovery must not adopt the checksum-less extensions as index data: both
+            // sections come back empty (the original entries are gone with their prefixes)
+            // and the truncation is durable.
             let mut oversized: Oversized<_, TestEntry, TestValue> =
                 Oversized::init(context.child("second"), cfg.clone(), None)
                     .await
@@ -4269,6 +4272,7 @@ mod tests {
                     .expect("Failed to reopen index blob");
                 assert_eq!(recovered_size, 0);
 
+                // The recovered sections accept new entries from position zero.
                 let position;
                 (oversized, position, _, _) = oversized
                     .append(section, TestEntry::new(section, 0, 0), &[section as u8; 16])
@@ -4279,6 +4283,7 @@ mod tests {
             oversized = oversized.sync_all().await.expect("Failed to sync sentinel");
             drop(oversized);
 
+            // The sentinel entries written after recovery survive a clean reopen.
             let oversized: Oversized<_, TestEntry, TestValue> =
                 Oversized::init(context.child("third"), cfg, None)
                     .await

--- a/storage/src/journal/segmented/variable.rs
+++ b/storage/src/journal/segmented/variable.rs
@@ -202,9 +202,10 @@ impl<E: Storage + Metrics, V: CodecShared> Inner<E, V> {
     ///
     /// The buffer must be in the on-disk format produced by [Self::encode_item].
     async fn append_raw(&mut self, section: u64, buf: IoBuf) -> Result<u64, Error> {
-        if self.unrecovered.contains(&section) {
-            return Err(Error::ReplayRequired(section));
-        }
+        assert!(
+            !self.unrecovered.contains(&section),
+            "section {section} must be replayed before append"
+        );
         let blob = self.manager.get_or_create(section).await?;
         let offset = blob.append_owned(buf).await?;
         trace!(blob = section, offset, "appended item");
@@ -492,8 +493,10 @@ impl<E: Storage + Metrics, V: CodecShared> Journal<E, V> {
     /// where the item was written and the size of the item (which may differ
     /// from the raw encoded size if compression is enabled).
     ///
-    /// Returns [Error::ReplayRequired] when `section` contained data at initialization and has not
-    /// completed a replay from offset zero.
+    /// # Panics
+    ///
+    /// Panics when `section` contained data at initialization and has not completed a replay
+    /// from offset zero.
     pub async fn append(mut self, section: u64, item: &V) -> Result<(Self, u64, u32), Error> {
         let (offset, item_len) = self.0.append(section, item).await?;
         Ok((self, offset, item_len))
@@ -1000,6 +1003,7 @@ mod tests {
     }
 
     #[test_traced]
+    #[should_panic(expected = "must be replayed before append")]
     fn test_segmented_variable_rejects_append_before_replay() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
@@ -1012,15 +1016,12 @@ mod tests {
             assert_eq!(offset, 0);
             let (journal, offset, _) = journal.append(NEW_SECTION, &16).await.unwrap();
             assert_eq!(offset, 9);
-            let result = journal.append(TORN_SECTION, &15).await;
-            assert!(
-                matches!(result, Err(Error::ReplayRequired(TORN_SECTION))),
-                "an unrecovered section must reject new appends"
-            );
+            let _ = journal.append(TORN_SECTION, &15).await;
         });
     }
 
     #[test_traced]
+    #[should_panic(expected = "must be replayed before append")]
     fn test_segmented_variable_partial_replay_keeps_append_guard() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
@@ -1036,10 +1037,7 @@ mod tests {
                 item.unwrap();
             }
             let journal = replay.finish().unwrap();
-            assert!(matches!(
-                journal.append(SECTION, &7).await,
-                Err(Error::ReplayRequired(SECTION))
-            ));
+            let _ = journal.append(SECTION, &7).await;
         });
     }
 

--- a/storage/src/journal/segmented/variable.rs
+++ b/storage/src/journal/segmented/variable.rs
@@ -89,7 +89,7 @@ use crate::journal::{
 };
 use commonware_codec::{Codec, CodecShared, varint::MAX_U32_VARINT_SIZE};
 use commonware_runtime::{
-    Blob, Buf, Handle, IoBuf, Metrics, ReadOptions, Storage,
+    Blob, Buf, Error as RError, Handle, IoBuf, Metrics, ReadOptions, Storage,
     buffer::paged::{CacheRef, Replay as BlobReplay, Writer},
 };
 use std::{
@@ -141,6 +141,16 @@ struct Inner<E: Storage + Metrics, V: Codec> {
 
     /// Codec configuration.
     codec_config: V::Cfg,
+}
+
+impl<E: Storage + Metrics, V: Codec> Inner<E, V> {
+    /// The section's writer. A replayed section cannot be removed while the replay owns the
+    /// journal.
+    fn writer(&mut self, section: u64) -> &mut Writer<E::Blob> {
+        self.manager
+            .get_mut(section)
+            .expect("replayed section is present")
+    }
 }
 
 impl<E: Storage + Metrics, V: CodecShared> Inner<E, V> {
@@ -654,45 +664,60 @@ pub struct Replay<E: Storage + Metrics, V: Codec> {
 }
 
 impl<E: Storage + Metrics, V: CodecShared> Replay<E, V> {
-    /// Repair a torn page discovered by the ordered replay pass, then resume at the last complete
-    /// frame boundary. Clean sections never enter this path or pay for a separate prefix scan.
-    async fn repair_torn_front(&mut self, source: commonware_runtime::Error) -> Result<(), Error> {
-        if !matches!(source, commonware_runtime::Error::InvalidChecksum) {
-            self.sections.pop_front();
+    /// Validate that the front section's checksum failure is a repairable torn page, returning
+    /// the truncation target.
+    async fn plan_front_repair(&mut self, source: RError) -> Result<u64, Error> {
+        // Only a checksum failure is repairable: it marks a torn write, while any other error
+        // is an I/O failure this repair must not mask.
+        if !matches!(source, RError::InvalidChecksum) {
             return Err(source.into());
         }
 
+        // The bytes already replayed are validated: they bound the truncation from below.
         let current = self.sections.front().expect("replayed section is present");
         let section = current.section;
         let size = current.reader.blob_size();
         let valid_offset = current.valid_offset;
-        let recoverable = match self
+
+        // Forward-validate from the replayed prefix to find where well-formed pages end.
+        let recoverable = self
             .journal
             .0
-            .manager
-            .get_mut(section)
-            .expect("replayed section is present")
+            .writer(section)
             .recoverable_prefix_len(valid_offset, self.buffer, self.read_options)
-            .await
-        {
-            Ok(recoverable) => recoverable,
-            Err(err) => {
-                self.sections.pop_front();
-                return Err(err.into());
-            }
-        };
+            .await?;
+
+        // A whole-blob recoverable prefix means the checksum failure did not come from a torn
+        // page: surface the original error instead of truncating valid data.
         if recoverable >= size {
-            self.sections.pop_front();
             return Err(source.into());
         }
+
+        // The cut must not drop below the validated replay prefix: that would lose data the
+        // replay already handed out.
         if recoverable < valid_offset {
-            self.sections.pop_front();
             return Err(Error::ItemOutOfRange(valid_offset));
         }
 
+        Ok(recoverable)
+    }
+
+    /// Repair a torn page discovered by ordered replay and resume at the last complete item.
+    async fn repair_torn_front(&mut self, source: RError) -> Result<(), Error> {
+        // A rejected plan mutates nothing: drop the damaged section and surface its error.
+        let recoverable = match self.plan_front_repair(source).await {
+            Ok(target) => target,
+            Err(err) => {
+                self.sections.pop_front();
+                return Err(err);
+            }
+        };
+
+        let current = self.sections.front().expect("replayed section is present");
+        let (section, valid_offset) = (current.section, current.valid_offset);
         warn!(
             section,
-            invalid_size = size,
+            invalid_size = current.reader.blob_size(),
             new_size = recoverable,
             "torn page detected: truncating"
         );
@@ -709,9 +734,7 @@ impl<E: Storage + Metrics, V: CodecShared> Replay<E, V> {
         let mut reader = self
             .journal
             .0
-            .manager
-            .get_mut(section)
-            .expect("repaired section is present")
+            .writer(section)
             .replay(self.buffer, self.read_options)
             .await?;
         reader.seek_to(valid_offset)?;
@@ -723,6 +746,27 @@ impl<E: Storage + Metrics, V: CodecShared> Replay<E, V> {
             valid_offset,
             pending: None,
         });
+        self.repairing = false;
+        Ok(())
+    }
+
+    /// Truncate the front section to its validated prefix and make the repair durable.
+    async fn repair_tail(&mut self, message: &'static str) -> Result<(), Error> {
+        let current = self.sections.front().expect("replayed section is present");
+        let (section, offset, valid_offset) =
+            (current.section, current.offset, current.valid_offset);
+        warn!(
+            blob = section,
+            bad_offset = offset,
+            new_size = valid_offset,
+            "{message}"
+        );
+
+        // Tail repair is exceptional. Make it durable immediately so callers do not need to
+        // track replay-time repaired sections separately. Keep the interruption guard set
+        // until the repair is durable.
+        self.repairing = true;
+        repair_blob(&mut self.journal, section, valid_offset).await?;
         self.repairing = false;
         Ok(())
     }
@@ -796,26 +840,14 @@ impl<E: Storage + Metrics, V: CodecShared> Replay<E, V> {
                                 || before_remaining < MAX_U32_VARINT_SIZE
                             {
                                 // Treat as trailing bytes
-                                if current.valid_offset < blob_size && current.offset < blob_size {
-                                    warn!(
-                                        blob = current.section,
-                                        bad_offset = current.offset,
-                                        new_size = current.valid_offset,
-                                        "trailing bytes detected: truncating"
-                                    );
-                                    // Tail repair is exceptional. Make it durable
-                                    // immediately so callers do not need to track
-                                    // replay-time repaired sections separately.
-                                    let (section, valid_offset) =
-                                        (current.section, current.valid_offset);
-                                    self.repairing = true;
-                                    if let Err(err) =
-                                        repair_blob(&mut self.journal, section, valid_offset).await
-                                    {
-                                        self.sections.pop_front();
-                                        return self.fail(err);
-                                    }
-                                    self.repairing = false;
+                                if current.valid_offset < blob_size
+                                    && current.offset < blob_size
+                                    && let Err(err) = self
+                                        .repair_tail("trailing bytes detected: truncating")
+                                        .await
+                                {
+                                    self.sections.pop_front();
+                                    return self.fail(err);
                                 }
                                 self.sections.pop_front();
                                 continue;
@@ -832,19 +864,10 @@ impl<E: Storage + Metrics, V: CodecShared> Replay<E, V> {
                 Ok(true) => {}
                 Ok(false) => {
                     // Incomplete item at end - truncate
-                    warn!(
-                        blob = current.section,
-                        bad_offset = current.offset,
-                        new_size = current.valid_offset,
-                        "incomplete item at end: truncating"
-                    );
-                    let (section, valid_offset) = (current.section, current.valid_offset);
-                    self.repairing = true;
-                    if let Err(err) = repair_blob(&mut self.journal, section, valid_offset).await {
+                    if let Err(err) = self.repair_tail("incomplete item at end: truncating").await {
                         self.sections.pop_front();
                         return self.fail(err);
                     }
-                    self.repairing = false;
                     self.sections.pop_front();
                     continue;
                 }
@@ -925,12 +948,7 @@ async fn repair_blob<E: Storage + Metrics, V: Codec>(
     section: u64,
     size: u64,
 ) -> Result<(), Error> {
-    // The journal is owned by the reader, so a replayed section cannot be removed.
-    let blob = journal
-        .0
-        .manager
-        .get_mut(section)
-        .expect("replayed section must exist");
+    let blob = journal.0.writer(section);
     blob.resize(size).await?;
     blob.sync().await?;
     Ok(())
@@ -2063,35 +2081,32 @@ mod tests {
             // lifecycle boundary: replay setup and consumption of an earlier section must not
             // read or repair this later section.
             let journal = journal_with_torn_interior_page(&context, PARTITION, false).await;
-            let original_size = context
+            let (_, original_size) = context
                 .open(PARTITION, &TORN_SECTION.to_be_bytes())
                 .await
-                .unwrap()
-                .1;
+                .unwrap();
             let mut replay = journal
                 .replay(FIRST_SECTION, 0, NZUsize!(1024), ReadOptions::default())
                 .await
                 .unwrap();
 
+            let (_, size) = context
+                .open(PARTITION, &TORN_SECTION.to_be_bytes())
+                .await
+                .unwrap();
             assert_eq!(
-                context
-                    .open(PARTITION, &TORN_SECTION.to_be_bytes())
-                    .await
-                    .unwrap()
-                    .1,
-                original_size,
+                size, original_size,
                 "replay setup must not repair a later section"
             );
 
             let (section, offset, _, value) = replay.next().await.unwrap().unwrap();
             assert_eq!((section, offset, value), (FIRST_SECTION, 0, u64::MAX));
+            let (_, size) = context
+                .open(PARTITION, &TORN_SECTION.to_be_bytes())
+                .await
+                .unwrap();
             assert_eq!(
-                context
-                    .open(PARTITION, &TORN_SECTION.to_be_bytes())
-                    .await
-                    .unwrap()
-                    .1,
-                original_size,
+                size, original_size,
                 "consuming an earlier section must not repair a later section"
             );
 
@@ -2121,11 +2136,10 @@ mod tests {
             const START_OFFSET: u64 = 72;
 
             let journal = journal_with_torn_interior_page(&context, PARTITION, false).await;
-            let original_size = context
+            let (_, original_size) = context
                 .open(PARTITION, &SECTION.to_be_bytes())
                 .await
-                .unwrap()
-                .1;
+                .unwrap();
             let mut replay = journal
                 .replay(
                     SECTION,
@@ -2140,13 +2154,12 @@ mod tests {
                 replay.next().await,
                 Some(Err(Error::ItemOutOfRange(START_OFFSET)))
             ));
+            let (_, size) = context
+                .open(PARTITION, &SECTION.to_be_bytes())
+                .await
+                .unwrap();
             assert_eq!(
-                context
-                    .open(PARTITION, &SECTION.to_be_bytes())
-                    .await
-                    .unwrap()
-                    .1,
-                original_size,
+                size, original_size,
                 "an unvalidated start offset must not become a repair boundary"
             );
             assert!(matches!(replay.finish(), Err(Error::ReplayFailed)));

--- a/storage/src/journal/segmented/variable.rs
+++ b/storage/src/journal/segmented/variable.rs
@@ -666,7 +666,7 @@ pub struct Replay<E: Storage + Metrics, V: Codec> {
 impl<E: Storage + Metrics, V: CodecShared> Replay<E, V> {
     /// Validate that the front section's checksum failure is a repairable torn page, returning
     /// the truncation target.
-    async fn plan_front_repair(&mut self, source: RError) -> Result<u64, Error> {
+    async fn plan_repair(&mut self, source: RError) -> Result<u64, Error> {
         // Only a checksum failure is repairable: it marks a torn write, while any other error
         // is an I/O failure this repair must not mask.
         if !matches!(source, RError::InvalidChecksum) {
@@ -703,9 +703,9 @@ impl<E: Storage + Metrics, V: CodecShared> Replay<E, V> {
     }
 
     /// Repair a torn page discovered by ordered replay and resume at the last complete item.
-    async fn repair_torn_front(&mut self, source: RError) -> Result<(), Error> {
+    async fn repair(&mut self, source: RError) -> Result<(), Error> {
         // A rejected plan mutates nothing: drop the damaged section and surface its error.
-        let recoverable = match self.plan_front_repair(source).await {
+        let recoverable = match self.plan_repair(source).await {
             Ok(target) => target,
             Err(err) => {
                 self.sections.pop_front();
@@ -808,7 +808,7 @@ impl<E: Storage + Metrics, V: CodecShared> Replay<E, V> {
                             // Buffer still has data - continue to try decoding
                         }
                         Err(err) => {
-                            if let Err(err) = self.repair_torn_front(err).await {
+                            if let Err(err) = self.repair(err).await {
                                 return self.fail(err);
                             }
                             continue;
@@ -872,7 +872,7 @@ impl<E: Storage + Metrics, V: CodecShared> Replay<E, V> {
                     continue;
                 }
                 Err(err) => {
-                    if let Err(err) = self.repair_torn_front(err).await {
+                    if let Err(err) = self.repair(err).await {
                         return self.fail(err);
                     }
                     continue;

--- a/storage/src/journal/segmented/variable.rs
+++ b/storage/src/journal/segmented/variable.rs
@@ -92,7 +92,11 @@ use commonware_runtime::{
     Blob, Buf, Handle, IoBuf, Metrics, ReadOptions, Storage,
     buffer::paged::{CacheRef, Replay as BlobReplay, Writer},
 };
-use std::{collections::VecDeque, io::Cursor, num::NonZeroUsize};
+use std::{
+    collections::{BTreeSet, VecDeque},
+    io::Cursor,
+    num::NonZeroUsize,
+};
 use tracing::{trace, warn};
 
 /// Configuration for `Journal` storage.
@@ -129,6 +133,9 @@ struct SectionReplay<B: Blob> {
 struct Inner<E: Storage + Metrics, V: Codec> {
     manager: Manager<E, AppendFactory>,
 
+    /// Nonempty sections opened at initialization that have not been replayed from offset zero.
+    unrecovered: BTreeSet<u64>,
+
     /// Compression level (if enabled).
     compression: Option<u8>,
 
@@ -147,9 +154,16 @@ impl<E: Storage + Metrics, V: CodecShared> Inner<E, V> {
             },
         };
         let manager = Manager::init(context, manager_cfg).await?;
+        let mut unrecovered = BTreeSet::new();
+        for section in manager.sections() {
+            if manager.size(section)? != 0 {
+                unrecovered.insert(section);
+            }
+        }
 
         Ok(Self {
             manager,
+            unrecovered,
             compression: cfg.compression,
             codec_config: cfg.codec_config,
         })
@@ -188,6 +202,9 @@ impl<E: Storage + Metrics, V: CodecShared> Inner<E, V> {
     ///
     /// The buffer must be in the on-disk format produced by [Self::encode_item].
     async fn append_raw(&mut self, section: u64, buf: IoBuf) -> Result<u64, Error> {
+        if self.unrecovered.contains(&section) {
+            return Err(Error::ReplayRequired(section));
+        }
         let blob = self.manager.get_or_create(section).await?;
         let offset = blob.append_owned(buf).await?;
         trace!(blob = section, offset, "appended item");
@@ -290,12 +307,21 @@ impl<E: Storage + Metrics, V: CodecShared> Inner<E, V> {
 
     /// See [Journal::rewind].
     async fn rewind(&mut self, section: u64, size: u64) -> Result<(), Error> {
-        self.manager.rewind(section, size).await
+        self.manager.rewind(section, size).await?;
+        self.unrecovered.retain(|candidate| *candidate <= section);
+        if size == 0 {
+            self.unrecovered.remove(&section);
+        }
+        Ok(())
     }
 
     /// See [Journal::rewind_section].
     async fn rewind_section(&mut self, section: u64, size: u64) -> Result<(), Error> {
-        self.manager.rewind_section(section, size).await
+        self.manager.rewind_section(section, size).await?;
+        if size == 0 {
+            self.unrecovered.remove(&section);
+        }
+        Ok(())
     }
 
     /// See [Journal::sync].
@@ -315,7 +341,11 @@ impl<E: Storage + Metrics, V: CodecShared> Inner<E, V> {
 
     /// See [Journal::prune].
     async fn prune(&mut self, min: u64) -> Result<bool, Error> {
-        self.manager.prune(min).await
+        let pruned = self.manager.prune(min).await?;
+        if pruned {
+            self.unrecovered.retain(|section| *section >= min);
+        }
+        Ok(pruned)
     }
 
     /// See [Journal::pruned].
@@ -350,7 +380,9 @@ impl<E: Storage + Metrics, V: CodecShared> Inner<E, V> {
 
     /// See [Journal::clear].
     async fn clear(&mut self) -> Result<(), Error> {
-        self.manager.clear().await
+        self.manager.clear().await?;
+        self.unrecovered.clear();
+        Ok(())
     }
 }
 
@@ -367,6 +399,8 @@ impl<E: Storage + Metrics, V: CodecShared> Inner<E, V> {
 /// the first invalid data read will be considered the new end of the journal (and the
 /// underlying [Blob] will be truncated to the last valid item). Repair occurs during
 /// replay (not init) because any blob could have trailing bytes.
+/// A nonempty section opened during initialization must be replayed from offset zero before it
+/// accepts new appends. Sections created during the current execution can be appended immediately.
 ///
 /// Mutating functions consume the journal and return it only on success: an error (or a dropped
 /// future) destroys the handle. [Journal::replay] consumes the journal into an owned [Replay]
@@ -398,10 +432,13 @@ impl<E: Storage + Metrics, V: CodecShared> Journal<E, V> {
     /// with the item at the given `start_section` and `start_offset` into that section.
     ///
     /// Setup flushes buffered pages so the reader observes every accepted write. It
-    /// validates replay setup but does not allocate `buffer` bytes per blob. Page buffers
+    /// validates the requested start bound but does not allocate `buffer` bytes per blob. Page buffers
     /// are allocated lazily as the reader advances. Every backing blob read performed by
     /// the returned replay uses `read_options`, including reads after advancing to
     /// another section.
+    ///
+    /// A nonzero start must be a boundary already validated by a prior replay or a durable
+    /// marker: torn-page repair treats everything below it as proven.
     pub async fn replay(
         mut self,
         start_section: u64,
@@ -411,9 +448,6 @@ impl<E: Storage + Metrics, V: CodecShared> Journal<E, V> {
     ) -> Result<Replay<E, V>, Error> {
         let mut sections = VecDeque::new();
         for (&section, blob) in self.0.manager.sections_from(start_section) {
-            if section == start_section && start_offset > blob.size() {
-                return Err(Error::ItemOutOfRange(start_offset));
-            }
             let reader = blob.replay(buffer, read_options).await?;
             let skip_bytes = if section == start_section {
                 start_offset
@@ -430,18 +464,36 @@ impl<E: Storage + Metrics, V: CodecShared> Journal<E, V> {
             });
         }
         let finished = sections.is_empty();
-        Ok(Replay {
+        let replay = Replay {
             journal: self,
             sections,
+            fully_replayed_from: if start_offset == 0 {
+                Some(start_section)
+            } else {
+                start_section.checked_add(1)
+            },
+            buffer,
+            read_options,
             finished,
             errored: false,
             repairing: false,
-        })
+        };
+
+        if let Some(current) = replay.sections.front()
+            && current.section == start_section
+            && start_offset > current.reader.blob_size()
+        {
+            return Err(Error::ItemOutOfRange(start_offset));
+        }
+        Ok(replay)
     }
 
     /// Appends an item to `Journal` in a given `section`, returning the offset
     /// where the item was written and the size of the item (which may differ
     /// from the raw encoded size if compression is enabled).
+    ///
+    /// Returns [Error::ReplayRequired] when `section` contained data at initialization and has not
+    /// completed a replay from offset zero.
     pub async fn append(mut self, section: u64, item: &V) -> Result<(Self, u64, u32), Error> {
         let (offset, item_len) = self.0.append(section, item).await?;
         Ok((self, offset, item_len))
@@ -590,26 +642,103 @@ impl<E: Storage + Metrics, V: CodecShared> Journal<E, V> {
 pub struct Replay<E: Storage + Metrics, V: Codec> {
     journal: Journal<E, V>,
     sections: VecDeque<SectionReplay<E::Blob>>,
+    fully_replayed_from: Option<u64>,
+    buffer: NonZeroUsize,
+    read_options: ReadOptions,
     finished: bool,
     errored: bool,
     repairing: bool,
 }
 
 impl<E: Storage + Metrics, V: CodecShared> Replay<E, V> {
+    /// Repair a torn page discovered by the ordered replay pass, then resume at the last complete
+    /// frame boundary. Clean sections never enter this path or pay for a separate prefix scan.
+    async fn repair_torn_front(&mut self, source: commonware_runtime::Error) -> Result<(), Error> {
+        if !matches!(source, commonware_runtime::Error::InvalidChecksum) {
+            self.sections.pop_front();
+            return Err(source.into());
+        }
+
+        let current = self.sections.front().expect("replayed section is present");
+        let section = current.section;
+        let size = current.reader.blob_size();
+        let valid_offset = current.valid_offset;
+        let recoverable = match self
+            .journal
+            .0
+            .manager
+            .get_mut(section)
+            .expect("replayed section is present")
+            .recoverable_prefix_len(valid_offset, self.buffer, self.read_options)
+            .await
+        {
+            Ok(recoverable) => recoverable,
+            Err(err) => {
+                self.sections.pop_front();
+                return Err(err.into());
+            }
+        };
+        if recoverable >= size {
+            self.sections.pop_front();
+            return Err(source.into());
+        }
+        if recoverable < valid_offset {
+            self.sections.pop_front();
+            return Err(Error::ItemOutOfRange(valid_offset));
+        }
+
+        warn!(
+            section,
+            invalid_size = size,
+            new_size = recoverable,
+            "torn page detected: truncating"
+        );
+
+        // Once mutation begins, a dropped future makes the writer and blob state ambiguous. Keep
+        // the interruption guard set until the repaired reader has replaced the stale one.
+        self.repairing = true;
+        let current = self
+            .sections
+            .pop_front()
+            .expect("repaired section is present");
+        drop(current.reader);
+        repair_blob(&mut self.journal, section, recoverable).await?;
+        let mut reader = self
+            .journal
+            .0
+            .manager
+            .get_mut(section)
+            .expect("repaired section is present")
+            .replay(self.buffer, self.read_options)
+            .await?;
+        reader.seek_to(valid_offset)?;
+        self.sections.push_front(SectionReplay {
+            section,
+            reader,
+            skip_bytes: 0,
+            offset: valid_offset,
+            valid_offset,
+            pending: None,
+        });
+        self.repairing = false;
+        Ok(())
+    }
+
     /// Returns the next `(section, offset, size, item)`, or `None` once every section is
     /// exhausted.
     ///
-    /// An error ends the section that produced it, and iteration continues with the
-    /// next section. The exception is [Error::ReplayInterrupted], which ends the
+    /// An error ends the section that produced it, and iteration continues with the next section.
+    /// Errors while mutating storage to repair a section, and [Error::ReplayInterrupted], end the
     /// replay.
     pub async fn next(&mut self) -> Option<Result<(u64, u64, u32, V), Error>> {
-        // A dropped future can interrupt a repair, leaving the section's writer with
-        // in-memory state that no longer matches the blob. Fail the replay rather than
-        // repair or decode over it.
+        // A repair that does not complete successfully leaves the section's writer unusable.
+        // A cancelled repair still needs an error. A completed failure already yielded one.
         if self.repairing {
             self.repairing = false;
             self.sections.clear();
-            return self.fail(Error::ReplayInterrupted);
+            if !self.errored {
+                return self.fail(Error::ReplayInterrupted);
+            }
         }
         while let Some(current) = self.sections.front_mut() {
             let blob_size = current.reader.blob_size();
@@ -632,8 +761,10 @@ impl<E: Storage + Metrics, V: CodecShared> Replay<E, V> {
                             // Buffer still has data - continue to try decoding
                         }
                         Err(err) => {
-                            self.sections.pop_front();
-                            return self.fail(err.into());
+                            if let Err(err) = self.repair_torn_front(err).await {
+                                return self.fail(err);
+                            }
+                            continue;
                         }
                     }
 
@@ -669,19 +800,19 @@ impl<E: Storage + Metrics, V: CodecShared> Replay<E, V> {
                                         new_size = current.valid_offset,
                                         "trailing bytes detected: truncating"
                                     );
-                                    // Tail repair is exceptional; make it durable
+                                    // Tail repair is exceptional. Make it durable
                                     // immediately so callers do not need to track
                                     // replay-time repaired sections separately.
                                     let (section, valid_offset) =
                                         (current.section, current.valid_offset);
                                     self.repairing = true;
-                                    let repaired =
-                                        repair_blob(&mut self.journal, section, valid_offset).await;
-                                    self.repairing = false;
-                                    if let Err(err) = repaired {
+                                    if let Err(err) =
+                                        repair_blob(&mut self.journal, section, valid_offset).await
+                                    {
                                         self.sections.pop_front();
                                         return self.fail(err);
                                     }
+                                    self.repairing = false;
                                 }
                                 self.sections.pop_front();
                                 continue;
@@ -706,18 +837,19 @@ impl<E: Storage + Metrics, V: CodecShared> Replay<E, V> {
                     );
                     let (section, valid_offset) = (current.section, current.valid_offset);
                     self.repairing = true;
-                    let repaired = repair_blob(&mut self.journal, section, valid_offset).await;
-                    self.repairing = false;
-                    if let Err(err) = repaired {
+                    if let Err(err) = repair_blob(&mut self.journal, section, valid_offset).await {
                         self.sections.pop_front();
                         return self.fail(err);
                     }
+                    self.repairing = false;
                     self.sections.pop_front();
                     continue;
                 }
                 Err(err) => {
-                    self.sections.pop_front();
-                    return self.fail(err.into());
+                    if let Err(err) = self.repair_torn_front(err).await {
+                        return self.fail(err);
+                    }
+                    continue;
                 }
             }
 
@@ -770,9 +902,15 @@ impl<E: Storage + Metrics, V: CodecShared> Replay<E, V> {
     ///
     /// Fails when the reader was not fully drained or yielded an error: the journal is
     /// destroyed and recovery is re-initialization.
-    pub fn finish(self) -> Result<Journal<E, V>, Error> {
+    pub fn finish(mut self) -> Result<Journal<E, V>, Error> {
         if self.errored || !self.finished {
             return Err(Error::ReplayFailed);
+        }
+        if let Some(start) = self.fully_replayed_from {
+            self.journal
+                .0
+                .unrecovered
+                .retain(|section| *section < start);
         }
         Ok(self.journal)
     }
@@ -801,7 +939,9 @@ mod tests {
     use commonware_codec::{EncodeSize, Write as _, varint::UInt};
     use commonware_macros::test_traced;
     use commonware_runtime::{
-        Blob, BufMut, Runner, Storage, Supervisor as _, WriteOptions, deterministic,
+        Blob, BufMut, Runner, Storage, Supervisor as _, WriteOptions,
+        buffer::paged::corrupt_page,
+        deterministic,
         mocks::{DelayedSyncContext, PendingSyncs, RecordingContext, release_pending_syncs},
     };
     use commonware_utils::{NZU16, NZUsize, probability};
@@ -809,6 +949,99 @@ mod tests {
 
     const PAGE_SIZE: NonZeroU16 = NZU16!(1024);
     const PAGE_CACHE_SIZE: NonZeroUsize = NZUsize!(10);
+
+    async fn journal_with_torn_interior_page(
+        context: &deterministic::Context,
+        partition: &str,
+        later_section: bool,
+    ) -> Journal<deterministic::Context, u64> {
+        const LOGICAL_PAGE_SIZE: u64 = 64;
+        const FIRST_SECTION: u64 = 0;
+        const TORN_SECTION: u64 = 1;
+
+        let cfg = Config {
+            partition: partition.into(),
+            compression: None,
+            codec_config: (),
+            page_cache: CacheRef::from_pooler(
+                context,
+                NZU16!(LOGICAL_PAGE_SIZE as u16),
+                NZUsize!(4),
+            ),
+            write_buffer: NZUsize!(256),
+        };
+        let mut journal = Journal::<_, u64>::init(context.child("first"), cfg.clone())
+            .await
+            .unwrap();
+        (journal, _, _) = journal.append(FIRST_SECTION, &u64::MAX).await.unwrap();
+        for value in 0..15u64 {
+            let offset;
+            (journal, offset, _) = journal.append(TORN_SECTION, &value).await.unwrap();
+            assert_eq!(offset, value * 9);
+        }
+        if later_section {
+            (journal, _, _) = journal.append(2, &u64::MIN).await.unwrap();
+        }
+        journal = journal.sync_all().await.unwrap();
+        drop(journal);
+
+        corrupt_page(
+            context,
+            &cfg.partition,
+            &TORN_SECTION.to_be_bytes(),
+            1,
+            LOGICAL_PAGE_SIZE,
+        )
+        .await;
+
+        Journal::<_, u64>::init(context.child("recover"), cfg)
+            .await
+            .unwrap()
+    }
+
+    #[test_traced]
+    fn test_segmented_variable_rejects_append_before_replay() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            const PARTITION: &str = "segmented-variable-append-before-replay";
+            const NEW_SECTION: u64 = 2;
+            const TORN_SECTION: u64 = 1;
+
+            let journal = journal_with_torn_interior_page(&context, PARTITION, false).await;
+            let (journal, offset, _) = journal.append(NEW_SECTION, &15).await.unwrap();
+            assert_eq!(offset, 0);
+            let (journal, offset, _) = journal.append(NEW_SECTION, &16).await.unwrap();
+            assert_eq!(offset, 9);
+            let result = journal.append(TORN_SECTION, &15).await;
+            assert!(
+                matches!(result, Err(Error::ReplayRequired(TORN_SECTION))),
+                "an unrecovered section must reject new appends"
+            );
+        });
+    }
+
+    #[test_traced]
+    fn test_segmented_variable_partial_replay_keeps_append_guard() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            const PARTITION: &str = "segmented-variable-partial-replay-append";
+            const SECTION: u64 = 1;
+
+            let journal = journal_with_torn_interior_page(&context, PARTITION, false).await;
+            let mut replay = journal
+                .replay(SECTION, 9, NZUsize!(1024), ReadOptions::default())
+                .await
+                .unwrap();
+            while let Some(item) = replay.next().await {
+                item.unwrap();
+            }
+            let journal = replay.finish().unwrap();
+            assert!(matches!(
+                journal.append(SECTION, &7).await,
+                Err(Error::ReplayRequired(SECTION))
+            ));
+        });
+    }
 
     #[test_traced]
     fn test_segmented_variable_replay_propagates_read_options() {
@@ -1812,6 +2045,181 @@ mod tests {
                 .await
                 .expect("Failed to open blob");
             assert_eq!(blob_size, 0);
+        });
+    }
+
+    #[test_traced]
+    fn test_segmented_variable_replay_repairs_torn_interior_page_when_reached() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            const FIRST_SECTION: u64 = 0;
+            const PARTITION: &str = "segmented-variable-torn-interior";
+            const TORN_SECTION: u64 = 1;
+
+            // Fifteen nine-byte frames occupy 135 bytes. Pages 0 and 2 remain valid while page 1
+            // is torn, so backward sizing reports the full tail. Forward page validation must
+            // first truncate to 64 bytes. Frame replay can then retain the seven complete frames
+            // ending at byte 63 and safely discard the one-byte frame prefix at the page boundary.
+            // The replay buffer spans all three pages, proving recovery does not lose page 0 when
+            // a prefetched later page fails validation. FIRST_SECTION establishes the ordered
+            // lifecycle boundary: replay setup and consumption of an earlier section must not
+            // read or repair this later section.
+            let journal = journal_with_torn_interior_page(&context, PARTITION, false).await;
+            let original_size = context
+                .open(PARTITION, &TORN_SECTION.to_be_bytes())
+                .await
+                .unwrap()
+                .1;
+            let mut replay = journal
+                .replay(FIRST_SECTION, 0, NZUsize!(1024), ReadOptions::default())
+                .await
+                .unwrap();
+
+            assert_eq!(
+                context
+                    .open(PARTITION, &TORN_SECTION.to_be_bytes())
+                    .await
+                    .unwrap()
+                    .1,
+                original_size,
+                "replay setup must not repair a later section"
+            );
+
+            let (section, offset, _, value) = replay.next().await.unwrap().unwrap();
+            assert_eq!((section, offset, value), (FIRST_SECTION, 0, u64::MAX));
+            assert_eq!(
+                context
+                    .open(PARTITION, &TORN_SECTION.to_be_bytes())
+                    .await
+                    .unwrap()
+                    .1,
+                original_size,
+                "consuming an earlier section must not repair a later section"
+            );
+
+            let mut values = Vec::new();
+            while let Some(result) = replay.next().await {
+                let (section, offset, _, value) = result.unwrap();
+                assert_eq!(section, TORN_SECTION);
+                assert_eq!(offset, value * 9);
+                values.push(value);
+            }
+            assert_eq!(values, (0..7).collect::<Vec<_>>());
+
+            let journal = replay.finish().unwrap();
+            assert_eq!(journal.size(TORN_SECTION).unwrap(), 63);
+            let (journal, offset, _) = journal.append(TORN_SECTION, &7).await.unwrap();
+            assert_eq!(offset, 63);
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    #[test_traced]
+    fn test_segmented_variable_replay_rejects_start_beyond_torn_prefix_without_repair() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            const PARTITION: &str = "segmented-variable-torn-start";
+            const SECTION: u64 = 1;
+            const START_OFFSET: u64 = 72;
+
+            let journal = journal_with_torn_interior_page(&context, PARTITION, false).await;
+            let original_size = context
+                .open(PARTITION, &SECTION.to_be_bytes())
+                .await
+                .unwrap()
+                .1;
+            let mut replay = journal
+                .replay(
+                    SECTION,
+                    START_OFFSET,
+                    NZUsize!(1024),
+                    ReadOptions::default(),
+                )
+                .await
+                .expect("apparent tail still covers the requested start");
+
+            assert!(matches!(
+                replay.next().await,
+                Some(Err(Error::ItemOutOfRange(START_OFFSET)))
+            ));
+            assert_eq!(
+                context
+                    .open(PARTITION, &SECTION.to_be_bytes())
+                    .await
+                    .unwrap()
+                    .1,
+                original_size,
+                "an unvalidated start offset must not become a repair boundary"
+            );
+            assert!(matches!(replay.finish(), Err(Error::ReplayFailed)));
+        });
+    }
+
+    #[test_traced]
+    fn test_segmented_variable_replay_stops_after_failed_interior_repair() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let journal = journal_with_torn_interior_page(
+                &context,
+                "segmented-variable-failed-interior-repair",
+                true,
+            )
+            .await;
+            *context.storage_fault_config().write() = deterministic::FaultConfig {
+                resize_rate: Some(deterministic::ResizeConfig {
+                    failure_rate: probability!(1.0),
+                    partial_rate: probability!(0.0),
+                }),
+                ..Default::default()
+            };
+
+            // Section 0 delays validation of the torn section until iteration. Section 2 proves a
+            // fatal repair error cannot be treated like an ordinary per-section decode error.
+            let mut replay = journal
+                .replay(0, 0, NZUsize!(1024), ReadOptions::default())
+                .await
+                .unwrap();
+            assert!(matches!(replay.next().await, Some(Ok((0, 0, _, u64::MAX)))));
+            assert!(matches!(replay.next().await, Some(Err(Error::Runtime(_)))));
+            assert!(replay.next().await.is_none());
+            assert!(matches!(replay.finish(), Err(Error::ReplayFailed)));
+        });
+    }
+
+    #[test_traced]
+    fn test_segmented_variable_replay_stops_after_failed_tail_repair() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let journal = journal_with_torn_interior_page(
+                &context,
+                "segmented-variable-failed-tail-repair",
+                true,
+            )
+            .await;
+            let mut replay = journal
+                .replay(0, 0, NZUsize!(1024), ReadOptions::default())
+                .await
+                .unwrap();
+
+            assert!(matches!(replay.next().await, Some(Ok((0, 0, _, u64::MAX)))));
+            for expected in 0..7 {
+                let (section, offset, _, value) = replay.next().await.unwrap().unwrap();
+                assert_eq!((section, offset, value), (1, expected * 9, expected));
+            }
+
+            *context.storage_fault_config().write() = deterministic::FaultConfig {
+                write_rate: Some(deterministic::WriteConfig {
+                    failure_rate: probability!(1.0),
+                    retention_rate: probability!(1.0),
+                    mode: deterministic::PartialWriteMode::Prefix,
+                }),
+                ..Default::default()
+            };
+            assert!(matches!(replay.next().await, Some(Err(Error::Runtime(_)))));
+            *context.storage_fault_config().write() = deterministic::FaultConfig::default();
+
+            assert!(replay.next().await.is_none());
+            assert!(matches!(replay.finish(), Err(Error::ReplayFailed)));
         });
     }
 

--- a/storage/src/journal/segmented/variable.rs
+++ b/storage/src/journal/segmented/variable.rs
@@ -478,7 +478,7 @@ impl<E: Storage + Metrics, V: CodecShared> Journal<E, V> {
         let replay = Replay {
             journal: self,
             sections,
-            fully_replayed_from: if start_offset == 0 {
+            recovered_from: if start_offset == 0 {
                 Some(start_section)
             } else {
                 start_section.checked_add(1)
@@ -490,6 +490,9 @@ impl<E: Storage + Metrics, V: CodecShared> Journal<E, V> {
             repairing: false,
         };
 
+        // A start offset beyond the front section's apparent tail can never resolve to an
+        // item boundary. Reject it up front rather than yielding a silently empty replay:
+        // the offset is caller-supplied and unvalidated, so it must never be adopted.
         if let Some(current) = replay.sections.front()
             && current.section == start_section
             && start_offset > current.reader.blob_size()
@@ -655,7 +658,9 @@ impl<E: Storage + Metrics, V: CodecShared> Journal<E, V> {
 pub struct Replay<E: Storage + Metrics, V: Codec> {
     journal: Journal<E, V>,
     sections: VecDeque<SectionReplay<E::Blob>>,
-    fully_replayed_from: Option<u64>,
+    /// The first section this replay fully covers: [Replay::finish] marks it and every
+    /// later section recovered.
+    recovered_from: Option<u64>,
     buffer: NonZeroUsize,
     read_options: ReadOptions,
     finished: bool,
@@ -932,7 +937,7 @@ impl<E: Storage + Metrics, V: CodecShared> Replay<E, V> {
         if self.errored || !self.finished {
             return Err(Error::ReplayFailed);
         }
-        if let Some(start) = self.fully_replayed_from {
+        if let Some(start) = self.recovered_from {
             self.journal
                 .0
                 .unrecovered

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -13,6 +13,31 @@ commonware_macros::stability_scope!(BETA {
     #[cfg(not(feature = "std"))]
     extern crate alloc;
 
+    /// Lossless widening for nonzero integers, covering the conversions std provides no
+    /// [From] impl for (for example `NonZeroU16` into `u64`).
+    pub trait Widen<T> {
+        /// Convert without loss.
+        fn widen(self) -> T;
+    }
+
+    macro_rules! impl_widen {
+        ($($nz:ty => $($t:ty),+);+ $(;)?) => {$($(
+            impl Widen<$t> for $nz {
+                #[inline]
+                fn widen(self) -> $t {
+                    <$t>::from(self.get())
+                }
+            }
+        )+)+};
+    }
+    impl_widen!(
+        core::num::NonZeroU8 => u16, u32, u64, u128, usize;
+        core::num::NonZeroU16 => u32, u64, u128, usize;
+        core::num::NonZeroU32 => u64, u128;
+        core::num::NonZeroU64 => u128;
+    );
+
+
     #[cfg(not(feature = "std"))]
     use alloc::{boxed::Box, vec::Vec};
     use bytes::{BufMut, BytesMut};

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -37,7 +37,6 @@ commonware_macros::stability_scope!(BETA {
         core::num::NonZeroU64 => u128;
     );
 
-
     #[cfg(not(feature = "std"))]
     use alloc::{boxed::Box, vec::Vec};
     use bytes::{BufMut, BytesMut};


### PR DESCRIPTION
Segmented journal recovery rework: torn-page repair moves into ordered replay, appends on unreplayed sections are rejected (`Error::ReplayRequired`), and a non-mutating preflight (floor / checkpoint-restore) derives floors only from observed-successful joint sync completions, lowering them durably before any bytes they authorize are freed. Oversized gains marker-aware tracked recovery (`init_tracked`/`finish_tracked`, consumed by the prunable archive one PR up — hence two staging `#[allow(dead_code)]` markers removed there) and durable truncation before offset reuse. The freezer rejects tables shorter than the checkpointed size (`CheckpointMismatch`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
