### PR TITLE
[storage/qmdb] Expose batch operations and proofs

### DIFF
--- a/storage/src/journal/authenticated.rs
+++ b/storage/src/journal/authenticated.rs
@@ -674,10 +674,9 @@ where
 
     /// Inclusion proof for the items `batch` appends, anchored at the batch's speculative tip.
     ///
-    /// Nodes below the batch chain are read from this journal's in-memory Merkle tier,
-    /// which retains them at least until the batch's changes are flushed. Calling this
-    /// after that flush can fail with [merkle::Error::ElementPruned], never produce a
-    /// wrong proof.
+    /// Nodes below the batch chain are read from this journal's
+    /// [in-memory Merkle tier][crate::merkle::mem::Mem], which retains them at least until
+    /// the batch's changes are flushed.
     pub fn speculative_proof(
         &self,
         batch: &MerkleizedBatch<F, H::Digest, C::Item, S>,

--- a/storage/src/journal/authenticated.rs
+++ b/storage/src/journal/authenticated.rs
@@ -181,8 +181,6 @@ impl<F: Family, D: Digest, Item: Send + Sync, S: Strategy> MerkleizedBatch<F, D,
     }
 
     /// Inclusion proof for the element at `loc`.
-    ///
-    /// Nodes below this batch chain are read from `base`.
     pub fn proof(
         &self,
         base: &Mem<F, D>,
@@ -194,8 +192,6 @@ impl<F: Family, D: Digest, Item: Send + Sync, S: Strategy> MerkleizedBatch<F, D,
     }
 
     /// Inclusion proof for all elements in `range`.
-    ///
-    /// Nodes below this batch chain are read from `base`.
     pub fn range_proof(
         &self,
         base: &Mem<F, D>,

--- a/storage/src/journal/authenticated.rs
+++ b/storage/src/journal/authenticated.rs
@@ -675,7 +675,7 @@ where
     /// Inclusion proof for the items `batch` appends, anchored at the batch's speculative tip.
     ///
     /// Nodes below the batch chain are read from this journal's
-    /// [in-memory Merkle tier][crate::merkle::mem::Mem], which retains them at least until
+    /// [Merkle store][crate::merkle::mem::Mem], which retains them at least until
     /// the batch's changes are flushed.
     pub fn speculative_proof(
         &self,

--- a/storage/src/journal/authenticated.rs
+++ b/storage/src/journal/authenticated.rs
@@ -181,23 +181,29 @@ impl<F: Family, D: Digest, Item: Send + Sync, S: Strategy> MerkleizedBatch<F, D,
     }
 
     /// Inclusion proof for the element at `loc`.
+    ///
+    /// Nodes below this batch chain are read from `base`.
     pub fn proof(
         &self,
+        base: &Mem<F, D>,
         hasher: &impl merkle::hasher::Hasher<F, Digest = D>,
         loc: Location<F>,
         inactive_peaks: usize,
     ) -> Result<Proof<F, D>, merkle::Error<F>> {
-        self.inner.proof(hasher, loc, inactive_peaks)
+        self.inner.proof(base, hasher, loc, inactive_peaks)
     }
 
     /// Inclusion proof for all elements in `range`.
+    ///
+    /// Nodes below this batch chain are read from `base`.
     pub fn range_proof(
         &self,
+        base: &Mem<F, D>,
         hasher: &impl merkle::hasher::Hasher<F, Digest = D>,
         range: core::ops::Range<Location<F>>,
         inactive_peaks: usize,
     ) -> Result<Proof<F, D>, merkle::Error<F>> {
-        self.inner.range_proof(hasher, range, inactive_peaks)
+        self.inner.range_proof(base, hasher, range, inactive_peaks)
     }
 
     /// The items added in this batch.
@@ -664,6 +670,26 @@ where
     ) -> Result<(Proof<F, H::Digest>, Vec<C::Item>), Error<F>> {
         self.historical_proof(self.size(), start_loc, max_ops, inactive_peaks)
             .await
+    }
+
+    /// Inclusion proof for the items `batch` appends, anchored at the batch's speculative tip.
+    ///
+    /// Nodes below the batch chain are read from this journal's in-memory Merkle tier,
+    /// which retains them at least until the batch's changes are flushed. Calling this
+    /// after that flush can fail with [merkle::Error::ElementPruned], never produce a
+    /// wrong proof.
+    pub fn speculative_proof(
+        &self,
+        batch: &MerkleizedBatch<F, H::Digest, C::Item, S>,
+        inactive_peaks: usize,
+    ) -> Result<Proof<F, H::Digest>, Error<F>> {
+        let end = batch.size();
+        let start = Location::new(end - batch.items().len() as u64);
+        self.merkle
+            .with_mem(|mem| {
+                batch.range_proof(mem, &self.hasher, start..Location::new(end), inactive_peaks)
+            })
+            .map_err(Error::Merkle)
     }
 
     /// Generate a historical proof with respect to the state of the Merkle structure when it had

