### PR TITLE
[glue/stateful] Hand off finalized artifacts

### DIFF
--- a/examples/reshare/src/application.rs
+++ b/examples/reshare/src/application.rs
@@ -54,6 +54,7 @@ where
     type Context = Context<sha256::Digest, ed25519::PublicKey>;
     type Block = Block;
     type Databases = Database<E>;
+    type FinalizedArtifact = ();
     type Provider = ();
     type Input = ReshareInput<(), MinSig, ed25519::PrivateKey>;
 
@@ -108,6 +109,15 @@ where
         batches: <Self::Databases as DatabaseSet<E>>::Unmerkleized,
     ) -> <Self::Databases as DatabaseSet<E>>::Merkleized {
         Self::execute(block.height(), batches).await
+    }
+
+    async fn capture_finalized(
+        &mut self,
+        _context: (E, Self::Context),
+        _block: &Self::Block,
+        _batches: &<Self::Databases as DatabaseSet<E>>::Merkleized,
+        _readers: <Self::Databases as DatabaseSet<E>>::Readers,
+    ) {
     }
 
     fn sync_targets(block: &Self::Block) -> <Self::Databases as DatabaseSet<E>>::SyncTargets {

--- a/examples/reshare/src/application.rs
+++ b/examples/reshare/src/application.rs
@@ -120,6 +120,15 @@ where
     ) {
     }
 
+    async fn finalized(
+        &mut self,
+        _context: (E, Self::Context),
+        _block: &Self::Block,
+        _captured: Self::Captured,
+        _readers: <Self::Databases as DatabaseSet<E>>::Readers,
+    ) {
+    }
+
     fn sync_targets(block: &Self::Block) -> <Self::Databases as DatabaseSet<E>>::SyncTargets {
         Target::new(block.state_root, block.range.clone())
     }

--- a/examples/reshare/src/application.rs
+++ b/examples/reshare/src/application.rs
@@ -54,7 +54,7 @@ where
     type Context = Context<sha256::Digest, ed25519::PublicKey>;
     type Block = Block;
     type Databases = Database<E>;
-    type FinalizedArtifact = ();
+    type Captured = ();
     type Provider = ();
     type Input = ReshareInput<(), MinSig, ed25519::PrivateKey>;
 
@@ -111,7 +111,7 @@ where
         Self::execute(block.height(), batches).await
     }
 
