### PR TITLE
[storage] Retain repeated-key locations when rebuilding immutable snapshots

### DIFF
--- a/glue/src/stateful/db/immutable/compact.rs
+++ b/glue/src/stateful/db/immutable/compact.rs
@@ -504,7 +504,6 @@ mod tests {
                 replay_buffer: NZUsize!(1024),
             },
             translator: TwoCap,
-            init_cache_size: Some(NZUsize!(1024)),
             init_buffer: NZUsize!(1 << 21),
         }
     }

--- a/glue/src/stateful/db/mod.rs
+++ b/glue/src/stateful/db/mod.rs
@@ -2249,7 +2249,6 @@ mod tests {
                 merkle_config: merkle_config(context, suffix),
                 log: fixed_journal_config(context, suffix),
                 translator: TwoCap,
-                init_cache_size: Some(NZUsize!(1024)),
                 init_buffer: NZUsize!(1 << 21),
             }
         }
@@ -2262,7 +2261,6 @@ mod tests {
                 merkle_config: merkle_config(context, suffix),
                 log: variable_journal_config(context, suffix, ((), ())),
                 translator: TwoCap,
-                init_cache_size: Some(NZUsize!(1024)),
                 init_buffer: NZUsize!(1 << 21),
             }
         }

--- a/storage/fuzz/fuzz_targets/qmdb_immutable_operations.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_immutable_operations.rs
@@ -119,7 +119,6 @@ fn db_config(
             page_cache,
         },
         translator: TwoCap,
-        init_cache_size: Some(NZUsize!(3)),
         init_buffer: NZUsize!(1 << 21),
     }
 }

--- a/storage/src/qmdb/benches/common.rs
+++ b/storage/src/qmdb/benches/common.rs
@@ -195,7 +195,6 @@ pub fn imm_fix_cfg_with(
         merkle_config: merkle_cfg(PARTITION_IMM, ctx, page_cache.clone(), items_per_blob),
         log: fix_log_cfg(PARTITION_IMM, page_cache, items_per_blob),
         translator: EightCap,
-        init_cache_size: INIT_CACHE_SIZE,
         init_buffer: NZUsize!(1 << 21),
     }
 }

--- a/storage/src/qmdb/conformance.rs
+++ b/storage/src/qmdb/conformance.rs
@@ -228,7 +228,6 @@ fn immutable_fixed_config(
         merkle_config: merkle_config(suffix, &pc),
         log: fixed_log_config(suffix, pc),
         translator: TwoCap,
-        init_cache_size: Some(NZUsize!(1024)),
         init_buffer: NZUsize!(1 << 21),
     }
 }
@@ -242,7 +241,6 @@ fn immutable_variable_config(
         merkle_config: merkle_config(suffix, &pc),
         log: variable_log_config(suffix, pc, ((), ())),
         translator: TwoCap,
-        init_cache_size: Some(NZUsize!(1024)),
         init_buffer: NZUsize!(1 << 21),
     }
 }

--- a/storage/src/qmdb/immutable/fixed.rs
+++ b/storage/src/qmdb/immutable/fixed.rs
@@ -53,14 +53,7 @@ impl<F: Family, E: Context, K: Array, V: FixedValue, H: Hasher, T: Translator, S
             ROOT_BAGGING,
         )
         .await?;
-        Self::init_from_journal(
-            journal,
-            context,
-            cfg.translator,
-            cfg.init_buffer,
-            cfg.init_cache_size,
-        )
-        .await
+        Self::init_from_journal(journal, context, cfg.translator, cfg.init_buffer).await
     }
 }
 
@@ -572,6 +565,8 @@ mod tests {
         test_fixed_get_many_unexpected_data => run_get_many_unexpected_data, open;
         test_fixed_rewind_after_reopen_repeated_key_gap => run_rewind_after_reopen_repeated_key_gap, open;
         test_fixed_rewind_after_reopen_mixed_gap_retained => run_rewind_after_reopen_mixed_gap_retained, open;
+        test_fixed_rewind_repeated_key_live => run_rewind_repeated_key_live, open;
+        test_fixed_rewind_after_reopen_repeated_key_retained => run_rewind_after_reopen_repeated_key_retained, open;
     }
 
     #[boxed]

