### PR TITLE
[storage] Fix ordered child batches treating parent-deleted keys as live

### DIFF
--- a/storage/fuzz/Cargo.toml
+++ b/storage/fuzz/Cargo.toml
@@ -36,6 +36,20 @@ doc = false
 bench = false
 
 [[bin]]
+name = "qmdb_ordered_batch_root"
+path = "fuzz_targets/qmdb_ordered_batch_root.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "current_ordered_batch_root"
+path = "fuzz_targets/current_ordered_batch_root.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
 name = "qmdb_ordered_operations"
 path = "fuzz_targets/qmdb_ordered_operations.rs"
 test = false

--- a/storage/fuzz/fuzz_targets/current_ordered_batch_root.rs
+++ b/storage/fuzz/fuzz_targets/current_ordered_batch_root.rs
@@ -1,0 +1,218 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use commonware_cryptography::Sha256;
+use commonware_parallel::Sequential;
+use commonware_runtime::{
+    BufferPooler, Runner, Supervisor as _, buffer::paged::CacheRef, deterministic,
+};
+use commonware_storage::{
+    journal::contiguous::fixed::Config as FConfig,
+    merkle::{Graftable, full::Config as MerkleConfig, mmb, mmr},
+    qmdb::current::{FixedConfig as Config, ordered::fixed::Db as CurrentDb},
+    translator::OneCap,
+};
+use commonware_utils::{NZU16, NZU64, NZUsize, sequence::FixedBytes};
+use libfuzzer_sys::fuzz_target;
+use std::num::NonZeroU16;
+
+type Key = FixedBytes<32>;
+type Value = FixedBytes<32>;
+type Db<F> = CurrentDb<F, deterministic::Context, Key, Value, Sha256, OneCap, 32, Sequential>;
+
+const PAGE_SIZE: NonZeroU16 = NZU16!(137);
+
+// A small key space with few translated-key buckets forces frequent collisions between distinct
+// full keys, so a parent-deleted key and a colliding sibling routinely land in one bucket.
+const COLLISION_GROUPS: u8 = 4;
+const KEY_SPACE: u64 = 32;
+const MAX_INITIAL_WRITES: usize = 16;
+const MAX_PARENT_MUTATIONS: usize = 16;
+const MAX_CHILD_MUTATIONS: usize = 16;
+
+#[derive(Arbitrary, Debug, Clone, Copy)]
+struct KeySeed {
+    prefix: u8,
+    suffix: u64,
+}
+
+#[derive(Arbitrary, Debug, Clone)]
+struct SeededWrite {
+    key: KeySeed,
+    value: [u8; 32],
+}
+
+#[derive(Arbitrary, Debug, Clone)]
+enum Mutation {
+    Write { key: KeySeed, value: [u8; 32] },
+    Delete { key: KeySeed },
+}
+
+#[derive(Debug)]
+struct FuzzInput {
+    initial: Vec<SeededWrite>,
+    parent: Vec<Mutation>,
+    child: Vec<Mutation>,
+}
+
+impl<'a> Arbitrary<'a> for FuzzInput {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        let initial_len = u.int_in_range(0..=MAX_INITIAL_WRITES)?;
+        let parent_len = u.int_in_range(1..=MAX_PARENT_MUTATIONS)?;
+        let child_len = u.int_in_range(1..=MAX_CHILD_MUTATIONS)?;
+
+        let initial = (0..initial_len)
+            .map(|_| SeededWrite::arbitrary(u))
+            .collect::<Result<Vec<_>, _>>()?;
+        let parent = (0..parent_len)
+            .map(|_| Mutation::arbitrary(u))
+            .collect::<Result<Vec<_>, _>>()?;
+        let child = (0..child_len)
+            .map(|_| Mutation::arbitrary(u))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(Self {
+            initial,
+            parent,
+            child,
+        })
+    }
+}
+
+fn test_config(name: &str, pooler: &impl BufferPooler) -> Config<OneCap, Sequential> {
+    let page_cache = CacheRef::from_pooler(pooler, PAGE_SIZE, NZUsize!(2));
+    Config {
+        merkle_config: MerkleConfig {
+            journal_partition: format!("{name}-merkle"),
+            metadata_partition: format!("{name}-meta"),
+            items_per_blob: NZU64!(17),
+            write_buffer: NZUsize!(1024),
+            replay_buffer: NZUsize!(1024),
+            strategy: Sequential,
+            page_cache: page_cache.clone(),
+        },
+        journal_config: FConfig {
+            partition: format!("{name}-log"),
+            items_per_blob: NZU64!(13),
+            write_buffer: NZUsize!(1024),
+            replay_buffer: NZUsize!(1024),
+            page_cache,
+        },
+        grafted_metadata_partition: format!("{name}-grafted"),
+        translator: OneCap,
+        init_cache_size: Some(NZUsize!(3)),
+        init_buffer: NZUsize!(1 << 21),
+        init_concurrency: (),
+    }
+}
+
+fn key_from_seed(seed: KeySeed) -> Key {
+    let mut bytes = [0u8; 32];
+    // The first byte selects the translated-key bucket (OneCap keys on it), the suffix keeps the
+    // full keys distinct within a bucket so ordered next-key bookkeeping stays exercised.
+    bytes[0] = seed.prefix % COLLISION_GROUPS;
+    let suffix = seed.suffix % KEY_SPACE;
+    bytes[24..].copy_from_slice(&suffix.to_be_bytes());
+    Key::new(bytes)
+}
+
+fn value_from_bytes(bytes: [u8; 32]) -> Value {
+    Value::new(bytes)
+}
+
+fn fuzz_family<F: Graftable>(input: &FuzzInput, test_name: &str) {
+    let runner = deterministic::Runner::default();
+
+    let test_name = test_name.to_string();
+    runner.start(|context| async move {
+        let cfg = test_config(&test_name, &context);
+        let db: Db<F> = Db::init(context.child("storage"), cfg)
+            .await
+            .expect("init current ordered db");
+
+        // Seed committed base state so parent/child batching sees translated-key collisions
+        // against the committed snapshot.
+        let mut batch = db.new_batch();
+        for write in &input.initial {
+            batch = batch.write(
+                key_from_seed(write.key),
+                Some(value_from_bytes(write.value)),
+            );
+        }
+        let initial = batch.merkleize(&db, None).await.unwrap();
+        let (db, _) = db.apply_batch(initial).await.unwrap();
+        let db = db.commit().await.unwrap();
+
+        // Build the child while the parent is still pending, so the child resolves through the
+        // parent's diff plus the committed snapshot. A parent-deleted key with a colliding
+        // committed sibling is the advisory's trigger: the ordered classifier must not consume
+        // the deleted key's stale committed location via the sibling's snapshot-bucket scan.
+        let mut batch = db.new_batch();
+        for mutation in &input.parent {
+            batch = match mutation {
+                Mutation::Write { key, value } => {
+                    batch.write(key_from_seed(*key), Some(value_from_bytes(*value)))
+                }
+                Mutation::Delete { key } => batch.write(key_from_seed(*key), None),
+            };
+        }
+        let parent = batch.merkleize(&db, None).await.unwrap();
+        let mut batch = parent.new_batch::<Sha256>();
+        for mutation in &input.child {
+            batch = match mutation {
+                Mutation::Write { key, value } => {
+                    batch.write(key_from_seed(*key), Some(value_from_bytes(*value)))
+                }
+                Mutation::Delete { key } => batch.write(key_from_seed(*key), None),
+            };
+        }
+        let pending_child = batch.merkleize(&db, None).await.unwrap();
+
+        // Commit the parent, then rebuild the same logical child from committed state. Both the
+        // canonical root and the ops root must be independent of the parent's pending state.
+        let (db, _) = db.apply_batch(parent).await.unwrap();
+        let db = db.commit().await.unwrap();
+
+        let mut batch = db.new_batch();
+        for mutation in &input.child {
+            batch = match mutation {
+                Mutation::Write { key, value } => {
+                    batch.write(key_from_seed(*key), Some(value_from_bytes(*value)))
+                }
+                Mutation::Delete { key } => batch.write(key_from_seed(*key), None),
+            };
+        }
+        let committed_child = batch.merkleize(&db, None).await.unwrap();
+
+        assert_eq!(
+            pending_child.root(),
+            committed_child.root(),
+            "current root depended on pending-vs-committed parent path"
+        );
+        assert_eq!(
+            pending_child.ops_root(),
+            committed_child.ops_root(),
+            "current ops root depended on pending-vs-committed parent path"
+        );
+
+        // Apply the pending child and verify the DB state matches.
+        let (db, _) = db.apply_batch(pending_child).await.unwrap();
+        assert_eq!(
+            db.root(),
+            committed_child.root(),
+            "pending child canonical root diverged"
+        );
+        assert_eq!(
+            db.ops_root(),
+            committed_child.ops_root(),
+            "pending child ops root diverged"
+        );
+
+        db.destroy().await.unwrap();
+    });
+}
+
+fuzz_target!(|input: FuzzInput| {
+    fuzz_family::<mmr::Family>(&input, "fuzz-mmr-current-ordered-batch-root");
+    fuzz_family::<mmb::Family>(&input, "fuzz-mmb-current-ordered-batch-root");
+});

