### PR TITLE
[storage/qmdb] Export compact keyless batch artifacts

### DIFF
--- a/storage/src/journal/authenticated.rs
+++ b/storage/src/journal/authenticated.rs
@@ -11,6 +11,10 @@
 //! method returns an error, or its future is dropped before it finishes, the journal is
 //! gone: state that was not yet durable is discarded, but everything already on disk stays
 //! recoverable.
+//!
+//! Merkle batches retain ancestor nodes after parents are dropped. Journal batches require
+//! uncommitted ancestors to remain alive until descendants are merkleized so their items can be
+//! retained separately.
 
 use crate::{
     Context,
@@ -209,8 +213,9 @@ impl<F: Family, D: Digest, Item: Send + Sync, S: Strategy> MerkleizedBatch<F, D,
 
     /// Create a new speculative batch of operations with this batch as its parent.
     ///
-    /// The batch becomes invalid if any ancestor is dropped before being applied, or a sibling
-    /// fork has been applied.
+    /// Uncommitted ancestors must remain alive until the descendant is merkleized so their journal
+    /// items can be retained. Dropping them afterward is safe. Applying a sibling fork
+    /// invalidates the batch.
     pub fn new_batch<H: Hasher<Digest = D>>(self: &Arc<Self>) -> UnmerkleizedBatch<F, H, Item, S>
     where
         Item: Encode,
@@ -341,7 +346,6 @@ where
     where
         C::Item: 'static,
     {
-        let ancestors = batch.inner.retain_ancestors();
         let mem = self.merkle.snapshot();
         let hasher = self.hasher.clone();
         let strategy = self.strategy().clone();
@@ -349,7 +353,6 @@ where
             .spawn(items.len(), move |_| {
                 let merkleized = batch.add_many(items).merkleize(&mem);
                 let root = merkleized.root(&mem, &hasher, inactive_peaks)?;
-                drop(ancestors);
                 Ok((merkleized, root))
             })
             .await
@@ -3669,9 +3672,9 @@ mod tests {
         executor.start(test_merkleize_after_committed_prefix_dropped_inner::<mmb::Family>);
     }
 
-    /// A detached merkleization job owns the full ancestor chain after its waiter is dropped.
+    /// A detached merkleization job finishes cleanly after its waiter is dropped.
     #[test_traced("INFO")]
-    fn test_merkleize_retains_ancestors_after_cancellation() {
+    fn test_merkleize_finishes_after_cancellation() {
         deterministic::Runner::default().start(|context| async move {
             let strategy = Rayon::new(NZUsize!(2)).unwrap();
             let merkle_cfg = merkle_config_with("cancelled-merkleize", &context, strategy);
@@ -3706,7 +3709,6 @@ mod tests {
             let b_batch = a.new_batch::<Sha256>().add_many(b_items);
             let b = journal.merkle.with_mem(|mem| b_batch.merkleize(mem));
 
-            let ancestor = Arc::downgrade(&a.inner);
             let c_batch = b.new_batch::<Sha256>();
             drop(b);
 
@@ -3717,7 +3719,6 @@ mod tests {
             drop(merkleize);
             drop(a);
 
-            assert!(ancestor.upgrade().is_some());
             drop(release);
             assert!(
                 clean_drop
@@ -3725,7 +3726,6 @@ mod tests {
                     .expect("detached merkleization did not finish"),
                 "detached merkleization panicked"
             );
-            assert!(ancestor.upgrade().is_none());
         });
     }
 }

--- a/storage/src/merkle/batch.rs
+++ b/storage/src/merkle/batch.rs
@@ -38,15 +38,10 @@
 //! [`Mem::apply_batch`] to replay uncommitted ancestors without requiring the
 //! ancestor batches to still be alive.
 //!
-//! A `Weak` pointer to the parent is kept for [`MerkleizedBatch::get_node`] lookups
-//! (used during a child's merkleize) and for walking the chain to collect ancestor
-//! batch data. Committed-and-dropped ancestors truncate the `Weak` walk, leaving their
-//! data in the committed [`Mem`]. `ancestor_base_size` records the position before the
-//! oldest retained ancestor so the remaining suffix is replayed at the correct offset.
-//!
-//! During [`UnmerkleizedBatch::merkleize`], the parent is held as a strong `Arc`
-//! (keeping it alive for the walk), and the `Weak` chain is walked to collect
-//! ancestor data. After merkleize, the parent is downgraded to `Weak`.
+//! Each batch retains `Arc` refs to the ancestor data needed by [`MerkleizedBatch::get_node`] and
+//! [`Mem::apply_batch`]. These snapshots are inherited by the next generation, so dropping an
+//! ancestor batch does not lose uncommitted data. `ancestor_base_size` records the position before
+//! the oldest retained ancestor so the remaining suffix is replayed at the correct offset.
 //!
 //! In a pipelining pattern (build next batch from prev, apply prev, repeat), each batch
 //! holds at most one ancestor batch (its immediate parent's data, as an `Arc` ref).
@@ -59,9 +54,8 @@
 //!
 //! # Batch invalidation
 //!
-//! A batch becomes _invalid_ when an unapplied ancestor is dropped, or a sibling fork has been
-//! applied. Invalid batches must not be used: their methods may return incorrect data rather than
-//! erroring.
+//! A batch becomes _invalid_ when a sibling fork is applied. Invalid batches must not be used.
+//! Their methods may return incorrect data rather than errors.
 //!
 //! # Example (MMR)
 //!
@@ -85,10 +79,7 @@ use crate::merkle::{
     Error, Family, Location, Position, Readable, hasher::Hasher, mem::Mem, path, proof::Proof,
 };
 use ahash::RandomState;
-use alloc::{
-    sync::{Arc, Weak},
-    vec::Vec,
-};
+use alloc::{sync::Arc, vec::Vec};
 #[cfg(feature = "std")]
 use commonware_codec::Write;
 use commonware_cryptography::Digest;
@@ -138,20 +129,6 @@ impl<F: Family, D: Digest, S: Strategy> UnmerkleizedBatch<F, D, S> {
     /// Return a reference to the batch's strategy.
     pub fn strategy(&self) -> &S {
         &self.parent.strategy
-    }
-
-    /// Retain the live parent chain up to the first dropped weak link.
-    ///
-    /// Nodes beyond that link are read from committed state.
-    #[cfg(feature = "std")]
-    pub(crate) fn retain_ancestors(&self) -> Vec<Arc<MerkleizedBatch<F, D, S>>> {
-        let mut ancestors = Vec::new();
-        let mut current = Some(Arc::clone(&self.parent));
-        while let Some(batch) = current {
-            current = batch.parent.as_ref().and_then(Weak::upgrade);
-            ancestors.push(batch);
-        }
-        ancestors
     }
 
     /// The total number of nodes visible through this batch.
@@ -386,13 +363,12 @@ impl<F: Family, D: Digest, S: Strategy> UnmerkleizedBatch<F, D, S> {
             self.merkleize_bucket(base, hasher, positions, height as u32);
         }
 
-        // Collect ancestor data by walking the parent chain (strong Arc + Weak walk).
+        // Inherit the parent's snapshot so dropping the batch cannot lose older ancestors.
         let (ancestor_base_size, ancestor_appended, ancestor_overwrites) =
-            collect_ancestor_batches(&self.parent);
+            collect_ancestor_batches(&self.parent, base);
 
         let parent_size = self.parent.size();
         Arc::new(MerkleizedBatch {
-            parent: Some(Arc::downgrade(&self.parent)),
             appended: Arc::new(self.appended),
             overwrites: Arc::new(self.overwrites),
             parent_size,
@@ -475,36 +451,65 @@ impl<F: Family, D: Digest, S: Strategy> UnmerkleizedBatch<F, D, S> {
     }
 }
 
-/// Collect ancestor batch data by walking the parent + its Weak chain.
+/// Inherit the parent's retained snapshot and append the parent's own data.
+///
 /// Returns the size before the oldest retained ancestor followed by its appended nodes and
-/// overwrites in root-to-tip order. Skips empty batches (e.g. root batches from `from_mem`).
+/// overwrites in root-to-tip order. A committed prefix ending in an append is discarded. An
+/// overwrite-only prefix is discarded when its changes are already visible in committed state.
 #[allow(clippy::type_complexity)]
 fn collect_ancestor_batches<F: Family, D: Digest, S: Strategy>(
     parent: &Arc<MerkleizedBatch<F, D, S>>,
+    base: &Mem<F, D>,
 ) -> (Position<F>, Vec<Arc<Vec<D>>>, Vec<Arc<Overwrites<F, D>>>) {
-    let mut appended = Vec::new();
-    let mut overwrites = Vec::new();
-    let mut base_size = parent.parent_size;
-
-    // Parent is alive (strong Arc held by UnmerkleizedBatch).
+    let mut appended = parent.ancestor_appended.clone();
+    let mut overwrites = parent.ancestor_overwrites.clone();
+    let mut base_size = parent.ancestor_base_size;
     if !parent.appended.is_empty() || !parent.overwrites.is_empty() {
         appended.push(Arc::clone(&parent.appended));
         overwrites.push(Arc::clone(&parent.overwrites));
     }
+    let committed_size = base.size();
+    let pruning_boundary = Position::try_from(base.pruning_boundary()).expect("valid boundary");
 
-    // Walk Weak chain for grandparents+.
-    let mut current = parent.parent.as_ref().and_then(Weak::upgrade);
-    while let Some(batch) = current {
-        base_size = batch.parent_size;
-        if !batch.appended.is_empty() || !batch.overwrites.is_empty() {
-            appended.push(Arc::clone(&batch.appended));
-            overwrites.push(Arc::clone(&batch.overwrites));
+    let mut cursor = base_size;
+    let mut retained_start = 0;
+    let mut pending_overwrites = Overwrites::default();
+    let mut mismatches = 0usize;
+    for (index, ancestor) in appended.iter().enumerate() {
+        cursor += ancestor.len() as u64;
+        if cursor > committed_size {
+            break;
         }
-        current = batch.parent.as_ref().and_then(Weak::upgrade);
+
+        if !ancestor.is_empty() {
+            retained_start = index + 1;
+            base_size = cursor;
+            pending_overwrites.clear();
+            mismatches = 0;
+            continue;
+        }
+
+        for (&position, &digest) in overwrites[index].iter() {
+            let represented =
+                |value| position < pruning_boundary || base.get_node(position) == Some(value);
+            if let Some(previous) = pending_overwrites.insert(position, digest) {
+                mismatches -= usize::from(!represented(previous));
+            }
+            mismatches += usize::from(!represented(digest));
+        }
+        if mismatches != 0 {
+            continue;
+        }
+
+        retained_start = index + 1;
+        base_size = cursor;
+        pending_overwrites.clear();
+    }
+    if retained_start > 0 {
+        appended.drain(..retained_start);
+        overwrites.drain(..retained_start);
     }
 
-    appended.reverse();
-    overwrites.reverse();
     (base_size, appended, overwrites)
 }
 
@@ -516,9 +521,6 @@ fn collect_ancestor_batches<F: Family, D: Digest, S: Strategy>(
 /// [`UnmerkleizedBatch`].
 #[derive(Debug)]
 pub struct MerkleizedBatch<F: Family, D: Digest, S: Strategy> {
-    /// The parent batch in the chain, if any.
-    parent: Option<Weak<Self>>,
-
     /// This batch's appended nodes only (not accumulated from ancestors).
     pub(crate) appended: Arc<Vec<D>>,
 
@@ -539,12 +541,11 @@ pub struct MerkleizedBatch<F: Family, D: Digest, S: Strategy> {
     /// unchanged by all descendants, like `base_size`.
     pruning_boundary: Location<F>,
 
-    /// Arc refs to each ancestor's appended nodes, collected during merkleize while
-    /// ancestors are alive. Root-to-tip order.
+    /// Arc refs to each ancestor's appended nodes, inherited during merkleize in root-to-tip
+    /// order.
     pub(crate) ancestor_appended: Vec<Arc<Vec<D>>>,
 
-    /// Arc refs to each ancestor's overwrites, collected during merkleize while
-    /// ancestors are alive. Root-to-tip order.
+    /// Arc refs to each ancestor's overwrites, inherited during merkleize in root-to-tip order.
     pub(crate) ancestor_overwrites: Vec<Arc<Overwrites<F, D>>>,
 
     pub(crate) strategy: S,
@@ -563,7 +564,6 @@ impl<F: Family, D: Digest, S: Strategy> MerkleizedBatch<F, D, S> {
     /// for merkleization.
     pub fn from_mem_with_strategy(mem: &Mem<F, D>, strategy: S) -> Arc<Self> {
         Arc::new(Self {
-            parent: None,
             appended: Arc::new(Vec::new()),
             overwrites: Arc::new(Overwrites::default()),
             parent_size: mem.size(),
@@ -581,7 +581,7 @@ impl<F: Family, D: Digest, S: Strategy> MerkleizedBatch<F, D, S> {
         Position::new(*self.parent_size + self.appended.len() as u64)
     }
 
-    /// Resolve a node: own data -> Weak parent chain.
+    /// Resolve a node from this batch or its retained ancestors.
     ///
     /// Returns `None` for positions that only exist in the committed [`Mem`].
     /// Callers that need committed data should fall back to [`Mem::get_node`]
@@ -597,18 +597,21 @@ impl<F: Family, D: Digest, S: Strategy> MerkleizedBatch<F, D, S> {
             let i = (*pos - *self.parent_size) as usize;
             return self.appended.get(i).copied();
         }
-        // Walk Weak parent chain.
-        let mut current = self.parent.as_ref().and_then(Weak::upgrade);
-        while let Some(batch) = current {
-            if let Some(d) = batch.overwrites.get(&pos) {
-                return Some(*d);
+        for overwrites in self.ancestor_overwrites.iter().rev() {
+            if let Some(digest) = overwrites.get(&pos) {
+                return Some(*digest);
             }
-            if pos >= batch.parent_size {
-                let i = (*pos - *batch.parent_size) as usize;
-                return batch.appended.get(i).copied();
-            }
-            current = batch.parent.as_ref().and_then(Weak::upgrade);
         }
+
+        let mut start = self.ancestor_base_size;
+        for appended in &self.ancestor_appended {
+            let end = start + appended.len() as u64;
+            if pos >= start && pos < end {
+                return appended.get((*pos - *start) as usize).copied();
+            }
+            start = end;
+        }
+        debug_assert_eq!(start, self.parent_size);
         None
     }
 
@@ -681,8 +684,7 @@ impl<F: Family, D: Digest, S: Strategy> MerkleizedBatch<F, D, S> {
 
     /// Create a child batch on top of this merkleized batch.
     ///
-    /// The batch becomes invalid if any ancestor is dropped before being applied, or a sibling
-    /// fork has been applied.
+    /// The batch becomes invalid if a sibling fork has been applied.
     pub fn new_batch(self: &Arc<Self>) -> UnmerkleizedBatch<F, D, S> {
         UnmerkleizedBatch::new(Arc::clone(self))
     }
@@ -1120,6 +1122,86 @@ mod tests {
         });
     }
 
+    fn dropped_grandparent_snapshot<F: Family>() {
+        let executor = deterministic::Runner::default();
+        executor.start(|_| async move {
+            let hasher: H = Standard::new(ForwardFold);
+            let mut base = build_reference::<F>(&hasher, 50);
+            let updated = b"grandparent-update";
+            let mut grandparent_batch = base
+                .new_batch()
+                .update_leaf(&hasher, Location::new(5), updated)
+                .unwrap();
+            for i in 50u64..60 {
+                let element = hasher.digest(&i.to_be_bytes());
+                grandparent_batch = grandparent_batch.add(&hasher, &element);
+            }
+            let grandparent = grandparent_batch.merkleize(&base, &hasher);
+
+            let mut parent_batch = grandparent.new_batch();
+            for i in 60u64..70 {
+                let element = hasher.digest(&i.to_be_bytes());
+                parent_batch = parent_batch.add(&hasher, &element);
+            }
+            let parent = parent_batch.merkleize(&base, &hasher);
+
+            let mut child_batch = parent.new_batch();
+            for i in 70u64..80 {
+                let element = hasher.digest(&i.to_be_bytes());
+                child_batch = child_batch.add(&hasher, &element);
+            }
+
+            let grandparent_ref = Arc::downgrade(&grandparent);
+            drop(grandparent);
+            assert!(grandparent_ref.upgrade().is_none());
+
+            let child = child_batch.merkleize(&base, &hasher);
+            drop(parent);
+            let root = batch_root(&base, &child, &hasher);
+            let updated_location = Location::new(5);
+            let updated_position = Position::<F>::try_from(updated_location).unwrap();
+            assert_eq!(
+                child.get_node(updated_position),
+                Some(hasher.leaf_digest(updated_position, updated)),
+            );
+
+            let appended_location = Location::new(55);
+            let appended_position = Position::<F>::try_from(appended_location).unwrap();
+            let appended_element = hasher.digest(&55u64.to_be_bytes());
+            assert_eq!(
+                child.get_node(appended_position),
+                Some(hasher.leaf_digest(appended_position, &appended_element)),
+            );
+
+            let updated_proof = child.proof(&base, &hasher, updated_location, 0).unwrap();
+            assert!(updated_proof.verify_element_inclusion(
+                &hasher,
+                updated,
+                updated_location,
+                &root,
+            ));
+            let appended_proof = child.proof(&base, &hasher, appended_location, 0).unwrap();
+            assert!(appended_proof.verify_element_inclusion(
+                &hasher,
+                &appended_element,
+                appended_location,
+                &root,
+            ));
+
+            base.apply_batch(&child).unwrap();
+            assert_eq!(mem_root(&base, &hasher), root);
+
+            let mut reference = build_reference::<F>(&hasher, 80);
+            let update = reference
+                .new_batch()
+                .update_leaf(&hasher, updated_location, updated)
+                .unwrap()
+                .merkleize(&reference, &hasher);
+            reference.apply_batch(&update).unwrap();
+            assert_eq!(mem_root(&base, &hasher), mem_root(&reference, &hasher));
+        });
+    }
+
     fn overwrite_collision<F: Family>() {
         let executor = deterministic::Runner::default();
         executor.start(|_| async move {
@@ -1274,6 +1356,10 @@ mod tests {
         three_deep_stacking::<crate::mmr::Family>();
     }
     #[test]
+    fn mmr_dropped_grandparent_snapshot() {
+        dropped_grandparent_snapshot::<crate::mmr::Family>();
+    }
+    #[test]
     fn mmr_overwrite_collision() {
         overwrite_collision::<crate::mmr::Family>();
     }
@@ -1396,6 +1482,10 @@ mod tests {
     #[test]
     fn mmb_three_deep_stacking() {
         three_deep_stacking::<crate::mmb::Family>();
+    }
+    #[test]
+    fn mmb_dropped_grandparent_snapshot() {
+        dropped_grandparent_snapshot::<crate::mmb::Family>();
     }
     #[test]
     fn mmb_overwrite_collision() {

--- a/storage/src/merkle/mem.rs
+++ b/storage/src/merkle/mem.rs
@@ -460,10 +460,8 @@ impl<F: Family, D: Digest> Mem<F, D> {
             self.nodes.push_back(digest);
         }
 
-        // Detect missing ancestor data. If an uncommitted ancestor was dropped
-        // before this batch was merkleized, its appended nodes are absent and the
-        // Mem ends up smaller than expected. This does not catch dropped
-        // overwrite-only ancestors (they don't change the size).
+        // Merkle batches own their ancestor nodes. A size mismatch means the batch ancestry does
+        // not connect to the current structure, which indicates use against an incompatible fork.
         if self.size() != batch.size() {
             return Err(Error::AncestorDropped {
                 expected: batch.size(),
@@ -1124,27 +1122,6 @@ mod tests {
         assert_eq!(plain_root(&mem, &hasher), plain_root(&reference, &hasher));
     }
 
-    /// Dropping an uncommitted ancestor before merkleizing a descendant must
-    /// be detected at apply time, not silently corrupt data.
-    fn apply_batch_detects_dropped_ancestor<F: Family>() {
-        let hasher: H = Standard::new(ForwardFold);
-        let mut mem = Mem::<F, D>::new();
-
-        let a = mem.new_batch().add(&hasher, b"a").merkleize(&mem, &hasher);
-        let b = a.new_batch().add(&hasher, b"b").merkleize(&mem, &hasher);
-        drop(a); // A dropped before C is merkleized, so its data is lost
-        let c = b.new_batch().add(&hasher, b"c").merkleize(&mem, &hasher);
-
-        let result = mem.apply_batch(&c);
-        assert!(
-            matches!(
-                result,
-                Err(Error::AncestorDropped { expected, .. }) if expected == c.size()
-            ),
-            "expected AncestorDropped, got {result:?}"
-        );
-    }
-
     /// Dropping a committed ancestor before merkleizing a descendant must not
     /// shift the retained uncommitted suffix back to the original fork point.
     fn apply_batch_after_committed_ancestor_dropped<F: Family>() {
@@ -1283,6 +1260,36 @@ mod tests {
         );
     }
 
+    fn sequential_overwrite_apply_bounds_retained_ancestors<F: Family>() {
+        let hasher: H = Standard::new(ForwardFold);
+        let mut mem = build_raw::<F>(&hasher, 10);
+
+        let first = mem
+            .new_batch()
+            .update_leaf(&hasher, Location::new(0), b"first")
+            .unwrap()
+            .merkleize(&mem, &hasher);
+        let oldest = alloc::sync::Arc::downgrade(&first.overwrites);
+        mem.apply_batch(&first).unwrap();
+
+        let second = first
+            .new_batch()
+            .update_leaf(&hasher, Location::new(1), b"second")
+            .unwrap()
+            .merkleize(&mem, &hasher);
+        mem.apply_batch(&second).unwrap();
+        drop(first);
+
+        let third = second
+            .new_batch()
+            .update_leaf(&hasher, Location::new(2), b"third")
+            .unwrap()
+            .merkleize(&mem, &hasher);
+
+        assert!(third.ancestor_overwrites.is_empty());
+        assert!(oldest.upgrade().is_none());
+    }
+
     fn split_root_matches_recompute<F: Family>() {
         let hasher: H = Standard::new(ForwardFold);
         let plain = build::<F>(&hasher, 49);
@@ -1389,12 +1396,12 @@ mod tests {
         apply_batch_skips_only_committed_ancestors::<crate::mmr::Family>();
     }
     #[test]
-    fn mmr_apply_batch_detects_dropped_ancestor() {
-        apply_batch_detects_dropped_ancestor::<crate::mmr::Family>();
-    }
-    #[test]
     fn mmr_apply_batch_overwrite_only_ancestor() {
         apply_batch_overwrite_only_ancestor::<crate::mmr::Family>();
+    }
+    #[test]
+    fn mmr_sequential_overwrite_apply_bounds_retained_ancestors() {
+        sequential_overwrite_apply_bounds_retained_ancestors::<crate::mmr::Family>();
     }
     #[test]
     fn mmr_split_root_matches_recompute() {
@@ -1488,10 +1495,6 @@ mod tests {
         apply_batch_skips_only_committed_ancestors::<crate::mmb::Family>();
     }
     #[test]
-    fn mmb_apply_batch_detects_dropped_ancestor() {
-        apply_batch_detects_dropped_ancestor::<crate::mmb::Family>();
-    }
-    #[test]
     fn mmb_apply_batch_after_committed_ancestor_dropped() {
         apply_batch_after_committed_ancestor_dropped::<crate::mmb::Family>();
     }
@@ -1502,6 +1505,10 @@ mod tests {
     #[test]
     fn mmb_apply_batch_overwrite_only_ancestor() {
         apply_batch_overwrite_only_ancestor::<crate::mmb::Family>();
+    }
+    #[test]
+    fn mmb_sequential_overwrite_apply_bounds_retained_ancestors() {
+        sequential_overwrite_apply_bounds_retained_ancestors::<crate::mmb::Family>();
     }
     #[test]
     fn mmb_split_root_matches_recompute() {

--- a/storage/src/merkle/mod.rs
+++ b/storage/src/merkle/mod.rs
@@ -361,13 +361,16 @@ pub enum Error<F: Family> {
         actual: Position<F>,
     },
 
-    /// An ancestor batch was dropped before this batch was applied, causing
-    /// data loss. All ancestors must be kept alive until descendants are applied.
+    /// Applying a batch could not reconstruct its expected ancestry.
+    ///
+    /// Merkle batches retain ancestor nodes, so this indicates use against an incompatible fork.
+    /// Higher-level structures such as authenticated journals can also report it when separately
+    /// retained ancestor items were dropped before a descendant was merkleized.
     #[error("ancestor dropped: expected size {expected}, actual size {actual}")]
     AncestorDropped {
-        /// The expected size after applying all ancestors + this batch.
+        /// The expected size after applying all ancestors and this batch.
         expected: Position<F>,
-        /// The actual size (less than expected due to missing ancestor data).
+        /// The actual size after applying the available ancestor data.
         actual: Position<F>,
     },
 

--- a/storage/src/merkle/persisted/compact.rs
+++ b/storage/src/merkle/persisted/compact.rs
@@ -50,13 +50,6 @@ impl<F: Family, D: Digest, S: Strategy> UnmerkleizedBatch<F, D, S> {
         self.inner.leaves()
     }
 
-    /// Retain the live parent chain up to the first dropped weak link.
-    ///
-    /// Nodes beyond that link are read from committed state.
-    pub(crate) fn retain_ancestors(&self) -> Vec<Arc<batch::MerkleizedBatch<F, D, S>>> {
-        self.inner.retain_ancestors()
-    }
-
     /// Consume this batch and produce an immutable [`batch::MerkleizedBatch`] with computed root.
     pub fn merkleize(
         self,

--- a/storage/src/qmdb/compact/batch.rs
+++ b/storage/src/qmdb/compact/batch.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 pub(crate) async fn merkleize_ops<F, H, S, Op>(
     merkle: &compact::Merkle<F, H::Digest, S>,
     batch: compact::UnmerkleizedBatch<F, H::Digest, S>,
-    ops: Vec<Op>,
+    ops: impl Into<Arc<Vec<Op>>>,
     inactive_peaks: usize,
 ) -> Result<(Arc<batch::MerkleizedBatch<F, H::Digest, S>>, H::Digest), merkle::Error<F>>
 where
@@ -29,8 +29,8 @@ where
     S: Strategy,
     Op: EncodeShared + 'static,
 {
+    let ops = ops.into();
     let first_leaf = batch.leaves();
-    let ancestors = batch.retain_ancestors();
     let mem = merkle.snapshot();
     let strategy = merkle.strategy().clone();
     strategy
@@ -48,7 +48,6 @@ where
             let batch = batch.add_leaf_digests(leaf_digests);
             let merkleized = batch.merkleize(&mem, &hasher);
             let root = merkleized.root(&mem, &hasher, inactive_peaks)?;
-            drop(ancestors);
             Ok((merkleized, root))
         })
         .await
@@ -74,10 +73,14 @@ mod tests {
             compact::Merkle::<F, <Sha256 as Hasher>::Digest, Sequential>::new(Sequential);
 
         // Build a speculative suffix over a prefix that will be committed independently.
-        let (prefix, _) =
-            merkleize_ops::<F, Sha256, _, _>(&merkle, merkle.new_batch(), (0..8u64).collect(), 0)
-                .await
-                .unwrap();
+        let (prefix, _) = merkleize_ops::<F, Sha256, _, _>(
+            &merkle,
+            merkle.new_batch(),
+            (0..8u64).collect::<Vec<_>>(),
+            0,
+        )
+        .await
+        .unwrap();
         let (pending, _) = merkleize_ops::<F, Sha256, _, _>(
             &merkle,
             compact::UnmerkleizedBatch::wrap(prefix.new_batch()),
@@ -120,9 +123,9 @@ mod tests {
             .start(|_| test_merkleize_ops_after_committed_prefix_dropped_inner::<mmb::Family>());
     }
 
-    /// A detached merkleization job owns the full ancestor chain after its waiter is dropped.
+    /// A detached merkleization job finishes cleanly after its waiter is dropped.
     #[test_traced]
-    fn test_merkleize_ops_retains_ancestors_after_cancellation() {
+    fn test_merkleize_ops_finishes_after_cancellation() {
         deterministic::Runner::default().start(|_| async move {
             let strategy = Rayon::new(NZUsize!(2)).unwrap();
             let merkle =
@@ -140,7 +143,6 @@ mod tests {
             }
             let b = merkle.with_mem(|mem| b_batch.merkleize(mem, &hasher));
 
-            let ancestor = Arc::downgrade(&a);
             let c_batch = compact::UnmerkleizedBatch::wrap(b.new_batch());
             drop(b);
 
@@ -156,7 +158,6 @@ mod tests {
             drop(merkleize);
             drop(a);
 
-            assert!(ancestor.upgrade().is_some());
             drop(release);
             assert!(
                 clean_drop
@@ -164,7 +165,6 @@ mod tests {
                     .expect("detached merkleization did not finish"),
                 "detached merkleization panicked"
             );
-            assert!(ancestor.upgrade().is_none());
         });
     }
 }

--- a/storage/src/qmdb/current/batch.rs
+++ b/storage/src/qmdb/current/batch.rs
@@ -751,7 +751,7 @@ where
     overlay
 }
 
-/// Merkleize grafted chunk digests while retaining the live ancestor chain.
+/// Merkleize grafted chunk digests.
 async fn merkleize_grafted_batch<F, H, S, const N: usize>(
     strategy: &S,
     grafted_parent: Arc<GenericMerkleizedBatch<F, H::Digest, S>>,
@@ -766,7 +766,6 @@ where
 {
     let old_grafted_leaves = *grafted_parent.leaves() as usize;
     let mut grafted_batch = grafted_parent.new_batch();
-    let ancestors = grafted_batch.retain_ancestors();
     let grafted_tree = Arc::clone(grafted_tree);
     strategy
         .clone()
@@ -782,9 +781,7 @@ where
                 }
             }
             let grafted_hasher = grafting::hasher::<F, H>(grafting_height);
-            let merkleized = grafted_batch.merkleize(&grafted_tree, &grafted_hasher);
-            drop(ancestors);
-            merkleized
+            grafted_batch.merkleize(&grafted_tree, &grafted_hasher)
         })
         .await
 }
@@ -1094,9 +1091,9 @@ where
 {
     /// Create a new speculative batch of operations with this batch as its parent.
     ///
-    /// All uncommitted ancestors in the chain must be kept alive until the child (or any
-    /// descendant) is merkleized. Dropping an uncommitted ancestor causes data
-    /// loss detected at `apply_batch` time.
+    /// Uncommitted operation ancestors in the authenticated journal chain must remain alive until
+    /// the child or any descendant is merkleized so their items can be retained. Grafted Merkle
+    /// nodes are retained independently.
     ///
     /// This is only valid while `self` is still on the winning branch. If a different branch has
     /// been applied since `self` was created, `self` is no longer a valid parent and must not be
@@ -1377,9 +1374,9 @@ mod tests {
         (a, b)
     }
 
-    /// A detached grafted-tree merkleization owns the full ancestor chain after cancellation.
+    /// A detached grafted-tree merkleization finishes after its waiter is dropped.
     #[test_traced]
-    fn test_grafted_merkleize_retains_ancestors_after_cancellation() {
+    fn test_grafted_merkleize_finishes_after_cancellation() {
         let strategy = Rayon::new(NZUsize!(2)).unwrap();
         let manual = strategy.manual();
         let mem = Arc::new(Mem::<mmb::Family, <Sha256 as Hasher>::Digest>::new());
@@ -1388,9 +1385,9 @@ mod tests {
         let waker = futures::task::noop_waker();
         let mut context = TaskContext::from_waker(&waker);
 
-        // Observe the worker result so a missing grandparent fails the test directly.
+        // Observe the result to prove retained snapshots let the worker finish successfully after
+        // its ancestor handles are dropped.
         let (a, b) = grafted_chain(&manual, &mem);
-        let ancestor = Arc::downgrade(&a);
         let release = block_strategy(&strategy, 2);
         let mut merkleize = Box::pin(merkleize_grafted_batch::<mmb::Family, Sha256, _, 1>(
             &manual,
@@ -1403,13 +1400,12 @@ mod tests {
         drop(b);
         drop(a);
         drop(release);
-        let _ = futures::executor::block_on(merkleize);
-        assert!(ancestor.upgrade().is_none());
+        drop(futures::executor::block_on(merkleize));
 
-        // Drop the waiter while the worker is queued to prove the guard moved with it.
+        // Drop the waiter while an equivalent worker is queued to prove detached work terminates.
         let (a, b) = grafted_chain(&manual, &mem);
-        let ancestor = Arc::downgrade(&a);
         let release = block_strategy(&strategy, 2);
+        let worker_tree = Arc::downgrade(&mem);
         let mut merkleize = Box::pin(merkleize_grafted_batch::<mmb::Family, Sha256, _, 1>(
             &manual,
             Arc::clone(&b),
@@ -1421,14 +1417,14 @@ mod tests {
         drop(merkleize);
         drop(b);
         drop(a);
-        assert!(ancestor.upgrade().is_some());
+        drop(mem);
 
         drop(release);
         let deadline = Instant::now() + Duration::from_secs(10);
-        while ancestor.upgrade().is_some() {
+        while worker_tree.upgrade().is_some() {
             assert!(
                 Instant::now() < deadline,
-                "detached grafted merkleization did not release its ancestors"
+                "detached grafted merkleization did not finish"
             );
             std::thread::yield_now();
         }

--- a/storage/src/qmdb/keyless/compact.rs
+++ b/storage/src/qmdb/keyless/compact.rs
@@ -28,7 +28,7 @@ pub use crate::qmdb::compact::Config;
 use crate::{
     Context,
     journal::contiguous::variable::{self, Config as JournalConfig},
-    merkle::{Family, Location, batch, compact as compact_merkle},
+    merkle::{Family, Location, Proof, batch, compact as compact_merkle},
     qmdb::{
         self, Error,
         any::value::ValueEncoding,
@@ -108,6 +108,7 @@ where
     Operation<F, V>: EncodeShared,
 {
     pub(super) merkle_batch: Arc<batch::MerkleizedBatch<F, D, S>>,
+    operations: Arc<Vec<Operation<F, V>>>,
     pub(super) commit_metadata: Option<V::Value>,
     pub(super) parent: Option<Weak<Self>>,
     pub(super) bounds: batch_chain::Bounds<F, D>,
@@ -134,6 +135,67 @@ where
     /// Return the [`Bounds`] of the batch.
     pub const fn bounds(&self) -> &Bounds<F, D> {
         &self.bounds
+    }
+
+    /// Return the operations this batch appends to the log and the location of the first.
+    pub fn operations(&self) -> (Location<F>, Arc<Vec<Operation<F, V>>>) {
+        (self.bounds.base.size, Arc::clone(&self.operations))
+    }
+
+    /// Inclusion proof for the operations returned by [`Self::operations`], anchored at
+    /// this batch's tip. The operations, proof, and [`Self::pinned_nodes`] verify against
+    /// [`Self::root`] via [`crate::qmdb::verify_proof_and_pinned_nodes`].
+    ///
+    /// Nodes below this batch chain are read from `db`'s
+    /// [Merkle store][crate::merkle::mem::Mem]. Capture the proof before calling
+    /// [`Db::apply_batch`], which may prune those nodes.
+    pub fn proof<E, C, H>(&self, db: &Db<F, E, V, H, C, S>) -> Result<Proof<F, D>, Error<F>>
+    where
+        E: Context,
+        H: Hasher<Digest = D>,
+        C: Clone + Send + Sync + 'static,
+        Operation<F, V>: Read<Cfg = C>,
+    {
+        let inactive_peaks = F::inactive_peaks(self.bounds.tip.size, self.bounds.inactivity_floor);
+        let hasher = qmdb::hasher::<H>();
+        db.merkle
+            .with_mem(|base| {
+                self.merkle_batch.range_proof(
+                    base,
+                    &hasher,
+                    self.bounds.base.size..self.bounds.tip.size,
+                    inactive_peaks,
+                )
+            })
+            .map_err(Into::into)
+    }
+
+    /// Pinned nodes for the operations returned by [`Self::operations`]. The operations,
+    /// [`Self::proof`], and pinned nodes verify against [`Self::root`] via
+    /// [`crate::qmdb::verify_proof_and_pinned_nodes`].
+    ///
+    /// Nodes below this batch chain are read from `db`'s
+    /// [Merkle store][crate::merkle::mem::Mem]. Capture the pinned nodes before calling
+    /// [`Db::apply_batch`], which may prune them.
+    pub fn pinned_nodes<E, C, H>(&self, db: &Db<F, E, V, H, C, S>) -> Result<Vec<D>, Error<F>>
+    where
+        E: Context,
+        H: Hasher<Digest = D>,
+        C: Clone + Send + Sync + 'static,
+        Operation<F, V>: Read<Cfg = C>,
+    {
+        db.merkle
+            .with_mem(|base| {
+                F::nodes_to_pin(self.bounds.base.size)
+                    .map(|pos| {
+                        self.merkle_batch
+                            .get_node(pos)
+                            .or_else(|| base.get_node(pos))
+                            .ok_or(crate::merkle::Error::ElementPruned(pos))
+                    })
+                    .collect::<Result<Vec<_>, _>>()
+            })
+            .map_err(Into::into)
     }
 
     /// Create a new speculative batch with this one as its parent.
@@ -227,12 +289,13 @@ where
         }
         ops.push(Operation::Commit(metadata.clone(), inactivity_floor));
 
-        let total_size = self.base.size + ops.len() as u64;
+        let operations = Arc::new(ops);
+        let total_size = self.base.size + operations.len() as u64;
         let inactive_peaks = F::inactive_peaks(total_size, inactivity_floor);
         let (merkle, root) = compact_batch::merkleize_ops::<F, H, S, _>(
             &db.merkle,
             self.merkle_batch,
-            ops,
+            Arc::clone(&operations),
             inactive_peaks,
         )
         .await
@@ -246,6 +309,7 @@ where
 
         Arc::new(MerkleizedBatch {
             merkle_batch: merkle,
+            operations,
             commit_metadata: metadata,
             parent: self.parent.as_ref().map(Arc::downgrade),
             bounds: batch_chain::Bounds {
@@ -415,6 +479,7 @@ where
     {
         Arc::new(MerkleizedBatch {
             merkle_batch: self.merkle.to_batch(),
+            operations: Arc::new(Vec::new()),
             commit_metadata: self.last_commit_metadata.clone(),
             parent: None,
             bounds: batch_chain::Bounds::from_db(self.commitment(), self.inactivity_floor_loc),
@@ -616,8 +681,8 @@ where
 mod tests {
     use super::*;
     use crate::{
-        merkle::mmr,
-        qmdb::{any::value::FixedEncoding, compact::witness},
+        merkle::{mmb, mmr},
+        qmdb::{any::value::FixedEncoding, compact::witness, verify_proof_and_pinned_nodes},
     };
     use commonware_cryptography::{Sha256, sha256::Digest};
     use commonware_macros::test_traced;
@@ -657,6 +722,170 @@ mod tests {
         Db::init_from_merkle(merkle, context.child("witness"), witness_cfg, ())
             .await
             .unwrap()
+    }
+
+    async fn operations_and_proof_cover_own_suffix_inner<F: Family>(
+        context: deterministic::Context,
+    ) {
+        let db = open_db::<F>(context.child("db"), "keyless-operations-and-proof").await;
+
+        let mut seed = db.new_batch();
+        for value in 1u64..=6 {
+            seed = seed.append(U64::new(value));
+        }
+        let seed = seed
+            .merkleize(&db, Some(U64::new(7)), Location::new(0))
+            .await;
+        let (db, _) = db.apply_batch(seed).await.unwrap();
+        let db = db.sync().await.unwrap();
+        let floor = db.size();
+        assert_eq!(floor, Location::new(8));
+
+        let mut parent = db.new_batch();
+        for value in 8u64..=12 {
+            parent = parent.append(U64::new(value));
+        }
+        let parent = parent.merkleize(&db, Some(U64::new(13)), floor).await;
+        let child = parent
+            .new_batch::<Sha256>()
+            .append(U64::new(14))
+            .merkleize(&db, Some(U64::new(15)), floor)
+            .await;
+
+        let parent_end = parent.bounds().tip.size;
+        drop(parent);
+
+        let (child_start, child_ops) = child.operations();
+        let (_, child_ops_again) = child.operations();
+        let child_end = child.bounds().tip.size;
+        let child_root = child.root();
+        let child_proof = child.proof(&db).unwrap();
+        let child_pins = child.pinned_nodes(&db).unwrap();
+        let expected_child_pins = db.merkle.with_mem(|base| {
+            F::nodes_to_pin(child_start)
+                .map(|pos| {
+                    child
+                        .merkle_batch
+                        .get_node(pos)
+                        .or_else(|| base.get_node(pos))
+                        .unwrap()
+                })
+                .collect::<Vec<_>>()
+        });
+
+        assert!(Arc::ptr_eq(&child_ops, &child_ops_again));
+        assert_eq!(child_start, parent_end);
+        assert_eq!(*child_start + child_ops.len() as u64, *child_end);
+        assert_eq!(child_end, Location::new(16));
+        assert!(matches!(
+            child_ops.as_slice(),
+            [Operation::Append(value), Operation::Commit(Some(metadata), operation_floor)]
+                if value == &U64::new(14)
+                    && metadata == &U64::new(15)
+                    && operation_floor == &floor
+        ));
+        assert_eq!(child_proof.leaves, child_end);
+        assert_eq!(
+            child_proof.inactive_peaks,
+            F::inactive_peaks(child_end, floor),
+        );
+        assert_eq!(child_pins, expected_child_pins);
+        assert!(verify_proof_and_pinned_nodes::<Sha256, _, _>(
+            &child_proof,
+            child_start,
+            &child_ops,
+            &child_pins,
+            &child_root
+        ));
+
+        assert!(child_pins.len() > 1);
+        let mut reordered_child_pins = child_pins.clone();
+        reordered_child_pins.swap(0, 1);
+        assert!(!verify_proof_and_pinned_nodes::<Sha256, _, _>(
+            &child_proof,
+            child_start,
+            &child_ops,
+            &reordered_child_pins,
+            &child_root
+        ));
+
+        let (db, child_range) = db.apply_batch(child).await.unwrap();
+        assert_eq!(child_range, floor..child_end);
+
+        let commit_floor = db.size();
+        let commit_only = db
+            .new_batch()
+            .merkleize(&db, Some(U64::new(16)), commit_floor)
+            .await;
+        let (commit_start, commit_ops) = commit_only.operations();
+        let commit_end = commit_only.bounds().tip.size;
+        let commit_root = commit_only.root();
+        let commit_proof = commit_only.proof(&db).unwrap();
+        let commit_pins = commit_only.pinned_nodes(&db).unwrap();
+
+        assert_eq!(commit_start, commit_floor);
+        assert!(matches!(
+            commit_ops.as_slice(),
+            [Operation::Commit(Some(metadata), operation_floor)]
+                if metadata == &U64::new(16) && operation_floor == &commit_floor
+        ));
+        assert_eq!(*commit_start + commit_ops.len() as u64, *commit_end);
+        assert_eq!(commit_proof.leaves, commit_end);
+        assert_eq!(
+            commit_proof.inactive_peaks,
+            F::inactive_peaks(commit_end, commit_floor)
+        );
+        assert!(verify_proof_and_pinned_nodes::<Sha256, _, _>(
+            &commit_proof,
+            commit_start,
+            &commit_ops,
+            &commit_pins,
+            &commit_root
+        ));
+
+        let (db, commit_range) = db.apply_batch(commit_only).await.unwrap();
+        assert_eq!(commit_range, commit_start..commit_end);
+        let db = db.sync().await.unwrap();
+        assert!(verify_proof_and_pinned_nodes::<Sha256, _, _>(
+            &commit_proof,
+            commit_start,
+            &commit_ops,
+            &commit_pins,
+            &commit_root
+        ));
+
+        let late = db
+            .new_batch()
+            .append(U64::new(17))
+            .merkleize(&db, Some(U64::new(18)), db.size())
+            .await;
+        let (late_start, late_ops) = late.operations();
+        let late_root = late.root();
+        let (db, _) = db.apply_batch(Arc::clone(&late)).await.unwrap();
+        let db = db.sync().await.unwrap();
+        if let (Ok(proof), Ok(pinned_nodes)) = (late.proof(&db), late.pinned_nodes(&db)) {
+            assert!(verify_proof_and_pinned_nodes::<Sha256, _, _>(
+                &proof,
+                late_start,
+                &late_ops,
+                &pinned_nodes,
+                &late_root
+            ));
+        }
+
+        db.destroy().await.unwrap();
+    }
+
+    #[test_traced]
+    fn test_operations_and_proof_cover_own_suffix_mmr() {
+        deterministic::Runner::default()
+            .start(operations_and_proof_cover_own_suffix_inner::<mmr::Family>);
+    }
+
+    #[test_traced]
+    fn test_operations_and_proof_cover_own_suffix_mmb() {
+        deterministic::Runner::default()
+            .start(operations_and_proof_cover_own_suffix_inner::<mmb::Family>);
     }
 
     /// Open the persisted witness journal directly so tests can corrupt the tip entry.


### PR DESCRIPTION
Exposes the operation suffix, range proof, and pinned frontier nodes produced while merkleizing a compact keyless QMDB batch, which allows consumers to authenticate and replay the batch against its resulting root. 

Also makes Merkle batches retain required ancestor nodes so asynchronous merkleization remains valid after external ancestor handles are dropped. Artifact retrieval is guaranteed until applied changes are committed or synchronized, after which access may return an error.