--- a/storage/src/qmdb/immutable/fixed.rs
+++ b/storage/src/qmdb/immutable/fixed.rs
@@ -113,7 +113,6 @@ mod tests {
                 replay_buffer: NZUsize!(1024),
             },
             translator: TwoCap,
-            init_cache_size: Some(NZUsize!(1024)),
             init_buffer: NZUsize!(1 << 21),
         }
     }

--- a/storage/src/qmdb/immutable/mod.rs
+++ b/storage/src/qmdb/immutable/mod.rs
@@ -134,10 +134,6 @@ pub struct Config<T: Translator, J, S: Strategy> {
     /// The translator used by the compressed index.
     pub translator: T,
 
-    /// Capacity (in entries) of the `(location -> key)` cache used during init to resolve snapshot
-    /// collisions without re-reading the log; `None` disables it.
-    pub init_cache_size: Option<NonZeroUsize>,
-
     /// Size (in bytes) of the read buffer used to replay the log during init.
     pub init_buffer: NonZeroUsize,
 }

--- a/storage/src/qmdb/immutable/mod.rs
+++ b/storage/src/qmdb/immutable/mod.rs
@@ -80,7 +80,7 @@ use crate::{
     },
     merkle::{Family, Location, Proof, full::Config as MerkleConfig},
     qmdb::{
-        Error, any::ValueEncoding, batch_chain, build_snapshot_from_log, metrics::Metrics,
+        Error, any::ValueEncoding, batch_chain, build_retained_snapshot_from_log, metrics::Metrics,
         operation::Key, single_operation_root,
     },
     translator::Translator,
@@ -230,7 +230,6 @@ where
         context: E,
         translator: T,
         init_buffer: NonZeroUsize,