--- a/storage/fuzz/fuzz_targets/qmdb_ordered_batch_root.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_ordered_batch_root.rs
@@ -1,0 +1,318 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use commonware_cryptography::Sha256;
+use commonware_parallel::Sequential;
+use commonware_runtime::{
+    BufferPooler, Runner, Supervisor as _, buffer::paged::CacheRef, deterministic,
+};
+use commonware_storage::{
+    journal::contiguous::fixed::Config as FConfig,
+    merkle::{Family as MerkleFamily, full::Config as MerkleConfig, mmb, mmr},
+    qmdb::any::{
+        FixedConfig as Config,
+        batch::UnmerkleizedBatch,
+        ordered::{Update, fixed::Db as AnyDb},
+    },
+    translator::OneCap,
+};
+use commonware_utils::{NZU16, NZU64, NZUsize, sequence::FixedBytes};
+use libfuzzer_sys::fuzz_target;
+use std::{collections::BTreeMap, num::NonZeroU16};
+
+type Key = FixedBytes<32>;
+type Value = FixedBytes<32>;
+type Db<F> = AnyDb<F, deterministic::Context, Key, Value, Sha256, OneCap, Sequential>;
+type Batch<F> = UnmerkleizedBatch<F, Sha256, Update<Key, FixedEncoding>, Sequential>;
+
+use commonware_storage::qmdb::any::value::FixedEncoding as FixedEncodingGeneric;
+type FixedEncoding = FixedEncodingGeneric<Value>;
+
+const PAGE_SIZE: NonZeroU16 = NZU16!(131);
+
+// A small key space with few translated-key buckets forces frequent collisions between distinct
+// full keys, so a parent-deleted key and a colliding sibling routinely land in one bucket.
+const COLLISION_GROUPS: u8 = 4;
+const KEY_SPACE: u64 = 32;
+const MAX_INITIAL_WRITES: usize = 16;
+const MAX_PARENT_MUTATIONS: usize = 16;
+const MAX_CHILD_MUTATIONS: usize = 16;
+const MAX_GRANDCHILD_MUTATIONS: usize = 16;
+
+#[derive(Arbitrary, Debug, Clone, Copy)]
+enum Schedule {
+    PendingParent,
+    DroppedCommittedPrefix,
+}
+
+#[derive(Arbitrary, Debug, Clone, Copy)]
+struct KeySeed {
+    prefix: u8,
+    suffix: u64,
+}
+
+#[derive(Arbitrary, Debug, Clone)]
+struct SeededWrite {
+    key: KeySeed,
+    value: [u8; 32],
+}
+
+#[derive(Arbitrary, Debug, Clone)]
+enum Mutation {
+    Write { key: KeySeed, value: [u8; 32] },
+    Delete { key: KeySeed },
+}
+
+#[derive(Debug)]
+struct FuzzInput {
+    schedule: Schedule,
+    initial: Vec<SeededWrite>,
+    parent: Vec<Mutation>,
+    child: Vec<Mutation>,
+    grandchild: Vec<Mutation>,
+}
+
+impl<'a> Arbitrary<'a> for FuzzInput {
+    fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        let schedule = Schedule::arbitrary(u)?;
+        let initial_len = u.int_in_range(0..=MAX_INITIAL_WRITES)?;
+        let parent_len = u.int_in_range(1..=MAX_PARENT_MUTATIONS)?;
+        let child_len = u.int_in_range(1..=MAX_CHILD_MUTATIONS)?;
+        let grandchild_len = u.int_in_range(1..=MAX_GRANDCHILD_MUTATIONS)?;
+
+        let initial = (0..initial_len)
+            .map(|_| SeededWrite::arbitrary(u))
+            .collect::<Result<Vec<_>, _>>()?;
+        let parent = (0..parent_len)
+            .map(|_| Mutation::arbitrary(u))
+            .collect::<Result<Vec<_>, _>>()?;
+        let child = (0..child_len)
+            .map(|_| Mutation::arbitrary(u))
+            .collect::<Result<Vec<_>, _>>()?;
+        let grandchild = (0..grandchild_len)
+            .map(|_| Mutation::arbitrary(u))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(Self {
+            schedule,
+            initial,
+            parent,
+            child,
+            grandchild,
+        })
+    }
+}
+
+fn test_config(name: &str, pooler: &impl BufferPooler) -> Config<OneCap, Sequential> {
+    let page_cache = CacheRef::from_pooler(pooler, PAGE_SIZE, NZUsize!(2));
+    Config {
+        merkle_config: MerkleConfig {
+            journal_partition: format!("{name}-merkle"),
+            metadata_partition: format!("{name}-meta"),
+            items_per_blob: NZU64!(17),
+            write_buffer: NZUsize!(1024),
+            replay_buffer: NZUsize!(1024),
+            strategy: Sequential,
+            page_cache: page_cache.clone(),
+        },
+        journal_config: FConfig {
+            partition: format!("{name}-log"),
+            items_per_blob: NZU64!(13),
+            write_buffer: NZUsize!(1024),
+            replay_buffer: NZUsize!(1024),
+            page_cache,
+        },
+        translator: OneCap,
+        init_cache_size: Some(NZUsize!(3)),
+        init_buffer: NZUsize!(1 << 21),
+        init_concurrency: (),
+    }
+}
+
+fn key_from_seed(seed: KeySeed) -> Key {
+    let mut bytes = [0u8; 32];
+    // The first byte selects the translated-key bucket (OneCap keys on it), the suffix keeps the
+    // full keys distinct within a bucket so ordered next-key bookkeeping stays exercised.
+    bytes[0] = seed.prefix % COLLISION_GROUPS;
+    let suffix = seed.suffix % KEY_SPACE;
+    bytes[24..].copy_from_slice(&suffix.to_be_bytes());
+    Key::new(bytes)
+}
+
+fn value_from_bytes(bytes: [u8; 32]) -> Value {
+    Value::new(bytes)
+}
+
+fn apply_mutations<F: MerkleFamily>(mut batch: Batch<F>, mutations: &[Mutation]) -> Batch<F> {
+    for mutation in mutations {
+        batch = match mutation {
+            Mutation::Write { key, value } => {
+                batch.write(key_from_seed(*key), Some(value_from_bytes(*value)))
+            }
+            Mutation::Delete { key } => batch.write(key_from_seed(*key), None),
+        };
+    }
+    batch
+}
+
+// A minimal model of committed key-value state, used only to confirm that whichever operation
+// stream a schedule produced, the applied database ends up holding the expected keys.
+fn apply_to_model(model: &mut BTreeMap<Key, Value>, mutations: &[Mutation]) {
+    for mutation in mutations {
+        let key = key_from_seed(match mutation {
+            Mutation::Write { key, .. } | Mutation::Delete { key } => *key,
+        });
+        match mutation {
+            Mutation::Write { value, .. } => {
+                model.insert(key, value_from_bytes(*value));
+            }
+            Mutation::Delete { .. } => {
+                model.remove(&key);
+            }
+        }
+    }
+}
+
+async fn assert_matches_model<F: MerkleFamily>(db: &Db<F>, model: &BTreeMap<Key, Value>) {
+    assert_eq!(
+        db.is_empty(),
+        model.is_empty(),
+        "empty-db state diverged from model (active-key accounting)"
+    );
+    for (key, value) in model {
+        let got = db
+            .get(key)
+            .await
+            .expect("get should not fail")
+            .expect("model key missing from db");
+        assert_eq!(
+            got.as_ref(),
+            value.as_ref(),
+            "value mismatch for a live key"
+        );
+    }
+}
+
+fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
+    let runner = deterministic::Runner::default();
+
+    runner.start(|context| async move {
+        let cfg = test_config(suffix, &context);
+        let db: Db<F> = Db::init(context.child("storage"), cfg)
+            .await
+            .expect("init ordered any db");
+
+        // Seed committed base state so parent/child batching sees both translated-key
+        // collisions against the committed snapshot and ordinary committed lookups.
+        let mut model: BTreeMap<Key, Value> = BTreeMap::new();
+        let mut batch = db.new_batch();
+        for write in &input.initial {
+            batch = batch.write(
+                key_from_seed(write.key),
+                Some(value_from_bytes(write.value)),
+            );
+            model.insert(key_from_seed(write.key), value_from_bytes(write.value));
+        }
+        let initial = batch.merkleize(&db, None).await.unwrap();
+        let (db, _) = db.apply_batch(initial).await.unwrap();
+        let db = db.commit().await.unwrap();
+
+        let db = match input.schedule {
+            Schedule::PendingParent => {
+                // Build a parent batch, then build the child while the parent is still pending so
+                // the child must resolve through the parent's diff plus the committed snapshot.
+                // A parent-deleted key with a colliding committed sibling is the advisory's
+                // trigger: the ordered classifier must not consume the deleted key's stale
+                // committed location via the sibling's snapshot-bucket scan.
+                let batch = apply_mutations(db.new_batch(), &input.parent);
+                let parent = batch.merkleize(&db, None).await.unwrap();
+                let batch = apply_mutations(parent.new_batch::<Sha256>(), &input.child);
+                let pending_child = batch.merkleize(&db, None).await.unwrap();
+
+                // Commit the parent, then rebuild the same logical child from committed state.
+                // Both speculative roots must match regardless of the parent's pending state.
+                let (db, _) = db.apply_batch(parent).await.unwrap();
+                let db = db.commit().await.unwrap();
+
+                let batch = apply_mutations(db.new_batch(), &input.child);
+                let committed_child = batch.merkleize(&db, None).await.unwrap();
+
+                assert_eq!(
+                    pending_child.root(),
+                    committed_child.root(),
+                    "child root depended on pending-vs-committed parent path"
+                );
+
+                let (db, _) = db.apply_batch(pending_child).await.unwrap();
+                assert_eq!(
+                    db.root(),
+                    committed_child.root(),
+                    "pending child root diverged"
+                );
+                let db = db.commit().await.unwrap();
+
+                apply_to_model(&mut model, &input.parent);
+                apply_to_model(&mut model, &input.child);
+                assert_matches_model(&db, &model).await;
+                db
+            }
+            Schedule::DroppedCommittedPrefix => {
+                // Build A -> B, then commit and drop A before merkleizing C. C must retain only B
+                // and position that suffix relative to the now-committed A.
+                let batch = apply_mutations(db.new_batch(), &input.parent);
+                let a = batch.merkleize(&db, None).await.unwrap();
+                let batch = apply_mutations(a.new_batch::<Sha256>(), &input.child);
+                let b = batch.merkleize(&db, None).await.unwrap();
+
+                // Applying A consumes its last strong reference; B retains only a Weak parent.
+                let (db, _) = db.apply_batch(a).await.unwrap();
+                let db = db.commit().await.unwrap();
+
+                let batch = apply_mutations(b.new_batch::<Sha256>(), &input.grandchild);
+                let retained_child = batch.merkleize(&db, None).await.unwrap();
+
+                // Rebuild B -> C from the committed A state as a reference.
+                let batch = apply_mutations(db.new_batch(), &input.child);
+                let rebuilt_b = batch.merkleize(&db, None).await.unwrap();
+                let batch = apply_mutations(rebuilt_b.new_batch::<Sha256>(), &input.grandchild);
+                let rebuilt_child = batch.merkleize(&db, None).await.unwrap();
+
+                assert_eq!(
+                    retained_child.root(),
+                    rebuilt_child.root(),
+                    "child root depended on a committed-and-dropped prefix"
+                );
+
+                let (db, _) = db.apply_batch(retained_child).await.unwrap();
+                assert_eq!(
+                    db.root(),
+                    rebuilt_child.root(),
+                    "retained-suffix child root diverged"
+                );
+                let db = db.commit().await.unwrap();
+
+                // The parent (A) was committed at apply_batch above, and the retained child
+                // applied B (child) then C (grandchild) on top, so the database holds all three.
+                apply_to_model(&mut model, &input.parent);
+                apply_to_model(&mut model, &input.child);
+                apply_to_model(&mut model, &input.grandchild);
+                assert_matches_model(&db, &model).await;
+                db
+            }
+        };
+
+        db.destroy().await.unwrap();
+    });
+}
+
+fuzz_target!(|input: FuzzInput| {
+    match input.schedule {
+        Schedule::PendingParent => {
+            fuzz_family::<mmr::Family>(&input, "fuzz-mmr-qmdb-ordered-batch-root");
+            fuzz_family::<mmb::Family>(&input, "fuzz-mmb-qmdb-ordered-batch-root");
+        }
+        Schedule::DroppedCommittedPrefix => {
+            fuzz_family::<mmb::Family>(&input, "fuzz-mmb-qmdb-ordered-dropped-prefix");
+        }
+    }
+});

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -5333,6 +5333,82 @@ mod tests {
         });
     }
 