--- a/storage/src/merkle/batch.rs
+++ b/storage/src/merkle/batch.rs
@@ -633,8 +633,11 @@ impl<F: Family, D: Digest, S: Strategy> MerkleizedBatch<F, D, S> {
 
     /// Inclusion proof for the element at `loc` using `inactive_peaks` and the bagging carried by
     /// `hasher`.
+    ///
+    /// Nodes below this batch chain are read from `base`.
     pub fn proof(
         &self,
+        base: &Mem<F, D>,
         hasher: &impl Hasher<F, Digest = D>,
         loc: Location<F>,
         inactive_peaks: usize,
@@ -642,7 +645,7 @@ impl<F: Family, D: Digest, S: Strategy> MerkleizedBatch<F, D, S> {
         if !loc.is_valid_index() {
             return Err(Error::LocationOverflow(loc));
         }
-        self.range_proof(hasher, loc..loc + 1, inactive_peaks)
+        self.range_proof(base, hasher, loc..loc + 1, inactive_peaks)
             .map_err(|e| match e {
                 Error::RangeOutOfBounds(_) => Error::LeafOutOfBounds(loc),
                 _ => e,
@@ -651,8 +654,11 @@ impl<F: Family, D: Digest, S: Strategy> MerkleizedBatch<F, D, S> {
 
     /// Inclusion proof for all elements in `range` using `inactive_peaks` and the bagging carried
     /// by `hasher`.
+    ///
+    /// Nodes below this batch chain are read from `base`.
     pub fn range_proof(
         &self,
+        base: &Mem<F, D>,
         hasher: &impl Hasher<F, Digest = D>,
         range: Range<Location<F>>,
         inactive_peaks: usize,
@@ -662,7 +668,7 @@ impl<F: Family, D: Digest, S: Strategy> MerkleizedBatch<F, D, S> {
             self.leaves(),
             inactive_peaks,
             range,
-            |pos| Self::get_node(self, pos),
+            |pos| Self::get_node(self, pos).or_else(|| base.get_node(pos)),
             Error::ElementPruned,
         )
     }

--- a/storage/src/merkle/batch.rs
+++ b/storage/src/merkle/batch.rs
@@ -633,8 +633,6 @@ impl<F: Family, D: Digest, S: Strategy> MerkleizedBatch<F, D, S> {
 
     /// Inclusion proof for the element at `loc` using `inactive_peaks` and the bagging carried by
     /// `hasher`.
-    ///
-    /// Nodes below this batch chain are read from `base`.
     pub fn proof(
         &self,
         base: &Mem<F, D>,
@@ -654,8 +652,6 @@ impl<F: Family, D: Digest, S: Strategy> MerkleizedBatch<F, D, S> {
 
     /// Inclusion proof for all elements in `range` using `inactive_peaks` and the bagging carried
     /// by `hasher`.
-    ///
-    /// Nodes below this batch chain are read from `base`.
     pub fn range_proof(
         &self,
         base: &Mem<F, D>,

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -2605,7 +2605,7 @@ where
     /// [`crate::qmdb::verify_proof`].
     ///
     /// Nodes below this batch chain are read from `db`'s
-    /// [in-memory Merkle tier][crate::merkle::mem::Mem], which retains them at least until
+    /// [Merkle store][crate::merkle::mem::Mem], which retains them at least until
     /// this batch's changes are flushed (by a commit or sync after apply).
     pub fn proof<E, C, I, H, const N: usize>(
         &self,

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -2549,6 +2549,8 @@ impl<F: Family, D: Digest, U: update::Update, S: Strategy> MerkleizedBatch<F, D,
     }
 
     /// Return the operations this batch appends to the log and the location of the first.
+    ///
+    /// Includes floor-raise moves and the trailing commit.
     pub fn operations(&self) -> (Location<F>, Arc<Vec<Operation<F, U>>>) {
         (
             self.bounds.base.size,
@@ -2605,7 +2607,7 @@ where
     /// Nodes below this batch chain are read from `db`'s in-memory Merkle tier, which
     /// retains them at least until this batch's changes are flushed (by a commit or sync
     /// after apply). Calling this later can fail with a pruned-node error, never produce
-    /// a wrong proof.
+    /// a wrong proof. Errors for a batch created by `to_batch`, which appends nothing.
     pub fn proof<E, C, I, H, const N: usize>(
         &self,
         db: &Db<F, E, C, I, H, U, N, S>,
@@ -3676,12 +3678,21 @@ mod tests {
             assert_eq!(child_start, child_range.start);
             assert_eq!(*child_start + child_ops.len() as u64, *child_range.end);
 
+            // A write-free batch still captures its commit-only suffix.
+            let empty = db.new_batch().merkleize(&db, None).await.unwrap();
+            let (empty_start, empty_ops) = empty.operations();
+            let (empty_root, empty_proof) = (empty.root(), empty.proof(&db).unwrap());
+            let (db, empty_range) = db.apply_batch(empty).await.unwrap();
+            assert_eq!(empty_start, empty_range.start);
+            assert_eq!(*empty_start + empty_ops.len() as u64, *empty_range.end);
+
             // Every captured delta and proof must match what the log recovers for its
             // range, and verify against the batch's own root.
             for (start, ops, proof, root) in [
                 (seed_start, seed_ops, seed_proof, seed_root),
                 (parent_start, parent_ops, parent_proof, parent_root),
                 (child_start, child_ops, child_proof, child_root),
+                (empty_start, empty_ops, empty_proof, empty_root),
             ] {
                 let len = core::num::NonZeroU64::new(ops.len() as u64).unwrap();
                 let end = Location::new(*start + ops.len() as u64);
@@ -3692,20 +3703,6 @@ mod tests {
                     &proof, start, &ops, &root
                 ));
             }
-
-            // A write-free batch still captures its commit-only suffix.
-            let empty = db.new_batch().merkleize(&db, None).await.unwrap();
-            let (empty_start, empty_ops) = empty.operations();
-            let (empty_root, empty_proof) = (empty.root(), empty.proof(&db).unwrap());
-            let (db, empty_range) = db.apply_batch(empty).await.unwrap();
-            assert_eq!(empty_start, empty_range.start);
-            assert_eq!(*empty_start + empty_ops.len() as u64, *empty_range.end);
-            assert!(crate::qmdb::verify_proof::<Sha256, _, _>(
-                &empty_proof,
-                empty_start,
-                &empty_ops,
-                &empty_root
-            ));
 
             // After the batch's changes are flushed, proof is a verifying proof or an
             // error, never a wrong proof.

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -2604,10 +2604,9 @@ where
     /// this batch's tip. The pair verifies against [`Self::root`] via
     /// [`crate::qmdb::verify_proof`].
     ///
-    /// Nodes below this batch chain are read from `db`'s in-memory Merkle tier, which
-    /// retains them at least until this batch's changes are flushed (by a commit or sync
-    /// after apply). Calling this later can fail with a pruned-node error, never produce
-    /// a wrong proof. Errors for a batch created by `to_batch`, which appends nothing.
+    /// Nodes below this batch chain are read from `db`'s
+    /// [in-memory Merkle tier][crate::merkle::mem::Mem], which retains them at least until
+    /// this batch's changes are flushed (by a commit or sync after apply).
     pub fn proof<E, C, I, H, const N: usize>(
         &self,
         db: &Db<F, E, C, I, H, U, N, S>,

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -7,7 +7,7 @@ use crate::{
         authenticated,
         contiguous::{Contiguous, Mutable},
     },
-    merkle::{Family, Location},
+    merkle::{Family, Location, Proof},
     qmdb::{
         any::{
             ValueEncoding,
@@ -2548,6 +2548,14 @@ impl<F: Family, D: Digest, U: update::Update, S: Strategy> MerkleizedBatch<F, D,
         &self.bounds
     }
 
+    /// Return the operations this batch appends to the log and the location of the first.
+    pub fn operations(&self) -> (Location<F>, Arc<Vec<Operation<F, U>>>) {
+        (
+            self.bounds.base.size,
+            Arc::clone(self.journal_batch.items()),
+        )
+    }
+
     /// Iterate over ancestor batches (parent first, then grandparent, etc.). Stops when a
     /// Weak ref fails to upgrade (ancestor was freed).
     pub(crate) fn ancestors(&self) -> impl Iterator<Item = Arc<Self>> + use<F, D, U, S> {
@@ -2588,6 +2596,30 @@ where
             mutations: BTreeMap::new(),
             base: Base::Child(Arc::clone(self)),
         }
+    }
+
+    /// Inclusion proof for the operations returned by [`Self::operations`], anchored at
+    /// this batch's tip. The pair verifies against [`Self::root`] via
+    /// [`crate::qmdb::verify_proof`].
+    ///
+    /// Nodes below this batch chain are read from `db`'s in-memory Merkle tier, which
+    /// retains them at least until this batch's changes are flushed (by a commit or sync
+    /// after apply). Calling this later can fail with a pruned-node error, never produce
+    /// a wrong proof.
+    pub fn proof<E, C, I, H, const N: usize>(
+        &self,
+        db: &Db<F, E, C, I, H, U, N, S>,
+    ) -> Result<Proof<F, D>, crate::qmdb::Error<F>>
+    where
+        E: Context,
+        C: Contiguous<Item = Operation<F, U>>,
+        I: UnorderedIndex<Value = Location<F>>,
+        H: Hasher<Digest = D>,
+    {
+        let inactive_peaks = F::inactive_peaks(self.bounds.tip.size, self.bounds.inactivity_floor);
+        db.log
+            .speculative_proof(&self.journal_batch, inactive_peaks)
+            .map_err(Into::into)
     }
 
     /// Read through: local diff -> parent chain -> committed DB.
@@ -3578,6 +3610,123 @@ mod tests {
         // Mutation unchanged.
         assert_eq!(mutations.len(), 1);
         assert!(mutations.contains_key(&1));
+    }
+
+    /// `operations()` must cover exactly the batch's own applied range and match the
+    /// operations a post-apply `historical_proof` recovers from the log, including
+    /// floor-raise moves and the trailing commit, for a db-based batch and for a chained
+    /// batch applied after its ancestor.
+    #[test]
+    fn operations_match_applied_log() {
+        let runner = deterministic::Runner::default();
+        runner.start(|context| async move {
+            type TestDb = UnorderedFixedDb<
+                mmr::Family,
+                deterministic::Context,
+                sha256::Digest,
+                sha256::Digest,
+                Sha256,
+                OneCap,
+                Sequential,
+            >;
+
+            let config = fixed_db_config::<OneCap>("operations-match-applied-log", &context);
+            let db = TestDb::init(context, config).await.unwrap();
+
+            let key_a = Sha256::hash(&[b"operations-a"]);
+            let key_b = Sha256::hash(&[b"operations-b"]);
+
+            let seed = db
+                .new_batch()
+                .write(key_a, Some(Sha256::hash(&[b"seed-a"])))
+                .write(key_b, Some(Sha256::hash(&[b"seed-b"])))
+                .merkleize(&db, None)
+                .await
+                .unwrap();
+            let (seed_start, seed_ops) = seed.operations();
+            let seed_root = seed.root();
+            let seed_proof = seed.proof(&db).unwrap();
+            let (db, seed_range) = db.apply_batch(seed).await.unwrap();
+            assert_eq!(seed_start, seed_range.start);
+            assert_eq!(*seed_start + seed_ops.len() as u64, *seed_range.end);
+
+            // A chained batch's operations are its own suffix only, even though it was
+            // merkleized on top of a pending ancestor.
+            let parent = db
+                .new_batch()
+                .write(key_a, Some(Sha256::hash(&[b"parent-a"])))
+                .merkleize(&db, None)
+                .await
+                .unwrap();
+            let child = parent
+                .new_batch::<Sha256>()
+                .write(key_b, Some(Sha256::hash(&[b"child-b"])))
+                .merkleize(&db, None)
+                .await
+                .unwrap();
+            let (parent_start, parent_ops) = parent.operations();
+            let (child_start, child_ops) = child.operations();
+            let (parent_root, child_root) = (parent.root(), child.root());
+            let (parent_proof, child_proof) =
+                (parent.proof(&db).unwrap(), child.proof(&db).unwrap());
+            let (db, parent_range) = db.apply_batch(parent).await.unwrap();
+            let (db, child_range) = db.apply_batch(child).await.unwrap();
+            assert_eq!(parent_start, parent_range.start);
+            assert_eq!(*parent_start + parent_ops.len() as u64, *parent_range.end);
+            assert_eq!(child_start, child_range.start);
+            assert_eq!(*child_start + child_ops.len() as u64, *child_range.end);
+
+            // Every captured delta and proof must match what the log recovers for its
+            // range, and verify against the batch's own root.
+            for (start, ops, proof, root) in [
+                (seed_start, seed_ops, seed_proof, seed_root),
+                (parent_start, parent_ops, parent_proof, parent_root),
+                (child_start, child_ops, child_proof, child_root),
+            ] {
+                let len = core::num::NonZeroU64::new(ops.len() as u64).unwrap();
+                let end = Location::new(*start + ops.len() as u64);
+                let (log_proof, log_ops) = db.historical_proof(end, start, len).await.unwrap();
+                assert_eq!(log_ops, *ops);
+                assert_eq!(log_proof, proof);
+                assert!(crate::qmdb::verify_proof::<Sha256, _, _>(
+                    &proof, start, &ops, &root
+                ));
+            }
+
+            // A write-free batch still captures its commit-only suffix.
+            let empty = db.new_batch().merkleize(&db, None).await.unwrap();
+            let (empty_start, empty_ops) = empty.operations();
+            let (empty_root, empty_proof) = (empty.root(), empty.proof(&db).unwrap());
+            let (db, empty_range) = db.apply_batch(empty).await.unwrap();
+            assert_eq!(empty_start, empty_range.start);
+            assert_eq!(*empty_start + empty_ops.len() as u64, *empty_range.end);
+            assert!(crate::qmdb::verify_proof::<Sha256, _, _>(
+                &empty_proof,
+                empty_start,
+                &empty_ops,
+                &empty_root
+            ));
+
+            // After the batch's changes are flushed, proof is a verifying proof or an
+            // error, never a wrong proof.
+            let late = db
+                .new_batch()
+                .write(key_a, Some(Sha256::hash(&[b"late-a"])))
+                .merkleize(&db, None)
+                .await
+                .unwrap();
+            let (late_start, late_ops) = late.operations();
+            let late_root = late.root();
+            let (db, _) = db.apply_batch(Arc::clone(&late)).await.unwrap();
+            let db = db.commit().await.unwrap();
+            if let Ok(proof) = late.proof(&db) {
+                assert!(crate::qmdb::verify_proof::<Sha256, _, _>(
+                    &proof, late_start, &late_ops, &late_root
+                ));
+            }
+
+            db.destroy().await.unwrap();
+        });
     }
 
     #[test]

--- a/storage/src/qmdb/current/batch.rs
+++ b/storage/src/qmdb/current/batch.rs
@@ -1063,6 +1063,16 @@ impl<F: Graftable, D: Digest, U: update::Update, const N: usize, S: Strategy>
         self.inner.bounds()
     }
 
+    /// Return the operations this batch appends to the ops log and the location of the first.
+    ///
+    /// Delegates to the wrapped ops-level batch. The bitmap state contributes to the
+    /// canonical root but appends no log operations. There is no matching proof method:
+    /// an ops-level proof verifies only against [`Self::ops_root`], never the grafted
+    /// [`Self::root`] that blocks commit to.
+    pub fn operations(&self) -> (Location<F>, Arc<Vec<Operation<F, U>>>) {
+        self.inner.operations()
+    }
+
     /// Return the batch's safe sync boundary.
     ///
     /// This equals the boundary [`super::db::Db::sync_boundary`] reports once this batch is applied.

--- a/storage/src/qmdb/current/db.rs
+++ b/storage/src/qmdb/current/db.rs
@@ -1497,6 +1497,35 @@ mod tests {
         db.commit().await.unwrap()
     }
 
+    /// `operations()` on a current batch must cover exactly the batch's own applied range
+    /// in the ops log.
+    #[test_traced]
+    fn test_operations_match_applied_range() {
+        let executor = deterministic::Runner::default();
+        executor.start(|ctx| async move {
+            let db = MmrDb::init(
+                ctx.child("db"),
+                fixed_config::<OneCap>("operations-match-applied-range", &ctx),
+            )
+            .await
+            .unwrap();
+            let db = populate_fixed_db::<mmr::Family, _>(db, 0, 8).await;
+
+            let mut batch = db.new_batch();
+            for idx in 0..4u64 {
+                let key = Sha256::hash(&[&idx.to_be_bytes()]);
+                let value = Sha256::hash(&[&(idx + 100).to_be_bytes()]);
+                batch = batch.write(key, Some(value));
+            }
+            let merkleized = batch.merkleize(&db, None).await.unwrap();
+            let (start, ops) = merkleized.operations();
+            let (db, range) = db.apply_batch(merkleized).await.unwrap();
+            assert_eq!(start, range.start);
+            assert_eq!(*start + ops.len() as u64, *range.end);
+            db.destroy().await.unwrap();
+        });
+    }
+
     /// State committed via an awaited start_sync handle is recovered on reopen, including the
     /// grafted bitmap contribution to the root.
     #[test_traced]

--- a/storage/src/qmdb/immutable/batch.rs
+++ b/storage/src/qmdb/immutable/batch.rs
@@ -4,7 +4,7 @@ use super::Immutable;
 use crate::{
     Context,
     journal::{authenticated, contiguous::Mutable},
-    merkle::{Family, Location},
+    merkle::{Family, Location, Proof},
     qmdb::{
         Error,
         any::{ValueEncoding, batch::lookup_sorted},
@@ -320,6 +320,39 @@ where
     /// Return the [`Bounds`] of the batch.
     pub const fn bounds(&self) -> &Bounds<F, D> {
         &self.bounds
+    }
+
+    /// Return the operations this batch appends to the log and the location of the first.
+    #[allow(clippy::type_complexity)]
+    pub fn operations(&self) -> (Location<F>, Arc<Vec<Operation<F, K, V>>>) {
+        (
+            self.bounds.base.size,
+            Arc::clone(self.journal_batch.items()),
+        )
+    }
+
+    /// Inclusion proof for the operations returned by [`Self::operations`], anchored at
+    /// this batch's tip. The pair verifies against [`Self::root`] via
+    /// [`crate::qmdb::verify_proof`].
+    ///
+    /// Nodes below this batch chain are read from `db`'s in-memory Merkle tier, which
+    /// retains them at least until this batch's changes are flushed (by a commit or sync
+    /// after apply). Calling this later can fail with a pruned-node error, never produce
+    /// a wrong proof.
+    pub fn proof<E, C, H, T>(
+        &self,
+        db: &Immutable<F, E, K, V, C, H, T, S>,
+    ) -> Result<Proof<F, D>, Error<F>>
+    where
+        E: Context,
+        C: Mutable<Item = Operation<F, K, V>>,
+        H: Hasher<Digest = D>,
+        T: Translator,
+    {
+        let inactive_peaks = F::inactive_peaks(self.bounds.tip.size, self.bounds.inactivity_floor);
+        db.journal
+            .speculative_proof(&self.journal_batch, inactive_peaks)
+            .map_err(Into::into)
     }
 
     /// Iterate over ancestor batches (parent first, then grandparent, etc.).

--- a/storage/src/qmdb/immutable/batch.rs
+++ b/storage/src/qmdb/immutable/batch.rs
@@ -341,10 +341,9 @@ where
     /// this batch's tip. The pair verifies against [`Self::root`] via
     /// [`crate::qmdb::verify_proof`].
     ///
-    /// Nodes below this batch chain are read from `db`'s in-memory Merkle tier, which
-    /// retains them at least until this batch's changes are flushed (by a commit or sync
-    /// after apply). Calling this later can fail with a pruned-node error, never produce
-    /// a wrong proof. Errors for a batch created by `to_batch`, which appends nothing.
+    /// Nodes below this batch chain are read from `db`'s
+    /// [in-memory Merkle tier][crate::merkle::mem::Mem], which retains them at least until
+    /// this batch's changes are flushed (by a commit or sync after apply).
     pub fn proof<E, C, H, T>(
         &self,
         db: &Immutable<F, E, K, V, C, H, T, S>,

--- a/storage/src/qmdb/immutable/batch.rs
+++ b/storage/src/qmdb/immutable/batch.rs
@@ -64,6 +64,12 @@ type JournalBatch<F, D, K, V, S> = Arc<authenticated::MerkleizedBatch<F, D, Oper
 
 /// A speculative batch of operations whose root digest has been computed,
 /// in contrast to [`UnmerkleizedBatch`].
+///
+/// # Branch validity
+///
+/// Reads through the chain, constructing child batches, and applying the batch later are
+/// only valid while every batch applied to the DB since this batch was merkleized is an
+/// ancestor of this batch (see [`crate::qmdb::batch_chain`] for more details).
 #[derive(Clone)]
 pub struct MerkleizedBatch<F: Family, D: Digest, K: Key, V: ValueEncoding, S: Strategy> {
     /// Authenticated journal batch (Merkle state + local items).
@@ -338,7 +344,7 @@ where
     /// Nodes below this batch chain are read from `db`'s in-memory Merkle tier, which
     /// retains them at least until this batch's changes are flushed (by a commit or sync
     /// after apply). Calling this later can fail with a pruned-node error, never produce
-    /// a wrong proof.
+    /// a wrong proof. Errors for a batch created by `to_batch`, which appends nothing.
     pub fn proof<E, C, H, T>(
         &self,
         db: &Immutable<F, E, K, V, C, H, T, S>,

--- a/storage/src/qmdb/immutable/batch.rs
+++ b/storage/src/qmdb/immutable/batch.rs
@@ -342,7 +342,7 @@ where
     /// [`crate::qmdb::verify_proof`].
     ///
     /// Nodes below this batch chain are read from `db`'s
-    /// [in-memory Merkle tier][crate::merkle::mem::Mem], which retains them at least until
+    /// [Merkle store][crate::merkle::mem::Mem], which retains them at least until
     /// this batch's changes are flushed (by a commit or sync after apply).
     pub fn proof<E, C, H, T>(
         &self,

--- a/storage/src/qmdb/immutable/fixed.rs
+++ b/storage/src/qmdb/immutable/fixed.rs
@@ -525,6 +525,7 @@ mod tests {
         test_fixed_proof_verify => run_proof_verify, open;
         test_fixed_prune => run_prune, open;
         test_fixed_batch_chain => run_batch_chain, open;
+        test_fixed_operations_match_applied_log => run_operations_match_applied_log, open;
         test_fixed_build_and_authenticate => run_build_and_authenticate, open;
         test_fixed_recovery_from_failed_merkle_sync => run_recovery_from_failed_merkle_sync, open;
         test_fixed_recovery_from_failed_log_sync => run_recovery_from_failed_log_sync, open;

--- a/storage/src/qmdb/immutable/mod.rs
+++ b/storage/src/qmdb/immutable/mod.rs
@@ -1236,21 +1236,6 @@ pub(super) mod tests {
         assert_eq!(child_start, child_range.start);
         assert_eq!(*child_start + child_ops.len() as u64, *child_range.end);
 
-        // Every captured delta and proof must match what the log recovers for its
-        // range, and verify against the batch's own root.
-        for (start, ops, proof, root) in [
-            (seed_start, seed_ops, seed_proof, seed_root),
-            (parent_start, parent_ops, parent_proof, parent_root),
-            (child_start, child_ops, child_proof, child_root),
-        ] {
-            let len = core::num::NonZeroU64::new(ops.len() as u64).unwrap();
-            let end = Location::new(*start + ops.len() as u64);
-            let (log_proof, log_ops) = db.historical_proof(end, start, len).await.unwrap();
-            assert_eq!(log_ops, *ops);
-            assert_eq!(log_proof, proof);
-            assert!(verify_proof::<Sha256, _, _>(&proof, start, &ops, &root));
-        }
-
         // A write-free batch still captures its commit-only suffix.
         let empty = db
             .new_batch()
@@ -1261,12 +1246,22 @@ pub(super) mod tests {
         let (db, empty_range) = db.apply_batch(empty).await.unwrap();
         assert_eq!(empty_start, empty_range.start);
         assert_eq!(*empty_start + empty_ops.len() as u64, *empty_range.end);
-        assert!(verify_proof::<Sha256, _, _>(
-            &empty_proof,
-            empty_start,
-            &empty_ops,
-            &empty_root
-        ));
+
+        // Every captured delta and proof must match what the log recovers for its
+        // range, and verify against the batch's own root.
+        for (start, ops, proof, root) in [
+            (seed_start, seed_ops, seed_proof, seed_root),
+            (parent_start, parent_ops, parent_proof, parent_root),
+            (child_start, child_ops, child_proof, child_root),
+            (empty_start, empty_ops, empty_proof, empty_root),
+        ] {
+            let len = core::num::NonZeroU64::new(ops.len() as u64).unwrap();
+            let end = Location::new(*start + ops.len() as u64);
+            let (log_proof, log_ops) = db.historical_proof(end, start, len).await.unwrap();
+            assert_eq!(log_ops, *ops);
+            assert_eq!(log_proof, proof);
+            assert!(verify_proof::<Sha256, _, _>(&proof, start, &ops, &root));
+        }
 
         // After the batch's changes are flushed, proof is a verifying proof or an
         // error, never a wrong proof.

--- a/storage/src/qmdb/immutable/mod.rs
+++ b/storage/src/qmdb/immutable/mod.rs
@@ -1185,6 +1185,109 @@ pub(super) mod tests {
         db.destroy().await.unwrap();
     }
 
+    /// `operations()` must cover exactly the batch's own applied range and match the
+    /// operations a post-apply `historical_proof` recovers from the log, for a db-based
+    /// batch and for a chained batch applied after its ancestor.
+    #[boxed]
+    pub(crate) async fn run_operations_match_applied_log<F: Family, V, C>(
+        context: deterministic::Context,
+        open_db: impl Fn(
+            deterministic::Context,
+        ) -> Pin<Box<dyn Future<Output = TestDb<F, V, C>> + Send>>,
+    ) where
+        V: ValueEncoding<Value = Digest>,
+        C: Mutable<Item = Operation<F, Digest, V>>,
+        C::Item: EncodeShared + PartialEq + core::fmt::Debug,
+    {
+        let db = open_db(context.child("db")).await;
+
+        let seed = db
+            .new_batch()
+            .set(Sha256::fill(1u8), Sha256::fill(11u8))
+            .set(Sha256::fill(2u8), Sha256::fill(12u8))
+            .merkleize(&db, None, db.inactivity_floor_loc())
+            .await;
+        let (seed_start, seed_ops) = seed.operations();
+        let seed_root = seed.root();
+        let seed_proof = seed.proof(&db).unwrap();
+        let (db, seed_range) = db.apply_batch(seed).await.unwrap();
+        assert_eq!(seed_start, seed_range.start);
+        assert_eq!(*seed_start + seed_ops.len() as u64, *seed_range.end);
+
+        // A chained batch's operations are its own suffix only.
+        let parent = db
+            .new_batch()
+            .set(Sha256::fill(3u8), Sha256::fill(13u8))
+            .merkleize(&db, None, db.inactivity_floor_loc())
+            .await;
+        let child = parent
+            .new_batch::<Sha256>()
+            .set(Sha256::fill(4u8), Sha256::fill(14u8))
+            .merkleize(&db, None, db.inactivity_floor_loc())
+            .await;
+        let (parent_start, parent_ops) = parent.operations();
+        let (child_start, child_ops) = child.operations();
+        let (parent_root, child_root) = (parent.root(), child.root());
+        let (parent_proof, child_proof) = (parent.proof(&db).unwrap(), child.proof(&db).unwrap());
+        let (db, parent_range) = db.apply_batch(parent).await.unwrap();
+        let (db, child_range) = db.apply_batch(child).await.unwrap();
+        assert_eq!(parent_start, parent_range.start);
+        assert_eq!(*parent_start + parent_ops.len() as u64, *parent_range.end);
+        assert_eq!(child_start, child_range.start);
+        assert_eq!(*child_start + child_ops.len() as u64, *child_range.end);
+
+        // Every captured delta and proof must match what the log recovers for its
+        // range, and verify against the batch's own root.
+        for (start, ops, proof, root) in [
+            (seed_start, seed_ops, seed_proof, seed_root),
+            (parent_start, parent_ops, parent_proof, parent_root),
+            (child_start, child_ops, child_proof, child_root),
+        ] {
+            let len = core::num::NonZeroU64::new(ops.len() as u64).unwrap();
+            let end = Location::new(*start + ops.len() as u64);
+            let (log_proof, log_ops) = db.historical_proof(end, start, len).await.unwrap();
+            assert_eq!(log_ops, *ops);
+            assert_eq!(log_proof, proof);
+            assert!(verify_proof::<Sha256, _, _>(&proof, start, &ops, &root));
+        }
+
+        // A write-free batch still captures its commit-only suffix.
+        let empty = db
+            .new_batch()
+            .merkleize(&db, None, db.inactivity_floor_loc())
+            .await;
+        let (empty_start, empty_ops) = empty.operations();
+        let (empty_root, empty_proof) = (empty.root(), empty.proof(&db).unwrap());
+        let (db, empty_range) = db.apply_batch(empty).await.unwrap();
+        assert_eq!(empty_start, empty_range.start);
+        assert_eq!(*empty_start + empty_ops.len() as u64, *empty_range.end);
+        assert!(verify_proof::<Sha256, _, _>(
+            &empty_proof,
+            empty_start,
+            &empty_ops,
+            &empty_root
+        ));
+
+        // After the batch's changes are flushed, proof is a verifying proof or an
+        // error, never a wrong proof.
+        let late = db
+            .new_batch()
+            .set(Sha256::fill(5u8), Sha256::fill(15u8))
+            .merkleize(&db, None, db.inactivity_floor_loc())
+            .await;
+        let (late_start, late_ops) = late.operations();
+        let late_root = late.root();
+        let (db, _) = db.apply_batch(Arc::clone(&late)).await.unwrap();
+        let db = db.commit().await.unwrap();
+        if let Ok(proof) = late.proof(&db) {
+            assert!(verify_proof::<Sha256, _, _>(
+                &proof, late_start, &late_ops, &late_root
+            ));
+        }
+
+        db.destroy().await.unwrap();
+    }
+
     #[boxed]
     pub(crate) async fn run_batch_chain<F: Family, V, C>(
         context: deterministic::Context,

--- a/storage/src/qmdb/immutable/variable.rs
+++ b/storage/src/qmdb/immutable/variable.rs
@@ -251,6 +251,7 @@ mod tests {
         test_variable_proof_verify => run_proof_verify, open;
         test_variable_prune => run_prune, open;
         test_variable_batch_chain => run_batch_chain, open;
+        test_variable_operations_match_applied_log => run_operations_match_applied_log, open;
         test_variable_build_and_authenticate => run_build_and_authenticate, open;
         test_variable_recovery_from_failed_merkle_sync => run_recovery_from_failed_merkle_sync, open;
         test_variable_recovery_from_failed_log_sync => run_recovery_from_failed_log_sync, open;

--- a/storage/src/qmdb/keyless/batch.rs
+++ b/storage/src/qmdb/keyless/batch.rs
@@ -347,7 +347,7 @@ where
     /// [`crate::qmdb::verify_proof`].
     ///
     /// Nodes below this batch chain are read from `db`'s
-    /// [in-memory Merkle tier][crate::merkle::mem::Mem], which retains them at least until
+    /// [Merkle store][crate::merkle::mem::Mem], which retains them at least until
     /// this batch's changes are flushed (by a commit or sync after apply).
     pub fn proof<E, C, H>(&self, db: &Keyless<F, E, V, C, H, S>) -> Result<Proof<F, D>, Error<F>>
     where

--- a/storage/src/qmdb/keyless/batch.rs
+++ b/storage/src/qmdb/keyless/batch.rs
@@ -46,6 +46,12 @@ where
 
 /// A speculative batch of operations whose root digest has been computed,
 /// in contrast to [`UnmerkleizedBatch`].
+///
+/// # Branch validity
+///
+/// Reads through the chain, constructing child batches, and applying the batch later are
+/// only valid while every batch applied to the DB since this batch was merkleized is an
+/// ancestor of this batch (see [`crate::qmdb::batch_chain`] for more details).
 #[derive(Clone)]
 pub struct MerkleizedBatch<F: Family, D: Digest, V: ValueEncoding, S: Strategy>
 where
@@ -343,7 +349,7 @@ where
     /// Nodes below this batch chain are read from `db`'s in-memory Merkle tier, which
     /// retains them at least until this batch's changes are flushed (by a commit or sync
     /// after apply). Calling this later can fail with a pruned-node error, never produce
-    /// a wrong proof.
+    /// a wrong proof. Errors for a batch created by `to_batch`, which appends nothing.
     pub fn proof<E, C, H>(&self, db: &Keyless<F, E, V, C, H, S>) -> Result<Proof<F, D>, Error<F>>
     where
         E: Context,

--- a/storage/src/qmdb/keyless/batch.rs
+++ b/storage/src/qmdb/keyless/batch.rs
@@ -4,7 +4,7 @@ use super::{Keyless, operation::Operation};
 use crate::{
     Context,
     journal::{authenticated, contiguous::Mutable},
-    merkle::{Family, Location},
+    merkle::{Family, Location, Proof},
     qmdb::{
         Error,
         any::value::ValueEncoding,
@@ -326,6 +326,34 @@ where
     /// Return the [`Bounds`] of the batch.
     pub const fn bounds(&self) -> &Bounds<F, D> {
         &self.bounds
+    }
+
+    /// Return the operations this batch appends to the log and the location of the first.
+    pub fn operations(&self) -> (Location<F>, Arc<Vec<Operation<F, V>>>) {
+        (
+            self.bounds.base.size,
+            Arc::clone(self.journal_batch.items()),
+        )
+    }
+
+    /// Inclusion proof for the operations returned by [`Self::operations`], anchored at
+    /// this batch's tip. The pair verifies against [`Self::root`] via
+    /// [`crate::qmdb::verify_proof`].
+    ///
+    /// Nodes below this batch chain are read from `db`'s in-memory Merkle tier, which
+    /// retains them at least until this batch's changes are flushed (by a commit or sync
+    /// after apply). Calling this later can fail with a pruned-node error, never produce
+    /// a wrong proof.
+    pub fn proof<E, C, H>(&self, db: &Keyless<F, E, V, C, H, S>) -> Result<Proof<F, D>, Error<F>>
+    where
+        E: Context,
+        C: Mutable<Item = Operation<F, V>>,
+        H: Hasher<Digest = D>,
+    {
+        let inactive_peaks = F::inactive_peaks(self.bounds.tip.size, self.bounds.inactivity_floor);
+        db.journal
+            .speculative_proof(&self.journal_batch, inactive_peaks)
+            .map_err(Into::into)
     }
 
     /// Read a value at `loc`.

--- a/storage/src/qmdb/keyless/batch.rs
+++ b/storage/src/qmdb/keyless/batch.rs
@@ -346,10 +346,9 @@ where
     /// this batch's tip. The pair verifies against [`Self::root`] via
     /// [`crate::qmdb::verify_proof`].
     ///
-    /// Nodes below this batch chain are read from `db`'s in-memory Merkle tier, which
-    /// retains them at least until this batch's changes are flushed (by a commit or sync
-    /// after apply). Calling this later can fail with a pruned-node error, never produce
-    /// a wrong proof. Errors for a batch created by `to_batch`, which appends nothing.
+    /// Nodes below this batch chain are read from `db`'s
+    /// [in-memory Merkle tier][crate::merkle::mem::Mem], which retains them at least until
+    /// this batch's changes are flushed (by a commit or sync after apply).
     pub fn proof<E, C, H>(&self, db: &Keyless<F, E, V, C, H, S>) -> Result<Proof<F, D>, Error<F>>
     where
         E: Context,

--- a/storage/src/qmdb/keyless/fixed.rs
+++ b/storage/src/qmdb/keyless/fixed.rs
@@ -458,6 +458,7 @@ mod tests {
         test_keyless_fixed_batch_speculative_root => run_batch_speculative_root, db;
         test_keyless_fixed_merkleized_batch_get => run_merkleized_batch_get, db;
         test_keyless_fixed_batch_chained => run_batch_chained, db;
+        test_keyless_fixed_operations_match_applied_log => run_operations_match_applied_log, db;
         test_keyless_fixed_batch_chained_apply_sequential => run_batch_chained_apply_sequential, db;
         test_keyless_fixed_batch_many_sequential => run_batch_many_sequential, db;
         test_keyless_fixed_batch_empty => run_batch_empty, db;

--- a/storage/src/qmdb/keyless/mod.rs
+++ b/storage/src/qmdb/keyless/mod.rs
@@ -746,6 +746,105 @@ pub(crate) mod tests {
         db.destroy().await.unwrap();
     }
 
+    /// `operations()` must cover exactly the batch's own applied range and match the
+    /// operations a post-apply `historical_proof` recovers from the log, for a db-based
+    /// batch and for a chained batch applied after its ancestor.
+    #[boxed]
+    pub(crate) async fn run_operations_match_applied_log<F: Family, V, C, H, S: Strategy>(
+        db: TestKeyless<F, V, C, H, S>,
+    ) where
+        V: ValueEncoding<Value: TestValue>,
+        C: Mutable<Item = Operation<F, V>>,
+        H: Hasher,
+        Operation<F, V>: EncodeShared + PartialEq + core::fmt::Debug,
+    {
+        let seed = db
+            .new_batch()
+            .append(V::Value::make(1))
+            .append(V::Value::make(2))
+            .merkleize(&db, None, db.inactivity_floor_loc())
+            .await;
+        let (seed_start, seed_ops) = seed.operations();
+        let seed_root = seed.root();
+        let seed_proof = seed.proof(&db).unwrap();
+        let (db, seed_range) = db.apply_batch(seed).await.unwrap();
+        assert_eq!(seed_start, seed_range.start);
+        assert_eq!(*seed_start + seed_ops.len() as u64, *seed_range.end);
+
+        // A chained batch's operations are its own suffix only.
+        let parent = db
+            .new_batch()
+            .append(V::Value::make(3))
+            .merkleize(&db, None, db.inactivity_floor_loc())
+            .await;
+        let child = parent
+            .new_batch::<H>()
+            .append(V::Value::make(4))
+            .merkleize(&db, None, db.inactivity_floor_loc())
+            .await;
+        let (parent_start, parent_ops) = parent.operations();
+        let (child_start, child_ops) = child.operations();
+        let (parent_root, child_root) = (parent.root(), child.root());
+        let (parent_proof, child_proof) = (parent.proof(&db).unwrap(), child.proof(&db).unwrap());
+        let (db, parent_range) = db.apply_batch(parent).await.unwrap();
+        let (db, child_range) = db.apply_batch(child).await.unwrap();
+        assert_eq!(parent_start, parent_range.start);
+        assert_eq!(*parent_start + parent_ops.len() as u64, *parent_range.end);
+        assert_eq!(child_start, child_range.start);
+        assert_eq!(*child_start + child_ops.len() as u64, *child_range.end);
+
+        // Every captured delta and proof must match what the log recovers for its
+        // range, and verify against the batch's own root.
+        for (start, ops, proof, root) in [
+            (seed_start, seed_ops, seed_proof, seed_root),
+            (parent_start, parent_ops, parent_proof, parent_root),
+            (child_start, child_ops, child_proof, child_root),
+        ] {
+            let len = core::num::NonZeroU64::new(ops.len() as u64).unwrap();
+            let end = Location::new(*start + ops.len() as u64);
+            let (log_proof, log_ops) = db.historical_proof(end, start, len).await.unwrap();
+            assert_eq!(log_ops, *ops);
+            assert_eq!(log_proof, proof);
+            assert!(verify_proof::<H, _, _>(&proof, start, &ops, &root));
+        }
+
+        // A write-free batch still captures its commit-only suffix.
+        let empty = db
+            .new_batch()
+            .merkleize(&db, None, db.inactivity_floor_loc())
+            .await;
+        let (empty_start, empty_ops) = empty.operations();
+        let (empty_root, empty_proof) = (empty.root(), empty.proof(&db).unwrap());
+        let (db, empty_range) = db.apply_batch(empty).await.unwrap();
+        assert_eq!(empty_start, empty_range.start);
+        assert_eq!(*empty_start + empty_ops.len() as u64, *empty_range.end);
+        assert!(verify_proof::<H, _, _>(
+            &empty_proof,
+            empty_start,
+            &empty_ops,
+            &empty_root
+        ));
+
+        // After the batch's changes are flushed, proof is a verifying proof or an
+        // error, never a wrong proof.
+        let late = db
+            .new_batch()
+            .append(V::Value::make(5))
+            .merkleize(&db, None, db.inactivity_floor_loc())
+            .await;
+        let (late_start, late_ops) = late.operations();
+        let late_root = late.root();
+        let (db, _) = db.apply_batch(Arc::clone(&late)).await.unwrap();
+        let db = db.commit().await.unwrap();
+        if let Ok(proof) = late.proof(&db) {
+            assert!(verify_proof::<H, _, _>(
+                &proof, late_start, &late_ops, &late_root
+            ));
+        }
+
+        db.destroy().await.unwrap();
+    }
+
     #[boxed]
     pub(crate) async fn run_commit_after_sync_recovery<F: Family, V, C, H, S: Strategy>(
         context: deterministic::Context,

--- a/storage/src/qmdb/keyless/mod.rs
+++ b/storage/src/qmdb/keyless/mod.rs
@@ -793,21 +793,6 @@ pub(crate) mod tests {
         assert_eq!(child_start, child_range.start);
         assert_eq!(*child_start + child_ops.len() as u64, *child_range.end);
 
-        // Every captured delta and proof must match what the log recovers for its
-        // range, and verify against the batch's own root.
-        for (start, ops, proof, root) in [
-            (seed_start, seed_ops, seed_proof, seed_root),
-            (parent_start, parent_ops, parent_proof, parent_root),
-            (child_start, child_ops, child_proof, child_root),
-        ] {
-            let len = core::num::NonZeroU64::new(ops.len() as u64).unwrap();
-            let end = Location::new(*start + ops.len() as u64);
-            let (log_proof, log_ops) = db.historical_proof(end, start, len).await.unwrap();
-            assert_eq!(log_ops, *ops);
-            assert_eq!(log_proof, proof);
-            assert!(verify_proof::<H, _, _>(&proof, start, &ops, &root));
-        }
-
         // A write-free batch still captures its commit-only suffix.
         let empty = db
             .new_batch()
@@ -818,12 +803,22 @@ pub(crate) mod tests {
         let (db, empty_range) = db.apply_batch(empty).await.unwrap();
         assert_eq!(empty_start, empty_range.start);
         assert_eq!(*empty_start + empty_ops.len() as u64, *empty_range.end);
-        assert!(verify_proof::<H, _, _>(
-            &empty_proof,
-            empty_start,
-            &empty_ops,
-            &empty_root
-        ));
+
+        // Every captured delta and proof must match what the log recovers for its
+        // range, and verify against the batch's own root.
+        for (start, ops, proof, root) in [
+            (seed_start, seed_ops, seed_proof, seed_root),
+            (parent_start, parent_ops, parent_proof, parent_root),
+            (child_start, child_ops, child_proof, child_root),
+            (empty_start, empty_ops, empty_proof, empty_root),
+        ] {
+            let len = core::num::NonZeroU64::new(ops.len() as u64).unwrap();
+            let end = Location::new(*start + ops.len() as u64);
+            let (log_proof, log_ops) = db.historical_proof(end, start, len).await.unwrap();
+            assert_eq!(log_ops, *ops);
+            assert_eq!(log_proof, proof);
+            assert!(verify_proof::<H, _, _>(&proof, start, &ops, &root));
+        }
 
         // After the batch's changes are flushed, proof is a verifying proof or an
         // error, never a wrong proof.

--- a/storage/src/qmdb/keyless/variable.rs
+++ b/storage/src/qmdb/keyless/variable.rs
@@ -190,6 +190,7 @@ mod tests {
         test_keyless_variable_batch_speculative_root => run_batch_speculative_root, db;
         test_keyless_variable_merkleized_batch_get => run_merkleized_batch_get, db;
         test_keyless_variable_batch_chained => run_batch_chained, db;
+        test_keyless_variable_operations_match_applied_log => run_operations_match_applied_log, db;
         test_keyless_variable_batch_chained_apply_sequential => run_batch_chained_apply_sequential, db;
         test_keyless_variable_batch_many_sequential => run_batch_many_sequential, db;
         test_keyless_variable_batch_empty => run_batch_empty, db;


### PR DESCRIPTION
Each merkleized QMDB batch now exposes its own operation suffix as the first log location plus an `Arc`-backed operation vector, so callers can emit a batch without rereading the journal. `any`, immutable, and keyless batches also expose the matching inclusion proof against the speculative batch root; chained batches return and prove only their own suffix.

Proof construction resolves nodes through the live batch chain and the committed in-memory Merkle tier. Callers should capture proofs before a commit or sync flush; later construction may return a pruning error. Current QMDB intentionally exposes only operations because its canonical root also commits to grafted bitmap state.

Deterministic tests compare emitted operations and proofs with post-apply historical proofs for direct, chained, and commit-only batches across MMR/MMB fixed and variable variants, including floor-raise operations where applicable. They also verify any proof that remains available after a flush.