-        cache_size: Option<NonZeroUsize>,
     ) -> Result<Self, Error<F>> {
         if journal.size() == 0 {
             warn!("Authenticated log is empty, initialized new db.");
@@ -256,14 +255,14 @@ where
                 return Err(Error::DataCorrupted("inactivity floor exceeds last commit"));
             }
 
-            // Replay the log from the inactivity floor to build the snapshot.
-            build_snapshot_from_log::<F, _, _, _>(
+            // Replay the log from the inactivity floor to build the snapshot. Every keyed
+            // location is retained, mirroring the live apply path, so a repeated key keeps
+            // serving one of its written values across restarts and rewinds.
+            build_retained_snapshot_from_log::<F, _, _>(
                 inactivity_floor_loc,
                 &journal.journal,
                 &mut snapshot,
                 init_buffer,
-                cache_size,
-                |_, _| {},
             )
             .await?;
 
@@ -3505,6 +3504,83 @@ pub(super) mod tests {
 
         // Rewind further to commit A: the v2 entry is dropped and get() must
         // serve v1, proving the gap fill restored the v1 location.
+        let db = db.rewind(first_size).await.unwrap();
+        assert_eq!(db.get(&key).await.unwrap(), Some(v1));
+
+        db.destroy().await.unwrap();
+    }
+
+    /// A live db retains every location of a repeated key, so rewinding across the newer
+    /// write keeps serving the older retained one with no reopen involved.
+    #[boxed]
+    pub(crate) async fn run_rewind_repeated_key_live<F: Family, V, C>(
+        context: deterministic::Context,
+        open_db: impl Fn(
+            deterministic::Context,
+        ) -> Pin<Box<dyn Future<Output = TestDb<F, V, C>> + Send>>,
+    ) where
+        V: ValueEncoding<Value = Digest>,
+        C: Mutable<Item = Operation<F, Digest, V>>,
+        C::Item: EncodeShared,
+    {
+        let db = open_db(context.child("first")).await;
+
+        let key = Sha256::fill(7u8);
+        let v1 = Sha256::fill(17u8);
+        let v2 = Sha256::fill(18u8);
+
+        // Commit A: Set(key, v1) with floor=0.
+        let (db, _) = commit_sets(db, [(key, v1)], None).await;
+        let first_size = db.bounds().end;
+
+        // Commit B: Set(key, v2) with floor=0. Either written value may be served.
+        let (db, _) = commit_sets(db, [(key, v2)], None).await;
+        let live = db.get(&key).await.unwrap().unwrap();
+        assert!(live == v1 || live == v2);
+
+        // Rewind to commit A: the v2 location is dropped and the retained v1
+        // location keeps serving the key.
+        let db = db.rewind(first_size).await.unwrap();
+        assert_eq!(db.get(&key).await.unwrap(), Some(v1));
+
+        db.destroy().await.unwrap();
+    }
+
+    /// Replay keeps only a repeated key's newest location, so a reopened db must still honor
+    /// the repeated-key read contract after a rewind that crosses the newer write: the older
+    /// write stays retained at an unchanged floor, and reads of the key may return any of its
+    /// written values, never `None`.
+    #[boxed]
+    pub(crate) async fn run_rewind_after_reopen_repeated_key_retained<F: Family, V, C>(
+        context: deterministic::Context,
+        open_db: impl Fn(
+            deterministic::Context,
+        ) -> Pin<Box<dyn Future<Output = TestDb<F, V, C>> + Send>>,
+    ) where
+        V: ValueEncoding<Value = Digest>,
+        C: Mutable<Item = Operation<F, Digest, V>>,
+        C::Item: EncodeShared,
+    {
+        let db = open_db(context.child("first")).await;
+
+        let key = Sha256::fill(7u8);
+        let v1 = Sha256::fill(17u8);
+        let v2 = Sha256::fill(18u8);
+
+        // Commit A: Set(key, v1) with floor=0.
+        let (db, _) = commit_sets(db, [(key, v1)], None).await;
+        let first_size = db.bounds().end;
+
+        // Commit B: Set(key, v2) with floor=0, then persist for the reopen.
+        let (db, _) = commit_sets(db, [(key, v2)], None).await;
+        db.sync().await.unwrap();
+
+        // Reopen: replay visits both writes and keeps only the newer location.
+        let db = open_db(context.child("second")).await;
+        assert_eq!(db.get(&key).await.unwrap(), Some(v2));
+
+        // Rewind to commit A with an unchanged floor: the newer location is dropped, and the
+        // older write, still retained in the restored journal, must keep the key readable.
         let db = db.rewind(first_size).await.unwrap();
         assert_eq!(db.get(&key).await.unwrap(), Some(v1));
 

--- a/storage/src/qmdb/immutable/mod.rs
+++ b/storage/src/qmdb/immutable/mod.rs
@@ -80,8 +80,8 @@ use crate::{
     },
     merkle::{Family, Location, Proof, full::Config as MerkleConfig},
     qmdb::{
-        Error, any::ValueEncoding, batch_chain, build_retained_snapshot_from_log, metrics::Metrics,
-        operation::Key, single_operation_root,
+        Error, any::ValueEncoding, batch_chain, metrics::Metrics, operation::Key,
+        single_operation_root,
     },
     translator::Translator,
 };
@@ -90,8 +90,9 @@ use commonware_codec::EncodeShared;
 use commonware_cryptography::Hasher;
 use commonware_macros::boxed;
 use commonware_parallel::Strategy;
-use commonware_runtime::Handle;
+use commonware_runtime::{Handle, ReadOptions};
 use core::num::{NonZeroU64, NonZeroUsize};
+use futures::{StreamExt, pin_mut};
 use std::{ops::Range, sync::Arc};
 use tracing::warn;
 
@@ -107,6 +108,40 @@ pub use compact::{
     UnmerkleizedBatch as CompactUnmerkleizedBatch,
 };
 pub use operation::Operation;
+
+/// Build the snapshot by replaying the log from `inactivity_floor_loc`, inserting the location of
+/// every retained [Operation::Set] and keeping prior locations of the same key. Assumes the log
+/// is not pruned beyond the inactivity floor.
+///
+/// Repeats of a full key all land in the snapshot, matching a snapshot maintained live, so reads
+/// of a repeated key keep returning one of its written values however the snapshot was built.
+///
+/// `init_buffer` sizes the replay read buffer (in bytes).
+async fn build_snapshot<F, K, V, C, T>(
+    inactivity_floor_loc: Location<F>,
+    log: &C,
+    snapshot: &mut Index<T, Location<F>>,
+    init_buffer: NonZeroUsize,
+) -> Result<(), Error<F>>
+where
+    F: Family,
+    K: Key,
+    V: ValueEncoding,
+    C: Contiguous<Item = Operation<F, K, V>>,
+    T: Translator,
+{
+    let stream = log
+        .replay(*inactivity_floor_loc, init_buffer, ReadOptions::default())
+        .await?;
+    pin_mut!(stream);
+    while let Some(result) = stream.next().await {
+        let (loc, op) = result?;
+        if let Operation::Set(key, _) = op {
+            snapshot.insert(&key, Location::new(loc));
+        }
+    }
+    Ok(())
+}
 
 /// Compute the authenticated root of a newly initialized database without opening storage.
 ///
@@ -251,10 +286,10 @@ where
                 return Err(Error::DataCorrupted("inactivity floor exceeds last commit"));
             }
 
-            // Replay the log from the inactivity floor to build the snapshot. Every keyed
-            // location is retained, mirroring the live apply path, so a repeated key keeps
+            // Replay the log from the inactivity floor to build the snapshot. Every retained
+            // location is inserted, mirroring the live apply path, so a repeated key keeps
             // serving one of its written values across restarts and rewinds.
-            build_retained_snapshot_from_log::<F, _, _>(
+            build_snapshot(
                 inactivity_floor_loc,
                 &journal.journal,
                 &mut snapshot,

--- a/storage/src/qmdb/immutable/sync/mod.rs
+++ b/storage/src/qmdb/immutable/sync/mod.rs
@@ -9,7 +9,6 @@ use crate::{
     qmdb::{
         self, Error,
         any::ValueEncoding,
-        build_retained_snapshot_from_log,
         immutable::{self, CompactDb, Metrics, Operation},
         operation::Key,
         sync,
@@ -105,10 +104,10 @@ where
             )
             .await?;
 
-            // Replay the log from the inactivity floor to build the snapshot. Every keyed
-            // location is retained, mirroring the live apply path, so a repeated key keeps
+            // Replay the log from the inactivity floor to build the snapshot. Every retained
+            // location is inserted, mirroring the live apply path, so a repeated key keeps
             // serving one of its written values across restarts and rewinds.
-            build_retained_snapshot_from_log::<F, _, _>(
+            immutable::build_snapshot(
                 inactivity_floor_loc,
                 &journal.journal,
                 &mut snapshot,

--- a/storage/src/qmdb/immutable/sync/mod.rs
+++ b/storage/src/qmdb/immutable/sync/mod.rs
@@ -9,7 +9,7 @@ use crate::{
     qmdb::{
         self, Error,
         any::ValueEncoding,
-        build_snapshot_from_log,
+        build_retained_snapshot_from_log,
         immutable::{self, CompactDb, Metrics, Operation},
         operation::Key,
         sync,
@@ -105,14 +105,14 @@ where
             )
             .await?;
 
-            // Replay the log from the inactivity floor to build the snapshot.
-            build_snapshot_from_log::<F, _, _, _>(
+            // Replay the log from the inactivity floor to build the snapshot. Every keyed
+            // location is retained, mirroring the live apply path, so a repeated key keeps
+            // serving one of its written values across restarts and rewinds.
+            build_retained_snapshot_from_log::<F, _, _>(
                 inactivity_floor_loc,
                 &journal.journal,
                 &mut snapshot,
                 db_config.init_buffer,
-                db_config.init_cache_size,
-                |_, _| {},
             )
             .await?;
 

--- a/storage/src/qmdb/immutable/sync/tests.rs
+++ b/storage/src/qmdb/immutable/sync/tests.rs
@@ -892,7 +892,6 @@ pub(crate) mod harnesses {
                 replay_buffer: NZUsize!(1024),
             },
             translator: TwoCap,
-            init_cache_size: Some(NZUsize!(1024)),
             init_buffer: NZUsize!(1 << 21),
         }
     }
@@ -1286,7 +1285,6 @@ mod compact_variable_mmr {
                 replay_buffer: NZUsize!(1024),
             },
             translator: TwoCap,
-            init_cache_size: Some(NZUsize!(1024)),
             init_buffer: NZUsize!(1 << 21),
         }
     }
@@ -2025,7 +2023,6 @@ mod compact_variable_mmb {
                 replay_buffer: NZUsize!(1024),
             },
             translator: TwoCap,
-            init_cache_size: Some(NZUsize!(1024)),
             init_buffer: NZUsize!(1 << 21),
         }
     }

--- a/storage/src/qmdb/immutable/variable.rs
+++ b/storage/src/qmdb/immutable/variable.rs
@@ -57,14 +57,7 @@ impl<F: Family, E: Context, K: Key, V: VariableValue, H: Hasher, T: Translator, 
             ROOT_BAGGING,
         )
         .await?;
-        Self::init_from_journal(
-            journal,
-            context,
-            cfg.translator,
-            cfg.init_buffer,
-            cfg.init_cache_size,
-        )
-        .await
+        Self::init_from_journal(journal, context, cfg.translator, cfg.init_buffer).await
     }
 }
 