+    /// While the parent's delete is pending, the deleted key's op remains in the
+    /// committed snapshot, so a child write to the same bucket reads it during the
+    /// bucket scan. That stale op must contribute no candidates: they reorder the
+    /// predecessor rewrites, so the root differs from the committed-parent path.
+    #[test]
+    fn ordered_stale_sibling_scan_candidates_root_matches() {
+        let runner = deterministic::Runner::default();
+        runner.start(|context| async move {
+            type TestDb = OrderedFixedDb<
+                mmr::Family,
+                deterministic::Context,
+                sha256::Digest,
+                sha256::Digest,
+                Sha256,
+                OneCap,
+                Sequential,
+            >;
+            let config = fixed_db_config::<OneCap>("ordered-stale-sibling-scan", &context);
+            let db = TestDb::init(context, config).await.unwrap();
+            let v = |n| colliding_digest(0xB0, n);
+            let initial = db
+                .new_batch()
+                .write(colliding_digest(3, 1), Some(v(1)))
+                .write(colliding_digest(3, 23), Some(v(2)))
+                .write(colliding_digest(3, 31), Some(v(4)))
+                .merkleize(&db, None)
+                .await
+                .unwrap();
+            let (db, _) = db.apply_batch(initial).await.unwrap();
+            let db = db.commit().await.unwrap();
+
+            // Parent: delete the bucket's largest key.
+            let parent = db
+                .new_batch()
+                .write(colliding_digest(3, 31), None)
+                .merkleize(&db, None)
+                .await
+                .unwrap();
+
+            // Child: write a colliding sibling (its bucket scan reads the deleted
+            // key's stale committed op), re-create the deleted key, and create a
+            // new smallest key so the wraparound predecessor search consults the
+            // candidate set.
+            let pending_child = parent
+                .new_batch::<Sha256>()
+                .write(colliding_digest(3, 7), Some(v(5)))
+                .write(colliding_digest(3, 31), Some(v(6)))
+                .write(colliding_digest(0, 0), Some(v(7)))
+                .merkleize(&db, None)
+                .await
+                .unwrap();
+
+            let (db, _) = db.apply_batch(parent).await.unwrap();
+            let db = db.commit().await.unwrap();
+
+            let committed_child = db
+                .new_batch()
+                .write(colliding_digest(3, 7), Some(v(5)))
+                .write(colliding_digest(3, 31), Some(v(6)))
+                .write(colliding_digest(0, 0), Some(v(7)))
+                .merkleize(&db, None)
+                .await
+                .unwrap();
+
+            assert_eq!(
+                pending_child.root(),
+                committed_child.root(),
+                "child root depended on pending-vs-committed parent path"
+            );
+            let (db, _) = db.apply_batch(pending_child).await.unwrap();
+            assert_eq!(db.root(), committed_child.root());
+
+            db.destroy().await.unwrap();
+        });
+    }
+
     /// Redundant deletes of two parent-deleted keys must not drive the active-key
     /// count negative while a colliding create pulls their stale committed locations
     /// into the classifier's read set.

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -5090,9 +5090,9 @@ mod tests {
     }
 
     /// Ordered mirror of [`recreate_deleted_key_with_collision_sibling_root_matches`]:
