### PR TITLE
[marshal] Release pending floor anchors superseded by the round floor

### DIFF
--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -562,7 +562,9 @@ where
                     // Apply in-memory progress updates for this acknowledged
                     // block. The metadata sync below makes drained updates durable.
                     self.update_processed_height(height, resolver);
-                    self = self.update_processed_round(height, resolver).await;
+                    self = self
+                        .update_processed_round(height, buffer, application, resolver)
+                        .await;
                 }
                 Err(e) => return Err((height, e)),
             }
@@ -795,7 +797,7 @@ where
                     let height = block.height();
                     let stored;
                     (self, stored) = self
-                        .update_processed_round_floor(height, round, resolver)
+                        .update_processed_round_floor(height, round, buffer, application, resolver)
                         .await
                         .store_finalization(
                             height,
@@ -1318,7 +1320,13 @@ where
                 .take_pending_anchor()
                 .expect("pending floor anchor missing");
             self = self
-                .update_processed_round_floor(height, finalization.round(), resolver)
+                .update_processed_round_floor(
+                    height,
+                    finalization.round(),
+                    buffer,
+                    application,
+                    resolver,
+                )
                 .await;
             let commitments = self.take_superseded_ack_commitments();
             buffer.retire(Retirement {
@@ -1363,7 +1371,7 @@ where
             .expect("floor anchor above processed height must have predecessor");
         self.update_processed_height(dispatch_floor, resolver);
         self = self
-            .update_processed_round_floor(dispatch_floor, round, resolver)
+            .update_processed_round_floor(dispatch_floor, round, buffer, application, resolver)
             .await;
         self.stream = self
             .stream
@@ -1467,7 +1475,13 @@ where
                 let finalization = self.cache.get_finalization_for(digest).await;
                 if let Some(finalization) = &finalization {
                     self = self
-                        .update_processed_round_floor(height, finalization.round(), resolver)
+                        .update_processed_round_floor(
+                            height,
+                            finalization.round(),
+                            buffer,
+                            application,
+                            resolver,
+                        )
                         .await;
                 }
                 if finalization.is_some()
@@ -1710,7 +1724,7 @@ where
                     }
 
                     (self, _) = self
-                        .update_processed_round_floor(height, round, resolver)
+                        .update_processed_round_floor(height, round, buffer, application, resolver)
                         .await
                         .store_finalization(
                             height,
@@ -1770,7 +1784,13 @@ where
                     // and we resolve the notarization request before the block request.
                     if let Some(finalization) = self.cache.get_finalization_for(digest).await {
                         self = self
-                            .update_processed_round_floor(height, finalization.round(), resolver)
+                            .update_processed_round_floor(
+                                height,
+                                finalization.round(),
+                                buffer,
+                                application,
+                                resolver,
+                            )
                             .await;
 
                         // SAFETY: `digest` identifies a unique `commitment`, so this
@@ -2419,23 +2439,37 @@ where
     }
 
     /// Buffers a processed round update in memory and prunes round-bound requests.
-    async fn update_processed_round(
+    async fn update_processed_round<Buf: Buffer<V>>(
         self: Box<Self>,
         height: Height,
+        buffer: &mut Buf,
+        application: &mut impl Reporter<Activity = Update<V::ApplicationBlock, A>>,
         resolver: &mut impl Resolver<Key = ResolverRequestFor<V>, Subscriber = Annotation>,
     ) -> Box<Self> {
         let Some(finalization) = self.get_finalization_by_height(height).await else {
             return self;
         };
-        self.update_processed_round_floor(height, finalization.round(), resolver)
-            .await
+        self.update_processed_round_floor(
+            height,
+            finalization.round(),
+            buffer,
+            application,
+            resolver,
+        )
+        .await
     }
 
     /// Buffers a processed round floor update in memory and prunes round-bound requests.
-    async fn update_processed_round_floor(
+    ///
+    /// A pending floor anchor whose round the new floor covers is released: the
+    /// same retention that prunes its fetch proves it sits at or below the
+    /// processed height, so repair and dispatch resume without it.
+    async fn update_processed_round_floor<Buf: Buffer<V>>(
         mut self: Box<Self>,
         height: Height,
         round: Round,
+        buffer: &mut Buf,
+        application: &mut impl Reporter<Activity = Update<V::ApplicationBlock, A>>,
         resolver: &mut impl Resolver<Key = ResolverRequestFor<V>, Subscriber = Annotation>,
     ) -> Box<Self> {
         let processed_round = self.floor.round();
@@ -2455,7 +2489,23 @@ where
 
         // Resolver request retention is independent of caller-owned block subscriptions.
         resolver.retain(handler::above_round_floor::<V::Commitment>(round));
-        self
+
+        // A superseded anchor is an ancestor of a processed block, so the floor
+        // it announced is already active. Retire the acks it displaced and resume.
+        if self.floor.take_superseded_anchor(round).is_none() {
+            return self;
+        }
+        let commitments = self.take_superseded_ack_commitments();
+        buffer.retire(Retirement {
+            round_floor: round,
+            exact_retirements: commitments,
+        });
+        let repaired;
+        (self, repaired) = self.try_repair_gaps(buffer, resolver, application).await;
+        if repaired {
+            self = self.sync_finalized().await;
+        }
+        self.try_dispatch_blocks(application).await
     }
 
     /// Prunes finalized blocks and certificates below the given height.

--- a/consensus/src/marshal/core/floor.rs
+++ b/consensus/src/marshal/core/floor.rs
@@ -109,6 +109,15 @@ impl<S: Scheme, C: Digest> State<S, C> {
         self.pending.take()
     }
 
+    /// Takes the pending anchor if the processed round floor now covers its round.
+    ///
+    /// Finalized rounds and heights increase together along the finalized chain, so
+    /// an anchor at or below the round floor sits at or below the processed height.
+    #[must_use]
+    pub(super) fn take_superseded_anchor(&mut self, round: Round) -> Option<Finalization<S, C>> {
+        self.pending.take_if(|pending| pending.round() <= round)
+    }
+
     /// Returns true when the resolver request is above all processed floors.
     fn permits(&self, fetch: &Request<C>) -> bool {
         if let Some(height) = self.height

--- a/consensus/src/marshal/standard/mod.rs
+++ b/consensus/src/marshal/standard/mod.rs
@@ -6951,6 +6951,143 @@ mod tests {
         });
     }
 
+    /// A round-floor advance that supersedes the pending floor anchor must
+    /// release the floor transition rather than strand it once its anchor
+    /// fetch is pruned.
+    #[test_traced("WARN")]
+    fn test_standard_round_floor_advance_releases_superseded_pending_floor() {
+        let runner = deterministic::Runner::timed(Duration::from_secs(30));
+        runner.start(|mut context| async move {
+            let Fixture { schemes, .. } =
+                bls12381_threshold_vrf::fixture::<V, _>(&mut context, NAMESPACE, NUM_VALIDATORS);
+            let partition_prefix = "round-floor-releases-pending-floor";
+
+            // Models a prunable deployment after section pruning: the application
+            // processed through height 3, the section holding earlier heights was
+            // pruned, and height 3 was repaired by walkback without a direct
+            // finalization, so the recovered round floor lags every finalization
+            // on the chain.
+            let anchor_round = Round::new(Epoch::zero(), View::new(2));
+            let anchor = make_raw_block(Sha256::hash(&[b"anchor-parent"]), Height::new(2), 200);
+            let anchor_finalization = StandardHarness::make_finalization(
+                Proposal::new(
+                    anchor_round,
+                    View::new(1),
+                    StandardHarness::commitment(&anchor),
+                ),
+                &schemes,
+                QUORUM,
+            );
+            let processed_round = Round::new(Epoch::zero(), View::new(3));
+            let processed = make_raw_block(anchor.digest(), Height::new(3), 300);
+            let processed_finalization = StandardHarness::make_finalization(
+                Proposal::new(
+                    processed_round,
+                    View::new(2),
+                    StandardHarness::commitment(&processed),
+                ),
+                &schemes,
+                QUORUM,
+            );
+            let next = make_raw_block(processed.digest(), Height::new(4), 400);
+            seed_processed_height(context.child("metadata"), partition_prefix, Height::new(3))
+                .await;
+            seed_inconsistent_restart_state(
+                context.child("storage"),
+                partition_prefix,
+                &[processed.clone(), next.clone()],
+                &[],
+            )
+            .await;
+
+            // A configured floor for the pruned height 2 block is above the
+            // recovered round floor, so marshal fetches it as a pending anchor.
+            let application = Application::<B>::manual_ack();
+            let (mailbox, _buffer, resolver, _actor_handle) = start_standard_actor(
+                context.child("validator"),
+                partition_prefix,
+                ConstantProvider::new(schemes[0].clone()),
+                application.clone(),
+                Some(RecordingBuffer::default()),
+                Start::Floor(anchor_finalization),
+            )
+            .await;
+            let mut mailbox = mailbox;
+            let is_anchor_fetch = |fetch: &FetchRecord| {
+                matches!(
+                    (&fetch.key, &fetch.subscriber),
+                    (
+                        handler::Key::Block(commitment),
+                        handler::Annotation::Finalized(handler::Finalized::ByRound { round }),
+                    ) if *commitment == StandardHarness::commitment(&anchor)
+                        && *round == anchor_round
+                )
+            };
+            wait_until(
+                &context,
+                Duration::from_secs(5),
+                "floor anchor fetch",
+                || resolver.active_fetches().iter().any(is_anchor_fetch),
+            )
+            .await;
+            context.sleep(Duration::from_millis(100)).await;
+            assert!(
+                application.pending_ack_heights().is_empty(),
+                "pending floor must hold dispatch until the anchor resolves"
+            );
+
+            // A finalization for the retained height 3 block (for example,
+            // re-reported by consensus on restart) advances the round floor
+            // past the pending anchor round.
+            let retains_before = resolver.retain_count();
+            StandardHarness::report_finalization(&mut mailbox, processed_finalization).await;
+            wait_until(
+                &context,
+                Duration::from_secs(5),
+                "round floor advance",
+                || resolver.retain_count() > retains_before,
+            )
+            .await;
+
+            // The anchor is now provably at or below the processed height. If
+            // marshal still wants it, serve it. Either way the superseded
+            // floor must release application dispatch.
+            if let Some(fetch) = resolver
+                .active_fetches()
+                .into_iter()
+                .find(is_anchor_fetch)
+            {
+                let (response, response_rx) = oneshot::channel();
+                assert!(
+                    resolver
+                        .enqueue(handler::Message::Deliver {
+                            delivery: Delivery {
+                                key: fetch.key,
+                                subscribers: NonEmptyVec::new((
+                                    fetch.subscriber,
+                                    tracing::Span::none()
+                                )),
+                            },
+                            value: anchor.encode(),
+                            response,
+                        })
+                        .accepted()
+                );
+                assert!(response_rx.await.expect("delivery response missing"));
+            }
+            select! {
+                height = application.acknowledged() => {
+                    assert_eq!(height, Height::new(4));
+                },
+                _ = context.sleep(Duration::from_secs(5)) => {
+                    panic!(
+                        "superseded pending floor stranded dispatch: anchor fetch pruned without releasing the floor"
+                    );
+                },
+            }
+        });
+    }
+
     /// When the provider has no verifier for an epoch, in-flight deliveries
     /// for that epoch must be acknowledged (`true`) so the serving peer is
     /// not blamed, rather than rejected (`false`).


### PR DESCRIPTION
## Problem

`install_floor` accepts any verified floor finalization whose round is above the processed round floor. When the anchor block is not available locally, it records the finalization as the pending anchor, clears in-flight acks, and issues a `Finalized::ByRound` block fetch. Dispatch and gap repair then wait on that anchor (`blocks_progress`).

The anchor's height is unknown at that point. It can already be at or below the processed height (the block was pruned by the application) while the round floor lags behind it: gap-repair walkback stores blocks without height-indexed finalizations, so acks at those heights never advance the round, and `latest_processed_round` recovers the same lagging round on restart. In that state a later finalization for a retained processed-height block runs `update_processed_round_floor`, which advances the round floor past the anchor round and prunes the anchor fetch through `resolver.retain(above_round_floor)`, but leaves `floor.pending` in place. `store_finalization` then drops the block as below the processed height, so no repair or dispatch follows. The actor keeps storing later finalizations but never emits another `Update::Block` and never repairs gaps.

Nothing recovers on its own. Re-sending the same floor is rejected as below the round floor, and no fetch site can re-request the anchor because `permits` now denies its round. Restart does not reliably help either: the superseding finalization is never persisted at or below the processed height, so `Start::Floor` re-installs the same anchor and simplex journal replay re-reports the superseding finalization before the network fetch can answer. The same call also runs from the `Key::Block` delivery path with a cached finalization and from the notarized-delivery path, so the defect is not specific to the consensus `Finalization` message.

## Fix

Rounds and heights increase together on the finalized chain, so a round floor that covers the pending anchor's round proves the anchor sits at or below the processed height. The retention that prunes the anchor fetch already relies on that inference. `update_processed_round_floor` now applies it to the pending state as well: after retention it takes a pending anchor whose round the new floor covers (`State::take_superseded_anchor`), retires the acks that anchor displaced, repairs gaps, syncs if anything was written, and resumes dispatch. This is the tail `apply_pending_floor` already runs for an anchor that arrives at or below the processed height. Whenever the round floor moves, the `store_finalization` that follows is a no-op under the same height guard, so no buffered write interleaves with the resumed repair.

`update_processed_round_floor` takes the buffer and application for that tail. Placing the release there covers every caller instead of one mailbox arm.

## Test

`test_standard_round_floor_advance_releases_superseded_pending_floor` seeds a processed height whose earlier section was pruned and that carries no height-indexed finalizations, starts marshal with `Start::Floor` for the pruned block, waits for the `ByRound` anchor fetch, then reports a finalization for the retained processed-height block. On `main` the anchor fetch is pruned and the application never receives the next block. With the fix dispatch resumes.

## Reaching it

`Start` documents that a configured anchor is re-supplied on every boot and that durable progress from a previous run takes precedence when it already supersedes that anchor. The failure is that contract breaking down in one corner. A reasonable path:

1. A node boots with a configured or persisted floor `F` (glue does this with the in-progress state-sync floor), syncs from it, and processes far past it.
2. The application prunes marshal's finalized archives behind its retention window with `prune`, removing `F`'s block and the height-indexed finalizations around it.
3. The node later catches up through a range marshal filled by walkback repair. Those heights have blocks but no height-indexed finalizations unless the cache still held them, so if the node crashes while processing that range, `latest_processed_round` recovers a round floor below `F`'s round.
4. On restart `Start::Floor(F)` now passes the round check, the block is gone, and marshal parks a pending anchor with a round-bound fetch. Simplex replays its journal and re-reports a finalization for one of those already-processed heights. Marshal finds that block locally, advances the round floor past `F`'s round, and the anchor fetch is pruned with the pending anchor still set.

From there every restart repeats the sequence, because the replayed finalization is never persisted below the processed height. Each step is supported behavior and none is a misuse, but the combination is narrow and no in-repo caller currently performs all of them. The same trigger also arrives through a block delivery with a cached finalization, so the fix is not tied to the replay path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
