### PR TITLE
[utils] Add weighted committees

### DIFF
--- a/consensus/fuzz/src/bounds.rs
+++ b/consensus/fuzz/src/bounds.rs
@@ -83,15 +83,17 @@ mod tests {
         for n in 1..=21u32 {
             let expected_f = max_faults(n);
             let expected_q = quorum(n);
-            let actual_f = N3f1::max_faults(n);
-            let actual_q = N3f1::quorum(n);
+            let actual_f = N3f1::max_faults(u64::from(n));
+            let actual_q = N3f1::quorum(u64::from(n));
 
             assert_eq!(
-                actual_f, expected_f,
+                actual_f,
+                u64::from(expected_f),
                 "N3f1::max_faults({n}) = {actual_f}, expected {expected_f}"
             );
             assert_eq!(
-                actual_q, expected_q,
+                actual_q,
+                u64::from(expected_q),
                 "N3f1::quorum({n}) = {actual_q}, expected {expected_q}"
             );
 

--- a/consensus/src/aggregation/engine.rs
+++ b/consensus/src/aggregation/engine.rs
@@ -500,8 +500,7 @@ impl<
                 return (self, false);
             }
         };
-        let quorum = usize::try_from(scheme.participants().quorum::<N3f1>())
-            .expect("quorum exceeds usize::MAX");
+        let quorum = scheme.participants().quorum_count::<N3f1>() as usize;
 
         // Get the acks and check digest consistency
         let acks_by_epoch = match self.pending.get_mut(&ack.item.height) {

--- a/consensus/src/aggregation/safe_tip.rs
+++ b/consensus/src/aggregation/safe_tip.rs
@@ -47,7 +47,7 @@ impl<P: PublicKey> SafeTip<P> {
 
         // Get the number of validators and the maximum number of faults
         let n = validators.len();
-        let f = validators.max_faults::<N3f1>() as usize;
+        let f = validators.max_faults_count::<N3f1>() as usize;
 
         // Initialize the tips map
         let mut tips = HashMap::with_capacity(n);

--- a/consensus/src/aggregation/types.rs
+++ b/consensus/src/aggregation/types.rs
@@ -538,8 +538,9 @@ mod tests {
 
         // Test Activity codec - Certified variant
         // Collect enough acks for a certificate
-        let expected = schemes[0].participants().quorum::<N3f1>();
-        let expected_count = usize::try_from(expected).expect("quorum exceeds usize::MAX");
+        let expected_count = schemes[0].participants().quorum_count::<N3f1>();
+        let expected = u64::from(expected_count);
+        let expected_count = usize::try_from(expected_count).expect("quorum exceeds usize::MAX");
         let acks: Vec<_> = schemes
             .iter()
             .take(expected_count)
@@ -548,7 +549,7 @@ mod tests {
 
         // A non-empty sub-quorum still reports the exact shortfall.
         let insufficient = &acks[..acks.len() - 1];
-        let found = u32::try_from(insufficient.len()).expect("ack count exceeds u32::MAX");
+        let found = u64::try_from(insufficient.len()).expect("ack count exceeds u64::MAX");
         assert!(matches!(
             Certificate::from_acks(
                 &schemes[0],

--- a/consensus/src/marshal/coding/types.rs
+++ b/consensus/src/marshal/coding/types.rs
@@ -576,7 +576,7 @@ impl<B: Block + Eq, C: Scheme, H: Hasher> Eq for StoredCodedBlock<B, C, H> {}
 ///
 /// Panics if `n_participants < 4`.
 pub fn coding_config_for_participants(n_participants: u16) -> CodingConfig {
-    let max_faults = N3f1::max_faults(n_participants);
+    let max_faults = N3f1::max_faults(u64::from(n_participants));
     assert!(
         max_faults >= 1,
         "Need at least 4 participants to maintain fault tolerance"

--- a/consensus/src/simplex/actors/batcher/actor.rs
+++ b/consensus/src/simplex/actors/batcher/actor.rs
@@ -132,7 +132,7 @@ where
             Buckets::CRYPTOGRAPHY,
         );
         let (sender, receiver) = mailbox::new(context.child("mailbox"), cfg.mailbox_size);
-        let mut required_active = participants.quorum::<N3f1>() as usize;
+        let mut required_active = participants.quorum_count::<N3f1>() as usize;
         if scheme.me().is_some() {
             // We are live by construction (we never observe our own messages).
             required_active = required_active

--- a/consensus/src/simplex/actors/batcher/round.rs
+++ b/consensus/src/simplex/actors/batcher/round.rs
@@ -63,7 +63,7 @@ impl<
         reporter: R,
         track_historical_votes: bool,
     ) -> Self {
-        let quorum = scheme.participants().quorum::<N3f1>();
+        let quorum = scheme.participants().quorum_count::<N3f1>();
         let len = scheme.participants().len();
         Self {
             blocker,

--- a/consensus/src/simplex/actors/batcher/verifier.rs
+++ b/consensus/src/simplex/actors/batcher/verifier.rs
@@ -699,6 +699,13 @@ mod tests {
 
     const NAMESPACE: &[u8] = b"test";
 
+    fn count_quorum(participants: usize) -> u32 {
+        u32::try_from(N3f1::quorum(
+            u64::try_from(participants).expect("participant count exceeds u64::MAX"),
+        ))
+        .expect("quorum for a u32-indexed participant set must fit in u32")
+    }
+
     impl<V> Certification<V> {
         /// Returns the pending buffer (empty once complete).
         fn pending(&self) -> &[V] {
@@ -732,7 +739,7 @@ mod tests {
     fn test_verifier_allocates_vote_buffers_lazily() {
         let mut rng = test_rng();
         let Fixture { schemes, .. } = ed25519::fixture(&mut rng, NAMESPACE, 5);
-        let quorum = N3f1::quorum(schemes.len());
+        let quorum = count_quorum(schemes.len());
         let round = Round::new(Epoch::new(0), View::new(1));
         let mut verifier =
             Verifier::<ed25519::Scheme, Sha256>::new(round, schemes[0].clone(), quorum);
@@ -836,7 +843,7 @@ mod tests {
     {
         let mut rng = test_rng();
         let Fixture { schemes, .. } = fixture(&mut rng, NAMESPACE, 5);
-        let quorum = N3f1::quorum(schemes.len());
+        let quorum = count_quorum(schemes.len());
         let mut verifier = Verifier::<S, Sha256>::new(
             Round::new(Epoch::new(0), View::new(1)),
             schemes[0].clone(),
@@ -907,7 +914,7 @@ mod tests {
     {
         let mut rng = test_rng();
         let Fixture { schemes, .. } = fixture(&mut rng, NAMESPACE, 5);
-        let quorum = N3f1::quorum(schemes.len());
+        let quorum = count_quorum(schemes.len());
         let mut verifier = Verifier::<S, Sha256>::new(
             Round::new(Epoch::new(0), View::new(1)),
             schemes[0].clone(),
@@ -1006,7 +1013,7 @@ mod tests {
     {
         let mut rng = test_rng();
         let Fixture { schemes, .. } = fixture(&mut rng, NAMESPACE, 5);
-        let quorum = N3f1::quorum(schemes.len());
+        let quorum = count_quorum(schemes.len());
         let mut verifier = Verifier::<S, Sha256>::new(
             Round::new(Epoch::new(0), View::new(1)),
             schemes[0].clone(),
@@ -1099,7 +1106,7 @@ mod tests {
     {
         let mut rng = test_rng();
         let Fixture { schemes, .. } = fixture(&mut rng, NAMESPACE, 5);
-        let quorum = N3f1::quorum(schemes.len());
+        let quorum = count_quorum(schemes.len());
         let mut verifier = Verifier::<S, Sha256>::new(
             Round::new(Epoch::new(0), View::new(1)),
             schemes[0].clone(),
@@ -1137,7 +1144,7 @@ mod tests {
     {
         let mut rng = test_rng();
         let Fixture { schemes, .. } = fixture(&mut rng, NAMESPACE, 5);
-        let quorum = N3f1::quorum(schemes.len());
+        let quorum = count_quorum(schemes.len());
         let mut verifier = Verifier::<S, Sha256>::new(
             Round::new(Epoch::new(0), View::new(1)),
             schemes[0].clone(),
@@ -1191,7 +1198,7 @@ mod tests {
     {
         let mut rng = test_rng();
         let Fixture { schemes, .. } = fixture(&mut rng, NAMESPACE, 5);
-        let quorum = N3f1::quorum(schemes.len());
+        let quorum = count_quorum(schemes.len());
         let mut verifier = Verifier::<S, Sha256>::new(
             Round::new(Epoch::new(0), View::new(1)),
             schemes[0].clone(),
@@ -1246,7 +1253,7 @@ mod tests {
     {
         let mut rng = test_rng();
         let Fixture { schemes, .. } = fixture(&mut rng, NAMESPACE, 5);
-        let quorum = N3f1::quorum(schemes.len());
+        let quorum = count_quorum(schemes.len());
         let mut verifier = Verifier::<S, Sha256>::new(
             Round::new(Epoch::new(0), View::new(1)),
             schemes[0].clone(),
@@ -1305,7 +1312,7 @@ mod tests {
     {
         let mut rng = test_rng();
         let Fixture { schemes, .. } = fixture(&mut rng, NAMESPACE, 5);
-        let quorum = N3f1::quorum(schemes.len());
+        let quorum = count_quorum(schemes.len());
         let mut verifier = Verifier::<S, Sha256>::new(
             Round::new(Epoch::new(0), View::new(1)),
             schemes[0].clone(),
@@ -1422,7 +1429,7 @@ mod tests {
     {
         let mut rng = test_rng();
         let Fixture { schemes, .. } = fixture(&mut rng, NAMESPACE, 5);
-        let quorum = N3f1::quorum(schemes.len());
+        let quorum = count_quorum(schemes.len());
         let mut verifier = Verifier::<S, Sha256>::new(
             Round::new(Epoch::new(0), View::new(1)),
             schemes[0].clone(),
@@ -1478,7 +1485,7 @@ mod tests {
     {
         let mut rng = test_rng();
         let Fixture { schemes, .. } = fixture(&mut rng, NAMESPACE, 3);
-        let quorum = N3f1::quorum(schemes.len());
+        let quorum = count_quorum(schemes.len());
         let mut verifier = Verifier::<S, Sha256>::new(
             Round::new(Epoch::new(0), View::new(1)),
             schemes[0].clone(),
@@ -1536,7 +1543,7 @@ mod tests {
     {
         let mut rng = test_rng();
         let Fixture { schemes, .. } = fixture(&mut rng, NAMESPACE, 3);
-        let quorum = N3f1::quorum(schemes.len());
+        let quorum = count_quorum(schemes.len());
         let test_verifier_finalize = || {
             let mut verifier = Verifier::<S, Sha256>::new(
                 Round::new(Epoch::new(0), View::new(1)),
@@ -1609,7 +1616,7 @@ mod tests {
     {
         let mut rng = test_rng();
         let Fixture { schemes, .. } = fixture(&mut rng, NAMESPACE, 5);
-        let quorum = N3f1::quorum(schemes.len());
+        let quorum = count_quorum(schemes.len());
         let mut verifier = Verifier::<S, Sha256>::new(
             Round::new(Epoch::new(0), View::new(3)),
             schemes[0].clone(),
@@ -1675,7 +1682,8 @@ mod tests {
     async fn test_nonbatchable_finalize_accounting_tracks_proposal_override() {
         let mut rng = test_rng();
         let Fixture { schemes, .. } = secp256r1::fixture(&mut rng, NAMESPACE, 5);
-        let quorum = N3f1::quorum(schemes.len()) as usize;
+        let quorum = usize::try_from(count_quorum(schemes.len()))
+            .expect("participant quorum exceeds usize::MAX");
         let mut verifier = Verifier::<_, Sha256>::new(
             Round::new(Epoch::new(333), View::new(7)),
             schemes[0].clone(),
@@ -1740,7 +1748,7 @@ mod tests {
     {
         let mut rng = test_rng();
         let Fixture { schemes, .. } = fixture(&mut rng, NAMESPACE, 3);
-        let quorum = N3f1::quorum(schemes.len());
+        let quorum = count_quorum(schemes.len());
         let mut verifier = Verifier::<S, Sha256>::new(
             Round::new(Epoch::new(0), View::new(1)),
             schemes[0].clone(),
@@ -1772,7 +1780,7 @@ mod tests {
     {
         let mut rng = test_rng();
         let Fixture { schemes, .. } = fixture(&mut rng, NAMESPACE, 3);
-        let quorum = N3f1::quorum(schemes.len());
+        let quorum = count_quorum(schemes.len());
         let mut verifier = Verifier::<S, Sha256>::new(
             Round::new(Epoch::new(0), View::new(1)),
             schemes[0].clone(),
@@ -1808,7 +1816,7 @@ mod tests {
     {
         let mut rng = test_rng();
         let Fixture { schemes, .. } = fixture(&mut rng, NAMESPACE, 3);
-        let quorum = N3f1::quorum(schemes.len());
+        let quorum = count_quorum(schemes.len());
         let mut verifier = Verifier::<S, Sha256>::new(
             Round::new(Epoch::new(0), View::new(1)),
             schemes[0].clone(),
@@ -1845,7 +1853,7 @@ mod tests {
     {
         let mut rng = test_rng();
         let Fixture { schemes, .. } = fixture(&mut rng, NAMESPACE, 5);
-        let quorum = N3f1::quorum(schemes.len());
+        let quorum = count_quorum(schemes.len());
         let mut verifier = Verifier::<S, Sha256>::new(
             Round::new(Epoch::new(0), View::new(1)),
             schemes[0].clone(),
@@ -1907,7 +1915,7 @@ mod tests {
     {
         let mut rng = test_rng();
         let Fixture { schemes, .. } = fixture(&mut rng, NAMESPACE, 5);
-        let quorum = N3f1::quorum(schemes.len());
+        let quorum = count_quorum(schemes.len());
         let mut verifier = Verifier::<S, Sha256>::new(
             Round::new(Epoch::new(0), View::new(1)),
             schemes[0].clone(),
@@ -1953,7 +1961,7 @@ mod tests {
     {
         let mut rng = test_rng();
         let Fixture { schemes, .. } = fixture(&mut rng, NAMESPACE, 5);
-        let quorum = N3f1::quorum(schemes.len());
+        let quorum = count_quorum(schemes.len());
         let mut verifier = Verifier::<S, Sha256>::new(
             Round::new(Epoch::new(0), View::new(1)),
             schemes[0].clone(),
@@ -2004,7 +2012,7 @@ mod tests {
     {
         let mut rng = test_rng();
         let Fixture { schemes, .. } = fixture(&mut rng, NAMESPACE, 5);
-        let quorum = N3f1::quorum(schemes.len());
+        let quorum = count_quorum(schemes.len());
         assert!(
             schemes.len() > quorum as usize,
             "test requires more validators than the quorum"
@@ -2066,7 +2074,7 @@ mod tests {
     {
         let mut rng = test_rng();
         let Fixture { schemes, .. } = fixture(&mut rng, NAMESPACE, 5);
-        let quorum = N3f1::quorum(schemes.len());
+        let quorum = count_quorum(schemes.len());
         assert!(
             schemes.len() > quorum as usize,
             "test requires more validators than the quorum"
@@ -2120,7 +2128,7 @@ mod tests {
     {
         let mut rng = test_rng();
         let Fixture { schemes, .. } = fixture(&mut rng, NAMESPACE, 5);
-        let quorum = N3f1::quorum(schemes.len());
+        let quorum = count_quorum(schemes.len());
         assert!(
             schemes.len() > quorum as usize,
             "test requires more validators than the quorum"
@@ -2245,7 +2253,7 @@ mod tests {
     {
         let mut rng = test_rng();
         let Fixture { schemes, .. } = fixture(&mut rng, NAMESPACE, 5);
-        let quorum = N3f1::quorum(schemes.len());
+        let quorum = count_quorum(schemes.len());
         let mut verifier = Verifier::<S, Sha256>::new(
             Round::new(Epoch::new(0), View::new(1)),
             schemes[0].clone(),
@@ -2283,7 +2291,7 @@ mod tests {
             .into_iter()
             .map(|scheme| wrapped::Scheme::new(scheme, wrapped::Behavior::RecoveryFailure))
             .collect();
-        let quorum = N3f1::quorum(schemes.len());
+        let quorum = count_quorum(schemes.len());
         let quorum_size = usize::try_from(quorum).expect("quorum exceeds usize::MAX");
         let round = Round::new(Epoch::new(0), View::new(1));
         let mut verifier = Verifier::<_, Sha256>::new(round, schemes[0].clone(), quorum);
@@ -2304,7 +2312,7 @@ mod tests {
     async fn test_construct_drains_kinds_in_order() {
         let mut rng = test_rng();
         let Fixture { schemes, .. } = ed25519::fixture(&mut rng, NAMESPACE, 5);
-        let quorum = N3f1::quorum(schemes.len());
+        let quorum = count_quorum(schemes.len());
         let mut verifier = Verifier::<_, Sha256>::new(
             Round::new(Epoch::new(0), View::new(1)),
             schemes[0].clone(),

--- a/consensus/src/simplex/elector.rs
+++ b/consensus/src/simplex/elector.rs
@@ -807,7 +807,10 @@ mod tests {
         let participants = Set::try_from_iter(participants).unwrap();
         let elector: RandomElector<ThresholdScheme> =
             Random::new(RandomVersion::V1).build(&participants);
-        let quorum = N3f1::quorum(schemes.len()) as usize;
+        let quorum = usize::try_from(N3f1::quorum(
+            u64::try_from(schemes.len()).expect("participant count exceeds u64::MAX"),
+        ))
+        .expect("quorum exceeds usize::MAX");
 
         // Create certificate for round (1, 2)
         let round1 = Round::new(Epoch::new(1), View::new(2));
@@ -933,8 +936,10 @@ mod tests {
             } = bls12381_threshold_vrf::fixture::<MinPk, _>(&mut rng, NAMESPACE, n);
             let participants = Set::try_from_iter(participants).unwrap();
             let elector: RandomElector<ThresholdScheme> = version.build(&participants);
-            let quorum =
-                usize::try_from(N3f1::quorum(schemes.len())).expect("quorum exceeds usize::MAX");
+            let quorum = usize::try_from(N3f1::quorum(
+                u64::try_from(schemes.len()).expect("participant count exceeds u64::MAX"),
+            ))
+            .expect("quorum exceeds usize::MAX");
 
             // Generate deterministic round parameters
             let epoch = rng.random_range(0..1000);

--- a/consensus/src/simplex/mod.rs
+++ b/consensus/src/simplex/mod.rs
@@ -647,7 +647,8 @@ pub mod mocks;
 pub(crate) fn quorum(n: u32) -> u32 {
     use commonware_utils::{Faults, N3f1};
 
-    N3f1::quorum(n)
+    u32::try_from(N3f1::quorum(u64::from(n)))
+        .expect("quorum for a u32 participant count must fit in u32")
 }
 
 #[cfg(test)]
@@ -7990,7 +7991,8 @@ mod tests {
         L: elector::Config<S>,
     {
         let n = campaign.n;
-        let faults = N3f1::max_faults(n) as usize;
+        let faults = usize::try_from(N3f1::max_faults(u64::from(n)))
+            .expect("maximum faults exceeds usize::MAX");
         let cases = twins::cases(
             rng,
             twins::Framework {

--- a/consensus/src/simplex/scheme/bls12381_threshold/vrf.rs
+++ b/consensus/src/simplex/scheme/bls12381_threshold/vrf.rs
@@ -164,7 +164,7 @@ impl<P: PublicKey, V: Variant> Scheme<P, V> {
         );
         assert_eq!(
             polynomial.required(),
-            participants.quorum::<N3f1>(),
+            participants.quorum_count::<N3f1>(),
             "polynomial threshold must equal quorum"
         );
         polynomial.precompute_partial_publics();
@@ -207,7 +207,7 @@ impl<P: PublicKey, V: Variant> Scheme<P, V> {
         );
         assert_eq!(
             polynomial.required(),
-            participants.quorum::<N3f1>(),
+            participants.quorum_count::<N3f1>(),
             "polynomial threshold must equal quorum"
         );
         polynomial.precompute_partial_publics();
@@ -961,7 +961,7 @@ mod tests {
     };
     use commonware_math::algebra::{Additive, CryptoGroup, Random};
     use commonware_parallel::Sequential;
-    use commonware_utils::{Faults, N3f1, N5f1, NZU32, test_rng};
+    use commonware_utils::{N3f1, N5f1, NZU32, test_rng};
     use rand::{SeedableRng, rngs::StdRng};
 
     const NAMESPACE: &[u8] = b"bls-threshold-signing-scheme";
@@ -1223,7 +1223,8 @@ mod tests {
     fn verify_votes_filters_bad_signers<V: Variant>() {
         let mut rng = test_rng();
         let (schemes, _) = setup_signers::<V>(5, 13);
-        let quorum = N3f1::quorum(schemes.len()) as usize;
+        let quorum = usize::try_from(schemes[0].participants().quorum_count::<N3f1>())
+            .expect("quorum exceeds usize::MAX");
         let proposal = sample_proposal(Epoch::new(0), View::new(5), 3);
 
         let mut votes: Vec<_> = schemes
@@ -1270,7 +1271,7 @@ mod tests {
 
     fn assemble_certificate_requires_quorum<V: Variant>() {
         let (schemes, _) = setup_signers::<V>(4, 17);
-        let quorum = N3f1::quorum(schemes.len());
+        let quorum = u64::from(schemes[0].participants().quorum_count::<N3f1>());
         let subquorum = usize::try_from(quorum - 1).expect("quorum exceeds usize::MAX");
         let proposal = sample_proposal(Epoch::new(0), View::new(7), 4);
 
@@ -1300,8 +1301,8 @@ mod tests {
 
     fn assemble_certificate_rejects_duplicate_signers<V: Variant>() {
         let (schemes, _) = setup_signers::<V>(4, 18);
-        let quorum =
-            usize::try_from(N3f1::quorum(schemes.len())).expect("quorum exceeds usize::MAX");
+        let quorum = usize::try_from(schemes[0].participants().quorum_count::<N3f1>())
+            .expect("quorum exceeds usize::MAX");
         let proposal = sample_proposal(Epoch::new(0), View::new(8), 4);
         let mut votes: Vec<_> = schemes
             .iter()
@@ -1331,8 +1332,8 @@ mod tests {
 
     fn assemble_certificate_rejects_unknown_signer<V: Variant>() {
         let (schemes, _) = setup_signers::<V>(4, 19);
-        let quorum =
-            usize::try_from(N3f1::quorum(schemes.len())).expect("quorum exceeds usize::MAX");
+        let quorum = usize::try_from(schemes[0].participants().quorum_count::<N3f1>())
+            .expect("quorum exceeds usize::MAX");
         let proposal = sample_proposal(Epoch::new(0), View::new(9), 4);
         let mut votes: Vec<_> = schemes
             .iter()
@@ -1364,8 +1365,8 @@ mod tests {
 
     fn assemble_certificate_rejects_malformed_signature<V: Variant>() {
         let (schemes, _) = setup_signers::<V>(4, 20);
-        let quorum =
-            usize::try_from(N3f1::quorum(schemes.len())).expect("quorum exceeds usize::MAX");
+        let quorum = usize::try_from(schemes[0].participants().quorum_count::<N3f1>())
+            .expect("quorum exceeds usize::MAX");
         let proposal = sample_proposal(Epoch::new(0), View::new(10), 4);
         let mut votes: Vec<_> = schemes
             .iter()
@@ -1396,7 +1397,8 @@ mod tests {
 
     fn verify_certificate<V: Variant>() {
         let (schemes, verifier) = setup_signers::<V>(4, 19);
-        let quorum = N3f1::quorum(schemes.len()) as usize;
+        let quorum = usize::try_from(schemes[0].participants().quorum_count::<N3f1>())
+            .expect("quorum exceeds usize::MAX");
         let proposal = sample_proposal(Epoch::new(0), View::new(9), 5);
 
         let votes: Vec<_> = schemes
@@ -1434,7 +1436,8 @@ mod tests {
     fn verify_certificate_detects_corruption<V: Variant>() {
         let mut rng = test_rng();
         let (schemes, verifier) = setup_signers::<V>(4, 23);
-        let quorum = N3f1::quorum(schemes.len()) as usize;
+        let quorum = usize::try_from(schemes[0].participants().quorum_count::<N3f1>())
+            .expect("quorum exceeds usize::MAX");
         let proposal = sample_proposal(Epoch::new(0), View::new(11), 6);
 
         let votes: Vec<_> = schemes
@@ -1487,8 +1490,8 @@ mod tests {
     fn verify_certificate_rejects_identity_components<V: Variant>() {
         let mut rng = test_rng();
         let (schemes, verifier) = setup_signers::<V>(4, 27);
-        let quorum =
-            usize::try_from(N3f1::quorum(schemes.len())).expect("quorum exceeds usize::MAX");
+        let quorum = usize::try_from(schemes[0].participants().quorum_count::<N3f1>())
+            .expect("quorum exceeds usize::MAX");
         let proposal = sample_proposal(Epoch::new(0), View::new(12), 7);
         let votes: Vec<_> = schemes
             .iter()
@@ -1538,7 +1541,8 @@ mod tests {
 
     fn certificate_codec_roundtrip<V: Variant>() {
         let (schemes, _) = setup_signers::<V>(5, 29);
-        let quorum = N3f1::quorum(schemes.len()) as usize;
+        let quorum = usize::try_from(schemes[0].participants().quorum_count::<N3f1>())
+            .expect("quorum exceeds usize::MAX");
         let proposal = sample_proposal(Epoch::new(0), View::new(13), 7);
 
         let votes: Vec<_> = schemes
@@ -1570,7 +1574,8 @@ mod tests {
 
     fn seed_codec_roundtrip<V: Variant>() {
         let (schemes, _) = setup_signers::<V>(4, 5);
-        let quorum = N3f1::quorum(schemes.len()) as usize;
+        let quorum = usize::try_from(schemes[0].participants().quorum_count::<N3f1>())
+            .expect("quorum exceeds usize::MAX");
         let proposal = sample_proposal(Epoch::new(0), View::new(1), 0);
 
         let votes: Vec<_> = schemes
@@ -1605,7 +1610,8 @@ mod tests {
 
     fn seed_verify<V: Variant>() {
         let (schemes, _) = setup_signers::<V>(4, 5);
-        let quorum = N3f1::quorum(schemes.len()) as usize;
+        let quorum = usize::try_from(schemes[0].participants().quorum_count::<N3f1>())
+            .expect("quorum exceeds usize::MAX");
         let proposal = sample_proposal(Epoch::new(0), View::new(1), 0);
 
         let votes: Vec<_> = schemes
@@ -1646,7 +1652,8 @@ mod tests {
 
     fn seedable<V: Variant>() {
         let (schemes, _) = setup_signers::<V>(4, 5);
-        let quorum = N3f1::quorum(schemes.len()) as usize;
+        let quorum = usize::try_from(schemes[0].participants().quorum_count::<N3f1>())
+            .expect("quorum exceeds usize::MAX");
         let proposal = sample_proposal(Epoch::new(0), View::new(1), 0);
 
         let notarizes: Vec<_> = schemes
@@ -1711,7 +1718,8 @@ mod tests {
 
     fn certificate_verifier_accepts_certificates<V: Variant>() {
         let (schemes, _) = setup_signers::<V>(4, 37);
-        let quorum = N3f1::quorum(schemes.len()) as usize;
+        let quorum = usize::try_from(schemes[0].participants().quorum_count::<N3f1>())
+            .expect("quorum exceeds usize::MAX");
         let proposal = sample_proposal(Epoch::new(0), View::new(15), 8);
 
         let votes: Vec<_> = schemes
@@ -1791,7 +1799,8 @@ mod tests {
 
     fn verify_certificate_returns_seed_randomness<V: Variant>() {
         let (schemes, _) = setup_signers::<V>(4, 43);
-        let quorum = N3f1::quorum(schemes.len()) as usize;
+        let quorum = usize::try_from(schemes[0].participants().quorum_count::<N3f1>())
+            .expect("quorum exceeds usize::MAX");
         let proposal = sample_proposal(Epoch::new(0), View::new(19), 10);
 
         let votes: Vec<_> = schemes
@@ -1823,7 +1832,8 @@ mod tests {
 
     fn certificate_decode_rejects_length_mismatch<V: Variant>() {
         let (schemes, _) = setup_signers::<V>(4, 47);
-        let quorum = N3f1::quorum(schemes.len()) as usize;
+        let quorum = usize::try_from(schemes[0].participants().quorum_count::<N3f1>())
+            .expect("quorum exceeds usize::MAX");
         let proposal = sample_proposal(Epoch::new(0), View::new(21), 11);
 
         let votes: Vec<_> = schemes
@@ -1895,7 +1905,8 @@ mod tests {
     fn verify_certificate_detects_seed_corruption<V: Variant>() {
         let mut rng = test_rng();
         let (schemes, verifier) = setup_signers::<V>(4, 59);
-        let quorum = N3f1::quorum(schemes.len()) as usize;
+        let quorum = usize::try_from(schemes[0].participants().quorum_count::<N3f1>())
+            .expect("quorum exceeds usize::MAX");
         let proposal = sample_proposal(Epoch::new(0), View::new(25), 13);
 
         let votes: Vec<_> = schemes
@@ -1948,7 +1959,8 @@ mod tests {
     fn encrypt_decrypt<V: Variant>() {
         let mut rng = test_rng();
         let (schemes, verifier) = setup_signers::<V>(4, 61);
-        let quorum = N3f1::quorum(schemes.len()) as usize;
+        let quorum = usize::try_from(schemes[0].participants().quorum_count::<N3f1>())
+            .expect("quorum exceeds usize::MAX");
 
         // Prepare a message to encrypt
         let message = b"Secret message for future view10";
@@ -2146,7 +2158,8 @@ mod tests {
     fn verify_certificate_rejects_malleability<V: Variant>() {
         let mut rng = test_rng();
         let (schemes, verifier) = setup_signers::<V>(4, 73);
-        let quorum = N3f1::quorum(schemes.len()) as usize;
+        let quorum = usize::try_from(schemes[0].participants().quorum_count::<N3f1>())
+            .expect("quorum exceeds usize::MAX");
         let proposal = sample_proposal(Epoch::new(0), View::new(31), 16);
 
         let votes: Vec<_> = schemes
@@ -2210,7 +2223,8 @@ mod tests {
     fn verify_certificates_rejects_malleability<V: Variant>() {
         let mut rng = test_rng();
         let (schemes, verifier) = setup_signers::<V>(4, 79);
-        let quorum = N3f1::quorum(schemes.len()) as usize;
+        let quorum = usize::try_from(schemes[0].participants().quorum_count::<N3f1>())
+            .expect("quorum exceeds usize::MAX");
         let proposal1 = sample_proposal(Epoch::new(0), View::new(33), 17);
         let proposal2 = sample_proposal(Epoch::new(0), View::new(34), 18);
 
@@ -2320,7 +2334,8 @@ mod tests {
         schemes: &[Scheme<V>],
         proposal: &Proposal<Sha256Digest>,
     ) -> Certificate<V> {
-        let quorum = N3f1::quorum(schemes.len()) as usize;
+        let quorum = usize::try_from(schemes[0].participants().quorum_count::<N3f1>())
+            .expect("quorum exceeds usize::MAX");
         let votes: Vec<_> = schemes
             .iter()
             .take(quorum)
@@ -2336,7 +2351,8 @@ mod tests {
         schemes: &[Scheme<V>],
         proposal: &Proposal<Sha256Digest>,
     ) -> Certificate<V> {
-        let quorum = N3f1::quorum(schemes.len()) as usize;
+        let quorum = usize::try_from(schemes[0].participants().quorum_count::<N3f1>())
+            .expect("quorum exceeds usize::MAX");
         let votes: Vec<_> = schemes
             .iter()
             .skip(schemes.len() - quorum)

--- a/consensus/src/simplex/types.rs
+++ b/consensus/src/simplex/types.rs
@@ -3606,7 +3606,10 @@ mod tests {
         let wrong_fixture = setup_seeded(5, 1, &f);
         let round = Round::new(Epoch::new(0), View::new(10));
         let proposal = Proposal::new(round, View::new(5), sample_digest(3));
-        let quorum = N3f1::quorum(fixture.schemes.len()) as usize;
+        let quorum = usize::try_from(N3f1::quorum(
+            u64::try_from(fixture.schemes.len()).expect("participant count exceeds u64::MAX"),
+        ))
+        .expect("quorum exceeds usize::MAX");
         let notarizes: Vec<_> = fixture
             .schemes
             .iter()
@@ -3644,7 +3647,10 @@ mod tests {
         let mut rng = test_rng();
         let round = Round::new(Epoch::new(0), View::new(10));
         let proposal = Proposal::new(round, View::new(5), sample_digest(4));
-        let quorum = N3f1::quorum(fixture.schemes.len()) as usize;
+        let quorum = usize::try_from(N3f1::quorum(
+            u64::try_from(fixture.schemes.len()).expect("participant count exceeds u64::MAX"),
+        ))
+        .expect("quorum exceeds usize::MAX");
         let notarizes: Vec<_> = fixture
             .schemes
             .iter()
@@ -3696,8 +3702,8 @@ mod tests {
         assert_eq!(
             Notarization::from_notarizes(&fixture.schemes[0], non_empty![@&notarizes], &Sequential),
             Err(AssemblyError::InsufficientAttestations(
-                quorum_size,
-                quorum_size - 1
+                u64::from(quorum_size),
+                u64::from(quorum_size - 1)
             )),
             "insufficient votes should not form a notarization"
         );
@@ -3794,7 +3800,10 @@ mod tests {
         let wrong_fixture = setup_seeded(5, 1, &f);
         let round = Round::new(Epoch::new(0), View::new(10));
         let proposal = Proposal::new(round, View::new(5), sample_digest(9));
-        let quorum = N3f1::quorum(fixture.schemes.len()) as usize;
+        let quorum = usize::try_from(N3f1::quorum(
+            u64::try_from(fixture.schemes.len()).expect("participant count exceeds u64::MAX"),
+        ))
+        .expect("quorum exceeds usize::MAX");
         let finalizes: Vec<_> = fixture
             .schemes
             .iter()

--- a/cryptography/src/bls12381/benches/dkg/feldman_desmedt.rs
+++ b/cryptography/src/bls12381/benches/dkg/feldman_desmedt.rs
@@ -124,7 +124,7 @@ fn bench_dkg(c: &mut Criterion, reshare: bool) {
     };
     let mut rng = test_rng();
     for &n in CONTRIBUTORS {
-        let t = N3f1::quorum(n);
+        let t = N3f1::quorum(u64::from(n));
         let bench = Bench::new(&mut rng, reshare, n);
         for &concurrency in CONCURRENCY {
             let strategy = Rayon::new(NZUsize!(concurrency)).unwrap();

--- a/cryptography/src/bls12381/benches/evaluate_point.rs
+++ b/cryptography/src/bls12381/benches/evaluate_point.rs
@@ -16,7 +16,9 @@ fn bench_evaluate_point(c: &mut Criterion) {
                     b.iter_batched(
                         || {
                             let mut rng = test_rng();
-                            let polynomial: Poly<G1> = Poly::commit(Poly::new(&mut rng, t - 1));
+                            let degree =
+                                u32::try_from(t - 1).expect("quorum degree must fit in u32");
+                            let polynomial: Poly<G1> = Poly::commit(Poly::new(&mut rng, degree));
                             let scalar = Scalar::random(&mut rng);
                             (scalar, polynomial)
                         },

--- a/cryptography/src/bls12381/benches/threshold_batch_verify_same_message.rs
+++ b/cryptography/src/bls12381/benches/threshold_batch_verify_same_message.rs
@@ -37,7 +37,7 @@ fn bench_threshold_batch_verify_same_message(c: &mut Criterion) {
                                 || {
                                     let mut rng = test_rng();
                                     let players = (0..n)
-                                        .map(|i| PrivateKey::from_seed(i as u64).public_key())
+                                        .map(|i| PrivateKey::from_seed(i).public_key())
                                         .try_collect()
                                         .unwrap();
                                     let (output, shares) =

--- a/cryptography/src/bls12381/benches/threshold_batch_verify_same_message_pre.rs
+++ b/cryptography/src/bls12381/benches/threshold_batch_verify_same_message_pre.rs
@@ -37,7 +37,7 @@ fn bench_threshold_batch_verify_same_message_pre(c: &mut Criterion) {
                                 || {
                                     let mut rng = test_rng();
                                     let players = (0..n)
-                                        .map(|i| PrivateKey::from_seed(i as u64).public_key())
+                                        .map(|i| PrivateKey::from_seed(i).public_key())
                                         .try_collect()
                                         .unwrap();
                                     let (output, shares) =

--- a/cryptography/src/bls12381/benches/threshold_batch_verify_same_signer.rs
+++ b/cryptography/src/bls12381/benches/threshold_batch_verify_same_signer.rs
@@ -35,7 +35,7 @@ fn bench_threshold_batch_verify_same_signer(c: &mut Criterion) {
                                 || {
                                     let mut rng = test_rng();
                                     let players = (0..n)
-                                        .map(|i| PrivateKey::from_seed(i as u64).public_key())
+                                        .map(|i| PrivateKey::from_seed(i).public_key())
                                         .try_collect()
                                         .unwrap();
                                     let (output, shares) =

--- a/cryptography/src/bls12381/benches/threshold_recover.rs
+++ b/cryptography/src/bls12381/benches/threshold_recover.rs
@@ -24,7 +24,7 @@ fn bench_threshold_recover(c: &mut Criterion) {
                     b.iter_batched(
                         || {
                             let players = (0..n)
-                                .map(|i| PrivateKey::from_seed(i as u64).public_key())
+                                .map(|i| PrivateKey::from_seed(i).public_key())
                                 .try_collect()
                                 .unwrap();
                             let (public, shares) = deal::<MinSig, _, N3f1>(&mut rng, mode, players)

--- a/cryptography/src/bls12381/certificate/multisig/mod.rs
+++ b/cryptography/src/bls12381/certificate/multisig/mod.rs
@@ -253,8 +253,8 @@ impl<P: PublicKey, V: Variant, N: Namespace> Generic<P, V, N> {
 
         // Produce signers and aggregate signature.
         let (signers, signatures): (Vec<_>, Vec<_>) = entries.into_iter().unzip();
-        let signers = Signers::try_from((self.participants.keys(), signers))?
-            .require(self.participants.quorum::<S::Faults>())?;
+        let quorum = self.participants.quorum_count::<S::Faults>();
+        let signers = Signers::try_from((self.participants.keys(), signers))?.require(quorum)?;
         let signatures = non_empty![@signatures.iter()];
         let signature = aggregate::combine_signatures::<V, _>(signatures);
 
@@ -283,7 +283,8 @@ impl<P: PublicKey, V: Variant, N: Namespace> Generic<P, V, N> {
         }
 
         // If the certificate does not meet the quorum, return false.
-        if certificate.signers.count() < self.participants.quorum::<S::Faults>() as usize {
+        let quorum = self.participants.quorum_count::<S::Faults>() as usize;
+        if certificate.signers.count() < quorum {
             return false;
         }
 
@@ -669,7 +670,7 @@ mod tests {
     use commonware_codec::{Decode, Encode};
     use commonware_math::algebra::{CryptoGroup, Random};
     use commonware_parallel::Sequential;
-    use commonware_utils::{Faults, N3f1, Participant, TryCollect, ordered::BiMap, test_rng};
+    use commonware_utils::{N3f1, Participant, TryCollect, ordered::BiMap, test_rng};
 
     const NAMESPACE: &[u8] = b"test-bls12381-multisig";
     const MESSAGE: &[u8] = b"test message";
@@ -789,7 +790,8 @@ mod tests {
     fn test_verify_attestations_filters_invalid<V: Variant>() {
         let mut rng = test_rng();
         let (schemes, _) = setup_signers::<V>(&mut rng, 5);
-        let quorum = N3f1::quorum(schemes.len() as u32) as usize;
+        let quorum = usize::try_from(schemes[0].participants().quorum_count::<N3f1>())
+            .expect("quorum exceeds usize::MAX");
 
         let attestations: Vec<_> = schemes
             .iter()
@@ -851,7 +853,8 @@ mod tests {
     fn test_assemble_certificate<V: Variant>() {
         let mut rng = test_rng();
         let (schemes, _) = setup_signers::<V>(&mut rng, 4);
-        let quorum = N3f1::quorum(schemes.len() as u32) as usize;
+        let quorum = usize::try_from(schemes[0].participants().quorum_count::<N3f1>())
+            .expect("quorum exceeds usize::MAX");
 
         let attestations: Vec<_> = schemes
             .iter()
@@ -921,7 +924,8 @@ mod tests {
     fn test_verify_certificate<V: Variant>() {
         let mut rng = test_rng();
         let (schemes, verifier) = setup_signers::<V>(&mut rng, 4);
-        let quorum = N3f1::quorum(schemes.len() as u32) as usize;
+        let quorum = usize::try_from(schemes[0].participants().quorum_count::<N3f1>())
+            .expect("quorum exceeds usize::MAX");
 
         let attestations: Vec<_> = schemes
             .iter()
@@ -957,7 +961,8 @@ mod tests {
     fn test_verify_certificate_detects_corruption<V: Variant>() {
         let mut rng = test_rng();
         let (schemes, verifier) = setup_signers::<V>(&mut rng, 4);
-        let quorum = N3f1::quorum(schemes.len() as u32) as usize;
+        let quorum = usize::try_from(schemes[0].participants().quorum_count::<N3f1>())
+            .expect("quorum exceeds usize::MAX");
 
         let attestations: Vec<_> = schemes
             .iter()
@@ -1006,7 +1011,8 @@ mod tests {
     fn test_certificate_codec_roundtrip<V: Variant>() {
         let mut rng = test_rng();
         let (schemes, _) = setup_signers::<V>(&mut rng, 4);
-        let quorum = N3f1::quorum(schemes.len() as u32) as usize;
+        let quorum = usize::try_from(schemes[0].participants().quorum_count::<N3f1>())
+            .expect("quorum exceeds usize::MAX");
 
         let attestations: Vec<_> = schemes
             .iter()
@@ -1037,7 +1043,7 @@ mod tests {
     fn test_certificate_rejects_sub_quorum<V: Variant>() {
         let mut rng = test_rng();
         let (schemes, _) = setup_signers::<V>(&mut rng, 4);
-        let expected = N3f1::quorum(schemes.len());
+        let expected = u64::from(schemes[0].participants().quorum_count::<N3f1>());
         let found = expected - 1;
         let found_count = usize::try_from(found).expect("quorum exceeds usize::MAX");
 
@@ -1067,8 +1073,8 @@ mod tests {
     fn test_certificate_rejects_invalid_signer<V: Variant>() {
         let mut rng = test_rng();
         let (schemes, _) = setup_signers::<V>(&mut rng, 4);
-        let quorum =
-            usize::try_from(N3f1::quorum(schemes.len())).expect("quorum exceeds usize::MAX");
+        let quorum = usize::try_from(schemes[0].participants().quorum_count::<N3f1>())
+            .expect("quorum exceeds usize::MAX");
 
         let mut attestations: Vec<_> = schemes
             .iter()
@@ -1099,8 +1105,8 @@ mod tests {
     fn test_certificate_rejects_malformed_signature<V: Variant>() {
         let mut rng = test_rng();
         let (schemes, _) = setup_signers::<V>(&mut rng, 4);
-        let quorum =
-            usize::try_from(N3f1::quorum(schemes.len())).expect("quorum exceeds usize::MAX");
+        let quorum = usize::try_from(schemes[0].participants().quorum_count::<N3f1>())
+            .expect("quorum exceeds usize::MAX");
 
         let mut attestations: Vec<_> = schemes
             .iter()
@@ -1214,7 +1220,8 @@ mod tests {
     fn test_verify_certificates_batch<V: Variant>() {
         let mut rng = test_rng();
         let (schemes, verifier) = setup_signers::<V>(&mut rng, 4);
-        let quorum = N3f1::quorum(schemes.len() as u32) as usize;
+        let quorum = usize::try_from(schemes[0].participants().quorum_count::<N3f1>())
+            .expect("quorum exceeds usize::MAX");
 
         let messages: Vec<Bytes> = [b"msg1".as_slice(), b"msg2".as_slice(), b"msg3".as_slice()]
             .into_iter()
@@ -1265,7 +1272,8 @@ mod tests {
     fn test_verify_certificates_batch_detects_failure<V: Variant>() {
         let mut rng = test_rng();
         let (schemes, verifier) = setup_signers::<V>(&mut rng, 4);
-        let quorum = N3f1::quorum(schemes.len() as u32) as usize;
+        let quorum = usize::try_from(schemes[0].participants().quorum_count::<N3f1>())
+            .expect("quorum exceeds usize::MAX");
 
         let messages: Vec<Bytes> = [b"msg1".as_slice(), b"msg2".as_slice()]
             .into_iter()

--- a/cryptography/src/bls12381/certificate/threshold/mod.rs
+++ b/cryptography/src/bls12381/certificate/threshold/mod.rs
@@ -107,7 +107,7 @@ impl<P: PublicKey, V: Variant, N: Namespace> Generic<P, V, N> {
         );
         assert_eq!(
             polynomial.required(),
-            participants.quorum::<M>(),
+            participants.quorum_count::<M>(),
             "polynomial threshold must equal quorum"
         );
         #[cfg(feature = "std")]
@@ -154,7 +154,7 @@ impl<P: PublicKey, V: Variant, N: Namespace> Generic<P, V, N> {
         );
         assert_eq!(
             polynomial.required(),
-            participants.quorum::<M>(),
+            participants.quorum_count::<M>(),
             "polynomial threshold must equal quorum"
         );
         #[cfg(feature = "std")]
@@ -773,9 +773,7 @@ mod tests {
     use commonware_codec::{DecodeExt, Encode, types::lazy::Lazy};
     use commonware_math::algebra::{Additive, Random};
     use commonware_parallel::Sequential;
-    use commonware_utils::{
-        Faults, N3f1, N5f1, NZU32, Participant, TryCollect, ordered::Set, test_rng,
-    };
+    use commonware_utils::{N3f1, N5f1, NZU32, Participant, TryCollect, ordered::Set, test_rng};
 
     const NAMESPACE: &[u8] = b"test-bls12381-threshold";
     const MESSAGE: &[u8] = b"test message";
@@ -883,7 +881,8 @@ mod tests {
     fn test_verify_attestations_filters_invalid<V: Variant>() {
         let mut rng = test_rng();
         let (schemes, _, _) = setup_signers::<V>(&mut rng, 5);
-        let quorum = N3f1::quorum(schemes.len() as u32) as usize;
+        let quorum = usize::try_from(schemes[0].participants().quorum_count::<N3f1>())
+            .expect("quorum exceeds usize::MAX");
 
         let attestations: Vec<_> = schemes
             .iter()
@@ -945,7 +944,8 @@ mod tests {
     fn test_assemble_certificate<V: Variant>() {
         let mut rng = test_rng();
         let (schemes, verifier, _) = setup_signers::<V>(&mut rng, 4);
-        let quorum = N3f1::quorum(schemes.len() as u32) as usize;
+        let quorum = usize::try_from(schemes[0].participants().quorum_count::<N3f1>())
+            .expect("quorum exceeds usize::MAX");
 
         let attestations: Vec<_> = schemes
             .iter()
@@ -982,7 +982,8 @@ mod tests {
     fn test_verify_certificate<V: Variant>() {
         let mut rng = test_rng();
         let (schemes, verifier, _) = setup_signers::<V>(&mut rng, 4);
-        let quorum = N3f1::quorum(schemes.len() as u32) as usize;
+        let quorum = usize::try_from(schemes[0].participants().quorum_count::<N3f1>())
+            .expect("quorum exceeds usize::MAX");
 
         let attestations: Vec<_> = schemes
             .iter()
@@ -1018,7 +1019,8 @@ mod tests {
     fn test_verify_certificate_detects_corruption<V: Variant>() {
         let mut rng = test_rng();
         let (schemes, verifier, _) = setup_signers::<V>(&mut rng, 4);
-        let quorum = N3f1::quorum(schemes.len() as u32) as usize;
+        let quorum = usize::try_from(schemes[0].participants().quorum_count::<N3f1>())
+            .expect("quorum exceeds usize::MAX");
 
         let attestations: Vec<_> = schemes
             .iter()
@@ -1066,7 +1068,8 @@ mod tests {
     fn test_certificate_codec_roundtrip<V: Variant>() {
         let mut rng = test_rng();
         let (schemes, _, _) = setup_signers::<V>(&mut rng, 4);
-        let quorum = N3f1::quorum(schemes.len() as u32) as usize;
+        let quorum = usize::try_from(schemes[0].participants().quorum_count::<N3f1>())
+            .expect("quorum exceeds usize::MAX");
 
         let attestations: Vec<_> = schemes
             .iter()
@@ -1096,7 +1099,7 @@ mod tests {
     fn test_certificate_rejects_sub_quorum<V: Variant>() {
         let mut rng = test_rng();
         let (schemes, _, _) = setup_signers::<V>(&mut rng, 4);
-        let expected = N3f1::quorum(schemes.len());
+        let expected = u64::from(schemes[0].participants().quorum_count::<N3f1>());
         let found = expected - 1;
         let found_count = usize::try_from(found).expect("quorum exceeds usize::MAX");
 
@@ -1126,8 +1129,8 @@ mod tests {
     fn test_certificate_rejects_duplicate_signers<V: Variant>() {
         let mut rng = test_rng();
         let (schemes, _, _) = setup_signers::<V>(&mut rng, 4);
-        let quorum =
-            usize::try_from(N3f1::quorum(schemes.len())).expect("quorum exceeds usize::MAX");
+        let quorum = usize::try_from(schemes[0].participants().quorum_count::<N3f1>())
+            .expect("quorum exceeds usize::MAX");
         let mut attestations: Vec<_> = schemes
             .iter()
             .take(quorum)
@@ -1157,8 +1160,8 @@ mod tests {
     fn test_certificate_rejects_unknown_signer<V: Variant>() {
         let mut rng = test_rng();
         let (schemes, _, _) = setup_signers::<V>(&mut rng, 4);
-        let quorum =
-            usize::try_from(N3f1::quorum(schemes.len())).expect("quorum exceeds usize::MAX");
+        let quorum = usize::try_from(schemes[0].participants().quorum_count::<N3f1>())
+            .expect("quorum exceeds usize::MAX");
         let mut attestations: Vec<_> = schemes
             .iter()
             .take(quorum)
@@ -1190,8 +1193,8 @@ mod tests {
     fn test_certificate_rejects_malformed_signature<V: Variant>() {
         let mut rng = test_rng();
         let (schemes, _, _) = setup_signers::<V>(&mut rng, 4);
-        let quorum =
-            usize::try_from(N3f1::quorum(schemes.len())).expect("quorum exceeds usize::MAX");
+        let quorum = usize::try_from(schemes[0].participants().quorum_count::<N3f1>())
+            .expect("quorum exceeds usize::MAX");
         let mut attestations: Vec<_> = schemes
             .iter()
             .take(quorum)
@@ -1222,7 +1225,8 @@ mod tests {
     fn test_verify_certificates_batch<V: Variant>() {
         let mut rng = test_rng();
         let (schemes, verifier, _) = setup_signers::<V>(&mut rng, 4);
-        let quorum = N3f1::quorum(schemes.len() as u32) as usize;
+        let quorum = usize::try_from(schemes[0].participants().quorum_count::<N3f1>())
+            .expect("quorum exceeds usize::MAX");
 
         let messages: [Bytes; 3] = [
             Bytes::from_static(b"msg1"),
@@ -1274,7 +1278,8 @@ mod tests {
     fn test_verify_certificates_batch_detects_failure<V: Variant>() {
         let mut rng = test_rng();
         let (schemes, verifier, _) = setup_signers::<V>(&mut rng, 4);
-        let quorum = N3f1::quorum(schemes.len() as u32) as usize;
+        let quorum = usize::try_from(schemes[0].participants().quorum_count::<N3f1>())
+            .expect("quorum exceeds usize::MAX");
 
         let messages: [Bytes; 2] = [Bytes::from_static(b"msg1"), Bytes::from_static(b"msg2")];
         let mut certificates = Vec::new();
@@ -1325,7 +1330,8 @@ mod tests {
     fn test_certificate_verifier<V: Variant>() {
         let mut rng = test_rng();
         let (schemes, _, polynomial) = setup_signers::<V>(&mut rng, 4);
-        let quorum = N3f1::quorum(schemes.len() as u32) as usize;
+        let quorum = usize::try_from(schemes[0].participants().quorum_count::<N3f1>())
+            .expect("quorum exceeds usize::MAX");
 
         let attestations: Vec<_> = schemes
             .iter()
@@ -1632,7 +1638,8 @@ mod tests {
     fn certificate_decode_rejects_length_mismatch<V: Variant>() {
         let mut rng = test_rng();
         let (schemes, _, _) = setup_signers::<V>(&mut rng, 4);
-        let quorum = N3f1::quorum(schemes.len() as u32) as usize;
+        let quorum = usize::try_from(schemes[0].participants().quorum_count::<N3f1>())
+            .expect("quorum exceeds usize::MAX");
 
         let attestations: Vec<_> = schemes
             .iter()

--- a/cryptography/src/bls12381/dkg/feldman_desmedt.rs
+++ b/cryptography/src/bls12381/dkg/feldman_desmedt.rs
@@ -581,7 +581,7 @@ impl<V: Variant, P: Ord> Output<V, P> {
 
     /// Return the quorum, i.e. the number of players needed to reconstruct the key.
     pub fn quorum<M: Faults>(&self) -> u32 {
-        self.players.quorum::<M>()
+        self.players.quorum_count::<M>()
     }
 
     /// Get the public polynomial associated with this output.
@@ -673,7 +673,10 @@ where
         )
         .map_err(|_| arbitrary::Error::IncorrectFormat)?;
 
-        let max_revealed = N3f1::max_faults(total) as usize;
+        let max_revealed = usize::try_from(N3f1::max_faults(
+            u64::try_from(total).expect("participant count exceeds u64::MAX"),
+        ))
+        .expect("maximum faults exceeds usize::MAX");
         let revealed = Set::from_iter_dedup(
             players
                 .iter()
@@ -761,11 +764,11 @@ impl<V: Variant, P: PublicKey> Info<V, P> {
     }
 
     fn degree<M: Faults>(&self) -> u32 {
-        self.players.quorum::<M>().saturating_sub(1)
+        self.players.quorum_count::<M>().saturating_sub(1)
     }
 
     fn required_commitments<M: Faults>(&self) -> u32 {
-        let dealer_quorum = self.dealers.quorum::<M>();
+        let dealer_quorum = self.dealers.quorum_count::<M>();
         let prev_quorum = self
             .previous
             .as_ref()
@@ -775,17 +778,21 @@ impl<V: Variant, P: PublicKey> Info<V, P> {
     }
 
     fn max_reveals<M: Faults>(&self) -> u32 {
-        self.players.max_faults::<M>()
+        self.players.max_faults_count::<M>()
     }
 
     fn reveal_threshold<M: Faults>(&self) -> u32 {
         #[allow(deprecated)]
         match self.reveal {
-            Reveal::V0 => self.players.max_faults::<M>() + 1,
+            Reveal::V0 => self
+                .players
+                .max_faults_count::<M>()
+                .checked_add(1)
+                .expect("reveal threshold exceeds u32::MAX"),
             Reveal::V1 => {
                 let max_faults = self.previous.as_ref().map_or_else(
-                    || self.dealers.max_faults::<M>(),
-                    |previous| previous.players.max_faults::<M>(),
+                    || self.dealers.max_faults_count::<M>(),
+                    |previous| previous.players.max_faults_count::<M>(),
                 );
                 self.required_commitments::<M>()
                     .checked_sub(max_faults)
@@ -954,7 +961,9 @@ impl<V: Variant, P: PublicKey> Info<V, P> {
             {
                 return Err(Error::DealerNotInRound(format!("{unknown:?}")));
             }
-            if dealers.len() < previous.quorum::<M>() as usize {
+            if dealers.len()
+                < usize::try_from(previous.quorum::<M>()).expect("quorum exceeds usize::MAX")
+            {
                 return Err(Error::NumDealers(dealers.len()));
             }
         }
@@ -2205,8 +2214,8 @@ pub fn deal<V: Variant, P: Clone + Ord, M: Faults>(
     if players.is_empty() {
         return Err(Error::NumPlayers(0));
     }
-    let n = NZU32!(players.len() as u32);
-    let t = players.quorum::<M>();
+    let n = NZU32!(u32::try_from(players.len()).expect("player count exceeds u32::MAX"));
+    let t = players.quorum_count::<M>();
     let private = Poly::new(&mut rng, t - 1);
     let shares: Map<_, _> = players
         .iter()
@@ -2509,8 +2518,12 @@ mod test_plan {
                     }
                 }
                 // Must have >= quorum(prev_players) dealers
-                let required = N3f1::quorum(prev_players.len());
-                if (self.dealers.len() as u32) < required {
+                let required = N3f1::quorum(
+                    u64::try_from(prev_players.len()).expect("participant count exceeds u64::MAX"),
+                );
+                if u64::try_from(self.dealers.len()).expect("dealer count exceeds u64::MAX")
+                    < required
+                {
                     return Err(anyhow!(
                         "not enough dealers: have {}, need {} (quorum of {} previous players)",
                         self.dealers.len(),
@@ -2528,7 +2541,11 @@ mod test_plan {
                 return true;
             }
             if let Some(shift) = self.shift_degrees.get(&dealer) {
-                let degree = N3f1::quorum(self.players.len()) as i32 - 1;
+                let degree = i32::try_from(N3f1::quorum(
+                    u64::try_from(self.players.len()).expect("participant count exceeds u64::MAX"),
+                ))
+                .expect("player quorum exceeds i32::MAX")
+                    - 1;
                 // We shift the degree, but saturate at 0, so it's possible
                 // that the shift isn't actually doing anything.
                 //
@@ -2548,7 +2565,10 @@ mod test_plan {
                 .chain(self.no_acks.iter().copied())
                 .filter_map(|(d, p)| if d == dealer { Some(p) } else { None })
                 .collect::<BTreeSet<_>>();
-            revealed_players.len() as u32 > N3f1::max_faults(self.players.len())
+            u64::try_from(revealed_players.len()).expect("revealed player count exceeds u64::MAX")
+                > N3f1::max_faults(
+                    u64::try_from(self.players.len()).expect("participant count exceeds u64::MAX"),
+                )
         }
 
         /// Determine if this round is expected to fail.
@@ -2559,9 +2579,12 @@ mod test_plan {
                 .filter(|&&d| !self.bad(previous_successful_round.is_some(), d))
                 .count();
             let required = previous_successful_round
-                .map(N3f1::quorum)
+                .map(|count| N3f1::quorum(u64::from(count)))
                 .unwrap_or_default()
-                .max(N3f1::quorum(self.dealers.len())) as usize;
+                .max(N3f1::quorum(
+                    u64::try_from(self.dealers.len()).expect("dealer count exceeds u64::MAX"),
+                ));
+            let required = usize::try_from(required).expect("dealer quorum exceeds usize::MAX");
             good_dealer_count < required
         }
     }
@@ -3216,7 +3239,10 @@ mod test_plan {
             last_successful_players: Option<&Set<u32>>,
         ) -> arbitrary::Result<Round> {
             let dealers = if let Some(players) = last_successful_players {
-                let to_pick = u.int_in_range(players.quorum::<N3f1>() as usize..=players.len())?;
+                let to_pick = u.int_in_range(
+                    usize::try_from(players.quorum_count::<N3f1>())
+                        .expect("quorum exceeds usize::MAX")..=players.len(),
+                )?;
                 pick(u, to_pick, players.into_iter().copied().collect())?
             } else {
                 let to_pick = u.int_in_range(1..=num_participants as usize)?;
@@ -3271,7 +3297,12 @@ mod test_plan {
                     indices
                         .into_iter()
                         .map(|k| {
-                            let expected = N3f1::quorum(players.len()) as i32 - 1;
+                            let expected = i32::try_from(N3f1::quorum(
+                                u64::try_from(players.len())
+                                    .expect("participant count exceeds u64::MAX"),
+                            ))
+                            .expect("quorum exceeds i32::MAX")
+                                - 1;
                             let shift = u.int_in_range(1..=expected.max(1))?;
                             let shift = if bool::arbitrary(u)? { -shift } else { shift };
                             Ok((k, NonZeroI32::new(shift).expect("checked to not be zero")))

--- a/cryptography/src/bls12381/dkg/golden/mod.rs
+++ b/cryptography/src/bls12381/dkg/golden/mod.rs
@@ -367,10 +367,10 @@ impl Info {
                 return Err(Error::NumDealers(dealers.len()));
             }
         }
-        let player_quorum =
-            NonZeroU32::new(players.quorum::<M>()).expect("non-empty players have non-zero quorum");
-        let dealer_quorum =
-            NonZeroU32::new(dealers.quorum::<M>()).expect("non-empty dealers have non-zero quorum");
+        let player_quorum = NonZeroU32::new(players.quorum_count::<M>())
+            .expect("a non-empty player set must have a non-zero quorum");
+        let dealer_quorum = NonZeroU32::new(dealers.quorum_count::<M>())
+            .expect("a non-empty dealer set must have a non-zero quorum");
         let required_commitments = previous
             .as_ref()
             .map(|previous| dealer_quorum.max(previous.quorum()))
@@ -1184,8 +1184,12 @@ mod test_plan {
             let Some(&shift) = self.shift_degrees.get(&dealer) else {
                 return false;
             };
-            let degree = N3f1::quorum(self.num_players).saturating_sub(1);
-            let new_degree = (degree as i32 + shift).max(0) as u32;
+            let degree = u32::try_from(N3f1::quorum(u64::from(self.num_players)).saturating_sub(1))
+                .expect("player quorum must fit in u32");
+            let new_degree = u32::try_from(
+                (i32::try_from(degree).expect("polynomial degree exceeds i32::MAX") + shift).max(0),
+            )
+            .expect("shifted polynomial degree must be non-negative");
             new_degree != degree
         }
 
@@ -1201,15 +1205,15 @@ mod test_plan {
         }
 
         fn expect_failure(&self) -> bool {
-            let required = N3f1::quorum(self.num_dealers);
+            let required = N3f1::quorum(u64::from(self.num_dealers));
             let previous_quorum = if self.reshare {
                 // In reshare, dealers == players from previous round.
-                N3f1::quorum(self.num_dealers)
+                N3f1::quorum(u64::from(self.num_dealers))
             } else {
                 0
             };
             let required = required.max(previous_quorum);
-            self.honest_dealer_count() < required
+            u64::from(self.honest_dealer_count()) < required
         }
 
         fn make_info(

--- a/cryptography/src/bls12381/primitives/sharing.rs
+++ b/cryptography/src/bls12381/primitives/sharing.rs
@@ -599,7 +599,9 @@ mod fuzz {
             let total: u32 = u.int_in_range(1..=100)?;
             let mode: Mode = u.arbitrary()?;
             let seed: u64 = u.arbitrary()?;
-            let poly = Poly::new(TestRng::new(seed), N3f1::quorum(total) - 1);
+            let degree = u32::try_from(N3f1::quorum(u64::from(total)) - 1)
+                .expect("quorum degree must fit in u32");
+            let poly = Poly::new(TestRng::new(seed), degree);
             Ok(Self::new(
                 mode,
                 NZU32!(total),

--- a/cryptography/src/certificate.rs
+++ b/cryptography/src/certificate.rs
@@ -165,7 +165,7 @@ impl<S: Scheme> Verification<S> {
 pub enum AssemblyError {
     /// Structurally valid attestations do not meet the scheme's quorum.
     #[error("insufficient attestations: expected={0}, found={1}")]
-    InsufficientAttestations(u32, u32),
+    InsufficientAttestations(u64, u64),
     /// An attestation references an index outside the participant set.
     #[error("unknown signer: {0}")]
     UnknownSigner(Participant),
@@ -568,7 +568,10 @@ impl Signers {
     pub(crate) fn require(self, required: u32) -> Result<Self, AssemblyError> {
         let found = u32::try_from(self.count()).expect("signer count exceeds u32::MAX");
         if found < required {
-            return Err(AssemblyError::InsufficientAttestations(required, found));
+            return Err(AssemblyError::InsufficientAttestations(
+                u64::from(required),
+                u64::from(found),
+            ));
         }
 
         Ok(self)

--- a/cryptography/src/certificate/mocks.rs
+++ b/cryptography/src/certificate/mocks.rs
@@ -345,7 +345,8 @@ where
 
         let signers =
             Signers::try_from((&self.participants, signers)).map_err(Self::assembly_error)?;
-        let signers = signers.require(self.participants.quorum::<S::Faults>())?;
+        let quorum = self.participants.quorum_count::<S::Faults>();
+        let signers = signers.require(quorum)?;
 
         let subject = signed_subject.expect("non-empty attestations establish a signed subject");
         let stored_subject = subject.clone();

--- a/cryptography/src/ed25519/certificate/mod.rs
+++ b/cryptography/src/ed25519/certificate/mod.rs
@@ -200,8 +200,8 @@ impl<N: Namespace> Generic<N> {
         // Sort the signatures by signer index.
         entries.sort_by_key(|(signer, _)| *signer);
         let (signer, signatures): (Vec<Participant>, Vec<_>) = entries.into_iter().unzip();
-        let signers = Signers::try_from((&self.participants, signer))?
-            .require(self.participants.quorum::<S::Faults>())?;
+        let quorum = self.participants.quorum_count::<S::Faults>();
+        let signers = Signers::try_from((&self.participants, signer))?.require(quorum)?;
         let signatures = signatures.into_iter().map(Lazy::from).collect();
 
         Ok(Certificate {
@@ -235,7 +235,8 @@ impl<N: Namespace> Generic<N> {
         }
 
         // If the certificate does not meet the quorum, return false.
-        if certificate.signers.count() < self.participants.quorum::<S::Faults>() as usize {
+        let quorum = self.participants.quorum_count::<S::Faults>() as usize;
+        if certificate.signers.count() < quorum {
             return false;
         }
 
@@ -615,9 +616,7 @@ mod tests {
     use commonware_codec::{Decode, Encode};
     use commonware_math::algebra::Random;
     use commonware_parallel::Sequential;
-    use commonware_utils::{
-        Faults, N3f1, Participant, TryCollect, non_empty, ordered::Set, test_rng,
-    };
+    use commonware_utils::{N3f1, Participant, TryCollect, non_empty, ordered::Set, test_rng};
 
     const NAMESPACE: &[u8] = b"test-ed25519";
     const MESSAGE: &[u8] = b"test message";
@@ -711,7 +710,8 @@ mod tests {
     fn test_verify_attestations_filters_invalid() {
         let mut rng = test_rng();
         let (schemes, _) = setup_signers(&mut rng, 5);
-        let quorum = N3f1::quorum(schemes.len()) as usize;
+        let quorum = usize::try_from(schemes[0].participants().quorum_count::<N3f1>())
+            .expect("quorum exceeds usize::MAX");
 
         let attestations: Vec<_> = schemes
             .iter()
@@ -769,7 +769,8 @@ mod tests {
     fn test_assemble_certificate() {
         let mut rng = test_rng();
         let (schemes, _) = setup_signers(&mut rng, 4);
-        let quorum = N3f1::quorum(schemes.len()) as usize;
+        let quorum = usize::try_from(schemes[0].participants().quorum_count::<N3f1>())
+            .expect("quorum exceeds usize::MAX");
 
         let attestations: Vec<_> = schemes
             .iter()
@@ -832,7 +833,8 @@ mod tests {
     fn test_verify_certificate() {
         let mut rng = test_rng();
         let (schemes, verifier) = setup_signers(&mut rng, 4);
-        let quorum = N3f1::quorum(schemes.len()) as usize;
+        let quorum = usize::try_from(schemes[0].participants().quorum_count::<N3f1>())
+            .expect("quorum exceeds usize::MAX");
 
         let attestations: Vec<_> = schemes
             .iter()
@@ -863,7 +865,8 @@ mod tests {
     fn test_verify_certificate_detects_corruption() {
         let mut rng = test_rng();
         let (schemes, verifier) = setup_signers(&mut rng, 4);
-        let quorum = N3f1::quorum(schemes.len()) as usize;
+        let quorum = usize::try_from(schemes[0].participants().quorum_count::<N3f1>())
+            .expect("quorum exceeds usize::MAX");
 
         let attestations: Vec<_> = schemes
             .iter()
@@ -907,7 +910,8 @@ mod tests {
     fn test_certificate_codec_roundtrip() {
         let mut rng = test_rng();
         let (schemes, _) = setup_signers(&mut rng, 4);
-        let quorum = N3f1::quorum(schemes.len()) as usize;
+        let quorum = usize::try_from(schemes[0].participants().quorum_count::<N3f1>())
+            .expect("quorum exceeds usize::MAX");
 
         let attestations: Vec<_> = schemes
             .iter()
@@ -932,7 +936,7 @@ mod tests {
     fn test_certificate_rejects_sub_quorum() {
         let mut rng = test_rng();
         let (schemes, _) = setup_signers(&mut rng, 4);
-        let expected = N3f1::quorum(schemes.len());
+        let expected = u64::from(schemes[0].participants().quorum_count::<N3f1>());
         let found = expected - 1;
         let found_count = usize::try_from(found).expect("quorum exceeds usize::MAX");
 
@@ -957,8 +961,8 @@ mod tests {
     fn test_certificate_rejects_invalid_signer() {
         let mut rng = test_rng();
         let (schemes, _) = setup_signers(&mut rng, 4);
-        let quorum =
-            usize::try_from(N3f1::quorum(schemes.len())).expect("quorum exceeds usize::MAX");
+        let quorum = usize::try_from(schemes[0].participants().quorum_count::<N3f1>())
+            .expect("quorum exceeds usize::MAX");
 
         let mut attestations: Vec<_> = schemes
             .iter()
@@ -985,8 +989,8 @@ mod tests {
     fn test_certificate_rejects_malformed_signature() {
         let mut rng = test_rng();
         let (schemes, _) = setup_signers(&mut rng, 4);
-        let quorum =
-            usize::try_from(N3f1::quorum(schemes.len())).expect("quorum exceeds usize::MAX");
+        let quorum = usize::try_from(schemes[0].participants().quorum_count::<N3f1>())
+            .expect("quorum exceeds usize::MAX");
 
         let mut attestations: Vec<_> = schemes
             .iter()
@@ -1083,7 +1087,8 @@ mod tests {
     fn test_verify_certificates_batch() {
         let mut rng = test_rng();
         let (schemes, verifier) = setup_signers(&mut rng, 4);
-        let quorum = N3f1::quorum(schemes.len()) as usize;
+        let quorum = usize::try_from(schemes[0].participants().quorum_count::<N3f1>())
+            .expect("quorum exceeds usize::MAX");
 
         let messages: Vec<Bytes> = [b"msg1".as_slice(), b"msg2".as_slice(), b"msg3".as_slice()]
             .into_iter()
@@ -1129,7 +1134,8 @@ mod tests {
     fn test_verify_certificates_batch_detects_failure() {
         let mut rng = test_rng();
         let (schemes, verifier) = setup_signers(&mut rng, 4);
-        let quorum = N3f1::quorum(schemes.len()) as usize;
+        let quorum = usize::try_from(schemes[0].participants().quorum_count::<N3f1>())
+            .expect("quorum exceeds usize::MAX");
 
         let messages: Vec<Bytes> = [b"msg1".as_slice(), b"msg2".as_slice()]
             .into_iter()

--- a/cryptography/src/secp256r1/certificate/mod.rs
+++ b/cryptography/src/secp256r1/certificate/mod.rs
@@ -194,8 +194,8 @@ impl<P: crate::PublicKey, N: Namespace> Generic<P, N> {
         // Sort the signatures by signer index.
         entries.sort_by_key(|(signer, _)| *signer);
         let (signer, signatures): (Vec<Participant>, Vec<_>) = entries.into_iter().unzip();
-        let signers = Signers::try_from((self.participants.keys(), signer))?
-            .require(self.participants.quorum::<S::Faults>())?;
+        let quorum = self.participants.quorum_count::<S::Faults>();
+        let signers = Signers::try_from((self.participants.keys(), signer))?.require(quorum)?;
         let signatures = signatures.into_iter().map(Lazy::from).collect();
 
         Ok(Certificate {
@@ -228,7 +228,8 @@ impl<P: crate::PublicKey, N: Namespace> Generic<P, N> {
         }
 
         // If the certificate does not meet the quorum, return false.
-        if certificate.signers.count() < self.participants.quorum::<S::Faults>() as usize {
+        let quorum = self.participants.quorum_count::<S::Faults>() as usize;
+        if certificate.signers.count() < quorum {
             return false;
         }
 
@@ -562,7 +563,7 @@ mod tests {
     use commonware_codec::{Decode, Encode};
     use commonware_math::algebra::Random;
     use commonware_parallel::Sequential;
-    use commonware_utils::{Faults, N3f1, TryCollect, non_empty, ordered::BiMap, test_rng};
+    use commonware_utils::{N3f1, TryCollect, non_empty, ordered::BiMap, test_rng};
     use rand_core::CryptoRng;
 
     const NAMESPACE: &[u8] = b"test-secp256r1";
@@ -665,7 +666,8 @@ mod tests {
     fn test_verify_attestations_filters_invalid() {
         let mut rng = test_rng();
         let (schemes, _) = setup_signers(&mut rng, 5);
-        let quorum = N3f1::quorum(schemes.len()) as usize;
+        let quorum = usize::try_from(schemes[0].participants().quorum_count::<N3f1>())
+            .expect("quorum exceeds usize::MAX");
 
         let attestations: Vec<_> = schemes
             .iter()
@@ -724,7 +726,8 @@ mod tests {
     fn test_assemble_certificate() {
         let mut rng = test_rng();
         let (schemes, _) = setup_signers(&mut rng, 4);
-        let quorum = N3f1::quorum(schemes.len()) as usize;
+        let quorum = usize::try_from(schemes[0].participants().quorum_count::<N3f1>())
+            .expect("quorum exceeds usize::MAX");
 
         let attestations: Vec<_> = schemes
             .iter()
@@ -787,7 +790,8 @@ mod tests {
     fn test_verify_certificate() {
         let mut rng = test_rng();
         let (schemes, verifier) = setup_signers(&mut rng, 4);
-        let quorum = N3f1::quorum(schemes.len()) as usize;
+        let quorum = usize::try_from(schemes[0].participants().quorum_count::<N3f1>())
+            .expect("quorum exceeds usize::MAX");
 
         let attestations: Vec<_> = schemes
             .iter()
@@ -818,7 +822,8 @@ mod tests {
     fn test_verify_certificate_detects_corruption() {
         let mut rng = test_rng();
         let (schemes, verifier) = setup_signers(&mut rng, 4);
-        let quorum = N3f1::quorum(schemes.len()) as usize;
+        let quorum = usize::try_from(schemes[0].participants().quorum_count::<N3f1>())
+            .expect("quorum exceeds usize::MAX");
 
         let attestations: Vec<_> = schemes
             .iter()
@@ -862,7 +867,8 @@ mod tests {
     fn test_certificate_codec_roundtrip() {
         let mut rng = test_rng();
         let (schemes, _) = setup_signers(&mut rng, 4);
-        let quorum = N3f1::quorum(schemes.len()) as usize;
+        let quorum = usize::try_from(schemes[0].participants().quorum_count::<N3f1>())
+            .expect("quorum exceeds usize::MAX");
 
         let attestations: Vec<_> = schemes
             .iter()
@@ -887,7 +893,7 @@ mod tests {
     fn test_certificate_rejects_sub_quorum() {
         let mut rng = test_rng();
         let (schemes, _) = setup_signers(&mut rng, 4);
-        let expected = N3f1::quorum(schemes.len());
+        let expected = u64::from(schemes[0].participants().quorum_count::<N3f1>());
         let found = expected - 1;
         let found_count = usize::try_from(found).expect("quorum exceeds usize::MAX");
 
@@ -912,8 +918,8 @@ mod tests {
     fn test_certificate_rejects_invalid_signer() {
         let mut rng = test_rng();
         let (schemes, _) = setup_signers(&mut rng, 4);
-        let quorum =
-            usize::try_from(N3f1::quorum(schemes.len())).expect("quorum exceeds usize::MAX");
+        let quorum = usize::try_from(schemes[0].participants().quorum_count::<N3f1>())
+            .expect("quorum exceeds usize::MAX");
 
         let mut attestations: Vec<_> = schemes
             .iter()
@@ -940,8 +946,8 @@ mod tests {
     fn test_assemble_certificate_rejects_malformed_signature() {
         let mut rng = test_rng();
         let (schemes, _) = setup_signers(&mut rng, 4);
-        let quorum =
-            usize::try_from(N3f1::quorum(schemes.len())).expect("quorum exceeds usize::MAX");
+        let quorum = usize::try_from(schemes[0].participants().quorum_count::<N3f1>())
+            .expect("quorum exceeds usize::MAX");
 
         let mut attestations: Vec<_> = schemes
             .iter()
@@ -1038,7 +1044,8 @@ mod tests {
     fn test_verify_certificates_batch() {
         let mut rng = test_rng();
         let (schemes, verifier) = setup_signers(&mut rng, 4);
-        let quorum = N3f1::quorum(schemes.len()) as usize;
+        let quorum = usize::try_from(schemes[0].participants().quorum_count::<N3f1>())
+            .expect("quorum exceeds usize::MAX");
 
         let messages: Vec<Bytes> = [b"msg1".as_slice(), b"msg2".as_slice(), b"msg3".as_slice()]
             .into_iter()
@@ -1084,7 +1091,8 @@ mod tests {
     fn test_verify_certificates_batch_detects_failure() {
         let mut rng = test_rng();
         let (schemes, verifier) = setup_signers(&mut rng, 4);
-        let quorum = N3f1::quorum(schemes.len()) as usize;
+        let quorum = usize::try_from(schemes[0].participants().quorum_count::<N3f1>())
+            .expect("quorum exceeds usize::MAX");
 
         let messages: Vec<Bytes> = [b"msg1".as_slice(), b"msg2".as_slice()]
             .into_iter()

--- a/examples/reshare/src/setup.rs
+++ b/examples/reshare/src/setup.rs
@@ -158,7 +158,9 @@ fn validate(args: &Setup) -> anyhow::Result<()> {
     if args.committee_size > args.peers {
         anyhow::bail!("committee size exceeds peer count");
     }
-    if u64::from(N3f1::quorum(args.committee_size)) > dealer_log_slots() {
+    if N3f1::quorum(u64::try_from(args.committee_size).expect("committee size exceeds u64::MAX"))
+        > dealer_log_slots()
+    {
         anyhow::bail!("committee quorum exceeds available dealer log slots");
     }
     port(args, args.peers - 1)?;

--- a/glue/src/dkg/reshare/store.rs
+++ b/glue/src/dkg/reshare/store.rs
@@ -571,7 +571,8 @@ pub(crate) enum AckOutcome {
 impl<V: Variant, C: Signer> Dealer<V, C> {
     /// Returns whether the recorded acknowledgements form a quorum.
     pub fn has_acknowledgement_quorum<M: Faults>(&self, players: usize) -> bool {
-        self.unsent.len() <= M::max_faults(players) as usize
+        u64::try_from(self.unsent.len()).expect("unsent count exceeds u64::MAX")
+            <= M::max_faults(u64::try_from(players).expect("player count exceeds u64::MAX"))
     }
 
     /// Records a player ack.

--- a/glue/src/dkg/types.rs
+++ b/glue/src/dkg/types.rs
@@ -200,7 +200,8 @@ impl<P: PublicKey> Participants<P> {
     }
 
     fn required_dealer_logs<V: Variant>(&self, previous: Option<&Output<V, P>>) -> u64 {
-        let dealer_quorum = u64::from(N3f1::quorum(self.dealers.len()));
+        let dealer_quorum =
+            N3f1::quorum(u64::try_from(self.dealers.len()).expect("dealer count exceeds u64::MAX"));
         let previous_quorum = previous
             .map(|previous| u64::from(previous.quorum::<N3f1>()))
             .unwrap_or_default();

--- a/glue/src/stateful/probe/sample.rs
+++ b/glue/src/stateful/probe/sample.rs
@@ -123,7 +123,11 @@ where
                     (floor, replies + 1)
                 });
         let floor = floor?;
-        if replies < N3f1::max_faults(committee_size) as usize + 1 {
+        if u64::try_from(replies).expect("reply count exceeds u64::MAX")
+            < N3f1::max_faults(
+                u64::try_from(committee_size).expect("committee size exceeds u64::MAX"),
+            ) + 1
+        {
             return None;
         }
 

--- a/math/benches/interpolation.rs
+++ b/math/benches/interpolation.rs
@@ -4,8 +4,9 @@ use core::num::NonZeroU32;
 use criterion::{Criterion, criterion_group, criterion_main};
 
 fn bench_interpolator_creation(c: &mut Criterion) {
-    for &n in &[4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096] {
-        let t = N3f1::quorum(n);
+    for &n in &[4u32, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096] {
+        let t = u32::try_from(N3f1::quorum(u64::from(n)))
+            .expect("quorum for a u32 participant count must fit in u32");
         let total = NonZeroU32::new(n).unwrap();
         let points = BiMap::try_from_iter((0..t).map(|i| (i, i + 1)))
             .expect("points should be in bijection");

--- a/utils/fuzz/fuzz_targets/lib_functions.rs
+++ b/utils/fuzz/fuzz_targets/lib_functions.rs
@@ -104,6 +104,7 @@ fn fuzz(input: FuzzInput) {
             if n == 0 {
                 return;
             }
+            let n = u64::from(n);
             let faults = N3f1::max_faults(n);
             assert_eq!(faults, (n.saturating_sub(1)) / 3);
 
@@ -115,6 +116,7 @@ fn fuzz(input: FuzzInput) {
             if n == 0 {
                 return;
             }
+            let n = u64::from(n);
             let q = N3f1::quorum(n);
             let faults = N3f1::max_faults(n);
 

--- a/utils/src/faults.rs
+++ b/utils/src/faults.rs
@@ -22,13 +22,11 @@
 //! assert_eq!(N5f1::max_faults(n), 1);  // f = (n-1)/5 = 1
 //! assert_eq!(N5f1::quorum(n), 9);       // q = n - f = 9
 //!
-//! // Works with any integer type
-//! let n_i32: i32 = 10;
-//! assert_eq!(N3f1::max_faults(n_i32), 3);
-//! assert_eq!(N3f1::quorum(n_i32), 7);
+//! // Weighted committees pass total weight.
+//! let weight = 10u64;
+//! assert_eq!(N3f1::max_faults(weight), 3);
+//! assert_eq!(N3f1::quorum(weight), 7);
 //! ```
-
-use num_traits::ToPrimitive;
 
 /// A Byzantine fault tolerance model that defines quorum calculations.
 ///
@@ -36,32 +34,28 @@ use num_traits::ToPrimitive;
 /// This trait abstracts over those requirements, allowing protocols to be
 /// parameterized by their fault model.
 ///
-/// All methods accept any integer type that implements [`ToPrimitive`], allowing
-/// callers to use `u32`, `u64`, `i32`, `usize`, etc. without explicit conversion.
-/// Output is always `u32`.
+/// All methods accept and return `u64`. Callers pass either a participant count
+/// or a total committee weight, depending on the collection being evaluated.
 pub trait Faults {
-    /// Compute the maximum number of faults that can be tolerated for `n` participants.
+    /// Compute the maximum number of faulty units tolerated for `n` total units.
     ///
     /// This is the maximum integer `f` such that the protocol's safety and liveness
-    /// properties hold when up to `f` participants are Byzantine.
+    /// properties hold when up to `f` units are Byzantine.
     ///
     /// # Panics
     ///
-    /// Panics if `n` is zero, negative, or exceeds `u32::MAX`.
-    fn max_faults(n: impl ToPrimitive) -> u32;
+    /// Panics if `n` is zero.
+    fn max_faults(n: u64) -> u64;
 
-    /// Compute the quorum size for `n` participants.
+    /// Compute the quorum for `n` total units.
     ///
-    /// This is the minimum number of participants that must agree for the protocol
-    /// to make progress. It equals `n - max_faults(n)`.
+    /// This is the minimum number of units that must agree for the protocol to make
+    /// progress. It equals `n - max_faults(n)`.
     ///
     /// # Panics
     ///
-    /// Panics if `n` is zero, negative, or exceeds `u32::MAX`.
-    fn quorum(n: impl ToPrimitive) -> u32 {
-        let n = n
-            .to_u32()
-            .expect("n must be a non-negative integer that fits in u32");
+    /// Panics if `n` is zero.
+    fn quorum(n: u64) -> u64 {
         assert!(n > 0, "n must not be zero");
         n - Self::max_faults(n)
     }
@@ -86,10 +80,7 @@ pub trait Faults {
 pub struct N3f1;
 
 impl Faults for N3f1 {
-    fn max_faults(n: impl ToPrimitive) -> u32 {
-        let n = n
-            .to_u32()
-            .expect("n must be a non-negative integer that fits in u32");
+    fn max_faults(n: u64) -> u64 {
         assert!(n > 0, "n must not be zero");
         (n - 1) / 3
     }
@@ -114,10 +105,7 @@ impl Faults for N3f1 {
 pub struct N5f1;
 
 impl Faults for N5f1 {
-    fn max_faults(n: impl ToPrimitive) -> u32 {
-        let n = n
-            .to_u32()
-            .expect("n must be a non-negative integer that fits in u32");
+    fn max_faults(n: u64) -> u64 {
         assert!(n > 0, "n must not be zero");
         (n - 1) / 5
     }
@@ -128,11 +116,8 @@ impl N5f1 {
     ///
     /// # Panics
     ///
-    /// Panics if `n` is zero, negative, or exceeds `u32::MAX`.
-    pub fn m_quorum(n: impl ToPrimitive) -> u32 {
-        let n = n
-            .to_u32()
-            .expect("n must be a non-negative integer that fits in u32");
+    /// Panics if `n` is zero.
+    pub fn m_quorum(n: u64) -> u64 {
         assert!(n > 0, "n must not be zero");
         2 * Self::max_faults(n) + 1
     }
@@ -143,8 +128,8 @@ impl N5f1 {
     ///
     /// # Panics
     ///
-    /// Panics if `n` is zero, negative, or exceeds `u32::MAX`.
-    pub fn l_quorum(n: impl ToPrimitive) -> u32 {
+    /// Panics if `n` is zero.
+    pub fn l_quorum(n: u64) -> u64 {
         Self::quorum(n)
     }
 }
@@ -189,10 +174,12 @@ mod tests {
     #[case(19, 6, 13)]
     #[case(20, 6, 14)]
     #[case(21, 6, 15)]
+    // above u32::MAX
+    #[case(4_294_967_297, 1_431_655_765, 2_863_311_532)]
     fn test_bft3f1_quorum_and_max_faults(
-        #[case] n: u32,
-        #[case] expected_f: u32,
-        #[case] expected_q: u32,
+        #[case] n: u64,
+        #[case] expected_f: u64,
+        #[case] expected_q: u64,
     ) {
         assert_eq!(N3f1::max_faults(n), expected_f);
         assert_eq!(N3f1::quorum(n), expected_q);
@@ -251,11 +238,13 @@ mod tests {
     #[case(20, 3, 17, 7)]
     // n=21: f=4
     #[case(21, 4, 17, 9)]
+    // above u32::MAX
+    #[case(4_294_967_297, 858_993_459, 3_435_973_838, 1_717_986_919)]
     fn test_bft5f1_quorums(
-        #[case] n: u32,
-        #[case] expected_f: u32,
-        #[case] expected_l_quorum: u32,
-        #[case] expected_m_quorum: u32,
+        #[case] n: u64,
+        #[case] expected_f: u64,
+        #[case] expected_l_quorum: u64,
+        #[case] expected_m_quorum: u64,
     ) {
         assert_eq!(N5f1::max_faults(n), expected_f);
         assert_eq!(N5f1::quorum(n), expected_l_quorum);
@@ -267,54 +256,6 @@ mod tests {
         assert_eq!(expected_m_quorum, 2 * expected_f + 1); // m = 2f + 1
     }
 
-    #[test]
-    fn test_generic_integer_types() {
-        // Test with various integer types
-        assert_eq!(N3f1::max_faults(10u8), 3);
-        assert_eq!(N3f1::max_faults(10u16), 3);
-        assert_eq!(N3f1::max_faults(10u32), 3);
-        assert_eq!(N3f1::max_faults(10u64), 3);
-        assert_eq!(N3f1::max_faults(10usize), 3);
-        assert_eq!(N3f1::max_faults(10i32), 3);
-        assert_eq!(N3f1::max_faults(10i64), 3);
-
-        assert_eq!(N3f1::quorum(10u8), 7);
-        assert_eq!(N3f1::quorum(10u16), 7);
-        assert_eq!(N3f1::quorum(10u64), 7);
-        assert_eq!(N3f1::quorum(10usize), 7);
-        assert_eq!(N3f1::quorum(10i32), 7);
-        assert_eq!(N3f1::quorum(10i64), 7);
-
-        assert_eq!(N5f1::max_faults(10u64), 1);
-        assert_eq!(N5f1::quorum(10usize), 9);
-        assert_eq!(N5f1::m_quorum(10i32), 3);
-        assert_eq!(N5f1::l_quorum(10i64), 9);
-    }
-
-    #[test]
-    #[should_panic(expected = "n must be a non-negative integer that fits in u32")]
-    fn test_max_faults_negative_panics() {
-        N3f1::max_faults(-1i32);
-    }
-
-    #[test]
-    #[should_panic(expected = "n must be a non-negative integer that fits in u32")]
-    fn test_max_faults_overflow_panics() {
-        N3f1::max_faults(u64::MAX);
-    }
-
-    #[test]
-    #[should_panic(expected = "n must be a non-negative integer that fits in u32")]
-    fn test_quorum_negative_panics() {
-        N3f1::quorum(-1i32);
-    }
-
-    #[test]
-    #[should_panic(expected = "n must be a non-negative integer that fits in u32")]
-    fn test_quorum_overflow_panics() {
-        N3f1::quorum(u64::MAX);
-    }
-
     proptest! {
         /// N5f1 quorum relationships must hold for all valid participant counts.
         ///
@@ -322,7 +263,7 @@ mod tests {
         /// - M-quorum (2f+1) < L-quorum (n-f)
         /// - Both quorums must be achievable (<= n)
         #[test]
-        fn test_n5f1_quorum_relationships(n in 6u32..10_000) {
+        fn test_n5f1_quorum_relationships(n in 6u64..10_000) {
             let m = N5f1::m_quorum(n);
             let l = N5f1::l_quorum(n);
 
@@ -345,7 +286,7 @@ mod tests {
         /// This ensures that any two quorums share at least one honest participant,
         /// which is fundamental for BFT consensus safety.
         #[test]
-        fn test_bft_model_safety_property(n in 1u32..10_000) {
+        fn test_bft_model_safety_property(n in 1u64..10_000) {
             // N3f1 safety
             let f_3f1 = N3f1::max_faults(n);
             let q_3f1 = N3f1::quorum(n);

--- a/utils/src/ordered.rs
+++ b/utils/src/ordered.rs
@@ -22,6 +22,10 @@ type VecIntoIter<T> = std::vec::IntoIter<T>;
 /// Errors that can occur when interacting with ordered collections.
 #[derive(Error, Debug, PartialEq, Eq)]
 pub enum Error {
+    /// A committee was empty.
+    #[error("committee must not be empty")]
+    EmptyCommittee,
+
     /// A key was duplicated.
     #[error("duplicate key")]
     DuplicateKey,
@@ -29,6 +33,26 @@ pub enum Error {
     /// A value was duplicated.
     #[error("duplicate value")]
     DuplicateValue,
+
+    /// A committee has more participants than can be indexed.
+    #[error("too many participants")]
+    TooManyParticipants,
+
+    /// A committee member has zero weight.
+    #[error("weight must not be zero")]
+    ZeroWeight,
+
+    /// The total committee weight overflowed `u64`.
+    #[error("total weight overflow")]
+    WeightOverflow,
+
+    /// A participant index was not greater than the previous index.
+    #[error("participant indices must be strictly increasing: {0}")]
+    NonIncreasingParticipant(Participant),
+
+    /// A participant index was not in the committee.
+    #[error("unknown participant: {0}")]
+    UnknownParticipant(Participant),
 }
 
 use crate::{Faults, Participant, TryFromIterator};
@@ -230,6 +254,176 @@ impl<T> From<Set<T>> for Vec<T> {
     }
 }
 
+/// An ordered participant set with a positive weight for each participant.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Committee<P> {
+    members: Map<P, u64>,
+    total_weight: u64,
+}
+
+impl<P: Ord> Committee<P> {
+    /// Returns the weight at `participant`, if it belongs to the committee.
+    pub fn weight(&self, participant: Participant) -> Option<u64> {
+        self.members.value(usize::from(participant)).copied()
+    }
+
+    /// Returns all weights in participant-key order.
+    pub fn weights(&self) -> &[u64] {
+        self.members.values()
+    }
+
+    /// Returns the total committee weight.
+    pub const fn total_weight(&self) -> u64 {
+        self.total_weight
+    }
+
+    /// Returns the participant key at the given index.
+    pub fn key(&self, index: Participant) -> Option<&P> {
+        self.members.get(usize::from(index))
+    }
+
+    /// Returns the index for the given participant key, if present.
+    pub fn index(&self, key: &P) -> Option<Participant> {
+        self.members.position(key).map(Participant::from_usize)
+    }
+
+    /// Returns the quorum weight for the selected fault model.
+    pub fn quorum_weight<M: Faults>(&self) -> u64 {
+        M::quorum(self.total_weight)
+    }
+
+    /// Returns the maximum faulty weight tolerated by the selected fault model.
+    pub fn max_fault_weight<M: Faults>(&self) -> u64 {
+        M::max_faults(self.total_weight)
+    }
+
+    /// Sums the weights of strictly increasing participant indices.
+    ///
+    /// Returns an error if the indices are not strictly increasing or an index
+    /// does not belong to the committee.
+    pub fn sum_ordered_weights<I>(&self, participants: I) -> Result<u64, Error>
+    where
+        I: IntoIterator<Item = Participant>,
+    {
+        let mut previous = None;
+        let mut sum = 0u64;
+        for participant in participants {
+            if previous.is_some_and(|previous| participant <= previous) {
+                return Err(Error::NonIncreasingParticipant(participant));
+            }
+            let weight = self
+                .weight(participant)
+                .ok_or(Error::UnknownParticipant(participant))?;
+            previous = Some(participant);
+            sum = sum
+                .checked_add(weight)
+                .expect("ordered committee weights cannot exceed total weight");
+        }
+        Ok(sum)
+    }
+
+    /// Returns quorum diagnostics for the selected fault model.
+    pub fn profile<M: Faults>(&self) -> Profile {
+        let max_faults = self.max_fault_weight::<M>();
+        let quorum = self.quorum_weight::<M>();
+        let mut weights = self.weights().to_vec();
+        weights.sort_unstable_by(|left, right| right.cmp(left));
+        let max_weight = weights[0];
+        let mut accumulated = 0u64;
+        let mut minimum_quorum_cardinality = 0u32;
+        for weight in weights {
+            accumulated = accumulated
+                .checked_add(weight)
+                .expect("committee weights cannot exceed total weight");
+            minimum_quorum_cardinality += 1;
+            if accumulated >= quorum {
+                break;
+            }
+        }
+        assert!(
+            accumulated >= quorum,
+            "the full committee must reach quorum"
+        );
+
+        Profile {
+            total_weight: self.total_weight,
+            max_fault_weight: max_faults,
+            quorum_weight: quorum,
+            max_weight,
+            minimum_quorum_cardinality,
+        }
+    }
+}
+
+impl<P: Ord> TryFromIterator<(P, u64)> for Committee<P> {
+    type Error = Error;
+
+    fn try_from_iter<I: IntoIterator<Item = (P, u64)>>(iter: I) -> Result<Self, Self::Error> {
+        let members = Map::try_from_iter(iter)?;
+        if members.is_empty() {
+            return Err(Error::EmptyCommittee);
+        }
+        u32::try_from(members.len()).map_err(|_| Error::TooManyParticipants)?;
+        let mut total_weight = 0u64;
+        for &weight in members.values() {
+            if weight == 0 {
+                return Err(Error::ZeroWeight);
+            }
+            total_weight = total_weight
+                .checked_add(weight)
+                .ok_or(Error::WeightOverflow)?;
+        }
+
+        Ok(Self {
+            members,
+            total_weight,
+        })
+    }
+}
+
+impl<P: Ord> TryFrom<Vec<(P, u64)>> for Committee<P> {
+    type Error = Error;
+
+    fn try_from(participants: Vec<(P, u64)>) -> Result<Self, Self::Error> {
+        Self::try_from_iter(participants)
+    }
+}
+
+impl<P> Deref for Committee<P> {
+    type Target = Set<P>;
+
+    fn deref(&self) -> &Self::Target {
+        self.members.as_ref()
+    }
+}
+
+/// Derived quorum diagnostics for a [`Committee`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Profile {
+    /// The sum of all participant weights.
+    pub total_weight: u64,
+    /// The maximum faulty weight tolerated by the selected fault model.
+    pub max_fault_weight: u64,
+    /// The quorum weight for the selected fault model.
+    pub quorum_weight: u64,
+    /// The greatest weight assigned to one participant.
+    pub max_weight: u64,
+    /// The fewest participants whose combined weight can reach quorum.
+    pub minimum_quorum_cardinality: u32,
+}
+
+impl Profile {
+    /// Returns whether one participant's weight exceeds the tolerated faulty weight.
+    pub const fn max_weight_exceeds_max_fault_weight(&self) -> bool {
+        self.max_weight > self.max_fault_weight
+    }
+
+    /// Returns whether one participant can form a quorum alone.
+    pub const fn max_weight_reaches_quorum(&self) -> bool {
+        self.max_weight >= self.quorum_weight
+    }
+}
+
 #[cfg(feature = "arbitrary")]
 impl<T> arbitrary::Arbitrary<'_> for Set<T>
 where
@@ -241,24 +435,24 @@ where
     }
 }
 
-/// Extension trait for [`Set`] participant sets providing quorum and index utilities.
+/// Extension trait for ordered participant sets providing count-based quorum and index utilities.
 pub trait Quorum {
     /// The type of items in this set.
     type Item: Ord;
 
-    /// Returns the quorum value for this participant set using the given fault model.
+    /// Returns the quorum count for this participant set using the given fault model.
     ///
     /// ## Panics
     ///
     /// Panics if the number of participants exceeds `u32::MAX`.
-    fn quorum<M: Faults>(&self) -> u32;
+    fn quorum_count<M: Faults>(&self) -> u32;
 
-    /// Returns the maximum number of faults tolerated by this participant set.
+    /// Returns the maximum number of faulty participants tolerated by this set.
     ///
     /// ## Panics
     ///
     /// Panics if the number of participants exceeds `u32::MAX`.
-    fn max_faults<M: Faults>(&self) -> u32;
+    fn max_faults_count<M: Faults>(&self) -> u32;
 
     /// Returns the participant key at the given index.
     fn key(&self, index: Participant) -> Option<&Self::Item>;
@@ -274,12 +468,16 @@ pub trait Quorum {
 impl<T: Ord> Quorum for Set<T> {
     type Item = T;
 
-    fn quorum<M: Faults>(&self) -> u32 {
-        M::quorum(u32::try_from(self.len()).expect("too many participants"))
+    fn quorum_count<M: Faults>(&self) -> u32 {
+        let count = u32::try_from(self.len()).expect("too many participants");
+        u32::try_from(M::quorum(u64::from(count)))
+            .expect("quorum count cannot exceed participant count")
     }
 
-    fn max_faults<M: Faults>(&self) -> u32 {
-        M::max_faults(self.len())
+    fn max_faults_count<M: Faults>(&self) -> u32 {
+        let count = u32::try_from(self.len()).expect("too many participants");
+        u32::try_from(M::max_faults(u64::from(count)))
+            .expect("fault count cannot exceed participant count")
     }
 
     fn key(&self, index: Participant) -> Option<&Self::Item> {
@@ -876,6 +1074,147 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::N3f1;
+    use proptest::prelude::*;
+
+    #[test]
+    fn test_committee_constructor_failures() {
+        assert_eq!(
+            Committee::<u8>::try_from_iter([]),
+            Err(Error::EmptyCommittee)
+        );
+        assert_eq!(
+            Committee::try_from_iter([(1u8, 1), (1, 2)]),
+            Err(Error::DuplicateKey)
+        );
+        assert_eq!(Committee::try_from_iter([(1u8, 0)]), Err(Error::ZeroWeight));
+        assert_eq!(
+            Committee::try_from_iter([(1u8, u64::MAX), (2, 1)]),
+            Err(Error::WeightOverflow)
+        );
+    }
+
+    #[test]
+    fn test_committee_alignment_lookups_and_sum() {
+        let committee = Committee::try_from_iter([('c', 7), ('a', 2), ('b', 5)]).unwrap();
+        assert_eq!(
+            committee.iter().copied().collect::<Vec<_>>(),
+            ['a', 'b', 'c']
+        );
+        assert_eq!(committee.weights(), &[2, 5, 7]);
+        assert_eq!(committee.total_weight(), 14);
+        assert_eq!(committee.weight(Participant::new(1)), Some(5));
+        assert_eq!(committee.weight(Participant::new(3)), None);
+        assert_eq!(committee.key(Participant::new(2)), Some(&'c'));
+        assert_eq!(committee.index(&'b'), Some(Participant::new(1)));
+        assert_eq!(
+            committee.sum_ordered_weights([Participant::new(0), Participant::new(2)]),
+            Ok(9)
+        );
+        assert_eq!(committee.sum_ordered_weights([]), Ok(0));
+        assert_eq!(
+            committee.sum_ordered_weights([Participant::new(1), Participant::new(1)]),
+            Err(Error::NonIncreasingParticipant(Participant::new(1)))
+        );
+        assert_eq!(
+            committee.sum_ordered_weights([Participant::new(2), Participant::new(1)]),
+            Err(Error::NonIncreasingParticipant(Participant::new(1)))
+        );
+        assert_eq!(
+            committee.sum_ordered_weights([Participant::new(3)]),
+            Err(Error::UnknownParticipant(Participant::new(3)))
+        );
+
+        let profile = committee.profile::<N3f1>();
+        assert_eq!(profile.total_weight, 14);
+        assert_eq!(profile.max_fault_weight, 4);
+        assert_eq!(profile.quorum_weight, 10);
+        assert_eq!(profile.max_weight, 7);
+        assert_eq!(profile.minimum_quorum_cardinality, 2);
+    }
+
+    #[test]
+    fn test_uniform_committee_matches_set_quorums() {
+        for count in 1u32..=100 {
+            let keys: Vec<_> = (0..count).collect();
+            let set = Set::try_from(keys.clone()).unwrap();
+            let committee = Committee::try_from_iter(keys.into_iter().map(|key| (key, 1))).unwrap();
+            assert_eq!(
+                committee.quorum_weight::<N3f1>(),
+                u64::from(set.quorum_count::<N3f1>())
+            );
+            assert_eq!(
+                committee.max_fault_weight::<N3f1>(),
+                u64::from(set.max_faults_count::<N3f1>())
+            );
+            assert_eq!(
+                committee.profile::<N3f1>().minimum_quorum_cardinality,
+                set.quorum_count::<N3f1>()
+            );
+        }
+    }
+
+    #[test]
+    fn test_count_and_weight_quorums_are_explicit() {
+        let committee =
+            Committee::try_from_iter([('a', 100), ('b', 1), ('c', 1), ('d', 1)]).unwrap();
+        assert_eq!(committee.quorum_count::<N3f1>(), 3);
+        assert_eq!(committee.quorum_weight::<N3f1>(), 69);
+    }
+
+    #[test]
+    fn test_profile_warning_boundaries() {
+        let at_max_faults = Committee::try_from_iter([(0u8, 2), (1, 2), (2, 2), (3, 1)]).unwrap();
+        let above_max_faults =
+            Committee::try_from_iter([(0u8, 3), (1, 2), (2, 1), (3, 1)]).unwrap();
+        assert!(
+            !at_max_faults
+                .profile::<N3f1>()
+                .max_weight_exceeds_max_fault_weight()
+        );
+        assert!(
+            above_max_faults
+                .profile::<N3f1>()
+                .max_weight_exceeds_max_fault_weight()
+        );
+
+        let below_quorum = Committee::try_from_iter([(0u8, 2), (1, 2)]).unwrap();
+        let at_quorum = Committee::try_from_iter([(0u8, 3), (1, 1)]).unwrap();
+        assert!(!below_quorum.profile::<N3f1>().max_weight_reaches_quorum());
+        assert!(at_quorum.profile::<N3f1>().max_weight_reaches_quorum());
+    }
+
+    proptest! {
+        #[test]
+        fn test_committee_quorum_matches_brute_force(weights in prop::collection::vec(1u64..20, 1..9)) {
+            let committee = Committee::try_from_iter(weights.iter().copied().enumerate()).unwrap();
+            let quorum = committee.quorum_weight::<N3f1>();
+            let subset_count = 1u16 << weights.len();
+            let mut minimum_cardinality = u32::MAX;
+
+            for mask in 0..subset_count {
+                let participants = (0..weights.len())
+                    .filter(|index| mask & (1u16 << index) != 0)
+                    .map(|index| Participant::new(u32::try_from(index).unwrap()));
+                let sum = committee.sum_ordered_weights(participants).unwrap();
+                let expected_sum = weights
+                    .iter()
+                    .enumerate()
+                    .filter(|(index, _)| mask & (1u16 << index) != 0)
+                    .map(|(_, weight)| weight)
+                    .sum::<u64>();
+                prop_assert_eq!(sum, expected_sum);
+                if sum >= quorum {
+                    minimum_cardinality = minimum_cardinality.min(mask.count_ones());
+                }
+            }
+
+            prop_assert_eq!(
+                committee.profile::<N3f1>().minimum_quorum_cardinality,
+                minimum_cardinality
+            );
+        }
+    }
 
     #[test]
     fn test_sorted_unique_construct_unseal() {


### PR DESCRIPTION
Part of #443.

## Summary

- add an ordered `Committee` with positive `u64` weights and checked total weight
- reject empty committees, duplicate keys, zero weights, excess participants, and total-weight overflow
- provide distinct count and weight quorum accessors
- sum ordered participant weights without allocation
- derive committee concentration profiles
- use `u64` fault arithmetic
- test unit-weight equivalence, concentration warning boundaries, and quorum cardinality against a subset oracle

## Scope

Protocol consumers remain count-based in this PR.

Include these public API changes in the next release notes.