-    /// a colliding sibling's bucket scan reintroduces the parent-deleted key's stale
-    /// committed location, and the classifier consumed the re-creation there as an
-    /// update.
+    /// re-creating a key deleted by a pending parent must match the committed-parent
+    /// path even though a colliding sibling's bucket scan exposes the deleted key's
+    /// stale committed location to the classifier.
     #[test]
     fn ordered_recreate_deleted_key_with_collision_sibling_root_matches() {
         let runner = deterministic::Runner::default();
@@ -5169,10 +5169,10 @@ mod tests {
         });
     }
 
-    /// Redundant-delete variant: the parent-deleted key's stale committed location
-    /// (reintroduced by the sibling's collision scan) consumed the child's redundant
-    /// delete as a live delete, double-decrementing active keys and raising the floor
-    /// to the tip while a key is still live.
+    /// Deleting a key already deleted by a pending parent must be a no-op: same root
+    /// as the committed-parent path and no double decrement of the active-key count,
+    /// even though the sibling update's bucket scan exposes the key's stale committed
+    /// location.
     #[test]
     fn ordered_redundant_delete_with_collision_sibling_root_matches() {
         let runner = deterministic::Runner::default();
@@ -5239,8 +5239,9 @@ mod tests {
         });
     }
 
-    /// Underflow variant: two redundant deletes double-decrement past zero, so
-    /// merkleizing the pending child hit the `active_keys underflow` assertion.
+    /// Redundant deletes of two parent-deleted keys must not drive the active-key
+    /// count negative while a colliding create pulls their stale committed locations
+    /// into the classifier's read set.
     #[test]
     fn ordered_redundant_delete_underflow_regression() {
         let runner = deterministic::Runner::default();

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -2198,20 +2198,22 @@ where
                 Operation::Update(data) => data,
                 _ => unreachable!("snapshot should only reference Update operations"),
             };
