### PR TITLE
[storage] Fuzz chained batches in all batch-root fuzzers and pin the classifier guard order

### DIFF
--- a/storage/fuzz/fuzz_targets/qmdb_any_ordered_batch_root.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_any_ordered_batch_root.rs
@@ -265,7 +265,7 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
                 let batch = apply_mutations(a.new_batch::<Sha256>(), &input.child);
                 let b = batch.merkleize(&db, None).await.unwrap();
 
-                // Applying A consumes its last strong reference; B retains only a Weak parent.
+                // Applying A consumes its last strong reference. B retains only a Weak parent.
                 let (db, _) = db.apply_batch(a).await.unwrap();
                 let db = db.commit().await.unwrap();
 
@@ -302,10 +302,9 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
             }
             Schedule::PendingChain => {
                 // Build parent -> child -> grandchild with parent and child both still
-                // pending, so the grandchild merkleizes with two live ancestors. This is the
-                // only schedule where ancestor resolution walks more than one diff
-                // (closest-first shadowing), which single-pending-ancestor schedules never
-                // exercise.
+                // pending, so the grandchild merkleizes with two live ancestors
+                // (closest-first shadowing). This is the only schedule that checks a
+                // multi-diff ancestor walk against a committed-only reference.
                 let batch = apply_mutations(db.new_batch(), &input.parent);
                 let parent = batch.merkleize(&db, None).await.unwrap();
                 let batch = apply_mutations(parent.new_batch::<Sha256>(), &input.child);
@@ -356,7 +355,7 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
                 let batch = apply_mutations(b.new_batch::<Sha256>(), &input.parent);
                 let c = batch.merkleize(&db, None).await.unwrap();
 
-                // Applying A consumes its last strong reference; B retains only a Weak parent.
+                // Applying A consumes its last strong reference. B retains only a Weak parent.
                 let (db, _) = db.apply_batch(a).await.unwrap();
                 let db = db.commit().await.unwrap();
 
@@ -401,6 +400,7 @@ fuzz_target!(|input: FuzzInput| {
             fuzz_family::<mmb::Family>(&input, "fuzz-mmb-qmdb-ordered-batch-root");
         }
         Schedule::DroppedCommittedPrefix => {
+            fuzz_family::<mmr::Family>(&input, "fuzz-mmr-qmdb-ordered-dropped-prefix");
             fuzz_family::<mmb::Family>(&input, "fuzz-mmb-qmdb-ordered-dropped-prefix");
         }
         Schedule::PendingChain => {
@@ -408,6 +408,7 @@ fuzz_target!(|input: FuzzInput| {
             fuzz_family::<mmb::Family>(&input, "fuzz-mmb-qmdb-ordered-pending-chain");
         }
         Schedule::DroppedPrefixChain => {
+            fuzz_family::<mmr::Family>(&input, "fuzz-mmr-qmdb-ordered-dropped-chain");
             fuzz_family::<mmb::Family>(&input, "fuzz-mmb-qmdb-ordered-dropped-chain");
         }
     }

--- a/storage/fuzz/fuzz_targets/qmdb_any_ordered_batch_root.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_any_ordered_batch_root.rs
@@ -13,6 +13,7 @@ use commonware_storage::{
         FixedConfig as Config,
         batch::UnmerkleizedBatch,
         ordered::{Update, fixed::Db as AnyDb},
+        value::FixedEncoding as FixedEncodingGeneric,
     },
     translator::OneCap,
 };
@@ -22,11 +23,9 @@ use std::{collections::BTreeMap, num::NonZeroU16};
 
 type Key = FixedBytes<32>;
 type Value = FixedBytes<32>;
+type FixedEncoding = FixedEncodingGeneric<Value>;
 type Db<F> = AnyDb<F, deterministic::Context, Key, Value, Sha256, OneCap, Sequential>;
 type Batch<F> = UnmerkleizedBatch<F, Sha256, Update<Key, FixedEncoding>, Sequential>;
-
-use commonware_storage::qmdb::any::value::FixedEncoding as FixedEncodingGeneric;
-type FixedEncoding = FixedEncodingGeneric<Value>;
 
 const PAGE_SIZE: NonZeroU16 = NZU16!(131);
 
@@ -43,6 +42,8 @@ const MAX_GRANDCHILD_MUTATIONS: usize = 16;
 enum Schedule {
     PendingParent,
     DroppedCommittedPrefix,
+    PendingChain,
+    DroppedPrefixChain,
 }
 
 #[derive(Arbitrary, Debug, Clone, Copy)]
@@ -299,6 +300,94 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
                 assert_matches_model(&db, &model).await;
                 db
             }
+            Schedule::PendingChain => {
+                // Build parent -> child -> grandchild with parent and child both still
+                // pending, so the grandchild merkleizes with two live ancestors. This is the
+                // only schedule where ancestor resolution walks more than one diff
+                // (closest-first shadowing), which single-pending-ancestor schedules never
+                // exercise.
+                let batch = apply_mutations(db.new_batch(), &input.parent);
+                let parent = batch.merkleize(&db, None).await.unwrap();
+                let batch = apply_mutations(parent.new_batch::<Sha256>(), &input.child);
+                let child = batch.merkleize(&db, None).await.unwrap();
+                let batch = apply_mutations(child.new_batch::<Sha256>(), &input.grandchild);
+                let pending_grandchild = batch.merkleize(&db, None).await.unwrap();
+
+                // Commit the chain prefix, then rebuild the same grandchild from committed
+                // state. The speculative root must be independent of the chain's pendency.
+                let (db, _) = db.apply_batch(parent).await.unwrap();
+                let db = db.commit().await.unwrap();
+                let (db, _) = db.apply_batch(child).await.unwrap();
+                let db = db.commit().await.unwrap();
+
+                let batch = apply_mutations(db.new_batch(), &input.grandchild);
+                let committed_grandchild = batch.merkleize(&db, None).await.unwrap();
+
+                assert_eq!(
+                    pending_grandchild.root(),
+                    committed_grandchild.root(),
+                    "grandchild root depended on pending-vs-committed ancestor chain"
+                );
+
+                let (db, _) = db.apply_batch(pending_grandchild).await.unwrap();
+                assert_eq!(
+                    db.root(),
+                    committed_grandchild.root(),
+                    "pending grandchild root diverged"
+                );
+                let db = db.commit().await.unwrap();
+
+                apply_to_model(&mut model, &input.parent);
+                apply_to_model(&mut model, &input.child);
+                apply_to_model(&mut model, &input.grandchild);
+                assert_matches_model(&db, &model).await;
+                db
+            }
+            Schedule::DroppedPrefixChain => {
+                // Build A -> B -> C, commit and drop A, then merkleize D on C: D's two live
+                // ancestors resolve closest-first between themselves while base locations for
+                // keys they touch trace across the dropped committed prefix. No other schedule
+                // combines multi-ancestor shadowing with a dropped prefix. C reuses the parent
+                // mutations so the chain re-deletes and re-creates the same colliding keys.
+                let batch = apply_mutations(db.new_batch(), &input.parent);
+                let a = batch.merkleize(&db, None).await.unwrap();
+                let batch = apply_mutations(a.new_batch::<Sha256>(), &input.child);
+                let b = batch.merkleize(&db, None).await.unwrap();
+                let batch = apply_mutations(b.new_batch::<Sha256>(), &input.parent);
+                let c = batch.merkleize(&db, None).await.unwrap();
+
+                // Applying A consumes its last strong reference; B retains only a Weak parent.
+                let (db, _) = db.apply_batch(a).await.unwrap();
+                let db = db.commit().await.unwrap();
+
+                let batch = apply_mutations(c.new_batch::<Sha256>(), &input.grandchild);
+                let retained_d = batch.merkleize(&db, None).await.unwrap();
+
+                // Rebuild B -> C -> D from the committed A state as a reference.
+                let batch = apply_mutations(db.new_batch(), &input.child);
+                let rebuilt_b = batch.merkleize(&db, None).await.unwrap();
+                let batch = apply_mutations(rebuilt_b.new_batch::<Sha256>(), &input.parent);
+                let rebuilt_c = batch.merkleize(&db, None).await.unwrap();
+                let batch = apply_mutations(rebuilt_c.new_batch::<Sha256>(), &input.grandchild);
+                let rebuilt_d = batch.merkleize(&db, None).await.unwrap();
+
+                assert_eq!(
+                    retained_d.root(),
+                    rebuilt_d.root(),
+                    "chain root depended on a committed-and-dropped prefix"
+                );
+
+                let (db, _) = db.apply_batch(retained_d).await.unwrap();
+                assert_eq!(db.root(), rebuilt_d.root(), "retained-chain root diverged");
+                let db = db.commit().await.unwrap();
+
+                apply_to_model(&mut model, &input.parent);
+                apply_to_model(&mut model, &input.child);
+                apply_to_model(&mut model, &input.parent);
+                apply_to_model(&mut model, &input.grandchild);
+                assert_matches_model(&db, &model).await;
+                db
+            }
         };
 
         db.destroy().await.unwrap();