--- a/storage/src/qmdb/immutable/variable.rs
+++ b/storage/src/qmdb/immutable/variable.rs
@@ -130,7 +130,6 @@ mod tests {
                 replay_buffer: NZUsize!(1024),
             },
             translator: TwoCap,
-            init_cache_size: Some(NZUsize!(1024)),
             init_buffer: NZUsize!(1 << 21),
         }
     }

--- a/storage/src/qmdb/immutable/variable.rs
+++ b/storage/src/qmdb/immutable/variable.rs
@@ -292,6 +292,8 @@ mod tests {
         test_variable_rewind_preserves_collision_bucket => run_rewind_preserves_collision_bucket, open;
         test_variable_rewind_after_reopen_repeated_key_gap => run_rewind_after_reopen_repeated_key_gap, open;
         test_variable_rewind_after_reopen_mixed_gap_retained => run_rewind_after_reopen_mixed_gap_retained, open;
+        test_variable_rewind_repeated_key_live => run_rewind_repeated_key_live, open;
+        test_variable_rewind_after_reopen_repeated_key_retained => run_rewind_after_reopen_repeated_key_retained, open;
     }
 
     #[boxed]

--- a/storage/src/qmdb/mod.rs
+++ b/storage/src/qmdb/mod.rs
@@ -257,6 +257,41 @@ impl<F: Family> From<crate::journal::authenticated::Error<F>> for Error<F> {
     }
 }
 