-            next_candidates.push(next_key);
-            prev_candidates.push((key.clone(), (Some(value), old_loc)));
-
             // A key resolved via the ancestor diff must only match at its ancestor-diff
-            // location. Without this guard, a stale snapshot collision (the pre-parent DB
-            // snapshot still containing the key's old location) can consume the mutation
-            // at a superseded location, misclassifying a parent-deleted key's re-creation
-            // as an update (or its redundant delete as a live delete) before
-            // extract_parent_deleted_creates runs.
+            // location. A stale snapshot collision (the pre-parent DB snapshot still
+            // containing the key's old location) must contribute nothing: consuming its
+            // mutation would misclassify a parent-deleted key's re-creation as an update
+            // (or its redundant delete as a live delete) before extract_parent_deleted_creates
+            // runs, and feeding its next_key or (key, old_loc) into the candidate sets would
+            // steer the predecessor rewrites only on the pending-ancestor path (the
+            // committed-ancestor path never reads the superseded op).
             if let Some(entry) = resolve_in_ancestors(&m.ancestors, &key)
                 && entry.loc() != Some(old_loc)
             {
                 continue;
             }
+
+            next_candidates.push(next_key);
+            prev_candidates.push((key.clone(), (Some(value), old_loc)));
 
             let Some(mutation) = mutations.remove(&key) else {
                 // Snapshot index collision: this operation's key does not match
@@ -2291,6 +2293,16 @@ where
                 Operation::Update(data) => data,
                 _ => unreachable!("expected update operation"),
             };
+
+            // Same stale-location guard as the mutation classifier above: the snapshot scan
+            // sees only committed state, so a key the ancestor diff supersedes at another
+            // location (or deletes) is stale here and must not steer the predecessor search.
+            // The ancestor-diff walk below contributes the live version of such keys.
+            if let Some(entry) = resolve_in_ancestors(&m.ancestors, &data.key)
+                && entry.loc() != Some(old_loc)
+            {
+                continue;
+            }
             next_candidates.push(data.next_key);
             prev_candidates.push((data.key, (Some(data.value), old_loc)));
         }