-    async fn capture_finalized(
+    async fn capture(
         &mut self,
         _context: (E, Self::Context),
         _block: &Self::Block,

--- a/glue/src/dkg/tests/reshare/harness.rs
+++ b/glue/src/dkg/tests/reshare/harness.rs
@@ -20,8 +20,8 @@ use crate::{
         reporter::MonitorReporter,
     },
     stateful::{
-        Application, Config as StatefulConfig, Input, Proposed, Stateful as StatefulActor,
-        SyncPlan,
+        Application, Config as StatefulConfig, Finalized, Input, Proposed,
+        Stateful as StatefulActor, SyncPlan,
         db::{
             DatabaseSet, Merkleized as _, Shared, SyncEngineConfig, Unmerkleized as _,
             p2p as qmdb_resolver,
@@ -375,6 +375,7 @@ impl<E: Rng + Spawner + Metrics + Clock + Storage + BufferPooler> Application<E>
     type Context = Context<sha256::Digest, ed25519::PublicKey>;
     type Block = Block;
     type Databases = Database<E>;
+    type FinalizedArtifact = ();
     type Provider = ();
     type Input = ReshareInput<(), MinPk, ed25519::PrivateKey, TestDirectory>;
 
@@ -428,10 +429,20 @@ impl<E: Rng + Spawner + Metrics + Clock + Storage + BufferPooler> Application<E>
         Self::execute(block.height(), batches).await
     }
 
+    async fn capture_finalized(
+        &mut self,
+        _context: (E, Self::Context),
+        _block: &Self::Block,
+        _batches: &<Self::Databases as DatabaseSet<E>>::Merkleized,
+        _readers: <Self::Databases as DatabaseSet<E>>::Readers,
+    ) {
+    }
+
     async fn finalized(
         &mut self,
         context: (E, Self::Context),
         block: &Self::Block,
+        _provenance: Finalized<Self::FinalizedArtifact>,
         _readers: <Self::Databases as DatabaseSet<E>>::Readers,
     ) {
         self.processed

--- a/glue/src/dkg/tests/reshare/harness.rs
+++ b/glue/src/dkg/tests/reshare/harness.rs
@@ -375,7 +375,7 @@ impl<E: Rng + Spawner + Metrics + Clock + Storage + BufferPooler> Application<E>
     type Context = Context<sha256::Digest, ed25519::PublicKey>;
     type Block = Block;
     type Databases = Database<E>;
-    type FinalizedArtifact = ();
+    type Captured = ();
     type Provider = ();
     type Input = ReshareInput<(), MinPk, ed25519::PrivateKey, TestDirectory>;
 
@@ -429,7 +429,7 @@ impl<E: Rng + Spawner + Metrics + Clock + Storage + BufferPooler> Application<E>
         Self::execute(block.height(), batches).await
     }
 
-    async fn capture_finalized(
+    async fn capture(
         &mut self,
         _context: (E, Self::Context),
         _block: &Self::Block,
@@ -442,7 +442,7 @@ impl<E: Rng + Spawner + Metrics + Clock + Storage + BufferPooler> Application<E>
         &mut self,
         context: (E, Self::Context),
         block: &Self::Block,
-        _artifact: Self::FinalizedArtifact,
+        _captured: Self::Captured,
         _readers: <Self::Databases as DatabaseSet<E>>::Readers,
     ) {
         self.processed

--- a/glue/src/dkg/tests/reshare/harness.rs
+++ b/glue/src/dkg/tests/reshare/harness.rs
@@ -20,8 +20,8 @@ use crate::{
         reporter::MonitorReporter,
     },
     stateful::{
-        Application, Config as StatefulConfig, Finalized, Input, Proposed,
-        Stateful as StatefulActor, SyncPlan,
+        Application, Config as StatefulConfig, Input, Proposed, Stateful as StatefulActor,
+        SyncPlan,
         db::{
             DatabaseSet, Merkleized as _, Shared, SyncEngineConfig, Unmerkleized as _,
             p2p as qmdb_resolver,
@@ -442,7 +442,7 @@ impl<E: Rng + Spawner + Metrics + Clock + Storage + BufferPooler> Application<E>
         &mut self,
         context: (E, Self::Context),
         block: &Self::Block,
-        _provenance: Finalized<Self::FinalizedArtifact>,
+        _artifact: Self::FinalizedArtifact,
         _readers: <Self::Databases as DatabaseSet<E>>::Readers,
     ) {
         self.processed

--- a/glue/src/stateful/actor/core/mod.rs
+++ b/glue/src/stateful/actor/core/mod.rs
@@ -403,7 +403,7 @@ mod tests {
             let (stateful, mut mailbox) = Stateful::init(
                 context.child("stateful"),
                 Config {
-                    application: TestApp,
+                    application: TestApp::default(),
                     db_config: (),
                     provider: (),
                     marshal: (marshal.mailbox, marshal.floor),
@@ -462,7 +462,7 @@ mod tests {
             let (stateful, mut mailbox) = Stateful::init(
                 context.child("stateful"),
                 Config {
-                    application: TestApp,
+                    application: TestApp::default(),
                     db_config: (),
                     provider: (),
                     marshal: (marshal.mailbox.clone(), marshal.floor),

--- a/glue/src/stateful/actor/core/processing.rs
+++ b/glue/src/stateful/actor/core/processing.rs
@@ -1,5 +1,5 @@
 use crate::stateful::{
-    Application, Input,
+    Application, Finalized, Input,
     actor::{
         core::{
             mailbox::Message,
@@ -419,6 +419,7 @@ where
                                 .drive(self.processor.notify_finalized(
                                     self.context.as_present(),
                                     block.as_ref(),
+                                    Finalized::Synchronized,
                                 ))
                                 .await;
                             acknowledgement.acknowledge();
@@ -441,9 +442,6 @@ where
                                 ))
                                 .await;
                             let Some(Applied { barrier, prune }) = applied else {
-                                // Duplicate report: marshal redelivers a processed
-                                // height only after a restart, where startup aligned
-                                // the databases to durable state.
                                 acknowledgement.acknowledge();
                                 return;
                             };
@@ -552,7 +550,7 @@ fn skip_finalized_block(skip_until: &mut Option<Height>, height: Height) -> bool
 mod tests {
     use super::{Message, Processing, VerificationRequest, skip_finalized_block};
     use crate::stateful::{
-        Application, Input, Proposed, PruneConfig,
+        Application, Finalized, Input, Proposed, PruneConfig,
         actor::{
             core::mailbox::Mailbox,
             metrics::Metrics as StatefulMetrics,
@@ -616,6 +614,7 @@ mod tests {
         type Context = <TestApp as Application<deterministic::Context>>::Context;
         type Block = TestBlock;
         type Databases = TestDatabases;
+        type FinalizedArtifact = ();
         type Provider = ();
         type Input = ();
 
@@ -669,6 +668,15 @@ mod tests {
         ) -> TestMerkleized {
             TestMerkleized
         }
+
+        async fn capture_finalized(
+            &mut self,
+            _context: (deterministic::Context, Self::Context),
+            _block: &Self::Block,
+            _batches: &TestMerkleized,
+            _readers: <Self::Databases as DatabaseSet<deterministic::Context>>::Readers,
+        ) {
+        }
     }
 
     #[derive(Clone)]
@@ -683,6 +691,7 @@ mod tests {
         type Context = <TestApp as Application<deterministic::Context>>::Context;
         type Block = TestBlock;
         type Databases = TestDatabases;
+        type FinalizedArtifact = ();
         type Provider = ();
         type Input = ();
 
@@ -733,6 +742,15 @@ mod tests {
         ) -> TestMerkleized {
             TestMerkleized
         }
+
+        async fn capture_finalized(
+            &mut self,
+            _context: (deterministic::Context, Self::Context),
+            _block: &Self::Block,
+            _batches: &TestMerkleized,
+            _readers: <Self::Databases as DatabaseSet<deterministic::Context>>::Readers,
+        ) {
+        }
     }
 
     #[derive(Clone)]
@@ -743,6 +761,8 @@ mod tests {
         gate_height: Height,
         apply_calls: Arc<AtomicUsize>,
         verify_calls: Arc<AtomicUsize>,
+        applied_finalizations: Arc<Mutex<Vec<Height>>>,
+        synchronized_finalizations: Arc<AtomicUsize>,
     }
 
     impl Application<deterministic::Context> for ReplayGatedApp {
@@ -750,6 +770,7 @@ mod tests {
         type Context = <TestApp as Application<deterministic::Context>>::Context;
         type Block = TestBlock;
         type Databases = TestDatabases;
+        type FinalizedArtifact = Height;
         type Provider = ();
         type Input = ();
 
@@ -803,12 +824,30 @@ mod tests {
             TestMerkleized
         }
 
+        async fn capture_finalized(
+            &mut self,
+            _context: (deterministic::Context, Self::Context),
+            block: &Self::Block,
+            _batches: &TestMerkleized,
+            _readers: <Self::Databases as DatabaseSet<deterministic::Context>>::Readers,
+        ) -> Self::FinalizedArtifact {
+            block.height()
+        }
+
         async fn finalized(
             &mut self,
             _context: (deterministic::Context, Self::Context),
             _block: &Self::Block,
+            provenance: Finalized<Self::FinalizedArtifact>,
             _readers: <Self::Databases as DatabaseSet<deterministic::Context>>::Readers,
         ) {
+            match provenance {
+                Finalized::Applied(height) => self.applied_finalizations.lock().push(height),
+                Finalized::Synchronized => {
+                    self.synchronized_finalizations
+                        .fetch_add(1, Ordering::SeqCst);
+                }
+            }
             let gate = self.finalized_gate.lock().take();
             if let Some(mut gate) = gate {
                 let _ = gate.started.send(());
@@ -1703,6 +1742,7 @@ mod tests {
             .await;
             let (verify_gate, verify_started, verify_release) = application_gate();
             let (finalized_gate, finalized_started, finalized_release) = application_gate();
+            let synchronized_finalizations = Arc::new(AtomicUsize::new(0));
             let app = ReplayGatedApp {
                 gates: Arc::new(Mutex::new(VecDeque::new())),
                 verify_gate: Arc::new(Mutex::new(Some(verify_gate))),
@@ -1710,6 +1750,8 @@ mod tests {
                 gate_height: finalized.height(),
                 apply_calls: Arc::new(AtomicUsize::new(0)),
                 verify_calls: Arc::new(AtomicUsize::new(0)),
+                applied_finalizations: Arc::default(),
+                synchronized_finalizations: synchronized_finalizations.clone(),
             };
             let processor = Processor::new(
                 app,
@@ -1767,10 +1809,72 @@ mod tests {
             actor.abort();
             drop(marshal.guards);
             assert!(valid);
+            assert_eq!(synchronized_finalizations.load(Ordering::SeqCst), 1);
             assert!(
                 result.is_some(),
                 "skipped finalization stalled a retained verification",
             );
+        });
+    }
+
+    #[test]
+    fn fresh_boot_genesis_is_reported_as_synchronized() {
+        deterministic::Runner::timed(Duration::from_secs(5)).start(|context| async move {
+            let genesis = TestBlock::new(0, 0);
+            let mut signing = context.child("signing");
+            let scheme =
+                scheme_mocks::fixture(&mut signing, b"fresh-boot-genesis", 1).schemes[0].clone();
+            let marshal = fixtures::marshal_fixture(
+                context.child("marshal"),
+                "fresh-boot-genesis",
+                scheme,
+                None,
+                NZUsize!(1),
+                false,
+            )
+            .await;
+            let apply_calls = Arc::new(AtomicUsize::new(0));
+            let applied_finalizations: Arc<Mutex<Vec<Height>>> = Arc::default();
+            let synchronized_finalizations = Arc::new(AtomicUsize::new(0));
+            let app = ReplayGatedApp {
+                gates: Arc::default(),
+                verify_gate: Arc::default(),
+                finalized_gate: Arc::default(),
+                gate_height: genesis.height(),
+                apply_calls: apply_calls.clone(),
+                verify_calls: Arc::new(AtomicUsize::new(0)),
+                applied_finalizations: applied_finalizations.clone(),
+                synchronized_finalizations: synchronized_finalizations.clone(),
+            };
+            let processor = Processor::new(
+                app,
+                test_databases(),
+                anchor(0, 0),
+                StatefulMetrics::new(&context),
+                None,
+            );
+            let (sender, receiver) = actor_mailbox::new(context.child("mailbox"), NZUsize!(1));
+            let mut mailbox = Mailbox::new(sender);
+            let processing = Processing {
+                context: ContextCell::new(context.child("processing")),
+                mailbox: receiver,
+                provider: (),
+                marshal: marshal.mailbox,
+                processor,
+                deferred_verifications: Vec::new(),
+                skip_finalized_until: None,
+            };
+            let actor = context.child("loop").spawn(move |_| processing.start());
+
+            let (acknowledgement, waiter) = Exact::handle();
+            let _ = mailbox.report(Update::Block(Arc::new(genesis), acknowledgement));
+            waiter.await.expect("genesis should be acknowledged");
+
+            assert_eq!(apply_calls.load(Ordering::SeqCst), 0);
+            assert!(applied_finalizations.lock().is_empty());
+            assert_eq!(synchronized_finalizations.load(Ordering::SeqCst), 1);
+            actor.abort();
+            drop(marshal.guards);
         });
     }
 
@@ -1893,6 +1997,8 @@ mod tests {
                 gate_height: parent.height(),
                 apply_calls: apply_calls.clone(),
                 verify_calls: verify_calls.clone(),
+                applied_finalizations: Arc::default(),
+                synchronized_finalizations: Arc::new(AtomicUsize::new(0)),
             };
             let processor = Processor::new(
                 app,
@@ -1991,6 +2097,8 @@ mod tests {
                 gate_height: finalized.height(),
                 apply_calls: apply_calls.clone(),
                 verify_calls: verify_calls.clone(),
+                applied_finalizations: Arc::default(),
+                synchronized_finalizations: Arc::new(AtomicUsize::new(0)),
             };
             let processor = Processor::new(
                 app,
@@ -2084,6 +2192,8 @@ mod tests {
                 gate_height: first.height(),
                 apply_calls: apply_calls.clone(),
                 verify_calls: verify_calls.clone(),
+                applied_finalizations: Arc::default(),
+                synchronized_finalizations: Arc::new(AtomicUsize::new(0)),
             };
             let processor = Processor::new(
                 app,
@@ -2190,6 +2300,8 @@ mod tests {
                 gate_height: first.height(),
                 apply_calls: Arc::new(AtomicUsize::new(0)),
                 verify_calls: Arc::new(AtomicUsize::new(0)),
+                applied_finalizations: Arc::default(),
+                synchronized_finalizations: Arc::new(AtomicUsize::new(0)),
             };
             let processor = Processor::new(
                 app,
@@ -2303,6 +2415,8 @@ mod tests {
                 gate_height: parent.height(),
                 apply_calls: apply_calls.clone(),
                 verify_calls: verify_calls.clone(),
+                applied_finalizations: Arc::default(),
+                synchronized_finalizations: Arc::new(AtomicUsize::new(0)),
             };
             let control = FlushControl::default();
             let (prune_started, prune_release) = control.gate_prune();
@@ -2650,6 +2764,109 @@ mod tests {
             let release = control.flushes.lock().remove(0);
             let _ = release.send(Ok(()));
             waiter2.await.expect("block 2 acknowledgement");
+        });
+    }
+
+    #[test]
+    fn finalized_handoff_survives_pending_sync() {
+        deterministic::Runner::timed(Duration::from_secs(10)).start(|context| async move {
+            let genesis = TestBlock::new(0, 0);
+            let block1 = TestBlock::child(&genesis, 1);
+            let block2 = TestBlock::child(&block1, 2);
+            let mut signing = context.child("signing");
+            let scheme =
+                scheme_mocks::fixture(&mut signing, b"handoff-sync-order", 1).schemes[0].clone();
+            let marshal = fixtures::marshal_fixture(
+                context.child("marshal"),
+                "handoff-sync-order",
+                scheme,
+                None,
+                NZUsize!(2),
+                false,
+            )
+            .await;
+            let (finalized_gate, finalized_started, finalized_release) = application_gate();
+            let applied_finalizations: Arc<Mutex<Vec<Height>>> = Arc::default();
+            let app = ReplayGatedApp {
+                gates: Arc::default(),
+                verify_gate: Arc::default(),
+                finalized_gate: Arc::new(Mutex::new(Some(finalized_gate))),
+                gate_height: block1.height(),
+                apply_calls: Arc::new(AtomicUsize::new(0)),
+                verify_calls: Arc::new(AtomicUsize::new(0)),
+                applied_finalizations: applied_finalizations.clone(),
+                synchronized_finalizations: Arc::new(AtomicUsize::new(0)),
+            };
+            let control = FlushControl::default();
+            let processor = Processor::new(
+                app,
+                Shared::new("test", TestDb::gated(control.clone())),
+                anchor(0, 0),
+                StatefulMetrics::new(&context),
+                None,
+            );
+            let (sender, receiver) = actor_mailbox::new(context.child("mailbox"), NZUsize!(2));
+            let mut mailbox = Mailbox::new(sender);
+            let processing = Processing {
+                context: ContextCell::new(context.child("processing")),
+                mailbox: receiver,
+                provider: (),
+                marshal: marshal.mailbox,
+                processor,
+                deferred_verifications: Vec::new(),
+                skip_finalized_until: None,
+            };
+            let actor = context.child("loop").spawn(move |_| processing.start());
+
+            let (acknowledgement, mut waiter1) = Exact::handle();
+            let _ = mailbox.report(Update::Block(Arc::new(block1), acknowledgement));
+            finalized_started
+                .await
+                .expect("finalized handoff should start");
+            assert_eq!(control.applied.load(Ordering::Relaxed), 1);
+            assert_eq!(applied_finalizations.lock().as_slice(), &[Height::new(1)],);
+            assert_eq!(control.flushes.lock().len(), 1);
+            assert!(poll!(&mut waiter1).is_pending());
+
+            finalized_release
+                .send(())
+                .expect("finalized handoff should remain active");
+
+            let (acknowledgement, mut waiter2) = Exact::handle();
+            let _ = mailbox.report(Update::Block(Arc::new(block2), acknowledgement));
+            while control.applied.load(Ordering::Relaxed) < 2 {
+                context.sleep(Duration::from_millis(10)).await;
+            }
+            assert_eq!(
+                applied_finalizations.lock().as_slice(),
+                &[Height::new(1), Height::new(2)],
+            );
+            assert_eq!(control.flushes.lock().len(), 1);
+            assert!(poll!(&mut waiter1).is_pending());
+            assert!(poll!(&mut waiter2).is_pending());
+
+            control
+                .flushes
+                .lock()
+                .remove(0)
+                .send(Ok(()))
+                .expect("first sync should remain pending");
+            waiter1.await.expect("block 1 should be acknowledged");
+            assert!(poll!(&mut waiter2).is_pending());
+
+            while control.flushes.lock().is_empty() {
+                context.sleep(Duration::from_millis(10)).await;
+            }
+            control
+                .flushes
+                .lock()
+                .remove(0)
+                .send(Ok(()))
+                .expect("successor sync should remain pending");
+            waiter2.await.expect("block 2 should be acknowledged");
+
+            actor.abort();
+            drop(marshal.guards);
         });
     }
 

--- a/glue/src/stateful/actor/core/processing.rs
+++ b/glue/src/stateful/actor/core/processing.rs
@@ -603,7 +603,7 @@ mod tests {
         type Context = <TestApp as Application<deterministic::Context>>::Context;
         type Block = TestBlock;
         type Databases = TestDatabases;
-        type FinalizedArtifact = ();
+        type Captured = ();
         type Provider = ();
         type Input = ();
 
@@ -658,7 +658,7 @@ mod tests {
             TestMerkleized
         }
 
-        async fn capture_finalized(
+        async fn capture(
             &mut self,
             _context: (deterministic::Context, Self::Context),
             _block: &Self::Block,
@@ -680,7 +680,7 @@ mod tests {
         type Context = <TestApp as Application<deterministic::Context>>::Context;
         type Block = TestBlock;
         type Databases = TestDatabases;
-        type FinalizedArtifact = ();
+        type Captured = ();
         type Provider = ();
         type Input = ();
 
@@ -732,7 +732,7 @@ mod tests {
             TestMerkleized
         }
 
-        async fn capture_finalized(
+        async fn capture(
             &mut self,
             _context: (deterministic::Context, Self::Context),
             _block: &Self::Block,
@@ -759,7 +759,7 @@ mod tests {
         type Context = <TestApp as Application<deterministic::Context>>::Context;
         type Block = TestBlock;
         type Databases = TestDatabases;
-        type FinalizedArtifact = Height;
+        type Captured = Height;
         type Provider = ();
         type Input = ();
 
@@ -813,13 +813,13 @@ mod tests {
             TestMerkleized
         }
 
-        async fn capture_finalized(
+        async fn capture(
             &mut self,
             _context: (deterministic::Context, Self::Context),
             block: &Self::Block,
             _batches: &TestMerkleized,
             _readers: <Self::Databases as DatabaseSet<deterministic::Context>>::Readers,
-        ) -> Self::FinalizedArtifact {
+        ) -> Self::Captured {
             self.capture_calls.fetch_add(1, Ordering::SeqCst);
             block.height()
         }
@@ -828,7 +828,7 @@ mod tests {
             &mut self,
             _context: (deterministic::Context, Self::Context),
             _block: &Self::Block,
-            height: Self::FinalizedArtifact,
+            height: Self::Captured,
             _readers: <Self::Databases as DatabaseSet<deterministic::Context>>::Readers,
         ) {
             self.applied_finalizations.lock().push(height);

--- a/glue/src/stateful/actor/core/processing.rs
+++ b/glue/src/stateful/actor/core/processing.rs
@@ -2798,7 +2798,7 @@ mod tests {
                 .await
                 .expect("finalized handoff should start");
             assert_eq!(control.applied.load(Ordering::Relaxed), 1);
-            assert_eq!(applied_finalizations.lock().as_slice(), &[Height::new(1)],);
+            assert_eq!(applied_finalizations.lock().as_slice(), &[Height::new(1)]);
             assert_eq!(control.flushes.lock().len(), 1);
             assert!(poll!(&mut waiter1).is_pending());
 

--- a/glue/src/stateful/actor/core/processing.rs
+++ b/glue/src/stateful/actor/core/processing.rs
@@ -1,5 +1,5 @@
 use crate::stateful::{
-    Application, Finalized, Input,
+    Application, Input,
     actor::{
         core::{
             mailbox::Message,
@@ -414,18 +414,7 @@ where
                 }) => {
                     let process = info_span!(parent: &span, "stateful.actor.finalized");
                     if skip_finalized_block(&mut self.skip_finalized_until, block.height()) {
-                        async {
-                            verifications
-                                .drive(self.processor.notify_finalized(
-                                    self.context.as_present(),
-                                    block.as_ref(),
-                                    Finalized::Synchronized,
-                                ))
-                                .await;
-                            acknowledgement.acknowledge();
-                        }
-                        .instrument(process)
-                        .await;
+                        acknowledgement.acknowledge();
                     } else {
                         let boundary = self.processor.finalization_boundary(block.as_ref());
                         let (retry, reject) = verifications
@@ -550,7 +539,7 @@ fn skip_finalized_block(skip_until: &mut Option<Height>, height: Height) -> bool
 mod tests {
     use super::{Message, Processing, VerificationRequest, skip_finalized_block};
     use crate::stateful::{
-        Application, Finalized, Input, Proposed, PruneConfig,
+        Application, Input, Proposed, PruneConfig,
         actor::{
             core::mailbox::Mailbox,
             metrics::Metrics as StatefulMetrics,
@@ -760,9 +749,9 @@ mod tests {
         finalized_gate: Arc<Mutex<Option<ApplicationGate>>>,
         gate_height: Height,
         apply_calls: Arc<AtomicUsize>,
+        capture_calls: Arc<AtomicUsize>,
         verify_calls: Arc<AtomicUsize>,
         applied_finalizations: Arc<Mutex<Vec<Height>>>,
-        synchronized_finalizations: Arc<AtomicUsize>,
     }
 
     impl Application<deterministic::Context> for ReplayGatedApp {
@@ -831,6 +820,7 @@ mod tests {
             _batches: &TestMerkleized,
             _readers: <Self::Databases as DatabaseSet<deterministic::Context>>::Readers,
         ) -> Self::FinalizedArtifact {
+            self.capture_calls.fetch_add(1, Ordering::SeqCst);
             block.height()
         }
 
@@ -838,16 +828,10 @@ mod tests {
             &mut self,
             _context: (deterministic::Context, Self::Context),
             _block: &Self::Block,
-            provenance: Finalized<Self::FinalizedArtifact>,
+            height: Self::FinalizedArtifact,
             _readers: <Self::Databases as DatabaseSet<deterministic::Context>>::Readers,
         ) {
-            match provenance {
-                Finalized::Applied(height) => self.applied_finalizations.lock().push(height),
-                Finalized::Synchronized => {
-                    self.synchronized_finalizations
-                        .fetch_add(1, Ordering::SeqCst);
-                }
-            }
+            self.applied_finalizations.lock().push(height);
             let gate = self.finalized_gate.lock().take();
             if let Some(mut gate) = gate {
                 let _ = gate.started.send(());
@@ -1741,17 +1725,18 @@ mod tests {
             )
             .await;
             let (verify_gate, verify_started, verify_release) = application_gate();
-            let (finalized_gate, finalized_started, finalized_release) = application_gate();
-            let synchronized_finalizations = Arc::new(AtomicUsize::new(0));
+            let apply_calls = Arc::new(AtomicUsize::new(0));
+            let capture_calls = Arc::new(AtomicUsize::new(0));
+            let applied_finalizations: Arc<Mutex<Vec<Height>>> = Arc::default();
             let app = ReplayGatedApp {
                 gates: Arc::new(Mutex::new(VecDeque::new())),
                 verify_gate: Arc::new(Mutex::new(Some(verify_gate))),
-                finalized_gate: Arc::new(Mutex::new(Some(finalized_gate))),
+                finalized_gate: Arc::default(),
                 gate_height: finalized.height(),
-                apply_calls: Arc::new(AtomicUsize::new(0)),
+                apply_calls: apply_calls.clone(),
+                capture_calls: capture_calls.clone(),
                 verify_calls: Arc::new(AtomicUsize::new(0)),
-                applied_finalizations: Arc::default(),
-                synchronized_finalizations: synchronized_finalizations.clone(),
+                applied_finalizations: applied_finalizations.clone(),
             };
             let processor = Processor::new(
                 app,
@@ -1785,40 +1770,29 @@ mod tests {
 
             let (acknowledgement, waiter) = Exact::handle();
             let _ = mailbox.report(Update::Block(Arc::new(finalized), acknowledgement));
-            finalized_started
-                .await
-                .expect("finalized hook should start");
-            verify_release
-                .send(())
-                .expect("child verification should remain active");
-            let result = select! {
-                valid = &mut verify_child => Some(valid),
-                _ = context.sleep(Duration::from_millis(100)) => None,
-            };
-
-            finalized_release
-                .send(())
-                .expect("finalized hook should remain active");
             waiter
                 .await
                 .expect("skipped finalized block should be acknowledged");
-            let valid = match result {
-                Some(valid) => valid,
-                None => verify_child.await,
-            };
+
+            assert!(
+                poll!(&mut verify_child).is_pending(),
+                "skipped finalization must not resolve a retained verification",
+            );
+            verify_release
+                .send(())
+                .expect("child verification should remain active");
+            let valid = verify_child.await;
             actor.abort();
             drop(marshal.guards);
             assert!(valid);
-            assert_eq!(synchronized_finalizations.load(Ordering::SeqCst), 1);
-            assert!(
-                result.is_some(),
-                "skipped finalization stalled a retained verification",
-            );
+            assert_eq!(apply_calls.load(Ordering::SeqCst), 0);
+            assert_eq!(capture_calls.load(Ordering::SeqCst), 0);
+            assert!(applied_finalizations.lock().is_empty());
         });
     }
 
     #[test]
-    fn fresh_boot_genesis_is_reported_as_synchronized() {
+    fn fresh_boot_genesis_skips_finalized_hook() {
         deterministic::Runner::timed(Duration::from_secs(5)).start(|context| async move {
             let genesis = TestBlock::new(0, 0);
             let mut signing = context.child("signing");
@@ -1834,17 +1808,17 @@ mod tests {
             )
             .await;
             let apply_calls = Arc::new(AtomicUsize::new(0));
+            let capture_calls = Arc::new(AtomicUsize::new(0));
             let applied_finalizations: Arc<Mutex<Vec<Height>>> = Arc::default();
-            let synchronized_finalizations = Arc::new(AtomicUsize::new(0));
             let app = ReplayGatedApp {
                 gates: Arc::default(),
                 verify_gate: Arc::default(),
                 finalized_gate: Arc::default(),
                 gate_height: genesis.height(),
                 apply_calls: apply_calls.clone(),
+                capture_calls: capture_calls.clone(),
                 verify_calls: Arc::new(AtomicUsize::new(0)),
                 applied_finalizations: applied_finalizations.clone(),
-                synchronized_finalizations: synchronized_finalizations.clone(),
             };
             let processor = Processor::new(
                 app,
@@ -1871,8 +1845,8 @@ mod tests {
             waiter.await.expect("genesis should be acknowledged");
 
             assert_eq!(apply_calls.load(Ordering::SeqCst), 0);
+            assert_eq!(capture_calls.load(Ordering::SeqCst), 0);
             assert!(applied_finalizations.lock().is_empty());
-            assert_eq!(synchronized_finalizations.load(Ordering::SeqCst), 1);
             actor.abort();
             drop(marshal.guards);
         });
@@ -1996,9 +1970,9 @@ mod tests {
                 finalized_gate: Arc::new(Mutex::new(Some(finalized_gate))),
                 gate_height: parent.height(),
                 apply_calls: apply_calls.clone(),
+                capture_calls: Arc::new(AtomicUsize::new(0)),
                 verify_calls: verify_calls.clone(),
                 applied_finalizations: Arc::default(),
-                synchronized_finalizations: Arc::new(AtomicUsize::new(0)),
             };
             let processor = Processor::new(
                 app,
@@ -2096,9 +2070,9 @@ mod tests {
                 finalized_gate: Arc::new(Mutex::new(None)),
                 gate_height: finalized.height(),
                 apply_calls: apply_calls.clone(),
+                capture_calls: Arc::new(AtomicUsize::new(0)),
                 verify_calls: verify_calls.clone(),
                 applied_finalizations: Arc::default(),
-                synchronized_finalizations: Arc::new(AtomicUsize::new(0)),
             };
             let processor = Processor::new(
                 app,
@@ -2191,9 +2165,9 @@ mod tests {
                 finalized_gate: Arc::new(Mutex::new(None)),
                 gate_height: first.height(),
                 apply_calls: apply_calls.clone(),
+                capture_calls: Arc::new(AtomicUsize::new(0)),
                 verify_calls: verify_calls.clone(),
                 applied_finalizations: Arc::default(),
-                synchronized_finalizations: Arc::new(AtomicUsize::new(0)),
             };
             let processor = Processor::new(
                 app,
@@ -2299,9 +2273,9 @@ mod tests {
                 finalized_gate: Arc::new(Mutex::new(Some(finalized_gate))),
                 gate_height: first.height(),
                 apply_calls: Arc::new(AtomicUsize::new(0)),
+                capture_calls: Arc::new(AtomicUsize::new(0)),
                 verify_calls: Arc::new(AtomicUsize::new(0)),
                 applied_finalizations: Arc::default(),
-                synchronized_finalizations: Arc::new(AtomicUsize::new(0)),
             };
             let processor = Processor::new(
                 app,
@@ -2414,9 +2388,9 @@ mod tests {
                 finalized_gate: Arc::new(Mutex::new(None)),
                 gate_height: parent.height(),
                 apply_calls: apply_calls.clone(),
+                capture_calls: Arc::new(AtomicUsize::new(0)),
                 verify_calls: verify_calls.clone(),
                 applied_finalizations: Arc::default(),
-                synchronized_finalizations: Arc::new(AtomicUsize::new(0)),
             };
             let control = FlushControl::default();
             let (prune_started, prune_release) = control.gate_prune();
@@ -2793,9 +2767,9 @@ mod tests {
                 finalized_gate: Arc::new(Mutex::new(Some(finalized_gate))),
                 gate_height: block1.height(),
                 apply_calls: Arc::new(AtomicUsize::new(0)),
+                capture_calls: Arc::new(AtomicUsize::new(0)),
                 verify_calls: Arc::new(AtomicUsize::new(0)),
                 applied_finalizations: applied_finalizations.clone(),
-                synchronized_finalizations: Arc::new(AtomicUsize::new(0)),
             };
             let control = FlushControl::default();
             let processor = Processor::new(

--- a/glue/src/stateful/actor/core/processing.rs
+++ b/glue/src/stateful/actor/core/processing.rs
@@ -412,10 +412,12 @@ where
                     acknowledgement,
                     retry_mailbox,
                 }) => {
-                    let process = info_span!(parent: &span, "stateful.actor.finalized");
                     if skip_finalized_block(&mut self.skip_finalized_until, block.height()) {
+                        // The block is already reflected in the database set by a
+                        // completed state sync, so there is nothing to capture or apply.
                         acknowledgement.acknowledge();
                     } else {
+                        let process = info_span!(parent: &span, "stateful.actor.finalized");
                         let boundary = self.processor.finalization_boundary(block.as_ref());
                         let (retry, reject) = verifications
                             .quiesce_where(|progress| boundary.disposition(progress))
@@ -431,6 +433,10 @@ where
                                 ))
                                 .await;
                             let Some(Applied { barrier, prune }) = applied else {
+                                // A duplicate report is the startup anchor redelivered by
+                                // marshal: genesis on a fresh boot or a newly installed
+                                // floor. Its state is durable before the actor starts, so
+                                // no barrier is needed.
                                 acknowledgement.acknowledge();
                                 return;
                             };
@@ -666,6 +672,15 @@ mod tests {
             _readers: <Self::Databases as DatabaseSet<deterministic::Context>>::Readers,
         ) {
         }
+
+        async fn finalized(
+            &mut self,
+            _context: (deterministic::Context, Self::Context),
+            _block: &Self::Block,
+            _captured: Self::Captured,
+            _readers: <Self::Databases as DatabaseSet<deterministic::Context>>::Readers,
+        ) {
+        }
     }
 
     #[derive(Clone)]
@@ -737,6 +752,15 @@ mod tests {
             _context: (deterministic::Context, Self::Context),
             _block: &Self::Block,
             _batches: &TestMerkleized,
+            _readers: <Self::Databases as DatabaseSet<deterministic::Context>>::Readers,
+        ) {
+        }
+
+        async fn finalized(
+            &mut self,
+            _context: (deterministic::Context, Self::Context),
+            _block: &Self::Block,
+            _captured: Self::Captured,
             _readers: <Self::Databases as DatabaseSet<deterministic::Context>>::Readers,
         ) {
         }
@@ -1792,7 +1816,7 @@ mod tests {
     }
 
     #[test]
-    fn fresh_boot_genesis_skips_finalized_hook() {
+    fn fresh_boot_genesis_skips_hooks() {
         deterministic::Runner::timed(Duration::from_secs(5)).start(|context| async move {
             let genesis = TestBlock::new(0, 0);
             let mut signing = context.child("signing");
@@ -2760,6 +2784,7 @@ mod tests {
             )
             .await;
             let (finalized_gate, finalized_started, finalized_release) = application_gate();
+            let capture_calls = Arc::new(AtomicUsize::new(0));
             let applied_finalizations: Arc<Mutex<Vec<Height>>> = Arc::default();
             let app = ReplayGatedApp {
                 gates: Arc::default(),
@@ -2767,7 +2792,7 @@ mod tests {
                 finalized_gate: Arc::new(Mutex::new(Some(finalized_gate))),
                 gate_height: block1.height(),
                 apply_calls: Arc::new(AtomicUsize::new(0)),
-                capture_calls: Arc::new(AtomicUsize::new(0)),
+                capture_calls: capture_calls.clone(),
                 verify_calls: Arc::new(AtomicUsize::new(0)),
                 applied_finalizations: applied_finalizations.clone(),
             };
@@ -2798,6 +2823,7 @@ mod tests {
                 .await
                 .expect("finalized handoff should start");
             assert_eq!(control.applied.load(Ordering::Relaxed), 1);
+            assert_eq!(capture_calls.load(Ordering::SeqCst), 1);
             assert_eq!(applied_finalizations.lock().as_slice(), &[Height::new(1)]);
             assert_eq!(control.flushes.lock().len(), 1);
             assert!(poll!(&mut waiter1).is_pending());
@@ -2811,6 +2837,7 @@ mod tests {
             while control.applied.load(Ordering::Relaxed) < 2 {
                 context.sleep(Duration::from_millis(10)).await;
             }
+            assert_eq!(capture_calls.load(Ordering::SeqCst), 2);
             assert_eq!(
                 applied_finalizations.lock().as_slice(),
                 &[Height::new(1), Height::new(2)],

--- a/glue/src/stateful/actor/core/syncing.rs
+++ b/glue/src/stateful/actor/core/syncing.rs
@@ -768,6 +768,8 @@ mod tests {
                 .as_mut()
                 .expect("harness must contain a sync artifact")
                 .databases = Shared::new("test", TestDb::gated(control.clone()));
+            let (application, hooks) = TestApp::observe_finalization();
+            harness.syncing.application = application;
 
             // Completion metadata must not be written until the handoff batch is durable.
             pending.arm();
@@ -826,6 +828,11 @@ mod tests {
             assert!(first_waiter.await.is_ok());
             assert!(second_waiter.await.is_ok());
             assert_eq!(control.pruned.lock().as_slice(), &[8]);
+            assert_eq!(
+                hooks.load(Ordering::SeqCst),
+                4,
+                "both applied handoff blocks must run capture and finalized",
+            );
 
             // The completed height is durable: reopen the metadata partition.
             let reopened =

--- a/glue/src/stateful/actor/core/syncing.rs
+++ b/glue/src/stateful/actor/core/syncing.rs
@@ -1,5 +1,5 @@
 use crate::stateful::{
-    Application,
+    Application, Finalized,
     actor::{
         core::{
             mailbox::Message, processing::Processing, verifications::Request as VerificationRequest,
@@ -334,7 +334,11 @@ where
                 FinalizedHandoff::Covered(block, acknowledgement)
                 | FinalizedHandoff::Reflected(block, acknowledgement) => {
                     processor
-                        .notify_finalized(self.context.as_present(), block.as_ref())
+                        .notify_finalized(
+                            self.context.as_present(),
+                            block.as_ref(),
+                            Finalized::Synchronized,
+                        )
                         .await;
                     acknowledgement.acknowledge();
                 }

--- a/glue/src/stateful/actor/core/syncing.rs
+++ b/glue/src/stateful/actor/core/syncing.rs
@@ -1,5 +1,5 @@
 use crate::stateful::{
-    Application, Finalized,
+    Application,
     actor::{
         core::{
             mailbox::Message, processing::Processing, verifications::Request as VerificationRequest,
@@ -331,15 +331,8 @@ where
 
         for handoff in handoffs {
             match handoff {
-                FinalizedHandoff::Covered(block, acknowledgement)
-                | FinalizedHandoff::Reflected(block, acknowledgement) => {
-                    processor
-                        .notify_finalized(
-                            self.context.as_present(),
-                            block.as_ref(),
-                            Finalized::Synchronized,
-                        )
-                        .await;
+                FinalizedHandoff::Covered(_, acknowledgement)
+                | FinalizedHandoff::Reflected(_, acknowledgement) => {
                     acknowledgement.acknowledge();
                 }
                 FinalizedHandoff::Apply(block, acknowledgement) => {
@@ -439,7 +432,11 @@ mod tests {
     };
     use commonware_utils::{Acknowledgement, NZUsize, acknowledgement::Exact, channel::oneshot};
     use futures::poll;
-    use std::{collections::VecDeque, sync::Arc, time::Duration};
+    use std::{
+        collections::VecDeque,
+        sync::{Arc, atomic::Ordering},
+        time::Duration,
+    };
 
     fn pending(block: TestBlock) -> PendingFinalization<Arc<TestBlock>> {
         let (acknowledgement, _waiter) = Exact::handle();
@@ -567,7 +564,7 @@ mod tests {
                 syncing: Syncing {
                     context: ContextCell::new(syncing_context.child("syncing")),
                     mailbox,
-                    application: TestApp,
+                    application: TestApp::default(),
                     provider: (),
                     marshal,
                     sync_metadata: StateSyncMetadata::init(&syncing_context, "syncing-test").await,
@@ -621,7 +618,7 @@ mod tests {
                 syncing: Syncing {
                     context: ContextCell::new(syncing_context.child("syncing")),
                     mailbox,
-                    application: TestApp,
+                    application: TestApp::default(),
                     provider: (),
                     marshal,
                     sync_metadata: StateSyncMetadata::init(&syncing_context, "syncing-test").await,
@@ -712,6 +709,35 @@ mod tests {
                 handoffs.front(),
                 Some(FinalizedHandoff::Covered(block, _)) if block.height() == Height::new(6)
             ));
+        });
+    }
+
+    #[test]
+    fn transition_skips_hooks_for_reflected_handoffs() {
+        deterministic::Runner::default().start(|context| async move {
+            let (application, hooks) = TestApp::observe_finalization();
+            let mut harness = TestHarness::new(context, anchor(7, 9)).await;
+            harness.syncing.application = application;
+
+            let (covered_acknowledgement, covered_waiter) = Exact::handle();
+            let (reflected_acknowledgement, reflected_waiter) = Exact::handle();
+            harness
+                .syncing
+                .transition([
+                    FinalizedHandoff::Covered(
+                        Arc::new(TestBlock::new(6, 8)),
+                        covered_acknowledgement,
+                    ),
+                    FinalizedHandoff::Reflected(
+                        Arc::new(TestBlock::new(7, 9)),
+                        reflected_acknowledgement,
+                    ),
+                ])
+                .await;
+
+            assert!(covered_waiter.await.is_ok());
+            assert!(reflected_waiter.await.is_ok());
+            assert_eq!(hooks.load(Ordering::SeqCst), 0);
         });
     }
 

--- a/glue/src/stateful/actor/processor/mod.rs
+++ b/glue/src/stateful/actor/processor/mod.rs
@@ -23,7 +23,7 @@
 //! digest. Proposal recovery remains actor-owned.
 
 use crate::stateful::{
-    Application, Finalized, Input, Proposed, PruneConfig,
+    Application, Input, Proposed, PruneConfig,
     actor::{core::Verification, metrics::Metrics as StatefulMetrics},
     db::{Anchor, Barrier, DatabaseSet},
 };
@@ -874,8 +874,6 @@ where
                 digest, last_processed.digest,
                 "received conflicting finalized block at processed height",
             );
-            self.notify_finalized(context, block, Finalized::Synchronized)
-                .await;
             return None;
         }
 
@@ -949,7 +947,13 @@ where
         } else {
             None
         };
-        self.notify_finalized(context, block, Finalized::Applied(artifact))
+        self.app
+            .finalized(
+                (context.child("finalized"), block.context()),
+                block,
+                artifact,
+                self.execution.databases.readers(),
+            )
             .await;
         let prune = self
             .pruning
@@ -959,24 +963,6 @@ where
         timer.observe(context);
 
         Some(Applied { barrier, prune })
-    }
-
-    /// Notify the application after a finalized block is reflected in the
-    /// database set.
-    pub(super) async fn notify_finalized(
-        &mut self,
-        context: &E,
-        block: &A::Block,
-        provenance: Finalized<A::FinalizedArtifact>,
-    ) {
-        self.app
-            .finalized(
-                (context.child("finalized"), block.context()),
-                block,
-                provenance,
-                self.execution.databases.readers(),
-            )
-            .await;
     }
 
     /// Cache merkleized pending state for a block digest.
@@ -1544,7 +1530,7 @@ mod tests {
         ReplayClaim, ReplayFlights, ReplayTracking, VerificationProgress, fetch_ancestor,
     };
     use crate::stateful::{
-        Application, Finalized, Input, Proposed, PruneConfig,
+        Application, Input, Proposed, PruneConfig,
         actor::metrics::Metrics as StatefulMetrics,
         db::{Anchor, Barrier, DatabaseSet, Merkleized as _, Shared, Unmerkleized as _},
     };
@@ -1822,16 +1808,10 @@ mod tests {
     }
 
     #[derive(Debug, PartialEq, Eq)]
-    enum FinalizedObservation {
-        Applied {
-            artifact: CapturedArtifact,
-            post_counter: u64,
-            post_height: u64,
-        },
-        Synchronized {
-            post_counter: u64,
-            post_height: u64,
-        },
+    struct FinalizedObservation {
+        artifact: CapturedArtifact,
+        post_counter: u64,
+        post_height: u64,
     }
 
     #[derive(Clone)]
@@ -1987,7 +1967,7 @@ mod tests {
             &mut self,
             _context: (deterministic::Context, Self::Context),
             block: &Self::Block,
-            provenance: Finalized<Self::FinalizedArtifact>,
+            artifact: Self::FinalizedArtifact,
             readers: <Self::Databases as DatabaseSet<deterministic::Context>>::Readers,
         ) {
             if let Some(probe) = &self.finalized_probe {
@@ -2010,16 +1990,10 @@ mod tests {
                 .map(|value| digest_to_u64(&value))
                 .expect("finalized counter should be reflected in the database set");
             drop(db);
-            let observation = match provenance {
-                Finalized::Applied(artifact) => FinalizedObservation::Applied {
-                    artifact,
-                    post_counter,
-                    post_height,
-                },
-                Finalized::Synchronized => FinalizedObservation::Synchronized {
-                    post_counter,
-                    post_height,
-                },
+            let observation = FinalizedObservation {
+                artifact,
+                post_counter,
+                post_height,
             };
             observer.lock().push(observation);
         }
@@ -2831,7 +2805,7 @@ mod tests {
             assert_durable(barrier).await;
             assert!(matches!(
                 observations.lock().as_slice(),
-                [FinalizedObservation::Applied { post_height: 1, .. }]
+                [FinalizedObservation { post_height: 1, .. }]
             ));
 
             retry_release
@@ -3792,7 +3766,7 @@ mod tests {
             assert_eq!(
                 observations.lock().as_slice(),
                 [
-                    FinalizedObservation::Applied {
+                    FinalizedObservation {
                         artifact: CapturedArtifact {
                             prior_counter: None,
                             batch_counter: 1,
@@ -3801,7 +3775,7 @@ mod tests {
                         post_counter: 1,
                         post_height: 1,
                     },
-                    FinalizedObservation::Applied {
+                    FinalizedObservation {
                         artifact: CapturedArtifact {
                             prior_counter: Some(1),
                             batch_counter: 2,
@@ -3817,7 +3791,7 @@ mod tests {
     }
 
     #[test]
-    fn execution_duplicate_finalization_is_synchronized() {
+    fn execution_duplicate_finalization_skips_finalized_hook() {
         deterministic::Runner::default().start(|context| async move {
             let (mut harness, observations) = Harness::new_with_finalized_observer(context).await;
             let genesis = Block::genesis();
@@ -3827,13 +3801,7 @@ mod tests {
             observations.lock().clear();
             assert!(!harness.finalize(block).await);
 
-            assert_eq!(
-                observations.lock().as_slice(),
-                [FinalizedObservation::Synchronized {
-                    post_counter: 1,
-                    post_height: 1,
-                }],
-            );
+            assert!(observations.lock().is_empty());
         });
     }
 

--- a/glue/src/stateful/actor/processor/mod.rs
+++ b/glue/src/stateful/actor/processor/mod.rs
@@ -23,7 +23,7 @@
 //! digest. Proposal recovery remains actor-owned.
 
 use crate::stateful::{
-    Application, Input, Proposed, PruneConfig,
+    Application, Finalized, Input, Proposed, PruneConfig,
     actor::{core::Verification, metrics::Metrics as StatefulMetrics},
     db::{Anchor, Barrier, DatabaseSet},
 };
@@ -874,6 +874,8 @@ where
                 digest, last_processed.digest,
                 "received conflicting finalized block at processed height",
             );
+            self.notify_finalized(context, block, Finalized::Synchronized)
+                .await;
             return None;
         }
 
@@ -932,13 +934,23 @@ where
         if let Some(owner) = reconstruction {
             owner.finish(Ok(()));
         }
+        let artifact = self
+            .app
+            .capture_finalized(
+                (context.child("capture_finalized"), block.context()),
+                block,
+                &batch,
+                self.execution.databases.readers(),
+            )
+            .await;
         self.execution.databases.apply(batch).await;
         let barrier = if start_sync {
             Some(self.execution.databases.finalize().await)
         } else {
             None
         };
-        self.notify_finalized(context, block).await;
+        self.notify_finalized(context, block, Finalized::Applied(artifact))
+            .await;
         let prune = self
             .pruning
             .as_mut()
@@ -949,13 +961,19 @@ where
         Some(Applied { barrier, prune })
     }
 
-    /// Notify the application that marshal delivered a finalized block already
-    /// reflected in the database set.
-    pub(super) async fn notify_finalized(&mut self, context: &E, block: &A::Block) {
+    /// Notify the application after a finalized block is reflected in the
+    /// database set.
+    pub(super) async fn notify_finalized(
+        &mut self,
+        context: &E,
+        block: &A::Block,
+        provenance: Finalized<A::FinalizedArtifact>,
+    ) {
         self.app
             .finalized(
                 (context.child("finalized"), block.context()),
                 block,
+                provenance,
                 self.execution.databases.readers(),
             )
             .await;
@@ -1526,7 +1544,7 @@ mod tests {
         ReplayClaim, ReplayFlights, ReplayTracking, VerificationProgress, fetch_ancestor,
     };
     use crate::stateful::{
-        Application, Input, Proposed, PruneConfig,
+        Application, Finalized, Input, Proposed, PruneConfig,
         actor::metrics::Metrics as StatefulMetrics,
         db::{Anchor, Barrier, DatabaseSet, Merkleized as _, Shared, Unmerkleized as _},
     };
@@ -1796,10 +1814,30 @@ mod tests {
         )
     }
 
+    #[derive(Debug, PartialEq, Eq)]
+    struct CapturedArtifact {
+        prior_counter: Option<u64>,
+        batch_counter: u64,
+        batch_height: u64,
+    }
+
+    #[derive(Debug, PartialEq, Eq)]
+    enum FinalizedObservation {
+        Applied {
+            artifact: CapturedArtifact,
+            post_counter: u64,
+            post_height: u64,
+        },
+        Synchronized {
+            post_counter: u64,
+            post_height: u64,
+        },
+    }
+
     #[derive(Clone)]
     struct ExecutionApp {
         genesis: Block,
-        finalized_observer: Option<Arc<Mutex<Vec<u64>>>>,
+        finalized_observer: Option<Arc<Mutex<Vec<FinalizedObservation>>>>,
         apply_probe: Option<ApplicationProbe>,
         finalized_probe: Option<ApplicationProbe>,
     }
@@ -1814,16 +1852,16 @@ mod tests {
             }
         }
 
-        fn with_finalized_observer() -> (Self, Arc<Mutex<Vec<u64>>>) {
-            let finalized_values = Arc::new(Mutex::new(Vec::new()));
+        fn with_finalized_observer() -> (Self, Arc<Mutex<Vec<FinalizedObservation>>>) {
+            let observations = Arc::new(Mutex::new(Vec::new()));
             (
                 Self {
                     genesis: Block::genesis(),
-                    finalized_observer: Some(finalized_values.clone()),
+                    finalized_observer: Some(observations.clone()),
                     apply_probe: None,
                     finalized_probe: None,
                 },
-                finalized_values,
+                observations,
             )
         }
 
@@ -1849,6 +1887,7 @@ mod tests {
         type Context = TestContext;
         type Block = Block;
         type Databases = DbSet<deterministic::Context>;
+        type FinalizedArtifact = CapturedArtifact;
         type Provider = ();
         type Input = ();
 
@@ -1910,25 +1949,79 @@ mod tests {
             Self::execute(block.height(), block.context.round.view(), batches).await
         }
 
+        async fn capture_finalized(
+            &mut self,
+            _context: (deterministic::Context, Self::Context),
+            block: &Self::Block,
+            batches: &TestMerkleized,
+            readers: <Self::Databases as DatabaseSet<deterministic::Context>>::Readers,
+        ) -> Self::FinalizedArtifact {
+            let prior_counter = readers
+                .read()
+                .await
+                .get(&counter_key())
+                .await
+                .expect("database read should succeed")
+                .map(|value| digest_to_u64(&value));
+            let pending = batches.new_batch();
+            let batch_counter = pending
+                .get(&counter_key())
+                .await
+                .expect("batch read should succeed")
+                .map(|value| digest_to_u64(&value))
+                .expect("winning batch should contain a counter");
+            let batch_height = pending
+                .get(&height_key(block.height()))
+                .await
+                .expect("batch read should succeed")
+                .map(|value| digest_to_u64(&value))
+                .expect("winning batch should contain its height");
+            CapturedArtifact {
+                prior_counter,
+                batch_counter,
+                batch_height,
+            }
+        }
+
         async fn finalized(
             &mut self,
             _context: (deterministic::Context, Self::Context),
             block: &Self::Block,
+            provenance: Finalized<Self::FinalizedArtifact>,
             readers: <Self::Databases as DatabaseSet<deterministic::Context>>::Readers,
         ) {
             if let Some(probe) = &self.finalized_probe {
                 probe.call(block.digest()).await;
             }
-            let Some(observer) = self.finalized_observer.clone() else {
+            let Some(observer) = &self.finalized_observer else {
                 return;
             };
             let db = readers.read().await;
-            let value = db
+            let post_height = db
                 .get(&height_key(block.height()))
                 .await
                 .expect("database read should succeed")
+                .map(|value| digest_to_u64(&value))
                 .expect("finalized height should be reflected in the database set");
-            observer.lock().push(digest_to_u64(&value));
+            let post_counter = db
+                .get(&counter_key())
+                .await
+                .expect("database read should succeed")
+                .map(|value| digest_to_u64(&value))
+                .expect("finalized counter should be reflected in the database set");
+            drop(db);
+            let observation = match provenance {
+                Finalized::Applied(artifact) => FinalizedObservation::Applied {
+                    artifact,
+                    post_counter,
+                    post_height,
+                },
+                Finalized::Synchronized => FinalizedObservation::Synchronized {
+                    post_counter,
+                    post_height,
+                },
+            };
+            observer.lock().push(observation);
         }
 
         fn sync_targets(
@@ -2028,13 +2121,13 @@ mod tests {
 
         async fn new_with_finalized_observer(
             context: deterministic::Context,
-        ) -> (Self, Arc<Mutex<Vec<u64>>>) {
+        ) -> (Self, Arc<Mutex<Vec<FinalizedObservation>>>) {
             let provider = MapProvider::default();
             let config = qmdb_config(&next_partition_prefix(), &context);
-            let (app, finalized_values) = ExecutionApp::with_finalized_observer();
+            let (app, observations) = ExecutionApp::with_finalized_observer();
             (
                 Self::with_app(context, provider, config, app).await,
-                finalized_values,
+                observations,
             )
         }
 
@@ -2655,8 +2748,7 @@ mod tests {
     #[test]
     fn finalized_reader_preserves_retained_replay_base() {
         deterministic::Runner::timed(Duration::from_secs(5)).start(|context| async move {
-            let (mut harness, finalized_values) =
-                Harness::new_with_finalized_observer(context).await;
+            let (mut harness, observations) = Harness::new_with_finalized_observer(context).await;
             let genesis = Block::genesis();
             let parent = harness.stage_pending_child(&genesis, View::new(1)).await;
             let (child, _) = harness.build_child(&parent, View::new(2)).await;
@@ -2737,7 +2829,10 @@ mod tests {
                 .await
                 .expect("finalized block should be newly applied");
             assert_durable(barrier).await;
-            assert_eq!(finalized_values.lock().as_slice(), [1]);
+            assert!(matches!(
+                observations.lock().as_slice(),
+                [FinalizedObservation::Applied { post_height: 1, .. }]
+            ));
 
             retry_release
                 .send(())
@@ -3675,43 +3770,69 @@ mod tests {
     }
 
     #[test]
-    fn execution_finalized_hook_runs_for_each_applied_block() {
+    fn execution_finalized_handoff_preserves_cached_and_reconstructed_artifacts() {
         deterministic::Runner::default().start(|context| async move {
-            let (mut harness, finalized_values) =
+            let (mut harness, observations) =
                 Harness::new_with_finalized_observer(context).await;
             let genesis = Block::genesis();
             let block1 = harness.stage_pending_child(&genesis, View::new(1)).await;
             let block2 = harness.stage_pending_child(&block1, View::new(2)).await;
 
             assert!(harness.finalize(block1).await);
+            harness.processor.clear_pending();
+            let probe = ApplicationProbe::new(block2.digest(), []);
+            harness.processor.app.apply_probe = Some(probe.clone());
             assert!(harness.finalize(block2).await);
             assert_eq!(
-                finalized_values.lock().clone(),
-                vec![1, 2],
-                "finalized hook should observe every applied block",
+                probe.calls(),
+                1,
+                "block2 should be reconstructed through Application::apply",
+            );
+
+            assert_eq!(
+                observations.lock().as_slice(),
+                [
+                    FinalizedObservation::Applied {
+                        artifact: CapturedArtifact {
+                            prior_counter: None,
+                            batch_counter: 1,
+                            batch_height: 1,
+                        },
+                        post_counter: 1,
+                        post_height: 1,
+                    },
+                    FinalizedObservation::Applied {
+                        artifact: CapturedArtifact {
+                            prior_counter: Some(1),
+                            batch_counter: 2,
+                            batch_height: 2,
+                        },
+                        post_counter: 2,
+                        post_height: 2,
+                    },
+                ],
+                "capture should see pre-apply state and finalized should receive the artifact after apply",
             );
         });
     }
 
     #[test]
-    fn execution_finalized_hook_runs_for_already_reflected_block() {
+    fn execution_duplicate_finalization_is_synchronized() {
         deterministic::Runner::default().start(|context| async move {
-            let (mut harness, finalized_values) =
-                Harness::new_with_finalized_observer(context).await;
+            let (mut harness, observations) = Harness::new_with_finalized_observer(context).await;
             let genesis = Block::genesis();
-            let block1 = harness.stage_pending_child(&genesis, View::new(1)).await;
+            let block = harness.stage_pending_child(&genesis, View::new(1)).await;
 
-            assert!(harness.finalize(block1.clone()).await);
+            assert!(harness.finalize(block.clone()).await);
+            observations.lock().clear();
+            assert!(!harness.finalize(block).await);
 
-            finalized_values.lock().clear();
-            harness
-                .processor
-                .notify_finalized(harness.context_cell.as_present(), &block1)
-                .await;
             assert_eq!(
-                finalized_values.lock().clone(),
-                vec![1],
-                "finalized hook should run for blocks already reflected in the database set",
+                observations.lock().as_slice(),
+                [FinalizedObservation::Synchronized {
+                    post_counter: 1,
+                    post_height: 1,
+                }],
             );
         });
     }

--- a/glue/src/stateful/actor/processor/mod.rs
+++ b/glue/src/stateful/actor/processor/mod.rs
@@ -1804,14 +1804,14 @@ mod tests {
     struct CapturedArtifact {
         prior_counter: Option<u64>,
         batch_counter: u64,
-        batch_height: u64,
+        batch_view: u64,
     }
 
     #[derive(Debug, PartialEq, Eq)]
     struct FinalizedObservation {
         artifact: CapturedArtifact,
         post_counter: u64,
-        post_height: u64,
+        post_view: u64,
     }
 
     #[derive(Clone)]
@@ -1950,16 +1950,16 @@ mod tests {
                 .expect("batch read should succeed")
                 .map(|value| digest_to_u64(&value))
                 .expect("winning batch should contain a counter");
-            let batch_height = pending
+            let batch_view = pending
                 .get(&height_key(block.height()))
                 .await
                 .expect("batch read should succeed")
                 .map(|value| digest_to_u64(&value))
-                .expect("winning batch should contain its height");
+                .expect("winning batch should contain its view");
             CapturedArtifact {
                 prior_counter,
                 batch_counter,
-                batch_height,
+                batch_view,
             }
         }
 
@@ -1977,12 +1977,12 @@ mod tests {
                 return;
             };
             let db = readers.read().await;
-            let post_height = db
+            let post_view = db
                 .get(&height_key(block.height()))
                 .await
                 .expect("database read should succeed")
                 .map(|value| digest_to_u64(&value))
-                .expect("finalized height should be reflected in the database set");
+                .expect("finalized view should be reflected in the database set");
             let post_counter = db
                 .get(&counter_key())
                 .await
@@ -1993,7 +1993,7 @@ mod tests {
             let observation = FinalizedObservation {
                 artifact,
                 post_counter,
-                post_height,
+                post_view,
             };
             observer.lock().push(observation);
         }
@@ -2203,7 +2203,7 @@ mod tests {
             prune
         }
 
-        async fn height_value(&self, height: Height) -> Option<u64> {
+        async fn view_at_height(&self, height: Height) -> Option<u64> {
             let db = self.processor.databases().read().await;
             db.get(&height_key(height))
                 .await
@@ -2219,7 +2219,7 @@ mod tests {
                 .map(|value| digest_to_u64(&value))
         }
 
-        async fn reopen_height_value(
+        async fn reopen_view_at_height(
             &self,
             context: deterministic::Context,
             height: Height,
@@ -2465,7 +2465,7 @@ mod tests {
                 "losing fork at finalized round should be pruned",
             );
             assert_eq!(harness.processor.last_processed().digest, winner.digest());
-            assert_eq!(harness.height_value(Height::new(2)).await, Some(3));
+            assert_eq!(harness.view_at_height(Height::new(2)).await, Some(3));
         });
     }
 
@@ -2805,7 +2805,7 @@ mod tests {
             assert_durable(barrier).await;
             assert!(matches!(
                 observations.lock().as_slice(),
-                [FinalizedObservation { post_height: 1, .. }]
+                [FinalizedObservation { post_view: 1, .. }]
             ));
 
             retry_release
@@ -3735,7 +3735,7 @@ mod tests {
             assert_eq!(harness.counter_value().await, Some(1));
             assert_eq!(
                 harness
-                    .reopen_height_value(context.child("reopen"), Height::new(1))
+                    .reopen_view_at_height(context.child("reopen"), Height::new(1))
                     .await,
                 Some(1),
                 "height state should survive reopen after finalization",
@@ -3749,16 +3749,23 @@ mod tests {
             let (mut harness, observations) =
                 Harness::new_with_finalized_observer(context).await;
             let genesis = Block::genesis();
-            let block1 = harness.stage_pending_child(&genesis, View::new(1)).await;
-            let block2 = harness.stage_pending_child(&block1, View::new(2)).await;
+            let block1 = harness.stage_pending_child(&genesis, View::new(7)).await;
+            let block2 = harness.stage_pending_child(&block1, View::new(11)).await;
 
+            let cached_probe = ApplicationProbe::new(block1.digest(), []);
+            harness.processor.app.apply_probe = Some(cached_probe.clone());
             assert!(harness.finalize(block1).await);
+            assert_eq!(
+                cached_probe.calls(),
+                0,
+                "block1 should use its cached merkleized batch",
+            );
             harness.processor.clear_pending();
-            let probe = ApplicationProbe::new(block2.digest(), []);
-            harness.processor.app.apply_probe = Some(probe.clone());
+            let reconstructed_probe = ApplicationProbe::new(block2.digest(), []);
+            harness.processor.app.apply_probe = Some(reconstructed_probe.clone());
             assert!(harness.finalize(block2).await);
             assert_eq!(
-                probe.calls(),
+                reconstructed_probe.calls(),
                 1,
                 "block2 should be reconstructed through Application::apply",
             );
@@ -3770,19 +3777,19 @@ mod tests {
                         artifact: CapturedArtifact {
                             prior_counter: None,
                             batch_counter: 1,
-                            batch_height: 1,
+                            batch_view: 7,
                         },
                         post_counter: 1,
-                        post_height: 1,
+                        post_view: 7,
                     },
                     FinalizedObservation {
                         artifact: CapturedArtifact {
                             prior_counter: Some(1),
                             batch_counter: 2,
-                            batch_height: 2,
+                            batch_view: 11,
                         },
                         post_counter: 2,
-                        post_height: 2,
+                        post_view: 11,
                     },
                 ],
                 "capture should see pre-apply state and finalized should receive the artifact after apply",

--- a/glue/src/stateful/actor/processor/mod.rs
+++ b/glue/src/stateful/actor/processor/mod.rs
@@ -932,10 +932,10 @@ where
         if let Some(owner) = reconstruction {
             owner.finish(Ok(()));
         }
-        let artifact = self
+        let captured = self
             .app
-            .capture_finalized(
-                (context.child("capture_finalized"), block.context()),
+            .capture(
+                (context.child("capture"), block.context()),
                 block,
                 &batch,
                 self.execution.databases.readers(),
@@ -951,7 +951,7 @@ where
             .finalized(
                 (context.child("finalized"), block.context()),
                 block,
-                artifact,
+                captured,
                 self.execution.databases.readers(),
             )
             .await;
@@ -1801,7 +1801,7 @@ mod tests {
     }
 
     #[derive(Debug, PartialEq, Eq)]
-    struct CapturedArtifact {
+    struct Captured {
         prior_counter: Option<u64>,
         batch_counter: u64,
         batch_view: u64,
@@ -1809,7 +1809,7 @@ mod tests {
 
     #[derive(Debug, PartialEq, Eq)]
     struct FinalizedObservation {
-        artifact: CapturedArtifact,
+        captured: Captured,
         post_counter: u64,
         post_view: u64,
     }
@@ -1867,7 +1867,7 @@ mod tests {
         type Context = TestContext;
         type Block = Block;
         type Databases = DbSet<deterministic::Context>;
-        type FinalizedArtifact = CapturedArtifact;
+        type Captured = Captured;
         type Provider = ();
         type Input = ();
 
@@ -1929,13 +1929,13 @@ mod tests {
             Self::execute(block.height(), block.context.round.view(), batches).await
         }
 
-        async fn capture_finalized(
+        async fn capture(
             &mut self,
             _context: (deterministic::Context, Self::Context),
             block: &Self::Block,
             batches: &TestMerkleized,
             readers: <Self::Databases as DatabaseSet<deterministic::Context>>::Readers,
-        ) -> Self::FinalizedArtifact {
+        ) -> Self::Captured {
             let prior_counter = readers
                 .read()
                 .await
@@ -1956,7 +1956,7 @@ mod tests {
                 .expect("batch read should succeed")
                 .map(|value| digest_to_u64(&value))
                 .expect("winning batch should contain its view");
-            CapturedArtifact {
+            Captured {
                 prior_counter,
                 batch_counter,
                 batch_view,
@@ -1967,7 +1967,7 @@ mod tests {
             &mut self,
             _context: (deterministic::Context, Self::Context),
             block: &Self::Block,
-            artifact: Self::FinalizedArtifact,
+            captured: Self::Captured,
             readers: <Self::Databases as DatabaseSet<deterministic::Context>>::Readers,
         ) {
             if let Some(probe) = &self.finalized_probe {
@@ -1991,7 +1991,7 @@ mod tests {
                 .expect("finalized counter should be reflected in the database set");
             drop(db);
             let observation = FinalizedObservation {
-                artifact,
+                captured,
                 post_counter,
                 post_view,
             };
@@ -3744,7 +3744,7 @@ mod tests {
     }
 
     #[test]
-    fn execution_finalized_handoff_preserves_cached_and_reconstructed_artifacts() {
+    fn execution_finalized_handoff_preserves_cached_and_reconstructed_captures() {
         deterministic::Runner::default().start(|context| async move {
             let (mut harness, observations) =
                 Harness::new_with_finalized_observer(context).await;
@@ -3774,7 +3774,7 @@ mod tests {
                 observations.lock().as_slice(),
                 [
                     FinalizedObservation {
-                        artifact: CapturedArtifact {
+                        captured: Captured {
                             prior_counter: None,
                             batch_counter: 1,
                             batch_view: 7,
@@ -3783,7 +3783,7 @@ mod tests {
                         post_view: 7,
                     },
                     FinalizedObservation {
-                        artifact: CapturedArtifact {
+                        captured: Captured {
                             prior_counter: Some(1),
                             batch_counter: 2,
                             batch_view: 11,
@@ -3792,7 +3792,7 @@ mod tests {
                         post_view: 11,
                     },
                 ],
-                "capture should see pre-apply state and finalized should receive the artifact after apply",
+                "capture should see pre-apply state and finalized should receive the captured value after apply",
             );
         });
     }

--- a/glue/src/stateful/actor/processor/mod.rs
+++ b/glue/src/stateful/actor/processor/mod.rs
@@ -3798,7 +3798,7 @@ mod tests {
     }
 
     #[test]
-    fn execution_duplicate_finalization_skips_finalized_hook() {
+    fn execution_duplicate_finalization_skips_hooks() {
         deterministic::Runner::default().start(|context| async move {
             let (mut harness, observations) = Harness::new_with_finalized_observer(context).await;
             let genesis = Block::genesis();

--- a/glue/src/stateful/actor/syncer/actor.rs
+++ b/glue/src/stateful/actor/syncer/actor.rs
@@ -343,6 +343,7 @@ mod tests {
         type Context = SimplexContext<Sha256Digest, ed25519::PublicKey>;
         type Block = TestBlock;
         type Databases = WedgeSet;
+        type FinalizedArtifact = ();
         type Provider = ();
         type Input = ();
 
@@ -380,6 +381,16 @@ mod tests {
             _block: &Self::Block,
             _batches: TestUnmerkleized,
         ) -> TestMerkleized {
+            unreachable!("WedgeApp only serves the syncer harness")
+        }
+
+        async fn capture_finalized(
+            &mut self,
+            _context: (deterministic::Context, Self::Context),
+            _block: &Self::Block,
+            _batches: &TestMerkleized,
+            _readers: <Self::Databases as DatabaseSet<deterministic::Context>>::Readers,
+        ) {
             unreachable!("WedgeApp only serves the syncer harness")
         }
     }

--- a/glue/src/stateful/actor/syncer/actor.rs
+++ b/glue/src/stateful/actor/syncer/actor.rs
@@ -393,6 +393,16 @@ mod tests {
         ) {
             unreachable!("WedgeApp only serves the syncer harness")
         }
+
+        async fn finalized(
+            &mut self,
+            _context: (deterministic::Context, Self::Context),
+            _block: &Self::Block,
+            _captured: Self::Captured,
+            _readers: <Self::Databases as DatabaseSet<deterministic::Context>>::Readers,
+        ) {
+            unreachable!("WedgeApp only serves the syncer harness")
+        }
     }
 
     #[test]

--- a/glue/src/stateful/actor/syncer/actor.rs
+++ b/glue/src/stateful/actor/syncer/actor.rs
@@ -343,7 +343,7 @@ mod tests {
         type Context = SimplexContext<Sha256Digest, ed25519::PublicKey>;
         type Block = TestBlock;
         type Databases = WedgeSet;
-        type FinalizedArtifact = ();
+        type Captured = ();
         type Provider = ();
         type Input = ();
 
@@ -384,7 +384,7 @@ mod tests {
             unreachable!("WedgeApp only serves the syncer harness")
         }
 
-        async fn capture_finalized(
+        async fn capture(
             &mut self,
             _context: (deterministic::Context, Self::Context),
             _block: &Self::Block,

--- a/glue/src/stateful/db/mod.rs
+++ b/glue/src/stateful/db/mod.rs
@@ -10,7 +10,7 @@
 //! 2. [`Merkleized`]: a sealed batch with a computed root.
 //! 3. Finalization applies the sealed batch via [`ManagedDb::apply`]. It then requests durability
 //!    via [`ManagedDb::finalize`] and observes completion through [`Barrier`]. A barrier covers the
-//!    state applied before it was requested. Later batches may reach storage while it is pending.
+//!    state applied before it was requested. Later batches may be applied while it is pending.
 //!
 //! [`DatabaseSet`] groups one or more [`ManagedDb`] instances into one logical
 //! unit for execution and commit.

--- a/glue/src/stateful/db/mod.rs
+++ b/glue/src/stateful/db/mod.rs
@@ -193,7 +193,7 @@ impl<DB> Shared<DB> {
 /// Unlike [`Shared`], this handle cannot acquire a write slot, construct or
 /// apply batches, finalize database state, prune, or rewind. Applications
 /// receive readers in
-/// [`Application::capture_finalized`](super::Application::capture_finalized)
+/// [`Application::capture`](super::Application::capture)
 /// and [`Application::finalized`](super::Application::finalized) so observing
 /// finalized state cannot invalidate concurrent speculative batches.
 ///

--- a/glue/src/stateful/db/mod.rs
+++ b/glue/src/stateful/db/mod.rs
@@ -8,9 +8,9 @@
 //! Normal execution has three stages:
 //! 1. [`Unmerkleized`]: mutable, in-progress batch (concrete types expose reads and writes).
 //! 2. [`Merkleized`]: a sealed batch with a computed root.
-//! 3. Finalization: apply the sealed batch via [`ManagedDb::apply`], then
-//!    start persisting applied state via [`ManagedDb::finalize`], observing
-//!    durability via [`Barrier`].
+//! 3. Finalization applies the sealed batch via [`ManagedDb::apply`]. It then requests durability
+//!    via [`ManagedDb::finalize`] and observes completion through [`Barrier`]. A barrier covers the
+//!    state applied before it was requested. Later batches may reach storage while it is pending.
 //!
 //! [`DatabaseSet`] groups one or more [`ManagedDb`] instances into one logical
 //! unit for execution and commit.
@@ -193,7 +193,8 @@ impl<DB> Shared<DB> {
 /// Unlike [`Shared`], this handle cannot acquire a write slot, construct or
 /// apply batches, finalize database state, prune, or rewind. Applications
 /// receive readers in
-/// [`Application::finalized`](super::Application::finalized) so observing
+/// [`Application::capture_finalized`](super::Application::capture_finalized)
+/// and [`Application::finalized`](super::Application::finalized) so observing
 /// finalized state cannot invalidate concurrent speculative batches.
 ///
 /// ```compile_fail

--- a/glue/src/stateful/mod.rs
+++ b/glue/src/stateful/mod.rs
@@ -177,7 +177,7 @@ where
     /// Owned data captured from winning batches before they are applied.
     ///
     /// Applications with nothing to capture use `()`.
-    type FinalizedArtifact: Send;
+    type Captured: Send;
 
     /// The stateful-owned provider, supplied through
     /// [`Config::provider`](crate::stateful::Config::provider).
@@ -319,7 +319,7 @@ where
     /// Only reads completed through `readers` during this call are guaranteed
     /// to observe database state before `batches`. Retain owned values instead
     /// of reader handles when the pre-apply state is required later. The
-    /// returned artifact is passed unchanged to [`finalized`](Self::finalized)
+    /// returned value is passed unchanged to [`finalized`](Self::finalized)
     /// after the batches are applied.
     ///
     /// This future and [`finalized`](Self::finalized) are awaited on the
@@ -327,21 +327,21 @@ where
     /// mailbox messages while either is pending. Keep this capture cheap and
     /// spawn expensive follow-on work from `finalized` instead of awaiting it
     /// on this path. Applications with nothing to capture return `()`.
-    fn capture_finalized(
+    fn capture(
         &mut self,
         context: (E, Self::Context),
         block: &Self::Block,
         batches: &<Self::Databases as DatabaseSet<E>>::Merkleized,
         readers: <Self::Databases as DatabaseSet<E>>::Readers,
-    ) -> impl Future<Output = Self::FinalizedArtifact> + Send;
+    ) -> impl Future<Output = Self::Captured> + Send;
 
     /// Observe a finalized block after its winning batches are applied.
     ///
     /// The wrapper calls this after every successful [`DatabaseSet::apply`] in
-    /// application order. `artifact` is the value returned by
-    /// [`capture_finalized`](Self::capture_finalized) for the exact applied
-    /// batches. The block's state is readable from the databases, but durability
-    /// through that block may still be pending. A database barrier may run
+    /// application order. `captured` is the value returned by
+    /// [`capture`](Self::capture) for the exact applied batches. The block's
+    /// state is readable from the databases, but durability through that block
+    /// may still be pending. A database barrier may run
     /// concurrently with this future. The wrapper releases the block's marshal
     /// acknowledgement only after this future resolves and a barrier covering
     /// the block completes.
@@ -366,7 +366,7 @@ where
         &mut self,
         _context: (E, Self::Context),
         _block: &Self::Block,
-        _artifact: Self::FinalizedArtifact,
+        _captured: Self::Captured,
         _readers: <Self::Databases as DatabaseSet<E>>::Readers,
     ) -> impl Future<Output = ()> + Send {
         async {}

--- a/glue/src/stateful/mod.rs
+++ b/glue/src/stateful/mod.rs
@@ -135,6 +135,19 @@ pub struct Input<Upstream, Provider> {
     pub provider: Provider,
 }
 
+/// Describes whether a finalized notification applied winning batches.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Finalized<T> {
+    /// The block's winning batches were captured and applied.
+    Applied(T),
+
+    /// The block was already reflected without winning batches to capture.
+    ///
+    /// This includes startup anchors, recovery alignment, and completed state
+    /// sync. It does not identify which path reflected the block.
+    Synchronized,
+}
+
 /// A stateful application whose storage is managed by a [`DatabaseSet`].
 ///
 /// Implementors receive [`DatabaseSet::Unmerkleized`] batches and
@@ -173,6 +186,11 @@ where
 
     /// The set of databases managed on behalf of this application.
     type Databases: DatabaseSet<E>;
+
+    /// Owned data captured from winning batches before they are applied.
+    ///
+    /// Applications with nothing to capture use `()`.
+    type FinalizedArtifact: Send + 'static;
 
     /// The stateful-owned provider, supplied through
     /// [`Config::provider`](crate::stateful::Config::provider).
@@ -305,17 +323,41 @@ where
         batches: <Self::Databases as DatabaseSet<E>>::Unmerkleized,
     ) -> impl Future<Output = <Self::Databases as DatabaseSet<E>>::Merkleized> + Send;
 
+    /// Capture data from winning batches before they are applied.
+    ///
+    /// Only reads completed through `readers` during this call are guaranteed
+    /// to observe database state before `batches`. Retain owned values instead
+    /// of reader handles when the pre-apply state is required later. The
+    /// returned artifact is passed unchanged to [`finalized`](Self::finalized)
+    /// after the batches are applied.
+    ///
+    /// Finalization of this block and every later block waits for this future.
+    /// Keep it to cheap reads and defer expensive work behind the durable
+    /// handoff. Applications with nothing to capture return `()`.
+    fn capture_finalized(
+        &mut self,
+        context: (E, Self::Context),
+        block: &Self::Block,
+        batches: &<Self::Databases as DatabaseSet<E>>::Merkleized,
+        readers: <Self::Databases as DatabaseSet<E>>::Readers,
+    ) -> impl Future<Output = Self::FinalizedArtifact> + Send;
+
     /// Observe a finalized block after it is reflected in the database set.
     ///
     /// Once the database set is ready, the wrapper calls this for every
     /// finalized block it receives from marshal before releasing that block's
     /// marshal acknowledgement. Blocks applied through normal processing are
-    /// reported after [`DatabaseSet::apply`] succeeds: the block's state is
+    /// reported after [`DatabaseSet::apply`] succeeds. The block's state is
     /// readable from the databases, but durability through that block may still
-    /// be pending. When an earlier database sync is active, the sync covering
-    /// this block may not have started yet. Blocks already reflected by startup
-    /// reconciliation or completed state sync are reported without reapplying
-    /// them.
+    /// be pending. A database barrier may run concurrently with this future.
+    /// The wrapper releases the block's marshal acknowledgement only after this
+    /// future resolves and a barrier covering the block completes.
+    ///
+    /// [`Finalized::Applied`] carries the artifact captured from the exact
+    /// batches applied for this notification. [`Finalized::Synchronized`]
+    /// means the block was already reflected and no winning batches were
+    /// available. This can occur for the startup anchor on a fresh boot, after
+    /// recovery alignment, or following completed state sync.
     ///
     /// During peer state sync, a finalized block may be absorbed into a recorded sync target and
     /// acknowledged without invoking this hook. Blocks still pending when sync completes are
@@ -327,10 +369,10 @@ where
     /// descendants. Result-affecting mutations must be made through normal block
     /// execution, not from this observer.
     ///
-    /// For blocks that are reported, this is an at-least-once notification inherited from
-    /// marshal's reporter stream: a crash after this hook runs but before a database sync covering
-    /// the block and marshal's processed position are durable may cause the same block to be
-    /// reported again.
+    /// For blocks that are reported, this is an at-least-once notification
+    /// inherited from marshal's reporter stream. A crash after this hook runs
+    /// but before a database sync covering the block and marshal's processed
+    /// position are durable may cause the same block to be reported again.
     ///
     /// # Panics
     ///
@@ -339,6 +381,7 @@ where
         &mut self,
         _context: (E, Self::Context),
         _block: &Self::Block,
+        _provenance: Finalized<Self::FinalizedArtifact>,
         _readers: <Self::Databases as DatabaseSet<E>>::Readers,
     ) -> impl Future<Output = ()> + Send {
         async {}

--- a/glue/src/stateful/mod.rs
+++ b/glue/src/stateful/mod.rs
@@ -322,9 +322,11 @@ where
     /// returned artifact is passed unchanged to [`finalized`](Self::finalized)
     /// after the batches are applied.
     ///
-    /// Finalization of this block and every later block waits for this future.
-    /// Keep it to cheap reads and defer expensive work behind the durable
-    /// handoff. Applications with nothing to capture return `()`.
+    /// This future and [`finalized`](Self::finalized) are awaited on the
+    /// stateful actor's serial mailbox path. The actor cannot process other
+    /// mailbox messages while either is pending. Keep this capture cheap and
+    /// spawn expensive follow-on work from `finalized` instead of awaiting it
+    /// on this path. Applications with nothing to capture return `()`.
     fn capture_finalized(
         &mut self,
         context: (E, Self::Context),

--- a/glue/src/stateful/mod.rs
+++ b/glue/src/stateful/mod.rs
@@ -135,19 +135,6 @@ pub struct Input<Upstream, Provider> {
     pub provider: Provider,
 }
 
-/// Describes whether a finalized notification applied winning batches.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum Finalized<T> {
-    /// The block's winning batches were captured and applied.
-    Applied(T),
-
-    /// The block was already reflected without winning batches to capture.
-    ///
-    /// This includes startup anchors, recovery alignment, and completed state
-    /// sync. It does not identify which path reflected the block.
-    Synchronized,
-}
-
 /// A stateful application whose storage is managed by a [`DatabaseSet`].
 ///
 /// Implementors receive [`DatabaseSet::Unmerkleized`] batches and
@@ -190,7 +177,7 @@ where
     /// Owned data captured from winning batches before they are applied.
     ///
     /// Applications with nothing to capture use `()`.
-    type FinalizedArtifact: Send + 'static;
+    type FinalizedArtifact: Send;
 
     /// The stateful-owned provider, supplied through
     /// [`Config::provider`](crate::stateful::Config::provider).
@@ -325,6 +312,10 @@ where
 
     /// Capture data from winning batches before they are applied.
     ///
+    /// The wrapper calls this immediately before applying each winning batch
+    /// set. It does not call this for blocks merely reflected through recovery
+    /// or state sync.
+    ///
     /// Only reads completed through `readers` during this call are guaranteed
     /// to observe database state before `batches`. Retain owned values instead
     /// of reader handles when the pre-apply state is required later. The
@@ -342,37 +333,29 @@ where
         readers: <Self::Databases as DatabaseSet<E>>::Readers,
     ) -> impl Future<Output = Self::FinalizedArtifact> + Send;
 
-    /// Observe a finalized block after it is reflected in the database set.
+    /// Observe a finalized block after its winning batches are applied.
     ///
-    /// Once the database set is ready, the wrapper calls this for every
-    /// finalized block it receives from marshal before releasing that block's
-    /// marshal acknowledgement. Blocks applied through normal processing are
-    /// reported after [`DatabaseSet::apply`] succeeds. The block's state is
-    /// readable from the databases, but durability through that block may still
-    /// be pending. A database barrier may run concurrently with this future.
-    /// The wrapper releases the block's marshal acknowledgement only after this
-    /// future resolves and a barrier covering the block completes.
+    /// The wrapper calls this after every successful [`DatabaseSet::apply`] in
+    /// application order. `artifact` is the value returned by
+    /// [`capture_finalized`](Self::capture_finalized) for the exact applied
+    /// batches. The block's state is readable from the databases, but durability
+    /// through that block may still be pending. A database barrier may run
+    /// concurrently with this future. The wrapper releases the block's marshal
+    /// acknowledgement only after this future resolves and a barrier covering
+    /// the block completes.
     ///
-    /// [`Finalized::Applied`] carries the artifact captured from the exact
-    /// batches applied for this notification. [`Finalized::Synchronized`]
-    /// means the block was already reflected and no winning batches were
-    /// available. This can occur for the startup anchor on a fresh boot, after
-    /// recovery alignment, or following completed state sync.
-    ///
-    /// During peer state sync, a finalized block may be absorbed into a recorded sync target and
-    /// acknowledged without invoking this hook. Blocks still pending when sync completes are
-    /// reported or applied during handoff. Applications must derive synchronized state from the
-    /// database set rather than rely on receiving every peer-state-sync finalization here.
+    /// State sync and recovery may reflect finalized blocks without applying
+    /// their individual batches. Those blocks do not invoke this hook.
+    /// Consecutive hook calls may therefore skip heights after state sync.
     ///
     /// This hook receives read-only database handles and may overlap verification
     /// of blocks built on the newly finalized block or one of its retained
     /// descendants. Result-affecting mutations must be made through normal block
     /// execution, not from this observer.
     ///
-    /// For blocks that are reported, this is an at-least-once notification
-    /// inherited from marshal's reporter stream. A crash after this hook runs
-    /// but before a database sync covering the block and marshal's processed
-    /// position are durable may cause the same block to be reported again.
+    /// A crash after this hook runs but before a database sync covering the
+    /// block and marshal's processed position are durable may cause the batch
+    /// to be applied and observed again after restart.
     ///
     /// # Panics
     ///
@@ -381,7 +364,7 @@ where
         &mut self,
         _context: (E, Self::Context),
         _block: &Self::Block,
-        _provenance: Finalized<Self::FinalizedArtifact>,
+        _artifact: Self::FinalizedArtifact,
         _readers: <Self::Databases as DatabaseSet<E>>::Readers,
     ) -> impl Future<Output = ()> + Send {
         async {}

--- a/glue/src/stateful/mod.rs
+++ b/glue/src/stateful/mod.rs
@@ -312,9 +312,10 @@ where
 
     /// Capture data from winning batches before they are applied.
     ///
-    /// The wrapper calls this immediately before applying each winning batch
-    /// set. It does not call this for blocks merely reflected through recovery
-    /// or state sync.
+    /// The wrapper calls this immediately before applying each block's winning
+    /// batches. It does not call this for blocks already reflected in the
+    /// database set: the genesis block on a fresh boot, blocks reconciled at
+    /// startup, and blocks covered by state sync.
     ///
     /// Only reads completed through `readers` during this call are guaranteed
     /// to observe database state before `batches`. Retain owned values instead
@@ -325,8 +326,13 @@ where
     /// This future and [`finalized`](Self::finalized) are awaited on the
     /// stateful actor's serial mailbox path. The actor cannot process other
     /// mailbox messages while either is pending. Keep this capture cheap and
-    /// spawn expensive follow-on work from `finalized` instead of awaiting it
-    /// on this path. Applications with nothing to capture return `()`.
+    /// spawn expensive follow-on work from [`finalized`](Self::finalized)
+    /// instead of awaiting it on this path. Applications with nothing to
+    /// capture return `()`.
+    ///
+    /// # Panics
+    ///
+    /// Implementations should panic if capturing pre-apply state fails.
     fn capture(
         &mut self,
         context: (E, Self::Context),
@@ -337,17 +343,17 @@ where
 
     /// Observe a finalized block after its winning batches are applied.
     ///
-    /// The wrapper calls this after every successful [`DatabaseSet::apply`] in
-    /// application order. `captured` is the value returned by
-    /// [`capture`](Self::capture) for the exact applied batches. The block's
-    /// state is readable from the databases, but durability through that block
-    /// may still be pending. A database barrier may run
-    /// concurrently with this future. The wrapper releases the block's marshal
-    /// acknowledgement only after this future resolves and a barrier covering
-    /// the block completes.
+    /// The wrapper calls this after every [`DatabaseSet::apply`] in application
+    /// order. `captured` is the value returned by [`capture`](Self::capture)
+    /// for the exact applied batches. The block's state is readable from the
+    /// databases, but durability through that block may still be pending. A
+    /// database barrier may run concurrently with this future. The wrapper
+    /// releases the block's marshal acknowledgement only after this future
+    /// resolves and a barrier covering the block completes.
     ///
-    /// State sync and recovery may reflect finalized blocks without applying
-    /// their individual batches. Those blocks do not invoke this hook.
+    /// Blocks already reflected in the database set invoke neither this hook
+    /// nor [`capture`](Self::capture): the genesis block on a fresh boot,
+    /// blocks reconciled at startup, and blocks covered by state sync.
     /// Consecutive hook calls may therefore skip heights after state sync.
     ///
     /// This hook receives read-only database handles and may overlap verification
@@ -356,19 +362,17 @@ where
     /// execution, not from this observer.
     ///
     /// A crash after this hook runs but before a database sync covering the
-    /// block and marshal's processed position are durable may cause the batch
-    /// to be applied and observed again after restart.
+    /// block and marshal's processed position are durable may cause the block's
+    /// batches to be captured, applied, and observed again after restart.
     ///
     /// # Panics
     ///
     /// Implementations should panic if observing finalized state fails.
     fn finalized(
         &mut self,
-        _context: (E, Self::Context),
-        _block: &Self::Block,
-        _captured: Self::Captured,
-        _readers: <Self::Databases as DatabaseSet<E>>::Readers,
-    ) -> impl Future<Output = ()> + Send {
-        async {}
-    }
+        context: (E, Self::Context),
+        block: &Self::Block,
+        captured: Self::Captured,
+        readers: <Self::Databases as DatabaseSet<E>>::Readers,
+    ) -> impl Future<Output = ()> + Send;
 }

--- a/glue/src/stateful/tests/mocks.rs
+++ b/glue/src/stateful/tests/mocks.rs
@@ -291,6 +291,7 @@ impl<
     type Context = SimplexContext<Sha256Digest, ed25519::PublicKey>;
     type Block = TestBlock;
     type Databases = TestDatabases;
+    type FinalizedArtifact = ();
     type Provider = ();
     type Input = ();
 
@@ -328,6 +329,15 @@ impl<
         _batches: <Self::Databases as DatabaseSet<E>>::Unmerkleized,
     ) -> <Self::Databases as DatabaseSet<E>>::Merkleized {
         TestMerkleized
+    }
+
+    async fn capture_finalized(
+        &mut self,
+        _context: (E, Self::Context),
+        _block: &Self::Block,
+        _batches: &<Self::Databases as DatabaseSet<E>>::Merkleized,
+        _readers: <Self::Databases as DatabaseSet<E>>::Readers,
+    ) {
     }
 }
 

--- a/glue/src/stateful/tests/mocks.rs
+++ b/glue/src/stateful/tests/mocks.rs
@@ -305,7 +305,7 @@ impl<
     type Context = SimplexContext<Sha256Digest, ed25519::PublicKey>;
     type Block = TestBlock;
     type Databases = TestDatabases;
-    type FinalizedArtifact = ();
+    type Captured = ();
     type Provider = ();
     type Input = ();
 
@@ -345,7 +345,7 @@ impl<
         TestMerkleized
     }
 
-    async fn capture_finalized(
+    async fn capture(
         &mut self,
         _context: (E, Self::Context),
         _block: &Self::Block,
@@ -361,7 +361,7 @@ impl<
         &mut self,
         _context: (E, Self::Context),
         _block: &Self::Block,
-        _artifact: Self::FinalizedArtifact,
+        _captured: Self::Captured,
         _readers: <Self::Databases as DatabaseSet<E>>::Readers,
     ) {
         if let Some(hooks) = &self.finalization_hooks {

--- a/glue/src/stateful/tests/mocks.rs
+++ b/glue/src/stateful/tests/mocks.rs
@@ -275,8 +275,22 @@ impl CertifiableBlock for TestBlock {
     }
 }
 
-#[derive(Clone)]
-pub(crate) struct TestApp;
+#[derive(Clone, Default)]
+pub(crate) struct TestApp {
+    finalization_hooks: Option<Arc<AtomicUsize>>,
+}
+
+impl TestApp {
+    pub(crate) fn observe_finalization() -> (Self, Arc<AtomicUsize>) {
+        let hooks: Arc<AtomicUsize> = Arc::default();
+        (
+            Self {
+                finalization_hooks: Some(hooks.clone()),
+            },
+            hooks,
+        )
+    }
+}
 
 impl<
     E: rand_core::Rng
@@ -338,6 +352,21 @@ impl<
         _batches: &<Self::Databases as DatabaseSet<E>>::Merkleized,
         _readers: <Self::Databases as DatabaseSet<E>>::Readers,
     ) {
+        if let Some(hooks) = &self.finalization_hooks {
+            hooks.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    async fn finalized(
+        &mut self,
+        _context: (E, Self::Context),
+        _block: &Self::Block,
+        _artifact: Self::FinalizedArtifact,
+        _readers: <Self::Databases as DatabaseSet<E>>::Readers,
+    ) {
+        if let Some(hooks) = &self.finalization_hooks {
+            hooks.fetch_add(1, Ordering::SeqCst);
+        }
     }
 }
 

--- a/glue/src/stateful/tests/mod.rs
+++ b/glue/src/stateful/tests/mod.rs
@@ -18,7 +18,7 @@ use crate::{
         property::Property,
     },
     stateful::{
-        Application, Config as StatefulConfig, Input, Proposed, PruneConfig,
+        Application, Config as StatefulConfig, Finalized, Input, Proposed, PruneConfig,
         Stateful as StatefulActor, SyncPlan,
         db::{AttachableResolver, DatabaseSet, Merkleized as _, Shared, SyncEngineConfig},
     },
@@ -952,6 +952,7 @@ impl Application<deterministic::Context> for GatedMultiApp {
     type Context = <MultiApp as Application<deterministic::Context>>::Context;
     type Block = MultiBlock;
     type Databases = MultiDatabaseSet<deterministic::Context>;
+    type FinalizedArtifact = <MultiApp as Application<deterministic::Context>>::FinalizedArtifact;
     type Provider = ();
     type Input = ();
 
@@ -1015,16 +1016,35 @@ impl Application<deterministic::Context> for GatedMultiApp {
         .await
     }
 
+    async fn capture_finalized(
+        &mut self,
+        context: (deterministic::Context, Self::Context),
+        block: &Self::Block,
+        batches: &<Self::Databases as DatabaseSet<deterministic::Context>>::Merkleized,
+        readers: <Self::Databases as DatabaseSet<deterministic::Context>>::Readers,
+    ) -> Self::FinalizedArtifact {
+        <MultiApp as Application<deterministic::Context>>::capture_finalized(
+            &mut self.inner,
+            context,
+            block,
+            batches,
+            readers,
+        )
+        .await
+    }
+
     async fn finalized(
         &mut self,
         context: (deterministic::Context, Self::Context),
         block: &Self::Block,
+        provenance: Finalized<Self::FinalizedArtifact>,
         readers: <Self::Databases as DatabaseSet<deterministic::Context>>::Readers,
     ) {
         <MultiApp as Application<deterministic::Context>>::finalized(
             &mut self.inner,
             context,
             block,
+            provenance,
             readers,
         )
         .await;

--- a/glue/src/stateful/tests/mod.rs
+++ b/glue/src/stateful/tests/mod.rs
@@ -952,7 +952,7 @@ impl Application<deterministic::Context> for GatedMultiApp {
     type Context = <MultiApp as Application<deterministic::Context>>::Context;
     type Block = MultiBlock;
     type Databases = MultiDatabaseSet<deterministic::Context>;
-    type FinalizedArtifact = <MultiApp as Application<deterministic::Context>>::FinalizedArtifact;
+    type Captured = <MultiApp as Application<deterministic::Context>>::Captured;
     type Provider = ();
     type Input = ();
 
@@ -1016,14 +1016,14 @@ impl Application<deterministic::Context> for GatedMultiApp {
         .await
     }
 
-    async fn capture_finalized(
+    async fn capture(
         &mut self,
         context: (deterministic::Context, Self::Context),
         block: &Self::Block,
         batches: &<Self::Databases as DatabaseSet<deterministic::Context>>::Merkleized,
         readers: <Self::Databases as DatabaseSet<deterministic::Context>>::Readers,
-    ) -> Self::FinalizedArtifact {
-        <MultiApp as Application<deterministic::Context>>::capture_finalized(
+    ) -> Self::Captured {
+        <MultiApp as Application<deterministic::Context>>::capture(
             &mut self.inner,
             context,
             block,
@@ -1037,14 +1037,14 @@ impl Application<deterministic::Context> for GatedMultiApp {
         &mut self,
         context: (deterministic::Context, Self::Context),
         block: &Self::Block,
-        artifact: Self::FinalizedArtifact,
+        captured: Self::Captured,
         readers: <Self::Databases as DatabaseSet<deterministic::Context>>::Readers,
     ) {
         <MultiApp as Application<deterministic::Context>>::finalized(
             &mut self.inner,
             context,
             block,
-            artifact,
+            captured,
             readers,
         )
         .await;

--- a/glue/src/stateful/tests/mod.rs
+++ b/glue/src/stateful/tests/mod.rs
@@ -18,7 +18,7 @@ use crate::{
         property::Property,
     },
     stateful::{
-        Application, Config as StatefulConfig, Finalized, Input, Proposed, PruneConfig,
+        Application, Config as StatefulConfig, Input, Proposed, PruneConfig,
         Stateful as StatefulActor, SyncPlan,
         db::{AttachableResolver, DatabaseSet, Merkleized as _, Shared, SyncEngineConfig},
     },
@@ -1037,14 +1037,14 @@ impl Application<deterministic::Context> for GatedMultiApp {
         &mut self,
         context: (deterministic::Context, Self::Context),
         block: &Self::Block,
-        provenance: Finalized<Self::FinalizedArtifact>,
+        artifact: Self::FinalizedArtifact,
         readers: <Self::Databases as DatabaseSet<deterministic::Context>>::Readers,
     ) {
         <MultiApp as Application<deterministic::Context>>::finalized(
             &mut self.inner,
             context,
             block,
-            provenance,
+            artifact,
             readers,
         )
         .await;

--- a/glue/src/stateful/tests/multi_db_app.rs
+++ b/glue/src/stateful/tests/multi_db_app.rs
@@ -288,6 +288,7 @@ impl<E: Rng + Spawner + StorageContext> Application<E> for App {
     type Context = Context<sha256::Digest, ed25519::PublicKey>;
     type Block = Block;
     type Databases = MultiDatabaseSet<E>;
+    type FinalizedArtifact = ();
     type Provider = ();
     type Input = ();
 
@@ -351,6 +352,15 @@ impl<E: Rng + Spawner + StorageContext> Application<E> for App {
         batches: <Self::Databases as DatabaseSet<E>>::Unmerkleized,
     ) -> <Self::Databases as DatabaseSet<E>>::Merkleized {
         Self::execute(block.height(), batches).await
+    }
+
+    async fn capture_finalized(
+        &mut self,
+        _context: (E, Self::Context),
+        _block: &Self::Block,
+        _batches: &<Self::Databases as DatabaseSet<E>>::Merkleized,
+        _readers: <Self::Databases as DatabaseSet<E>>::Readers,
+    ) {
     }
 
     fn sync_targets(block: &Self::Block) -> <Self::Databases as DatabaseSet<E>>::SyncTargets {

--- a/glue/src/stateful/tests/multi_db_app.rs
+++ b/glue/src/stateful/tests/multi_db_app.rs
@@ -288,7 +288,7 @@ impl<E: Rng + Spawner + StorageContext> Application<E> for App {
     type Context = Context<sha256::Digest, ed25519::PublicKey>;
     type Block = Block;
     type Databases = MultiDatabaseSet<E>;
-    type FinalizedArtifact = ();
+    type Captured = ();
     type Provider = ();
     type Input = ();
 
@@ -354,7 +354,7 @@ impl<E: Rng + Spawner + StorageContext> Application<E> for App {
         Self::execute(block.height(), batches).await
     }
 
-    async fn capture_finalized(
+    async fn capture(
         &mut self,
         _context: (E, Self::Context),
         _block: &Self::Block,

--- a/glue/src/stateful/tests/multi_db_app.rs
+++ b/glue/src/stateful/tests/multi_db_app.rs
@@ -363,6 +363,15 @@ impl<E: Rng + Spawner + StorageContext> Application<E> for App {
     ) {
     }
 
+    async fn finalized(
+        &mut self,
+        _context: (E, Self::Context),
+        _block: &Self::Block,
+        _captured: Self::Captured,
+        _readers: <Self::Databases as DatabaseSet<E>>::Readers,
+    ) {
+    }
+
     fn sync_targets(block: &Self::Block) -> <Self::Databases as DatabaseSet<E>>::SyncTargets {
         (
             Target::new(block.root_a, block.range_a.clone()),

--- a/glue/src/stateful/tests/single_db_app.rs
+++ b/glue/src/stateful/tests/single_db_app.rs
@@ -217,6 +217,7 @@ impl<E: Rng + Spawner + StorageContext> Application<E> for App {
     type Context = Context<sha256::Digest, ed25519::PublicKey>;
     type Block = Block;
     type Databases = SingleDatabaseSet<E>;
+    type FinalizedArtifact = ();
     type Provider = ();
     type Input = ();
 
@@ -271,6 +272,15 @@ impl<E: Rng + Spawner + StorageContext> Application<E> for App {
         batches: <Self::Databases as DatabaseSet<E>>::Unmerkleized,
     ) -> <Self::Databases as DatabaseSet<E>>::Merkleized {
         Self::execute(block.height(), batches).await
+    }
+
+    async fn capture_finalized(
+        &mut self,
+        _context: (E, Self::Context),
+        _block: &Self::Block,
+        _batches: &<Self::Databases as DatabaseSet<E>>::Merkleized,
+        _readers: <Self::Databases as DatabaseSet<E>>::Readers,
+    ) {
     }
 
     fn sync_targets(block: &Self::Block) -> <Self::Databases as DatabaseSet<E>>::SyncTargets {

--- a/glue/src/stateful/tests/single_db_app.rs
+++ b/glue/src/stateful/tests/single_db_app.rs
@@ -283,6 +283,15 @@ impl<E: Rng + Spawner + StorageContext> Application<E> for App {
     ) {
     }
 
+    async fn finalized(
+        &mut self,
+        _context: (E, Self::Context),
+        _block: &Self::Block,
+        _captured: Self::Captured,
+        _readers: <Self::Databases as DatabaseSet<E>>::Readers,
+    ) {
+    }
+
     fn sync_targets(block: &Self::Block) -> <Self::Databases as DatabaseSet<E>>::SyncTargets {
         Target::new(block.state_root, block.range.clone())
     }

--- a/glue/src/stateful/tests/single_db_app.rs
+++ b/glue/src/stateful/tests/single_db_app.rs
@@ -217,7 +217,7 @@ impl<E: Rng + Spawner + StorageContext> Application<E> for App {
     type Context = Context<sha256::Digest, ed25519::PublicKey>;
     type Block = Block;
     type Databases = SingleDatabaseSet<E>;
-    type FinalizedArtifact = ();
+    type Captured = ();
     type Provider = ();
     type Input = ();
 
@@ -274,7 +274,7 @@ impl<E: Rng + Spawner + StorageContext> Application<E> for App {
         Self::execute(block.height(), batches).await
     }
 
-    async fn capture_finalized(
+    async fn capture(
         &mut self,
         _context: (E, Self::Context),
         _block: &Self::Block,


### PR DESCRIPTION
Adds a two-stage finalized handoff that lets stateful applications capture owned artifacts from a winning batch immediately before application and receive the same artifact after successful application. 

The callbacks now represent applied batches rather than universal finalized-block notifications and run in application order. 

Blocks already reflected through startup recovery, duplicate delivery, or state sync invoke neither hook, so state-synced nodes may observe callback height gaps.