### PR TITLE
[consensus/simplex, glue/stateful] Support weighted committees

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -661,6 +661,14 @@ BLS multisig certificates form and verify quorum by weight. BLS threshold
 schemes remain count-based and reject non-uniform committees. Certificate
 encoding is unchanged ([#4635]).
 
+### Weighted Simplex Committees
+
+Simplex forms certificates and evaluates recent activity by committee weight.
+Elector configurations receive the full committee, while built-in electors remain
+participant-index based. Simplex also logs and exports committee quorum diagnostics
+when it installs an epoch. The stateful recovery probe selects its floor after reply
+weight exceeds the solicited committee's fault budget ([#4639]).
+
 ### Crash Recovery
 
 Runtime storage now recovers a blob whose initial header write was interrupted.
@@ -685,6 +693,7 @@ after restart ([#4420]).
 [#4275]: https://github.com/commonwarexyz/monorepo/pull/4275
 [#4420]: https://github.com/commonwarexyz/monorepo/pull/4420
 [#4635]: https://github.com/commonwarexyz/monorepo/pull/4635
+[#4639]: https://github.com/commonwarexyz/monorepo/pull/4639
 
 ## v2026.7.0
 

--- a/consensus/fuzz/fuzz_targets/simplex_elector.rs
+++ b/consensus/fuzz/fuzz_targets/simplex_elector.rs
@@ -15,7 +15,7 @@ use commonware_cryptography::{
     ed25519::{PrivateKey, PublicKey},
 };
 use commonware_math::algebra::Random as _;
-use commonware_utils::{TestRng, TryCollect, ordered::Set};
+use commonware_utils::{TestRng, TryCollect, ordered::Committee};
 use libfuzzer_sys::fuzz_target;
 use std::time::Duration;
 
@@ -44,16 +44,12 @@ where
         .map(|i| {
             let mut rng = TestRng::new(i as u64);
             let private_key = PrivateKey::random(&mut rng);
-            private_key.public_key()
+            (private_key.public_key(), 1)
         })
-        .try_collect::<Set<_>>()
+        .try_collect::<Committee<_>>()
     else {
         return;
     };
-
-    if participants.is_empty() {
-        return;
-    }
 
     let elector = elector_config.build(&participants);
 

--- a/consensus/src/simplex/actors/batcher/actor.rs
+++ b/consensus/src/simplex/actors/batcher/actor.rs
@@ -26,7 +26,7 @@ use commonware_runtime::{
         traces::TracedExt as _,
     },
 };
-use commonware_utils::{N3f1, ordered::Quorum};
+use commonware_utils::{N3f1, ordered::Committee};
 use rand_core::CryptoRng;
 use std::{
     collections::BTreeMap,
@@ -45,6 +45,36 @@ struct Current {
     view: View,
     leader: Option<Participant>,
     leader_nullify_hinted: bool,
+}
+
+fn required_active_weight<P: Ord>(participants: &Committee<P>, me: Option<Participant>) -> u64 {
+    let quorum_weight = participants.quorum_weight::<N3f1>();
+    me.map_or(quorum_weight, |me| {
+        // Local participants are live by construction because they do not receive their own
+        // messages.
+        quorum_weight.saturating_sub(
+            participants
+                .weight(me)
+                .expect("local participant must belong to committee"),
+        )
+    })
+}
+
+fn recent_activity_weight(
+    last_activity: &[Option<SystemTime>],
+    weights: &[u64],
+    min_time: SystemTime,
+) -> u64 {
+    debug_assert_eq!(last_activity.len(), weights.len());
+    last_activity
+        .iter()
+        .zip(weights)
+        .filter_map(|(activity, weight)| {
+            activity
+                .is_some_and(|activity| activity >= min_time)
+                .then_some(weight)
+        })
+        .sum()
 }
 
 pub struct Actor<E, S, B, D, Re, Rl, T>
@@ -78,11 +108,11 @@ where
     /// participant. `None` means no activity has been observed.
     last_activity: Vec<Option<SystemTime>>,
 
-    /// Number of observed participants that must be recently active for the
+    /// Weight of observed participants that must be recently active for the
     /// network to be considered responsive (see [Self::is_active]). We never
     /// observe our own messages, so when we are a participant we count
     /// ourselves as live by construction.
-    required_active: usize,
+    required_active: u64,
 
     mailbox_receiver: mailbox::Receiver<Message<S, D>>,
 
@@ -132,13 +162,7 @@ where
             Buckets::CRYPTOGRAPHY,
         );
         let (sender, receiver) = mailbox::new(context.child("mailbox"), cfg.mailbox_size);
-        let mut required_active = participants.quorum_count::<N3f1>() as usize;
-        if scheme.me().is_some() {
-            // We are live by construction (we never observe our own messages).
-            required_active = required_active
-                .checked_sub(1)
-                .expect("quorum is never zero");
-        }
+        let required_active = required_active_weight(participants, scheme.me());
         (
             Self {
                 context: ContextCell::new(context),
@@ -198,8 +222,8 @@ where
         }
     }
 
-    /// Returns true if the participant has sent a recent message, or if fewer
-    /// than a quorum of participants have (fail-open).
+    /// Returns true if the participant has sent a recent message or recent
+    /// activity is below the required weight.
     fn is_active(&self, participant: Participant, skip_timeout: Duration) -> bool {
         // Track activity with wall-clock time rather than raw view deltas. Stable-leader terms can
         // skip many view numbers at once, so we only fast-timeout when a quorum has been active
@@ -212,9 +236,13 @@ where
         let recent =
             |activity: &Option<SystemTime>| activity.is_some_and(|activity| activity >= min_time);
 
-        // If fewer than the required number of participants are recently active, we "fail-open"
-        // since we know the network is not expected to be responsive.
-        let active = self.last_activity.iter().filter(|a| recent(a)).count();
+        // Treat every participant as active until the weight of recently active participants
+        // reaches the required threshold.
+        let active = recent_activity_weight(
+            &self.last_activity,
+            self.scheme.participants().weights(),
+            min_time,
+        );
         if active < self.required_active {
             return true;
         }
@@ -706,5 +734,45 @@ where
                 }
             },
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use commonware_utils::TryFromIterator;
+
+    fn committee(weights: impl IntoIterator<Item = u64>) -> Committee<u8> {
+        Committee::try_from_iter(
+            weights
+                .into_iter()
+                .enumerate()
+                .map(|(participant, weight)| (participant as u8, weight)),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn required_activity_uses_weight_and_saturates() {
+        let participants = committee([8, 1, 1]);
+        assert_eq!(participants.quorum_weight::<N3f1>(), 7);
+        assert_eq!(required_active_weight(&participants, None), 7);
+        assert_eq!(
+            required_active_weight(&participants, Some(Participant::new(0))),
+            0
+        );
+        assert_eq!(
+            required_active_weight(&participants, Some(Participant::new(1))),
+            6
+        );
+    }
+
+    #[test]
+    fn recent_activity_sums_participant_weight() {
+        let now = SystemTime::UNIX_EPOCH + Duration::from_secs(10);
+        let stale = SystemTime::UNIX_EPOCH + Duration::from_secs(1);
+        let activity = [Some(stale), Some(now), None, Some(now)];
+
+        assert_eq!(recent_activity_weight(&activity, &[1, 6, 1, 2], now), 8);
     }
 }

--- a/consensus/src/simplex/actors/batcher/round.rs
+++ b/consensus/src/simplex/actors/batcher/round.rs
@@ -14,7 +14,6 @@ use crate::{
 use commonware_cryptography::Digest;
 use commonware_p2p::Blocker;
 use commonware_parallel::Strategy;
-use commonware_utils::{N3f1, ordered::Quorum};
 use rand_core::CryptoRng;
 use std::sync::Arc;
 use tracing::Span;
@@ -63,12 +62,11 @@ impl<
         reporter: R,
         track_historical_votes: bool,
     ) -> Self {
-        let quorum = scheme.participants().quorum_count::<N3f1>();
         let len = scheme.participants().len();
         Self {
             blocker,
             reporter,
-            verifier: Verifier::new(round, scheme, quorum),
+            verifier: Verifier::new(round, scheme),
 
             votes: VoteTracker::new(len, track_historical_votes),
 

--- a/consensus/src/simplex/actors/batcher/verifier.rs
+++ b/consensus/src/simplex/actors/batcher/verifier.rs
@@ -8,10 +8,16 @@ use crate::{
     },
     types::{Participant, Round as Rnd},
 };
-use commonware_cryptography::{Digest, certificate::Verification};
+use commonware_cryptography::{
+    Digest,
+    certificate::{Attestation, Verification},
+};
 use commonware_parallel::Strategy;
 use commonware_runtime::telemetry::traces::TracedExt as _;
-use commonware_utils::{non_empty, ordered::Committee};
+use commonware_utils::{
+    N3f1, non_empty,
+    ordered::{Committee, Quorum as _},
+};
 use rand::rngs::StdRng;
 use rand_core::{CryptoRng, SeedableRng};
 use std::{future::Future, mem, sync::Arc};
@@ -31,13 +37,32 @@ where
         .instrument(span)
 }
 
+fn participant_weight<P: Ord>(committee: &Committee<P>, participant: Participant) -> u64 {
+    committee.weight(participant).unwrap_or(0)
+}
+
+fn attestation_weight<'a, S, D>(
+    scheme: &S,
+    attestations: impl Iterator<Item = &'a Attestation<S>>,
+) -> u64
+where
+    S: Scheme<D> + 'a,
+    D: Digest,
+{
+    attestations
+        .map(|attestation| participant_weight(scheme.participants(), attestation.signer))
+        .sum()
+}
+
 /// Certification progress for one kind of vote.
 ///
 /// Each kind certifies independently: a view can legitimately certify both
 /// a notarization and a nullification.
 struct Certification<V> {
-    /// Verified votes required to recover a certificate.
-    quorum: usize,
+    /// Verified weight required to recover a certificate.
+    quorum_weight: u64,
+    /// Participant-count target for initial vote buffer reservations.
+    reservation_capacity: usize,
     /// Whether the scheme benefits from batching signature verification.
     batchable: bool,
     /// Progress toward a certificate.
@@ -50,8 +75,12 @@ enum State<V> {
     Incomplete {
         /// Votes awaiting signature verification.
         pending: Vec<V>,
+        /// Weight of votes awaiting signature verification.
+        pending_weight: u64,
         /// Votes with verified signatures, held for certificate recovery.
         verified: Vec<V>,
+        /// Weight of votes with verified signatures.
+        verified_weight: u64,
     },
     /// A certificate exists. Further votes are dropped.
     Complete,
@@ -59,13 +88,16 @@ enum State<V> {
 
 impl<V> Certification<V> {
     /// Creates an empty [State::Incomplete] whose vote buffers allocate lazily.
-    const fn new(quorum: usize, batchable: bool) -> Self {
+    const fn new(quorum_weight: u64, reservation_capacity: usize, batchable: bool) -> Self {
         Self {
-            quorum,
+            quorum_weight,
+            reservation_capacity,
             batchable,
             state: State::Incomplete {
                 pending: Vec::new(),
+                pending_weight: 0,
                 verified: Vec::new(),
+                verified_weight: 0,
             },
         }
     }
@@ -73,9 +105,15 @@ impl<V> Certification<V> {
     /// Buffers a vote for verification (or, if already verified, for
     /// certificate recovery). The caller owns signer uniqueness. Votes that
     /// arrive after completion are dropped.
-    fn add(&mut self, vote: V, is_verified: bool) {
+    fn add(&mut self, vote: V, weight: u64, is_verified: bool) {
         // Completed certifications drop subsequent votes without allocating.
-        let State::Incomplete { pending, verified } = &mut self.state else {
+        let State::Incomplete {
+            pending,
+            pending_weight,
+            verified,
+            verified_weight,
+        } = &mut self.state
+        else {
             return;
         };
 
@@ -83,15 +121,24 @@ impl<V> Certification<V> {
         // only needs the remaining unverified slots, while a non-batchable
         // pending buffer is consumed after each vote.
         let initial_capacity = if is_verified || self.batchable {
-            self.quorum.saturating_sub(verified.len()).max(1)
+            self.reservation_capacity
+                .saturating_sub(verified.len())
+                .max(1)
         } else {
             1
         };
-        let votes = if is_verified { verified } else { pending };
+        let (votes, accumulated_weight) = if is_verified {
+            (verified, verified_weight)
+        } else {
+            (pending, pending_weight)
+        };
         if votes.capacity() == 0 {
             votes.reserve_exact(initial_capacity);
         }
         votes.push(vote);
+        *accumulated_weight = accumulated_weight
+            .checked_add(weight)
+            .expect("signer-unique vote weight cannot exceed committee weight");
     }
 
     /// Returns true if a batch verification should run: pending votes exist,
@@ -99,10 +146,19 @@ impl<V> Certification<V> {
     /// could reach it.
     const fn should_verify(&self) -> bool {
         match &self.state {
-            State::Incomplete { pending, verified } => {
+            State::Incomplete {
+                pending,
+                pending_weight,
+                verified_weight,
+                ..
+            } => {
                 !pending.is_empty()
-                    && verified.len() < self.quorum
-                    && (!self.batchable || verified.len() + pending.len() >= self.quorum)
+                    && *verified_weight < self.quorum_weight
+                    && (!self.batchable
+                        || verified_weight
+                            .checked_add(*pending_weight)
+                            .expect("signer-unique vote weight cannot exceed committee weight")
+                            >= self.quorum_weight)
             }
             State::Complete => false,
         }
@@ -112,37 +168,59 @@ impl<V> Certification<V> {
     /// returns, or `None` if a batch is not worth verifying (see
     /// [Self::should_verify]).
     ///
-    /// `f` receives the pending and previously verified votes and returns the
-    /// new verified set plus the signers that failed verification. Returns
-    /// the number of votes processed alongside those signers.
+    /// `f` receives pending votes and prior verified votes. It returns their
+    /// combined verified set, the weight contributed by newly verified pending
+    /// votes, and invalid signers. This method returns the pending batch length
+    /// with those invalid signers.
     async fn try_verify<F, Fut>(&mut self, f: F) -> Option<(usize, Vec<Participant>)>
     where
         F: FnOnce(Vec<V>, Vec<V>) -> Fut,
-        Fut: Future<Output = (Vec<V>, Vec<Participant>)>,
+        Fut: Future<Output = (Vec<V>, u64, Vec<Participant>)>,
     {
         if !self.should_verify() {
             return None;
         }
-        let State::Incomplete { pending, verified } = &mut self.state else {
+        let State::Incomplete {
+            pending,
+            pending_weight,
+            verified,
+            verified_weight,
+        } = &mut self.state
+        else {
             unreachable!("certification complete despite should_verify");
         };
         let batch = pending.len();
         let (pending, prior) = (mem::take(pending), mem::take(verified));
-        let (votes, invalid) = f(pending, prior).await;
-        let State::Incomplete { verified, .. } = &mut self.state else {
+        let prior_weight = mem::take(verified_weight);
+        *pending_weight = 0;
+        let (votes, added_weight, invalid) = f(pending, prior).await;
+        let State::Incomplete {
+            verified,
+            verified_weight,
+            ..
+        } = &mut self.state
+        else {
             unreachable!("certification completed mid-verification");
         };
         *verified = votes;
+        *verified_weight = prior_weight
+            .checked_add(added_weight)
+            .expect("signer-unique vote weight cannot exceed committee weight");
         Some((batch, invalid))
     }
 
     /// Completes with a verified quorum, surrendering it for certificate
     /// recovery, or `None` if the quorum is unmet.
     fn try_complete(&mut self) -> Option<Vec<V>> {
-        let State::Incomplete { verified, .. } = &mut self.state else {
+        let State::Incomplete {
+            verified,
+            verified_weight,
+            ..
+        } = &mut self.state
+        else {
             return None;
         };
-        if verified.len() < self.quorum {
+        if *verified_weight < self.quorum_weight {
             return None;
         }
         let votes = mem::take(verified);
@@ -161,10 +239,18 @@ impl<V> Certification<V> {
     }
 
     /// Retains only the votes matching `f`.
-    fn retain(&mut self, f: impl Fn(&V) -> bool) {
-        if let State::Incomplete { pending, verified } = &mut self.state {
+    fn retain(&mut self, f: impl Fn(&V) -> bool, weight: impl Fn(&V) -> u64) {
+        if let State::Incomplete {
+            pending,
+            pending_weight,
+            verified,
+            verified_weight,
+        } = &mut self.state
+        {
             pending.retain(|v| f(v));
             verified.retain(|v| f(v));
+            *pending_weight = pending.iter().map(&weight).sum();
+            *verified_weight = verified.iter().map(weight).sum();
         }
     }
 }
@@ -226,8 +312,7 @@ impl<D: Digest> ProposalState<D> {
 /// efficient batch verification. For schemes where `is_batchable()` returns `false` (such as [secp256r1]),
 /// signatures are verified eagerly as they arrive since there is no batching benefit.
 ///
-/// To avoid unnecessary verification, it also tracks the number of already verified messages (ensuring
-/// we no longer attempt to verify messages after a quorum of valid messages have already been verified).
+/// The verifier tracks verified weight and stops verification after reaching quorum.
 ///
 /// Once polled, async verification moves the pending batch and accumulated verified votes into
 /// the worker. Do not cancel an in-flight verification unless the verifier will also be discarded.
@@ -268,22 +353,23 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
     ///
     /// * `round` - The round being certified.
     /// * `scheme` - Scheme handle used to verify and aggregate votes.
-    /// * `quorum` - Number of votes (2f+1) required to reach a quorum.
-    pub fn new(round: Rnd, scheme: impl Into<Arc<S>>, quorum: u32) -> Self {
-        // Hold quorum as usize to simplify comparisons against queue lengths.
-        let quorum = quorum as usize;
+    pub fn new(round: Rnd, scheme: impl Into<Arc<S>>) -> Self {
+        let scheme = scheme.into();
+        let quorum_weight = scheme.participants().quorum_weight::<N3f1>();
+        let reservation_capacity = usize::try_from(scheme.participants().quorum_count::<N3f1>())
+            .expect("participant quorum must fit in usize");
         let batchable = S::is_batchable();
         Self {
-            scheme: scheme.into(),
+            scheme,
 
             round,
 
             leader: None,
             proposal: ProposalState::Unknown,
 
-            notarize: Certification::new(quorum, batchable),
-            nullify: Certification::new(quorum, batchable),
-            finalize: Certification::new(quorum, batchable),
+            notarize: Certification::new(quorum_weight, reservation_capacity, batchable),
+            nullify: Certification::new(quorum_weight, reservation_capacity, batchable),
+            finalize: Certification::new(quorum_weight, reservation_capacity, batchable),
         }
     }
 
@@ -417,8 +503,15 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
                 replaced: false,
             };
         };
-        self.notarize.retain(|n| &n.proposal == proposal);
-        self.finalize.retain(|f| &f.proposal == proposal);
+        let participants = self.scheme.participants();
+        self.notarize.retain(
+            |n| &n.proposal == proposal,
+            |n| participant_weight(participants, n.signer()),
+        );
+        self.finalize.retain(
+            |f| &f.proposal == proposal,
+            |f| participant_weight(participants, f.signer()),
+        );
         ProposalUpdate {
             changed: true,
             replaced,
@@ -445,6 +538,7 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
     pub fn add(&mut self, msg: Vote<S, D>, verified: bool) {
         match msg {
             Vote::Notarize(notarize) => {
+                let weight = participant_weight(self.scheme.participants(), notarize.signer());
                 self.try_set_proposal_from_leader(&notarize);
 
                 // If the proposal is known and the message is not for it, drop it
@@ -453,19 +547,21 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
                 {
                     return;
                 }
-                self.notarize.add(notarize, verified);
+                self.notarize.add(notarize, weight, verified);
             }
             Vote::Nullify(nullify) => {
-                self.nullify.add(nullify, verified);
+                let weight = participant_weight(self.scheme.participants(), nullify.signer());
+                self.nullify.add(nullify, weight, verified);
             }
             Vote::Finalize(finalize) => {
+                let weight = participant_weight(self.scheme.participants(), finalize.signer());
                 // If the proposal is known and the message is not for it, drop it
                 if let Some(proposal) = self.proposal()
                     && proposal != &finalize.proposal
                 {
                     return;
                 }
-                self.finalize.add(finalize, verified);
+                self.finalize.add(finalize, weight, verified);
             }
         }
     }
@@ -546,13 +642,14 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
                         &strategy,
                     );
 
+                    let added_weight = attestation_weight(scheme.as_ref(), verified.iter());
                     verified_notarizes.extend(verified.into_iter().zip(proposals).map(
                         |(attestation, proposal)| Notarize {
                             proposal,
                             attestation,
                         },
                     ));
-                    (verified_notarizes, invalid)
+                    (verified_notarizes, added_weight, invalid)
                 })
             })
             .await
@@ -596,12 +693,13 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
                         &strategy,
                     );
 
+                    let added_weight = attestation_weight(scheme.as_ref(), verified.iter());
                     verified_nullifies.extend(
                         verified
                             .into_iter()
                             .map(|attestation| Nullify { round, attestation }),
                     );
-                    (verified_nullifies, invalid)
+                    (verified_nullifies, added_weight, invalid)
                 })
             })
             .await
@@ -658,13 +756,14 @@ impl<S: Scheme<D>, D: Digest> Verifier<S, D> {
                         &strategy,
                     );
 
+                    let added_weight = attestation_weight(scheme.as_ref(), verified.iter());
                     verified_finalizes.extend(verified.into_iter().zip(proposals).map(
                         |(attestation, proposal)| Finalize {
                             proposal,
                             attestation,
                         },
                     ));
-                    (verified_finalizes, invalid)
+                    (verified_finalizes, added_weight, invalid)
                 })
             })
             .await
@@ -689,21 +788,46 @@ mod tests {
     };
     use commonware_cryptography::{
         bls12381::primitives::variant::{MinPk, MinSig},
-        certificate::mocks::Fixture,
+        certificate::{Scheme as _, mocks::Fixture},
         ed25519::PublicKey,
         sha256::Digest as Sha256,
     };
     use commonware_macros::test_async;
     use commonware_parallel::Sequential;
-    use commonware_utils::{Faults, N3f1, TestRng, test_rng};
+    use commonware_utils::{Faults, N3f1, TestRng, ordered::Committee, test_rng};
 
     const NAMESPACE: &[u8] = b"test";
 
-    fn count_quorum(participants: usize) -> u32 {
-        u32::try_from(N3f1::quorum(
-            u64::try_from(participants).expect("participant count exceeds u64::MAX"),
-        ))
-        .expect("quorum for a u32-indexed participant set must fit in u32")
+    fn count_quorum(participants: usize) -> u64 {
+        N3f1::quorum(u64::try_from(participants).expect("participant count exceeds u64::MAX"))
+    }
+
+    fn weighted_ed25519(weights: &[u64]) -> Vec<ed25519::Scheme> {
+        let mut rng = test_rng();
+        let Fixture {
+            participants,
+            private_keys,
+            ..
+        } = ed25519::fixture(
+            &mut rng,
+            NAMESPACE,
+            u32::try_from(weights.len()).expect("test committee must fit in u32"),
+        );
+        let committee = Committee::try_from(
+            participants
+                .into_iter()
+                .zip(weights.iter().copied())
+                .collect::<Vec<_>>(),
+        )
+        .expect("test committee must be valid");
+
+        private_keys
+            .into_iter()
+            .map(|private_key| {
+                ed25519::Scheme::signer(NAMESPACE, committee.clone(), private_key)
+                    .expect("private key must belong to test committee")
+            })
+            .collect()
     }
 
     impl<V> Certification<V> {
@@ -726,9 +850,21 @@ mod tests {
         /// Returns the capacities of the pending and verified vote buffers.
         fn capacities(&self) -> (usize, usize) {
             match &self.state {
-                State::Incomplete { pending, verified } => {
-                    (pending.capacity(), verified.capacity())
-                }
+                State::Incomplete {
+                    pending, verified, ..
+                } => (pending.capacity(), verified.capacity()),
+                State::Complete => (0, 0),
+            }
+        }
+
+        /// Returns the pending and verified vote weights.
+        fn weights(&self) -> (u64, u64) {
+            match &self.state {
+                State::Incomplete {
+                    pending_weight,
+                    verified_weight,
+                    ..
+                } => (*pending_weight, *verified_weight),
                 State::Complete => (0, 0),
             }
         }
@@ -741,8 +877,7 @@ mod tests {
         let Fixture { schemes, .. } = ed25519::fixture(&mut rng, NAMESPACE, 5);
         let quorum = count_quorum(schemes.len());
         let round = Round::new(Epoch::new(0), View::new(1));
-        let mut verifier =
-            Verifier::<ed25519::Scheme, Sha256>::new(round, schemes[0].clone(), quorum);
+        let mut verifier = Verifier::<ed25519::Scheme, Sha256>::new(round, schemes[0].clone());
 
         assert_eq!(verifier.notarize.capacities(), (0, 0));
         assert_eq!(verifier.nullify.capacities(), (0, 0));
@@ -763,20 +898,21 @@ mod tests {
     #[test_async]
     async fn test_non_batchable_certification_avoids_repeated_quorum_reservations() {
         let quorum = 64;
-        let mut certification = Certification::new(quorum, false);
-        certification.add(1u8, false);
+        let mut certification = Certification::new(quorum, quorum as usize, false);
+        certification.add(1u8, 1, false);
         certification
             .try_verify(|pending, mut verified| async move {
+                let added_weight = pending.len() as u64;
                 verified.extend(pending);
-                (verified, Vec::new())
+                (verified, added_weight, Vec::new())
             })
             .await
             .expect("non-batchable pending votes must verify eagerly");
 
-        certification.add(2u8, false);
+        certification.add(2u8, 1, false);
         let (pending, _) = certification.capacities();
         assert!(
-            pending < quorum,
+            pending < quorum as usize,
             "a single eagerly verified vote should not reserve a quorum-sized buffer"
         );
     }
@@ -784,24 +920,115 @@ mod tests {
     #[test_async]
     async fn test_batchable_certification_reserves_only_remaining_quorum() {
         let quorum = 64;
-        let mut certification = Certification::new(quorum, true);
+        let mut certification = Certification::new(quorum, quorum as usize, true);
         for vote in 0..quorum {
-            certification.add(vote, false);
+            certification.add(vote, 1, false);
         }
         certification
             .try_verify(|mut pending, _| async move {
                 pending.pop().expect("quorum batch must be non-empty");
-                (pending, Vec::new())
+                let weight = pending.len() as u64;
+                (pending, weight, Vec::new())
             })
             .await
             .expect("a quorum of pending votes must trigger batch verification");
 
-        certification.add(quorum, false);
+        certification.add(quorum, 1, false);
         let (pending, _) = certification.capacities();
         assert!(
-            pending < quorum,
+            pending < quorum as usize,
             "one replacement vote should not reserve a quorum-sized buffer"
         );
+    }
+
+    #[test_async]
+    async fn test_count_quorum_is_insufficient_without_quorum_weight() {
+        let schemes = weighted_ed25519(&[4, 1, 1, 1]);
+        let round = Round::new(Epoch::new(0), View::new(1));
+        let mut verifier = Verifier::<ed25519::Scheme, Sha256>::new(round, schemes[0].clone());
+
+        for scheme in schemes.iter().skip(1) {
+            verifier.add(Vote::Nullify(create_nullify(scheme, round)), true);
+        }
+
+        assert_eq!(verifier.nullify.verified().len(), 3);
+        assert!(
+            verifier
+                .try_construct_certificate(&Sequential)
+                .await
+                .is_none(),
+            "three signer-unique votes have count quorum but only weight three"
+        );
+    }
+
+    #[test_async]
+    async fn test_exact_weighted_boundary_verifies_and_completes() {
+        let schemes = weighted_ed25519(&[4, 1, 1, 1]);
+        let round = Round::new(Epoch::new(0), View::new(1));
+        let quorum_weight = schemes[0].participants().quorum_weight::<N3f1>();
+        assert_eq!(quorum_weight, 5);
+        let mut verifier = Verifier::<ed25519::Scheme, Sha256>::new(round, schemes[0].clone());
+
+        for scheme in schemes.iter().take(2) {
+            verifier.add(Vote::Nullify(create_nullify(scheme, round)), false);
+        }
+        assert!(verifier.nullify.should_verify());
+        let (_, invalid) = verifier
+            .try_verify_nullifies(&mut test_rng(), &Sequential)
+            .await
+            .expect("exact quorum weight must trigger verification");
+        assert!(invalid.is_empty());
+        assert!(
+            verifier
+                .try_construct_certificate(&Sequential)
+                .await
+                .is_some(),
+            "exact verified quorum weight must complete"
+        );
+    }
+
+    #[test_async]
+    async fn test_invalid_heavy_signature_does_not_complete_with_valid_lights() {
+        let schemes = weighted_ed25519(&[4, 1, 1, 1]);
+        let round = Round::new(Epoch::new(0), View::new(1));
+        let mut verifier = Verifier::<ed25519::Scheme, Sha256>::new(round, schemes[0].clone());
+
+        let mut invalid_heavy = create_nullify(&schemes[1], round);
+        invalid_heavy.attestation.signer = Participant::new(0);
+        verifier.add(Vote::Nullify(invalid_heavy), false);
+        for scheme in schemes.iter().skip(1) {
+            verifier.add(Vote::Nullify(create_nullify(scheme, round)), false);
+        }
+
+        assert!(verifier.nullify.should_verify());
+        let (_, invalid) = verifier
+            .try_verify_nullifies(&mut test_rng(), &Sequential)
+            .await
+            .expect("claimed pending weight reaches quorum");
+        assert_eq!(invalid, vec![Participant::new(0)]);
+        assert_eq!(verifier.nullify.verified().len(), 3);
+        assert!(
+            verifier
+                .try_construct_certificate(&Sequential)
+                .await
+                .is_none(),
+            "only the weight of valid signatures may complete certification"
+        );
+    }
+
+    #[test]
+    fn test_large_weights_do_not_increase_vote_buffer_capacity() {
+        let schemes = weighted_ed25519(&[1_000_000, 1, 1, 1]);
+        let round = Round::new(Epoch::new(0), View::new(1));
+        let quorum_weight = schemes[0].participants().quorum_weight::<N3f1>();
+        let mut verifier = Verifier::<ed25519::Scheme, Sha256>::new(round, schemes[0].clone());
+
+        verifier.add(Vote::Nullify(create_nullify(&schemes[0], round)), false);
+        let (pending, verified) = verifier.nullify.capacities();
+        assert_eq!(verifier.nullify.reservation_capacity, 3);
+        assert!(pending >= verifier.nullify.reservation_capacity);
+        assert_eq!(verified, 0);
+        assert!(pending < quorum_weight as usize);
     }
 
     // Helper function to create a sample digest
@@ -843,12 +1070,8 @@ mod tests {
     {
         let mut rng = test_rng();
         let Fixture { schemes, .. } = fixture(&mut rng, NAMESPACE, 5);
-        let quorum = count_quorum(schemes.len());
-        let mut verifier = Verifier::<S, Sha256>::new(
-            Round::new(Epoch::new(0), View::new(1)),
-            schemes[0].clone(),
-            quorum,
-        );
+        let mut verifier =
+            Verifier::<S, Sha256>::new(Round::new(Epoch::new(0), View::new(1)), schemes[0].clone());
 
         let round = Round::new(Epoch::new(0), View::new(1));
         let leader_notarize = create_notarize(&schemes[0], round, View::new(0), 1);
@@ -875,11 +1098,8 @@ mod tests {
         verifier.add(Vote::Notarize(notarize_diff), false);
         assert_eq!(verifier.notarize.pending().len(), 2);
 
-        let mut verifier2 = Verifier::<S, Sha256>::new(
-            Round::new(Epoch::new(0), View::new(1)),
-            schemes[0].clone(),
-            quorum,
-        );
+        let mut verifier2 =
+            Verifier::<S, Sha256>::new(Round::new(Epoch::new(0), View::new(1)), schemes[0].clone());
         let round2 = Round::new(Epoch::new(0), View::new(2));
         let notarize_non_leader = create_notarize(&schemes[1], round2, View::new(1), 3);
         let notarize_leader = create_notarize(&schemes[0], round2, View::new(1), 3);
@@ -914,12 +1134,8 @@ mod tests {
     {
         let mut rng = test_rng();
         let Fixture { schemes, .. } = fixture(&mut rng, NAMESPACE, 5);
-        let quorum = count_quorum(schemes.len());
-        let mut verifier = Verifier::<S, Sha256>::new(
-            Round::new(Epoch::new(0), View::new(1)),
-            schemes[0].clone(),
-            quorum,
-        );
+        let mut verifier =
+            Verifier::<S, Sha256>::new(Round::new(Epoch::new(0), View::new(1)), schemes[0].clone());
 
         let round = Round::new(Epoch::new(0), View::new(1));
         let leader_notarize = create_notarize(&schemes[0], round, View::new(0), 1);
@@ -938,11 +1154,8 @@ mod tests {
         assert_eq!(verifier.proposal(), Some(&leader_notarize.proposal));
         assert_eq!(verifier.notarize.pending().len(), 2);
 
-        let mut verifier2 = Verifier::<S, Sha256>::new(
-            Round::new(Epoch::new(0), View::new(1)),
-            schemes[0].clone(),
-            quorum,
-        );
+        let mut verifier2 =
+            Verifier::<S, Sha256>::new(Round::new(Epoch::new(0), View::new(1)), schemes[0].clone());
         verifier2.add(Vote::Notarize(leader_notarize.clone()), true);
         verifier2.set_leader(leader, Some(&leader_notarize));
         assert_eq!(verifier2.leader(), Some(leader));
@@ -977,11 +1190,8 @@ mod tests {
 
         // If the notarization arrives first, setting the leader cannot replace
         // its proposal with a conflicting buffered leader vote.
-        let mut verifier3 = Verifier::<S, Sha256>::new(
-            Round::new(Epoch::new(0), View::new(1)),
-            schemes[0].clone(),
-            quorum,
-        );
+        let mut verifier3 =
+            Verifier::<S, Sha256>::new(Round::new(Epoch::new(0), View::new(1)), schemes[0].clone());
         assert!(
             verifier3
                 .set_proposal(ProposalState::Certificate(notarized_proposal.clone()))
@@ -1014,11 +1224,8 @@ mod tests {
         let mut rng = test_rng();
         let Fixture { schemes, .. } = fixture(&mut rng, NAMESPACE, 5);
         let quorum = count_quorum(schemes.len());
-        let mut verifier = Verifier::<S, Sha256>::new(
-            Round::new(Epoch::new(0), View::new(1)),
-            schemes[0].clone(),
-            quorum,
-        );
+        let mut verifier =
+            Verifier::<S, Sha256>::new(Round::new(Epoch::new(0), View::new(1)), schemes[0].clone());
         let round = Round::new(Epoch::new(0), View::new(1));
         let notarizes: Vec<_> = schemes
             .iter()
@@ -1051,11 +1258,8 @@ mod tests {
         assert!(verifier.notarize.pending().is_empty());
         assert!(!verifier.notarize.should_verify());
 
-        let mut verifier2 = Verifier::<S, Sha256>::new(
-            Round::new(Epoch::new(0), View::new(1)),
-            schemes[0].clone(),
-            quorum,
-        );
+        let mut verifier2 =
+            Verifier::<S, Sha256>::new(Round::new(Epoch::new(0), View::new(1)), schemes[0].clone());
         let round2 = Round::new(Epoch::new(0), View::new(2));
         let leader_vote = create_notarize(&schemes[0], round2, View::new(1), 10);
         let mut faulty_vote = create_notarize(&schemes[1], round2, View::new(1), 10);
@@ -1064,7 +1268,9 @@ mod tests {
         faulty_vote.attestation.signer = Participant::from_usize(schemes.len() + 10);
         verifier2.add(Vote::Notarize(faulty_vote.clone()), false);
 
-        for scheme in schemes.iter().skip(2).take(quorum as usize - 2) {
+        // The malformed out-of-range signer contributes no pending weight, so
+        // add a full quorum of valid signer weight alongside it.
+        for scheme in schemes.iter().skip(2).take(quorum as usize - 1) {
             verifier2.add(
                 Vote::Notarize(create_notarize(scheme, round2, View::new(1), 10)),
                 false,
@@ -1076,7 +1282,7 @@ mod tests {
             .try_verify_notarizes(&mut rng, &Sequential)
             .await
             .unwrap();
-        assert_eq!(batch, quorum as usize);
+        assert_eq!(batch, quorum as usize + 1);
         assert!(
             verifier2
                 .notarize
@@ -1106,12 +1312,8 @@ mod tests {
     {
         let mut rng = test_rng();
         let Fixture { schemes, .. } = fixture(&mut rng, NAMESPACE, 5);
-        let quorum = count_quorum(schemes.len());
-        let mut verifier = Verifier::<S, Sha256>::new(
-            Round::new(Epoch::new(0), View::new(1)),
-            schemes[0].clone(),
-            quorum,
-        );
+        let mut verifier =
+            Verifier::<S, Sha256>::new(Round::new(Epoch::new(0), View::new(1)), schemes[0].clone());
         let round = Round::new(Epoch::new(0), View::new(1));
         let pending_nullify = create_nullify(&schemes[0], round);
         let verified_nullify = create_nullify(&schemes[1], round);
@@ -1144,12 +1346,8 @@ mod tests {
     {
         let mut rng = test_rng();
         let Fixture { schemes, .. } = fixture(&mut rng, NAMESPACE, 5);
-        let quorum = count_quorum(schemes.len());
-        let mut verifier = Verifier::<S, Sha256>::new(
-            Round::new(Epoch::new(0), View::new(1)),
-            schemes[0].clone(),
-            quorum,
-        );
+        let mut verifier =
+            Verifier::<S, Sha256>::new(Round::new(Epoch::new(0), View::new(1)), schemes[0].clone());
         let round = Round::new(Epoch::new(0), View::new(1));
         let nullifies: Vec<_> = schemes
             .iter()
@@ -1198,12 +1396,8 @@ mod tests {
     {
         let mut rng = test_rng();
         let Fixture { schemes, .. } = fixture(&mut rng, NAMESPACE, 5);
-        let quorum = count_quorum(schemes.len());
-        let mut verifier = Verifier::<S, Sha256>::new(
-            Round::new(Epoch::new(0), View::new(1)),
-            schemes[0].clone(),
-            quorum,
-        );
+        let mut verifier =
+            Verifier::<S, Sha256>::new(Round::new(Epoch::new(0), View::new(1)), schemes[0].clone());
         let round = Round::new(Epoch::new(0), View::new(1));
         let finalize_a = create_finalize(&schemes[0], round, View::new(0), 1);
         let finalize_b = create_finalize(&schemes[1], round, View::new(0), 2);
@@ -1253,12 +1447,8 @@ mod tests {
     {
         let mut rng = test_rng();
         let Fixture { schemes, .. } = fixture(&mut rng, NAMESPACE, 5);
-        let quorum = count_quorum(schemes.len());
-        let mut verifier = Verifier::<S, Sha256>::new(
-            Round::new(Epoch::new(0), View::new(1)),
-            schemes[0].clone(),
-            quorum,
-        );
+        let mut verifier =
+            Verifier::<S, Sha256>::new(Round::new(Epoch::new(0), View::new(1)), schemes[0].clone());
         let round = Round::new(Epoch::new(0), View::new(1));
         let finalizes: Vec<_> = schemes
             .iter()
@@ -1312,12 +1502,8 @@ mod tests {
     {
         let mut rng = test_rng();
         let Fixture { schemes, .. } = fixture(&mut rng, NAMESPACE, 5);
-        let quorum = count_quorum(schemes.len());
-        let mut verifier = Verifier::<S, Sha256>::new(
-            Round::new(Epoch::new(0), View::new(1)),
-            schemes[0].clone(),
-            quorum,
-        );
+        let mut verifier =
+            Verifier::<S, Sha256>::new(Round::new(Epoch::new(0), View::new(1)), schemes[0].clone());
         let round = Round::new(Epoch::new(0), View::new(1));
         let proposal_a = Proposal::new(round, View::new(0), sample_digest(10));
         let proposal_b = Proposal::new(round, View::new(0), sample_digest(20));
@@ -1355,6 +1541,8 @@ mod tests {
         assert_eq!(verifier.finalize.pending()[0].proposal, proposal_a);
         assert_eq!(verifier.finalize.verified().len(), 1);
         assert_eq!(verifier.finalize.verified()[0].proposal, proposal_a);
+        assert_eq!(verifier.notarize.weights(), (1, 1));
+        assert_eq!(verifier.finalize.weights(), (1, 1));
     }
 
     #[test]
@@ -1378,7 +1566,6 @@ mod tests {
         let mut verifier = Verifier::<ed25519::Scheme, Sha256>::new(
             Round::new(Epoch::new(0), View::new(1)),
             schemes[0].clone(),
-            3,
         );
         let leader = Participant::new(0);
         verifier.set_leader(leader, None);
@@ -1395,7 +1582,6 @@ mod tests {
         let mut verifier = Verifier::<ed25519::Scheme, Sha256>::new(
             Round::new(Epoch::new(0), View::new(1)),
             schemes[0].clone(),
-            3,
         );
         verifier.set_leader(Participant::new(0), None);
         verifier.set_leader(Participant::new(1), None);
@@ -1411,7 +1597,6 @@ mod tests {
         let mut verifier = Verifier::<ed25519::Scheme, Sha256>::new(
             Round::new(Epoch::new(0), View::new(1)),
             schemes[0].clone(),
-            3,
         );
         let notarize = create_notarize(
             &schemes[1],
@@ -1430,11 +1615,8 @@ mod tests {
         let mut rng = test_rng();
         let Fixture { schemes, .. } = fixture(&mut rng, NAMESPACE, 5);
         let quorum = count_quorum(schemes.len());
-        let mut verifier = Verifier::<S, Sha256>::new(
-            Round::new(Epoch::new(0), View::new(1)),
-            schemes[0].clone(),
-            quorum,
-        );
+        let mut verifier =
+            Verifier::<S, Sha256>::new(Round::new(Epoch::new(0), View::new(1)), schemes[0].clone());
         let round = Round::new(Epoch::new(0), View::new(1));
         let leader_vote = create_notarize(&schemes[0], round, View::new(0), 1);
 
@@ -1486,11 +1668,8 @@ mod tests {
         let mut rng = test_rng();
         let Fixture { schemes, .. } = fixture(&mut rng, NAMESPACE, 3);
         let quorum = count_quorum(schemes.len());
-        let mut verifier = Verifier::<S, Sha256>::new(
-            Round::new(Epoch::new(0), View::new(1)),
-            schemes[0].clone(),
-            quorum,
-        );
+        let mut verifier =
+            Verifier::<S, Sha256>::new(Round::new(Epoch::new(0), View::new(1)), schemes[0].clone());
         let round = Round::new(Epoch::new(0), View::new(1));
 
         let notarizes: Vec<_> = schemes
@@ -1548,7 +1727,6 @@ mod tests {
             let mut verifier = Verifier::<S, Sha256>::new(
                 Round::new(Epoch::new(0), View::new(1)),
                 schemes[0].clone(),
-                quorum,
             );
             let round = Round::new(Epoch::new(0), View::new(1));
             let finalizes: Vec<_> = schemes
@@ -1617,11 +1795,8 @@ mod tests {
         let mut rng = test_rng();
         let Fixture { schemes, .. } = fixture(&mut rng, NAMESPACE, 5);
         let quorum = count_quorum(schemes.len());
-        let mut verifier = Verifier::<S, Sha256>::new(
-            Round::new(Epoch::new(0), View::new(3)),
-            schemes[0].clone(),
-            quorum,
-        );
+        let mut verifier =
+            Verifier::<S, Sha256>::new(Round::new(Epoch::new(0), View::new(3)), schemes[0].clone());
         let round = Round::new(Epoch::new(0), View::new(3));
         let conflicting = Proposal::new(round, View::new(2), sample_digest(8));
         let proposal = Proposal::new(round, View::new(2), sample_digest(9));
@@ -1687,7 +1862,6 @@ mod tests {
         let mut verifier = Verifier::<_, Sha256>::new(
             Round::new(Epoch::new(333), View::new(7)),
             schemes[0].clone(),
-            quorum.try_into().unwrap(),
         );
         let round = Round::new(Epoch::new(333), View::new(7));
         let proposal_a = Proposal::new(round, View::new(6), sample_digest(1));
@@ -1710,9 +1884,10 @@ mod tests {
         assert!(failed.is_empty());
         assert_eq!(verifier.finalize.verified().len(), 1);
 
-        // The override drops the verified finalize for the old proposal.
+        // The override drops the verified finalize for the old proposal and its weight.
         verifier.set_proposal(ProposalState::Certificate(proposal_b.clone()));
         assert!(verifier.finalize.verified().is_empty());
+        assert_eq!(verifier.finalize.weights(), (0, 0));
 
         for scheme in schemes.iter().take(quorum).skip(1) {
             verifier.add(
@@ -1748,12 +1923,8 @@ mod tests {
     {
         let mut rng = test_rng();
         let Fixture { schemes, .. } = fixture(&mut rng, NAMESPACE, 3);
-        let quorum = count_quorum(schemes.len());
-        let mut verifier = Verifier::<S, Sha256>::new(
-            Round::new(Epoch::new(0), View::new(1)),
-            schemes[0].clone(),
-            quorum,
-        );
+        let mut verifier =
+            Verifier::<S, Sha256>::new(Round::new(Epoch::new(0), View::new(1)), schemes[0].clone());
         let round = Round::new(Epoch::new(0), View::new(1));
         let leader_notarize = create_notarize(&schemes[0], round, View::new(0), 1);
         verifier.set_leader(leader_notarize.signer(), Some(&leader_notarize));
@@ -1780,12 +1951,8 @@ mod tests {
     {
         let mut rng = test_rng();
         let Fixture { schemes, .. } = fixture(&mut rng, NAMESPACE, 3);
-        let quorum = count_quorum(schemes.len());
-        let mut verifier = Verifier::<S, Sha256>::new(
-            Round::new(Epoch::new(0), View::new(1)),
-            schemes[0].clone(),
-            quorum,
-        );
+        let mut verifier =
+            Verifier::<S, Sha256>::new(Round::new(Epoch::new(0), View::new(1)), schemes[0].clone());
         assert!(verifier.nullify.pending().is_empty());
         assert!(!verifier.nullify.should_verify());
         assert!(
@@ -1816,12 +1983,8 @@ mod tests {
     {
         let mut rng = test_rng();
         let Fixture { schemes, .. } = fixture(&mut rng, NAMESPACE, 3);
-        let quorum = count_quorum(schemes.len());
-        let mut verifier = Verifier::<S, Sha256>::new(
-            Round::new(Epoch::new(0), View::new(1)),
-            schemes[0].clone(),
-            quorum,
-        );
+        let mut verifier =
+            Verifier::<S, Sha256>::new(Round::new(Epoch::new(0), View::new(1)), schemes[0].clone());
         verifier.set_leader(Participant::new(0), None);
         assert!(verifier.finalize.pending().is_empty());
         assert!(!verifier.finalize.should_verify());
@@ -1854,11 +2017,8 @@ mod tests {
         let mut rng = test_rng();
         let Fixture { schemes, .. } = fixture(&mut rng, NAMESPACE, 5);
         let quorum = count_quorum(schemes.len());
-        let mut verifier = Verifier::<S, Sha256>::new(
-            Round::new(Epoch::new(0), View::new(1)),
-            schemes[0].clone(),
-            quorum,
-        );
+        let mut verifier =
+            Verifier::<S, Sha256>::new(Round::new(Epoch::new(0), View::new(1)), schemes[0].clone());
         let round = Round::new(Epoch::new(0), View::new(1));
 
         let leader_vote = create_notarize(&schemes[0], round, View::new(0), 1);
@@ -1916,11 +2076,8 @@ mod tests {
         let mut rng = test_rng();
         let Fixture { schemes, .. } = fixture(&mut rng, NAMESPACE, 5);
         let quorum = count_quorum(schemes.len());
-        let mut verifier = Verifier::<S, Sha256>::new(
-            Round::new(Epoch::new(0), View::new(1)),
-            schemes[0].clone(),
-            quorum,
-        );
+        let mut verifier =
+            Verifier::<S, Sha256>::new(Round::new(Epoch::new(0), View::new(1)), schemes[0].clone());
         let round = Round::new(Epoch::new(0), View::new(1));
 
         verifier.add(Vote::Nullify(create_nullify(&schemes[0], round)), true);
@@ -1962,11 +2119,8 @@ mod tests {
         let mut rng = test_rng();
         let Fixture { schemes, .. } = fixture(&mut rng, NAMESPACE, 5);
         let quorum = count_quorum(schemes.len());
-        let mut verifier = Verifier::<S, Sha256>::new(
-            Round::new(Epoch::new(0), View::new(1)),
-            schemes[0].clone(),
-            quorum,
-        );
+        let mut verifier =
+            Verifier::<S, Sha256>::new(Round::new(Epoch::new(0), View::new(1)), schemes[0].clone());
         let round = Round::new(Epoch::new(0), View::new(1));
         let leader_finalize = create_finalize(&schemes[0], round, View::new(0), 1);
         let leader_notarize = create_notarize(&schemes[0], round, View::new(0), 1);
@@ -2017,11 +2171,8 @@ mod tests {
             schemes.len() > quorum as usize,
             "test requires more validators than the quorum"
         );
-        let mut verifier = Verifier::<S, Sha256>::new(
-            Round::new(Epoch::new(0), View::new(1)),
-            schemes[0].clone(),
-            quorum,
-        );
+        let mut verifier =
+            Verifier::<S, Sha256>::new(Round::new(Epoch::new(0), View::new(1)), schemes[0].clone());
         let round = Round::new(Epoch::new(0), View::new(1));
 
         // Pre-load the leader vote as if it had already been processed.
@@ -2079,11 +2230,8 @@ mod tests {
             schemes.len() > quorum as usize,
             "test requires more validators than the quorum"
         );
-        let mut verifier = Verifier::<S, Sha256>::new(
-            Round::new(Epoch::new(0), View::new(1)),
-            schemes[0].clone(),
-            quorum,
-        );
+        let mut verifier =
+            Verifier::<S, Sha256>::new(Round::new(Epoch::new(0), View::new(1)), schemes[0].clone());
         let round = Round::new(Epoch::new(0), View::new(1));
 
         // First mark a quorum's worth of verified nullifies.
@@ -2133,11 +2281,8 @@ mod tests {
             schemes.len() > quorum as usize,
             "test requires more validators than the quorum"
         );
-        let mut verifier = Verifier::<S, Sha256>::new(
-            Round::new(Epoch::new(0), View::new(1)),
-            schemes[0].clone(),
-            quorum,
-        );
+        let mut verifier =
+            Verifier::<S, Sha256>::new(Round::new(Epoch::new(0), View::new(1)), schemes[0].clone());
         let round = Round::new(Epoch::new(0), View::new(1));
 
         // Prime the leader state so the quorum is already satisfied by verified finalizes.
@@ -2185,22 +2330,22 @@ mod tests {
     #[test_async]
     async fn test_certification_lifecycle() {
         // Non-batchable schemes verify eagerly whenever votes are pending.
-        let mut eager = Certification::<u64>::new(3, false);
-        eager.add(1, false);
+        let mut eager = Certification::<u64>::new(3, 3, false);
+        eager.add(1, 1, false);
         assert!(eager.should_verify());
 
         // Certification owns the pending and verified buffer lifecycle; its
         // caller owns signer uniqueness. Opaque values keep this test focused
         // on that boundary.
-        let mut votes = Certification::<u64>::new(3, true);
-        votes.add(1, false);
-        votes.add(2, true);
+        let mut votes = Certification::<u64>::new(3, 3, true);
+        votes.add(1, 1, false);
+        votes.add(2, 1, true);
         assert_eq!(votes.pending(), &[1]);
         assert_eq!(votes.verified(), &[2]);
 
         // Batchable schemes wait until the buffers could reach quorum.
         assert!(!votes.should_verify());
-        votes.add(3, false);
+        votes.add(3, 1, false);
         assert!(votes.should_verify());
 
         // Verification consumes both buffers and stores the new verified set.
@@ -2209,20 +2354,21 @@ mod tests {
             .try_verify(|pending, verified| async move {
                 assert_eq!(pending, vec![1, 3]);
                 assert_eq!(verified, vec![2]);
-                (vec![1, 2], vec![])
+                (vec![1, 2], 1, vec![])
             })
             .await
             .unwrap();
         assert_eq!(batch, 2);
         assert!(invalid.is_empty());
         assert!(votes.pending().is_empty());
+        assert_eq!(votes.weights(), (0, 2));
         assert_eq!(votes.try_complete(), None);
 
         // At quorum, recovery completes the phase and consumes the votes.
-        votes.add(3, true);
+        votes.add(3, 1, true);
         assert_eq!(votes.try_complete(), Some(vec![1, 2, 3]));
         assert!(votes.is_complete());
-        votes.add(5, false);
+        votes.add(5, 1, false);
         assert!(votes.pending().is_empty());
         assert!(votes.verified().is_empty());
         assert!(
@@ -2237,11 +2383,37 @@ mod tests {
         assert!(votes.is_complete());
 
         // Network certificates complete without any votes.
-        let mut votes = Certification::<u64>::new(3, true);
-        votes.add(1, false);
+        let mut votes = Certification::<u64>::new(3, 3, true);
+        votes.add(1, 1, false);
         votes.complete();
         assert!(votes.is_complete());
         assert!(votes.pending().is_empty());
+    }
+
+    /// Retaining votes recomputes both cached weights from the surviving votes.
+    #[test]
+    fn test_retain_recomputes_weights() {
+        // Votes are (id, weight) pairs so the weight closure has something to read.
+        let weight = |vote: &(u8, u64)| vote.1;
+        let mut votes = Certification::<(u8, u64)>::new(5, 4, true);
+        votes.add((1, 1), 1, false);
+        votes.add((2, 3), 3, false);
+        votes.add((3, 1), 1, true);
+        votes.add((4, 3), 3, true);
+        assert_eq!(votes.weights(), (4, 4));
+
+        // Dropping the light votes leaves weight 3 in each buffer: not the stale 4 and not a
+        // count of one.
+        votes.retain(|vote| vote.1 == 3, weight);
+        assert_eq!(votes.pending(), &[(2, 3)]);
+        assert_eq!(votes.verified(), &[(4, 3)]);
+        assert_eq!(votes.weights(), (3, 3));
+
+        // Stale weight would complete here (4 + 1 >= 5); the recomputed weight does not.
+        votes.add((5, 1), 1, true);
+        assert_eq!(votes.try_complete(), None);
+        votes.add((6, 1), 1, true);
+        assert_eq!(votes.try_complete(), Some(vec![(4, 3), (5, 1), (6, 1)]));
     }
 
     /// The leader's late notarize must still set the proposal after the
@@ -2253,12 +2425,8 @@ mod tests {
     {
         let mut rng = test_rng();
         let Fixture { schemes, .. } = fixture(&mut rng, NAMESPACE, 5);
-        let quorum = count_quorum(schemes.len());
-        let mut verifier = Verifier::<S, Sha256>::new(
-            Round::new(Epoch::new(0), View::new(1)),
-            schemes[0].clone(),
-            quorum,
-        );
+        let mut verifier =
+            Verifier::<S, Sha256>::new(Round::new(Epoch::new(0), View::new(1)), schemes[0].clone());
         let round = Round::new(Epoch::new(0), View::new(1));
 
         verifier.record_certificate(Kind::Notarization);
@@ -2294,7 +2462,7 @@ mod tests {
         let quorum = count_quorum(schemes.len());
         let quorum_size = usize::try_from(quorum).expect("quorum exceeds usize::MAX");
         let round = Round::new(Epoch::new(0), View::new(1));
-        let mut verifier = Verifier::<_, Sha256>::new(round, schemes[0].clone(), quorum);
+        let mut verifier = Verifier::<_, Sha256>::new(round, schemes[0].clone());
 
         let leader_notarize = create_notarize(&schemes[0], round, View::new(0), 1);
         verifier.set_leader(leader_notarize.signer(), Some(&leader_notarize));
@@ -2313,11 +2481,8 @@ mod tests {
         let mut rng = test_rng();
         let Fixture { schemes, .. } = ed25519::fixture(&mut rng, NAMESPACE, 5);
         let quorum = count_quorum(schemes.len());
-        let mut verifier = Verifier::<_, Sha256>::new(
-            Round::new(Epoch::new(0), View::new(1)),
-            schemes[0].clone(),
-            quorum,
-        );
+        let mut verifier =
+            Verifier::<_, Sha256>::new(Round::new(Epoch::new(0), View::new(1)), schemes[0].clone());
         let round = Round::new(Epoch::new(0), View::new(1));
 
         // Give every kind a pre-verified quorum

--- a/consensus/src/simplex/actors/voter/mod.rs
+++ b/consensus/src/simplex/actors/voter/mod.rs
@@ -7950,9 +7950,8 @@ mod tests {
 
             // Setup application mock and voter
             let elector = RoundRobin::<Sha256>::default();
-            let built_elector: RoundRobinElector<S> = elector
-                .clone()
-                .build(&participants.clone().try_into().unwrap());
+            let built_elector: RoundRobinElector<S> =
+                elector.clone().build(schemes[0].participants());
             let (mut mailbox, mut batcher_receiver, _, _, _) = setup_voter(
                 &context,
                 &oracle,
@@ -8069,9 +8068,8 @@ mod tests {
 
             // Setup application mock and voter
             let elector = RoundRobin::<Sha256>::default();
-            let built_elector: RoundRobinElector<S> = elector
-                .clone()
-                .build(&participants.clone().try_into().unwrap());
+            let built_elector: RoundRobinElector<S> =
+                elector.clone().build(schemes[0].participants());
             let (mut mailbox, mut batcher_receiver, _, relay, _) = setup_voter(
                 &context,
                 &oracle,
@@ -8221,9 +8219,8 @@ mod tests {
 
             // Setup application mock and voter
             let elector = RoundRobin::<Sha256>::default();
-            let built_elector: RoundRobinElector<S> = elector
-                .clone()
-                .build(&participants.clone().try_into().unwrap());
+            let built_elector: RoundRobinElector<S> =
+                elector.clone().build(schemes[0].participants());
             let (mut mailbox, mut batcher_receiver, _, _, _) = setup_voter(
                 &context,
                 &oracle,

--- a/consensus/src/simplex/elector.rs
+++ b/consensus/src/simplex/elector.rs
@@ -32,19 +32,19 @@ use commonware_codec::Encode;
 use commonware_cryptography::{
     Hasher, PublicKey, Sha256, bls12381::primitives::variant::Variant, certificate::Scheme,
 };
-use commonware_utils::{modulo, ordered::Set};
+use commonware_utils::{modulo, ordered::Committee};
 use std::{fmt, marker::PhantomData, time::Duration};
 
 /// Configuration for creating an [`Elector`].
 ///
 /// Users create and configure this type, then pass it to the consensus configuration.
 /// Consensus will call [`build`](Config::build) internally with the correct
-/// participant set to create the initialized [`Elector`].
+/// committee to create the initialized [`Elector`].
 ///
 /// # Determinism Requirement
 ///
 /// Implementations **must** be deterministic. Honest participants with the same
-/// configuration and participant set must select the same leader for each round.
+/// configuration and committee must select the same leader for each round.
 /// This is stronger than returning the same output for identical inputs because
 /// honest participants may call [`Elector::elect`] with different certificates for
 /// the same round. See [`Elector`] for the certificate handling requirements.
@@ -52,14 +52,8 @@ pub trait Config<S: Scheme>: Clone + Send + 'static {
     /// The initialized elector type.
     type Elector: Elector<S>;
 
-    /// Builds the elector with the given participants.
-    ///
-    /// Called internally by consensus with the correct participant set.
-    ///
-    /// # Panics
-    ///
-    /// Implementations should panic if `participants` is empty.
-    fn build(self, participants: &Set<S::PublicKey>) -> Self::Elector;
+    /// Builds the elector for the epoch committee.
+    fn build(self, participants: &Committee<S::PublicKey>) -> Self::Elector;
 }
 
 /// Leadership term structure reported by an [`Elector`].
@@ -293,9 +287,7 @@ impl<H: Hasher> RoundRobin<H> {
 impl<S: Scheme, H: Hasher> Config<S> for RoundRobin<H> {
     type Elector = RoundRobinElector<S>;
 
-    fn build(self, participants: &Set<S::PublicKey>) -> RoundRobinElector<S> {
-        assert!(!participants.is_empty(), "no participants");
-
+    fn build(self, participants: &Committee<S::PublicKey>) -> RoundRobinElector<S> {
         let mut permutation: Vec<Participant> = (0..participants.len())
             .map(Participant::from_usize)
             .collect();
@@ -432,9 +424,8 @@ where
 
     fn build(
         self,
-        participants: &Set<P>,
+        participants: &Committee<P>,
     ) -> RandomElector<bls12381_threshold_vrf::Scheme<P, V>, H> {
-        assert!(!participants.is_empty(), "no participants");
         RandomElector {
             n: participants.len() as u32,
             version: self,
@@ -521,6 +512,11 @@ mod tests {
     type ThresholdScheme =
         bls12381_threshold_vrf::Scheme<commonware_cryptography::ed25519::PublicKey, MinPk>;
 
+    fn unit_committee<P: Ord>(participants: impl IntoIterator<Item = P>) -> Committee<P> {
+        Committee::try_from_iter(participants.into_iter().map(|participant| (participant, 1)))
+            .unwrap()
+    }
+
     #[test]
     fn stable_terms_preserve_optimistic_views() {
         let stall = Duration::from_secs(1);
@@ -539,7 +535,7 @@ mod tests {
     fn round_robin_rotates_through_participants() {
         let mut rng = test_rng();
         let Fixture { participants, .. } = ed25519::fixture(&mut rng, NAMESPACE, 4);
-        let participants = Set::try_from_iter(participants).unwrap();
+        let participants = unit_committee(participants);
         let n = participants.len() as u32;
         let elector: RoundRobinElector<ed25519::Scheme> =
             RoundRobin::<Sha256>::default().build(&participants);
@@ -559,10 +555,31 @@ mod tests {
     }
 
     #[test]
+    fn round_robin_ignores_nonuniform_weights() {
+        let mut rng = test_rng();
+        let Fixture { participants, .. } = ed25519::fixture(&mut rng, NAMESPACE, 4);
+        let participants =
+            Committee::try_from_iter(participants.into_iter().zip([100, 1, 7, 2])).unwrap();
+        let elector: RoundRobinElector<ed25519::Scheme> =
+            RoundRobin::<Sha256>::default().build(&participants);
+        let epoch = Epoch::new(0);
+
+        let leaders: Vec<_> = (1..=4)
+            .map(|view| elector.elect(Round::new(epoch, View::new(view)), None))
+            .collect();
+
+        assert_eq!(
+            leaders,
+            [1, 2, 3, 0].map(Participant::new),
+            "round-robin schedule must remain participant-index based"
+        );
+    }
+
+    #[test]
     fn round_robin_cycles_through_epochs() {
         let mut rng = test_rng();
         let Fixture { participants, .. } = ed25519::fixture(&mut rng, NAMESPACE, 5);
-        let participants = Set::try_from_iter(participants).unwrap();
+        let participants = unit_committee(participants);
         let n = participants.len();
         let elector: RoundRobinElector<ed25519::Scheme> =
             RoundRobin::<Sha256>::default().build(&participants);
@@ -588,7 +605,7 @@ mod tests {
     fn round_robin_handles_wrapping_epoch_plus_term_index() {
         let mut rng = test_rng();
         let Fixture { participants, .. } = ed25519::fixture(&mut rng, NAMESPACE, 5);
-        let participants = Set::try_from_iter(participants).unwrap();
+        let participants = unit_committee(participants);
         let elector: RoundRobinElector<ed25519::Scheme> = RoundRobin::<Sha256>::default()
             .with_term(
                 TermLength::new(NZU32!(5)),
@@ -611,7 +628,7 @@ mod tests {
     fn round_robin_uses_stable_leaders_within_terms() {
         let mut rng = test_rng();
         let Fixture { participants, .. } = ed25519::fixture(&mut rng, NAMESPACE, 4);
-        let participants = Set::try_from_iter(participants).unwrap();
+        let participants = unit_committee(participants);
         let elector: RoundRobinElector<ed25519::Scheme> = RoundRobin::<Sha256>::default()
             .with_term(
                 TermLength::new(NZU32!(3)),
@@ -639,7 +656,7 @@ mod tests {
     fn round_robin_epoch_transition_shifts_stable_term_leader() {
         let mut rng = test_rng();
         let Fixture { participants, .. } = ed25519::fixture(&mut rng, NAMESPACE, 4);
-        let participants = Set::try_from_iter(participants).unwrap();
+        let participants = unit_committee(participants);
         let elector: RoundRobinElector<ed25519::Scheme> = RoundRobin::<Sha256>::default()
             .with_term(
                 TermLength::new(NZU32!(3)),
@@ -667,7 +684,7 @@ mod tests {
     fn round_robin_shuffled_changes_order() {
         let mut rng = test_rng();
         let Fixture { participants, .. } = ed25519::fixture(&mut rng, NAMESPACE, 5);
-        let participants = Set::try_from_iter(participants).unwrap();
+        let participants = unit_committee(participants);
 
         let elector_no_seed: RoundRobinElector<ed25519::Scheme> =
             RoundRobin::<Sha256>::default().build(&participants);
@@ -726,7 +743,7 @@ mod tests {
     fn round_robin_same_seed_is_deterministic() {
         let mut rng = test_rng();
         let Fixture { participants, .. } = ed25519::fixture(&mut rng, NAMESPACE, 5);
-        let participants = Set::try_from_iter(participants).unwrap();
+        let participants = unit_committee(participants);
 
         let elector1: RoundRobinElector<ed25519::Scheme> =
             RoundRobin::<Sha256>::shuffled(b"same_seed").build(&participants);
@@ -741,19 +758,11 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "no participants")]
-    fn round_robin_build_panics_on_empty_participants() {
-        let participants: Set<commonware_cryptography::ed25519::PublicKey> = Set::default();
-        let _: RoundRobinElector<ed25519::Scheme> =
-            RoundRobin::<Sha256>::default().build(&participants);
-    }
-
-    #[test]
     fn random_falls_back_to_round_robin_for_view_1() {
         let mut rng = test_rng();
         let Fixture { participants, .. } =
             bls12381_threshold_vrf::fixture::<MinPk, _>(&mut rng, NAMESPACE, 5);
-        let participants = Set::try_from_iter(participants).unwrap();
+        let participants = unit_committee(participants);
         let n = participants.len();
         let elector: RandomElector<ThresholdScheme> =
             Random::new(RandomVersion::V1).build(&participants);
@@ -782,7 +791,7 @@ mod tests {
         let mut rng = test_rng();
         let Fixture { participants, .. } =
             bls12381_threshold_vrf::fixture::<MinPk, _>(&mut rng, NAMESPACE, 5);
-        let participants = Set::try_from_iter(participants).unwrap();
+        let participants = unit_committee(participants);
         let random: RandomElector<ThresholdScheme> =
             Random::new(RandomVersion::V1).build(&participants);
         let round_robin: RoundRobinElector<ThresholdScheme> =
@@ -804,7 +813,7 @@ mod tests {
             schemes,
             ..
         } = bls12381_threshold_vrf::fixture::<MinPk, _>(&mut rng, NAMESPACE, 5);
-        let participants = Set::try_from_iter(participants).unwrap();
+        let participants = unit_committee(participants);
         let elector: RandomElector<ThresholdScheme> =
             Random::new(RandomVersion::V1).build(&participants);
         let quorum = usize::try_from(N3f1::quorum(
@@ -855,19 +864,12 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "no participants")]
-    fn random_build_panics_on_empty_participants() {
-        let participants: Set<commonware_cryptography::ed25519::PublicKey> = Set::default();
-        let _: RandomElector<ThresholdScheme> = Random::new(RandomVersion::V1).build(&participants);
-    }
-
-    #[test]
     #[should_panic]
     fn random_panics_on_none_certificate_after_view_1() {
         let mut rng = test_rng();
         let Fixture { participants, .. } =
             bls12381_threshold_vrf::fixture::<MinPk, _>(&mut rng, NAMESPACE, 5);
-        let participants = Set::try_from_iter(participants).unwrap();
+        let participants = unit_committee(participants);
         let elector: RandomElector<ThresholdScheme> =
             Random::new(RandomVersion::V1).build(&participants);
 
@@ -898,7 +900,7 @@ mod tests {
                 // Generate deterministic participants (using ed25519 fixture)
                 let n = rng.random_range(1..=100);
                 let Fixture { participants, .. } = ed25519::fixture(&mut rng, NAMESPACE, n);
-                let participants = Set::try_from_iter(participants).unwrap();
+                let participants = unit_committee(participants);
 
                 // Generate a random seed for shuffling
                 let shuffle_seed: [u8; 32] = rng.random();
@@ -934,7 +936,7 @@ mod tests {
                 schemes,
                 ..
             } = bls12381_threshold_vrf::fixture::<MinPk, _>(&mut rng, NAMESPACE, n);
-            let participants = Set::try_from_iter(participants).unwrap();
+            let participants = unit_committee(participants);
             let elector: RandomElector<ThresholdScheme> = version.build(&participants);
             let quorum = usize::try_from(N3f1::quorum(
                 u64::try_from(schemes.len()).expect("participant count exceeds u64::MAX"),

--- a/consensus/src/simplex/engine.rs
+++ b/consensus/src/simplex/engine.rs
@@ -2,6 +2,7 @@ use super::{
     actors::{batcher, resolver, voter},
     config::{Config, SkipPolicy},
     elector::{self, Elector as _},
+    metrics,
     types::{Activity, Context},
 };
 use crate::{
@@ -15,8 +16,9 @@ use commonware_parallel::Strategy;
 use commonware_runtime::{
     BufferPooler, Clock, ContextCell, Handle, Metrics, Spawner, Storage, spawn_cell,
 };
+use commonware_utils::N3f1;
 use rand_core::CryptoRng;
-use tracing::debug;
+use tracing::{debug, info, warn};
 
 /// Instance of `simplex` consensus engine.
 pub struct Engine<
@@ -31,6 +33,7 @@ pub struct Engine<
     T: Strategy,
 > {
     context: ContextCell<E>,
+    _committee_metrics: metrics::CommitteeProfile,
 
     voter: voter::Actor<E, S, L::Elector, B, D, A, R, F>,
     voter_mailbox: voter::Mailbox<S, D>,
@@ -58,6 +61,7 @@ impl<
     pub fn new(mut context: E, cfg: Config<S, L, B, D, A, R, F, T>) -> Self {
         // Ensure configuration is valid
         cfg.assert(&mut context);
+        let profile = cfg.scheme.participants().profile::<N3f1>();
         let skip_budget = match cfg.skip {
             SkipPolicy::Disabled => 0,
             SkipPolicy::Enabled { budget, .. } => budget.resolve(cfg.scheme.participants().len()),
@@ -131,9 +135,36 @@ impl<
             },
         );
 
+        info!(
+            epoch = %cfg.epoch,
+            total_weight = profile.total_weight,
+            max_fault_weight = profile.max_fault_weight,
+            quorum_weight = profile.quorum_weight,
+            max_participant_weight = profile.max_weight,
+            minimum_quorum_cardinality = profile.minimum_quorum_cardinality,
+            "installed committee",
+        );
+        if profile.max_weight_reaches_quorum() {
+            warn!(
+                epoch = %cfg.epoch,
+                max_participant_weight = profile.max_weight,
+                quorum_weight = profile.quorum_weight,
+                "participant weight reaches quorum",
+            );
+        } else if profile.max_weight_exceeds_max_fault_weight() {
+            warn!(
+                epoch = %cfg.epoch,
+                max_participant_weight = profile.max_weight,
+                max_fault_weight = profile.max_fault_weight,
+                "participant weight exceeds maximum faulty weight",
+            );
+        }
+        let committee_metrics = metrics::CommitteeProfile::init(&context, cfg.epoch, profile);
+
         // Return the engine
         Self {
             context: ContextCell::new(context),
+            _committee_metrics: committee_metrics,
 
             voter,
             voter_mailbox,

--- a/consensus/src/simplex/metrics.rs
+++ b/consensus/src/simplex/metrics.rs
@@ -1,6 +1,62 @@
+use crate::types::Epoch;
 use commonware_cryptography::PublicKey;
-use commonware_runtime::telemetry::metrics::{EncodeLabelSet, EncodeLabelValue, EncodeStruct};
-use commonware_utils::Array;
+use commonware_runtime::{
+    Metrics as RuntimeMetrics,
+    telemetry::metrics::{EncodeLabelSet, EncodeLabelValue, EncodeStruct, Registered, raw},
+};
+use commonware_utils::{Array, ordered::Profile};
+use std::sync::atomic::AtomicU64;
+
+/// A gauge that holds a committee weight.
+type WeightGauge = Registered<raw::Gauge<u64, AtomicU64>>;
+
+/// Committee profile metrics retained by the engine.
+pub(crate) struct CommitteeProfile {
+    _total_weight: WeightGauge,
+    _max_fault_weight: WeightGauge,
+    _quorum_weight: WeightGauge,
+    _max_participant_weight: WeightGauge,
+    _minimum_quorum_cardinality: WeightGauge,
+}
+
+impl CommitteeProfile {
+    /// Registers metrics for an epoch's committee profile.
+    pub(crate) fn init(context: &impl RuntimeMetrics, epoch: Epoch, profile: Profile) -> Self {
+        let context = context.child("committee").with_attribute("epoch", epoch);
+        let register = |name, help, value: u64| {
+            let gauge = raw::Gauge::<u64, AtomicU64>::default();
+            gauge.set(value);
+            context.register(name, help, gauge)
+        };
+        Self {
+            _total_weight: register(
+                "total_weight",
+                "Total weight of the committee",
+                profile.total_weight,
+            ),
+            _max_fault_weight: register(
+                "max_fault_weight",
+                "Maximum faulty weight tolerated by the committee",
+                profile.max_fault_weight,
+            ),
+            _quorum_weight: register(
+                "quorum_weight",
+                "Weight required for a committee quorum",
+                profile.quorum_weight,
+            ),
+            _max_participant_weight: register(
+                "max_participant_weight",
+                "Maximum weight of one committee participant",
+                profile.max_weight,
+            ),
+            _minimum_quorum_cardinality: register(
+                "minimum_quorum_cardinality",
+                "Minimum number of participants required to reach committee quorum",
+                profile.minimum_quorum_cardinality.into(),
+            ),
+        }
+    }
+}
 
 /// Per-peer label.
 #[derive(Clone, Debug, Hash, PartialEq, Eq, EncodeStruct)]
@@ -164,5 +220,62 @@ impl Inbound {
             peer: peer.to_string(),
             message: MessageType::Finalization,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use commonware_runtime::{Runner as _, deterministic};
+
+    #[test]
+    fn committee_profile_preserves_u64_values() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let total_weight = i64::MAX as u64 + 5;
+            let profile = Profile {
+                total_weight,
+                max_fault_weight: 3,
+                quorum_weight: total_weight - 3,
+                max_weight: total_weight - 4,
+                minimum_quorum_cardinality: 2,
+            };
+            let _metrics = CommitteeProfile::init(&context, Epoch::new(7), profile);
+            let encoded = context.encode();
+
+            for (name, value) in [
+                ("committee_total_weight", total_weight),
+                ("committee_max_fault_weight", 3),
+                ("committee_quorum_weight", total_weight - 3),
+                ("committee_max_participant_weight", total_weight - 4),
+                ("committee_minimum_quorum_cardinality", 2),
+            ] {
+                let expected = format!("{name}{{epoch=\"7\"}} {value}");
+                assert!(
+                    encoded.lines().any(|line| line == expected),
+                    "missing {name}={value} in:\n{encoded}"
+                );
+            }
+        });
+    }
+
+    #[test]
+    fn committee_profiles_are_scoped_by_epoch() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let profile = |total_weight| Profile {
+                total_weight,
+                max_fault_weight: 1,
+                quorum_weight: total_weight - 1,
+                max_weight: total_weight - 2,
+                minimum_quorum_cardinality: 2,
+            };
+            let _first = CommitteeProfile::init(&context, Epoch::new(1), profile(10));
+            let _second = CommitteeProfile::init(&context, Epoch::new(2), profile(20));
+            let encoded = context.encode();
+
+            assert!(encoded.contains("committee_total_weight{epoch=\"1\"} 10"));
+            assert!(encoded.contains("committee_total_weight{epoch=\"2\"} 20"));
+        });
     }
 }

--- a/consensus/src/simplex/mocks/reporter.rs
+++ b/consensus/src/simplex/mocks/reporter.rs
@@ -109,7 +109,7 @@ where
     D: Digest + Eq + Hash + Clone,
 {
     pub fn new(context: E, cfg: Config<S, L>) -> Self {
-        let elector = cfg.elector.build(&cfg.participants);
+        let elector = cfg.elector.build(cfg.scheme.participants());
 
         Self {
             context: Arc::new(Mutex::new(context)),

--- a/consensus/src/simplex/mocks/twins.rs
+++ b/consensus/src/simplex/mocks/twins.rs
@@ -76,7 +76,7 @@ use crate::{
 };
 use commonware_cryptography::certificate::Scheme;
 use commonware_p2p::simulated::SplitTarget;
-use commonware_utils::ordered::Set;
+use commonware_utils::ordered::Committee;
 use rand::{Rng, RngExt as _, seq::SliceRandom};
 use std::{
     collections::{HashMap, HashSet},
@@ -308,7 +308,7 @@ where
 {
     type Elector = ElectorState<C::Elector>;
 
-    fn build(self, participants: &Set<S::PublicKey>) -> Self::Elector {
+    fn build(self, participants: &Committee<S::PublicKey>) -> Self::Elector {
         ElectorState {
             fallback: self.fallback.build(participants),
             round_leaders: self.round_leaders,
@@ -1265,7 +1265,7 @@ mod tests {
         types::{Epoch, ViewDelta},
     };
     use commonware_cryptography::{Sha256, Signer, ed25519::PrivateKey};
-    use commonware_utils::{NZU32, TestRng, ordered::Set, test_rng};
+    use commonware_utils::{NZU32, TestRng, ordered::Committee, test_rng};
     use std::{collections::HashSet, time::Duration};
 
     fn round(_: usize, leader: usize, primary_mask: u64, secondary_mask: u64) -> RoundScenario {
@@ -2223,7 +2223,13 @@ mod tests {
         let participants: Vec<_> = (0..framework.participants as u64)
             .map(|seed| PrivateKey::from_seed(seed).public_key())
             .collect();
-        let participants = Set::try_from(participants).expect("participants should be unique");
+        let participants = Committee::try_from(
+            participants
+                .into_iter()
+                .map(|participant| (participant, 1))
+                .collect::<Vec<_>>(),
+        )
+        .expect("participants should be unique");
         let twins = <Elector<RoundRobin<Sha256>> as elector::Config<ed25519::Scheme>>::build(
             Elector::new(
                 RoundRobin::<Sha256>::default(),
@@ -2271,7 +2277,13 @@ mod tests {
         let participants: Vec<_> = (0..3)
             .map(|seed| PrivateKey::from_seed(seed).public_key())
             .collect();
-        let participants = Set::try_from(participants).expect("participants should be unique");
+        let participants = Committee::try_from(
+            participants
+                .into_iter()
+                .map(|participant| (participant, 1))
+                .collect::<Vec<_>>(),
+        )
+        .expect("participants should be unique");
         let term_length = TermLength::new(NZU32!(3));
         let twins = <Elector<RoundRobin<Sha256>> as elector::Config<ed25519::Scheme>>::build(
             Elector::new(

--- a/consensus/src/simplex/mocks/wrapped.rs
+++ b/consensus/src/simplex/mocks/wrapped.rs
@@ -120,7 +120,7 @@ where
 
     fn build(
         self,
-        participants: &commonware_utils::ordered::Set<<Scheme<S> as Verifier>::PublicKey>,
+        participants: &commonware_utils::ordered::Committee<<Scheme<S> as Verifier>::PublicKey>,
     ) -> Self::Elector {
         Elector {
             inner: self.0.build(participants),

--- a/consensus/src/simplex/mod.rs
+++ b/consensus/src/simplex/mod.rs
@@ -26,13 +26,21 @@
 //! [`Config::floor`](config::Config::floor) supplies the initial finalized state. Voting begins
 //! at view 1, with the first proposal referencing genesis as its parent.
 //!
+//! ### Weighted Quorums
+//!
+//! Each epoch's [`Committee`](commonware_utils::ordered::Committee) assigns a positive weight to
+//! every participant. Let `W` be the total committee weight, `f = floor((W - 1) / 3)` the maximum
+//! faulty weight, and `q = W - f` the quorum weight. A certificate forms when votes from unique
+//! participants have combined weight at least `q`. Uniform unit weights recover the count-based
+//! protocol. When `W = 3f + 1`, `q = 2f + 1`.
+//!
 //! ### Specification for View `v`
 //!
 //! Upon entering view `v`:
 //! * Determine leader `l` for view `v`
 //! * Set timer for leader proposal `t_l = 2Δ` and advance `t_a = 3Δ`
-//!     * If leader `l` has not been active for the configured skip timeout while a quorum of
-//!       participants has been, set both `t_l` and `t_a` to 0.
+//!     * If leader `l` has not been active for the configured skip timeout while active
+//!       participants have reached quorum weight, set both `t_l` and `t_a` to 0.
 //! * If leader `l`, broadcast `notarize(c,v)`
 //!   * If can't propose container in view `v` because missing notarization/nullification for a
 //!     previous view `v_m`, request `v_m`
@@ -45,7 +53,7 @@
 //!   be exactly `v-1`), verify `c` and broadcast `notarize(c,v)`
 //!     * If verification of `c` fails, immediately broadcast `nullify(v)`
 //!
-//! Upon receiving `2f+1` `notarize(c,v)`:
+//! Upon receiving quorum weight `q` in `notarize(c,v)` votes:
 //! * Mark `c` as notarized
 //! * Broadcast `notarization(c,v)` (even if we have not verified `c`)
 //! * Attempt to certify `c` (see [Certification](#certification)), leaving `t_a` armed so a
@@ -54,11 +62,11 @@
 //!       `nullify(v)` or observed `l` equivocate in `v`)
 //!     * On failure: treat as immediate timeout expiry and broadcast `nullify(v)`
 //!
-//! Upon receiving `2f+1` `nullify(v)`:
+//! Upon receiving quorum weight `q` in `nullify(v)` votes:
 //! * Broadcast `nullification(v)`
 //! * Enter `next_term_start(v)` (equivalent to `v+1` when `term_length = 1`)
 //!
-//! Upon receiving `2f+1` `finalize(c,v)`:
+//! Upon receiving quorum weight `q` in `finalize(c,v)` votes:
 //! * Mark `c` as finalized (and recursively finalize its parents)
 //! * Broadcast `finalization(c,v)` (even if we have not verified `c`)
 //!
@@ -71,16 +79,17 @@
 //!      when `term_length` is 1), otherwise the notarization of `v-1`. If we hold none (as in
 //!      view 1), rebroadcast `nullify(v)` alone.
 //!
-//! _When `2f+1` votes of a given type (`notarize(c,v)`, `nullify(v)`, or `finalize(c,v)`) have been collected
-//! from unique participants, a certificate (`notarization(c,v)`, `nullification(v)`, or `finalization(c,v)`) can be assembled.
+//! _When votes of a given type (`notarize(c,v)`, `nullify(v)`, or `finalize(c,v)`) from unique
+//! participants reach quorum weight `q`, a certificate (`notarization(c,v)`, `nullification(v)`,
+//! or `finalization(c,v)`) can be assembled.
 //! These certificates serve as a standalone proof of consensus progress that downstream systems can ingest without executing
 //! the protocol._
 //!
 //! ### Joining Consensus
 //!
-//! As soon as `2f+1` nullifies or finalizes are observed for some view `v`, the `Voter` will
-//! enter the corresponding successor view (`next_term_start(v)` for nullification, `v+1` for
-//! finalization). Notarizations advance the view if-and-only-if the application certifies them.
+//! As soon as the `Voter` observes quorum weight `q` in nullifies or finalizes for view `v`, it
+//! enters the corresponding successor view (`next_term_start(v)` for nullification, `v+1` for
+//! finalization). Notarizations advance the view only if the application certifies them.
 //! This means that a new participant joining consensus will immediately jump ahead on the previous
 //! view's nullification or finalization and begin participating in consensus at the current view.
 //!
@@ -98,7 +107,8 @@
 //! broadcast `nullify` or observed the leader equivocate) and enters the next view. If `certify` returns `false`, the participant broadcasts
 //! `nullify` for the view instead (treating it as an immediate timeout), and will refuse to build upon the
 //! proposal or notarize proposals that build upon it.
-//! Thus, a payload can only be finalized if a quorum of participants certify it.
+//! Thus, a payload can be finalized only if participants with combined weight at least `q`
+//! certify it.
 //!
 //! Certification of some notarization should only be abandoned once a finalization at the same or higher view is observed.
 //! Until then (say a nullification certificate for a view arrives before certification completes), the application should continue
@@ -117,8 +127,8 @@
 //!   either a "block" or a "dummy block", respectively.
 //! * Introduce a "leader timeout" to trigger early view transitions for unresponsive leaders.
 //! * Skip "leader timeout" and "certification timeout" if a designated leader has not participated
-//!   for the configured skip timeout while a quorum of participants has (again to trigger early
-//!   view transition for an unresponsive leader).
+//!   for the configured skip timeout while activity has reached quorum weight. This triggers an
+//!   early view transition for an unresponsive leader.
 //! * Introduce message rebroadcast to continue making progress if messages from a given view are dropped (only way
 //!   to ensure messages are reliably delivered is with a heavyweight reliable broadcast protocol).
 //! * Treat local proposal failure as immediate timeout expiry and broadcast `nullify(v)`.
@@ -156,22 +166,22 @@
 //!
 //! 1. To propose in view `v+k`, the leader must reference a certified parent in some view `v_p`
 //!    and possess required nullifications covering the skipped views from `v_p` to `v+k`.
-//! 2. A nullification certificate requires `2f+1` `nullify` votes for the covered view or an
-//!    earlier view in the same term.
+//! 2. A nullification certificate requires quorum weight `q` in `nullify` votes for the covered
+//!    view or an earlier view in the same term.
 //! 3. An honest participant only broadcasts `nullify` on a nullify trigger: an expired timeout
 //!    (`t_l`, `t_a`, or the stall timeout) or an event treated as immediate timeout expiry
 //!    (proposal build failure, verification failure, certification failure, the leader's own
 //!    `nullify`, or leader inactivity, as listed in
 //!    [Deviations](#deviations-from-simplex-consensus)).
 //!
-//! Therefore, a nullification covering `v` can only form if at least `f+1` honest participants
-//! broadcast `nullify` at a single view `u` in `[term_start(v), v]`. If every view in that term
-//! prefix completes without any nullify trigger (just view `v` itself when
+//! Therefore, a nullification covering `v` can form only if honest participants with total weight
+//! greater than `f` broadcast `nullify` at a single view `u` in `[term_start(v), v]`. If every
+//! view in that term prefix completes without any nullify trigger (just view `v` itself when
 //! `term_length` is 1), no honest participant has broadcast a covering `nullify`: at most `f`
-//! covering votes exist at any single view, which is insufficient to form a nullification
-//! certificate. Without that certificate, no future leader can skip view `v`, and the notarized
-//! payload must be included as an ancestor in all subsequent proposals. Note that a clean view
-//! `v` alone is not enough when `term_length > 1`: an honest `nullify` broadcast at an earlier
+//! faulty weight can provide covering votes at any single view. This is insufficient to form a
+//! nullification certificate. Without that certificate, no future leader can skip view `v`, and
+//! the notarized payload must be included as an ancestor in all subsequent proposals. A clean
+//! view `v` alone is not enough when `term_length > 1`: an honest `nullify` broadcast at an earlier
 //! view of the term (say, after a transient timeout at a view that later notarized) covers `v`
 //! even though no trigger fired at `v` itself.
 //!
@@ -252,11 +262,11 @@
 //! compared to the 3 hops required for full finalization (proposal + notarization + finalization).
 //! Observing the notarization does not by itself rule out exclusion: honest participants may
 //! still be inside a view of the term prefix, where a trigger can still fire (say, a
-//! certification that outlives `t_a`). Exclusion requires `f+1` or more honest participants to
-//! broadcast `nullify` at a single view of that prefix. Because certification is deterministic,
-//! it either fails for all honest participants or none, so a certification failure always
-//! produces a nullification. In the common case (no faults, no timeouts), exclusion cannot
-//! happen.
+//! certification that outlives `t_a`). Exclusion requires participants representing more than `f`
+//! honest weight to broadcast `nullify` at a single view of that prefix. Because certification is
+//! deterministic, it either fails for all honest participants or none. A certification failure
+//! therefore always produces a nullification. In the common case (no faults, no timeouts),
+//! exclusion cannot happen.
 //!
 //! A Byzantine leader, however, can exclude even its own valid, certifiable, and timely proposal:
 //! honest participants treat the leader's `nullify(v)` as an immediate timeout, so a leader can
@@ -271,13 +281,13 @@
 //! `notarization(c,v)`, it broadcasts `finalize(c,v)` and immediately enters `v+1`,
 //! regardless of what happens in subsequent views. These `finalize(c,v)` votes accumulate
 //! independently of the current view: even if views `v+1` through `v+k` all time out
-//! (producing nullifications), the `finalize(c,v)` votes still count toward the `2f+1`
-//! threshold needed to form `finalization(c,v)`.
+//! (producing nullifications), the `finalize(c,v)` votes still count toward quorum weight `q`
+//! needed to form `finalization(c,v)`.
 //!
 //! This means a payload notarized in view `v` can be finalized while the network is
 //! in view `v+k` for any `k >= 1`. There is no requirement that a particular view
-//! after `v` succeeds or that any subsequent leader cooperates. As long as `2f+1`
-//! participants eventually certify and broadcast `finalize(c,v)`, the finalization
+//! after `v` succeeds or that any subsequent leader cooperates. As long as participants with
+//! quorum weight eventually certify and broadcast `finalize(c,v)`, the finalization
 //! certificate will form.
 //!
 //! ## Architecture
@@ -683,7 +693,7 @@ mod tests {
     use commonware_cryptography::{
         Hasher as _, Sha256, Signer as _,
         bls12381::primitives::variant::{MinPk, MinSig, Variant},
-        certificate::mocks::Fixture,
+        certificate::{Scheme as _, mocks::Fixture},
         ed25519::{PrivateKey, PublicKey},
         sha256::{Digest as Sha256Digest, Digest as D},
     };
@@ -699,8 +709,11 @@ mod tests {
         buffer::paged::CacheRef, deterministic, telemetry::metrics::count_running_tasks,
     };
     use commonware_utils::{
-        Faults, N3f1, NZU16, NZU32, NZUsize, TestRng, non_empty, ordered::Set, probability,
-        sync::Mutex, test_rng,
+        Faults, N3f1, NZU16, NZU32, NZUsize, TestRng, TryCollect, non_empty,
+        ordered::{Committee, Set},
+        probability,
+        sync::Mutex,
+        test_rng,
     };
     use engine::Engine;
     use futures::future::join_all;
@@ -781,6 +794,53 @@ mod tests {
 
     const PAGE_SIZE: NonZeroU16 = NZU16!(1024);
     const PAGE_CACHE_SIZE: NonZeroUsize = NZUsize!(10);
+
+    fn unit_committee<P: Ord + Clone>(participants: &[P]) -> Committee<P> {
+        participants
+            .iter()
+            .cloned()
+            .map(|participant| (participant, 1))
+            .try_collect()
+            .unwrap()
+    }
+
+    fn weighted_ed25519_fixture<R: CryptoRng>(
+        rng: &mut R,
+        namespace: &[u8],
+        weights: &[u64],
+    ) -> Fixture<ed25519::Scheme> {
+        let Fixture {
+            participants,
+            private_keys,
+            ..
+        } = ed25519::fixture(
+            rng,
+            namespace,
+            u32::try_from(weights.len()).expect("test committee must fit in u32"),
+        );
+        let committee: Committee<_> = participants
+            .iter()
+            .cloned()
+            .zip(weights.iter().copied())
+            .try_collect()
+            .expect("test committee must be valid");
+        let schemes = private_keys
+            .iter()
+            .cloned()
+            .map(|private_key| {
+                ed25519::Scheme::signer(namespace, committee.clone(), private_key)
+                    .expect("private key must belong to test committee")
+            })
+            .collect();
+        let verifier = ed25519::Scheme::verifier(namespace, committee);
+
+        Fixture {
+            participants,
+            private_keys,
+            schemes,
+            verifier,
+        }
+    }
     const TEST_QUOTA: Quota = Quota::per_second(NonZeroU32::MAX);
 
     type TestChannel = (
@@ -1281,6 +1341,141 @@ mod tests {
         );
     }
 
+    #[test_group("slow")]
+    #[test_traced]
+    fn test_weighted_engine_finalizes_with_weight_quorum() {
+        let executor = deterministic::Runner::timed(Duration::from_secs(60));
+        executor.start(|mut context| async move {
+            let namespace = b"consensus".to_vec();
+            let Fixture {
+                participants,
+                schemes,
+                ..
+            } = weighted_ed25519_fixture(&mut context, &namespace, &[4, 1, 1, 1]);
+            let committee = schemes[0].participants().clone();
+            assert_eq!(committee.quorum_weight::<N3f1>(), 5);
+
+            let mut oracle =
+                start_test_network_with_peers(context.child("network"), participants.clone(), true)
+                    .await;
+            let mut registrations = register_validators(&mut oracle, &participants).await;
+            let link = Link {
+                latency: Duration::from_millis(10),
+                jitter: Duration::from_millis(1),
+                success_rate: probability!(1.0),
+            };
+            link_validators(
+                &mut oracle,
+                &participants,
+                Action::Link(link),
+                Some(|_, i, j| i < 2 && j < 2),
+            )
+            .await;
+
+            let relay = Arc::new(mocks::relay::Relay::<Sha256Digest, _>::new());
+            let mut reporters = Vec::new();
+            let mut engine_handlers = Vec::new();
+            for (idx, validator) in participants.iter().enumerate().take(2) {
+                let context = context
+                    .child("validator")
+                    .with_attribute("public_key", validator);
+                let reporter = mocks::reporter::Reporter::new(
+                    context.child("reporter"),
+                    mocks::reporter::Config {
+                        participants: participants.clone().try_into().unwrap(),
+                        scheme: schemes[idx].clone(),
+                        elector: RoundRobin::<Sha256>::default(),
+                    },
+                );
+                reporters.push(reporter.clone());
+                let (actor, application) = mocks::application::Application::new(
+                    context.child("application"),
+                    mocks::application::Config::<Sha256, _> {
+                        relay: relay.clone(),
+                        me: validator.clone(),
+                        propose_latency: (10.0, 5.0),
+                        verify_latency: (10.0, 5.0),
+                        certify_latency: (10.0, 5.0),
+                        should_certify: mocks::application::Certifier::Always,
+                    },
+                );
+                actor.start();
+                let engine = Engine::new(
+                    context.child("engine"),
+                    config::Config {
+                        scheme: schemes[idx].clone(),
+                        elector: RoundRobin::<Sha256>::default(),
+                        blocker: oracle.control(validator.clone()),
+                        automaton: application.clone(),
+                        relay: application.clone(),
+                        reporter: reporter.clone(),
+                        strategy: Sequential,
+                        partition: validator.to_string(),
+                        mailbox_size: NZUsize!(1024),
+                        epoch: Epoch::new(333),
+                        floor: config::Floor::Genesis(mocks::application::genesis::<Sha256>(
+                            Epoch::new(333),
+                        )),
+                        leader_timeout: Duration::from_secs(1),
+                        certification_timeout: Duration::from_secs(2),
+                        timeout_retry: Duration::from_secs(1),
+                        fetch_timeout: Duration::from_secs(1),
+                        view_retention: ViewDelta::new(10),
+                        skip: SkipPolicy::Disabled,
+                        replay_buffer: NZUsize!(1024 * 1024),
+                        write_buffer: NZUsize!(1024 * 1024),
+                        page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
+                        forward: ForwardPolicy::Disabled,
+                        track_historical_votes: false,
+                    },
+                );
+                let (pending, recovered, resolver) = registrations
+                    .remove(validator)
+                    .expect("validator should be registered");
+                engine_handlers.push(engine.start(pending, recovered, resolver));
+            }
+
+            let required_view = View::new(4);
+            let mut finalizers = Vec::new();
+            for reporter in &mut reporters {
+                let (mut latest, mut monitor) = reporter.subscribe().await;
+                finalizers.push(context.child("finalizer").spawn(move |_| async move {
+                    while latest < required_view {
+                        latest = monitor.recv().await.expect("event missing");
+                    }
+                }));
+            }
+            join_all(finalizers).await;
+
+            for reporter in &reporters {
+                reporter.assert_no_faults();
+                reporter.assert_no_invalid();
+                let exact_weight_quorum = reporter.finalizes.lock().values().any(|payloads| {
+                    payloads.values().any(|signers| {
+                        signers.len() == 2
+                            && signers
+                                .iter()
+                                .map(|signer| {
+                                    committee
+                                        .index(signer)
+                                        .and_then(|participant| committee.weight(participant))
+                                        .unwrap_or(0)
+                                })
+                                .sum::<u64>()
+                                == 5
+                    })
+                });
+                assert!(
+                    exact_weight_quorum,
+                    "the heavy participant and one light participant must finalize"
+                );
+            }
+
+            assert!(oracle.blocked().await.unwrap().is_empty());
+            drop(engine_handlers);
+        });
+    }
+
     fn non_genesis_floor_joiner_catches_tip<S, F, L>(fixture: F, elector: L)
     where
         S: Scheme<Sha256Digest, PublicKey = PublicKey>,
@@ -1602,7 +1797,7 @@ mod tests {
             link_validators(&mut oracle, &participants, Action::Link(link), None).await;
 
             let elector = RoundRobin::default();
-            let participants_set: Set<S::PublicKey> = participants.clone().try_into().unwrap();
+            let participants_set = unit_committee(&participants);
             let built_elector = elector.clone().build(&participants_set);
             let relay = Arc::new(mocks::relay::Relay::<Sha256Digest, _>::new());
             let mut reporters = Vec::new();
@@ -1823,7 +2018,7 @@ mod tests {
             engine.start(pending, recovered, resolver);
         }
 
-        let participants_set = participants.clone().try_into().unwrap();
+        let participants_set = unit_committee(&participants);
         let built_elector: elector::RoundRobinElector<ed25519::Scheme> =
             elector.build(&participants_set);
         let leader_idx = usize::from(built_elector.elect(Round::new(epoch, View::new(1)), None));
@@ -6458,7 +6653,7 @@ mod tests {
             // participant leads view 10, the group leads views 11..=12, and the
             // lone participant leads view 13.
             let epoch = Epoch::new(333);
-            let participant_set: Set<PublicKey> = participants.clone().try_into().unwrap();
+            let participant_set = unit_committee(&participants);
             let schedule = elector.clone().build(&participant_set);
             let leader_of =
                 |view: u64| usize::from(schedule.elect(Round::new(epoch, View::new(view)), None));
@@ -6668,7 +6863,7 @@ mod tests {
             // participant leads view 10, the lone participant leads view 11, and
             // the group leads views 12..=13.
             let epoch = Epoch::new(333);
-            let participant_set: Set<PublicKey> = participants.clone().try_into().unwrap();
+            let participant_set = unit_committee(&participants);
             let schedule = elector.clone().build(&participant_set);
             let leader_of =
                 |view: u64| usize::from(schedule.elect(Round::new(epoch, View::new(view)), None));
@@ -6883,7 +7078,7 @@ mod tests {
             // participant leads view 10, the group leads views 11..=12, and the
             // lone participant leads view 13.
             let epoch = Epoch::new(333);
-            let participant_set: Set<PublicKey> = participants.clone().try_into().unwrap();
+            let participant_set = unit_committee(&participants);
             let schedule = elector.clone().build(&participant_set);
             let leader_of =
                 |view: u64| usize::from(schedule.elect(Round::new(epoch, View::new(view)), None));
@@ -7120,7 +7315,7 @@ mod tests {
 
             // Choose an epoch where the same participant leads terms 1 and 5.
             let epoch = Epoch::new(2);
-            let participant_set: Set<PublicKey> = participants.clone().try_into().unwrap();
+            let participant_set = unit_committee(&participants);
             let schedule = elector.clone().build(&participant_set);
             let leader_of =
                 |view: u64| usize::from(schedule.elect(Round::new(epoch, View::new(view)), None));

--- a/glue/src/dkg/probe/actor/discovery.rs
+++ b/glue/src/dkg/probe/actor/discovery.rs
@@ -23,7 +23,7 @@ use commonware_p2p::{Blocker, Receiver, Recipients, Sender};
 use commonware_parallel::Strategy;
 use commonware_runtime::{Clock, ContextCell, Metrics, Spawner};
 use commonware_utils::{
-    NonZeroDuration,
+    Faults, N3f1, NonZeroDuration,
     channel::{fallible::OneshotExt as _, oneshot},
 };
 use futures::future::{self, Either};
@@ -369,10 +369,10 @@ where
         boundary_sender: &mut impl Sender<PublicKey = S::PublicKey>,
     ) -> bool {
         // The all-epoch verifier judges every recorded reply.
-        let Some(floor) = self
-            .sample
-            .select(self.bootstrap_participants.dealers.len(), |_| true)
-        else {
+        let participant_count = u64::try_from(self.bootstrap_participants.dealers.len())
+            .expect("bootstrap participant count exceeds u64::MAX");
+        let required_replies = N3f1::max_faults(participant_count) + 1;
+        let Some(floor) = self.sample.select(required_replies, |_| 1, |_| true) else {
             return false;
         };
         let target = floor.epoch();

--- a/glue/src/stateful/probe/actor/discovery.rs
+++ b/glue/src/stateful/probe/actor/discovery.rs
@@ -21,7 +21,7 @@ use commonware_p2p::{Blocker, Receiver, Recipients, Sender};
 use commonware_parallel::Strategy;
 use commonware_runtime::{Clock, ContextCell, Metrics, Spawner};
 use commonware_utils::{
-    NonZeroDuration,
+    N3f1, NonZeroDuration,
     channel::{fallible::OneshotExt, oneshot},
 };
 use futures::future::{self, Either};
@@ -230,13 +230,19 @@ where
         let Some(scheme) = self.provider.scheme(self.sample.minimum_epoch()) else {
             return;
         };
+        let participants = scheme.participants();
+        let required_weight = participants.max_fault_weight::<N3f1>() + 1;
         let provider = &self.provider;
-        let Some(floor) = self
-            .sample
-            .select(scheme.participants().len(), |finalization| {
-                provider.scoped(finalization.epoch()).is_some()
-            })
-        else {
+        let Some(floor) = self.sample.select(
+            required_weight,
+            |peer| {
+                participants
+                    .index(peer)
+                    .and_then(|participant| participants.weight(participant))
+                    .unwrap_or(0)
+            },
+            |finalization| provider.scoped(finalization.epoch()).is_some(),
+        ) else {
             return;
         };
 

--- a/glue/src/stateful/probe/mod.rs
+++ b/glue/src/stateful/probe/mod.rs
@@ -3,7 +3,7 @@
 //! A node that is starting fresh (or recovering from far behind) needs a recent, trustworthy
 //! finalization, the "floor", as the point to begin state sync from. It cannot trust any
 //! single peer to name that point, so the [`Probe`] asks many peers and adopts the
-//! highest valid finalization from `f + 1` distinct peer replies.
+//! highest valid finalization after the replying weight exceeds the fault budget.
 //!
 //! # Protocol
 //!
@@ -32,7 +32,7 @@
 //! Each peer answers with its own latest finalization (or nothing, if it has none). Every response
 //! is verified against the certificate scheme for its epoch, and its sender must be a participant
 //! in the committee that was solicited. At most one finalization is counted per peer, so no single
-//! peer can inflate the sample on its own. Once `f + 1` distinct peers have replied, the highest
+//! peer can inflate the sample on its own. Once the replying weight exceeds `f`, the highest
 //! finalized round becomes the floor:
 //!
 //! ```text
@@ -62,16 +62,16 @@
 //!            (retry_timeout elapsed)
 //! ```
 //!
-//! # Why the sample is `f + 1`
+//! # Why the sample exceeds `f`
 //!
 //! The `f` used here comes from the configured minimum epoch's committee: the committee that
 //! received the request. Returned finalizations are still verified against their own epoch's
 //! certificate scheme, so an old-committee member may safely report a newer finalization from a
 //! later epoch where it no longer participates.
 //!
-//! Assume at most `f` of the `n` participants in that epoch are faulty. In this protocol, `f` makes
-//! no distinction between Byzantine and crashed nodes: a peer that does not answer and a peer that
-//! answers adversarially both count against the same fault budget.
+//! Assume faulty participants in that epoch have total weight at most `f`. In this protocol, `f`
+//! makes no distinction between Byzantine and crashed nodes: a peer that does not answer and a
+//! peer that answers adversarially both count against the same fault budget.
 //!
 //! A finalization is self-certifying: it carries a quorum certificate, so any one that verifies
 //! proves the network truly finalized that block. Accepting a single peer's finalization is
@@ -83,16 +83,16 @@
 //!
 //! Under [`simplex`](commonware_consensus::simplex)'s synchrony assumptions, after one honest node
 //! advances to a new view, other honest nodes may remain in the previous view until that transition
-//! is delivered within the network-delay bound (`delta`). Waiting for `f + 1` replies guarantees at
-//! least one honest response in the sample: at most `f` responders can be Byzantine, and crashed
-//! nodes do not respond. The selected finalization is therefore at least as recent as that honest
-//! response. Byzantine peers can still replay old certificates, but old certificates lose to newer
-//! honest replies. If they report something higher, it must still be a valid finalization, so it is
-//! a real finalized block rather than a rollback.
+//! is delivered within the network-delay bound (`delta`). Waiting for more than `f` reply weight
+//! guarantees at least one honest response in the sample: Byzantine participants have total weight
+//! at most `f`, and crashed nodes do not respond. The selected finalization is therefore at least
+//! as recent as that honest response. Byzantine peers can still replay old certificates, but old
+//! certificates lose to newer honest replies. If they report something higher, it must still be a
+//! valid finalization, so it is a real finalized block rather than a rollback.
 //!
-//! If fewer than `f + 1` solicited peers can answer for that epoch, probe cannot resolve that
+//! If responding participants have total weight at most `f`, probe cannot resolve that
 //! request round and will retry. This is a liveness tradeoff, not a safety one: using the
-//! solicited committee's `f + 1` threshold preserves the assumption that every completed sample
+//! solicited committee's weight threshold preserves the assumption that every completed sample
 //! includes at least one honest response from the relevant historical committee.
 //!
 //! [`Config::minimum_epoch`] bounds that historical search. A caller that initializes peers from a
@@ -101,7 +101,7 @@
 //! finalizations reported by its participants.
 //!
 //! ```text
-//!   any f + 1 sample:
+//!   any sample with reply weight > f:
 //!
 //!     [ B   B  ...  B ]  [ H ]       at most f Byzantine
 //!      \____ <= f ____/    \_ at least one honest response
@@ -169,8 +169,9 @@ mod test {
     };
     use commonware_storage::archive::immutable;
     use commonware_utils::{
-        Acknowledgement, NZDuration, NZU16, NZU64, NZUsize, NonZeroDuration, TestRng, TryCollect,
-        channel::oneshot, non_empty, probability, sync::Mutex, test_rng,
+        Acknowledgement, NZDuration, NZU16, NZU64, NZUsize, NonZeroDuration, Participant, TestRng,
+        TryCollect, channel::oneshot, non_empty, ordered::Committee, probability, sync::Mutex,
+        test_rng,
     };
     use std::{
         collections::BTreeMap,
@@ -364,9 +365,13 @@ mod test {
             n: u32,
             retry_timeout: NonZeroDuration,
         ) -> Self {
-            Self::setup_with(context, n, retry_timeout, Epoch::zero(), |scheme| {
-                ConstantProvider::new(scheme.clone())
-            })
+            Self::setup_with(
+                context,
+                vec![1; n as usize],
+                retry_timeout,
+                Epoch::zero(),
+                |scheme| ConstantProvider::new(scheme.clone()),
+            )
             .await
         }
 
@@ -375,7 +380,7 @@ mod test {
         /// provider to exercise multi-epoch verification.
         async fn setup_with<D, F>(
             context: &deterministic::Context,
-            n: u32,
+            weights: Vec<u64>,
             retry_timeout: NonZeroDuration,
             minimum_epoch: Epoch,
             make_provider: F,
@@ -384,12 +389,28 @@ mod test {
             D: Provider<Scope = Epoch, Scheme = Scheme>,
             F: Fn(&Scheme) -> D,
         {
+            let n = u32::try_from(weights.len()).expect("participant count must fit in u32");
             let mut rng = test_rng();
-            let Fixture {
-                participants,
-                schemes,
-                ..
-            } = scheme_mocks::fixture(&mut rng, NAMESPACE, n);
+            let Fixture { participants, .. } = scheme_mocks::fixture(&mut rng, NAMESPACE, n);
+            assert_eq!(participants.len(), weights.len());
+            let committee = participants
+                .iter()
+                .cloned()
+                .zip(weights)
+                .try_collect::<Committee<_>>()
+                .expect("weighted committee must be valid");
+            let shared = Shared::default();
+            let schemes = (0..n)
+                .map(|index| {
+                    Scheme::signer(
+                        NAMESPACE,
+                        committee.clone(),
+                        Participant::new(index),
+                        shared.clone(),
+                    )
+                    .expect("scheme signer must be a participant")
+                })
+                .collect::<Vec<_>>();
 
             // Simulated network with all participants tracked in a single peer set.
             let (network, oracle) = Network::new_with_peers(
@@ -902,7 +923,7 @@ mod test {
             let provider = ConstantProvider::new(schemes[0].clone());
             let mut harness = Harness::setup_with(
                 &context,
-                7,
+                vec![1; 7],
                 NZDuration!(Duration::from_secs(3600)),
                 Epoch::zero(),
                 move |_scheme| provider.clone(),
@@ -943,7 +964,7 @@ mod test {
             let provider = ConstantProvider::new(schemes[0].clone());
             let mut harness = Harness::setup_with(
                 &context,
-                7,
+                vec![1; 7],
                 NZDuration!(Duration::from_secs(3600)),
                 Epoch::zero(),
                 move |_scheme| provider.clone(),
@@ -1175,6 +1196,41 @@ mod test {
         });
     }
 
+    /// Discovery derives reply weights and the threshold from its non-uniform committee.
+    #[test]
+    fn test_discovery_selects_by_weight() {
+        let runner = deterministic::Runner::timed(Duration::from_secs(30));
+        runner.start(|context| async move {
+            // With weights [1, 7, 1, 1], f = 3 and replies must have weight at least 4.
+            let mut harness = Harness::setup_with(
+                &context,
+                vec![1, 7, 1, 1],
+                NZDuration!(Duration::from_secs(3600)),
+                Epoch::zero(),
+                |scheme| ConstantProvider::new(scheme.clone()),
+            )
+            .await;
+            harness.start_probes();
+            let mut subscription = harness.nodes[0].probe.subscribe();
+            let (_, finalization) = harness.finalization(1, 1);
+
+            // Two light replies would satisfy a count threshold of `f + 1 = 2` for four
+            // participants, but their weight of 2 is below the weight threshold of 4.
+            harness.send_raw(2, 0, finalization_bytes(finalization.clone()));
+            harness.send_raw(3, 0, finalization_bytes(finalization.clone()));
+            context.sleep(Duration::from_millis(100)).await;
+            assert!(matches!(
+                subscription.try_recv(),
+                Err(oneshot::error::TryRecvError::Empty)
+            ));
+
+            // The heavyweight reply crosses the weight threshold.
+            harness.send_raw(1, 0, finalization_bytes(finalization.clone()));
+            context.sleep(Duration::from_millis(100)).await;
+            assert_eq!(subscription.try_recv(), Ok(finalization));
+        });
+    }
+
     /// Finalizations are verified against the scheme for their own epoch: a non-zero-epoch
     /// finalization, signed by that epoch's committee and reported by enough peers, resolves
     /// the floor (exercises the epoch-scoped scheme lookup and per-epoch sample size).
@@ -1191,7 +1247,7 @@ mod test {
 
             let mut harness = Harness::setup_with(
                 &context,
-                4,
+                vec![1; 4],
                 NZDuration!(Duration::from_secs(3600)),
                 Epoch::zero(),
                 {
@@ -1233,7 +1289,7 @@ mod test {
             let provider = EpochProvider::default();
             let mut harness = Harness::setup_with(
                 &context,
-                7,
+                vec![1; 7],
                 NZDuration!(Duration::from_secs(3600)),
                 Epoch::zero(),
                 {
@@ -1291,7 +1347,7 @@ mod test {
             let provider = EpochProvider::default();
             let mut harness = Harness::setup_with(
                 &context,
-                4,
+                vec![1; 4],
                 NZDuration!(Duration::from_secs(3600)),
                 Epoch::new(1),
                 {
@@ -1457,7 +1513,7 @@ mod test {
 
             let mut harness = Harness::setup_with(
                 &context,
-                4,
+                vec![1; 4],
                 NZDuration!(Duration::from_secs(3600)),
                 Epoch::zero(),
                 {
@@ -1506,7 +1562,7 @@ mod test {
 
             let mut harness = Harness::setup_with(
                 &context,
-                4,
+                vec![1; 4],
                 NZDuration!(Duration::from_secs(3600)),
                 Epoch::zero(),
                 {

--- a/glue/src/stateful/probe/sample.rs
+++ b/glue/src/stateful/probe/sample.rs
@@ -2,9 +2,9 @@
 //!
 //! [`stateful::probe`](crate::stateful::probe) and
 //! [`dkg::probe`](crate::dkg::probe) both discover a floor by soliciting a
-//! committee's latest finalizations and selecting the highest from `f + 1`
-//! distinct replies. [`Sample`] owns the bookkeeping of that protocol:
-//! per-peer reply dedup, the fault-budget threshold, and max-selection. Each
+//! committee's latest finalizations and selecting the highest after replies
+//! exceed the fault budget. [`Sample`] owns the bookkeeping of that protocol:
+//! per-peer reply dedup, reply-mass accounting, and max-selection. Each
 //! probe keeps its own wire format, committee source, minimum-epoch filter,
 //! verification, and peer blocking.
 
@@ -17,17 +17,15 @@ use commonware_consensus::{
     types::Epoch,
 };
 use commonware_cryptography::Digest;
-use commonware_utils::{Faults, N3f1};
 use std::collections::BTreeMap;
 
-/// An `f + 1` sample of a committee's latest finalizations.
+/// A fault-budget sample of a committee's latest finalizations.
 ///
 /// The sample counts at most one reply per peer and resolves to the highest
-/// reply once `f + 1` distinct peers have contributed, where `f` is the
-/// maximum fault count of the solicited committee under the `3f + 1` model.
-/// Waiting for `f + 1` replies guarantees at least one comes from an honest,
-/// current committee member, so the selected floor is at least as recent as
-/// that member's latest finalization.
+/// reply once the mass of contributed replies exceeds the caller's fault
+/// budget. Waiting for that threshold guarantees at least one reply comes from
+/// an honest, current committee member, so the selected floor is at least as
+/// recent as that member's latest finalization.
 ///
 /// Callers verify replies and enforce committee membership before recording
 /// them, and judge which recorded replies are currently usable at selection
@@ -95,24 +93,25 @@ where
     ///
     /// Only replies for which `judgeable` returns true are counted or
     /// eligible: a recorded reply whose epoch can no longer be judged must not
-    /// contribute to the sample. Selection requires `f + 1` judgeable replies,
-    /// where `f` is derived from `committee_size`. Returns the floor exactly
+    /// contribute to the sample. Selection requires judgeable replies whose
+    /// total `mass` is at least `required_mass`. Returns the floor exactly
     /// once, when it is first selected.
     pub(crate) fn select(
         &mut self,
-        committee_size: usize,
+        required_mass: u64,
+        mass: impl Fn(&S::PublicKey) -> u64,
         judgeable: impl Fn(&Finalization<S, D>) -> bool,
     ) -> Option<Finalization<S, D>> {
         if self.floor.is_some() {
             return None;
         }
 
-        let (floor, replies) =
+        let (floor, reply_mass) =
             self.replies
-                .values()
-                .fold((None, 0usize), |(floor, replies), finalization| {
+                .iter()
+                .fold((None, 0u64), |(floor, reply_mass), (peer, finalization)| {
                     if !judgeable(finalization) {
-                        return (floor, replies);
+                        return (floor, reply_mass);
                     }
                     let floor = floor
                         .is_none_or(|candidate: &Finalization<S, D>| {
@@ -120,14 +119,15 @@ where
                         })
                         .then_some(finalization)
                         .or(floor);
-                    (floor, replies + 1)
+                    (
+                        floor,
+                        reply_mass
+                            .checked_add(mass(peer))
+                            .expect("reply mass exceeds u64::MAX"),
+                    )
                 });
         let floor = floor?;
-        if u64::try_from(replies).expect("reply count exceeds u64::MAX")
-            < N3f1::max_faults(
-                u64::try_from(committee_size).expect("committee size exceeds u64::MAX"),
-            ) + 1
-        {
+        if reply_mass < required_mass {
             return None;
         }
 


### PR DESCRIPTION
Stacked on #4635.

Part of #443.

## Summary

- gate Simplex vote verification and certificate construction by committee weight
- measure recent activity by weight; vote buffers, indices, and skip budgets remain count-based
- pass the epoch committee to elector configurations; built-in electors remain participant-index based
- log committee profiles, warn about concentrated weight, and export per-epoch profile metrics
- size stateful-probe floor samples by reply weight while keeping DKG sampling count-based

Tests cover weighted quorum and activity accounting, invalid heavyweight signatures, large weights, index-based leader selection, engine-level finalization, and probe sampling.