@@ -5234,6 +5246,88 @@ mod tests {
             assert_eq!(pending_child.root(), committed_child.root());
             assert_eq!(pending_child.total_active_keys, 1);
             assert_eq!(committed_child.total_active_keys, 1);
+
+            db.destroy().await.unwrap();
+        });
+    }
+
+    /// Reduced from a fuzzer counterexample: a parent deletes keys whose buckets the child
+    /// later touches, and building the child on the pending parent must produce the same
+    /// root as building it on the committed parent. The final key-value state is identical
+    /// either way; a divergence means the emitted operation streams (next-key pointers or
+    /// floor moves) depended on whether the parent was pending.
+    #[test]
+    fn ordered_stale_ancestor_candidates_root_matches() {
+        let runner = deterministic::Runner::default();
+        runner.start(|context| async move {
+            type TestDb = OrderedFixedDb<
+                mmr::Family,
+                deterministic::Context,
+                sha256::Digest,
+                sha256::Digest,
+                Sha256,
+                OneCap,
+                Sequential,
+            >;
+
+            let config = fixed_db_config::<OneCap>("ordered-stale-candidates", &context);
+            let db = TestDb::init(context, config).await.unwrap();
+
+            let v = |n| colliding_digest(0xB0, n);
+            let initial = db
+                .new_batch()
+                .write(colliding_digest(2, 23), Some(v(0)))
+                .write(colliding_digest(3, 31), Some(v(1)))
+                .merkleize(&db, None)
+                .await
+                .unwrap();
+            let (db, _) = db.apply_batch(initial).await.unwrap();
+            let db = db.commit().await.unwrap();
+
+            // Parent: a no-op delete and a live delete in bucket 3, plus a create in bucket 1.
+            let parent = db
+                .new_batch()
+                .write(colliding_digest(3, 11), None)
+                .write(colliding_digest(3, 31), None)
+                .write(colliding_digest(1, 9), Some(v(2)))
+                .merkleize(&db, None)
+                .await
+                .unwrap();
+
+            // Child: re-create the parent-deleted key and create in buckets 1 and 0.
+            let pending_child = parent
+                .new_batch::<Sha256>()
+                .write(colliding_digest(3, 31), Some(v(3)))
+                .write(colliding_digest(1, 20), Some(v(4)))
+                .write(colliding_digest(0, 0), Some(v(5)))
+                .merkleize(&db, None)
+                .await
+                .unwrap();
+
+            let (db, _) = db.apply_batch(parent).await.unwrap();
+            let db = db.commit().await.unwrap();
+
+            let committed_child = db
+                .new_batch()
+                .write(colliding_digest(3, 31), Some(v(3)))
+                .write(colliding_digest(1, 20), Some(v(4)))
+                .write(colliding_digest(0, 0), Some(v(5)))
+                .merkleize(&db, None)
+                .await
+                .unwrap();
+
+            assert_eq!(
+                pending_child.root(),
+                committed_child.root(),
+                "child root depended on pending-vs-committed parent path"
+            );
+
+            let (db, _) = db.apply_batch(pending_child).await.unwrap();
+            assert_eq!(
+                db.root(),
+                committed_child.root(),
+                "applied pending child root diverged"
+            );
 
             db.destroy().await.unwrap();
         });

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -2198,6 +2198,7 @@ where
                 Operation::Update(data) => data,
                 _ => unreachable!("snapshot should only reference Update operations"),
             };
+
             // A key resolved via the ancestor diff must only match at its ancestor-diff
             // location. A stale snapshot collision (the pre-parent DB snapshot still
             // containing the key's old location) must contribute nothing: consuming its
@@ -2205,7 +2206,7 @@ where
             // (or its redundant delete as a live delete) before extract_parent_deleted_creates
             // runs, and feeding its next_key or (key, old_loc) into the candidate sets would
             // steer the predecessor rewrites only on the pending-ancestor path (the
-            // committed-ancestor path never reads the superseded op).
+            // applied-ancestor path never reads the superseded op).
             if let Some(entry) = resolve_in_ancestors(&m.ancestors, &key)
                 && entry.loc() != Some(old_loc)
             {
@@ -2295,7 +2296,7 @@ where
             };
 
             // Same stale-location guard as the mutation classifier above: the snapshot scan
-            // sees only committed state, so a key the ancestor diff supersedes at another
+            // sees only applied state, so a key the ancestor diff supersedes at another
             // location (or deletes) is stale here and must not steer the predecessor search.
             // The ancestor-diff walk below contributes the live version of such keys.
             if let Some(entry) = resolve_in_ancestors(&m.ancestors, &data.key)
@@ -5102,7 +5103,7 @@ mod tests {
     }
 
     /// Ordered mirror of [`recreate_deleted_key_with_collision_sibling_root_matches`]:
-    /// re-creating a key deleted by a pending parent must match the committed-parent
+    /// re-creating a key deleted by a pending parent must match the applied-parent
     /// path even though a colliding sibling's bucket scan exposes the deleted key's
     /// stale committed location to the classifier.
     #[test]
@@ -5182,7 +5183,7 @@ mod tests {
     }
 
     /// Deleting a key already deleted by a pending parent must be a no-op: same root
-    /// as the committed-parent path and no double decrement of the active-key count,
+    /// as the applied-parent path and no double decrement of the active-key count,
     /// even though the sibling update's bucket scan exposes the key's stale committed
     /// location.
     #[test]
