### PR TITLE
[parallel] Provide a recording strategy mock; keep Manual construction internal

### DIFF
--- a/parallel/src/lib.rs
+++ b/parallel/src/lib.rs
@@ -107,6 +107,17 @@ commonware_macros::stability_scope!(BETA {
     }
 
     impl<S> Manual<S> {
+        /// Wraps `strategy` for manually partitioned work planned at `parallelism`.
+        ///
+        /// Crate-private: [Manual] is only constructible through this crate's [Strategy]
+        /// implementations, which strip any adaptive state before wrapping themselves.
+        pub(crate) const fn new(strategy: S, parallelism: usize) -> Self {
+            Self {
+                strategy,
+                parallelism,
+            }
+        }
+
         /// Returns the parallelism to use for manually partitioned work.
         pub const fn parallelism(&self) -> usize {
             self.parallelism
@@ -118,6 +129,11 @@ commonware_macros::stability_scope!(BETA {
     /// This trait abstracts over sequential and parallel execution, allowing algorithms
     /// to be written generically and then executed with different strategies depending
     /// on the use case (e.g., sequential for testing/debugging, parallel for production).
+    ///
+    /// This trait cannot be implemented outside this crate: [`manual`](Self::manual)
+    /// returns a [`Manual`], which only this crate constructs. Dependent crates that
+    /// need a test double use the `mocks` module (available with the `test-utils`
+    /// feature).
     pub trait Strategy: Clone + Send + Sync + fmt::Debug + 'static {
         /// Returns a strategy wrapper for manually partitioned work.
         fn manual(&self) -> Manual<Self>
@@ -613,10 +629,7 @@ commonware_macros::stability_scope!(BETA {
 
     impl<S: Strategy> Strategy for Manual<S> {
         fn manual(&self) -> Manual<Self> {
-            Manual {
-                strategy: self.clone(),
-                parallelism: self.parallelism,
-            }
+            Manual::new(self.clone(), self.parallelism)
         }
 
         #[track_caller]
@@ -804,10 +817,7 @@ commonware_macros::stability_scope!(BETA {
 
     impl Strategy for Sequential {
         fn manual(&self) -> Manual<Self> {
-            Manual {
-                strategy: Self,
-                parallelism: 1,
-            }
+            Manual::new(Self, 1)
         }
 
         fn spawn<F, T>(
@@ -1023,14 +1033,16 @@ commonware_macros::stability_scope!(BETA, cfg(any(feature = "std", test)) {
 
     impl Strategy for Rayon {
         fn manual(&self) -> Manual<Self> {
-            Manual {
-                strategy: Self {
+            // Manual planning bypasses adaptive decisions, so the wrapped strategy drops the
+            // adaptive policy.
+            Manual::new(
+                Self {
                     thread_pool: self.thread_pool.clone(),
                     parallelism: self.parallelism,
                     policy: None,
                 },
-                parallelism: self.parallelism,
-            }
+                self.parallelism,
+            )
         }
 
         #[track_caller]

--- a/parallel/src/mocks.rs
+++ b/parallel/src/mocks.rs
@@ -1,9 +1,9 @@
 //! Mock strategy configurations for testing.
 
-use crate::{Rayon, ThreadPool};
+use crate::{Manual, Rayon, Sequential, Strategy, ThreadPool};
 use core::num::NonZeroUsize;
 use rayon::ThreadPoolBuilder;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 /// Returns a strategy whose spawned jobs run inline at submission: a single-worker pool with the
 /// manual parallelism overridden to `parallelism`.
@@ -35,6 +35,148 @@ pub fn pending(workers: NonZeroUsize) -> Rayon {
     Rayon::with_pool(pool)
 }
 
+/// A sequential-executing strategy that reports a chosen planning parallelism and records the
+/// work hints passed to multiplier-aware operations.
+///
+/// Every operation executes like [Sequential], so tests stay deterministic, while the reported
+/// parallelism engages callers' parallel planning paths and [Recording::multiplier_calls]
+/// exposes the hints they passed.
+#[derive(Clone, Debug)]
+pub struct Recording {
+    parallelism: usize,
+    multiplier_calls: Arc<Mutex<Vec<(usize, usize)>>>,
+}
+
+/// Returns a [Recording] strategy whose [Strategy::manual] reports `parallelism`.
+pub fn recording(parallelism: NonZeroUsize) -> Recording {
+    Recording {
+        parallelism: parallelism.get(),
+        multiplier_calls: Arc::new(Mutex::new(Vec::new())),
+    }
+}
+
+impl Recording {
+    /// The `(items, multiplier)` pairs passed to multiplier-aware operations, in call order.
+    pub fn multiplier_calls(&self) -> Vec<(usize, usize)> {
+        self.multiplier_calls.lock().expect("lock poisoned").clone()
+    }
+}
+
+impl Strategy for Recording {
+    fn manual(&self) -> Manual<Self> {
+        Manual::new(self.clone(), self.parallelism)
+    }
+
+    fn spawn<F, T>(
+        &self,
+        _len: usize,
+        f: F,
+    ) -> impl core::future::Future<Output = T> + Send + 'static
+    where
+        F: FnOnce(Self) -> T + Send + 'static,
+        T: Send + 'static,
+    {
+        core::future::ready(f(self.clone()))
+    }
+
+    fn run<R, SEQ, PAR>(&self, len: usize, serial: SEQ, parallel: PAR) -> R
+    where
+        R: Send,
+        SEQ: FnOnce() -> R + Send,
+        PAR: FnOnce() -> R + Send,
+    {
+        Sequential.run(len, serial, parallel)
+    }
+
+    fn try_run<R, E, SEQ, PAR>(&self, len: usize, serial: SEQ, parallel: PAR) -> Result<R, E>
+    where
+        R: Send,
+        E: Send,
+        SEQ: FnOnce() -> Result<R, E> + Send,
+        PAR: FnOnce() -> Result<R, E> + Send,
+    {
+        Sequential.try_run(len, serial, parallel)
+    }
+
+    fn fold_init<I, INIT, T, R, ID, F, RD>(
+        &self,
+        iter: I,
+        init: INIT,
+        identity: ID,
+        fold_op: F,
+        reduce_op: RD,
+    ) -> R
+    where
+        I: IntoIterator<IntoIter: Send, Item: Send> + Send,
+        INIT: Fn() -> T + Send + Sync,
+        T: Send,
+        R: Send,
+        ID: Fn() -> R + Send + Sync,
+        F: Fn(R, &mut T, I::Item) -> R + Send + Sync,
+        RD: Fn(R, R) -> R + Send + Sync,
+    {
+        Sequential.fold_init(iter, init, identity, fold_op, reduce_op)
+    }
+
+    fn try_fold<I, R, E, ID, F, RD>(
+        &self,
+        iter: I,
+        identity: ID,
+        fold_op: F,
+        reduce_op: RD,
+    ) -> Result<R, E>
+    where
+        I: IntoIterator<IntoIter: Send, Item: Send> + Send,
+        R: Send,
+        E: Send,
+        ID: Fn() -> R + Send + Sync,
+        F: Fn(R, I::Item) -> Result<R, E> + Send + Sync,
+        RD: Fn(R, R) -> R + Send + Sync,
+    {
+        Sequential.try_fold(iter, identity, fold_op, reduce_op)
+    }
+
+    fn join<A, B, RA, RB>(&self, a: A, b: B) -> (RA, RB)
+    where
+        A: FnOnce() -> RA + Send,
+        B: FnOnce() -> RB + Send,
+        RA: Send,
+        RB: Send,
+    {
+        Sequential.join(a, b)
+    }
+
+    fn sort_by<T, C>(&self, items: &mut [T], compare: C)
+    where
+        T: Send,
+        C: Fn(&T, &T) -> core::cmp::Ordering + Send + Sync,
+    {
+        Sequential.sort_by(items, compare)
+    }
+
+    fn map_init_collect_vec_with_multiplier<I, INIT, T, F, R>(
+        &self,
+        iter: I,
+        multiplier: usize,
+        init: INIT,
+        map_op: F,
+    ) -> Vec<R>
+    where
+        I: IntoIterator<IntoIter: Send, Item: Send> + Send,
+        INIT: Fn() -> T + Send + Sync,
+        T: Send,
+        F: Fn(&mut T, I::Item) -> R + Send + Sync,
+        R: Send,
+    {
+        let items: Vec<I::Item> = iter.into_iter().collect();
+        self.multiplier_calls
+            .lock()
+            .expect("lock poisoned")
+            .push((items.len(), multiplier));
+        Sequential.map_init_collect_vec(items, init, map_op)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -62,5 +204,23 @@ mod tests {
     #[should_panic(expected = "pending requires a multi-worker pool")]
     fn pending_rejects_single_worker() {
         pending(NonZeroUsize::MIN);
+    }
+
+    /// The recording strategy reports the requested planning parallelism, executes
+    /// sequentially, and records the hints passed through the multiplier-aware maps
+    /// (including calls routed through the stateless convenience wrapper).
+    #[test]
+    fn recording_reports_parallelism_and_records_multiplier_calls() {
+        let strategy = recording(NonZeroUsize::new(4).unwrap());
+        assert_eq!(strategy.manual().parallelism(), 4);
+
+        let doubled: Vec<usize> = strategy.map_collect_vec_with_multiplier(0..3, 7, |x| x * 2);
+        assert_eq!(doubled, vec![0, 2, 4]);
+        assert_eq!(strategy.multiplier_calls(), vec![(3, 7)]);
+
+        let summed: Vec<usize> =
+            strategy.map_init_collect_vec_with_multiplier(0..2, 9, || 1, |state, x| *state + x);
+        assert_eq!(summed, vec![1, 2]);
+        assert_eq!(strategy.multiplier_calls(), vec![(3, 7), (2, 9)]);
     }
 }


### PR DESCRIPTION
Since #4423 removed `Manual`'s public constructor, `Strategy` cannot be implemented outside this crate: `manual()` must return a `Manual<Self>` that external code has no way to construct. The first casualty was a dependent crate's test double (the `RecordingStrategy` in #4454).

Per review discussion, this keeps the trait closed rather than reopening construction: `Manual` stays internal, so every `Manual` provably wraps a strategy that already stripped its adaptive state.

- The `Strategy` docs now state that the trait cannot be implemented outside the crate and point to `mocks` for test doubles.
- A crate-private `Manual::new` unifies the three in-crate construction sites (`Rayon`, `Sequential`, `Manual`).
- `mocks::recording(parallelism)` provides the double an external implementation would otherwise exist for: sequential execution with a chosen planning parallelism (so callers' parallel planning paths engage deterministically), recording the `(items, multiplier)` hints passed to the multiplier-aware maps via `Recording::multiplier_calls`.

## Validation

The parallel unit suite passes, including the new mock test; `cargo check --no-default-features` and `just check-stability` pass.

Note: #4454 (stack #4511) will replace its bespoke `RecordingStrategy` with `mocks::recording` once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q4BFdANo2LhVEr2ko3FK9n