+/// Builds a snapshot by replaying the log starting at `inactivity_floor_loc`, inserting the
+/// location of every keyed operation and retaining prior locations of the same key. Assumes the
+/// log is not pruned beyond the inactivity floor.
+///
+/// Suitable only for logs without update or delete operations, where every retained keyed
+/// operation stays readable. Repeats of a full key all land in the snapshot, matching a snapshot
+/// maintained live, so reads keep returning one of the key's written values however the snapshot
+/// was built.
+///
+/// `init_buffer` sizes the replay read buffer (in bytes).
+pub(super) async fn build_retained_snapshot_from_log<F, C, I>(
+    inactivity_floor_loc: crate::merkle::Location<F>,
+    reader: &C,
+    snapshot: &mut I,
+    init_buffer: NonZeroUsize,
+) -> Result<(), Error<F>>
+where
+    F: crate::merkle::Family,
+    C: Contiguous<Item: Operation<F>>,
+    I: Index<Value = crate::merkle::Location<F>>,
+{
+    let stream = reader
+        .replay(*inactivity_floor_loc, init_buffer, ReadOptions::default())
+        .await?;
+    pin_mut!(stream);
+    while let Some(result) = stream.next().await {
+        let (loc, op) = result?;
+        debug_assert!(!op.is_delete());
+        if let Some(key) = op.key() {
+            snapshot.insert(key, crate::merkle::Location::new(loc));
+        }
+    }
+    Ok(())
+}
+
 /// Builds the database's snapshot by replaying the log starting at the inactivity floor. Assumes
 /// the log is not pruned beyond the inactivity floor. The callback is invoked for each replayed
 /// operation, indicating activity status updates. The first argument of the callback is the