@@ -5253,7 +5254,7 @@ mod tests {
 
     /// Reduced from a fuzzer counterexample: a parent deletes keys whose buckets the child
     /// later touches, and building the child on the pending parent must produce the same
-    /// root as building it on the committed parent. The final key-value state is identical
+    /// root as building it on the applied parent. The final key-value state is identical
     /// either way; a divergence means the emitted operation streams (next-key pointers or
     /// floor moves) depended on whether the parent was pending.
     #[test]
@@ -5319,7 +5320,7 @@ mod tests {
             assert_eq!(
                 pending_child.root(),
                 committed_child.root(),
-                "child root depended on pending-vs-committed parent path"
+                "child root depended on pending-vs-applied parent path"
             );
 
             let (db, _) = db.apply_batch(pending_child).await.unwrap();
@@ -5334,9 +5335,9 @@ mod tests {
     }
 
     /// While the parent's delete is pending, the deleted key's op remains in the
-    /// committed snapshot, so a child write to the same bucket reads it during the
+    /// pre-parent snapshot, so a child write to the same bucket reads it during the
     /// bucket scan. That stale op must contribute no candidates: they reorder the
-    /// predecessor rewrites, so the root differs from the committed-parent path.
+    /// predecessor rewrites, so the root differs from the applied-parent path.
     #[test]
     fn ordered_stale_sibling_scan_candidates_root_matches() {
         let runner = deterministic::Runner::default();
@@ -5400,7 +5401,7 @@ mod tests {
             assert_eq!(
                 pending_child.root(),
                 committed_child.root(),
-                "child root depended on pending-vs-committed parent path"
+                "child root depended on pending-vs-applied parent path"
             );
             let (db, _) = db.apply_batch(pending_child).await.unwrap();
             assert_eq!(db.root(), committed_child.root());

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -2199,11 +2199,21 @@ where
                 _ => unreachable!("snapshot should only reference Update operations"),
             };
             next_candidates.push(next_key);
-
-            let mutation = mutations.remove(&key);
             prev_candidates.push((key.clone(), (Some(value), old_loc)));
 
-            let Some(mutation) = mutation else {
+            // A key resolved via the ancestor diff must only match at its ancestor-diff
+            // location. Without this guard, a stale snapshot collision (the pre-parent DB
+            // snapshot still containing the key's old location) can consume the mutation
+            // at a superseded location, misclassifying a parent-deleted key's re-creation
+            // as an update (or its redundant delete as a live delete) before
+            // extract_parent_deleted_creates runs.
+            if let Some(entry) = resolve_in_ancestors(&m.ancestors, &key)
+                && entry.loc() != Some(old_loc)
+            {
+                continue;
+            }
+
+            let Some(mutation) = mutations.remove(&key) else {
                 // Snapshot index collision: this operation's key does not match
                 // the mutation key (the snapshot uses a compressed translated key
                 // that can collide). The mutation will be handled as a create below.
@@ -5074,6 +5084,229 @@ mod tests {
                 "root depended on pending-vs-committed parent path \
                  when re-creating a deleted key with collision siblings"
             );
+
+            db.destroy().await.unwrap();
+        });
+    }
+
+    /// Ordered mirror of [`recreate_deleted_key_with_collision_sibling_root_matches`]:
+    /// a colliding sibling's bucket scan reintroduces the parent-deleted key's stale
+    /// committed location, and the classifier consumed the re-creation there as an
+    /// update.
+    #[test]
+    fn ordered_recreate_deleted_key_with_collision_sibling_root_matches() {
+        let runner = deterministic::Runner::default();
+        runner.start(|context| async move {
+            type TestDb = OrderedFixedDb<
+                mmr::Family,
+                deterministic::Context,
+                sha256::Digest,
+                sha256::Digest,
+                Sha256,
+                OneCap,
+                Sequential,
+            >;
+
+            let config = fixed_db_config::<OneCap>("ordered-recreate-deleted-collision", &context);
+            let db = TestDb::init(context, config).await.unwrap();
+
+            let k0 = colliding_digest(0xAA, 0);
+            let k6 = colliding_digest(0xAA, 6);
+            let k29 = colliding_digest(0xAA, 29);
+
+            // Seed both keys so the snapshot bucket contains two entries.
+            let initial = db
+                .new_batch()
+                .write(k0, Some(colliding_digest(0xBB, 0)))
+                .write(k6, Some(colliding_digest(0xBB, 6)))
+                .merkleize(&db, None)
+                .await
+                .unwrap();
+            let (db, _) = db.apply_batch(initial).await.unwrap();
+            let db = db.commit().await.unwrap();
+
+            // Parent: delete k0. k6 remains untouched.
+            let parent = db
+                .new_batch()
+                .write(k0, None)
+                .merkleize(&db, None)
+                .await
+                .unwrap();
+
+            // Child (pending parent): re-create k0 and write a new colliding key k29.
+            let pending_child = parent
+                .new_batch::<Sha256>()
+                .write(k0, Some(colliding_digest(0xCC, 0)))
+                .write(k29, Some(colliding_digest(0xCC, 29)))
+                .merkleize(&db, None)
+                .await
+                .unwrap();
+
+            // Commit the parent, then rebuild the same child.
+            let (db, _) = db.apply_batch(parent).await.unwrap();
+            let db = db.commit().await.unwrap();
+
+            let committed_child = db
+                .new_batch()
+                .write(k0, Some(colliding_digest(0xCC, 0)))
+                .write(k29, Some(colliding_digest(0xCC, 29)))
+                .merkleize(&db, None)
+                .await
+                .unwrap();
+
+            assert_eq!(pending_child.root(), committed_child.root());
+            assert_eq!(
+                pending_child.total_active_keys,
+                committed_child.total_active_keys
+            );
+
+            // Apply the pending child; the resulting DB must match a child built
+            // directly from the committed DB.
+            let (db, _) = db.apply_batch(pending_child).await.unwrap();
+            assert_eq!(db.root(), committed_child.root());
+
+            db.destroy().await.unwrap();
+        });
+    }
+
+    /// Redundant-delete variant: the parent-deleted key's stale committed location
+    /// (reintroduced by the sibling's collision scan) consumed the child's redundant
+    /// delete as a live delete, double-decrementing active keys and raising the floor
+    /// to the tip while a key is still live.
+    #[test]
+    fn ordered_redundant_delete_with_collision_sibling_root_matches() {
+        let runner = deterministic::Runner::default();
+        runner.start(|context| async move {
+            type TestDb = OrderedFixedDb<
+                mmr::Family,
+                deterministic::Context,
+                sha256::Digest,
+                sha256::Digest,
+                Sha256,
+                OneCap,
+                Sequential,
+            >;
+
+            let config = fixed_db_config::<OneCap>("ordered-redundant-delete-collision", &context);
+            let db = TestDb::init(context, config).await.unwrap();
+
+            let k0 = colliding_digest(0xAA, 0);
+            let k6 = colliding_digest(0xAA, 6);
+
+            let initial = db
+                .new_batch()
+                .write(k0, Some(colliding_digest(0xBB, 0)))
+                .write(k6, Some(colliding_digest(0xBB, 6)))
+                .merkleize(&db, None)
+                .await
+                .unwrap();
+            let (db, _) = db.apply_batch(initial).await.unwrap();
+            let db = db.commit().await.unwrap();
+
+            // Parent: delete k0.
+            let parent = db
+                .new_batch()
+                .write(k0, None)
+                .merkleize(&db, None)
+                .await
+                .unwrap();
+
+            // Child (pending parent): delete k0 again and update the colliding sibling k6.
+            let pending_child = parent
+                .new_batch::<Sha256>()
+                .write(k0, None)
+                .write(k6, Some(colliding_digest(0xCC, 6)))
+                .merkleize(&db, None)
+                .await
+                .unwrap();
+
+            let (db, _) = db.apply_batch(parent).await.unwrap();
+            let db = db.commit().await.unwrap();
+
+            let committed_child = db
+                .new_batch()
+                .write(k0, None)
+                .write(k6, Some(colliding_digest(0xCC, 6)))
+                .merkleize(&db, None)
+                .await
+                .unwrap();
+
+            assert_eq!(pending_child.root(), committed_child.root());
+            assert_eq!(pending_child.total_active_keys, 1);
+            assert_eq!(committed_child.total_active_keys, 1);
+
+            db.destroy().await.unwrap();
+        });
+    }
+
+    /// Underflow variant: two redundant deletes double-decrement past zero, so
+    /// merkleizing the pending child hit the `active_keys underflow` assertion.
+    #[test]
+    fn ordered_redundant_delete_underflow_regression() {
+        let runner = deterministic::Runner::default();
+        runner.start(|context| async move {
+            type TestDb = OrderedFixedDb<
+                mmr::Family,
+                deterministic::Context,
+                sha256::Digest,
+                sha256::Digest,
+                Sha256,
+                OneCap,
+                Sequential,
+            >;
+
+            let config = fixed_db_config::<OneCap>("ordered-redundant-delete-underflow", &context);
+            let db = TestDb::init(context, config).await.unwrap();
+
+            let k0 = colliding_digest(0xAA, 0);
+            let k6 = colliding_digest(0xAA, 6);
+            let k29 = colliding_digest(0xAA, 29);
+
+            let initial = db
+                .new_batch()
+                .write(k0, Some(colliding_digest(0xBB, 0)))
+                .write(k6, Some(colliding_digest(0xBB, 6)))
+                .merkleize(&db, None)
+                .await
+                .unwrap();
+            let (db, _) = db.apply_batch(initial).await.unwrap();
+            let db = db.commit().await.unwrap();
+
+            // Parent: delete both keys.
+            let parent = db
+                .new_batch()
+                .write(k0, None)
+                .write(k6, None)
+                .merkleize(&db, None)
+                .await
+                .unwrap();
+
+            // Child (pending parent): delete both again and create the colliding k29,
+            // whose bucket scan reintroduces both stale committed locations.
+            let pending_child = parent
+                .new_batch::<Sha256>()
+                .write(k0, None)
+                .write(k6, None)
+                .write(k29, Some(colliding_digest(0xCC, 29)))
+                .merkleize(&db, None)
+                .await
+                .unwrap();
+
+            let (db, _) = db.apply_batch(parent).await.unwrap();
+            let db = db.commit().await.unwrap();
+
+            let committed_child = db
+                .new_batch()
+                .write(k0, None)
+                .write(k6, None)
+                .write(k29, Some(colliding_digest(0xCC, 29)))
+                .merkleize(&db, None)
+                .await
+                .unwrap();
+
+            assert_eq!(pending_child.root(), committed_child.root());
+            assert_eq!(pending_child.total_active_keys, 1);
+            assert_eq!(committed_child.total_active_keys, 1);
 
             db.destroy().await.unwrap();
         });


### PR DESCRIPTION
## Problem

In ordered QMDB, `gather_existing_locations` skips a key whose closest pending ancestor deleted it, but a colliding sibling mutation's bucket scan can reintroduce that key's stale committed location (the parent's delete lives only in the pending diff, not the committed index). The ordered classifier then consumed the key's mutation at that stale location, before `extract_parent_deleted_creates` ran. A re-creation was classified as an update (wrong position in the operation stream, no active-key increment, no predecessor rewrite) and a redundant delete as a live delete (a second decrement on top of the parent's).

The same logical writes therefore produced different operation streams, inactivity floors, and roots depending on whether the parent was pending or committed. The double decrement could also drive the active-key count to zero while keys were still live, advancing the inactivity floor to the tip so pruning removes live operations, or negative, hitting the `active_keys underflow` assertion.

The unordered classifier already rejects this case by checking that an ancestor-resolved key only matches at its ancestor location. The ordered classifier lacked that check. All ordered merkleization (any and current, plain and staged) funnels through the one affected loop.

## Fix

Mirror the unordered guard in the ordered classifier: resolve the key in the ancestor chain and skip the location, without consuming the mutation, when the ancestor entry's location disagrees. A parent-deleted key's mutation then always reaches `extract_parent_deleted_creates` (re-creation) or the delete-of-nonexistent-key skip (redundant delete), matching the committed-parent path. With no pending ancestors the guard is a no-op.