### PR TITLE
[storage] Remove dead errors

### DIFF
--- a/storage/src/archive/mod.rs
+++ b/storage/src/archive/mod.rs
@@ -37,8 +37,6 @@ pub enum Error {
     Freezer(#[from] crate::freezer::Error),
     #[error("record corrupted")]
     RecordCorrupted,
-    #[error("record too large")]
-    RecordTooLarge,
 }
 
 // Preserve the archive's error classification for journal-owned metadata operations.

--- a/storage/src/cache/conformance.rs
+++ b/storage/src/cache/conformance.rs
@@ -1,6 +1,9 @@
 //! Cache storage conformance tests.
 
-use crate::cache::{Cache, Config, Error};
+use crate::{
+    cache::{Cache, Config},
+    journal::Error,
+};
 use commonware_codec::RangeCfg;
 use commonware_conformance::conformance_tests;
 use commonware_runtime::{

--- a/storage/src/cache/mod.rs
+++ b/storage/src/cache/mod.rs
@@ -79,23 +79,11 @@
 
 use commonware_runtime::buffer::paged::CacheRef;
 use std::num::{NonZeroU64, NonZeroUsize};
-use thiserror::Error;
 
 #[cfg(all(test, feature = "arbitrary"))]
 mod conformance;
 mod storage;
 pub use storage::Cache;
-
-/// Errors that can occur when interacting with the cache.
-#[derive(Debug, Error)]
-pub enum Error {
-    #[error("journal error: {0}")]
-    Journal(#[from] crate::journal::Error),
-    #[error("record corrupted")]
-    RecordCorrupted,
-    #[error("record too large")]
-    RecordTooLarge,
-}
 
 /// Configuration for [Cache] storage.
 #[derive(Clone)]
@@ -180,10 +168,7 @@ mod tests {
                 page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
             };
             let result = Cache::<_, i32>::init(context.child("second"), cfg.clone()).await;
-            assert!(matches!(
-                result,
-                Err(Error::Journal(JournalError::Codec(_)))
-            ));
+            assert!(matches!(result, Err(JournalError::Codec(_))));
         });
     }
 

--- a/storage/src/cache/storage.rs
+++ b/storage/src/cache/storage.rs
@@ -1,6 +1,9 @@
-use super::{Config, Error};
+use super::Config;
 use crate::{
-    journal::segmented::variable::{Config as JConfig, Journal},
+    journal::{
+        Error,
+        segmented::variable::{Config as JConfig, Journal},
+    },
     rmap::RMap,
 };
 use commonware_codec::{CodecShared, EncodeSize, Read, ReadExt, Write, varint::UInt};
@@ -196,7 +199,7 @@ impl<E: Storage + Metrics, V: CodecShared> Inner<E, V> {
         debug!(min, "pruning cache");
 
         // Prune journal
-        (self.journal, _) = self.journal.prune(min).await.map_err(Error::Journal)?;
+        (self.journal, _) = self.journal.prune(min).await?;
 
         // Remove pending writes (no need to call `sync` as we are pruning)
         loop {
@@ -272,7 +275,7 @@ impl<E: Storage + Metrics, V: CodecShared> Inner<E, V> {
 
     /// See [Cache::destroy].
     async fn destroy(self) -> Result<(), Error> {
-        self.journal.destroy().await.map_err(Error::Journal)
+        self.journal.destroy().await
     }
 }
 

--- a/storage/src/journal/mod.rs
+++ b/storage/src/journal/mod.rs
@@ -37,8 +37,6 @@ pub enum Error {
     AlreadyPrunedToSection(u64),
     #[error("section out of range: {0}")]
     SectionOutOfRange(u64),
-    #[error("usize too small")]
-    UsizeTooSmall,
     #[error("offset overflow")]
     OffsetOverflow,
     #[error("replay interrupted during repair")]
@@ -47,8 +45,6 @@ pub enum Error {
     ReplayFailed,
     #[error("size overflow")]
     SizeOverflow,
-    #[error("missing blob: {0}")]
-    MissingBlob(u64),
     #[error("item out of range: {0}")]
     ItemOutOfRange(u64),
     #[error("item pruned: {0}")]

--- a/storage/src/merkle/mod.rs
+++ b/storage/src/merkle/mod.rs
@@ -388,10 +388,6 @@ pub enum Error<F: Family> {
     #[error("root mismatch")]
     RootMismatch,
 
-    /// A required digest is missing.
-    #[error("missing digest: {0}")]
-    MissingDigest(Position<F>),
-
     /// A metadata error occurred.
     #[cfg(feature = "std")]
     #[error("metadata error: {0}")]
@@ -401,11 +397,6 @@ pub enum Error<F: Family> {
     #[cfg(feature = "std")]
     #[error("journal error: {0}")]
     Journal(#[from] crate::journal::Error),
-
-    /// A runtime error occurred.
-    #[cfg(feature = "std")]
-    #[error("runtime error: {0}")]
-    Runtime(#[from] commonware_runtime::Error),
 
     /// A required node is missing.
     #[error("missing node: {0}")]

--- a/storage/src/ordinal/mod.rs
+++ b/storage/src/ordinal/mod.rs
@@ -112,8 +112,6 @@ use thiserror::Error;
 pub enum Error {
     #[error("runtime error: {0}")]
     Runtime(#[from] commonware_runtime::Error),
-    #[error("codec error: {0}")]
-    Codec(#[from] commonware_codec::Error),
     #[error("invalid blob name: {0}")]
     InvalidBlobName(String),
     #[error("invalid record: {0}")]


### PR DESCRIPTION
Eight error variants are never constructed:

- `journal::Error::{UsizeTooSmall, MissingBlob}`
- `cache::Error::{RecordCorrupted, RecordTooLarge}`
- `archive::Error::RecordTooLarge`
- `merkle::Error::{MissingDigest, Runtime}`
- `ordinal::Error::Codec`

Deleting cache's two variants leaves `cache::Error` as a single-variant wrapper around `journal::Error`, so the enum is deleted too. Cache functions now return `journal::Error` directly.