@@ -313,6 +402,13 @@ fuzz_target!(|input: FuzzInput| {
         }
         Schedule::DroppedCommittedPrefix => {
             fuzz_family::<mmb::Family>(&input, "fuzz-mmb-qmdb-ordered-dropped-prefix");
+        }
+        Schedule::PendingChain => {
+            fuzz_family::<mmr::Family>(&input, "fuzz-mmr-qmdb-ordered-pending-chain");
+            fuzz_family::<mmb::Family>(&input, "fuzz-mmb-qmdb-ordered-pending-chain");
+        }
+        Schedule::DroppedPrefixChain => {
+            fuzz_family::<mmb::Family>(&input, "fuzz-mmb-qmdb-ordered-dropped-chain");
         }
     }
 });

--- a/storage/fuzz/fuzz_targets/qmdb_any_unordered_batch_root.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_any_unordered_batch_root.rs
@@ -37,6 +37,8 @@ const MAX_GRANDCHILD_MUTATIONS: usize = 16;
 enum Schedule {
     PendingParent,
     DroppedCommittedPrefix,
+    PendingChain,
+    DroppedPrefixChain,
 }
 
 #[derive(Arbitrary, Debug, Clone, Copy)]
@@ -237,6 +239,81 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
                 );
                 db
             }
+            Schedule::PendingChain => {
+                // Build parent -> child -> grandchild with parent and child both still
+                // pending, so the grandchild merkleizes with two live ancestor diffs and
+                // resolves between them closest first, which single-pending-ancestor
+                // schedules never exercise.
+                let batch = apply_mutations(db.new_batch(), &input.parent);
+                let parent = batch.merkleize(&db, None).await.unwrap();
+                let batch = apply_mutations(parent.new_batch::<Sha256>(), &input.child);
+                let child = batch.merkleize(&db, None).await.unwrap();
+                let batch = apply_mutations(child.new_batch::<Sha256>(), &input.grandchild);
+                let pending_grandchild = batch.merkleize(&db, None).await.unwrap();
+
+                // Commit the chain prefix, then rebuild the same grandchild from the
+                // committed DB state. The speculative root must be independent of the
+                // chain's pendency.
+                let (db, _) = db.apply_batch(parent).await.unwrap();
+                let db = db.commit().await.unwrap();
+                let (db, _) = db.apply_batch(child).await.unwrap();
+                let db = db.commit().await.unwrap();
+
+                let batch = apply_mutations(db.new_batch(), &input.grandchild);
+                let committed_grandchild = batch.merkleize(&db, None).await.unwrap();
+
+                assert_eq!(
+                    pending_grandchild.root(),
+                    committed_grandchild.root(),
+                    "grandchild root depended on pending-vs-committed ancestor chain"
+                );
+
+                let (db, _) = db.apply_batch(pending_grandchild).await.unwrap();
+                assert_eq!(
+                    db.root(),
+                    committed_grandchild.root(),
+                    "pending grandchild root diverged"
+                );
+                db
+            }
+            Schedule::DroppedPrefixChain => {
+                // Build A -> B -> C, commit and drop A, then merkleize D on C: D's two
+                // live ancestors resolve closest-first between themselves while base
+                // locations for keys they touch trace across the dropped committed
+                // prefix. C reuses the parent mutations so the chain re-deletes and
+                // re-creates the same colliding keys.
+                let batch = apply_mutations(db.new_batch(), &input.parent);
+                let a = batch.merkleize(&db, None).await.unwrap();
+                let batch = apply_mutations(a.new_batch::<Sha256>(), &input.child);
+                let b = batch.merkleize(&db, None).await.unwrap();
+                let batch = apply_mutations(b.new_batch::<Sha256>(), &input.parent);
+                let c = batch.merkleize(&db, None).await.unwrap();
+
+                // Applying A consumes its last strong reference; B retains only a Weak parent.
+                let (db, _) = db.apply_batch(a).await.unwrap();
+                let db = db.commit().await.unwrap();
+
+                let batch = apply_mutations(c.new_batch::<Sha256>(), &input.grandchild);
+                let retained_d = batch.merkleize(&db, None).await.unwrap();
+
+                // Rebuild B -> C -> D from the committed A state as a reference.
+                let batch = apply_mutations(db.new_batch(), &input.child);
+                let rebuilt_b = batch.merkleize(&db, None).await.unwrap();
+                let batch = apply_mutations(rebuilt_b.new_batch::<Sha256>(), &input.parent);
+                let rebuilt_c = batch.merkleize(&db, None).await.unwrap();
+                let batch = apply_mutations(rebuilt_c.new_batch::<Sha256>(), &input.grandchild);
+                let rebuilt_d = batch.merkleize(&db, None).await.unwrap();
+
+                assert_eq!(
+                    retained_d.root(),
+                    rebuilt_d.root(),
+                    "chain root depended on a committed-and-dropped prefix"
+                );
+
+                let (db, _) = db.apply_batch(retained_d).await.unwrap();
+                assert_eq!(db.root(), rebuilt_d.root(), "retained-chain root diverged");
+                db
+            }
         };
 
         db.destroy().await.unwrap();
@@ -251,6 +328,13 @@ fuzz_target!(|input: FuzzInput| {
         }
         Schedule::DroppedCommittedPrefix => {
             fuzz_family::<mmb::Family>(&input, "fuzz-mmb-qmdb-unordered-dropped-prefix");
+        }
+        Schedule::PendingChain => {
+            fuzz_family::<mmr::Family>(&input, "fuzz-mmr-qmdb-unordered-pending-chain");
+            fuzz_family::<mmb::Family>(&input, "fuzz-mmb-qmdb-unordered-pending-chain");
+        }
+        Schedule::DroppedPrefixChain => {
+            fuzz_family::<mmb::Family>(&input, "fuzz-mmb-qmdb-unordered-dropped-chain");
         }
     }
 });

