### PR TITLE
[consensus] Document Canonical Block Encoding

### DIFF
--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -55,7 +55,9 @@ stability_scope!(BETA {
 
     /// Block is the interface for a block in the blockchain.
     ///
-    /// Blocks are used to track the progress of the consensus engine.
+    /// Blocks must use a canonical encoding: every byte sequence `bytes` accepted by the decoder
+    /// must satisfy `encode(decode(bytes)) == bytes`. Decoders must reject alternate encodings of
+    /// the same block.
     pub trait Block: Heightable + Codec + Digestible + Send + Sync + 'static {
         /// Get the parent block's digest.
         fn parent(&self) -> Self::Digest;


### PR DESCRIPTION
## Overview

Documents the canonical-encoding requirement for `Block`: every byte sequence `bytes` accepted by its decoder must satisfy `encode(decode(bytes)) == bytes`, so decoders reject alternate encodings of the same block.

This makes explicit the application contract consensus relies on when it authenticates a serialized block and later re-encodes it to reproduce the same commitment. This is a documentation-only clarification and does not change codec behavior or wire format.