### PR TITLE
[consensus/simplex] Fetch missing parent notarizations from any validator

### DIFF
--- a/consensus/src/simplex/actors/resolver/actor.rs
+++ b/consensus/src/simplex/actors/resolver/actor.rs
@@ -636,14 +636,18 @@ mod tests {
     use super::{super::test_helpers::*, *};
     use crate::{
         simplex::{
+            elector::{Config as _, Elector as _, RoundRobin, RoundRobinElector},
             scheme::ed25519,
             types::{Notarization, Notarize},
         },
-        types::TermLength,
+        types::{Round, TermLength, ViewDelta},
     };
     use commonware_actor::Feedback;
     use commonware_cryptography::{
-        certificate::mocks::Fixture, ed25519::PublicKey, sha256::Digest as Sha256Digest,
+        Sha256,
+        certificate::{Scheme as _, mocks::Fixture},
+        ed25519::PublicKey,
+        sha256::Digest as Sha256Digest,
     };
     use commonware_macros::{select, test_async};
     use commonware_p2p::simulated::{Config as NetworkConfig, Link, Network};
@@ -986,6 +990,15 @@ mod tests {
                 verifier,
                 ..
             } = ed25519::fixture(&mut context, NAMESPACE, 4);
+            let elector: RoundRobinElector<TestScheme> = RoundRobin::<Sha256>::default()
+                .with_term(TERM_LENGTH, Duration::from_secs(1), ViewDelta::new(0))
+                .build(schemes[0].participants());
+            let leader = usize::from(elector.elect(Round::new(EPOCH, View::new(1)), None));
+            assert_eq!(
+                leader, 2,
+                "fixture must leave the stable leader unavailable"
+            );
+
             let (network, oracle) = Network::new_with_peers(
                 context.child("network"),
                 NetworkConfig {
@@ -1011,8 +1024,8 @@ mod tests {
             }
             let mut connections = connections.into_iter();
             let requester_connection = connections.next().unwrap();
-            let _unavailable_leader_connection = connections.next().unwrap();
             let first_holder_connection = connections.next().unwrap();
+            let _unavailable_leader_connection = connections.next().unwrap();
             let second_holder_connection = connections.next().unwrap();
 
             let link = Link {
@@ -1020,7 +1033,7 @@ mod tests {
                 jitter: Duration::from_millis(1),
                 success_rate: probability!(1.0),
             };
-            for holder in &participants[2..] {
+            for holder in [&participants[1], &participants[3]] {
                 oracle
                     .add_link(participants[0].clone(), holder.clone(), link.clone())
                     .await
@@ -1053,7 +1066,7 @@ mod tests {
 
             let parent = build_notarization(&schemes, &verifier, EPOCH, View::new(2));
             let mut holders = Vec::new();
-            for (index, connection) in [(2, first_holder_connection), (3, second_holder_connection)]
+            for (index, connection) in [(1, first_holder_connection), (3, second_holder_connection)]
             {
                 let (voter_sender, voter_receiver) =
                     mailbox::new(context.child("holder_voter"), NZUsize!(8));

--- a/consensus/src/simplex/actors/resolver/actor.rs
+++ b/consensus/src/simplex/actors/resolver/actor.rs
@@ -378,7 +378,8 @@ impl<
         });
     }
 
-    /// Fetches missing proposal ancestry, preferring `target` when provided.
+    /// Fetches missing proposal ancestry. A provided `target` restricts the
+    /// fetch to that peer: the resolver never falls back to other peers.
     fn resolve<R>(
         &self,
         resolver: &mut R,

--- a/consensus/src/simplex/actors/resolver/actor.rs
+++ b/consensus/src/simplex/actors/resolver/actor.rs
@@ -974,6 +974,136 @@ mod tests {
         assert_targeted_fetch_does_not_restrict_existing_backfill(0);
     }
 
+    /// Certification recovery can fetch a missing mid-term parent from any
+    /// validator that holds it while the old leader is unavailable.
+    #[test_async]
+    async fn untargeted_parent_fetch_uses_available_holder() {
+        let runtime = deterministic::Runner::timed(Duration::from_secs(10));
+        runtime.start(|mut context| async move {
+            let Fixture {
+                participants,
+                schemes,
+                verifier,
+                ..
+            } = ed25519::fixture(&mut context, NAMESPACE, 4);
+            let (network, oracle) = Network::new_with_peers(
+                context.child("network"),
+                NetworkConfig {
+                    max_size: 1024 * 1024,
+                    max_peers_per_set: NZUsize!(participants.len()),
+                    disconnect_on_block: true,
+                    tracked_peer_sets: NZUsize!(1),
+                },
+                participants.clone(),
+            )
+            .await;
+            network.start();
+
+            let mut connections = Vec::new();
+            for participant in &participants {
+                connections.push(
+                    oracle
+                        .control(participant.clone())
+                        .register(2, Quota::per_second(NZU32!(1_000)))
+                        .await
+                        .unwrap(),
+                );
+            }
+            let mut connections = connections.into_iter();
+            let requester_connection = connections.next().unwrap();
+            let _unavailable_leader_connection = connections.next().unwrap();
+            let first_holder_connection = connections.next().unwrap();
+            let second_holder_connection = connections.next().unwrap();
+
+            let link = Link {
+                latency: Duration::from_millis(10),
+                jitter: Duration::from_millis(1),
+                success_rate: probability!(1.0),
+            };
+            for holder in &participants[2..] {
+                oracle
+                    .add_link(participants[0].clone(), holder.clone(), link.clone())
+                    .await
+                    .unwrap();
+                oracle
+                    .add_link(holder.clone(), participants[0].clone(), link.clone())
+                    .await
+                    .unwrap();
+            }
+
+            let (requester_voter_sender, mut requester_voter_receiver) =
+                mailbox::new(context.child("requester_voter"), NZUsize!(8));
+            let (requester, mut requester_mailbox) = TestActor::new(
+                context.child("requester"),
+                Config {
+                    scheme: schemes[0].clone(),
+                    blocker: NoopBlocker,
+                    strategy: Sequential,
+                    epoch: EPOCH,
+                    mailbox_size: NZUsize!(8),
+                    fetch_timeout: Duration::from_millis(200),
+                    term_length: TERM_LENGTH,
+                },
+            );
+            let _requester = requester.start(
+                voter::Mailbox::new(requester_voter_sender),
+                requester_connection.0,
+                requester_connection.1,
+            );
+
+            let parent = build_notarization(&schemes, &verifier, EPOCH, View::new(2));
+            let mut holders = Vec::new();
+            for (index, connection) in [(2, first_holder_connection), (3, second_holder_connection)]
+            {
+                let (voter_sender, voter_receiver) =
+                    mailbox::new(context.child("holder_voter"), NZUsize!(8));
+                let (holder, mut holder_mailbox) = TestActor::new(
+                    context.child("holder"),
+                    Config {
+                        scheme: schemes[index].clone(),
+                        blocker: NoopBlocker,
+                        strategy: Sequential,
+                        epoch: EPOCH,
+                        mailbox_size: NZUsize!(8),
+                        fetch_timeout: Duration::from_millis(200),
+                        term_length: TERM_LENGTH,
+                    },
+                );
+                let handle = holder.start(
+                    voter::Mailbox::new(voter_sender),
+                    connection.0,
+                    connection.1,
+                );
+                holder_mailbox.updated(Certificate::Notarization(parent.clone()));
+                holder_mailbox.certified(parent.view(), true);
+                // A holder exits when its mailbox closes, so keep the handles
+                // alive until the fetch completes.
+                holders.push((handle, holder_mailbox, voter_receiver));
+            }
+
+            // The certification request must not depend on the disconnected
+            // old leader. The voter-side regression supplies the held child.
+            context.sleep(Duration::from_millis(10)).await;
+            requester_mailbox.resolve(View::new(3), View::new(2), Kind::Notarization, None);
+
+            let recovered = select! {
+                message = requester_voter_receiver.recv() => {
+                    message.expect("voter mailbox closed")
+                },
+                _ = context.sleep(Duration::from_secs(5)) => {
+                    panic!("missing parent was not fetched from an available validator");
+                },
+            };
+            assert!(matches!(
+                recovered,
+                voter::Message::Verified {
+                    certificate: Certificate::Notarization(fetched),
+                    ..
+                } if fetched == parent
+            ));
+        });
+    }
+
     /// A valid notarization that does not settle the ask does not prevent a
     /// different peer from supplying the requested nullification.
     #[test_async]

--- a/consensus/src/simplex/actors/resolver/actor.rs
+++ b/consensus/src/simplex/actors/resolver/actor.rs
@@ -978,8 +978,8 @@ mod tests {
         assert_targeted_fetch_does_not_restrict_existing_backfill(0);
     }
 
-    /// Certification recovery can fetch a missing mid-term parent from any
-    /// validator that holds it while the old leader is unavailable.
+    /// Certification recovery fetches a missing mid-term parent from an
+    /// available holder when the term leader is unavailable.
     #[test_async]
     async fn untargeted_parent_fetch_uses_available_holder() {
         let runtime = deterministic::Runner::timed(Duration::from_secs(10));
@@ -1089,13 +1089,12 @@ mod tests {
                 );
                 holder_mailbox.updated(Certificate::Notarization(parent.clone()));
                 holder_mailbox.certified(parent.view(), true);
-                // A holder exits when its mailbox closes, so keep the handles
-                // alive until the fetch completes.
+                // Keep the holder and its mailboxes alive until the fetch completes.
                 holders.push((handle, holder_mailbox, voter_receiver));
             }
 
-            // The certification request must not depend on the disconnected
-            // old leader. The voter-side regression supplies the held child.
+            // Request the parent without targeting the disconnected term
+            // leader. The voter test covers the child that triggers this request.
             context.sleep(Duration::from_millis(10)).await;
             requester_mailbox.resolve(View::new(3), View::new(2), Kind::Notarization, None);
 

--- a/consensus/src/simplex/actors/resolver/actor.rs
+++ b/consensus/src/simplex/actors/resolver/actor.rs
@@ -1372,8 +1372,8 @@ mod tests {
         });
     }
 
-    /// A resolve without a target (no tracked round in the term knows the
-    /// leader) must fall back to an untargeted fetch, not be dropped.
+    /// A resolve without a target must open an untargeted fetch, not be
+    /// dropped.
     #[test_async]
     async fn resolve_without_target_falls_back_to_untargeted_fetch() {
         let runtime = deterministic::Runner::default();

--- a/consensus/src/simplex/actors/resolver/actor.rs
+++ b/consensus/src/simplex/actors/resolver/actor.rs
@@ -378,8 +378,8 @@ impl<
         });
     }
 
-    /// Fetches missing proposal ancestry. A provided `target` restricts the
-    /// fetch to that peer: the resolver never falls back to other peers.
+    /// Fetches missing proposal ancestry. If `target` is provided, the resolver
+    /// queries only that peer.
     fn resolve<R>(
         &self,
         resolver: &mut R,
@@ -1094,8 +1094,8 @@ mod tests {
                 holders.push((handle, holder_mailbox, voter_receiver));
             }
 
-            // Request the parent without targeting the disconnected term
-            // leader. The voter test covers the child that triggers this request.
+            // Request the parent from any peer. The voter test covers the child
+            // that triggers this request.
             context.sleep(Duration::from_millis(10)).await;
             requester_mailbox.resolve(View::new(3), View::new(2), Kind::Notarization, None);
 

--- a/consensus/src/simplex/actors/resolver/ingress.rs
+++ b/consensus/src/simplex/actors/resolver/ingress.rs
@@ -43,7 +43,7 @@ pub enum MailboxMessage<S: Scheme, D: Digest> {
         view: View,
         /// The certificate that is needed.
         kind: Kind,
-        /// Preferred peer, or `None` to use ordinary resolver peer selection.
+        /// When set, the resolver queries only this peer.
         target: Option<S::PublicKey>,
     },
 }

--- a/consensus/src/simplex/actors/resolver/ingress.rs
+++ b/consensus/src/simplex/actors/resolver/ingress.rs
@@ -147,10 +147,14 @@ impl<S: Scheme, D: Digest> Policy for MailboxMessage<S, D> {
             return;
         }
 
-        // Ignore the message if it is a duplicate
+        // Ignore duplicate work. Resolve requests for the same certificate
+        // share one network fetch, whose peer scope must remain as wide as any
+        // duplicate requested. Requests for different kinds at the same views
+        // are distinct work: neither certificate substitutes for the other
+        // (see [Kind]).
         if overflow
             .messages
-            .iter()
+            .iter_mut()
             .any(|old_message| match (&message, old_message) {
                 (
                     Self::Certificate {
@@ -178,14 +182,26 @@ impl<S: Scheme, D: Digest> Policy for MailboxMessage<S, D> {
                     Self::Resolve {
                         proposal: new_proposal,
                         view: new_view,
+                        kind: new_kind,
+                        target: new_target,
                         ..
                     },
                     Self::Resolve {
                         proposal: old_proposal,
                         view: old_view,
+                        kind: old_kind,
+                        target: old_target,
                         ..
                     },
-                ) => new_proposal == old_proposal && new_view == old_view,
+                ) if new_proposal == old_proposal
+                    && new_view == old_view
+                    && new_kind == old_kind =>
+                {
+                    if new_target.is_none() {
+                        *old_target = None;
+                    }
+                    true
+                }
                 _ => false,
             })
         {
@@ -471,6 +487,20 @@ mod tests {
         }
     }
 
+    fn unrestricted_resolve_msg(
+        proposal: View,
+        view: View,
+        kind: Kind,
+    ) -> MailboxMessage<TestScheme, Sha256Digest> {
+        MailboxMessage::Resolve {
+            span: Span::none(),
+            proposal,
+            view,
+            kind,
+            target: None,
+        }
+    }
+
     #[test]
     fn handler_drain_skips_closed_responses() {
         let mut overflow = HandlerPending::default();
@@ -570,7 +600,7 @@ mod tests {
     }
 
     #[test]
-    fn resolve_deduplicates_by_proposal_and_requested_view() {
+    fn resolve_deduplicates_by_proposal_view_and_kind() {
         let mut overflow = Pending::default();
         for kind in [Kind::Nullification, Kind::Nullification, Kind::Notarization] {
             MailboxMessage::handle(
@@ -580,7 +610,7 @@ mod tests {
         }
 
         let overflow = drain(overflow);
-        assert_eq!(overflow.len(), 1);
+        assert_eq!(overflow.len(), 2);
         assert!(matches!(
             &overflow[0],
             MailboxMessage::Resolve {
@@ -588,6 +618,87 @@ mod tests {
                 ..
             }
         ));
+        assert!(matches!(
+            &overflow[1],
+            MailboxMessage::Resolve {
+                kind: Kind::Notarization,
+                ..
+            }
+        ));
+    }
+
+    /// Regression: an unrestricted request must not widen or swallow a pending
+    /// request of the other kind, whose certificate it cannot substitute for.
+    #[test]
+    fn resolve_retains_target_across_kinds() {
+        let proposal = View::new(10);
+        let view = View::new(3);
+        let mut overflow = Pending::default();
+        MailboxMessage::handle(
+            &mut overflow,
+            resolve_msg(proposal, view, Kind::Nullification),
+        );
+        MailboxMessage::handle(
+            &mut overflow,
+            unrestricted_resolve_msg(proposal, view, Kind::Notarization),
+        );
+
+        let mut overflow = drain(overflow);
+        assert_eq!(overflow.len(), 2);
+        assert!(matches!(
+            overflow.pop_front(),
+            Some(MailboxMessage::Resolve {
+                kind: Kind::Nullification,
+                target: Some(_),
+                ..
+            })
+        ));
+        assert!(matches!(
+            overflow.pop_front(),
+            Some(MailboxMessage::Resolve {
+                kind: Kind::Notarization,
+                target: None,
+                ..
+            })
+        ));
+    }
+
+    /// Regression: a duplicate request must leave the pending request as wide
+    /// as either copy asked, whichever order they arrive in.
+    #[test]
+    fn resolve_widens_duplicate_to_unrestricted() {
+        let proposal = View::new(10);
+        let view = View::new(3);
+        for unrestricted_first in [false, true] {
+            let messages = if unrestricted_first {
+                [
+                    unrestricted_resolve_msg(proposal, view, Kind::Notarization),
+                    resolve_msg(proposal, view, Kind::Notarization),
+                ]
+            } else {
+                [
+                    resolve_msg(proposal, view, Kind::Notarization),
+                    unrestricted_resolve_msg(proposal, view, Kind::Notarization),
+                ]
+            };
+            let mut overflow = Pending::default();
+            for message in messages {
+                MailboxMessage::handle(&mut overflow, message);
+            }
+
+            let mut overflow = drain(overflow);
+            assert_eq!(overflow.len(), 1);
+            assert!(matches!(
+                overflow.pop_front(),
+                Some(MailboxMessage::Resolve {
+                    proposal: actual_proposal,
+                    view: actual_view,
+                    kind: Kind::Notarization,
+                    target: None,
+                    ..
+                }) if actual_proposal == proposal && actual_view == view
+            ));
+        }
     }
 
     #[test]

--- a/consensus/src/simplex/actors/resolver/ingress.rs
+++ b/consensus/src/simplex/actors/resolver/ingress.rs
@@ -147,11 +147,10 @@ impl<S: Scheme, D: Digest> Policy for MailboxMessage<S, D> {
             return;
         }
 
-        // Ignore duplicate work. Resolve requests for the same certificate
-        // share one network fetch, whose peer scope must remain as wide as any
-        // duplicate requested. Requests for different kinds at the same views
-        // are distinct work: neither certificate substitutes for the other
-        // (see [Kind]).
+        // Ignore duplicate work. Resolve requests with the same proposal,
+        // requested view, and kind share one network fetch. An unrestricted
+        // duplicate removes the target. Different kinds remain distinct
+        // because their certificates are not interchangeable.
         if overflow
             .messages
             .iter_mut()
@@ -627,8 +626,8 @@ mod tests {
         ));
     }
 
-    /// Regression: an unrestricted request must not widen or swallow a pending
-    /// request of the other kind, whose certificate it cannot substitute for.
+    /// An unrestricted request must not modify a pending request for another
+    /// certificate kind.
     #[test]
     fn resolve_retains_target_across_kinds() {
         let proposal = View::new(10);
@@ -663,8 +662,8 @@ mod tests {
         ));
     }
 
-    /// Regression: a duplicate request must leave the pending request as wide
-    /// as either copy asked, whichever order they arrive in.
+    /// An unrestricted duplicate must widen the pending request regardless of
+    /// arrival order.
     #[test]
     fn resolve_widens_duplicate_to_unrestricted() {
         let proposal = View::new(10);

--- a/consensus/src/simplex/actors/resolver/ingress.rs
+++ b/consensus/src/simplex/actors/resolver/ingress.rs
@@ -231,7 +231,8 @@ impl<S: Scheme, D: Digest> Mailbox<S, D> {
         });
     }
 
-    /// Requests missing proposal ancestry, preferring `target` when provided.
+    /// Requests missing proposal ancestry. A provided `target` restricts the
+    /// fetch to that peer, with no fallback to others.
     pub(crate) fn resolve(
         &mut self,
         proposal: View,

--- a/consensus/src/simplex/actors/resolver/ingress.rs
+++ b/consensus/src/simplex/actors/resolver/ingress.rs
@@ -231,8 +231,8 @@ impl<S: Scheme, D: Digest> Mailbox<S, D> {
         });
     }
 
-    /// Requests missing proposal ancestry. A provided `target` restricts the
-    /// fetch to that peer, with no fallback to others.
+    /// Requests missing proposal ancestry. If `target` is provided, the
+    /// resolver queries only that peer.
     pub(crate) fn resolve(
         &mut self,
         proposal: View,

--- a/consensus/src/simplex/actors/resolver/mod.rs
+++ b/consensus/src/simplex/actors/resolver/mod.rs
@@ -29,9 +29,10 @@
 //!
 //! Background repair cannot detect a split where one participant certifies a notarization while
 //! another holds a covering nullification. Proposal verification exposes the missing ancestry and
-//! targets the first gap at the proposal's leader. Matching evidence, finalization, or a failed
-//! certification verdict retires that request, whereas a certified-floor raise retires only
-//! background work.
+//! targets the first gap at the proposal's leader. A blocked certification exposes the same gap
+//! and asks any peer, since the leader that withheld the certificate may never answer. Matching
+//! evidence, finalization, or a failed certification verdict retires that request, whereas a
+//! certified-floor raise retires only background work.
 //!
 //! The wire key names only the view. A retained finalization settles every ask at or below it.
 //! Otherwise serving prefers an exact certified notarization to a covering nullification, matching

--- a/consensus/src/simplex/actors/voter/actor.rs
+++ b/consensus/src/simplex/actors/voter/actor.rs
@@ -1135,8 +1135,13 @@ impl<
                 // journal sync completed before this block runs, a child made
                 // eligible by its parent cannot become durable first.
                 let (candidates, fetches) = self.state.certify_candidates();
-                for CertificateFetch { proposal, view, kind, target } in fetches {
-                    resolver.resolve(proposal, view, kind, target);
+                for CertificateFetch {
+                    proposal,
+                    view,
+                    kind,
+                } in fetches
+                {
+                    resolver.resolve(proposal, view, kind, None);
                 }
                 for proposal in candidates {
                     let round = proposal.round;

--- a/consensus/src/simplex/actors/voter/actor.rs
+++ b/consensus/src/simplex/actors/voter/actor.rs
@@ -7,7 +7,7 @@ use crate::{
     CertifiableAutomaton, LATENCY, Relay, Reporter, Viewable,
     simplex::{
         Floor, Plan,
-        actors::{batcher, resolver},
+        actors::{Kind, batcher, resolver},
         elector::Elector,
         metrics::{self, Outbound, TimeoutReason},
         scheme::Scheme,
@@ -1135,13 +1135,8 @@ impl<
                 // journal sync completed before this block runs, a child made
                 // eligible by its parent cannot become durable first.
                 let (candidates, fetches) = self.state.certify_candidates();
-                for CertificateFetch {
-                    proposal,
-                    view,
-                    kind,
-                } in fetches
-                {
-                    resolver.resolve(proposal, view, kind, None);
+                for CertificateFetch { proposal, view } in fetches {
+                    resolver.resolve(proposal, view, Kind::Notarization, None);
                 }
                 for proposal in candidates {
                     let round = proposal.round;

--- a/consensus/src/simplex/actors/voter/mod.rs
+++ b/consensus/src/simplex/actors/voter/mod.rs
@@ -4020,6 +4020,7 @@ mod tests {
                 )
             };
             let (_, notarization_1) = build_notarization(&schemes, &proposal(1, 0), quorum);
+            let (_, notarization_2) = build_notarization(&schemes, &proposal(2, 1), quorum);
             let (_, notarization_3) = build_notarization(&schemes, &proposal(3, 2), quorum);
 
             // Deliver notarization(1) and wait for the voter to certify it and
@@ -4036,9 +4037,8 @@ mod tests {
             // Deliver notarization(3), skipping notarization(2): the voter
             // observed the certificate broadcast for view 3 but missed the one
             // for view 2. Certifying view 3 requires view 2's exact-view
-            // certificate, so the voter must fetch it. The certificate update
-            // must reach the resolver first: it opens unrestricted background
-            // repair that a later leader target cannot narrow.
+            // certificate, so the voter must fetch it. Certification recovery
+            // is untargeted because any validator may hold the certificate.
             mailbox.recovered(Certificate::Notarization(notarization_3));
             assert!(matches!(
                 resolver_receiver.recv().await.unwrap(),
@@ -4062,12 +4062,51 @@ mod tests {
                         assert_eq!(proposal, View::new(3));
                         assert_eq!(view, View::new(2));
                         assert!(matches!(kind, crate::simplex::actors::Kind::Notarization));
-                        assert!(target.is_some(), "certification repair should retain leader affinity");
+                        assert!(target.is_none());
                         break;
                     },
                     _ = context.sleep(Duration::from_secs(20)) => {
                         panic!("voter never requested the missed notarization");
                     },
+                }
+            }
+
+            // Deliver the fetched parent. The voter must certify the parent
+            // before its already-held child, then resume finalize voting.
+            while batcher_receiver.recv().now_or_never().flatten().is_some() {}
+            mailbox.recovered(Certificate::Notarization(notarization_2));
+            let mut certified = Vec::new();
+            let mut finalized = Vec::new();
+            loop {
+                select! {
+                    message = resolver_receiver.recv() => match message.unwrap() {
+                        MailboxMessage::Certified { view, success, .. }
+                            if view == View::new(2) || view == View::new(3) =>
+                        {
+                            assert!(success);
+                            certified.push(view);
+                        }
+                        MailboxMessage::Certificate { .. }
+                        | MailboxMessage::Certified { .. }
+                        | MailboxMessage::Resolve { .. } => {}
+                    },
+                    message = batcher_receiver.recv() => {
+                        if let batcher::Message::Constructed(Vote::Finalize(vote)) = message.unwrap()
+                            && (vote.view() == View::new(2) || vote.view() == View::new(3))
+                        {
+                            finalized.push(vote.view());
+                        }
+                    },
+                    _ = context.sleep(Duration::from_secs(20)) => {
+                        panic!(
+                            "recovery stalled: certified={certified:?}, finalized={finalized:?}"
+                        );
+                    },
+                }
+                if certified == [View::new(2), View::new(3)]
+                    && finalized.contains(&View::new(3))
+                {
+                    break;
                 }
             }
         });

--- a/consensus/src/simplex/actors/voter/mod.rs
+++ b/consensus/src/simplex/actors/voter/mod.rs
@@ -4034,11 +4034,10 @@ mod tests {
             }
             while resolver_receiver.recv().now_or_never().flatten().is_some() {}
 
-            // Deliver notarization(3), skipping notarization(2): the voter
-            // observed the certificate broadcast for view 3 but missed the one
-            // for view 2. Certifying view 3 requires view 2's exact-view
-            // certificate, so the voter must fetch it. Certification recovery
-            // is untargeted because any validator may hold the certificate.
+            // Deliver notarization(3) without notarization(2). The voter saw
+            // the certificate for view 3 but missed the one for view 2.
+            // Certifying view 3 requires the exact certificate for view 2, so
+            // the voter asks any validator for it.
             mailbox.recovered(Certificate::Notarization(notarization_3));
             assert!(matches!(
                 resolver_receiver.recv().await.unwrap(),
@@ -4072,7 +4071,7 @@ mod tests {
             }
 
             // Deliver the fetched parent. The voter must certify the parent
-            // before its already-held child, then resume finalize voting.
+            // before the child and then resume finalize voting.
             while batcher_receiver.recv().now_or_never().flatten().is_some() {}
             mailbox.recovered(Certificate::Notarization(notarization_2));
             let mut certified = Vec::new();

--- a/consensus/src/simplex/actors/voter/round.rs
+++ b/consensus/src/simplex/actors/voter/round.rs
@@ -161,7 +161,12 @@ impl<S: Scheme, D: Digest> Round<S, D> {
         self.proposal.request_verify()
     }
 
-    /// Records an ancestry view requested from the leader.
+    /// Records the ancestry view that verification requested from the
+    /// proposal's leader. Returns `false` for a repeated request.
+    ///
+    /// Certification repair does not consult this latch: its untargeted fetch
+    /// must reach the resolver even when verification already requested the
+    /// same view from the leader.
     pub fn request(&mut self, view: View) -> bool {
         if self.last_ancestry_request == Some(view) {
             return false;

--- a/consensus/src/simplex/actors/voter/round.rs
+++ b/consensus/src/simplex/actors/voter/round.rs
@@ -161,12 +161,11 @@ impl<S: Scheme, D: Digest> Round<S, D> {
         self.proposal.request_verify()
     }
 
-    /// Records the ancestry view that verification requested from the
-    /// proposal's leader. Returns `false` for a repeated request.
+    /// Records the ancestry view that proposal verification requested from the
+    /// leader. Returns `false` for a repeated request.
     ///
-    /// Certification repair does not consult this latch: its untargeted fetch
-    /// must reach the resolver even when verification already requested the
-    /// same view from the leader.
+    /// Certification repair bypasses this latch so an untargeted request can
+    /// widen the resolver fetch.
     pub fn request(&mut self, view: View) -> bool {
         if self.last_ancestry_request == Some(view) {
             return false;

--- a/consensus/src/simplex/actors/voter/state.rs
+++ b/consensus/src/simplex/actors/voter/state.rs
@@ -1202,10 +1202,10 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
             return None;
         }
 
-        // Certification exempts term starts, so the candidate and its parent
-        // sit mid-term. The fetch is untargeted: a resolver target is
-        // exclusive, and validators other than the term's leader (which may
-        // be unreachable) hold the parent's notarization.
+        // Only mid-term candidates require the previous view as their parent,
+        // so the candidate and parent are in the same term. Keep this fetch
+        // untargeted because resolver targets are exclusive and any validator
+        // can hold the parent's notarization.
         Some(CertificateFetch {
             proposal: *proposal_view,
             view: *parent_view,
@@ -3693,8 +3693,7 @@ mod tests {
             assert_eq!(fetches[0].proposal, View::new(6));
             assert_eq!(fetches[0].view, View::new(5));
             assert!(matches!(fetches[0].kind, Kind::Notarization));
-            // A same-term round still records the old leader, but
-            // certification recovery must not depend on that peer.
+            // Confirm that a same-term round records the old leader.
             assert!(state.leader_index(View::new(2)).is_some());
 
             // Repair cascades one view at a time: delivering notarization(5)

--- a/consensus/src/simplex/actors/voter/state.rs
+++ b/consensus/src/simplex/actors/voter/state.rs
@@ -1197,15 +1197,15 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
             return None;
         }
 
-        // Verification may have requested this parent from the proposal's
-        // leader. Bypass its request latch so the resolver removes the target
-        // from the in-flight fetch. The candidate remains dormant until its
-        // parent arrives, so this request does not repeat.
+        // Verification can request this parent only from the proposal's leader.
+        // Certification bypasses that request latch. If the fetch is in flight,
+        // the resolver removes its target. The candidate remains dormant until
+        // its parent arrives, so this request does not repeat.
         //
         // Only mid-term candidates require the previous view as their parent,
-        // so the candidate and parent are in the same term. Keep this fetch
-        // untargeted because resolver targets are exclusive and any validator
-        // can hold the parent's notarization.
+        // so the candidate and parent are in the same term. Any validator can
+        // hold the parent's notarization, so certification sends this request
+        // without a target.
         Some(CertificateFetch {
             proposal: *proposal_view,
             view: *parent_view,
@@ -3623,8 +3623,8 @@ mod tests {
                     && target == participants[2]
             ));
 
-            // Notarization(3) makes certification request the same parent
-            // without a target, widening the in-flight resolver fetch.
+            // Notarization(3) triggers an untargeted request for the same
+            // parent. This widens the in-flight resolver fetch.
             assert!(
                 state
                     .add_notarization(build_notarization(&verifier, &schemes, &p3))

--- a/consensus/src/simplex/actors/voter/state.rs
+++ b/consensus/src/simplex/actors/voter/state.rs
@@ -99,10 +99,8 @@ pub enum Verify<S: Scheme<D>, D: Digest> {
 pub struct CertificateFetch {
     /// View of the candidate that exposed the missing certificate.
     pub proposal: View,
-    /// View whose certificate is needed.
+    /// View whose notarization is needed.
     pub view: View,
-    /// Kind of certificate that is needed.
-    pub kind: Kind,
 }
 
 /// Configuration for initializing [`State`].
@@ -1187,7 +1185,7 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
     /// certificate once, and the candidate's own certificate proves the votes
     /// that could form it have stopped circulating. The certificate must be
     /// fetched, or the voter can never certify another view in the term.
-    fn certification_fetch(&mut self, err: &ParentPayloadError) -> Option<CertificateFetch> {
+    fn certification_fetch(&self, err: &ParentPayloadError) -> Option<CertificateFetch> {
         let ParentPayloadError::ParentNotCertified {
             proposal_view,
             parent_view,
@@ -1198,10 +1196,12 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
         if self.notarization(*parent_view).is_some() {
             return None;
         }
-        if !self.views.get_mut(proposal_view)?.request(*parent_view) {
-            return None;
-        }
 
+        // Verification may have requested this parent from the proposal's
+        // leader. Bypass its request latch so the resolver removes the target
+        // from the in-flight fetch. The candidate remains dormant until its
+        // parent arrives, so this request does not repeat.
+        //
         // Only mid-term candidates require the previous view as their parent,
         // so the candidate and parent are in the same term. Keep this fetch
         // untargeted because resolver targets are exclusive and any validator
@@ -1209,7 +1209,6 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
         Some(CertificateFetch {
             proposal: *proposal_view,
             view: *parent_view,
-            kind: Kind::Notarization,
         })
     }
 
@@ -3580,35 +3579,52 @@ mod tests {
         });
     }
 
-    /// Regression: a candidate blocked on a parent notarization we never
-    /// received must produce a fetch. Waiting cannot heal it: peers broadcast
-    /// a certificate once. Without the fetch the voter never certifies
-    /// another view in the term.
+    /// Regression: certification must widen a targeted verification fetch for
+    /// the same missing parent so any peer can answer it.
     #[test]
-    fn certify_candidates_fetches_missed_parent_notarization() {
+    fn certification_fetch_widens_targeted_verification_request() {
         let runtime = deterministic::Runner::default();
         runtime.start(|mut context| async move {
             let (
                 Fixture {
-                    schemes, verifier, ..
+                    participants,
+                    schemes,
+                    verifier,
+                    ..
                 },
                 mut state,
             ) = setup_state_with(
                 &mut context,
                 4,
-                2,
+                1,
                 9,
                 10,
                 TermLength::new(NZU32!(5)),
-                ViewDelta::new(2),
+                ViewDelta::new(0),
                 4,
             );
 
             certify_first_view(&mut state, &verifier, &schemes);
 
-            // Receive notarization(3) without notarization(2): certification
-            // of view 3 is blocked and the missing certificate is fetched.
+            // Receive proposal(3) without notarization(2). Verification first
+            // requests the parent only from the stable leader.
             let p3 = fetch_proposal(3, 2, 103);
+            state.set_leader(View::new(3), None);
+            assert!(state.set_proposal(View::new(3), p3.clone()));
+            assert!(matches!(
+                state.try_verify(),
+                Verify::Resolve {
+                    proposal,
+                    view,
+                    kind: Kind::Notarization,
+                    target,
+                } if proposal == View::new(3)
+                    && view == View::new(2)
+                    && target == participants[2]
+            ));
+
+            // Notarization(3) makes certification request the same parent
+            // without a target, widening the in-flight resolver fetch.
             assert!(
                 state
                     .add_notarization(build_notarization(&verifier, &schemes, &p3))
@@ -3619,7 +3635,6 @@ mod tests {
             assert_eq!(fetches.len(), 1);
             assert_eq!(fetches[0].proposal, View::new(3));
             assert_eq!(fetches[0].view, View::new(2));
-            assert!(matches!(fetches[0].kind, Kind::Notarization));
 
             // The blocked candidate is dormant, so another pass emits nothing.
             let (ready, fetches) = state.certify_candidates();
@@ -3692,7 +3707,6 @@ mod tests {
             assert_eq!(fetches.len(), 1);
             assert_eq!(fetches[0].proposal, View::new(6));
             assert_eq!(fetches[0].view, View::new(5));
-            assert!(matches!(fetches[0].kind, Kind::Notarization));
             // Confirm that a same-term round records the old leader.
             assert!(state.leader_index(View::new(2)).is_some());
 
@@ -3709,7 +3723,6 @@ mod tests {
             assert_eq!(fetches.len(), 1);
             assert_eq!(fetches[0].proposal, View::new(5));
             assert_eq!(fetches[0].view, View::new(4));
-            assert!(matches!(fetches[0].kind, Kind::Notarization));
         });
     }
 
@@ -3754,7 +3767,6 @@ mod tests {
             assert_eq!(fetches.len(), 1);
             assert_eq!(fetches[0].proposal, View::new(10));
             assert_eq!(fetches[0].view, View::new(9));
-            assert!(matches!(fetches[0].kind, Kind::Notarization));
         });
     }
 

--- a/consensus/src/simplex/actors/voter/state.rs
+++ b/consensus/src/simplex/actors/voter/state.rs
@@ -1,7 +1,4 @@
-use super::{
-    super::Kind,
-    round::{Leader as RoundLeader, Round},
-};
+use super::{super::Kind, round::Round};
 use crate::{
     Viewable,
     simplex::{
@@ -99,15 +96,13 @@ pub enum Verify<S: Scheme<D>, D: Digest> {
 
 /// A certificate fetch justified by a blocked certification (see
 /// [`State::certify_candidates`]).
-pub struct CertificateFetch<P> {
+pub struct CertificateFetch {
     /// View of the candidate that exposed the missing certificate.
     pub proposal: View,
     /// View whose certificate is needed.
     pub view: View,
     /// Kind of certificate that is needed.
     pub kind: Kind,
-    /// Leader to query, or `None` to ask any peer.
-    pub target: Option<P>,
 }
 
 /// Configuration for initializing [`State`].
@@ -380,21 +375,6 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
         }
         let leader = self.elector.elect(Rnd::new(self.epoch, view), certificate);
         self.create_round(view).set_leader(leader);
-    }
-
-    /// Returns the stable leader of the term containing `view`, from any
-    /// tracked round in that term that has one.
-    ///
-    /// Every leader-bearing round in a term holds the term's leader:
-    /// [`Self::set_leader`] stores the elector's leader for the round's own
-    /// view, and [`Self::inherit_leader`] never copies across a term end. A
-    /// term can also have no tracked leader: a bare certificate creates its
-    /// round without one beyond the optimistic frontier, and a notarization
-    /// for the term's final view seeds only the next term's leader.
-    fn term_leader(&self, view: View) -> Option<RoundLeader<S::PublicKey>> {
-        let term_length = self.term_length();
-        let term = view.term_start(term_length)..=view.term_end(term_length);
-        self.views.range(term).find_map(|(_, round)| round.leader())
     }
 
     /// Copies the same-term stable leader into an optimistic successor.
@@ -1154,9 +1134,7 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
     /// Takes newly notarized or unblocked certification candidates and returns
     /// proposals ready for certification, plus fetches for missing parent
     /// certificates (see [`Self::certification_fetch`]).
-    pub fn certify_candidates(
-        &mut self,
-    ) -> (Vec<Proposal<D>>, Vec<CertificateFetch<S::PublicKey>>) {
+    pub fn certify_candidates(&mut self) -> (Vec<Proposal<D>>, Vec<CertificateFetch>) {
         let candidates = take(&mut self.certification_candidates);
         let mut ready = Vec::new();
         let mut fetches = Vec::new();
@@ -1209,10 +1187,7 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
     /// certificate once, and the candidate's own certificate proves the votes
     /// that could form it have stopped circulating. The certificate must be
     /// fetched, or the voter can never certify another view in the term.
-    fn certification_fetch(
-        &mut self,
-        err: &ParentPayloadError,
-    ) -> Option<CertificateFetch<S::PublicKey>> {
+    fn certification_fetch(&mut self, err: &ParentPayloadError) -> Option<CertificateFetch> {
         let ParentPayloadError::ParentNotCertified {
             proposal_view,
             parent_view,
@@ -1228,18 +1203,13 @@ impl<E: Clock + CryptoRng + Metrics, S: Scheme<D>, L: Elector<S>, D: Digest> Sta
         }
 
         // Certification exempts term starts, so the candidate and its parent
-        // sit mid-term and share the term's stable leader (see
-        // [`Self::term_leader`]). Without a tracked leader the fetch asks any
-        // peer. A leader that is the local signer is also excluded: a fresh
-        // fetch targeted only at ourselves has no peer to serve it.
+        // sit mid-term. The fetch is untargeted: a resolver target is
+        // exclusive, and validators other than the term's leader (which may
+        // be unreachable) hold the parent's notarization.
         Some(CertificateFetch {
             proposal: *proposal_view,
             view: *parent_view,
             kind: Kind::Notarization,
-            target: self
-                .term_leader(*proposal_view)
-                .filter(|leader| !self.is_me(leader.idx))
-                .map(|leader| leader.key),
         })
     }
 
@@ -3650,12 +3620,6 @@ mod tests {
             assert_eq!(fetches[0].proposal, View::new(3));
             assert_eq!(fetches[0].view, View::new(2));
             assert!(matches!(fetches[0].kind, Kind::Notarization));
-            // The local signer is the term's stable leader, so the fetch is
-            // untargeted: a fresh fetch targeted only at ourselves has no
-            // peer to serve it.
-            let leader = state.term_leader(View::new(3)).expect("term leader");
-            assert!(state.is_me(leader.idx));
-            assert!(fetches[0].target.is_none());
 
             // The blocked candidate is dormant, so another pass emits nothing.
             let (ready, fetches) = state.certify_candidates();
@@ -3685,19 +3649,15 @@ mod tests {
     }
 
     /// Regression: the fetch must fire even when the certificate gap is wider
-    /// than the optimistic frontier. The candidate's and parent's rounds then
-    /// have no leader, so the fetch target must come from any same-term round
-    /// that knows the stable leader.
+    /// than the optimistic frontier. The fetch remains untargeted even when a
+    /// same-term round records the stable leader.
     #[test]
     fn certify_candidates_fetches_across_wide_gap() {
         let runtime = deterministic::Runner::default();
         runtime.start(|mut context| async move {
             let (
                 Fixture {
-                    participants,
-                    schemes,
-                    verifier,
-                    ..
+                    schemes, verifier, ..
                 },
                 mut state,
             ) = setup_state_with(
@@ -3717,15 +3677,14 @@ mod tests {
 
             // Receive notarization(6) without any of 2..=5. Views 5 and 6 sit
             // beyond the frontier, so neither round has a leader. The fetch
-            // still fires with the term's stable leader as target.
+            // still fires and may be served by any peer.
             let p6 = fetch_proposal(6, 5, 106);
             assert!(
                 state
                     .add_notarization(build_notarization(&verifier, &schemes, &p6))
                     .0
             );
-            // Precondition: the candidate's and parent's rounds are leaderless,
-            // so the fetch target can only come from the same-term scan.
+            // Precondition: the candidate's and parent's rounds are leaderless.
             assert!(!state.leader_is_set(View::new(6)));
             assert!(!state.leader_is_set(View::new(5)));
             let (ready, fetches) = state.certify_candidates();
@@ -3734,14 +3693,9 @@ mod tests {
             assert_eq!(fetches[0].proposal, View::new(6));
             assert_eq!(fetches[0].view, View::new(5));
             assert!(matches!(fetches[0].kind, Kind::Notarization));
-            // The target is the term's stable leader, held by view 2's round.
-            let leader = state
-                .leader_index(View::new(2))
-                .expect("view 2 must hold the term leader");
-            assert_eq!(
-                fetches[0].target.as_ref(),
-                Some(&participants[leader.get() as usize])
-            );
+            // A same-term round still records the old leader, but
+            // certification recovery must not depend on that peer.
+            assert!(state.leader_index(View::new(2)).is_some());
 
             // Repair cascades one view at a time: delivering notarization(5)
             // exposes the next gap, again from a leaderless round.
@@ -3763,7 +3717,7 @@ mod tests {
     /// Regression: a bare notarization for a term's final view can be the
     /// only artifact the voter holds from that term. It seeds a leader only
     /// for the next term's start, so no tracked round supplies the term's
-    /// leader. The fetch must still fire, without a target.
+    /// leader. The fetch must still fire.
     #[test]
     fn certify_candidates_fetches_term_end_without_leader() {
         let runtime = deterministic::Runner::default();
@@ -3802,7 +3756,6 @@ mod tests {
             assert_eq!(fetches[0].proposal, View::new(10));
             assert_eq!(fetches[0].view, View::new(9));
             assert!(matches!(fetches[0].kind, Kind::Notarization));
-            assert!(fetches[0].target.is_none());
         });
     }
 

--- a/consensus/src/simplex/mod.rs
+++ b/consensus/src/simplex/mod.rs
@@ -7201,28 +7201,26 @@ mod tests {
         );
     }
 
-    /// Two dead-leader terms leave the honest floors split across different
-    /// terms. Recovery requires fetching each missing parent notarization from
-    /// an honest validator instead of the unavailable term leader.
+    /// Two terms led by an offline validator give the honest validators
+    /// different certified floors. Progress requires a missing parent
+    /// notarization from an available validator.
     ///
     /// Terms are five views long and the offline participant leads term 1
     /// (views 1..=5) and term 5 (views 21..=25).
     ///
-    /// Pre-GST state (built with an injector while all validator links are
-    /// down):
+    /// An injector builds this pre-GST state while validator links are down:
     /// - `b` and `c` certify views 1 and 2 (term 1). `a` never sees them.
     /// - `a` and `b` certify views 21 and 22 (term 5). `c` never sees them.
     /// - Terms 2..=4 are nullified at their term starts for everyone.
     ///
-    /// After GST the offline participant is silent, so quorum is exactly the
-    /// three honest participants. Every honest proposal names the proposer's
-    /// own highest certified view, which sits in a term one of the other honest
-    /// participants never certified.
+    /// After GST, the three honest participants form the only quorum. Each
+    /// proposal names its proposer's highest certified view. One other honest
+    /// participant has not certified that term.
     ///
-    /// `suppress_backfill` decides where the deprived participant's covering
-    /// nullification sits. At the term start it hides the whole term from the
-    /// untargeted background backfill; one view later the backfill can still
-    /// see (and repair) the term's head.
+    /// `suppress_backfill` selects the deprived participant's covering
+    /// nullification. A term-start nullification suppresses background repair
+    /// for the term. A nullification one view later permits repair of the term
+    /// head.
     fn stable_leader_cross_term_certified_split<S, F, L>(
         mut fixture: F,
         elector: L,
@@ -7253,7 +7251,7 @@ mod tests {
             .await;
             let mut registrations = register_validators(&mut oracle, &participants).await;
 
-            // Pick an epoch that makes the same participant lead terms 1 and 5.
+            // Choose an epoch where the same participant leads terms 1 and 5.
             let epoch = Epoch::new(2);
             let participant_set: Set<PublicKey> = participants.clone().try_into().unwrap();
             let schedule = elector.clone().build(&participant_set);
@@ -7294,8 +7292,8 @@ mod tests {
             let proposal_2 =
                 Proposal::new(Round::new(epoch, View::new(2)), View::new(1), payload_2);
             // Term 5 chain (views 21 and 22), certified by `a` and `b`. The
-            // parent is genesis so `a`, which never certified term 1, could
-            // have voted for it.
+            // view-21 proposal names genesis, so `a` can vote without
+            // certifying term 1.
             let payload_21 = Sha256::hash(&[b"V21"]);
             let proposal_21 =
                 Proposal::new(Round::new(epoch, View::new(21)), View::new(0), payload_21);
@@ -7390,7 +7388,8 @@ mod tests {
                 );
             }
 
-            // Start honest engines before GST so preload rebroadcasts are lost.
+            // Start honest engines before GST. The partition drops their
+            // preload broadcasts.
             let relay = Arc::new(mocks::relay::Relay::<Sha256Digest, _>::new());
             let mut honest_reporters = HashMap::new();
             for (idx, validator) in participants.iter().enumerate() {
@@ -7492,8 +7491,7 @@ mod tests {
             // End the partition (GST).
             link_validators(&mut oracle, &participants, Action::Link(link.clone()), None).await;
 
-            // Wait until every honest validator finalizes in the first
-            // post-GST term.
+            // Wait until every honest validator finalizes after GST.
             let target = View::new(26);
             let mut finalizers = Vec::new();
             for (idx, reporter) in honest_reporters.iter_mut() {
@@ -7524,7 +7522,7 @@ mod tests {
                         .lock()
                         .keys()
                         .any(|view| *view >= target),
-                    "reporter {idx} never finalized the post-GST term"
+                    "reporter {idx} never finalized after GST"
                 );
             }
             let c_certifications = honest_reporters[&c].certifications.lock();

--- a/consensus/src/simplex/mod.rs
+++ b/consensus/src/simplex/mod.rs
@@ -7219,8 +7219,8 @@ mod tests {
     ///
     /// `suppress_backfill` selects the deprived participant's covering
     /// nullification. A term-start nullification suppresses background repair
-    /// for the term. A nullification one view later permits repair of the term
-    /// head.
+    /// for the term. A nullification one view past the notarized head (views 3
+    /// and 23) leaves the head visible to repair.
     fn stable_leader_cross_term_certified_split<S, F, L>(
         mut fixture: F,
         elector: L,
@@ -7264,6 +7264,13 @@ mod tests {
             for view in [6u64, 11, 16, 26, 31, 36] {
                 assert_ne!(leader_of(view), offline, "term start must be honest");
             }
+            // The final assertions expect the first post-GST proposal to build
+            // on view 22, so its leader must have certified term 5.
+            assert_ne!(
+                leader_of(26),
+                c,
+                "view-26 leader must hold certification 22"
+            );
 
             let build_notarization =
                 |proposal: &Proposal<D>, signers: [usize; 3]| -> TNotarization<_, D> {

--- a/consensus/src/simplex/mod.rs
+++ b/consensus/src/simplex/mod.rs
@@ -7214,13 +7214,13 @@ mod tests {
     /// - Terms 2..=4 are nullified at their term starts for everyone.
     ///
     /// After GST, the three honest participants form the only quorum. Each
-    /// proposal names its proposer's highest certified view. One other honest
-    /// participant has not certified that term.
+    /// proposal names its proposer's highest certified view. One honest peer
+    /// lacks the named chain.
     ///
-    /// `suppress_backfill` selects the deprived participant's covering
-    /// nullification. A term-start nullification suppresses background repair
-    /// for the term. A nullification one view past the notarized head (views 3
-    /// and 23) leaves the head visible to repair.
+    /// If `suppress_backfill` is true, the deprived participants receive
+    /// term-start nullifications that suppress background repair. Otherwise,
+    /// the nullifications occur one view past the notarized heads (views 3 and
+    /// 23), so repair can see each head.
     fn stable_leader_cross_term_certified_split<S, F, L>(
         mut fixture: F,
         elector: L,
@@ -7264,8 +7264,7 @@ mod tests {
             for view in [6u64, 11, 16, 26, 31, 36] {
                 assert_ne!(leader_of(view), offline, "term start must be honest");
             }
-            // The final assertions expect the first post-GST proposal to build
-            // on view 22, so its leader must have certified term 5.
+            // The view-26 leader must have certified view 22.
             assert_ne!(
                 leader_of(26),
                 c,

--- a/consensus/src/simplex/mod.rs
+++ b/consensus/src/simplex/mod.rs
@@ -7201,6 +7201,370 @@ mod tests {
         );
     }
 
+    /// Two dead-leader terms leave the honest floors split across different
+    /// terms. Recovery requires fetching each missing parent notarization from
+    /// an honest validator instead of the unavailable term leader.
+    ///
+    /// Terms are five views long and the offline participant leads term 1
+    /// (views 1..=5) and term 5 (views 21..=25).
+    ///
+    /// Pre-GST state (built with an injector while all validator links are
+    /// down):
+    /// - `b` and `c` certify views 1 and 2 (term 1). `a` never sees them.
+    /// - `a` and `b` certify views 21 and 22 (term 5). `c` never sees them.
+    /// - Terms 2..=4 are nullified at their term starts for everyone.
+    ///
+    /// After GST the offline participant is silent, so quorum is exactly the
+    /// three honest participants. Every honest proposal names the proposer's
+    /// own highest certified view, which sits in a term one of the other honest
+    /// participants never certified.
+    ///
+    /// `suppress_backfill` decides where the deprived participant's covering
+    /// nullification sits. At the term start it hides the whole term from the
+    /// untargeted background backfill; one view later the backfill can still
+    /// see (and repair) the term's head.
+    fn stable_leader_cross_term_certified_split<S, F, L>(
+        mut fixture: F,
+        elector: L,
+        suppress_backfill: bool,
+    ) where
+        S: Scheme<Sha256Digest, PublicKey = PublicKey>,
+        F: FnMut(&mut deterministic::Context, &[u8], u32) -> Fixture<S>,
+        L: elector::Config<S>,
+    {
+        let n = 4;
+        let quorum = quorum(n) as usize;
+        assert_eq!(quorum, 3);
+        let view_retention = ViewDelta::new(10);
+        let skip_timeout = Duration::from_secs(12);
+        let namespace = b"consensus".to_vec();
+        let executor = deterministic::Runner::timed(Duration::from_secs(120));
+        executor.start(|mut context| async move {
+            let Fixture {
+                participants,
+                schemes,
+                ..
+            } = fixture(&mut context, &namespace, n);
+            let mut oracle = start_test_network_with_peers(
+                context.child("network"),
+                participants.clone(),
+                false,
+            )
+            .await;
+            let mut registrations = register_validators(&mut oracle, &participants).await;
+
+            // Pick an epoch that makes the same participant lead terms 1 and 5.
+            let epoch = Epoch::new(2);
+            let participant_set: Set<PublicKey> = participants.clone().try_into().unwrap();
+            let schedule = elector.clone().build(&participant_set);
+            let leader_of =
+                |view: u64| usize::from(schedule.elect(Round::new(epoch, View::new(view)), None));
+            let offline = leader_of(1);
+            assert_eq!(offline, leader_of(21), "offline must lead terms 1 and 5");
+            let honest: Vec<usize> = (0..n as usize).filter(|idx| *idx != offline).collect();
+            let (a, b, c) = (honest[0], honest[1], honest[2]);
+            for view in [6u64, 11, 16, 26, 31, 36] {
+                assert_ne!(leader_of(view), offline, "term start must be honest");
+            }
+
+            let build_notarization =
+                |proposal: &Proposal<D>, signers: [usize; 3]| -> TNotarization<_, D> {
+                    let votes: Vec<_> = signers
+                        .iter()
+                        .map(|i| TNotarize::sign(&schemes[*i], proposal.clone()).unwrap())
+                        .collect();
+                    TNotarization::from_notarizes(&schemes[0], non_empty![@&votes], &Sequential)
+                        .expect("notarization quorum")
+                };
+            let build_nullification = |view: u64, signers: [usize; 3]| -> TNullification<_> {
+                let round = Round::new(epoch, View::new(view));
+                let votes: Vec<_> = signers
+                    .iter()
+                    .map(|i| TNullify::sign::<D>(&schemes[*i], round).unwrap())
+                    .collect();
+                TNullification::from_nullifies(&schemes[0], non_empty![@&votes], &Sequential)
+                    .expect("nullification quorum")
+            };
+
+            // Term 1 chain (views 1 and 2), certified by `b` and `c`.
+            let payload_1 = Sha256::hash(&[b"V1"]);
+            let proposal_1 =
+                Proposal::new(Round::new(epoch, View::new(1)), View::new(0), payload_1);
+            let payload_2 = Sha256::hash(&[b"V2"]);
+            let proposal_2 =
+                Proposal::new(Round::new(epoch, View::new(2)), View::new(1), payload_2);
+            // Term 5 chain (views 21 and 22), certified by `a` and `b`. The
+            // parent is genesis so `a`, which never certified term 1, could
+            // have voted for it.
+            let payload_21 = Sha256::hash(&[b"V21"]);
+            let proposal_21 =
+                Proposal::new(Round::new(epoch, View::new(21)), View::new(0), payload_21);
+            let payload_22 = Sha256::hash(&[b"V22"]);
+            let proposal_22 =
+                Proposal::new(Round::new(epoch, View::new(22)), View::new(21), payload_22);
+
+            let injector_pk = PrivateKey::from_seed(1_000_000).public_key();
+            let (mut injector_sender, _inj_certificate_receiver) = oracle
+                .control(injector_pk.clone())
+                .register(1, TEST_QUOTA)
+                .await
+                .unwrap();
+            let link = Link {
+                latency: Duration::from_millis(10),
+                jitter: Duration::from_millis(0),
+                success_rate: probability!(1.0),
+            };
+            for p in participants.iter() {
+                oracle
+                    .add_link(injector_pk.clone(), p.clone(), link.clone())
+                    .await
+                    .unwrap();
+            }
+            oracle.manager().track(
+                1,
+                TrackedPeers::new(
+                    Set::from_iter_dedup(participants.iter().cloned()),
+                    Set::from_iter_dedup(std::slice::from_ref(&injector_pk).iter().cloned()),
+                ),
+            );
+            context.sleep(Duration::from_millis(10)).await;
+
+            {
+                let mut send_to = |certificate: Certificate<S, D>, targets: &[usize]| {
+                    let msg = certificate.encode();
+                    for idx in targets {
+                        injector_sender.send(
+                            Recipients::One(participants[*idx].clone()),
+                            msg.clone(),
+                            true,
+                        );
+                    }
+                };
+
+                // Term 1: `b` and `c` follow the chain; `a` only learns the
+                // term was abandoned.
+                send_to(
+                    Certificate::Notarization(build_notarization(&proposal_1, [b, c, offline])),
+                    &[b, c],
+                );
+                send_to(
+                    Certificate::Notarization(build_notarization(&proposal_2, [b, c, offline])),
+                    &[b, c],
+                );
+                send_to(
+                    Certificate::Nullification(build_nullification(3, [b, c, offline])),
+                    &[b, c],
+                );
+                let a_skip = if suppress_backfill { 1 } else { 3 };
+                send_to(
+                    Certificate::Nullification(build_nullification(a_skip, [a, c, offline])),
+                    &[a, b],
+                );
+
+                // Terms 2..=4 are abandoned at their term starts by everyone.
+                for view in [6u64, 11, 16] {
+                    send_to(
+                        Certificate::Nullification(build_nullification(view, [a, b, c])),
+                        &[a, b, c],
+                    );
+                }
+
+                // Term 5: `a` and `b` follow the chain; `c` only learns the
+                // term was abandoned.
+                send_to(
+                    Certificate::Notarization(build_notarization(&proposal_21, [a, b, offline])),
+                    &[a, b],
+                );
+                send_to(
+                    Certificate::Notarization(build_notarization(&proposal_22, [a, b, offline])),
+                    &[a, b],
+                );
+                let c_skip = if suppress_backfill { 21 } else { 23 };
+                send_to(
+                    Certificate::Nullification(build_nullification(c_skip, [a, c, offline])),
+                    &[c],
+                );
+                send_to(
+                    Certificate::Nullification(build_nullification(23, [a, b, offline])),
+                    &[a, b],
+                );
+            }
+
+            // Start honest engines before GST so preload rebroadcasts are lost.
+            let relay = Arc::new(mocks::relay::Relay::<Sha256Digest, _>::new());
+            let mut honest_reporters = HashMap::new();
+            for (idx, validator) in participants.iter().enumerate() {
+                let (pending, recovered, resolver) = registrations
+                    .remove(validator)
+                    .expect("validator should be registered");
+                if idx == offline {
+                    drop(pending);
+                    drop(recovered);
+                    drop(resolver);
+                    continue;
+                }
+                let reporter_config = mocks::reporter::Config {
+                    participants: participants.clone().try_into().unwrap(),
+                    scheme: schemes[idx].clone(),
+                    elector: elector.clone(),
+                };
+                let reporter = mocks::reporter::Reporter::new(
+                    context
+                        .child("reporter")
+                        .with_attribute("public_key", validator),
+                    reporter_config,
+                );
+                honest_reporters.insert(idx, reporter.clone());
+
+                let application_cfg = mocks::application::Config::<Sha256, _> {
+                    relay: relay.clone(),
+                    me: validator.clone(),
+                    propose_latency: (250.0, 50.0),
+                    verify_latency: (10.0, 5.0),
+                    certify_latency: (10.0, 5.0),
+                    should_certify: mocks::application::Certifier::Always,
+                };
+                let (actor, application) = mocks::application::Application::new(
+                    context
+                        .child("application")
+                        .with_attribute("public_key", validator),
+                    application_cfg,
+                );
+                actor.start();
+                let blocker = oracle.control(validator.clone());
+                let cfg = config::Config {
+                    scheme: schemes[idx].clone(),
+                    elector: elector.clone(),
+                    blocker,
+                    automaton: application.clone(),
+                    relay: application.clone(),
+                    reporter: reporter.clone(),
+                    strategy: Sequential,
+                    partition: validator.to_string(),
+                    mailbox_size: NZUsize!(1024),
+                    epoch,
+                    floor: config::Floor::Genesis(mocks::application::genesis::<Sha256>(epoch)),
+                    leader_timeout: Duration::from_secs(10),
+                    certification_timeout: Duration::from_secs(11),
+                    timeout_retry: Duration::from_secs(10),
+                    fetch_timeout: Duration::from_secs(1),
+                    view_retention,
+                    skip: SkipPolicy::Enabled {
+                        timeout: skip_timeout,
+                        budget: SkipBudget::Participants,
+                    },
+                    replay_buffer: NZUsize!(1024 * 1024),
+                    write_buffer: NZUsize!(1024 * 1024),
+                    page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
+                    forward: ForwardPolicy::Disabled,
+                    track_historical_votes: false,
+                };
+                let engine = Engine::new(
+                    context
+                        .child("engine")
+                        .with_attribute("public_key", validator),
+                    cfg,
+                );
+                engine.start(pending, recovered, resolver);
+            }
+
+            // Drain the preload before checking the split.
+            context.sleep(Duration::from_secs(2)).await;
+
+            // Confirm the intended cross-term split before GST.
+            for (idx, reporter) in honest_reporters.iter() {
+                let certifications = reporter.certifications.lock();
+                let has_term1 = certifications.contains_key(&View::new(2));
+                let has_term5 = certifications.contains_key(&View::new(22));
+                if *idx == a {
+                    assert!(!has_term1 && has_term5, "a: {has_term1} {has_term5}");
+                } else if *idx == b {
+                    assert!(has_term1 && has_term5, "b: {has_term1} {has_term5}");
+                } else {
+                    assert!(has_term1 && !has_term5, "c: {has_term1} {has_term5}");
+                }
+                assert!(
+                    reporter.finalizations.lock().is_empty(),
+                    "reporter {idx} finalized during preload"
+                );
+            }
+
+            // End the partition (GST).
+            link_validators(&mut oracle, &participants, Action::Link(link.clone()), None).await;
+
+            // Wait until every honest validator finalizes in the first
+            // post-GST term.
+            let target = View::new(26);
+            let mut finalizers = Vec::new();
+            for (idx, reporter) in honest_reporters.iter_mut() {
+                let (mut latest, mut monitor) = reporter.subscribe().await;
+                finalizers.push(
+                    context
+                        .child("finalizer")
+                        .with_attribute("index", idx)
+                        .spawn(move |_| async move {
+                            while latest < target {
+                                latest = monitor.recv().await.expect("finalization missing");
+                            }
+                        }),
+                );
+            }
+            join_all(finalizers).await;
+
+            for reporter in honest_reporters.values() {
+                reporter.assert_no_faults();
+                reporter.assert_no_invalid();
+            }
+            let blocked = oracle.blocked().await.unwrap();
+            assert!(blocked.is_empty(), "blocked peers: {blocked:?}");
+            for (idx, reporter) in honest_reporters.iter() {
+                assert!(
+                    reporter
+                        .finalizations
+                        .lock()
+                        .keys()
+                        .any(|view| *view >= target),
+                    "reporter {idx} never finalized the post-GST term"
+                );
+            }
+            let c_certifications = honest_reporters[&c].certifications.lock();
+            for view in [View::new(21), View::new(22)] {
+                assert!(
+                    c_certifications.contains_key(&view),
+                    "c did not recover and certify view {view} from an honest validator"
+                );
+            }
+        });
+    }
+
+    #[test_group("slow")]
+    #[test_traced]
+    fn test_stable_leader_cross_term_certified_split_recovers() {
+        stable_leader_cross_term_certified_split::<_, _, RoundRobin>(
+            ed25519::fixture,
+            RoundRobin::default().with_term(
+                TermLength::new(NZU32!(5)),
+                Duration::from_secs(12),
+                ViewDelta::new(0),
+            ),
+            true,
+        );
+    }
+
+    #[test_group("slow")]
+    #[test_traced]
+    fn test_stable_leader_cross_term_certified_split_backfillable() {
+        stable_leader_cross_term_certified_split::<_, _, RoundRobin>(
+            ed25519::fixture,
+            RoundRobin::default().with_term(
+                TermLength::new(NZU32!(5)),
+                Duration::from_secs(12),
+                ViewDelta::new(0),
+            ),
+            false,
+        );
+    }
+
     fn tle<V, L>(elector: L)
     where
         V: Variant,

--- a/consensus/src/simplex/mod.rs
+++ b/consensus/src/simplex/mod.rs
@@ -7156,7 +7156,7 @@ mod tests {
                 c,
                 "view-26 leader must hold certification 22"
             );
-            // The halt detector below waits for the next Byzantine-led term.
+            // The halt detector ends when term 9 returns to the offline validator.
             assert_eq!(leader_of(41), offline, "term 9 must return to offline");
 
             let build_notarization =
@@ -7321,9 +7321,8 @@ mod tests {
                         }),
                 );
             }
-            // Reaching the next Byzantine-led term proves every honest
-            // participant led a full term without finalizing: protocol
-            // progress without recovery, not a stalled executor.
+            // Reaching the next offline-led term proves each honest validator
+            // led a full term without finalizing.
             let progress_reporters: Vec<_> = honest_reporters.values().cloned().collect();
             let next_byzantine_term =
                 context
@@ -7356,9 +7355,9 @@ mod tests {
             assert!(blocked.is_empty(), "blocked peers: {blocked:?}");
 
             if !finalized {
-                // Diagnose the halt: each deprived validator fetched the
-                // proposal parent from an honest proposer but could not
-                // certify it without the pinned previous view.
+                // Each deprived validator fetched the proposal parent from an
+                // honest proposer but lacks the preceding notarization needed
+                // to certify it.
                 let a_reporter = &honest_reporters[&a];
                 assert!(a_reporter.notarizations.lock().contains_key(&View::new(2)));
                 assert!(!a_reporter.notarizations.lock().contains_key(&View::new(1)));

--- a/consensus/src/simplex/mod.rs
+++ b/consensus/src/simplex/mod.rs
@@ -347,17 +347,17 @@
 //! an uncertified parent inside the optimistic issuance window: its certificate is still forming
 //! from live votes (see [Optimistic Validation](#optimistic-validation)).
 //!
-//! Certification repairs a missed certificate the same way. A notarized view certifies only after
-//! its parent certifies, which requires the parent's exact-view notarization. When the voter holds
-//! a view's notarization but not its parent's, the parent's votes have stopped circulating.
-//! Peers broadcast a certificate only once, so the voter requests the parent's notarization from
-//! the term's leader, or from any peer when the term's leader is unknown.
+//! The same split can block certification. A notarized view certifies only after its parent
+//! certifies, and certifying the parent requires its exact-view notarization. When the voter holds
+//! a view's notarization but not its parent's, the parent's votes have stopped circulating, and
+//! peers broadcast a certificate only once. A leader that withheld the certificate may never
+//! answer a fetch, so the voter requests the parent's notarization from any peer.
 //!
 //! A resolver key identifies a view, not a certificate. A notarization and a covering nullification
 //! for one view answer opposite questions, so a peer can return valid evidence that does not settle
 //! the request. The requester records that evidence and retries without faulting the peer. A
 //! delivered notarization completes its fetch on arrival, because certification judges evidence
-//! already in hand. Matching evidence or finalization retires targeted work.
+//! already in hand. Matching evidence or finalization retires pending work.
 //!
 //! ## Pluggable Hashing and Cryptography
 //!
@@ -6037,34 +6037,14 @@ mod tests {
             let null_a = build_nullification(Round::new(Epoch::new(333), View::new(f_view + 1)));
             let null_b = build_nullification(Round::new(Epoch::new(333), View::new(f_view + 2)));
 
-            // Create an 11th non-participant injector and obtain senders
-            let injector_pk = PrivateKey::from_seed(1_000_000).public_key();
-            let (mut injector_sender, _inj_certificate_receiver) = oracle
-                .control(injector_pk.clone())
-                .register(1, TEST_QUOTA)
-                .await
-                .unwrap();
-
-            // Create minimal one-way links from injector to all participants (not full mesh)
+            // Create an 11th non-participant injector with one-way links to all participants
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(0),
                 success_rate: probability!(1.0),
             };
-            for p in participants.iter() {
-                oracle
-                    .add_link(injector_pk.clone(), p.clone(), link.clone())
-                    .await
-                    .unwrap();
-            }
-            oracle.manager().track(
-                1,
-                TrackedPeers::new(
-                    Set::from_iter_dedup(participants.iter().cloned()),
-                    Set::from_iter_dedup(std::slice::from_ref(&injector_pk).iter().cloned()),
-                ),
-            );
-            context.sleep(Duration::from_millis(10)).await;
+            let mut injector_sender =
+                start_certificate_injector(&context, &mut oracle, &participants, &link).await;
 
             // ========== Broadcast certificates over recovered network. ==========
 
@@ -6387,7 +6367,7 @@ mod tests {
             let application_cfg = mocks::application::Config::<Sha256, _> {
                 relay: relay.clone(),
                 me: validator.clone(),
-                propose_latency: (250.0, 50.0),
+                propose_latency: (250.0, 50.0), // ensure we process certificates first
                 verify_latency: (10.0, 5.0),
                 certify_latency: (10.0, 5.0),
                 should_certify: mocks::application::Certifier::Always,
@@ -7359,14 +7339,32 @@ mod tests {
                 // honest proposer but lacks the preceding notarization needed
                 // to certify it.
                 let a_reporter = &honest_reporters[&a];
-                assert!(a_reporter.notarizations.lock().contains_key(&View::new(2)));
-                assert!(!a_reporter.notarizations.lock().contains_key(&View::new(1)));
-                assert!(!a_reporter.certifications.lock().contains_key(&View::new(2)));
+                assert!(
+                    a_reporter.notarizations.lock().contains_key(&View::new(2)),
+                    "halted, but a is missing notarization(2)"
+                );
+                assert!(
+                    !a_reporter.notarizations.lock().contains_key(&View::new(1)),
+                    "halted, but a repaired notarization(1)"
+                );
+                assert!(
+                    !a_reporter.certifications.lock().contains_key(&View::new(2)),
+                    "halted, but a certified view 2"
+                );
 
                 let c_reporter = &honest_reporters[&c];
-                assert!(c_reporter.notarizations.lock().contains_key(&View::new(22)));
-                assert!(!c_reporter.notarizations.lock().contains_key(&View::new(21)));
-                assert!(!c_reporter.certifications.lock().contains_key(&View::new(22)));
+                assert!(
+                    c_reporter.notarizations.lock().contains_key(&View::new(22)),
+                    "halted, but c is missing notarization(22)"
+                );
+                assert!(
+                    !c_reporter.notarizations.lock().contains_key(&View::new(21)),
+                    "halted, but c repaired notarization(21)"
+                );
+                assert!(
+                    !c_reporter.certifications.lock().contains_key(&View::new(22)),
+                    "halted, but c certified view 22"
+                );
 
                 panic!(
                     "all honest leaders exhausted a term, but recursive parent repair never finalized"

--- a/consensus/src/simplex/mod.rs
+++ b/consensus/src/simplex/mod.rs
@@ -782,6 +782,13 @@ mod tests {
     const PAGE_CACHE_SIZE: NonZeroUsize = NZUsize!(10);
     const TEST_QUOTA: Quota = Quota::per_second(NonZeroU32::MAX);
 
+    type TestChannel = (
+        Sender<PublicKey, deterministic::Context>,
+        Receiver<PublicKey>,
+    );
+    type TestRegistration = (TestChannel, TestChannel, TestChannel);
+    type TestRegistrations = HashMap<PublicKey, TestRegistration>;
+
     /// Builds a [Lookahead] with a term length of 5.
     fn test_lookahead(optimistic_views: u64) -> Lookahead {
         Lookahead {
@@ -872,20 +879,7 @@ mod tests {
     async fn register_validator(
         oracle: &mut Oracle<PublicKey, deterministic::Context>,
         validator: PublicKey,
-    ) -> (
-        (
-            Sender<PublicKey, deterministic::Context>,
-            Receiver<PublicKey>,
-        ),
-        (
-            Sender<PublicKey, deterministic::Context>,
-            Receiver<PublicKey>,
-        ),
-        (
-            Sender<PublicKey, deterministic::Context>,
-            Receiver<PublicKey>,
-        ),
-    ) {
+    ) -> TestRegistration {
         let control = oracle.control(validator.clone());
         let (vote_sender, vote_receiver) = control.register(0, TEST_QUOTA).await.unwrap();
         let (certificate_sender, certificate_receiver) =
@@ -902,23 +896,7 @@ mod tests {
     async fn register_validators(
         oracle: &mut Oracle<PublicKey, deterministic::Context>,
         validators: &[PublicKey],
-    ) -> HashMap<
-        PublicKey,
-        (
-            (
-                Sender<PublicKey, deterministic::Context>,
-                Receiver<PublicKey>,
-            ),
-            (
-                Sender<PublicKey, deterministic::Context>,
-                Receiver<PublicKey>,
-            ),
-            (
-                Sender<PublicKey, deterministic::Context>,
-                Receiver<PublicKey>,
-            ),
-        ),
-    > {
+    ) -> TestRegistrations {
         let mut registrations = HashMap::new();
         for validator in validators.iter() {
             let registration = register_validator(oracle, validator.clone()).await;
@@ -6314,6 +6292,154 @@ mod tests {
 
     test_for_all_fixtures!(split_views_no_lockup);
 
+    type CertifiedSplitReporter<S, L> =
+        mocks::reporter::Reporter<deterministic::Context, S, L, Sha256Digest>;
+
+    struct CertifiedSplitEngineConfig<'a, S, L> {
+        oracle: &'a Oracle<PublicKey, deterministic::Context>,
+        participants: &'a [PublicKey],
+        schemes: &'a [S],
+        registrations: &'a mut TestRegistrations,
+        silent: usize,
+        elector: &'a L,
+        epoch: Epoch,
+        view_retention: ViewDelta,
+        skip_timeout: Duration,
+    }
+
+    /// Registers a non-committee peer that can preload certificates while
+    /// validators are partitioned from one another.
+    async fn start_certificate_injector(
+        context: &deterministic::Context,
+        oracle: &mut Oracle<PublicKey, deterministic::Context>,
+        participants: &[PublicKey],
+        link: &Link,
+    ) -> Sender<PublicKey, deterministic::Context> {
+        let injector = PrivateKey::from_seed(1_000_000).public_key();
+        let (sender, _receiver) = oracle
+            .control(injector.clone())
+            .register(1, TEST_QUOTA)
+            .await
+            .unwrap();
+        for participant in participants {
+            oracle
+                .add_link(injector.clone(), participant.clone(), link.clone())
+                .await
+                .unwrap();
+        }
+        oracle.manager().track(
+            1,
+            TrackedPeers::new(
+                Set::from_iter_dedup(participants.iter().cloned()),
+                Set::from_iter_dedup(std::iter::once(injector)),
+            ),
+        );
+        context.sleep(Duration::from_millis(10)).await;
+        sender
+    }
+
+    /// Starts every validator except `silent`, whose network registration is
+    /// dropped.
+    fn start_certified_split_engines<S, L>(
+        context: &deterministic::Context,
+        cfg: CertifiedSplitEngineConfig<'_, S, L>,
+    ) -> HashMap<usize, CertifiedSplitReporter<S, L>>
+    where
+        S: Scheme<Sha256Digest, PublicKey = PublicKey>,
+        L: elector::Config<S>,
+    {
+        let CertifiedSplitEngineConfig {
+            oracle,
+            participants,
+            schemes,
+            registrations,
+            silent,
+            elector,
+            epoch,
+            view_retention,
+            skip_timeout,
+        } = cfg;
+        let relay = Arc::new(mocks::relay::Relay::<Sha256Digest, _>::new());
+        let mut reporters = HashMap::new();
+
+        for (idx, validator) in participants.iter().enumerate() {
+            let registration = registrations
+                .remove(validator)
+                .expect("validator should be registered");
+            if idx == silent {
+                drop(registration);
+                continue;
+            }
+
+            let reporter_config = mocks::reporter::Config {
+                participants: participants.to_vec().try_into().unwrap(),
+                scheme: schemes[idx].clone(),
+                elector: elector.clone(),
+            };
+            let reporter = mocks::reporter::Reporter::new(
+                context
+                    .child("reporter")
+                    .with_attribute("public_key", validator),
+                reporter_config,
+            );
+            reporters.insert(idx, reporter.clone());
+
+            let application_cfg = mocks::application::Config::<Sha256, _> {
+                relay: relay.clone(),
+                me: validator.clone(),
+                propose_latency: (250.0, 50.0),
+                verify_latency: (10.0, 5.0),
+                certify_latency: (10.0, 5.0),
+                should_certify: mocks::application::Certifier::Always,
+            };
+            let (actor, application) = mocks::application::Application::new(
+                context
+                    .child("application")
+                    .with_attribute("public_key", validator),
+                application_cfg,
+            );
+            actor.start();
+
+            let cfg = config::Config {
+                scheme: schemes[idx].clone(),
+                elector: elector.clone(),
+                blocker: oracle.control(validator.clone()),
+                automaton: application.clone(),
+                relay: application.clone(),
+                reporter: reporter.clone(),
+                strategy: Sequential,
+                partition: validator.to_string(),
+                mailbox_size: NZUsize!(1024),
+                epoch,
+                floor: config::Floor::Genesis(mocks::application::genesis::<Sha256>(epoch)),
+                leader_timeout: Duration::from_secs(10),
+                certification_timeout: Duration::from_secs(11),
+                timeout_retry: Duration::from_secs(10),
+                fetch_timeout: Duration::from_secs(1),
+                view_retention,
+                skip: SkipPolicy::Enabled {
+                    timeout: skip_timeout,
+                    budget: SkipBudget::Participants,
+                },
+                replay_buffer: NZUsize!(1024 * 1024),
+                write_buffer: NZUsize!(1024 * 1024),
+                page_cache: CacheRef::from_pooler(context, PAGE_SIZE, PAGE_CACHE_SIZE),
+                forward: ForwardPolicy::Disabled,
+                track_historical_votes: false,
+            };
+            let engine = Engine::new(
+                context
+                    .child("engine")
+                    .with_attribute("public_key", validator),
+                cfg,
+            );
+            let (pending, recovered, resolver) = registration;
+            engine.start(pending, recovered, resolver);
+        }
+
+        reporters
+    }
+
     /// Heals a certified-notarization/nullification split in a group-led view.
     ///
     /// One honest validator certifies Notarization(3), two hold Nullification(3), and
@@ -6394,31 +6520,13 @@ mod tests {
             let b3_notarization = build_notarization(&proposal_b3);
             let null_3 = build_nullification(3);
 
-            let injector_pk = PrivateKey::from_seed(1_000_000).public_key();
-            let (mut injector_sender, _inj_certificate_receiver) = oracle
-                .control(injector_pk.clone())
-                .register(1, TEST_QUOTA)
-                .await
-                .unwrap();
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(0),
                 success_rate: probability!(1.0),
             };
-            for p in participants.iter() {
-                oracle
-                    .add_link(injector_pk.clone(), p.clone(), link.clone())
-                    .await
-                    .unwrap();
-            }
-            oracle.manager().track(
-                1,
-                TrackedPeers::new(
-                    Set::from_iter_dedup(participants.iter().cloned()),
-                    Set::from_iter_dedup(std::slice::from_ref(&injector_pk).iter().cloned()),
-                ),
-            );
-            context.sleep(Duration::from_millis(10)).await;
+            let mut injector_sender =
+                start_certificate_injector(&context, &mut oracle, &participants, &link).await;
 
             // Split the view-3 certificates by role and share all other evidence.
             let msg = Certificate::<_, D>::Notarization(b2_notarization).encode();
@@ -6441,82 +6549,20 @@ mod tests {
             }
 
             // Start honest engines before GST so preload rebroadcasts are lost.
-            let relay = Arc::new(mocks::relay::Relay::<Sha256Digest, _>::new());
-            let mut honest_reporters = HashMap::new();
-            for (idx, validator) in participants.iter().enumerate() {
-                let (pending, recovered, resolver) = registrations
-                    .remove(validator)
-                    .expect("validator should be registered");
-                if idx == byzantine {
-                    drop(pending);
-                    drop(recovered);
-                    drop(resolver);
-                    continue;
-                }
-                let reporter_config = mocks::reporter::Config {
-                    participants: participants.clone().try_into().unwrap(),
-                    scheme: schemes[idx].clone(),
-                    elector: elector.clone(),
-                };
-                let reporter = mocks::reporter::Reporter::new(
-                    context
-                        .child("reporter")
-                        .with_attribute("public_key", validator),
-                    reporter_config,
-                );
-                honest_reporters.insert(idx, reporter.clone());
-
-                let application_cfg = mocks::application::Config::<Sha256, _> {
-                    relay: relay.clone(),
-                    me: validator.clone(),
-                    propose_latency: (250.0, 50.0), // ensure we process certificates first
-                    verify_latency: (10.0, 5.0),
-                    certify_latency: (10.0, 5.0),
-                    should_certify: mocks::application::Certifier::Always,
-                };
-                let (actor, application) = mocks::application::Application::new(
-                    context
-                        .child("application")
-                        .with_attribute("public_key", validator),
-                    application_cfg,
-                );
-                actor.start();
-                let blocker = oracle.control(validator.clone());
-                let cfg = config::Config {
-                    scheme: schemes[idx].clone(),
-                    elector: elector.clone(),
-                    blocker,
-                    automaton: application.clone(),
-                    relay: application.clone(),
-                    reporter: reporter.clone(),
-                    strategy: Sequential,
-                    partition: validator.to_string(),
-                    mailbox_size: NZUsize!(1024),
+            let mut honest_reporters = start_certified_split_engines(
+                &context,
+                CertifiedSplitEngineConfig {
+                    oracle: &oracle,
+                    participants: &participants,
+                    schemes: &schemes,
+                    registrations: &mut registrations,
+                    silent: byzantine,
+                    elector: &elector,
                     epoch,
-                    floor: config::Floor::Genesis(mocks::application::genesis::<Sha256>(epoch)),
-                    leader_timeout: Duration::from_secs(10),
-                    certification_timeout: Duration::from_secs(11),
-                    timeout_retry: Duration::from_secs(10),
-                    fetch_timeout: Duration::from_secs(1),
                     view_retention,
-                    skip: SkipPolicy::Enabled {
-                        timeout: skip_timeout,
-                        budget: SkipBudget::Participants,
-                    },
-                    replay_buffer: NZUsize!(1024 * 1024),
-                    write_buffer: NZUsize!(1024 * 1024),
-                    page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
-                    forward: ForwardPolicy::Disabled,
-                    track_historical_votes: false,
-                };
-                let engine = Engine::new(
-                    context
-                        .child("engine")
-                        .with_attribute("public_key", validator),
-                    cfg,
-                );
-                engine.start(pending, recovered, resolver);
-            }
+                    skip_timeout,
+                },
+            );
 
             // Drain the preload before checking the split.
             context.sleep(Duration::from_secs(2)).await;
@@ -6684,31 +6730,13 @@ mod tests {
             let b3_notarization = build_notarization(&proposal_b3);
             let null_3 = build_nullification(3);
 
-            let injector_pk = PrivateKey::from_seed(1_000_000).public_key();
-            let (mut injector_sender, _inj_certificate_receiver) = oracle
-                .control(injector_pk.clone())
-                .register(1, TEST_QUOTA)
-                .await
-                .unwrap();
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(0),
                 success_rate: probability!(1.0),
             };
-            for p in participants.iter() {
-                oracle
-                    .add_link(injector_pk.clone(), p.clone(), link.clone())
-                    .await
-                    .unwrap();
-            }
-            oracle.manager().track(
-                1,
-                TrackedPeers::new(
-                    Set::from_iter_dedup(participants.iter().cloned()),
-                    Set::from_iter_dedup(std::slice::from_ref(&injector_pk).iter().cloned()),
-                ),
-            );
-            context.sleep(Duration::from_millis(10)).await;
+            let mut injector_sender =
+                start_certificate_injector(&context, &mut oracle, &participants, &link).await;
 
             // Split the view-3 certificates by role and share all other evidence.
             let msg = Certificate::<_, D>::Notarization(b2_notarization).encode();
@@ -6731,82 +6759,20 @@ mod tests {
             }
 
             // Start honest engines before GST so preload rebroadcasts are lost.
-            let relay = Arc::new(mocks::relay::Relay::<Sha256Digest, _>::new());
-            let mut honest_reporters = HashMap::new();
-            for (idx, validator) in participants.iter().enumerate() {
-                let (pending, recovered, resolver) = registrations
-                    .remove(validator)
-                    .expect("validator should be registered");
-                if idx == byzantine {
-                    drop(pending);
-                    drop(recovered);
-                    drop(resolver);
-                    continue;
-                }
-                let reporter_config = mocks::reporter::Config {
-                    participants: participants.clone().try_into().unwrap(),
-                    scheme: schemes[idx].clone(),
-                    elector: elector.clone(),
-                };
-                let reporter = mocks::reporter::Reporter::new(
-                    context
-                        .child("reporter")
-                        .with_attribute("public_key", validator),
-                    reporter_config,
-                );
-                honest_reporters.insert(idx, reporter.clone());
-
-                let application_cfg = mocks::application::Config::<Sha256, _> {
-                    relay: relay.clone(),
-                    me: validator.clone(),
-                    propose_latency: (250.0, 50.0), // ensure we process certificates first
-                    verify_latency: (10.0, 5.0),
-                    certify_latency: (10.0, 5.0),
-                    should_certify: mocks::application::Certifier::Always,
-                };
-                let (actor, application) = mocks::application::Application::new(
-                    context
-                        .child("application")
-                        .with_attribute("public_key", validator),
-                    application_cfg,
-                );
-                actor.start();
-                let blocker = oracle.control(validator.clone());
-                let cfg = config::Config {
-                    scheme: schemes[idx].clone(),
-                    elector: elector.clone(),
-                    blocker,
-                    automaton: application.clone(),
-                    relay: application.clone(),
-                    reporter: reporter.clone(),
-                    strategy: Sequential,
-                    partition: validator.to_string(),
-                    mailbox_size: NZUsize!(1024),
+            let mut honest_reporters = start_certified_split_engines(
+                &context,
+                CertifiedSplitEngineConfig {
+                    oracle: &oracle,
+                    participants: &participants,
+                    schemes: &schemes,
+                    registrations: &mut registrations,
+                    silent: byzantine,
+                    elector: &elector,
                     epoch,
-                    floor: config::Floor::Genesis(mocks::application::genesis::<Sha256>(epoch)),
-                    leader_timeout: Duration::from_secs(10),
-                    certification_timeout: Duration::from_secs(11),
-                    timeout_retry: Duration::from_secs(10),
-                    fetch_timeout: Duration::from_secs(1),
                     view_retention,
-                    skip: SkipPolicy::Enabled {
-                        timeout: skip_timeout,
-                        budget: SkipBudget::Participants,
-                    },
-                    replay_buffer: NZUsize!(1024 * 1024),
-                    write_buffer: NZUsize!(1024 * 1024),
-                    page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
-                    forward: ForwardPolicy::Disabled,
-                    track_historical_votes: false,
-                };
-                let engine = Engine::new(
-                    context
-                        .child("engine")
-                        .with_attribute("public_key", validator),
-                    cfg,
-                );
-                engine.start(pending, recovered, resolver);
-            }
+                    skip_timeout,
+                },
+            );
 
             // Drain the preload before checking the split.
             context.sleep(Duration::from_secs(2)).await;
@@ -6978,31 +6944,13 @@ mod tests {
             let b2_finalization = build_finalization(&proposal_b2);
             let b5_notarization = build_notarization(&proposal_b5);
 
-            let injector_pk = PrivateKey::from_seed(1_000_000).public_key();
-            let (mut injector_sender, _inj_certificate_receiver) = oracle
-                .control(injector_pk.clone())
-                .register(1, TEST_QUOTA)
-                .await
-                .unwrap();
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(0),
                 success_rate: probability!(1.0),
             };
-            for p in participants.iter() {
-                oracle
-                    .add_link(injector_pk.clone(), p.clone(), link.clone())
-                    .await
-                    .unwrap();
-            }
-            oracle.manager().track(
-                1,
-                TrackedPeers::new(
-                    Set::from_iter_dedup(participants.iter().cloned()),
-                    Set::from_iter_dedup(std::slice::from_ref(&injector_pk).iter().cloned()),
-                ),
-            );
-            context.sleep(Duration::from_millis(10)).await;
+            let mut injector_sender =
+                start_certificate_injector(&context, &mut oracle, &participants, &link).await;
 
             // Split view-5 notarization from nullifications 3 through 5.
             let msg = Certificate::<_, D>::Notarization(b2_notarization).encode();
@@ -7027,82 +6975,20 @@ mod tests {
             }
 
             // Start honest engines before GST so preload rebroadcasts are lost.
-            let relay = Arc::new(mocks::relay::Relay::<Sha256Digest, _>::new());
-            let mut honest_reporters = HashMap::new();
-            for (idx, validator) in participants.iter().enumerate() {
-                let (pending, recovered, resolver) = registrations
-                    .remove(validator)
-                    .expect("validator should be registered");
-                if idx == byzantine {
-                    drop(pending);
-                    drop(recovered);
-                    drop(resolver);
-                    continue;
-                }
-                let reporter_config = mocks::reporter::Config {
-                    participants: participants.clone().try_into().unwrap(),
-                    scheme: schemes[idx].clone(),
-                    elector: elector.clone(),
-                };
-                let reporter = mocks::reporter::Reporter::new(
-                    context
-                        .child("reporter")
-                        .with_attribute("public_key", validator),
-                    reporter_config,
-                );
-                honest_reporters.insert(idx, reporter.clone());
-
-                let application_cfg = mocks::application::Config::<Sha256, _> {
-                    relay: relay.clone(),
-                    me: validator.clone(),
-                    propose_latency: (250.0, 50.0), // ensure we process certificates first
-                    verify_latency: (10.0, 5.0),
-                    certify_latency: (10.0, 5.0),
-                    should_certify: mocks::application::Certifier::Always,
-                };
-                let (actor, application) = mocks::application::Application::new(
-                    context
-                        .child("application")
-                        .with_attribute("public_key", validator),
-                    application_cfg,
-                );
-                actor.start();
-                let blocker = oracle.control(validator.clone());
-                let cfg = config::Config {
-                    scheme: schemes[idx].clone(),
-                    elector: elector.clone(),
-                    blocker,
-                    automaton: application.clone(),
-                    relay: application.clone(),
-                    reporter: reporter.clone(),
-                    strategy: Sequential,
-                    partition: validator.to_string(),
-                    mailbox_size: NZUsize!(1024),
+            let mut honest_reporters = start_certified_split_engines(
+                &context,
+                CertifiedSplitEngineConfig {
+                    oracle: &oracle,
+                    participants: &participants,
+                    schemes: &schemes,
+                    registrations: &mut registrations,
+                    silent: byzantine,
+                    elector: &elector,
                     epoch,
-                    floor: config::Floor::Genesis(mocks::application::genesis::<Sha256>(epoch)),
-                    leader_timeout: Duration::from_secs(10),
-                    certification_timeout: Duration::from_secs(11),
-                    timeout_retry: Duration::from_secs(10),
-                    fetch_timeout: Duration::from_secs(1),
                     view_retention,
-                    skip: SkipPolicy::Enabled {
-                        timeout: skip_timeout,
-                        budget: SkipBudget::Participants,
-                    },
-                    replay_buffer: NZUsize!(1024 * 1024),
-                    write_buffer: NZUsize!(1024 * 1024),
-                    page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
-                    forward: ForwardPolicy::Disabled,
-                    track_historical_votes: false,
-                };
-                let engine = Engine::new(
-                    context
-                        .child("engine")
-                        .with_attribute("public_key", validator),
-                    cfg,
-                );
-                engine.start(pending, recovered, resolver);
-            }
+                    skip_timeout,
+                },
+            );
 
             // Drain the preload before checking the split.
             context.sleep(Duration::from_secs(2)).await;
@@ -7236,7 +7122,7 @@ mod tests {
         let view_retention = ViewDelta::new(10);
         let skip_timeout = Duration::from_secs(12);
         let namespace = b"consensus".to_vec();
-        let executor = deterministic::Runner::timed(Duration::from_secs(120));
+        let executor = deterministic::Runner::timed(Duration::from_secs(300));
         executor.start(|mut context| async move {
             let Fixture {
                 participants,
@@ -7270,6 +7156,8 @@ mod tests {
                 c,
                 "view-26 leader must hold certification 22"
             );
+            // The halt detector below waits for the next Byzantine-led term.
+            assert_eq!(leader_of(41), offline, "term 9 must return to offline");
 
             let build_notarization =
                 |proposal: &Proposal<D>, signers: [usize; 3]| -> TNotarization<_, D> {
@@ -7307,31 +7195,13 @@ mod tests {
             let proposal_22 =
                 Proposal::new(Round::new(epoch, View::new(22)), View::new(21), payload_22);
 
-            let injector_pk = PrivateKey::from_seed(1_000_000).public_key();
-            let (mut injector_sender, _inj_certificate_receiver) = oracle
-                .control(injector_pk.clone())
-                .register(1, TEST_QUOTA)
-                .await
-                .unwrap();
             let link = Link {
                 latency: Duration::from_millis(10),
                 jitter: Duration::from_millis(0),
                 success_rate: probability!(1.0),
             };
-            for p in participants.iter() {
-                oracle
-                    .add_link(injector_pk.clone(), p.clone(), link.clone())
-                    .await
-                    .unwrap();
-            }
-            oracle.manager().track(
-                1,
-                TrackedPeers::new(
-                    Set::from_iter_dedup(participants.iter().cloned()),
-                    Set::from_iter_dedup(std::slice::from_ref(&injector_pk).iter().cloned()),
-                ),
-            );
-            context.sleep(Duration::from_millis(10)).await;
+            let mut injector_sender =
+                start_certificate_injector(&context, &mut oracle, &participants, &link).await;
 
             {
                 let mut send_to = |certificate: Certificate<S, D>, targets: &[usize]| {
@@ -7396,82 +7266,20 @@ mod tests {
 
             // Start honest engines before GST. The partition drops their
             // preload broadcasts.
-            let relay = Arc::new(mocks::relay::Relay::<Sha256Digest, _>::new());
-            let mut honest_reporters = HashMap::new();
-            for (idx, validator) in participants.iter().enumerate() {
-                let (pending, recovered, resolver) = registrations
-                    .remove(validator)
-                    .expect("validator should be registered");
-                if idx == offline {
-                    drop(pending);
-                    drop(recovered);
-                    drop(resolver);
-                    continue;
-                }
-                let reporter_config = mocks::reporter::Config {
-                    participants: participants.clone().try_into().unwrap(),
-                    scheme: schemes[idx].clone(),
-                    elector: elector.clone(),
-                };
-                let reporter = mocks::reporter::Reporter::new(
-                    context
-                        .child("reporter")
-                        .with_attribute("public_key", validator),
-                    reporter_config,
-                );
-                honest_reporters.insert(idx, reporter.clone());
-
-                let application_cfg = mocks::application::Config::<Sha256, _> {
-                    relay: relay.clone(),
-                    me: validator.clone(),
-                    propose_latency: (250.0, 50.0),
-                    verify_latency: (10.0, 5.0),
-                    certify_latency: (10.0, 5.0),
-                    should_certify: mocks::application::Certifier::Always,
-                };
-                let (actor, application) = mocks::application::Application::new(
-                    context
-                        .child("application")
-                        .with_attribute("public_key", validator),
-                    application_cfg,
-                );
-                actor.start();
-                let blocker = oracle.control(validator.clone());
-                let cfg = config::Config {
-                    scheme: schemes[idx].clone(),
-                    elector: elector.clone(),
-                    blocker,
-                    automaton: application.clone(),
-                    relay: application.clone(),
-                    reporter: reporter.clone(),
-                    strategy: Sequential,
-                    partition: validator.to_string(),
-                    mailbox_size: NZUsize!(1024),
+            let mut honest_reporters = start_certified_split_engines(
+                &context,
+                CertifiedSplitEngineConfig {
+                    oracle: &oracle,
+                    participants: &participants,
+                    schemes: &schemes,
+                    registrations: &mut registrations,
+                    silent: offline,
+                    elector: &elector,
                     epoch,
-                    floor: config::Floor::Genesis(mocks::application::genesis::<Sha256>(epoch)),
-                    leader_timeout: Duration::from_secs(10),
-                    certification_timeout: Duration::from_secs(11),
-                    timeout_retry: Duration::from_secs(10),
-                    fetch_timeout: Duration::from_secs(1),
                     view_retention,
-                    skip: SkipPolicy::Enabled {
-                        timeout: skip_timeout,
-                        budget: SkipBudget::Participants,
-                    },
-                    replay_buffer: NZUsize!(1024 * 1024),
-                    write_buffer: NZUsize!(1024 * 1024),
-                    page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
-                    forward: ForwardPolicy::Disabled,
-                    track_historical_votes: false,
-                };
-                let engine = Engine::new(
-                    context
-                        .child("engine")
-                        .with_attribute("public_key", validator),
-                    cfg,
-                );
-                engine.start(pending, recovered, resolver);
-            }
+                    skip_timeout,
+                },
+            );
 
             // Drain the preload before checking the split.
             context.sleep(Duration::from_secs(2)).await;
@@ -7513,7 +7321,32 @@ mod tests {
                         }),
                 );
             }
-            join_all(finalizers).await;
+            // Reaching the next Byzantine-led term proves every honest
+            // participant led a full term without finalizing: protocol
+            // progress without recovery, not a stalled executor.
+            let progress_reporters: Vec<_> = honest_reporters.values().cloned().collect();
+            let next_byzantine_term =
+                context
+                    .child("next_byzantine_term")
+                    .spawn(move |context| async move {
+                        loop {
+                            let reached = progress_reporters.iter().all(|reporter| {
+                                reporter
+                                    .nullifications
+                                    .lock()
+                                    .keys()
+                                    .any(|view| *view >= View::new(41))
+                            });
+                            if reached {
+                                return;
+                            }
+                            context.sleep(Duration::from_secs(1)).await;
+                        }
+                    });
+            let finalized = select! {
+                _ = join_all(finalizers) => true,
+                _ = next_byzantine_term => false,
+            };
 
             for reporter in honest_reporters.values() {
                 reporter.assert_no_faults();
@@ -7521,6 +7354,25 @@ mod tests {
             }
             let blocked = oracle.blocked().await.unwrap();
             assert!(blocked.is_empty(), "blocked peers: {blocked:?}");
+
+            if !finalized {
+                // Diagnose the halt: each deprived validator fetched the
+                // proposal parent from an honest proposer but could not
+                // certify it without the pinned previous view.
+                let a_reporter = &honest_reporters[&a];
+                assert!(a_reporter.notarizations.lock().contains_key(&View::new(2)));
+                assert!(!a_reporter.notarizations.lock().contains_key(&View::new(1)));
+                assert!(!a_reporter.certifications.lock().contains_key(&View::new(2)));
+
+                let c_reporter = &honest_reporters[&c];
+                assert!(c_reporter.notarizations.lock().contains_key(&View::new(22)));
+                assert!(!c_reporter.notarizations.lock().contains_key(&View::new(21)));
+                assert!(!c_reporter.certifications.lock().contains_key(&View::new(22)));
+
+                panic!(
+                    "all honest leaders exhausted a term, but recursive parent repair never finalized"
+                );
+            }
             for (idx, reporter) in honest_reporters.iter() {
                 assert!(
                     reporter


### PR DESCRIPTION
## Problem

Certification of a mid-term proposal requires its immediate parent's notarization. Proposal verification can request that notarization only from the term leader. The shared request latch can then suppress certification's untargeted request. An unavailable leader can therefore block recovery even when another validator holds the certificate.

The [proof of concept](https://gist.github.com/dnkolegov-ar/13a7e4df4ece2d5f26d29c2b1539963e) demonstrates this cross-term certified split with stable leaders.

## Solution

- Send certification recovery requests without a target.
- Widen an existing leader-targeted fetch when certification requests the same view.
- Keep proposal verification targeted. Resolver targets remain exclusive.
- Add deterministic component tests and a four-validator full-engine regression with an offline stable leader and split certified floors.
- Add a control where background repair resolves the split when nullification occurs later in the term.

## Manual testing

- `just test --profile slow -p commonware-consensus test_stable_leader_cross_term_certified_split` (2 passed)