--- a/storage/fuzz/fuzz_targets/qmdb_any_unordered_batch_root.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_any_unordered_batch_root.rs
@@ -212,7 +212,7 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
                 let batch = apply_mutations(a.new_batch::<Sha256>(), &input.child);
                 let b = batch.merkleize(&db, None).await.unwrap();
 
-                // Applying A consumes its last strong reference; B retains only a Weak parent.
+                // Applying A consumes its last strong reference. B retains only a Weak parent.
                 let (db, _) = db.apply_batch(a).await.unwrap();
                 let db = db.commit().await.unwrap();
 
@@ -242,8 +242,8 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
             Schedule::PendingChain => {
                 // Build parent -> child -> grandchild with parent and child both still
                 // pending, so the grandchild merkleizes with two live ancestor diffs and
-                // resolves between them closest first, which single-pending-ancestor
-                // schedules never exercise.
+                // resolves between them closest first. This is the only schedule that
+                // checks a multi-diff ancestor walk against a committed-only reference.
                 let batch = apply_mutations(db.new_batch(), &input.parent);
                 let parent = batch.merkleize(&db, None).await.unwrap();
                 let batch = apply_mutations(parent.new_batch::<Sha256>(), &input.child);
@@ -289,7 +289,7 @@ fn fuzz_family<F: MerkleFamily>(input: &FuzzInput, suffix: &str) {
                 let batch = apply_mutations(b.new_batch::<Sha256>(), &input.parent);
                 let c = batch.merkleize(&db, None).await.unwrap();
 
-                // Applying A consumes its last strong reference; B retains only a Weak parent.
+                // Applying A consumes its last strong reference. B retains only a Weak parent.
                 let (db, _) = db.apply_batch(a).await.unwrap();
                 let db = db.commit().await.unwrap();
 
@@ -327,6 +327,7 @@ fuzz_target!(|input: FuzzInput| {
             fuzz_family::<mmb::Family>(&input, "fuzz-mmb-qmdb-unordered-batch-root");
         }
         Schedule::DroppedCommittedPrefix => {
+            fuzz_family::<mmr::Family>(&input, "fuzz-mmr-qmdb-unordered-dropped-prefix");
             fuzz_family::<mmb::Family>(&input, "fuzz-mmb-qmdb-unordered-dropped-prefix");
         }
         Schedule::PendingChain => {
@@ -334,6 +335,7 @@ fuzz_target!(|input: FuzzInput| {
             fuzz_family::<mmb::Family>(&input, "fuzz-mmb-qmdb-unordered-pending-chain");
         }
         Schedule::DroppedPrefixChain => {
+            fuzz_family::<mmr::Family>(&input, "fuzz-mmr-qmdb-unordered-dropped-chain");
             fuzz_family::<mmb::Family>(&input, "fuzz-mmb-qmdb-unordered-dropped-chain");
         }
     }

--- a/storage/fuzz/fuzz_targets/qmdb_current_ordered_batch_root.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_current_ordered_batch_root.rs
@@ -227,7 +227,8 @@ fn fuzz_family<F: Graftable>(input: &FuzzInput, test_name: &str) {
             Schedule::PendingChain => {
                 // Build parent -> child -> grandchild with parent and child both pending, so
                 // the grandchild's grafted layer overlays two live ancestor diffs on the
-                // committed bitmap, which single-pending-ancestor schedules never exercise.
+                // committed bitmap. This is the only schedule that checks a multi-diff
+                // ancestor walk against a committed-only reference.
                 let batch = apply_mutations(db.new_batch(), &input.parent);
                 let parent = batch.merkleize(&db, None).await.unwrap();
                 let batch = apply_mutations(parent.new_batch::<Sha256>(), &input.child);
@@ -260,6 +261,11 @@ fn fuzz_family<F: Graftable>(input: &FuzzInput, test_name: &str) {
                     committed_grandchild.root(),
                     "pending grandchild canonical root diverged"
                 );
+                assert_eq!(
+                    db.ops_root(),
+                    committed_grandchild.ops_root(),
+                    "pending grandchild ops root diverged"
+                );
 
                 db.destroy().await.unwrap();
             }
@@ -275,7 +281,7 @@ fn fuzz_family<F: Graftable>(input: &FuzzInput, test_name: &str) {
                 let batch = apply_mutations(b.new_batch::<Sha256>(), &input.parent);
                 let c = batch.merkleize(&db, None).await.unwrap();
 
-                // Applying A consumes its last strong reference; B retains only a Weak parent.
+                // Applying A consumes its last strong reference. B retains only a Weak parent.
                 let (db, _) = db.apply_batch(a).await.unwrap();
                 let db = db.commit().await.unwrap();
 
@@ -307,6 +313,11 @@ fn fuzz_family<F: Graftable>(input: &FuzzInput, test_name: &str) {
                     rebuilt_d.root(),
                     "retained-chain canonical root diverged"
                 );
+                assert_eq!(
+                    db.ops_root(),
+                    rebuilt_d.ops_root(),
+                    "retained-chain ops root diverged"
+                );
 
                 db.destroy().await.unwrap();
             }
@@ -321,6 +332,7 @@ fuzz_target!(|input: FuzzInput| {
             fuzz_family::<mmb::Family>(&input, "fuzz-mmb-current-ordered-batch-root");
         }
         Schedule::DroppedPrefixChain => {
+            fuzz_family::<mmr::Family>(&input, "fuzz-mmr-current-ordered-dropped-chain");
             fuzz_family::<mmb::Family>(&input, "fuzz-mmb-current-ordered-dropped-chain");
         }
     }

--- a/storage/fuzz/fuzz_targets/qmdb_current_ordered_batch_root.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_current_ordered_batch_root.rs
@@ -9,7 +9,12 @@ use commonware_runtime::{
 use commonware_storage::{
     journal::contiguous::fixed::Config as FConfig,
     merkle::{Graftable, full::Config as MerkleConfig, mmb, mmr},
-    qmdb::current::{FixedConfig as Config, ordered::fixed::Db as CurrentDb},
+    qmdb::{
+        any::{ordered::Update, value::FixedEncoding as FixedEncodingGeneric},
+        current::{
+            FixedConfig as Config, batch::UnmerkleizedBatch, ordered::fixed::Db as CurrentDb,
+        },
+    },
     translator::OneCap,
 };
 use commonware_utils::{NZU16, NZU64, NZUsize, sequence::FixedBytes};
@@ -18,7 +23,9 @@ use std::num::NonZeroU16;
 
 type Key = FixedBytes<32>;
 type Value = FixedBytes<32>;
+type FixedEncoding = FixedEncodingGeneric<Value>;
 type Db<F> = CurrentDb<F, deterministic::Context, Key, Value, Sha256, OneCap, 32, Sequential>;
+type Batch<F> = UnmerkleizedBatch<F, Sha256, Update<Key, FixedEncoding>, 32, Sequential>;
 
 const PAGE_SIZE: NonZeroU16 = NZU16!(137);
 
@@ -29,6 +36,14 @@ const KEY_SPACE: u64 = 32;
 const MAX_INITIAL_WRITES: usize = 16;
 const MAX_PARENT_MUTATIONS: usize = 16;
 const MAX_CHILD_MUTATIONS: usize = 16;
+const MAX_GRANDCHILD_MUTATIONS: usize = 16;
+
+#[derive(Arbitrary, Debug, Clone, Copy)]
+enum Schedule {
+    PendingParent,
+    PendingChain,
+    DroppedPrefixChain,
+}
 
 #[derive(Arbitrary, Debug, Clone, Copy)]
 struct KeySeed {
@@ -50,16 +65,20 @@ enum Mutation {
 
 #[derive(Debug)]
 struct FuzzInput {
+    schedule: Schedule,
     initial: Vec<SeededWrite>,
     parent: Vec<Mutation>,
     child: Vec<Mutation>,
+    grandchild: Vec<Mutation>,
 }
 
 impl<'a> Arbitrary<'a> for FuzzInput {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        let schedule = Schedule::arbitrary(u)?;
         let initial_len = u.int_in_range(0..=MAX_INITIAL_WRITES)?;
         let parent_len = u.int_in_range(1..=MAX_PARENT_MUTATIONS)?;
         let child_len = u.int_in_range(1..=MAX_CHILD_MUTATIONS)?;
+        let grandchild_len = u.int_in_range(1..=MAX_GRANDCHILD_MUTATIONS)?;
 
         let initial = (0..initial_len)
             .map(|_| SeededWrite::arbitrary(u))
@@ -70,11 +89,16 @@ impl<'a> Arbitrary<'a> for FuzzInput {
         let child = (0..child_len)
             .map(|_| Mutation::arbitrary(u))
             .collect::<Result<Vec<_>, _>>()?;
+        let grandchild = (0..grandchild_len)
+            .map(|_| Mutation::arbitrary(u))
+            .collect::<Result<Vec<_>, _>>()?;
 
         Ok(Self {
+            schedule,
             initial,
             parent,
             child,
+            grandchild,
         })
     }
 }
@@ -120,6 +144,18 @@ fn value_from_bytes(bytes: [u8; 32]) -> Value {
     Value::new(bytes)
 }
 
+fn apply_mutations<F: Graftable>(mut batch: Batch<F>, mutations: &[Mutation]) -> Batch<F> {
+    for mutation in mutations {
+        batch = match mutation {
+            Mutation::Write { key, value } => {
+                batch.write(key_from_seed(*key), Some(value_from_bytes(*value)))
+            }
+            Mutation::Delete { key } => batch.write(key_from_seed(*key), None),
+        };
+    }
+    batch
+}
+
 fn fuzz_family<F: Graftable>(input: &FuzzInput, test_name: &str) {
     let runner = deterministic::Runner::default();
 
@@ -130,7 +166,7 @@ fn fuzz_family<F: Graftable>(input: &FuzzInput, test_name: &str) {
             .await
             .expect("init current ordered db");
 
-        // Seed committed base state so parent/child batching sees translated-key collisions
+        // Seed committed base state so recursive batching sees translated-key collisions
         // against the committed snapshot.
         let mut batch = db.new_batch();
         for write in &input.initial {
@@ -143,76 +179,149 @@ fn fuzz_family<F: Graftable>(input: &FuzzInput, test_name: &str) {
         let (db, _) = db.apply_batch(initial).await.unwrap();
         let db = db.commit().await.unwrap();
 
-        // Build the child while the parent is still pending, so the child resolves through the
-        // parent's diff plus the committed snapshot. A parent-deleted key with a colliding
-        // committed sibling is the advisory's trigger: the ordered classifier must not consume
-        // the deleted key's stale committed location via the sibling's snapshot-bucket scan.
-        let mut batch = db.new_batch();
-        for mutation in &input.parent {
-            batch = match mutation {
-                Mutation::Write { key, value } => {
-                    batch.write(key_from_seed(*key), Some(value_from_bytes(*value)))
-                }
-                Mutation::Delete { key } => batch.write(key_from_seed(*key), None),
-            };
+        match input.schedule {
+            Schedule::PendingParent => {
+                // Build the child while the parent is still pending, so the child resolves
+                // through the parent's diff plus the committed snapshot. A parent-deleted key
+                // with a colliding committed sibling is the advisory's trigger.
+                let batch = apply_mutations(db.new_batch(), &input.parent);
+                let parent = batch.merkleize(&db, None).await.unwrap();
+                let batch = apply_mutations(parent.new_batch::<Sha256>(), &input.child);
+                let pending_child = batch.merkleize(&db, None).await.unwrap();
+
+                // Commit the parent, then rebuild the same logical child from committed state.
+                // Both the canonical root and the ops root must be independent of the parent's
+                // pending state.
+                let (db, _) = db.apply_batch(parent).await.unwrap();
+                let db = db.commit().await.unwrap();
+
+                let batch = apply_mutations(db.new_batch(), &input.child);
+                let committed_child = batch.merkleize(&db, None).await.unwrap();
+
+                assert_eq!(
+                    pending_child.root(),
+                    committed_child.root(),
+                    "current root depended on pending-vs-committed parent path"
+                );
+                assert_eq!(
+                    pending_child.ops_root(),
+                    committed_child.ops_root(),
+                    "current ops root depended on pending-vs-committed parent path"
+                );
+
+                // Apply the pending child and verify the DB state matches.
+                let (db, _) = db.apply_batch(pending_child).await.unwrap();
+                assert_eq!(
+                    db.root(),
+                    committed_child.root(),
+                    "pending child canonical root diverged"
+                );
+                assert_eq!(
+                    db.ops_root(),
+                    committed_child.ops_root(),
+                    "pending child ops root diverged"
+                );
+
+                db.destroy().await.unwrap();
+            }
+            Schedule::PendingChain => {
+                // Build parent -> child -> grandchild with parent and child both pending, so
+                // the grandchild's grafted layer overlays two live ancestor diffs on the
+                // committed bitmap, which single-pending-ancestor schedules never exercise.
+                let batch = apply_mutations(db.new_batch(), &input.parent);
+                let parent = batch.merkleize(&db, None).await.unwrap();
+                let batch = apply_mutations(parent.new_batch::<Sha256>(), &input.child);
+                let child = batch.merkleize(&db, None).await.unwrap();
+                let batch = apply_mutations(child.new_batch::<Sha256>(), &input.grandchild);
+                let pending_grandchild = batch.merkleize(&db, None).await.unwrap();
+
+                let (db, _) = db.apply_batch(parent).await.unwrap();
+                let db = db.commit().await.unwrap();
+                let (db, _) = db.apply_batch(child).await.unwrap();
+                let db = db.commit().await.unwrap();
+
+                let batch = apply_mutations(db.new_batch(), &input.grandchild);
+                let committed_grandchild = batch.merkleize(&db, None).await.unwrap();
+
+                assert_eq!(
+                    pending_grandchild.root(),
+                    committed_grandchild.root(),
+                    "current root depended on pending-vs-committed ancestor chain"
+                );
+                assert_eq!(
+                    pending_grandchild.ops_root(),
+                    committed_grandchild.ops_root(),
+                    "current ops root depended on pending-vs-committed ancestor chain"
+                );
+
+                let (db, _) = db.apply_batch(pending_grandchild).await.unwrap();
+                assert_eq!(
+                    db.root(),
+                    committed_grandchild.root(),
+                    "pending grandchild canonical root diverged"
+                );
+
+                db.destroy().await.unwrap();
+            }
+            Schedule::DroppedPrefixChain => {
+                // Build A -> B -> C, commit and drop A, then merkleize D on C: D's grafted
+                // layer overlays two live ancestor diffs while base locations trace across the
+                // dropped committed prefix. C reuses the parent mutations so the chain
+                // re-deletes and re-creates the same colliding keys.
+                let batch = apply_mutations(db.new_batch(), &input.parent);
+                let a = batch.merkleize(&db, None).await.unwrap();
+                let batch = apply_mutations(a.new_batch::<Sha256>(), &input.child);
+                let b = batch.merkleize(&db, None).await.unwrap();
+                let batch = apply_mutations(b.new_batch::<Sha256>(), &input.parent);
+                let c = batch.merkleize(&db, None).await.unwrap();
+
+                // Applying A consumes its last strong reference; B retains only a Weak parent.
+                let (db, _) = db.apply_batch(a).await.unwrap();
+                let db = db.commit().await.unwrap();
+
+                let batch = apply_mutations(c.new_batch::<Sha256>(), &input.grandchild);
+                let retained_d = batch.merkleize(&db, None).await.unwrap();
+
+                // Rebuild B -> C -> D from the committed A state as a reference.
+                let batch = apply_mutations(db.new_batch(), &input.child);
+                let rebuilt_b = batch.merkleize(&db, None).await.unwrap();
+                let batch = apply_mutations(rebuilt_b.new_batch::<Sha256>(), &input.parent);
+                let rebuilt_c = batch.merkleize(&db, None).await.unwrap();
+                let batch = apply_mutations(rebuilt_c.new_batch::<Sha256>(), &input.grandchild);
+                let rebuilt_d = batch.merkleize(&db, None).await.unwrap();
+
+                assert_eq!(
+                    retained_d.root(),
+                    rebuilt_d.root(),
+                    "current root depended on a committed-and-dropped prefix"
+                );
+                assert_eq!(
+                    retained_d.ops_root(),
+                    rebuilt_d.ops_root(),
+                    "current ops root depended on a committed-and-dropped prefix"
+                );
+
+                let (db, _) = db.apply_batch(retained_d).await.unwrap();
+                assert_eq!(
+                    db.root(),
+                    rebuilt_d.root(),
+                    "retained-chain canonical root diverged"
+                );
+
+                db.destroy().await.unwrap();
+            }
         }
-        let parent = batch.merkleize(&db, None).await.unwrap();
-        let mut batch = parent.new_batch::<Sha256>();
-        for mutation in &input.child {
-            batch = match mutation {
-                Mutation::Write { key, value } => {
-                    batch.write(key_from_seed(*key), Some(value_from_bytes(*value)))
-                }
-                Mutation::Delete { key } => batch.write(key_from_seed(*key), None),
-            };
-        }
-        let pending_child = batch.merkleize(&db, None).await.unwrap();
-
-        // Commit the parent, then rebuild the same logical child from committed state. Both the
-        // canonical root and the ops root must be independent of the parent's pending state.
-        let (db, _) = db.apply_batch(parent).await.unwrap();
-        let db = db.commit().await.unwrap();
-
-        let mut batch = db.new_batch();
-        for mutation in &input.child {
-            batch = match mutation {
-                Mutation::Write { key, value } => {
-                    batch.write(key_from_seed(*key), Some(value_from_bytes(*value)))
-                }
-                Mutation::Delete { key } => batch.write(key_from_seed(*key), None),
-            };
-        }
-        let committed_child = batch.merkleize(&db, None).await.unwrap();
-
-        assert_eq!(
-            pending_child.root(),
-            committed_child.root(),
-            "current root depended on pending-vs-committed parent path"
-        );
-        assert_eq!(
-            pending_child.ops_root(),
-            committed_child.ops_root(),
-            "current ops root depended on pending-vs-committed parent path"
-        );
-
-        // Apply the pending child and verify the DB state matches.
-        let (db, _) = db.apply_batch(pending_child).await.unwrap();
-        assert_eq!(
-            db.root(),
-            committed_child.root(),
-            "pending child canonical root diverged"
-        );
-        assert_eq!(
-            db.ops_root(),
-            committed_child.ops_root(),
-            "pending child ops root diverged"
-        );
-
-        db.destroy().await.unwrap();
     });
 }
 
 fuzz_target!(|input: FuzzInput| {
-    fuzz_family::<mmr::Family>(&input, "fuzz-mmr-current-ordered-batch-root");
-    fuzz_family::<mmb::Family>(&input, "fuzz-mmb-current-ordered-batch-root");
+    match input.schedule {
+        Schedule::PendingParent | Schedule::PendingChain => {
+            fuzz_family::<mmr::Family>(&input, "fuzz-mmr-current-ordered-batch-root");
+            fuzz_family::<mmb::Family>(&input, "fuzz-mmb-current-ordered-batch-root");
+        }
+        Schedule::DroppedPrefixChain => {
+            fuzz_family::<mmb::Family>(&input, "fuzz-mmb-current-ordered-dropped-chain");
+        }
+    }
 });

--- a/storage/fuzz/fuzz_targets/qmdb_current_unordered_batch_root.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_current_unordered_batch_root.rs
@@ -9,7 +9,12 @@ use commonware_runtime::{
 use commonware_storage::{
     journal::contiguous::fixed::Config as FConfig,
     merkle::{Graftable, full::Config as MerkleConfig, mmb, mmr},
-    qmdb::current::{FixedConfig as Config, unordered::fixed::Db as CurrentDb},
+    qmdb::{
+        any::unordered::fixed::Update,
+        current::{
+            FixedConfig as Config, batch::UnmerkleizedBatch, unordered::fixed::Db as CurrentDb,
+        },
+    },
     translator::OneCap,
 };
 use commonware_utils::{NZU16, NZU64, NZUsize, sequence::FixedBytes};
@@ -19,6 +24,7 @@ use std::num::NonZeroU16;
 type Key = FixedBytes<32>;
 type Value = FixedBytes<32>;
 type Db<F> = CurrentDb<F, deterministic::Context, Key, Value, Sha256, OneCap, 32, Sequential>;
+type Batch<F> = UnmerkleizedBatch<F, Sha256, Update<Key, Value>, 32, Sequential>;
 
 const PAGE_SIZE: NonZeroU16 = NZU16!(137);
 const COLLISION_GROUPS: u8 = 4;
@@ -26,6 +32,14 @@ const KEY_SPACE: u64 = 32;
 const MAX_INITIAL_WRITES: usize = 16;
 const MAX_PARENT_MUTATIONS: usize = 16;
 const MAX_CHILD_MUTATIONS: usize = 16;
+const MAX_GRANDCHILD_MUTATIONS: usize = 16;
+
+#[derive(Arbitrary, Debug, Clone, Copy)]
+enum Schedule {
+    PendingParent,
+    PendingChain,
+    DroppedPrefixChain,
+}
 
 #[derive(Arbitrary, Debug, Clone, Copy)]
 struct KeySeed {
@@ -47,16 +61,20 @@ enum Mutation {
 
 #[derive(Debug)]
 struct FuzzInput {
+    schedule: Schedule,
     initial: Vec<SeededWrite>,
     parent: Vec<Mutation>,
     child: Vec<Mutation>,
+    grandchild: Vec<Mutation>,
 }
 
 impl<'a> Arbitrary<'a> for FuzzInput {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
+        let schedule = Schedule::arbitrary(u)?;
         let initial_len = u.int_in_range(0..=MAX_INITIAL_WRITES)?;
         let parent_len = u.int_in_range(1..=MAX_PARENT_MUTATIONS)?;
         let child_len = u.int_in_range(1..=MAX_CHILD_MUTATIONS)?;
+        let grandchild_len = u.int_in_range(1..=MAX_GRANDCHILD_MUTATIONS)?;
 
         let initial = (0..initial_len)
             .map(|_| SeededWrite::arbitrary(u))
@@ -67,11 +85,16 @@ impl<'a> Arbitrary<'a> for FuzzInput {
         let child = (0..child_len)
             .map(|_| Mutation::arbitrary(u))
             .collect::<Result<Vec<_>, _>>()?;
+        let grandchild = (0..grandchild_len)
+            .map(|_| Mutation::arbitrary(u))
+            .collect::<Result<Vec<_>, _>>()?;
 
         Ok(Self {
+            schedule,
             initial,
             parent,
             child,
+            grandchild,
         })
     }
 }
@@ -115,6 +138,18 @@ fn value_from_bytes(bytes: [u8; 32]) -> Value {
     Value::new(bytes)
 }
 
+fn apply_mutations<F: Graftable>(mut batch: Batch<F>, mutations: &[Mutation]) -> Batch<F> {
+    for mutation in mutations {
+        batch = match mutation {
+            Mutation::Write { key, value } => {
+                batch.write(key_from_seed(*key), Some(value_from_bytes(*value)))
+            }
+            Mutation::Delete { key } => batch.write(key_from_seed(*key), None),
+        };
+    }
+    batch
+}
+
 fn fuzz_family<F: Graftable>(input: &FuzzInput, test_name: &str) {
     let runner = deterministic::Runner::default();
 
@@ -138,73 +173,148 @@ fn fuzz_family<F: Graftable>(input: &FuzzInput, test_name: &str) {
         let (db, _) = db.apply_batch(initial).await.unwrap();
         let db = db.commit().await.unwrap();
 
-        // Build the child while the parent is still pending.
-        let mut batch = db.new_batch();
-        for mutation in &input.parent {
-            batch = match mutation {
-                Mutation::Write { key, value } => {
-                    batch.write(key_from_seed(*key), Some(value_from_bytes(*value)))
-                }
-                Mutation::Delete { key } => batch.write(key_from_seed(*key), None),
-            };
-        }
-        let parent = batch.merkleize(&db, None).await.unwrap();
-        let mut batch = parent.new_batch::<Sha256>();
-        for mutation in &input.child {
-            batch = match mutation {
-                Mutation::Write { key, value } => {
-                    batch.write(key_from_seed(*key), Some(value_from_bytes(*value)))
-                }
-                Mutation::Delete { key } => batch.write(key_from_seed(*key), None),
-            };
-        }
-        let pending_child = batch.merkleize(&db, None).await.unwrap();
+        let db = match input.schedule {
+            Schedule::PendingParent => {
+                // Build the child while the parent is still pending.
+                let batch = apply_mutations(db.new_batch(), &input.parent);
+                let parent = batch.merkleize(&db, None).await.unwrap();
+                let batch = apply_mutations(parent.new_batch::<Sha256>(), &input.child);
+                let pending_child = batch.merkleize(&db, None).await.unwrap();
 
-        // Commit the parent, then rebuild the same logical child from the
-        // committed wrapper state. Both canonical and ops roots must match.
-        let (db, _) = db.apply_batch(parent).await.unwrap();
-        let db = db.commit().await.unwrap();
+                // Commit the parent, then rebuild the same logical child from the
+                // committed wrapper state. Both canonical and ops roots must match.
+                let (db, _) = db.apply_batch(parent).await.unwrap();
+                let db = db.commit().await.unwrap();
 
-        let mut batch = db.new_batch();
-        for mutation in &input.child {
-            batch = match mutation {
-                Mutation::Write { key, value } => {
-                    batch.write(key_from_seed(*key), Some(value_from_bytes(*value)))
-                }
-                Mutation::Delete { key } => batch.write(key_from_seed(*key), None),
-            };
-        }
-        let committed_child = batch.merkleize(&db, None).await.unwrap();
+                let batch = apply_mutations(db.new_batch(), &input.child);
+                let committed_child = batch.merkleize(&db, None).await.unwrap();
 
-        assert_eq!(
-            pending_child.root(),
-            committed_child.root(),
-            "current root depended on pending-vs-committed parent path"
-        );
-        assert_eq!(
-            pending_child.ops_root(),
-            committed_child.ops_root(),
-            "current ops root depended on pending-vs-committed parent path"
-        );
+                assert_eq!(
+                    pending_child.root(),
+                    committed_child.root(),
+                    "current root depended on pending-vs-committed parent path"
+                );
+                assert_eq!(
+                    pending_child.ops_root(),
+                    committed_child.ops_root(),
+                    "current ops root depended on pending-vs-committed parent path"
+                );
 
-        // Apply the pending child and verify the DB state matches.
-        let (db, _) = db.apply_batch(pending_child).await.unwrap();
-        assert_eq!(
-            db.root(),
-            committed_child.root(),
-            "pending child canonical root diverged"
-        );
-        assert_eq!(
-            db.ops_root(),
-            committed_child.ops_root(),
-            "pending child ops root diverged"
-        );
+                // Apply the pending child and verify the DB state matches.
+                let (db, _) = db.apply_batch(pending_child).await.unwrap();
+                assert_eq!(
+                    db.root(),
+                    committed_child.root(),
+                    "pending child canonical root diverged"
+                );
+                assert_eq!(
+                    db.ops_root(),
+                    committed_child.ops_root(),
+                    "pending child ops root diverged"
+                );
+                db
+            }
+            Schedule::PendingChain => {
+                // Build parent -> child -> grandchild with parent and child both pending, so
+                // the grandchild's grafted layer overlays two live ancestor diffs on the
+                // committed bitmap, which single-pending-ancestor schedules never exercise.
+                let batch = apply_mutations(db.new_batch(), &input.parent);
+                let parent = batch.merkleize(&db, None).await.unwrap();
+                let batch = apply_mutations(parent.new_batch::<Sha256>(), &input.child);
+                let child = batch.merkleize(&db, None).await.unwrap();
+                let batch = apply_mutations(child.new_batch::<Sha256>(), &input.grandchild);
+                let pending_grandchild = batch.merkleize(&db, None).await.unwrap();
+
+                // Commit the chain prefix, then rebuild the same grandchild from the
+                // committed wrapper state. Both roots must be independent of the chain's
+                // pendency.
+                let (db, _) = db.apply_batch(parent).await.unwrap();
+                let db = db.commit().await.unwrap();
+                let (db, _) = db.apply_batch(child).await.unwrap();
+                let db = db.commit().await.unwrap();
+
+                let batch = apply_mutations(db.new_batch(), &input.grandchild);
+                let committed_grandchild = batch.merkleize(&db, None).await.unwrap();
+
+                assert_eq!(
+                    pending_grandchild.root(),
+                    committed_grandchild.root(),
+                    "current root depended on pending-vs-committed ancestor chain"
+                );
+                assert_eq!(
+                    pending_grandchild.ops_root(),
+                    committed_grandchild.ops_root(),
+                    "current ops root depended on pending-vs-committed ancestor chain"
+                );
+
+                let (db, _) = db.apply_batch(pending_grandchild).await.unwrap();
+                assert_eq!(
+                    db.root(),
+                    committed_grandchild.root(),
+                    "pending grandchild canonical root diverged"
+                );
+                db
+            }
+            Schedule::DroppedPrefixChain => {
+                // Build A -> B -> C, commit and drop A, then merkleize D on C: D's grafted
+                // layer overlays two live ancestor diffs while base locations trace across
+                // the dropped committed prefix. C reuses the parent mutations so the chain
+                // re-deletes and re-creates the same colliding keys.
+                let batch = apply_mutations(db.new_batch(), &input.parent);
+                let a = batch.merkleize(&db, None).await.unwrap();
+                let batch = apply_mutations(a.new_batch::<Sha256>(), &input.child);
+                let b = batch.merkleize(&db, None).await.unwrap();
+                let batch = apply_mutations(b.new_batch::<Sha256>(), &input.parent);
+                let c = batch.merkleize(&db, None).await.unwrap();
+
+                // Applying A consumes its last strong reference; B retains only a Weak parent.
+                let (db, _) = db.apply_batch(a).await.unwrap();
+                let db = db.commit().await.unwrap();
+
+                let batch = apply_mutations(c.new_batch::<Sha256>(), &input.grandchild);
+                let retained_d = batch.merkleize(&db, None).await.unwrap();
+
+                // Rebuild B -> C -> D from the committed A state as a reference.
+                let batch = apply_mutations(db.new_batch(), &input.child);
+                let rebuilt_b = batch.merkleize(&db, None).await.unwrap();
+                let batch = apply_mutations(rebuilt_b.new_batch::<Sha256>(), &input.parent);
+                let rebuilt_c = batch.merkleize(&db, None).await.unwrap();
+                let batch = apply_mutations(rebuilt_c.new_batch::<Sha256>(), &input.grandchild);
+                let rebuilt_d = batch.merkleize(&db, None).await.unwrap();
+
+                assert_eq!(
+                    retained_d.root(),
+                    rebuilt_d.root(),
+                    "current root depended on a committed-and-dropped prefix"
+                );
+                assert_eq!(
+                    retained_d.ops_root(),
+                    rebuilt_d.ops_root(),
+                    "current ops root depended on a committed-and-dropped prefix"
+                );
+
+                let (db, _) = db.apply_batch(retained_d).await.unwrap();
+                assert_eq!(
+                    db.root(),
+                    rebuilt_d.root(),
+                    "retained-chain canonical root diverged"
+                );
+                db
+            }
+        };
 
         db.destroy().await.unwrap();
     });
 }
 
 fuzz_target!(|input: FuzzInput| {
-    fuzz_family::<mmr::Family>(&input, "fuzz-mmr-current-unordered-batch-root");
-    fuzz_family::<mmb::Family>(&input, "fuzz-mmb-current-unordered-batch-root");
+    match input.schedule {
+        Schedule::PendingParent | Schedule::PendingChain => {
+            fuzz_family::<mmr::Family>(&input, "fuzz-mmr-current-unordered-batch-root");
+            fuzz_family::<mmb::Family>(&input, "fuzz-mmb-current-unordered-batch-root");
+        }
+        Schedule::DroppedPrefixChain => {
+            fuzz_family::<mmb::Family>(&input, "fuzz-mmb-current-unordered-dropped-chain");
+        }
+    }
 });

--- a/storage/fuzz/fuzz_targets/qmdb_current_unordered_batch_root.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_current_unordered_batch_root.rs
@@ -217,7 +217,8 @@ fn fuzz_family<F: Graftable>(input: &FuzzInput, test_name: &str) {
             Schedule::PendingChain => {
                 // Build parent -> child -> grandchild with parent and child both pending, so
                 // the grandchild's grafted layer overlays two live ancestor diffs on the
-                // committed bitmap, which single-pending-ancestor schedules never exercise.
+                // committed bitmap. This is the only schedule that checks a multi-diff
+                // ancestor walk against a committed-only reference.
                 let batch = apply_mutations(db.new_batch(), &input.parent);
                 let parent = batch.merkleize(&db, None).await.unwrap();
                 let batch = apply_mutations(parent.new_batch::<Sha256>(), &input.child);
@@ -253,6 +254,11 @@ fn fuzz_family<F: Graftable>(input: &FuzzInput, test_name: &str) {
                     committed_grandchild.root(),
                     "pending grandchild canonical root diverged"
                 );
+                assert_eq!(
+                    db.ops_root(),
+                    committed_grandchild.ops_root(),
+                    "pending grandchild ops root diverged"
+                );
                 db
             }
             Schedule::DroppedPrefixChain => {
@@ -267,7 +273,7 @@ fn fuzz_family<F: Graftable>(input: &FuzzInput, test_name: &str) {
                 let batch = apply_mutations(b.new_batch::<Sha256>(), &input.parent);
                 let c = batch.merkleize(&db, None).await.unwrap();
 
-                // Applying A consumes its last strong reference; B retains only a Weak parent.
+                // Applying A consumes its last strong reference. B retains only a Weak parent.
                 let (db, _) = db.apply_batch(a).await.unwrap();
                 let db = db.commit().await.unwrap();
 
@@ -299,6 +305,11 @@ fn fuzz_family<F: Graftable>(input: &FuzzInput, test_name: &str) {
                     rebuilt_d.root(),
                     "retained-chain canonical root diverged"
                 );
+                assert_eq!(
+                    db.ops_root(),
+                    rebuilt_d.ops_root(),
+                    "retained-chain ops root diverged"
+                );
                 db
             }
         };
@@ -314,6 +325,7 @@ fuzz_target!(|input: FuzzInput| {
             fuzz_family::<mmb::Family>(&input, "fuzz-mmb-current-unordered-batch-root");
         }
         Schedule::DroppedPrefixChain => {
+            fuzz_family::<mmr::Family>(&input, "fuzz-mmr-current-unordered-dropped-chain");
             fuzz_family::<mmb::Family>(&input, "fuzz-mmb-current-unordered-dropped-chain");
         }
     }

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -5285,10 +5285,9 @@ mod tests {
             let (db, _) = db.apply_batch(initial).await.unwrap();
             let db = db.commit().await.unwrap();
 
-            // Parent: a no-op delete and a live delete in bucket 3, plus a create in bucket 1.
+            // Parent: delete the bucket-3 key and create in bucket 1.
             let parent = db
                 .new_batch()
-                .write(colliding_digest(3, 11), None)
                 .write(colliding_digest(3, 31), None)
                 .write(colliding_digest(1, 9), Some(v(2)))
                 .merkleize(&db, None)
@@ -5321,6 +5320,101 @@ mod tests {
                 pending_child.root(),
                 committed_child.root(),
                 "child root depended on pending-vs-applied parent path"
+            );
+            assert_eq!(
+                pending_child.total_active_keys,
+                committed_child.total_active_keys
+            );
+
+            let (db, _) = db.apply_batch(pending_child).await.unwrap();
+            assert_eq!(
+                db.root(),
+                committed_child.root(),
+                "applied pending child root diverged"
+            );
+
+            db.destroy().await.unwrap();
+        });
+    }
+
+    /// A stale prev-candidate can also enter through the mutation classifier's own read set:
+    /// the child's sibling update pulls the parent-deleted key's committed location into
+    /// `gather_existing_locations`, so the classifier loop must not contribute candidates for
+    /// the op it skips. Otherwise `find_prev_key`'s wrap-around lands on the stale key, its
+    /// rewrite is skipped as batch-created, and the true predecessor's rewrite is emitted at
+    /// a different stream position than on the committed path.
+    #[test]
+    fn ordered_stale_classifier_candidates_root_matches() {
+        let runner = deterministic::Runner::default();
+        runner.start(|context| async move {
+            type TestDb = OrderedFixedDb<
+                mmr::Family,
+                deterministic::Context,
+                sha256::Digest,
+                sha256::Digest,
+                Sha256,
+                OneCap,
+                Sequential,
+            >;
+
+            let config = fixed_db_config::<OneCap>("ordered-stale-classifier", &context);
+            let db = TestDb::init(context, config).await.unwrap();
+
+            let v = |n| colliding_digest(0xB0, n);
+            let initial = db
+                .new_batch()
+                .write(colliding_digest(1, 9), Some(v(0)))
+                .write(colliding_digest(3, 10), Some(v(1)))
+                .write(colliding_digest(3, 20), Some(v(2)))
+                .write(colliding_digest(3, 31), Some(v(3)))
+                .merkleize(&db, None)
+                .await
+                .unwrap();
+            let (db, _) = db.apply_batch(initial).await.unwrap();
+            let db = db.commit().await.unwrap();
+
+            // Parent: delete the last key of bucket 3.
+            let parent = db
+                .new_batch()
+                .write(colliding_digest(3, 31), None)
+                .merkleize(&db, None)
+                .await
+                .unwrap();
+
+            // Child: update a colliding sibling (pulling the deleted key's stale committed
+            // location into the classifier's read set), re-create the deleted key, and
+            // create keys whose predecessor searches consult the candidate sets.
+            let pending_child = parent
+                .new_batch::<Sha256>()
+                .write(colliding_digest(3, 10), Some(v(4)))
+                .write(colliding_digest(3, 31), Some(v(5)))
+                .write(colliding_digest(1, 20), Some(v(6)))
+                .write(colliding_digest(0, 0), Some(v(7)))
+                .merkleize(&db, None)
+                .await
+                .unwrap();
+
+            let (db, _) = db.apply_batch(parent).await.unwrap();
+            let db = db.commit().await.unwrap();
+
+            let committed_child = db
+                .new_batch()
+                .write(colliding_digest(3, 10), Some(v(4)))
+                .write(colliding_digest(3, 31), Some(v(5)))
+                .write(colliding_digest(1, 20), Some(v(6)))
+                .write(colliding_digest(0, 0), Some(v(7)))
+                .merkleize(&db, None)
+                .await
+                .unwrap();
+
+            assert_eq!(
+                pending_child.root(),
+                committed_child.root(),
+                "child root depended on pending-vs-committed parent path"
+            );
+            assert_eq!(
+                pending_child.total_active_keys,
+                committed_child.total_active_keys
             );
 
             let (db, _) = db.apply_batch(pending_child).await.unwrap();

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -5337,12 +5337,18 @@ mod tests {
         });
     }
 
-    /// A stale prev-candidate can also enter through the mutation classifier's own read set:
-    /// the child's sibling update pulls the parent-deleted key's committed location into
-    /// `gather_existing_locations`, so the classifier loop must not contribute candidates for
-    /// the op it skips. Otherwise `find_prev_key`'s wrap-around lands on the stale key, its
-    /// rewrite is skipped as batch-created, and the true predecessor's rewrite is emitted at
-    /// a different stream position than on the committed path.
+    /// Pins the stale-ancestor guard's position above the classifier's candidate pushes.
+    ///
+    /// The classifier resolves each mutated key's prior state by scanning its translated
+    /// bucket in the committed snapshot, and the same loop pushes each entry it examines
+    /// into the next/prev candidate sets that stitch the ordered links. In this scenario the
+    /// child updates a sibling that collides with a parent-deleted key, so the scan pulls
+    /// the deleted key's stale committed location into the loop. The guard skips the stale
+    /// entry, and it must do so before the candidate pushes: a stale prev-candidate makes
+    /// `find_prev_key`'s wrap-around land on the deleted key, whose rewrite is then skipped
+    /// as batch-created, and the true predecessor's rewrite is emitted at a different stream
+    /// position than on the committed path, so the roots diverge with identical key-value
+    /// data.
     #[test]
     fn ordered_stale_classifier_candidates_root_matches() {
         let runner = deterministic::Runner::default();

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -5254,7 +5254,7 @@ mod tests {
 
     /// Reduced from a fuzzer counterexample: a parent deletes keys whose buckets the child
     /// later touches, and building the child on the pending parent must produce the same
-    /// root as building it on the applied parent. The final key-value state is identical
+    /// root as building it on the committed parent. The final key-value state is identical
     /// either way; a divergence means the emitted operation streams (next-key pointers or
     /// floor moves) depended on whether the parent was pending.
     #[test]
@@ -5319,7 +5319,7 @@ mod tests {
             assert_eq!(
                 pending_child.root(),
                 committed_child.root(),
-                "child root depended on pending-vs-applied parent path"
+                "child root depended on pending-vs-committed parent path"
             );
             assert_eq!(
                 pending_child.total_active_keys,
@@ -5501,7 +5501,7 @@ mod tests {
             assert_eq!(
                 pending_child.root(),
                 committed_child.root(),
-                "child root depended on pending-vs-applied parent path"
+                "child root depended on pending-vs-committed parent path"
             );
             let (db, _) = db.apply_batch(pending_child).await.unwrap();
             assert_eq!(db.root(), committed_child.root());


### PR DESCRIPTION
Follow-up to #4627 hardening the batch-root coverage it introduced.

## Regression test for the classifier guard's position

Background: when an ordered batch is merkleized, a pass in batch.rs walks the batch's mutations and classifies each one as a create, update, or delete by scanning the key's translated bucket in the committed snapshot. In ordered mode the same loop also feeds the next and prev key bookkeeping: each existing entry it examines pushes its next-key pointer and location into the candidate sets that `find_next_key` and `find_prev_key` later use to stitch the ordered links. Because the scan sees only committed state, an entry that a still-pending ancestor batch already deleted or moved is stale, and the guard added in #4627 makes the classifier skip it.

The guard's position inside that loop is load bearing: it must run before the entry's pointers are pushed into the candidate sets. If it runs after, a stale entry no longer misclassifies anything, but its next-key pointer still steers the predecessor search on the pending path only, so the pending and committed roots diverge even though the key-value data is identical. Until now only fuzzing enforced that placement. This PR adds a deterministic regression test (`ordered_stale_classifier_candidates_root_matches`) that fails if the pushes are ever hoisted above the guard, asserts active-key counts in both stale-ancestor tests, and drops a vestigial no-op delete left over from the earlier reduction.

## Deeper fuzz schedules

Adds `PendingChain` and `DroppedPrefixChain` schedules to all four batch-root fuzzers (`qmdb_any_ordered_batch_root`, `qmdb_current_ordered_batch_root`, `qmdb_any_unordered_batch_root`, `qmdb_current_unordered_batch_root`):

- `PendingChain` merkleizes a grandchild while its parent and grandparent are both pending, exercising multi-ancestor closest-first shadowing (and the current layer's two-diff chunk overlays), which no other schedule reaches.
- `DroppedPrefixChain` combines two live ancestors with a committed-and-dropped prefix so base-location tracing and shadowing interact.

The ordered targets already consumed (but did not use) the grandchild input; the unordered targets gain the schedule and grandchild inputs, and `qmdb_current_unordered_batch_root` picks up the `apply_mutations` helper in place of inlined mutation loops. The unordered mirror exercises the shared ancestor-resolution paths; the classifier machinery the ordered schedules also stress does not exist in unordered mode. These input-layout changes invalidate saved fuzz artifacts and corpora for all four targets; both previously confirmed crashes (ordered targets) are preserved as deterministic regression tests, and the unordered targets hold no confirmed crashes. Extended runs of both ordered targets on Linux came back clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q4BFdANo2LhVEr2ko3FK9n