--- a/storage/src/qmdb/mod.rs
+++ b/storage/src/qmdb/mod.rs
@@ -257,41 +257,6 @@ impl<F: Family> From<crate::journal::authenticated::Error<F>> for Error<F> {
     }
 }
 
-/// Builds a snapshot by replaying the log starting at `inactivity_floor_loc`, inserting the
-/// location of every keyed operation and retaining prior locations of the same key. Assumes the
-/// log is not pruned beyond the inactivity floor.
-///
-/// Suitable only for logs without update or delete operations, where every retained keyed
-/// operation stays readable. Repeats of a full key all land in the snapshot, matching a snapshot
-/// maintained live, so reads keep returning one of the key's written values however the snapshot
-/// was built.
-///
-/// `init_buffer` sizes the replay read buffer (in bytes).
-pub(super) async fn build_retained_snapshot_from_log<F, C, I>(
-    inactivity_floor_loc: crate::merkle::Location<F>,
-    reader: &C,
-    snapshot: &mut I,
-    init_buffer: NonZeroUsize,
-) -> Result<(), Error<F>>
-where
-    F: crate::merkle::Family,
-    C: Contiguous<Item: Operation<F>>,
-    I: Index<Value = crate::merkle::Location<F>>,
-{
-    let stream = reader
-        .replay(*inactivity_floor_loc, init_buffer, ReadOptions::default())
-        .await?;
-    pin_mut!(stream);
-    while let Some(result) = stream.next().await {
-        let (loc, op) = result?;
-        debug_assert!(!op.is_delete());
-        if let Some(key) = op.key() {
-            snapshot.insert(key, crate::merkle::Location::new(loc));
-        }
-    }
-    Ok(())
-}
-
 /// Builds the database's snapshot by replaying the log starting at the inactivity floor. Assumes
 /// the log is not pruned beyond the inactivity floor. The callback is invoked for each replayed
 /// operation, indicating activity status updates. The first argument of the callback is the


### PR DESCRIPTION
Fixes a reported divergence between the immutable QMDB's live snapshot and its rebuilt snapshot that lets a rewind make a retained key unreadable.

## The bug

The immutable db requires each key to be set at most once, and documents a fallback when that invariant is violated: reads of a repeated key may return any of its written values. The live apply path honors this by retaining every location of a repeated key in the snapshot (`insert_and_retain`). Snapshot replay did not: it routed through the shared update path, which replaces a key's previous location with the newest one. After a restart or sync, a repeated key was left with a single snapshot entry.

`rewind` removes snapshot locations at or above the rewind point for every rewound key, and repairs the snapshot only when the rewind target has a lower inactivity floor (the gap fill). So rewinding across the newest write of a repeated key, with the floor unchanged, deleted the key's only snapshot entry and restored nothing. `get` then returned `None` even though the restored journal still retained the older `Set`, which proof generation could still attest. Reads also became dependent on restart history: a replica that never restarted served the older value after the same rewind, while a restarted replica served `None`, letting replicas with identical journals and roots diverge through the Stateful crash recovery path.

## The fix

Snapshot replay now inserts every keyed operation's location and retains prior locations of the same key, matching the live apply path (and the same insertion the rewind gap fill already performs). A rebuilt snapshot is now equivalent to one maintained live, so rewind's existing logic keeps the older location and reads keep returning one of the key's written values across restarts, syncs, and rewinds.

Since the retained replay never re-reads the log to resolve translated key collisions, immutable init gets cheaper and the `init_cache_size` config knob loses its only consumer. The second commit removes it (ALPHA surface) and can be dropped if a minimal fix is preferred.

## Tests

Adds two rewind regression runners alongside the existing floor gap coverage: `run_rewind_repeated_key_live` pins the live path contract, and `run_rewind_after_reopen_repeated_key_retained` pins the restart case, which failed with `None` before this change in both merkle families.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q4BFdANo2LhVEr2ko3FK9n
