### PR TITLE
[runtime] Hold storage directories until dispatched operations finish

### DIFF
--- a/examples/reshare/src/main.rs
+++ b/examples/reshare/src/main.rs
@@ -49,7 +49,16 @@ impl Command {
 
 fn main() {
     let cli = Cli::parse();
-    let runtime_dir = cli.command.runtime_dir();
+
+    // Setup generates configuration and needs no runtime. Run it before the
+    // runner starts, since `Runner::start` acquires a hold on (and creates) the
+    // storage directory inside the node directory setup requires to be empty.
+    let command = match cli.command {
+        Command::Setup(args) => return setup::run(args),
+        command => command,
+    };
+
+    let runtime_dir = command.runtime_dir();
     let config = tokio::Config::new()
         .with_worker_threads(cli.worker_threads)
         .with_catch_panics(false)
@@ -66,10 +75,10 @@ fn main() {
             None,
         );
 
-        match cli.command {
+        match command {
             Command::Dkg(args) => dkg::run(context, args).await,
-            Command::Setup(args) => setup::run(args),
             Command::Validator(args) => validator::run(context, args).await,
+            Command::Setup(_) => unreachable!("setup runs without a runtime"),
         }
     });
 }

--- a/examples/reshare/src/main.rs
+++ b/examples/reshare/src/main.rs
@@ -57,6 +57,8 @@ fn main() {
         return setup::run(args);
     }
 
+    // The remaining commands run a node, so they get a runtime whose storage
+    // lives inside the node directory.
     let runtime_dir = cli.command.runtime_dir();
     let config = tokio::Config::new()
         .with_worker_threads(cli.worker_threads)

--- a/examples/reshare/src/main.rs
+++ b/examples/reshare/src/main.rs
@@ -53,12 +53,11 @@ fn main() {
     // Setup generates configuration and needs no runtime. Run it before the
     // runner starts, since `Runner::start` acquires a hold on (and creates) the
     // storage directory inside the node directory setup requires to be empty.
-    let command = match cli.command {
-        Command::Setup(args) => return setup::run(args),
-        command => command,
-    };
+    if let Command::Setup(args) = cli.command {
+        return setup::run(args);
+    }
 
-    let runtime_dir = command.runtime_dir();
+    let runtime_dir = cli.command.runtime_dir();
     let config = tokio::Config::new()
         .with_worker_threads(cli.worker_threads)
         .with_catch_panics(false)
@@ -75,7 +74,7 @@ fn main() {
             None,
         );
 
-        match command {
+        match cli.command {
             Command::Dkg(args) => dkg::run(context, args).await,
             Command::Validator(args) => validator::run(context, args).await,
             Command::Setup(_) => unreachable!("setup runs without a runtime"),

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -667,15 +667,15 @@ stability_scope!(BETA {
     /// recovery: data read at initialization can be assumed to survive a
     /// subsequent crash without an explicit [`Blob::sync`].
     ///
-    /// # Instances
+    /// # Cancellation
     ///
-    /// Dropping an in-flight operation's future does not cancel it: the
-    /// operation may still take effect later, and a caller that drops a future
-    /// and then reads through the same instance may observe that late effect.
+    /// Dropping an operation's future does not guarantee cancellation: the
+    /// operation may still complete, and a later operation on the same storage
+    /// may observe its effect.
     ///
-    /// Runtimes must ensure that no operation issued through a storage instance
-    /// takes effect after a successor instance rooted at the same location has
-    /// been constructed.
+    /// Runtimes must ensure that no operation from a previous run on the same
+    /// storage takes effect after user code starts executing, including
+    /// operations whose futures were dropped.
     ///
     /// # Partition Names
     ///

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -670,12 +670,11 @@ stability_scope!(BETA {
     /// # Cancellation
     ///
     /// Dropping an operation's future does not guarantee cancellation: the
-    /// operation may still complete, and a later operation on the same storage
-    /// may observe its effect.
+    /// operation may still complete, and later operations may observe its
+    /// effect.
     ///
-    /// Runtimes must ensure that no operation from a previous run on the same
-    /// storage takes effect after user code starts executing, including
-    /// operations whose futures were dropped.
+    /// Runtimes must ensure that no operation issued by a previous run against
+    /// the same storage is still in flight when a new run begins.
     ///
     /// # Partition Names
     ///

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -599,6 +599,16 @@ stability_scope!(BETA {
     /// recovery: data read at initialization can be assumed to survive a
     /// subsequent crash without an explicit [`Blob::sync`].
     ///
+    /// # Instances
+    ///
+    /// Dropping an in-flight operation's future does not cancel it: the
+    /// operation may still take effect later, and a caller that drops a future
+    /// and then reads through the same instance may observe that late effect.
+    ///
+    /// Runtimes must ensure that no operation issued through a storage instance
+    /// takes effect after a successor instance rooted at the same location has
+    /// been constructed.
+    ///
     /// # Partition Names
     ///
     /// Partition names must be non-empty and contain only ASCII alphanumeric

--- a/runtime/src/storage/hold.rs
+++ b/runtime/src/storage/hold.rs
@@ -9,7 +9,11 @@ use std::{
 };
 use tracing::warn;
 
-/// Name of the hold file within the storage directory.
+/// Name of the hold file at the storage directory root.
+///
+/// This never collides with stored data. Blobs live one level down inside a
+/// partition directory, so none can occupy the root, and `validate_partition_name`
+/// rejects the `.` in `.hold`, so no partition can either.
 const HOLD_NAME: &str = ".hold";
 
 /// An exclusive hold on a storage directory, backed by an OS advisory lock on
@@ -87,5 +91,19 @@ impl Hold {
         let _ = file.seek(SeekFrom::Start(0));
         let _ = file.write_all(format!("{}\n", std::process::id()).as_bytes());
         Ok(Arc::new(Self { _file: file }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::HOLD_NAME;
+    use crate::storage::validate_partition_name;
+
+    #[test]
+    fn test_hold_name_rejected_as_partition() {
+        // The hold file sits at the storage root alongside partition
+        // directories, so its name must never pass partition validation. A
+        // partition named after it would occupy the hold's own path.
+        assert!(validate_partition_name(HOLD_NAME).is_err());
     }
 }

--- a/runtime/src/storage/hold.rs
+++ b/runtime/src/storage/hold.rs
@@ -36,11 +36,6 @@ const HOLD_NAME: &str = ".hold";
 /// contents. The lock is bound to the hold file's inode: removing or recreating
 /// the storage directory while a run may still be alive voids the exclusion.
 ///
-/// A storage instance kept alive past its run (e.g. a context escaping
-/// `Runner::start`) keeps the hold, blocking a successor on the same
-/// directory until it drops. That is intentional: the escaped instance can
-/// still perform I/O.
-///
 /// The guarantee is scoped to one machine and to filesystems with real
 /// advisory locks: on network filesystems (NFS, SMB, FUSE) the lock may be
 /// client-local or per process, excluding neither other machines nor other
@@ -57,7 +52,6 @@ impl Hold {
     pub(crate) fn acquire(dir: &Path) -> io::Result<Arc<Self>> {
         std::fs::create_dir_all(dir)?;
         let file = OpenOptions::new()
-            .read(true)
             .write(true)
             .create(true)
             .truncate(false)
@@ -93,9 +87,6 @@ mod tests {
 
     #[test]
     fn test_hold_name_rejected_as_partition() {
-        // The hold file sits at the storage root alongside partition
-        // directories, so its name must never pass partition validation. A
-        // partition named after it would occupy the hold's own path.
         assert!(validate_partition_name(HOLD_NAME).is_err());
     }
 

--- a/runtime/src/storage/hold.rs
+++ b/runtime/src/storage/hold.rs
@@ -1,0 +1,91 @@
+//! An exclusive hold on a storage directory, ensuring operations dispatched by
+//! a previous run never interfere with a successor.
+
+use std::{
+    fs::{File, OpenOptions, TryLockError},
+    io::{self, Read as _, Seek as _, SeekFrom, Write as _},
+    path::Path,
+    sync::Arc,
+};
+use tracing::warn;
+
+/// Name of the hold file within the storage directory.
+const HOLD_NAME: &str = ".hold";
+
+/// An exclusive hold on a storage directory, backed by an OS advisory lock on
+/// a file within it.
+///
+/// A backend shares the hold (via [Arc]) with everything that can still touch
+/// the directory once its storage instance is gone: every blocking operation
+/// it dispatches, every blob it opened, and (for io_uring) the ring thread. The
+/// hold is released only once all of them have finished, including operations
+/// whose futures were dropped mid-flight (dropping a future does not cancel
+/// work already handed to a blocking pool or ring). [Hold::acquire] waits for
+/// that release, so a successor never observes a previous run's operations
+/// landing underneath it.
+///
+/// The lock is held by the open file description, not by the file's existence:
+/// the operating system releases it when the holding process exits (cleanly or
+/// not), so a crashed run never requires manual cleanup and the hold file is
+/// never deleted. Its contents (the pid of the last holder) are a debugging
+/// breadcrumb, never a liveness signal, and a startup blocked on the hold logs
+/// them. The lock is bound to the hold file's inode: removing or recreating the
+/// storage directory while a run may still be alive voids the exclusion.
+///
+/// A storage instance kept alive past its run (e.g. a context escaping
+/// `Runner::start`) keeps the hold, blocking a successor on the same
+/// directory until it drops. That is intentional: the escaped instance can
+/// still perform I/O.
+///
+/// The guarantee is scoped to one machine and to filesystems with real
+/// advisory locks: on network filesystems (NFS, SMB, FUSE) the lock may be
+/// client-local or per process, excluding neither other machines nor other
+/// instances in the same process. A filesystem without advisory-lock support
+/// fails acquisition, which fails storage construction.
+pub(crate) struct Hold {
+    _file: File,
+}
+
+impl Hold {
+    /// Acquire the hold for `dir`, creating the directory and hold file if
+    /// missing. Blocks until any previous holder releases, warning first if
+    /// the hold is contended.
+    pub(crate) fn acquire(dir: &Path) -> io::Result<Arc<Self>> {
+        std::fs::create_dir_all(dir)?;
+        let mut file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .truncate(false)
+            .open(dir.join(HOLD_NAME))?;
+        match file.try_lock() {
+            Ok(()) => {}
+            Err(TryLockError::WouldBlock) => {
+                // Name the holder so a blocked startup can be diagnosed from the log alone.
+                let mut holder = String::new();
+                let _ = file.read_to_string(&mut holder);
+                warn!(
+                    directory = %dir.display(),
+                    holder = holder.trim(),
+                    "waiting for storage directory hold (operations from a previous run may still be finishing)"
+                );
+
+                // flock is not restarted after a handled signal, so keep waiting on EINTR.
+                loop {
+                    match file.lock() {
+                        Ok(()) => break,
+                        Err(err) if err.kind() == io::ErrorKind::Interrupted => {}
+                        Err(err) => return Err(err),
+                    }
+                }
+            }
+            Err(TryLockError::Error(err)) => return Err(err),
+        }
+
+        // Record the holder's pid as a debugging breadcrumb.
+        let _ = file.set_len(0);
+        let _ = file.seek(SeekFrom::Start(0));
+        let _ = file.write_all(format!("{}\n", std::process::id()).as_bytes());
+        Ok(Arc::new(Self { _file: file }))
+    }
+}

--- a/runtime/src/storage/hold.rs
+++ b/runtime/src/storage/hold.rs
@@ -97,7 +97,8 @@ impl Hold {
 #[cfg(test)]
 mod tests {
     use super::HOLD_NAME;
-    use crate::storage::validate_partition_name;
+    use crate::storage::{has_partitions, validate_partition_name};
+    use std::fs;
 
     #[test]
     fn test_hold_name_rejected_as_partition() {
@@ -105,5 +106,27 @@ mod tests {
         // directories, so its name must never pass partition validation. A
         // partition named after it would occupy the hold's own path.
         assert!(validate_partition_name(HOLD_NAME).is_err());
+    }
+
+    #[test]
+    fn test_has_partitions() {
+        let base =
+            std::env::temp_dir().join(format!("commonware_has_partitions_{}", std::process::id()));
+        let _ = fs::remove_dir_all(&base);
+
+        // An unreadable (here, missing) directory is reported as holding
+        // partitions so the startup flush is never skipped by accident.
+        assert!(has_partitions(&base));
+
+        // A directory holding only the hold file has no partitions.
+        fs::create_dir_all(&base).unwrap();
+        fs::write(base.join(HOLD_NAME), b"1\n").unwrap();
+        assert!(!has_partitions(&base));
+
+        // A subdirectory is a partition that could hold unsynced blob data.
+        fs::create_dir(base.join("partition")).unwrap();
+        assert!(has_partitions(&base));
+
+        let _ = fs::remove_dir_all(&base);
     }
 }

--- a/runtime/src/storage/hold.rs
+++ b/runtime/src/storage/hold.rs
@@ -1,5 +1,5 @@
-//! An exclusive hold on a storage directory, ensuring operations dispatched by
-//! a previous run never interfere with a successor.
+//! An exclusive hold on a storage directory, so no operation from a previous
+//! run is still in flight when a new run begins.
 
 use std::{
     fs::{File, OpenOptions, TryLockError},
@@ -11,36 +11,39 @@ use tracing::warn;
 
 /// Name of the hold file at the storage directory root.
 ///
-/// This never collides with stored data. Blobs live one level down inside a
-/// partition directory, so none can occupy the root, and `validate_partition_name`
-/// rejects the `.` in `.hold`, so no partition can either.
+/// It cannot collide with stored data: blobs live inside partition directories,
+/// and `validate_partition_name` rejects the `.`, so no partition can take this
+/// name.
 const HOLD_NAME: &str = ".hold";
 
 /// An exclusive hold on a storage directory, backed by an OS advisory lock on
 /// a file within it.
 ///
 /// A backend shares the hold (via [Arc]) with everything that can still touch
-/// the directory once its storage instance is gone: every blocking operation
-/// it dispatches, every blob it opened, and (for io_uring) the ring thread. The
-/// hold is released only once all of them have finished, including operations
-/// whose futures were dropped mid-flight (dropping a future does not cancel
-/// work already handed to a blocking pool or ring). [Hold::acquire] waits for
-/// that release, so a successor never observes a previous run's operations
-/// landing underneath it.
+/// the directory after its storage instance is gone. For tokio that is every
+/// blob's file handle and every dispatched blocking operation. For io_uring it
+/// is the ring thread, which the instance and every blob keep alive through
+/// their ring handles. The hold is released only once all of them have
+/// finished, including operations whose futures were dropped, since dropping a
+/// future does not cancel work already handed to a blocking pool or ring.
+/// [Hold::acquire] waits for that release.
 ///
-/// The lock is held by the open file description, not by the file's existence:
-/// the operating system releases it when the holding process exits (cleanly or
-/// not), so a crashed run never requires manual cleanup. The hold file is empty
-/// and never deleted. It is only a lock target, so the holder of a contended
-/// lock is found with the usual tools (`lsof`, `fuser`) rather than from its
-/// contents. The lock is bound to the hold file's inode: removing or recreating
-/// the storage directory while a run may still be alive voids the exclusion.
+/// The lock lives on the open file description, not the file: the OS releases
+/// it when the holding process exits, cleanly or not, so a crash needs no
+/// cleanup. Every thread of the process shares that description, so a blocking
+/// pool thread holds the lock through the same file, and exit releases it only
+/// after every thread has stopped, so an operation still running when the
+/// process dies cannot land under a successor. Child processes do not inherit
+/// it, since the file is opened close-on-exec. The file is empty and never
+/// deleted, so a contended holder is found with `lsof` or `fuser`. The lock is
+/// bound to the inode: removing or recreating the directory while a run may
+/// still be alive voids the exclusion.
 ///
 /// The guarantee is scoped to one machine and to filesystems with real
-/// advisory locks: on network filesystems (NFS, SMB, FUSE) the lock may be
-/// client-local or per process, excluding neither other machines nor other
-/// instances in the same process. A filesystem without advisory-lock support
-/// fails acquisition, which fails storage construction.
+/// advisory locks. On network filesystems (NFS, SMB, FUSE) the lock may be
+/// client-local or per process, so it may exclude neither other machines nor
+/// other instances in the same process. A filesystem that rejects the lock
+/// fails storage construction.
 pub(crate) struct Hold {
     _file: File,
 }

--- a/runtime/src/storage/hold.rs
+++ b/runtime/src/storage/hold.rs
@@ -3,7 +3,7 @@
 
 use std::{
     fs::{File, OpenOptions, TryLockError},
-    io::{self, Read as _, Seek as _, SeekFrom, Write as _},
+    io,
     path::Path,
     sync::Arc,
 };
@@ -30,11 +30,11 @@ const HOLD_NAME: &str = ".hold";
 ///
 /// The lock is held by the open file description, not by the file's existence:
 /// the operating system releases it when the holding process exits (cleanly or
-/// not), so a crashed run never requires manual cleanup and the hold file is
-/// never deleted. Its contents (the pid of the last holder) are a debugging
-/// breadcrumb, never a liveness signal, and a startup blocked on the hold logs
-/// them. The lock is bound to the hold file's inode: removing or recreating the
-/// storage directory while a run may still be alive voids the exclusion.
+/// not), so a crashed run never requires manual cleanup. The hold file is empty
+/// and never deleted. It is only a lock target, so the holder of a contended
+/// lock is found with the usual tools (`lsof`, `fuser`) rather than from its
+/// contents. The lock is bound to the hold file's inode: removing or recreating
+/// the storage directory while a run may still be alive voids the exclusion.
 ///
 /// A storage instance kept alive past its run (e.g. a context escaping
 /// `Runner::start`) keeps the hold, blocking a successor on the same
@@ -53,10 +53,10 @@ pub(crate) struct Hold {
 impl Hold {
     /// Acquire the hold for `dir`, creating the directory and hold file if
     /// missing. Blocks until any previous holder releases, warning first if
-    /// the hold is contended.
+    /// the hold is contended. A handled signal does not interrupt the wait.
     pub(crate) fn acquire(dir: &Path) -> io::Result<Arc<Self>> {
         std::fs::create_dir_all(dir)?;
-        let mut file = OpenOptions::new()
+        let file = OpenOptions::new()
             .read(true)
             .write(true)
             .create(true)
@@ -65,12 +65,8 @@ impl Hold {
         match file.try_lock() {
             Ok(()) => {}
             Err(TryLockError::WouldBlock) => {
-                // Name the holder so a blocked startup can be diagnosed from the log alone.
-                let mut holder = String::new();
-                let _ = file.read_to_string(&mut holder);
                 warn!(
                     directory = %dir.display(),
-                    holder = holder.trim(),
                     "waiting for storage directory hold (operations from a previous run may still be finishing)"
                 );
 
@@ -85,19 +81,14 @@ impl Hold {
             }
             Err(TryLockError::Error(err)) => return Err(err),
         }
-
-        // Record the holder's pid as a debugging breadcrumb.
-        let _ = file.set_len(0);
-        let _ = file.seek(SeekFrom::Start(0));
-        let _ = file.write_all(format!("{}\n", std::process::id()).as_bytes());
         Ok(Arc::new(Self { _file: file }))
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::HOLD_NAME;
-    use crate::storage::{has_partitions, validate_partition_name};
+    use super::{HOLD_NAME, Hold};
+    use crate::storage::validate_partition_name;
     use std::fs;
 
     #[test]
@@ -109,24 +100,14 @@ mod tests {
     }
 
     #[test]
-    fn test_has_partitions() {
-        let base =
-            std::env::temp_dir().join(format!("commonware_has_partitions_{}", std::process::id()));
-        let _ = fs::remove_dir_all(&base);
-
-        // An unreadable (here, missing) directory is reported as holding
-        // partitions so the startup flush is never skipped by accident.
-        assert!(has_partitions(&base));
-
-        // A directory holding only the hold file has no partitions.
-        fs::create_dir_all(&base).unwrap();
-        fs::write(base.join(HOLD_NAME), b"1\n").unwrap();
-        assert!(!has_partitions(&base));
-
-        // A subdirectory is a partition that could hold unsynced blob data.
-        fs::create_dir(base.join("partition")).unwrap();
-        assert!(has_partitions(&base));
-
-        let _ = fs::remove_dir_all(&base);
+    fn test_acquire_fails_on_unusable_root() {
+        // A root occupied by a regular file can be neither created nor locked,
+        // which fails storage construction.
+        let dir =
+            std::env::temp_dir().join(format!("commonware_hold_occupied_{}", std::process::id()));
+        let _ = fs::remove_dir_all(&dir);
+        fs::write(&dir, b"not a directory").unwrap();
+        assert!(Hold::acquire(&dir).is_err());
+        let _ = fs::remove_file(&dir);
     }
 }

--- a/runtime/src/storage/iouring.rs
+++ b/runtime/src/storage/iouring.rs
@@ -20,7 +20,7 @@
 //! This implementation is only available on Linux systems that support io_uring.
 //! It requires Linux kernel 6.1 or newer. See [crate::iouring] for details.
 
-use super::Header;
+use super::{Header, hold::Hold};
 use crate::{
     Buf, BufferPool, Error, Handle, IoBufs, IoBufsMut, ReadOptions, WriteOptions,
     iouring::{self},
@@ -76,7 +76,9 @@ fn sync_dir(path: &Path) -> Result<(), Error> {
 pub struct Config {
     /// Where to store blobs.
     pub storage_directory: PathBuf,
-    /// Configuration for the iouring instance.
+    /// Configuration for the iouring instance. `single_issuer` is forced on and
+    /// `shutdown_timeout` is forced to `None`: the ring must drain every
+    /// in-flight operation before the directory hold releases.
     pub iouring_config: iouring::Config,
     /// Stack size for the dedicated io_uring worker thread.
     pub thread_stack_size: usize,
@@ -88,6 +90,7 @@ pub struct Storage {
     storage_directory: PathBuf,
     io_handle: iouring::Handle,
     pool: BufferPool,
+    hold: Arc<Hold>,
 }
 
 impl Storage {
@@ -105,16 +108,40 @@ impl Storage {
         // the ring is the only thread submitting work to it.
         iouring_config.single_issuer = true;
 
+        // The directory hold's guarantee requires the ring to drain in-flight
+        // operations before it exits: a finite shutdown deadline would let the
+        // loop abandon operations that then land after the hold releases.
+        iouring_config.shutdown_timeout = None;
+
         let (io_handle, iouring_loop) = iouring::IoUringLoop::new(iouring_config, registry);
+
+        // Acquire the directory hold, blocking until any previous holder,
+        // including operations still finishing from a previous run, releases.
+        let hold = Hold::acquire(&storage_directory).unwrap_or_else(|e| {
+            panic!(
+                "failed to acquire storage directory hold ({}): {e}",
+                storage_directory.display()
+            )
+        });
 
         let storage = Self {
             lock: Arc::new(Mutex::new(())),
             storage_directory,
             io_handle,
             pool,
+            hold: hold.clone(),
         };
 
-        utils::thread::spawn(thread_stack_size, move || iouring_loop.run());
+        utils::thread::spawn(thread_stack_size, move || {
+            // Hold the storage directory until the ring has drained: the loop
+            // exits only after every submitter is dropped and in-flight work
+            // completes, so a successor never observes straggling ring
+            // operations. The storage instance and its blobs share the hold,
+            // covering their synchronous filesystem operations (open, remove,
+            // scan, resize), which complete within a single poll.
+            let _hold = hold;
+            iouring_loop.run()
+        });
         storage
     }
 }
@@ -153,8 +180,8 @@ impl crate::Storage for Storage {
 
         let raw_len = file.metadata().map_err(|_| Error::ReadFailed)?.len();
 
-        // Handle header: existing blobs have their header read; new blobs and blobs left torn
-        // by an interrupted creation get a fresh header written.
+        // Handle the header. Existing blobs have their header read. New blobs and blobs left
+        // torn by an interrupted creation get a fresh header written.
         let existing = resolve_header(&mut file, raw_len, &versions, partition, name)?;
         let (logical_len, blob_version, data_offset) = match existing {
             Some(resolved) => resolved,
@@ -189,6 +216,7 @@ impl crate::Storage for Storage {
             self.io_handle.clone(),
             self.pool.clone(),
             data_offset,
+            self.hold.clone(),
         );
         Ok((blob, logical_len, blob_version))
     }
@@ -269,6 +297,8 @@ pub struct Blob {
     /// Whether the kernel and filesystem may support `RWF_DONTCACHE`.
     /// Cleared on the first EOPNOTSUPP to avoid probing on every hinted I/O operation.
     dont_cache_supported: Arc<AtomicBool>,
+    /// Hold on the storage directory, kept while this handle can still touch it.
+    hold: Arc<Hold>,
 }
 
 impl Clone for Blob {
@@ -281,6 +311,7 @@ impl Clone for Blob {
             pool: self.pool.clone(),
             data_offset: self.data_offset,
             dont_cache_supported: self.dont_cache_supported.clone(),
+            hold: self.hold.clone(),
         }
     }
 }
@@ -294,6 +325,7 @@ impl Blob {
         io_handle: iouring::Handle,
         pool: BufferPool,
         data_offset: u64,
+        hold: Arc<Hold>,
     ) -> Self {
         Self {
             partition,
@@ -303,6 +335,7 @@ impl Blob {
             pool,
             data_offset,
             dont_cache_supported: Arc::new(AtomicBool::new(true)),
+            hold,
         }
     }
 }
@@ -457,6 +490,11 @@ mod tests {
         BufferPool::new(BufferPoolConfig::for_storage(), scope)
     }
 
+    /// Acquire a hold on a fresh temporary directory for blobs built without a storage.
+    fn test_hold() -> Arc<Hold> {
+        Hold::acquire(&create_test_directory()).unwrap()
+    }
+
     /// Build a fresh storage instance rooted in a unique temporary directory.
     fn create_test_storage() -> (Storage, PathBuf) {
         let storage_directory = env::temp_dir().join(format!(
@@ -490,6 +528,46 @@ mod tests {
         let _ = std::fs::remove_dir_all(&storage_directory);
         std::fs::create_dir_all(&storage_directory).unwrap();
         storage_directory
+    }
+
+    #[tokio::test]
+    async fn test_hold_retained_by_open_blob() {
+        let (storage, storage_directory) = create_test_storage();
+
+        // An open blob keeps the ring alive (and with it the directory hold),
+        // since a write or resize through it can still straggle. Dropping the
+        // storage while the blob lives must not release the hold.
+        let (blob, _) = storage.open("partition", b"blob").await.unwrap();
+        drop(storage);
+
+        let dir = storage_directory.clone();
+        let (tx, rx) = std::sync::mpsc::channel();
+        let handle = std::thread::spawn(move || {
+            let mut registry = Registry::default();
+            let pool = test_pool(&mut registry.sub_registry("pool"));
+            let second = Storage::start(
+                Config {
+                    storage_directory: dir,
+                    iouring_config: Default::default(),
+                    thread_stack_size: thread::system_thread_stack_size(),
+                },
+                &mut registry.sub_registry("storage"),
+                pool,
+            );
+            tx.send(()).unwrap();
+            drop(second);
+        });
+        assert!(
+            rx.recv_timeout(std::time::Duration::from_millis(200))
+                .is_err(),
+            "second instance acquired the hold while an open blob kept it"
+        );
+        drop(blob);
+        rx.recv_timeout(std::time::Duration::from_secs(10))
+            .expect("second instance did not acquire the hold after the blob dropped");
+        handle.join().unwrap();
+
+        let _ = std::fs::remove_dir_all(&storage_directory);
     }
 
     /// Verify the end-to-end storage-page alignment invariant on the io_uring backend: paged
@@ -951,18 +1029,17 @@ mod tests {
     #[tokio::test]
     async fn test_open_reports_partition_creation_failure() {
         // Verify opening a blob reports partition-creation failures when the
-        // configured storage root is not a directory.
+        // partition path is occupied by a regular file. (An unusable storage
+        // root fails Storage::start itself, when the directory hold is
+        // acquired.)
         let storage_directory = create_test_directory();
-        let storage_root = storage_directory.join("root-file");
-        std::fs::write(&storage_root, b"not a directory").unwrap();
+        std::fs::write(storage_directory.join("partition"), b"not a directory").unwrap();
 
-        // Start storage against the invalid root so `open` reaches the
-        // filesystem setup path under realistic wrapper code.
         let mut registry = Registry::default();
         let pool = test_pool(&mut registry.sub_registry("pool"));
         let storage = Storage::start(
             Config {
-                storage_directory: storage_root.clone(),
+                storage_directory: storage_directory.clone(),
                 iouring_config: Default::default(),
                 thread_stack_size: utils::thread::system_thread_stack_size(),
             },
@@ -974,10 +1051,9 @@ mod tests {
             .open("partition", b"blob")
             .await
             .err()
-            .expect("invalid storage root should fail");
+            .expect("occupied partition path should fail");
         assert_eq!(err.to_string(), "partition creation failed: partition");
 
-        let _ = std::fs::remove_file(&storage_root);
         let _ = std::fs::remove_dir_all(&storage_directory);
     }
 
@@ -1088,6 +1164,7 @@ mod tests {
             submitter,
             pool,
             Layout::V0.data_offset(),
+            test_hold(),
         );
 
         let empty = blob.read_at(0, 0, ReadOptions::DONT_CACHE).await.unwrap();
@@ -1157,6 +1234,7 @@ mod tests {
             submitter,
             pool,
             Layout::V0.data_offset(),
+            test_hold(),
         );
         // Sync should fail through the blob-specific wrapper before any kernel work is attempted.
         let err = blob
@@ -1196,6 +1274,7 @@ mod tests {
             submitter,
             pool,
             Layout::V0.data_offset(),
+            test_hold(),
         );
         let err = blob
             .start_sync()
@@ -1239,6 +1318,7 @@ mod tests {
             submitter,
             pool,
             Layout::V0.data_offset(),
+            test_hold(),
         );
         let err = blob
             .resize(0)
@@ -1277,6 +1357,7 @@ mod tests {
             submitter.clone(),
             pool,
             Layout::V0.data_offset(),
+            test_hold(),
         );
         // The request should reach the kernel and come back as a wrapped sync failure.
         let err = blob

--- a/runtime/src/storage/iouring.rs
+++ b/runtime/src/storage/iouring.rs
@@ -490,9 +490,9 @@ mod tests {
         BufferPool::new(BufferPoolConfig::for_storage(), scope)
     }
 
-    /// Acquire a hold on a fresh temporary directory for blobs built without a storage.
-    fn test_hold() -> Arc<Hold> {
-        Hold::acquire(&create_test_directory()).unwrap()
+    /// Acquire a hold on a test's directory for blobs built without a storage.
+    fn test_hold(storage_directory: &Path) -> Arc<Hold> {
+        Hold::acquire(storage_directory).unwrap()
     }
 
     /// Build a fresh storage instance rooted in a unique temporary directory.
@@ -557,11 +557,10 @@ mod tests {
             tx.send(()).unwrap();
             drop(second);
         });
-        assert!(
-            rx.recv_timeout(std::time::Duration::from_millis(200))
-                .is_err(),
-            "second instance acquired the hold while an open blob kept it"
-        );
+        match rx.recv_timeout(std::time::Duration::from_millis(200)) {
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {}
+            other => panic!("second instance did not stay blocked on the hold: {other:?}"),
+        }
         drop(blob);
         rx.recv_timeout(std::time::Duration::from_secs(10))
             .expect("second instance did not acquire the hold after the blob dropped");
@@ -1164,7 +1163,7 @@ mod tests {
             submitter,
             pool,
             Layout::V0.data_offset(),
-            test_hold(),
+            test_hold(&storage_directory),
         );
 
         let empty = blob.read_at(0, 0, ReadOptions::DONT_CACHE).await.unwrap();
@@ -1234,7 +1233,7 @@ mod tests {
             submitter,
             pool,
             Layout::V0.data_offset(),
-            test_hold(),
+            test_hold(&storage_directory),
         );
         // Sync should fail through the blob-specific wrapper before any kernel work is attempted.
         let err = blob
@@ -1274,7 +1273,7 @@ mod tests {
             submitter,
             pool,
             Layout::V0.data_offset(),
-            test_hold(),
+            test_hold(&storage_directory),
         );
         let err = blob
             .start_sync()
@@ -1318,7 +1317,7 @@ mod tests {
             submitter,
             pool,
             Layout::V0.data_offset(),
-            test_hold(),
+            test_hold(&storage_directory),
         );
         let err = blob
             .resize(0)
@@ -1357,7 +1356,7 @@ mod tests {
             submitter.clone(),
             pool,
             Layout::V0.data_offset(),
-            test_hold(),
+            test_hold(&storage_directory),
         );
         // The request should reach the kernel and come back as a wrapped sync failure.
         let err = blob

--- a/runtime/src/storage/iouring.rs
+++ b/runtime/src/storage/iouring.rs
@@ -20,7 +20,7 @@
 //! This implementation is only available on Linux systems that support io_uring.
 //! It requires Linux kernel 6.1 or newer. See [crate::iouring] for details.
 
-use super::{Header, Layout, hold::Hold};
+use super::{Header, Layout, hold::Hold, resolve_header, sync_dir};
 use crate::{
     BlobVersion, Buf, BufferPool, Error, Handle, IoBufs, IoBufsMut, ReadOptions, WriteOptions,
     iouring::{self},
@@ -31,46 +31,11 @@ use commonware_formatting::{from_hex, hex};
 use commonware_utils::sync::Mutex;
 use std::{
     fs::{self, File},
-    io::{Error as IoError, Read, Seek, SeekFrom, Write},
+    io::{Error as IoError, Seek, SeekFrom, Write},
     ops::RangeInclusive,
-    path::{Path, PathBuf},
+    path::PathBuf,
     sync::{Arc, atomic::AtomicBool},
 };
-
-/// Reads a blob's leading bytes and resolves its header (see [super::header::resolve]).
-fn resolve_header(
-    file: &mut File,
-    raw_len: u64,
-    layouts: &RangeInclusive<Layout>,
-    versions: &RangeInclusive<BlobVersion>,
-    partition: &str,
-    name: &[u8],
-) -> Result<Option<(u64, BlobVersion, u64)>, Error> {
-    let mut raw = vec![0u8; Header::resolve_len(raw_len)];
-    file.seek(SeekFrom::Start(0))
-        .map_err(|_| Error::ReadFailed)?;
-    file.read_exact(&mut raw).map_err(|_| Error::ReadFailed)?;
-    super::header::resolve(&raw, raw_len, layouts, versions, partition, name)
-}
-
-/// Syncs a directory to ensure directory entry changes are durable.
-/// On Unix, directory metadata (file creation/deletion) must be explicitly fsynced.
-fn sync_dir(path: &Path) -> Result<(), Error> {
-    let dir = File::open(path).map_err(|e| {
-        Error::BlobOpenFailed(
-            path.to_string_lossy().to_string(),
-            "directory".to_string(),
-            e.into(),
-        )
-    })?;
-    dir.sync_all().map_err(|e| {
-        Error::BlobSyncFailed(
-            path.to_string_lossy().to_string(),
-            "directory".to_string(),
-            e.into(),
-        )
-    })
-}
 
 /// Configuration for a [Storage].
 #[derive(Clone, Debug)]
@@ -94,7 +59,6 @@ pub struct Storage {
     blob_layouts: RangeInclusive<Layout>,
     io_handle: iouring::Handle,
     pool: BufferPool,
-    hold: Arc<Hold>,
 }
 
 impl Storage {
@@ -120,8 +84,6 @@ impl Storage {
 
         let (io_handle, iouring_loop) = iouring::IoUringLoop::new(iouring_config, registry);
 
-        // Acquire the directory hold, blocking until any previous holder,
-        // including operations still finishing from a previous run, releases.
         let hold = Hold::acquire(&storage_directory).unwrap_or_else(|e| {
             panic!(
                 "failed to acquire storage directory hold ({}): {e}",
@@ -135,16 +97,13 @@ impl Storage {
             blob_layouts,
             io_handle,
             pool,
-            hold: hold.clone(),
         };
 
         utils::thread::spawn(thread_stack_size, move || {
-            // Hold the storage directory until the ring has drained: the loop
-            // exits only after every submitter is dropped and in-flight work
-            // completes, so a successor never observes straggling ring
-            // operations. The storage instance and its blobs share the hold,
-            // covering their synchronous filesystem operations (open, remove,
-            // scan, resize), which complete within a single poll.
+            // Hold the storage directory until the ring has drained. The loop
+            // exits only after every ring handle is dropped and in-flight work
+            // completes, and the storage instance and every blob own a handle,
+            // so the hold outlives them and every operation they issue.
             let _hold = hold;
             iouring_loop.run()
         });
@@ -229,7 +188,6 @@ impl crate::Storage for Storage {
             self.io_handle.clone(),
             self.pool.clone(),
             data_offset,
-            self.hold.clone(),
         );
         Ok((blob, logical_len, blob_version))
     }
@@ -310,8 +268,6 @@ pub struct Blob {
     /// Whether the kernel and filesystem may support `RWF_DONTCACHE`.
     /// Cleared on the first EOPNOTSUPP to avoid probing on every hinted I/O operation.
     dont_cache_supported: Arc<AtomicBool>,
-    /// Hold on the storage directory, kept while this handle can still touch it.
-    hold: Arc<Hold>,
 }
 
 impl Clone for Blob {
@@ -324,7 +280,6 @@ impl Clone for Blob {
             pool: self.pool.clone(),
             data_offset: self.data_offset,
             dont_cache_supported: self.dont_cache_supported.clone(),
-            hold: self.hold.clone(),
         }
     }
 }
@@ -338,7 +293,6 @@ impl Blob {
         io_handle: iouring::Handle,
         pool: BufferPool,
         data_offset: u64,
-        hold: Arc<Hold>,
     ) -> Self {
         Self {
             partition,
@@ -348,7 +302,6 @@ impl Blob {
             pool,
             data_offset,
             dont_cache_supported: Arc::new(AtomicBool::new(true)),
-            hold,
         }
     }
 }
@@ -502,11 +455,6 @@ mod tests {
 
     fn test_pool(scope: &mut impl Register) -> BufferPool {
         BufferPool::new(BufferPoolConfig::for_storage(), scope)
-    }
-
-    /// Acquire a hold on a test's directory for blobs built without a storage.
-    fn test_hold(storage_directory: &Path) -> Arc<Hold> {
-        Hold::acquire(storage_directory).unwrap()
     }
 
     /// Build a fresh storage instance rooted in a unique temporary directory.
@@ -1181,7 +1129,6 @@ mod tests {
             submitter,
             pool,
             Layout::V0.data_offset(),
-            test_hold(&storage_directory),
         );
 
         let empty = blob.read_at(0, 0, ReadOptions::DONT_CACHE).await.unwrap();
@@ -1251,7 +1198,6 @@ mod tests {
             submitter,
             pool,
             Layout::V0.data_offset(),
-            test_hold(&storage_directory),
         );
         // Sync should fail through the blob-specific wrapper before any kernel work is attempted.
         let err = blob
@@ -1291,7 +1237,6 @@ mod tests {
             submitter,
             pool,
             Layout::V0.data_offset(),
-            test_hold(&storage_directory),
         );
         let err = blob
             .start_sync()
@@ -1335,7 +1280,6 @@ mod tests {
             submitter,
             pool,
             Layout::V0.data_offset(),
-            test_hold(&storage_directory),
         );
         let err = blob
             .resize(0)
@@ -1374,7 +1318,6 @@ mod tests {
             submitter.clone(),
             pool,
             Layout::V0.data_offset(),
-            test_hold(&storage_directory),
         );
         // The request should reach the kernel and come back as a wrapped sync failure.
         let err = blob

--- a/runtime/src/storage/mod.rs
+++ b/runtime/src/storage/mod.rs
@@ -44,26 +44,6 @@ stability_scope!(BETA, cfg(not(target_arch = "wasm32")) {
         }
     }
 
-    /// Whether `dir` holds any partition: a subdirectory that could contain blob data a prior
-    /// instance left unsynced. The runtime calls this under the storage hold to decide whether a
-    /// startup [sync] is needed, since a directory with no partitions has nothing to flush.
-    ///
-    /// A directory that cannot be read (including an entry whose type cannot be determined) is
-    /// reported as holding partitions, so an uncertain directory is flushed rather than skipped.
-    pub(crate) fn has_partitions(dir: &std::path::Path) -> bool {
-        let Ok(entries) = std::fs::read_dir(dir) else {
-            return true;
-        };
-        for entry in entries {
-            let is_dir = entry.and_then(|entry| entry.file_type()).map(|t| t.is_dir());
-            match is_dir {
-                Ok(false) => {}
-                _ => return true,
-            }
-        }
-        false
-    }
-
     pub(crate) mod hold;
 });
 

--- a/runtime/src/storage/mod.rs
+++ b/runtime/src/storage/mod.rs
@@ -3,6 +3,14 @@
 use commonware_macros::stability_scope;
 
 stability_scope!(BETA, cfg(not(target_arch = "wasm32")) {
+    use crate::{BlobVersion, Error};
+    use std::{
+        fs::File,
+        io::{Read as _, Seek as _, SeekFrom},
+        ops::RangeInclusive,
+        path::Path,
+    };
+
     /// Flush the whole filesystem containing `dir` at startup so that bytes a prior process wrote
     /// but did not `fsync` are crash-durable before any storage structure reads.
     ///
@@ -12,16 +20,12 @@ stability_scope!(BETA, cfg(not(target_arch = "wasm32")) {
     ///   crash-durable.
     ///
     /// Assumes storage lives on a single filesystem; on Linux reliable error detection needs kernel
-    /// >= 5.8. A missing `dir` is treated as success.
+    /// >= 5.8.
     pub(crate) fn sync(dir: &std::path::Path) -> std::io::Result<()> {
         cfg_if::cfg_if! {
             if #[cfg(target_os = "linux")] {
                 use std::os::fd::AsRawFd;
-                let file = match std::fs::File::open(dir) {
-                    Ok(file) => file,
-                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
-                    Err(e) => return Err(e),
-                };
+                let file = std::fs::File::open(dir)?;
                 // SAFETY: `file` owns a valid fd that lives across the call; `syncfs` takes only
                 // that fd, performs no memory access, and returns -1 on error.
                 if unsafe { libc::syncfs(file.as_raw_fd()) } == -1 {
@@ -42,6 +46,41 @@ stability_scope!(BETA, cfg(not(target_arch = "wasm32")) {
                 Ok(())
             }
         }
+    }
+
+    /// Syncs a directory to ensure directory entry changes are durable.
+    /// On Unix, directory metadata (file creation/deletion) must be explicitly fsynced.
+    pub(crate) fn sync_dir(path: &Path) -> Result<(), Error> {
+        let dir = File::open(path).map_err(|e| {
+            Error::BlobOpenFailed(
+                path.to_string_lossy().to_string(),
+                "directory".to_string(),
+                e.into(),
+            )
+        })?;
+        dir.sync_all().map_err(|e| {
+            Error::BlobSyncFailed(
+                path.to_string_lossy().to_string(),
+                "directory".to_string(),
+                e.into(),
+            )
+        })
+    }
+
+    /// Reads a blob's leading bytes and resolves its header (see [header::resolve]).
+    pub(crate) fn resolve_header(
+        file: &mut File,
+        raw_len: u64,
+        layouts: &RangeInclusive<Layout>,
+        versions: &RangeInclusive<BlobVersion>,
+        partition: &str,
+        name: &[u8],
+    ) -> Result<Option<(u64, BlobVersion, u64)>, Error> {
+        let mut raw = vec![0u8; Header::resolve_len(raw_len)];
+        file.seek(SeekFrom::Start(0))
+            .map_err(|_| Error::ReadFailed)?;
+        file.read_exact(&mut raw).map_err(|_| Error::ReadFailed)?;
+        header::resolve(&raw, raw_len, layouts, versions, partition, name)
     }
 
     pub(crate) mod hold;

--- a/runtime/src/storage/mod.rs
+++ b/runtime/src/storage/mod.rs
@@ -43,6 +43,8 @@ stability_scope!(BETA, cfg(not(target_arch = "wasm32")) {
             }
         }
     }
+
+    pub(crate) mod hold;
 });
 
 stability_scope!(ALPHA {

--- a/runtime/src/storage/mod.rs
+++ b/runtime/src/storage/mod.rs
@@ -44,6 +44,26 @@ stability_scope!(BETA, cfg(not(target_arch = "wasm32")) {
         }
     }
 
+    /// Whether `dir` holds any partition: a subdirectory that could contain blob data a prior
+    /// instance left unsynced. The runtime calls this under the storage hold to decide whether a
+    /// startup [sync] is needed, since a directory with no partitions has nothing to flush.
+    ///
+    /// A directory that cannot be read (including an entry whose type cannot be determined) is
+    /// reported as holding partitions, so an uncertain directory is flushed rather than skipped.
+    pub(crate) fn has_partitions(dir: &std::path::Path) -> bool {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return true;
+        };
+        for entry in entries {
+            let is_dir = entry.and_then(|entry| entry.file_type()).map(|t| t.is_dir());
+            match is_dir {
+                Ok(false) => {}
+                _ => return true,
+            }
+        }
+        false
+    }
+
     pub(crate) mod hold;
 });
 

--- a/runtime/src/storage/tokio/blob.rs
+++ b/runtime/src/storage/tokio/blob.rs
@@ -8,6 +8,7 @@ use commonware_utils::channel::oneshot;
 use std::{
     fs::File,
     io::IoSlice,
+    ops::Deref,
     os::{fd::AsRawFd, unix::fs::FileExt},
     sync::{
         Arc,
@@ -48,20 +49,38 @@ impl Cache {
     }
 }
 
+/// A blob's file together with the hold on its storage directory, so any
+/// operation that reaches the file also keeps the directory held.
+struct Held {
+    file: File,
+    _hold: Arc<Hold>,
+}
+
+impl Held {
+    fn new(file: File, hold: Arc<Hold>) -> Arc<Self> {
+        Arc::new(Self { file, _hold: hold })
+    }
+}
+
+impl Deref for Held {
+    type Target = File;
+
+    fn deref(&self) -> &File {
+        &self.file
+    }
+}
+
 #[derive(Clone)]
 pub struct Blob {
     partition: String,
     name: Vec<u8>,
-    file: Arc<File>,
+    file: Arc<Held>,
     pool: BufferPool,
     /// Physical offset where logical offset 0 begins (the size of the header region).
     data_offset: u64,
     /// Whether the kernel and filesystem may support `RWF_DONTCACHE`.
     /// Cleared on the first EOPNOTSUPP to avoid probing on every hinted I/O operation.
     dont_cache_supported: Arc<AtomicBool>,
-    /// Hold on the storage directory, cloned into every dispatched blocking
-    /// operation so a successor storage instance waits for stragglers.
-    hold: Arc<Hold>,
 }
 
 impl Blob {
@@ -76,11 +95,10 @@ impl Blob {
         Self {
             partition,
             name: name.into(),
-            file: Arc::new(file),
+            file: Held::new(file, hold),
             pool,
             data_offset,
             dont_cache_supported: Arc::new(AtomicBool::new(true)),
-            hold,
         }
     }
 
@@ -283,9 +301,7 @@ impl crate::Blob for Blob {
         } else {
             Cache::Enabled
         };
-        let hold = self.hold.clone();
         task::spawn_blocking(move || {
-            let _hold = hold;
             if let Some(buf) = bufs.as_single_mut() {
                 // Read directly into the single buffer (zero-copy).
                 Self::read_exact_at(cache, &file, buf.as_mut(), offset)?;
@@ -326,10 +342,7 @@ impl crate::Blob for Blob {
         };
         let partition = sync.then(|| self.partition.clone());
         let name = sync.then(|| self.name.clone());
-        let hold = self.hold.clone();
         task::spawn_blocking(move || {
-            let _hold = hold;
-
             // Preserve the single-buffer fast path when no option requires per-write flags.
             let bufs = if !sync && !cache.is_disabled() {
                 match bufs.try_into_single() {
@@ -384,15 +397,13 @@ impl crate::Blob for Blob {
         let len = len
             .checked_add(self.data_offset)
             .ok_or(Error::OffsetOverflow)?;
-        let hold = self.hold.clone();
-        task::spawn_blocking(move || {
-            let _hold = hold;
-            file.set_len(len)
-        })
-        .await
-        .map_err(|e| e.into())
-        .and_then(|r| r)
-        .map_err(|e| Error::BlobResizeFailed(self.partition.clone(), hex(&self.name), e.into()))?;
+        task::spawn_blocking(move || file.set_len(len))
+            .await
+            .map_err(|e| e.into())
+            .and_then(|r| r)
+            .map_err(|e| {
+                Error::BlobResizeFailed(self.partition.clone(), hex(&self.name), e.into())
+            })?;
         Ok(())
     }
 
@@ -400,16 +411,12 @@ impl crate::Blob for Blob {
         let file = self.file.clone();
         let partition = self.partition.clone();
         let name = self.name.clone();
-        let hold = self.hold.clone();
-        task::spawn_blocking(move || {
-            let _hold = hold;
-            Self::sync_inner(&file, &partition, &name)
-        })
-        .await
-        .map_err(|e| {
-            let err: std::io::Error = e.into();
-            Error::BlobSyncFailed(self.partition.clone(), hex(&self.name), err.into())
-        })?
+        task::spawn_blocking(move || Self::sync_inner(&file, &partition, &name))
+            .await
+            .map_err(|e| {
+                let err: std::io::Error = e.into();
+                Error::BlobSyncFailed(self.partition.clone(), hex(&self.name), err.into())
+            })?
     }
 
     async fn start_sync(&self) -> Handle<()> {
@@ -417,9 +424,7 @@ impl crate::Blob for Blob {
         let file = self.file.clone();
         let partition = self.partition.clone();
         let name = self.name.clone();
-        let hold = self.hold.clone();
         task::spawn_blocking(move || {
-            let _hold = hold;
             let result = Self::sync_inner(&file, &partition, &name);
             let _ = tx.send(result);
         });

--- a/runtime/src/storage/tokio/blob.rs
+++ b/runtime/src/storage/tokio/blob.rs
@@ -49,8 +49,10 @@ impl Cache {
     }
 }
 
-/// A blob's file together with the hold on its storage directory, so any
-/// operation that reaches the file also keeps the directory held.
+/// A blob's file bundled with the hold on its storage directory.
+///
+/// An operation must capture the file to touch it, so it carries the hold
+/// into the blocking pool without having to remember to.
 struct Held {
     file: File,
     _hold: Arc<Hold>,

--- a/runtime/src/storage/tokio/blob.rs
+++ b/runtime/src/storage/tokio/blob.rs
@@ -1,4 +1,7 @@
-use crate::{Buf, BufferPool, Error, Handle, IoBufs, IoBufsMut, ReadOptions, WriteOptions};
+use crate::{
+    Buf, BufferPool, Error, Handle, IoBufs, IoBufsMut, ReadOptions, WriteOptions,
+    storage::hold::Hold,
+};
 use cfg_if::cfg_if;
 use commonware_formatting::hex;
 use commonware_utils::channel::oneshot;
@@ -56,15 +59,19 @@ pub struct Blob {
     /// Whether the kernel and filesystem may support `RWF_DONTCACHE`.
     /// Cleared on the first EOPNOTSUPP to avoid probing on every hinted I/O operation.
     dont_cache_supported: Arc<AtomicBool>,
+    /// Hold on the storage directory, cloned into every dispatched blocking
+    /// operation so a successor storage instance waits for stragglers.
+    hold: Arc<Hold>,
 }
 
 impl Blob {
-    pub fn new(
+    pub(crate) fn new(
         partition: String,
         name: &[u8],
         file: File,
         pool: BufferPool,
         data_offset: u64,
+        hold: Arc<Hold>,
     ) -> Self {
         Self {
             partition,
@@ -73,6 +80,7 @@ impl Blob {
             pool,
             data_offset,
             dont_cache_supported: Arc::new(AtomicBool::new(true)),
+            hold,
         }
     }
 
@@ -275,7 +283,9 @@ impl crate::Blob for Blob {
         } else {
             Cache::Enabled
         };
+        let hold = self.hold.clone();
         task::spawn_blocking(move || {
+            let _hold = hold;
             if let Some(buf) = bufs.as_single_mut() {
                 // Read directly into the single buffer (zero-copy).
                 Self::read_exact_at(cache, &file, buf.as_mut(), offset)?;
@@ -316,7 +326,10 @@ impl crate::Blob for Blob {
         };
         let partition = sync.then(|| self.partition.clone());
         let name = sync.then(|| self.name.clone());
+        let hold = self.hold.clone();
         task::spawn_blocking(move || {
+            let _hold = hold;
+
             // Preserve the single-buffer fast path when no option requires per-write flags.
             let bufs = if !sync && !cache.is_disabled() {
                 match bufs.try_into_single() {
@@ -371,13 +384,15 @@ impl crate::Blob for Blob {
         let len = len
             .checked_add(self.data_offset)
             .ok_or(Error::OffsetOverflow)?;
-        task::spawn_blocking(move || file.set_len(len))
-            .await
-            .map_err(|e| e.into())
-            .and_then(|r| r)
-            .map_err(|e| {
-                Error::BlobResizeFailed(self.partition.clone(), hex(&self.name), e.into())
-            })?;
+        let hold = self.hold.clone();
+        task::spawn_blocking(move || {
+            let _hold = hold;
+            file.set_len(len)
+        })
+        .await
+        .map_err(|e| e.into())
+        .and_then(|r| r)
+        .map_err(|e| Error::BlobResizeFailed(self.partition.clone(), hex(&self.name), e.into()))?;
         Ok(())
     }
 
@@ -385,12 +400,16 @@ impl crate::Blob for Blob {
         let file = self.file.clone();
         let partition = self.partition.clone();
         let name = self.name.clone();
-        task::spawn_blocking(move || Self::sync_inner(&file, &partition, &name))
-            .await
-            .map_err(|e| {
-                let err: std::io::Error = e.into();
-                Error::BlobSyncFailed(self.partition.clone(), hex(&self.name), err.into())
-            })?
+        let hold = self.hold.clone();
+        task::spawn_blocking(move || {
+            let _hold = hold;
+            Self::sync_inner(&file, &partition, &name)
+        })
+        .await
+        .map_err(|e| {
+            let err: std::io::Error = e.into();
+            Error::BlobSyncFailed(self.partition.clone(), hex(&self.name), err.into())
+        })?
     }
 
     async fn start_sync(&self) -> Handle<()> {
@@ -398,7 +417,9 @@ impl crate::Blob for Blob {
         let file = self.file.clone();
         let partition = self.partition.clone();
         let name = self.name.clone();
+        let hold = self.hold.clone();
         task::spawn_blocking(move || {
+            let _hold = hold;
             let result = Self::sync_inner(&file, &partition, &name);
             let _ = tx.send(result);
         });

--- a/runtime/src/storage/tokio/mod.rs
+++ b/runtime/src/storage/tokio/mod.rs
@@ -125,7 +125,6 @@ impl crate::Storage for Storage {
                 .truncate(false)
                 .open(&path)
                 .map_err(|e| Error::BlobOpenFailed(partition.clone(), hex(&name), e.into()))?;
-
             let raw_len = file.metadata().map_err(|_| Error::ReadFailed)?.len();
 
             // Handle the header. Existing blobs have their header read. New blobs and blobs

--- a/runtime/src/storage/tokio/mod.rs
+++ b/runtime/src/storage/tokio/mod.rs
@@ -1,35 +1,15 @@
-use super::{Header, Layout, hold::Hold};
+use super::{Header, Layout, hold::Hold, resolve_header, sync_dir};
 use crate::{BlobVersion, BufferPool, Error};
 use commonware_formatting::{from_hex, hex};
 use std::{
-    io::{Read as _, Seek as _, SeekFrom, Write as _},
+    io::{Seek as _, SeekFrom, Write as _},
     ops::RangeInclusive,
-    path::{Path, PathBuf},
+    path::PathBuf,
     sync::Arc,
 };
 use tokio::sync::Mutex;
 
 mod blob;
-
-/// Syncs a directory to ensure directory entry changes are durable.
-/// On Unix, directory metadata (file creation/deletion) must be explicitly
-/// fsynced.
-fn sync_dir(path: &Path) -> Result<(), Error> {
-    let dir = std::fs::File::open(path).map_err(|e| {
-        Error::BlobOpenFailed(
-            path.to_string_lossy().to_string(),
-            "directory".to_string(),
-            e.into(),
-        )
-    })?;
-    dir.sync_all().map_err(|e| {
-        Error::BlobSyncFailed(
-            path.to_string_lossy().to_string(),
-            "directory".to_string(),
-            e.into(),
-        )
-    })
-}
 
 #[derive(Clone)]
 pub struct Config {
@@ -51,23 +31,10 @@ pub struct Storage {
     lock: Arc<Mutex<()>>,
     cfg: Config,
     pool: BufferPool,
+    /// Hold on the storage directory, cloned into every dispatched blocking
+    /// operation and every blob so a successor storage instance waits for
+    /// stragglers.
     hold: Arc<Hold>,
-}
-
-/// Reads a blob's leading bytes and resolves its header (see [super::header::resolve]).
-fn resolve_header(
-    file: &mut std::fs::File,
-    raw_len: u64,
-    layouts: &RangeInclusive<Layout>,
-    versions: &RangeInclusive<BlobVersion>,
-    partition: &str,
-    name: &[u8],
-) -> Result<Option<(u64, BlobVersion, u64)>, Error> {
-    let mut raw = vec![0u8; Header::resolve_len(raw_len)];
-    file.seek(SeekFrom::Start(0))
-        .map_err(|_| Error::ReadFailed)?;
-    file.read_exact(&mut raw).map_err(|_| Error::ReadFailed)?;
-    super::header::resolve(&raw, raw_len, layouts, versions, partition, name)
 }
 
 impl Storage {
@@ -94,6 +61,29 @@ impl Storage {
             hold,
         }
     }
+
+    /// Run `f` to completion on the blocking pool while owning the filesystem
+    /// lock and the directory hold, so dropping the returned future neither
+    /// abandons `f` mid-sequence nor lets a successor storage instance
+    /// initialize before `f` has finished. A closure dropped unstarted at
+    /// runtime shutdown yields [Error::Closed].
+    async fn dispatch<T: Send + 'static>(
+        &self,
+        f: impl FnOnce() -> Result<T, Error> + Send + 'static,
+    ) -> Result<T, Error> {
+        let guard = self.lock.clone().lock_owned().await;
+        let hold = self.hold.clone();
+        let task = tokio::task::spawn_blocking(move || {
+            let _hold = hold;
+            let _guard = guard;
+            f()
+        });
+        match task.await {
+            Ok(result) => result,
+            Err(err) if err.is_panic() => std::panic::resume_unwind(err.into_panic()),
+            Err(_) => Err(Error::Closed),
+        }
+    }
 }
 
 impl crate::Storage for Storage {
@@ -107,27 +97,19 @@ impl crate::Storage for Storage {
     ) -> Result<(Self::Blob, u64, BlobVersion), Error> {
         super::validate_partition_name(partition)?;
 
-        // Acquire the filesystem lock, owned so the open runs serialized to
-        // completion even if this future is dropped.
-        let guard = self.lock.clone().lock_owned().await;
-
-        // Run the open to completion on the blocking pool: it mutates the
-        // partition directory and the blob (create, truncate, header write,
-        // syncs), and dropping this future must not abandon that sequence
-        // half-done (a straggling truncate could clobber a successor's blob)
-        // or leave a later open trusting a header whose syncs never ran. The
-        // closure owns the directory hold, so a successor storage instance
-        // cannot initialize until the open has finished.
+        // The open mutates the partition directory and the blob (create,
+        // truncate, header write, syncs). Dropping this future must not abandon
+        // that sequence half-done (a straggling truncate could clobber a
+        // successor's blob) or leave a later open trusting a header whose syncs
+        // never ran.
         let path = self.cfg.storage_directory.join(partition).join(hex(name));
         let storage_directory = self.cfg.storage_directory.clone();
         let partition = partition.to_string();
         let name = name.to_vec();
         let blob_layouts = self.cfg.blob_layouts.clone();
+        let pool = self.pool.clone();
         let hold = self.hold.clone();
-        let open = tokio::task::spawn_blocking(move || {
-            let _hold = hold;
-            let _guard = guard;
-
+        self.dispatch(move || {
             let parent = match path.parent() {
                 Some(parent) => parent,
                 None => return Err(Error::PartitionCreationFailed(partition)),
@@ -158,7 +140,7 @@ impl crate::Storage for Storage {
                 &partition,
                 &name,
             )?;
-            let resolved = match existing {
+            let (logical_size, blob_version, data_offset) = match existing {
                 Some(resolved) => resolved,
                 None => {
                     // Sync the directories before writing the header so a parseable
@@ -184,45 +166,23 @@ impl crate::Storage for Storage {
                     (0, blob_version, data_offset)
                 }
             };
-            Ok((file, partition, name, resolved))
-        });
-        let (file, partition, name, (logical_size, blob_version, data_offset)) = match open.await {
-            Ok(result) => result?,
-            Err(err) if err.is_panic() => std::panic::resume_unwind(err.into_panic()),
-            Err(_) => return Err(Error::Closed),
-        };
 
-        let blob = Self::Blob::new(
-            partition,
-            &name,
-            file,
-            self.pool.clone(),
-            data_offset,
-            self.hold.clone(),
-        );
-        Ok((blob, logical_size, blob_version))
+            let blob = Self::Blob::new(partition, &name, file, pool, data_offset, hold);
+            Ok((blob, logical_size, blob_version))
+        })
+        .await
     }
 
     async fn remove(&self, partition: &str, name: Option<&[u8]>) -> Result<(), Error> {
         super::validate_partition_name(partition)?;
 
-        // Acquire the filesystem lock. The guard is owned so the removal runs
-        // serialized to completion even if this future is dropped.
-        let guard = self.lock.clone().lock_owned().await;
-
-        // Run the removal to completion on the blocking pool: dropping this
-        // future must not abandon the sequence between an unlink and the
-        // directory sync that makes it durable. The closure owns the directory
-        // hold, so a successor storage instance cannot initialize until the
-        // removal has finished.
+        // Dropping this future must not abandon the sequence between an unlink
+        // and the directory sync that makes it durable.
         let path = self.cfg.storage_directory.join(partition);
         let storage_directory = self.cfg.storage_directory.clone();
         let partition = partition.to_string();
         let name = name.map(<[u8]>::to_vec);
-        let hold = self.hold.clone();
-        let removal = tokio::task::spawn_blocking(move || {
-            let _hold = hold;
-            let _guard = guard;
+        self.dispatch(move || {
             if let Some(name) = name {
                 let blob_path = path.join(hex(&name));
                 std::fs::remove_file(blob_path)
@@ -237,30 +197,16 @@ impl crate::Storage for Storage {
                 sync_dir(&storage_directory)?;
             }
             Ok(())
-        });
-        match removal.await {
-            Ok(result) => result,
-            Err(err) if err.is_panic() => std::panic::resume_unwind(err.into_panic()),
-            Err(_) => Err(Error::Closed),
-        }
+        })
+        .await
     }
 
     async fn scan(&self, partition: &str) -> Result<Vec<Vec<u8>>, Error> {
         super::validate_partition_name(partition)?;
 
-        // Acquire the filesystem lock, owned so the scan runs serialized to
-        // completion even if this future is dropped.
-        let guard = self.lock.clone().lock_owned().await;
-
-        // Run the scan on the blocking pool. The closure owns the directory
-        // hold, so a successor storage instance cannot initialize until it
-        // has finished.
         let path = self.cfg.storage_directory.join(partition);
         let partition = partition.to_string();
-        let hold = self.hold.clone();
-        let scan = tokio::task::spawn_blocking(move || {
-            let _hold = hold;
-            let _guard = guard;
+        self.dispatch(move || {
             let entries =
                 std::fs::read_dir(path).map_err(|_| Error::PartitionMissing(partition.clone()))?;
             let mut blobs = Vec::new();
@@ -284,12 +230,8 @@ impl crate::Storage for Storage {
                 }
             }
             Ok(blobs)
-        });
-        match scan.await {
-            Ok(result) => result,
-            Err(err) if err.is_panic() => std::panic::resume_unwind(err.into_panic()),
-            Err(_) => Err(Error::Closed),
-        }
+        })
+        .await
     }
 }
 

--- a/runtime/src/storage/tokio/mod.rs
+++ b/runtime/src/storage/tokio/mod.rs
@@ -292,7 +292,7 @@ mod tests {
     use commonware_utils::sys_rng;
     use futures::FutureExt as _;
     use rand::RngExt as _;
-    use std::env;
+    use std::{env, sync::mpsc::RecvTimeoutError};
 
     fn test_pool() -> BufferPool {
         let mut registry = Registry::default();
@@ -363,11 +363,10 @@ mod tests {
             tx.send(()).unwrap();
             drop(second);
         });
-        assert!(
-            rx.recv_timeout(std::time::Duration::from_millis(200))
-                .is_err(),
-            "second instance acquired the hold while an open blob kept it"
-        );
+        match rx.recv_timeout(std::time::Duration::from_millis(200)) {
+            Err(RecvTimeoutError::Timeout) => {}
+            other => panic!("second instance did not stay blocked on the hold: {other:?}"),
+        }
         drop(blob);
         rx.recv_timeout(std::time::Duration::from_secs(10))
             .expect("second instance did not acquire the hold after the blob dropped");
@@ -391,11 +390,10 @@ mod tests {
             tx.send(()).unwrap();
             drop(second);
         });
-        assert!(
-            rx.recv_timeout(std::time::Duration::from_millis(200))
-                .is_err(),
-            "second instance acquired the hold while the first held it"
-        );
+        match rx.recv_timeout(std::time::Duration::from_millis(200)) {
+            Err(RecvTimeoutError::Timeout) => {}
+            other => panic!("second instance did not stay blocked on the hold: {other:?}"),
+        }
         drop(first);
         rx.recv_timeout(std::time::Duration::from_secs(10))
             .expect("second instance did not acquire the hold after the first released it");

--- a/runtime/src/storage/tokio/mod.rs
+++ b/runtime/src/storage/tokio/mod.rs
@@ -1,31 +1,28 @@
-use super::Header;
+use super::{Header, hold::Hold};
 use crate::{BufferPool, Error};
 use commonware_formatting::{from_hex, hex};
 use std::{
+    io::{Read as _, Seek as _, SeekFrom, Write as _},
     ops::RangeInclusive,
     path::{Path, PathBuf},
     sync::Arc,
 };
-use tokio::{
-    fs,
-    io::{AsyncReadExt, AsyncSeekExt, AsyncWriteExt},
-    sync::Mutex,
-};
+use tokio::sync::Mutex;
 
 mod blob;
 
 /// Syncs a directory to ensure directory entry changes are durable.
 /// On Unix, directory metadata (file creation/deletion) must be explicitly
 /// fsynced.
-async fn sync_dir(path: &Path) -> Result<(), Error> {
-    let dir = fs::File::open(path).await.map_err(|e| {
+fn sync_dir(path: &Path) -> Result<(), Error> {
+    let dir = std::fs::File::open(path).map_err(|e| {
         Error::BlobOpenFailed(
             path.to_string_lossy().to_string(),
             "directory".to_string(),
             e.into(),
         )
     })?;
-    dir.sync_all().await.map_err(|e| {
+    dir.sync_all().map_err(|e| {
         Error::BlobSyncFailed(
             path.to_string_lossy().to_string(),
             "directory".to_string(),
@@ -37,15 +34,11 @@ async fn sync_dir(path: &Path) -> Result<(), Error> {
 #[derive(Clone)]
 pub struct Config {
     pub storage_directory: PathBuf,
-    pub maximum_buffer_size: usize,
 }
 
 impl Config {
-    pub const fn new(storage_directory: PathBuf, maximum_buffer_size: usize) -> Self {
-        Self {
-            storage_directory,
-            maximum_buffer_size,
-        }
+    pub const fn new(storage_directory: PathBuf) -> Self {
+        Self { storage_directory }
     }
 }
 
@@ -54,29 +47,46 @@ pub struct Storage {
     lock: Arc<Mutex<()>>,
     cfg: Config,
     pool: BufferPool,
+    hold: Arc<Hold>,
 }
 
 /// Reads a blob's leading bytes and resolves its header (see [super::header::resolve]).
-async fn resolve_header(
-    file: &mut fs::File,
+fn resolve_header(
+    file: &mut std::fs::File,
     raw_len: u64,
     versions: &RangeInclusive<u16>,
     partition: &str,
     name: &[u8],
 ) -> Result<Option<(u64, u16, u64)>, Error> {
     let mut raw = vec![0u8; Header::resolve_len(raw_len)];
-    file.read_exact(&mut raw)
-        .await
+    file.seek(SeekFrom::Start(0))
         .map_err(|_| Error::ReadFailed)?;
+    file.read_exact(&mut raw).map_err(|_| Error::ReadFailed)?;
     super::header::resolve(&raw, raw_len, versions, partition, name)
 }
 
 impl Storage {
+    /// Create a storage instance rooted at `cfg.storage_directory`, creating
+    /// the directory if missing.
+    ///
+    /// Acquires the directory hold, blocking until any previous holder,
+    /// including operations still finishing from a previous run, releases it.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the directory cannot be created or its hold cannot be acquired.
     pub fn new(cfg: Config, pool: BufferPool) -> Self {
+        let hold = Hold::acquire(&cfg.storage_directory).unwrap_or_else(|e| {
+            panic!(
+                "failed to acquire storage directory hold ({}): {e}",
+                cfg.storage_directory.display()
+            )
+        });
         Self {
             lock: Arc::new(Mutex::new(())),
             cfg,
             pool,
+            hold,
         }
     }
 }
@@ -92,153 +102,182 @@ impl crate::Storage for Storage {
     ) -> Result<(Self::Blob, u64, u16), Error> {
         super::validate_partition_name(partition)?;
 
-        // Acquire the filesystem lock. The guard is owned so the creation path can move it
-        // into a task that outlives a dropped open future.
+        // Acquire the filesystem lock, owned so the open runs serialized to
+        // completion even if this future is dropped.
         let guard = self.lock.clone().lock_owned().await;
 
-        // Construct the full path
+        // Run the open to completion on the blocking pool: it mutates the
+        // partition directory and the blob (create, truncate, header write,
+        // syncs), and dropping this future must not abandon that sequence
+        // half-done (a straggling truncate could clobber a successor's blob)
+        // or leave a later open trusting a header whose syncs never ran. The
+        // closure owns the directory hold, so a successor storage instance
+        // cannot initialize until the open has finished.
         let path = self.cfg.storage_directory.join(partition).join(hex(name));
-        let parent = match path.parent() {
-            Some(parent) => parent,
-            None => return Err(Error::PartitionCreationFailed(partition.into())),
-        };
+        let storage_directory = self.cfg.storage_directory.clone();
+        let partition = partition.to_string();
+        let name = name.to_vec();
+        let hold = self.hold.clone();
+        let open = tokio::task::spawn_blocking(move || {
+            let _hold = hold;
+            let _guard = guard;
 
-        // Create the partition directory, if it does not exist
-        fs::create_dir_all(parent)
-            .await
-            .map_err(|_| Error::PartitionCreationFailed(partition.into()))?;
+            let parent = match path.parent() {
+                Some(parent) => parent,
+                None => return Err(Error::PartitionCreationFailed(partition)),
+            };
 
-        // Open the file, creating it if it doesn't exist
-        let mut file = fs::OpenOptions::new()
-            .read(true)
-            .write(true)
-            .create(true)
-            .truncate(false)
-            .open(&path)
-            .await
-            .map_err(|e| Error::BlobOpenFailed(partition.into(), hex(name), e.into()))?;
+            // Create the partition directory, if it does not exist
+            std::fs::create_dir_all(parent)
+                .map_err(|_| Error::PartitionCreationFailed(partition.clone()))?;
 
-        let raw_len = file.metadata().await.map_err(|_| Error::ReadFailed)?.len();
+            // Open the file, creating it if it doesn't exist
+            let mut file = std::fs::OpenOptions::new()
+                .read(true)
+                .write(true)
+                .create(true)
+                .truncate(false)
+                .open(&path)
+                .map_err(|e| Error::BlobOpenFailed(partition.clone(), hex(&name), e.into()))?;
 
-        // Set the maximum buffer size
-        file.set_max_buf_size(self.cfg.maximum_buffer_size);
+            let raw_len = file.metadata().map_err(|_| Error::ReadFailed)?.len();
 
-        // Handle header: existing blobs have their header read; new blobs and blobs left torn
-        // by an interrupted creation get a fresh header written.
-        let existing = resolve_header(&mut file, raw_len, &versions, partition, name).await?;
-        let (file, guard, (logical_size, blob_version, data_offset)) = match existing {
-            Some(resolved) => (file, guard, resolved),
-            None => {
-                // Run creation to completion on a task that owns the filesystem lock:
-                // dropping the open future must not abandon the sequence half-done (a
-                // straggling truncate could clobber a successor's blob) or leave a later
-                // open trusting a header whose syncs never ran. The task hands the lock
-                // back so the open holds it until the blob is returned, like the reopen
-                // path.
-                let parent = parent.to_path_buf();
-                let storage_directory = self.cfg.storage_directory.clone();
-                let err_partition = partition.to_string();
-                let err_name = hex(name);
-                let creation = tokio::task::spawn(async move {
+            // Handle the header. Existing blobs have their header read. New blobs and blobs
+            // left torn by an interrupted creation get a fresh header written.
+            let existing = resolve_header(&mut file, raw_len, &versions, &partition, &name)?;
+            let resolved = match existing {
+                Some(resolved) => resolved,
+                None => {
                     // Sync the directories before writing the header so a parseable
                     // header always implies durable directory entries (an open that
                     // parses a header never re-runs these). The storage directory is
                     // synced unconditionally: the partition directory existing in the
                     // namespace does not imply its entry is durable.
-                    sync_dir(&parent).await?;
-                    sync_dir(&storage_directory).await?;
+                    sync_dir(parent)?;
+                    sync_dir(&storage_directory)?;
 
                     // Truncate to zero before writing, per the [Header::create] contract.
                     let (region, blob_version) =
                         Header::create(crate::storage::Layout::V1, &versions);
                     let data_offset = region.len() as u64;
-                    file.set_len(0).await.map_err(|e| {
-                        Error::BlobResizeFailed(err_partition.clone(), err_name.clone(), e.into())
+                    file.set_len(0).map_err(|e| {
+                        Error::BlobResizeFailed(partition.clone(), hex(&name), e.into())
                     })?;
-                    file.rewind().await.map_err(|_| Error::WriteFailed)?;
-                    file.write_all(&region)
-                        .await
+                    file.seek(SeekFrom::Start(0))
                         .map_err(|_| Error::WriteFailed)?;
-                    file.sync_all()
-                        .await
-                        .map_err(|e| Error::BlobSyncFailed(err_partition, err_name, e.into()))?;
-
-                    Ok::<_, Error>((file, guard, (0, blob_version, data_offset)))
-                });
-                match creation.await {
-                    Ok(result) => result?,
-                    Err(err) if err.is_panic() => std::panic::resume_unwind(err.into_panic()),
-                    Err(_) => return Err(Error::Closed),
+                    file.write_all(&region).map_err(|_| Error::WriteFailed)?;
+                    file.sync_all().map_err(|e| {
+                        Error::BlobSyncFailed(partition.clone(), hex(&name), e.into())
+                    })?;
+                    (0, blob_version, data_offset)
                 }
-            }
+            };
+            Ok((file, partition, name, resolved))
+        });
+        let (file, partition, name, (logical_size, blob_version, data_offset)) = match open.await {
+            Ok(result) => result?,
+            Err(err) if err.is_panic() => std::panic::resume_unwind(err.into_panic()),
+            Err(_) => return Err(Error::Closed),
         };
 
-        // Convert to a blocking std::fs::File
-        let file = file.into_std().await;
-
-        // Construct the blob while still holding the filesystem lock.
-        let blob = Self::Blob::new(partition.into(), name, file, self.pool.clone(), data_offset);
-        drop(guard);
+        let blob = Self::Blob::new(
+            partition,
+            &name,
+            file,
+            self.pool.clone(),
+            data_offset,
+            self.hold.clone(),
+        );
         Ok((blob, logical_size, blob_version))
     }
 
     async fn remove(&self, partition: &str, name: Option<&[u8]>) -> Result<(), Error> {
         super::validate_partition_name(partition)?;
 
-        // Acquire the filesystem lock
-        let _guard = self.lock.lock().await;
+        // Acquire the filesystem lock. The guard is owned so the removal runs
+        // serialized to completion even if this future is dropped.
+        let guard = self.lock.clone().lock_owned().await;
 
-        // Remove all related files
+        // Run the removal to completion on the blocking pool: dropping this
+        // future must not abandon the sequence between an unlink and the
+        // directory sync that makes it durable. The closure owns the directory
+        // hold, so a successor storage instance cannot initialize until the
+        // removal has finished.
         let path = self.cfg.storage_directory.join(partition);
-        if let Some(name) = name {
-            let blob_path = path.join(hex(name));
-            fs::remove_file(blob_path)
-                .await
-                .map_err(|_| Error::BlobMissing(partition.into(), hex(name)))?;
+        let storage_directory = self.cfg.storage_directory.clone();
+        let partition = partition.to_string();
+        let name = name.map(<[u8]>::to_vec);
+        let hold = self.hold.clone();
+        let removal = tokio::task::spawn_blocking(move || {
+            let _hold = hold;
+            let _guard = guard;
+            if let Some(name) = name {
+                let blob_path = path.join(hex(&name));
+                std::fs::remove_file(blob_path)
+                    .map_err(|_| Error::BlobMissing(partition, hex(&name)))?;
 
-            // Sync the partition directory to ensure the removal is durable.
-            sync_dir(&path).await?;
-        } else {
-            fs::remove_dir_all(&path)
-                .await
-                .map_err(|_| Error::PartitionMissing(partition.into()))?;
+                // Sync the partition directory to ensure the removal is durable.
+                sync_dir(&path)?;
+            } else {
+                std::fs::remove_dir_all(&path).map_err(|_| Error::PartitionMissing(partition))?;
 
-            // Sync the storage directory to ensure the removal is durable.
-            sync_dir(&self.cfg.storage_directory).await?;
+                // Sync the storage directory to ensure the removal is durable.
+                sync_dir(&storage_directory)?;
+            }
+            Ok(())
+        });
+        match removal.await {
+            Ok(result) => result,
+            Err(err) if err.is_panic() => std::panic::resume_unwind(err.into_panic()),
+            Err(_) => Err(Error::Closed),
         }
-        Ok(())
     }
 
     async fn scan(&self, partition: &str) -> Result<Vec<Vec<u8>>, Error> {
         super::validate_partition_name(partition)?;
 
-        // Acquire the filesystem lock
-        let _guard = self.lock.lock().await;
+        // Acquire the filesystem lock, owned so the scan runs serialized to
+        // completion even if this future is dropped.
+        let guard = self.lock.clone().lock_owned().await;
 
-        // Scan the partition directory
+        // Run the scan on the blocking pool. The closure owns the directory
+        // hold, so a successor storage instance cannot initialize until it
+        // has finished.
         let path = self.cfg.storage_directory.join(partition);
-        let mut entries = fs::read_dir(path)
-            .await
-            .map_err(|_| Error::PartitionMissing(partition.into()))?;
-        let mut blobs = Vec::new();
-        while let Some(entry) = entries.next_entry().await.map_err(|_| Error::ReadFailed)? {
-            let file_type = entry.file_type().await.map_err(|_| Error::ReadFailed)?;
-            if !file_type.is_file() {
-                return Err(Error::PartitionCorrupt(partition.into()));
-            }
-            if let Some(name) = entry.file_name().to_str() {
-                // Reject anything that isn't canonical lowercase hex (no `0x`
-                // prefix, no whitespace) since `from_hex` is lenient and
-                // storage only ever writes the canonical form via `hex()`.
-                let decoded = from_hex(name).ok_or(Error::PartitionCorrupt(partition.into()))?;
-                if hex(&decoded) != name {
-                    return Err(Error::PartitionCorrupt(partition.into()));
+        let partition = partition.to_string();
+        let hold = self.hold.clone();
+        let scan = tokio::task::spawn_blocking(move || {
+            let _hold = hold;
+            let _guard = guard;
+            let entries =
+                std::fs::read_dir(path).map_err(|_| Error::PartitionMissing(partition.clone()))?;
+            let mut blobs = Vec::new();
+            for entry in entries {
+                let entry = entry.map_err(|_| Error::ReadFailed)?;
+                let file_type = entry.file_type().map_err(|_| Error::ReadFailed)?;
+                if !file_type.is_file() {
+                    return Err(Error::PartitionCorrupt(partition));
                 }
+                if let Some(name) = entry.file_name().to_str() {
+                    // Reject anything that isn't canonical lowercase hex (no `0x`
+                    // prefix, no whitespace) since `from_hex` is lenient and
+                    // storage only ever writes the canonical form via `hex()`.
+                    let decoded =
+                        from_hex(name).ok_or_else(|| Error::PartitionCorrupt(partition.clone()))?;
+                    if hex(&decoded) != name {
+                        return Err(Error::PartitionCorrupt(partition));
+                    }
 
-                blobs.push(decoded);
+                    blobs.push(decoded);
+                }
             }
+            Ok(blobs)
+        });
+        match scan.await {
+            Ok(result) => result,
+            Err(err) if err.is_panic() => std::panic::resume_unwind(err.into_panic()),
+            Err(_) => Err(Error::Closed),
         }
-        Ok(blobs)
     }
 }
 
@@ -251,6 +290,7 @@ mod tests {
         telemetry::metrics::Registry,
     };
     use commonware_utils::sys_rng;
+    use futures::FutureExt as _;
     use rand::RngExt as _;
     use std::env;
 
@@ -265,11 +305,111 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_hold_waits_for_straggling_remove() {
+        let storage_directory =
+            env::temp_dir().join(format!("storage_tokio_hold_remove_{}", random_suffix()));
+        let config = Config::new(storage_directory.clone());
+        let storage = Storage::new(config.clone(), test_pool());
+
+        // Fill the partition with enough blobs that its removal takes a while,
+        // so a successor that failed to wait would observe it mid-flight.
+        let partition_path = storage_directory.join("partition");
+        std::fs::create_dir_all(&partition_path).unwrap();
+        for i in 0..5_000u64 {
+            std::fs::write(partition_path.join(hex(&i.to_be_bytes())), b"x").unwrap();
+        }
+
+        // Dispatch the partition's removal and drop its future mid-flight,
+        // leaving the removal to finish on the blocking pool as a straggler.
+        {
+            let mut remove = Box::pin(storage.remove("partition", None));
+            assert!(
+                (&mut remove).now_or_never().is_none(),
+                "removal completed before it could straggle"
+            );
+        }
+        drop(storage);
+
+        // A successor cannot initialize until the straggler finishes, so the
+        // partition is guaranteed gone by the time it scans.
+        let storage = Storage::new(config, test_pool());
+        let result = storage.scan("partition").await;
+        assert!(
+            matches!(result, Err(Error::PartitionMissing(_))),
+            "{result:?}"
+        );
+
+        drop(storage);
+        let _ = std::fs::remove_dir_all(&storage_directory);
+    }
+
+    #[tokio::test]
+    async fn test_hold_retained_by_open_blob() {
+        let storage_directory =
+            env::temp_dir().join(format!("storage_tokio_hold_blob_{}", random_suffix()));
+        let config = Config::new(storage_directory.clone());
+        let storage = Storage::new(config.clone(), test_pool());
+
+        // An open blob holds a clone of the directory hold, since a write or
+        // resize through it can still straggle. Dropping the storage while the
+        // blob lives must not release the hold.
+        let (blob, _) = storage.open("partition", b"blob").await.unwrap();
+        drop(storage);
+
+        let config_second = config.clone();
+        let (tx, rx) = std::sync::mpsc::channel();
+        let handle = std::thread::spawn(move || {
+            let second = Storage::new(config_second, test_pool());
+            tx.send(()).unwrap();
+            drop(second);
+        });
+        assert!(
+            rx.recv_timeout(std::time::Duration::from_millis(200))
+                .is_err(),
+            "second instance acquired the hold while an open blob kept it"
+        );
+        drop(blob);
+        rx.recv_timeout(std::time::Duration::from_secs(10))
+            .expect("second instance did not acquire the hold after the blob dropped");
+        handle.join().unwrap();
+
+        let _ = std::fs::remove_dir_all(&storage_directory);
+    }
+
+    #[test]
+    fn test_hold_blocks_second_instance() {
+        let storage_directory =
+            env::temp_dir().join(format!("storage_tokio_hold_block_{}", random_suffix()));
+        let config = Config::new(storage_directory.clone());
+        let first = Storage::new(config.clone(), test_pool());
+
+        // A second instance on the same directory cannot acquire the hold
+        // until the first releases it.
+        let (tx, rx) = std::sync::mpsc::channel();
+        let handle = std::thread::spawn(move || {
+            let second = Storage::new(config, test_pool());
+            tx.send(()).unwrap();
+            drop(second);
+        });
+        assert!(
+            rx.recv_timeout(std::time::Duration::from_millis(200))
+                .is_err(),
+            "second instance acquired the hold while the first held it"
+        );
+        drop(first);
+        rx.recv_timeout(std::time::Duration::from_secs(10))
+            .expect("second instance did not acquire the hold after the first released it");
+        handle.join().unwrap();
+
+        let _ = std::fs::remove_dir_all(&storage_directory);
+    }
+
+    #[tokio::test]
     async fn test_storage() {
         let mut rng = sys_rng();
         let storage_directory =
             env::temp_dir().join(format!("storage_tokio_{}", rng.random::<u64>()));
-        let config = Config::new(storage_directory, 2 * 1024 * 1024);
+        let config = Config::new(storage_directory);
         let storage = Storage::new(config, test_pool());
         run_storage_tests(storage).await;
     }
@@ -281,7 +421,7 @@ mod tests {
         let mut rng = sys_rng();
         let storage_directory =
             env::temp_dir().join(format!("storage_tokio_start_sync_{}", rng.random::<u64>()));
-        let config = Config::new(storage_directory, 2 * 1024 * 1024);
+        let config = Config::new(storage_directory);
         let storage = Storage::new(config, test_pool());
 
         let (blob, _) = storage.open("partition", b"test_blob").await.unwrap();
@@ -311,7 +451,7 @@ mod tests {
         let mut rng = sys_rng();
         let storage_directory =
             env::temp_dir().join(format!("storage_tokio_header_{}", rng.random::<u64>()));
-        let config = Config::new(storage_directory.clone(), 2 * 1024 * 1024);
+        let config = Config::new(storage_directory.clone());
         let storage = Storage::new(config, test_pool());
 
         // Test 1: New blob (V1 by default) returns logical size 0 and correct app version
@@ -419,7 +559,7 @@ mod tests {
     async fn test_v1_paged_alignment() {
         let storage_directory =
             env::temp_dir().join(format!("storage_tokio_aligned_{}", random_suffix()));
-        let config = Config::new(storage_directory.clone(), 2 * 1024 * 1024);
+        let config = Config::new(storage_directory.clone());
         let storage = Storage::new(config, test_pool());
 
         // A logical page size whose physical page is exactly one 4096-byte storage page.
@@ -472,13 +612,7 @@ mod tests {
     async fn test_blob_torn_creation_recovers() {
         let storage_directory =
             env::temp_dir().join(format!("test_torn_creation_{}", random_suffix()));
-        let storage = Storage::new(
-            Config {
-                storage_directory: storage_directory.clone(),
-                maximum_buffer_size: 1024 * 1024,
-            },
-            test_pool(),
-        );
+        let storage = Storage::new(Config::new(storage_directory.clone()), test_pool());
 
         // Create a durable V1 blob to obtain the canonical header region bytes.
         let (blob, _) = storage.open("partition", b"torn").await.unwrap();
@@ -560,13 +694,7 @@ mod tests {
 
         let storage_directory =
             env::temp_dir().join(format!("test_dropped_open_{}", random_suffix()));
-        let storage = Storage::new(
-            Config {
-                storage_directory: storage_directory.clone(),
-                maximum_buffer_size: 1024 * 1024,
-            },
-            test_pool(),
-        );
+        let storage = Storage::new(Config::new(storage_directory.clone()), test_pool());
 
         for depth in 0..64 {
             let name = format!("blob{depth}");
@@ -606,13 +734,7 @@ mod tests {
     async fn test_blob_v1_rejects_nonzero_header_padding() {
         let storage_directory =
             env::temp_dir().join(format!("test_v1_header_padding_{}", random_suffix()));
-        let storage = Storage::new(
-            Config {
-                storage_directory: storage_directory.clone(),
-                maximum_buffer_size: 1024 * 1024,
-            },
-            test_pool(),
-        );
+        let storage = Storage::new(Config::new(storage_directory.clone()), test_pool());
 
         let partition_dir = storage_directory.join("partition");
         std::fs::create_dir_all(&partition_dir).unwrap();
@@ -633,13 +755,7 @@ mod tests {
     async fn test_blob_v0_legacy_read() {
         let storage_directory =
             env::temp_dir().join(format!("test_v0_legacy_read_{}", random_suffix()));
-        let storage = Storage::new(
-            Config {
-                storage_directory: storage_directory.clone(),
-                maximum_buffer_size: 1024 * 1024,
-            },
-            test_pool(),
-        );
+        let storage = Storage::new(Config::new(storage_directory.clone()), test_pool());
 
         // Fabricate a legacy V0 blob on disk (creation is always V1): an 8-byte header
         // followed immediately by the payload.
@@ -682,13 +798,7 @@ mod tests {
     async fn test_blob_magic_mismatch() {
         let storage_directory =
             env::temp_dir().join(format!("test_magic_mismatch_{}", random_suffix()));
-        let storage = Storage::new(
-            Config {
-                storage_directory: storage_directory.clone(),
-                maximum_buffer_size: 1024 * 1024,
-            },
-            test_pool(),
-        );
+        let storage = Storage::new(Config::new(storage_directory.clone()), test_pool());
 
         // Create the partition directory and a file whose magic bytes are foreign (not a
         // prefix of any canonical header, so not a torn creation)
@@ -712,13 +822,7 @@ mod tests {
     async fn test_blob_partial_header_reset() {
         let storage_directory =
             env::temp_dir().join(format!("test_partial_header_reset_{}", random_suffix()));
-        let storage = Storage::new(
-            Config {
-                storage_directory: storage_directory.clone(),
-                maximum_buffer_size: 1024 * 1024,
-            },
-            test_pool(),
-        );
+        let storage = Storage::new(Config::new(storage_directory.clone()), test_pool());
         let partition_path = storage_directory.join("partition");
         std::fs::create_dir_all(&partition_path).unwrap();
 
@@ -765,13 +869,7 @@ mod tests {
                 bad_name.replace([' ', '0', 'x', 'X'], "_"),
                 random_suffix()
             ));
-            let storage = Storage::new(
-                Config {
-                    storage_directory: storage_directory.clone(),
-                    maximum_buffer_size: 1024 * 1024,
-                },
-                test_pool(),
-            );
+            let storage = Storage::new(Config::new(storage_directory.clone()), test_pool());
 
             let partition_path = storage_directory.join("partition");
             std::fs::create_dir_all(&partition_path).unwrap();

--- a/runtime/src/storage/tokio/mod.rs
+++ b/runtime/src/storage/tokio/mod.rs
@@ -2,6 +2,7 @@ use super::{Header, Layout, hold::Hold, resolve_header, sync_dir};
 use crate::{BlobVersion, BufferPool, Error};
 use commonware_formatting::{from_hex, hex};
 use std::{
+    fs,
     io::{Seek as _, SeekFrom, Write as _},
     ops::RangeInclusive,
     path::PathBuf,
@@ -38,11 +39,9 @@ pub struct Storage {
 }
 
 impl Storage {
-    /// Create a storage instance rooted at `cfg.storage_directory`, creating
-    /// the directory if missing.
-    ///
-    /// Acquires the directory hold, blocking until any previous holder,
-    /// including operations still finishing from a previous run, releases it.
+    /// Create a storage instance rooted at `cfg.storage_directory`, creating the
+    /// directory if missing and holding it until every operation of this
+    /// instance has finished. Blocks while a previous instance still holds it.
     ///
     /// # Panics
     ///
@@ -97,11 +96,7 @@ impl crate::Storage for Storage {
     ) -> Result<(Self::Blob, u64, BlobVersion), Error> {
         super::validate_partition_name(partition)?;
 
-        // The open mutates the partition directory and the blob (create,
-        // truncate, header write, syncs). Dropping this future must not abandon
-        // that sequence half-done (a straggling truncate could clobber a
-        // successor's blob) or leave a later open trusting a header whose syncs
-        // never ran.
+        // Construct the full path
         let path = self.cfg.storage_directory.join(partition).join(hex(name));
         let storage_directory = self.cfg.storage_directory.clone();
         let partition = partition.to_string();
@@ -109,6 +104,12 @@ impl crate::Storage for Storage {
         let blob_layouts = self.cfg.blob_layouts.clone();
         let pool = self.pool.clone();
         let hold = self.hold.clone();
+
+        // Run the open to completion: it mutates the partition directory and the
+        // blob (create, truncate, header write, syncs), and dropping this future
+        // must not abandon that sequence half-done (a straggling truncate could
+        // clobber a successor's blob) or leave a later open trusting a header
+        // whose syncs never ran.
         self.dispatch(move || {
             let parent = match path.parent() {
                 Some(parent) => parent,
@@ -116,11 +117,11 @@ impl crate::Storage for Storage {
             };
 
             // Create the partition directory, if it does not exist
-            std::fs::create_dir_all(parent)
+            fs::create_dir_all(parent)
                 .map_err(|_| Error::PartitionCreationFailed(partition.clone()))?;
 
             // Open the file, creating it if it doesn't exist
-            let mut file = std::fs::OpenOptions::new()
+            let mut file = fs::OpenOptions::new()
                 .read(true)
                 .write(true)
                 .create(true)
@@ -167,6 +168,7 @@ impl crate::Storage for Storage {
                 }
             };
 
+            // Construct the blob while still holding the filesystem lock.
             let blob = Self::Blob::new(partition, &name, file, pool, data_offset, hold);
             Ok((blob, logical_size, blob_version))
         })
@@ -176,22 +178,25 @@ impl crate::Storage for Storage {
     async fn remove(&self, partition: &str, name: Option<&[u8]>) -> Result<(), Error> {
         super::validate_partition_name(partition)?;
 
-        // Dropping this future must not abandon the sequence between an unlink
-        // and the directory sync that makes it durable.
         let path = self.cfg.storage_directory.join(partition);
         let storage_directory = self.cfg.storage_directory.clone();
         let partition = partition.to_string();
         let name = name.map(<[u8]>::to_vec);
+
+        // Run the removal to completion: dropping this future must not abandon
+        // the sequence between an unlink and the directory sync that makes it
+        // durable.
         self.dispatch(move || {
+            // Remove all related files
             if let Some(name) = name {
                 let blob_path = path.join(hex(&name));
-                std::fs::remove_file(blob_path)
+                fs::remove_file(blob_path)
                     .map_err(|_| Error::BlobMissing(partition, hex(&name)))?;
 
                 // Sync the partition directory to ensure the removal is durable.
                 sync_dir(&path)?;
             } else {
-                std::fs::remove_dir_all(&path).map_err(|_| Error::PartitionMissing(partition))?;
+                fs::remove_dir_all(&path).map_err(|_| Error::PartitionMissing(partition))?;
 
                 // Sync the storage directory to ensure the removal is durable.
                 sync_dir(&storage_directory)?;
@@ -207,8 +212,9 @@ impl crate::Storage for Storage {
         let path = self.cfg.storage_directory.join(partition);
         let partition = partition.to_string();
         self.dispatch(move || {
+            // Scan the partition directory
             let entries =
-                std::fs::read_dir(path).map_err(|_| Error::PartitionMissing(partition.clone()))?;
+                fs::read_dir(path).map_err(|_| Error::PartitionMissing(partition.clone()))?;
             let mut blobs = Vec::new();
             for entry in entries {
                 let entry = entry.map_err(|_| Error::ReadFailed)?;

--- a/runtime/src/storage/tokio/mod.rs
+++ b/runtime/src/storage/tokio/mod.rs
@@ -32,9 +32,6 @@ pub struct Storage {
     lock: Arc<Mutex<()>>,
     cfg: Config,
     pool: BufferPool,
-    /// Hold on the storage directory, cloned into every dispatched blocking
-    /// operation and every blob so a successor storage instance waits for
-    /// stragglers.
     hold: Arc<Hold>,
 }
 

--- a/runtime/src/tokio/mod.rs
+++ b/runtime/src/tokio/mod.rs
@@ -5,6 +5,14 @@
 //!
 //! Unless configured otherwise, any task panic will lead to a runtime panic.
 //!
+//! # Storage
+//!
+//! [crate::Runner::start] holds the storage directory (an advisory lock on its
+//! `.hold` file) until the run's storage and every operation it dispatched have
+//! finished. A start on a directory another run still holds blocks, with a
+//! warning, until then. A `Context`, `Storage`, or `Blob` kept past `start`
+//! keeps the hold.
+//!
 //! # Example
 //!
 //! ```rust

--- a/runtime/src/tokio/runtime.rs
+++ b/runtime/src/tokio/runtime.rs
@@ -165,13 +165,13 @@ pub struct Config {
     /// Whether or not to catch panics.
     catch_panics: bool,
 
-    /// Base directory for all storage operations.
-    storage_directory: PathBuf,
-
-    /// Maximum buffer size for operations on blobs.
+    /// Base directory for all storage operations, created at start if missing.
     ///
-    /// Tokio sets the default value to 2MB.
-    maximum_buffer_size: usize,
+    /// The runtime holds an exclusive advisory lock on a `.hold` file at its
+    /// root until its storage and every operation the storage dispatched have
+    /// finished. While a previous runtime still holds the directory,
+    /// [crate::Runner::start] blocks until that hold releases.
+    storage_directory: PathBuf,
 
     /// Network configuration.
     network_cfg: NetworkConfig,
@@ -195,7 +195,6 @@ impl Config {
             thread_stack_size: utils::thread::system_thread_stack_size(),
             catch_panics: false,
             storage_directory,
-            maximum_buffer_size: 2 * 1024 * 1024, // 2 MB
             network_cfg: NetworkConfig::default(),
             network_buffer_pool_cfg: None,
             storage_buffer_pool_cfg: None,
@@ -254,11 +253,6 @@ impl Config {
         self
     }
     /// See [Config]
-    pub const fn with_maximum_buffer_size(mut self, n: usize) -> Self {
-        self.maximum_buffer_size = n;
-        self
-    }
-    /// See [Config]
     pub fn with_network_buffer_pool_config(mut self, cfg: BufferPoolConfig) -> Self {
         self.network_buffer_pool_cfg = Some(cfg);
         self
@@ -309,10 +303,6 @@ impl Config {
     /// See [Config]
     pub const fn storage_directory(&self) -> &PathBuf {
         &self.storage_directory
-    }
-    /// See [Config]
-    pub const fn maximum_buffer_size(&self) -> usize {
-        self.maximum_buffer_size
     }
 
     /// Returns the network buffer pool config, deriving pool parallelism from
@@ -464,16 +454,13 @@ impl crate::Runner for Runner {
             &mut runtime_registry.sub_registry("storage_buffer_pool"),
         );
 
-        // Make any storage a prior process left in the page cache crash-durable before we open it,
-        // so the data read during init is durable.
-        if let Err(e) = crate::storage::sync(&self.cfg.storage_directory) {
-            panic!(
-                "failed to sync storage filesystem at startup ({}): {e}",
-                self.cfg.storage_directory.display()
-            );
-        }
+        // A directory that does not exist yet holds nothing a prior process
+        // could have left unsynced, so the flush below is skipped for it.
+        let fresh = !self.cfg.storage_directory.exists();
 
-        // Initialize storage
+        // Initialize storage. Construction acquires the storage directory
+        // hold, waiting for any operations still finishing from a previous
+        // run before the flush below.
         cfg_if::cfg_if! {
             if #[cfg(feature = "iouring-storage")] {
                 let mut iouring_registry = runtime_registry.sub_registry("iouring_storage");
@@ -492,15 +479,22 @@ impl crate::Runner for Runner {
             } else {
                 let storage = MeteredStorage::new(
                     TokioStorage::new(
-                        TokioStorageConfig::new(
-                            self.cfg.storage_directory.clone(),
-                            self.cfg.maximum_buffer_size,
-                        ),
+                        TokioStorageConfig::new(self.cfg.storage_directory.clone()),
                         storage_buffer_pool.clone(),
                     ),
                     &mut runtime_registry,
                 );
             }
+        }
+
+        // Make any storage a prior process left in the page cache crash-durable before we open it,
+        // so the data read during init is durable. This runs under the hold, after any straggling
+        // writes from a previous run have landed, so the flush covers them too.
+        if !fresh && let Err(e) = crate::storage::sync(&self.cfg.storage_directory) {
+            panic!(
+                "failed to sync storage filesystem at startup ({}): {e}",
+                self.cfg.storage_directory.display()
+            );
         }
 
         // Initialize network
@@ -916,11 +910,13 @@ impl crate::BufferPooler for Context {
 mod tests {
     use super::*;
     use crate::{
-        Metrics, Network, Resolver, Runner as _, Sink, Spawner as _, Strategizer as _, Stream,
-        Supervisor as _, telemetry::metrics::raw::Counter, tokio::telemetry,
+        Blob as _, Metrics, Network, Resolver, Runner as _, Sink, Spawner as _, Storage as _,
+        Strategizer as _, Stream, Supervisor as _, WriteOptions, telemetry::metrics::raw::Counter,
+        tokio::telemetry,
     };
     use bytes::Bytes;
     use commonware_parallel::Strategy as _;
+    use futures::FutureExt as _;
     use std::{
         self,
         collections::HashMap,
@@ -1094,6 +1090,42 @@ mod tests {
                 assert_runner_drains_spawned_task(execution, root_exit);
             }
         }
+    }
+
+    #[test]
+    fn test_runner_restart_waits_for_straggling_write() {
+        let cfg = Config::new();
+        let storage_directory = cfg.storage_directory().clone();
+        const LEN: usize = 64 * 1024 * 1024;
+
+        // The first run dispatches a large write and returns with the write's
+        // future dropped, leaving the write to finish on the blocking pool.
+        Runner::new(cfg.clone()).start(|context| async move {
+            let (blob, _) = context.open("partition", b"blob").await.unwrap();
+            let mut write = Box::pin(blob.write_at(0, vec![7u8; LEN], WriteOptions::default()));
+            assert!(
+                (&mut write).now_or_never().is_none(),
+                "write completed before it could straggle"
+            );
+        });
+
+        // A run releases its hold before returning, so a second run on the
+        // same directory neither blocks nor observes the write mid-flight. Run
+        // it on a helper thread so a hold that never releases fails the test
+        // instead of hanging it.
+        let (tx, rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let len = Runner::new(cfg).start(|context| async move {
+                let (_, len) = context.open("partition", b"blob").await.unwrap();
+                len
+            });
+            tx.send(len).unwrap();
+        });
+        let len = rx
+            .recv_timeout(Duration::from_secs(60))
+            .expect("second run did not start after the first returned");
+        assert_eq!(len, LEN as u64);
+        let _ = std::fs::remove_dir_all(storage_directory);
     }
 
     #[test]

--- a/runtime/src/tokio/runtime.rs
+++ b/runtime/src/tokio/runtime.rs
@@ -166,12 +166,8 @@ pub struct Config {
     /// Whether or not to catch panics.
     catch_panics: bool,
 
-    /// Base directory for all storage operations, created at start if missing.
-    ///
-    /// The runtime holds an exclusive advisory lock on a `.hold` file at its
-    /// root until its storage and every operation the storage dispatched have
-    /// finished. While a previous runtime still holds the directory,
-    /// [crate::Runner::start] blocks until that hold releases.
+    /// Base directory for all storage operations, created at start if missing
+    /// and held for the run (see [Runner]).
     storage_directory: PathBuf,
 
     /// Blob layouts accepted by storage.
@@ -490,9 +486,7 @@ impl crate::Runner for Runner {
             &mut runtime_registry.sub_registry("storage_buffer_pool"),
         );
 
-        // Initialize storage. Construction acquires the storage directory
-        // hold, waiting for any operations still finishing from a previous
-        // run before the flush below.
+        // Initialize storage
         cfg_if::cfg_if! {
             if #[cfg(feature = "iouring-storage")] {
                 let mut iouring_registry = runtime_registry.sub_registry("iouring_storage");
@@ -1225,19 +1219,29 @@ mod tests {
         const LEN: usize = 64 * 1024 * 1024;
 
         // The first run dispatches a large write and returns with the write's
-        // future dropped, leaving the write to finish on the blocking pool.
+        // future dropped, leaving the write to finish on the blocking pool. A
+        // blocking task the runtime has not started when it shuts down is
+        // dropped unrun, so wait for the write to reach the file first.
+        let path = storage_directory
+            .join("partition")
+            .join(commonware_formatting::hex(b"blob"));
         Runner::new(cfg.clone()).start(|context| async move {
             let (blob, _) = context.open("partition", b"blob").await.unwrap();
+            let header = std::fs::metadata(&path).unwrap().len();
             let mut write = Box::pin(blob.write_at(0, vec![7u8; LEN], WriteOptions::default()));
             assert!(
                 (&mut write).now_or_never().is_none(),
                 "write completed before it could straggle"
             );
+            while std::fs::metadata(&path).unwrap().len() == header {
+                std::thread::yield_now();
+            }
         });
 
-        // A run releases its hold before returning, so a second run on the
-        // same directory neither blocks nor observes the write mid-flight. Run
-        // it on a helper thread so a hold that never releases fails the test
+        // A run releases its hold once its storage work has finished (for
+        // io_uring storage, when the ring thread exits), so a second run on the
+        // same directory starts without observing the write mid-flight. Run it
+        // on a helper thread so a hold that never releases fails the test
         // instead of hanging it.
         let (tx, rx) = std::sync::mpsc::channel();
         std::thread::spawn(move || {

--- a/runtime/src/tokio/runtime.rs
+++ b/runtime/src/tokio/runtime.rs
@@ -942,12 +942,11 @@ mod tests {
     use super::*;
     use crate::{
         Blob as _, Metrics, Network, Resolver, Runner as _, Sink, Spawner as _, Storage as _,
-        Strategizer as _, Stream, Supervisor as _, WriteOptions, telemetry::metrics::raw::Counter,
+        Strategizer as _, Stream, Supervisor as _, telemetry::metrics::raw::Counter,
         tokio::telemetry,
     };
     use bytes::Bytes;
     use commonware_parallel::Strategy as _;
-    use futures::FutureExt as _;
     use std::{
         self,
         collections::HashMap,
@@ -1213,48 +1212,42 @@ mod tests {
     }
 
     #[test]
-    fn test_runner_restart_after_dropped_write() {
+    fn test_runner_start_waits_for_previous_run() {
         let cfg = Config::new();
         let storage_directory = cfg.storage_directory().clone();
-        const LEN: usize = 64 * 1024 * 1024;
 
-        // The first run dispatches a large write and returns with the write's
-        // future dropped, leaving the write to finish on the blocking pool. A
-        // blocking task the runtime has not started when it shuts down is
-        // dropped unrun, so wait for the write to reach the file first.
-        let path = storage_directory
-            .join("partition")
-            .join(commonware_formatting::hex(b"blob"));
-        Runner::new(cfg.clone()).start(|context| async move {
-            let (blob, _) = context.open("partition", b"blob").await.unwrap();
-            let header = std::fs::metadata(&path).unwrap().len();
-            let mut write = Box::pin(blob.write_at(0, vec![7u8; LEN], WriteOptions::default()));
-            assert!(
-                (&mut write).now_or_never().is_none(),
-                "write completed before it could straggle"
-            );
-            while std::fs::metadata(&path).unwrap().len() == header {
-                std::thread::yield_now();
-            }
-        });
-
-        // A run releases its hold once its storage work has finished (for
-        // io_uring storage, when the ring thread exits), so a second run on the
-        // same directory starts without observing the write mid-flight. Run it
-        // on a helper thread so a hold that never releases fails the test
-        // instead of hanging it.
-        let (tx, rx) = std::sync::mpsc::channel();
-        std::thread::spawn(move || {
-            let len = Runner::new(cfg).start(|context| async move {
-                let (_, len) = context.open("partition", b"blob").await.unwrap();
-                len
+        // The first run keeps its context, and with it the storage directory,
+        // until it is released.
+        let (started, first_started) = std::sync::mpsc::channel();
+        let (release, released) = futures::channel::oneshot::channel();
+        let first_cfg = cfg.clone();
+        let first = std::thread::spawn(move || {
+            Runner::new(first_cfg).start(|context| async move {
+                started.send(()).unwrap();
+                released.await.unwrap();
+                drop(context);
             });
-            tx.send(len).unwrap();
         });
-        let len = rx
-            .recv_timeout(Duration::from_secs(60))
+        first_started.recv_timeout(Duration::from_secs(10)).unwrap();
+
+        // A second run on the same directory cannot start until the first has
+        // returned.
+        let (started, second_started) = std::sync::mpsc::channel();
+        let second = std::thread::spawn(move || {
+            Runner::new(cfg).start(|_| async move {
+                started.send(()).unwrap();
+            });
+        });
+        match second_started.recv_timeout(Duration::from_millis(200)) {
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {}
+            other => panic!("second run started while the first held the directory: {other:?}"),
+        }
+        release.send(()).unwrap();
+        first.join().unwrap();
+        second_started
+            .recv_timeout(Duration::from_secs(10))
             .expect("second run did not start after the first returned");
-        assert_eq!(len, LEN as u64);
+        second.join().unwrap();
         let _ = std::fs::remove_dir_all(storage_directory);
     }
 

--- a/runtime/src/tokio/runtime.rs
+++ b/runtime/src/tokio/runtime.rs
@@ -454,10 +454,6 @@ impl crate::Runner for Runner {
             &mut runtime_registry.sub_registry("storage_buffer_pool"),
         );
 
-        // A directory that does not exist yet holds nothing a prior process
-        // could have left unsynced, so the flush below is skipped for it.
-        let fresh = !self.cfg.storage_directory.exists();
-
         // Initialize storage. Construction acquires the storage directory
         // hold, waiting for any operations still finishing from a previous
         // run before the flush below.
@@ -489,8 +485,13 @@ impl crate::Runner for Runner {
 
         // Make any storage a prior process left in the page cache crash-durable before we open it,
         // so the data read during init is durable. This runs under the hold, after any straggling
-        // writes from a previous run have landed, so the flush covers them too.
-        if !fresh && let Err(e) = crate::storage::sync(&self.cfg.storage_directory) {
+        // writes from a previous run have landed, so the flush covers them too. A directory holding
+        // no partitions has nothing to flush, so the flush is skipped for it. Freshness is judged
+        // here, under the hold, rather than before acquiring it, so a directory another instance
+        // populated while we waited is not mistaken for empty.
+        if crate::storage::has_partitions(&self.cfg.storage_directory)
+            && let Err(e) = crate::storage::sync(&self.cfg.storage_directory)
+        {
             panic!(
                 "failed to sync storage filesystem at startup ({}): {e}",
                 self.cfg.storage_directory.display()

--- a/runtime/src/tokio/runtime.rs
+++ b/runtime/src/tokio/runtime.rs
@@ -392,6 +392,15 @@ impl Drop for TaskGuard {
 }
 
 /// Implementation of [crate::Runner] for the `tokio` runtime.
+///
+/// [crate::Runner::start] holds the configured storage directory for the run:
+/// it takes an exclusive advisory lock on a `.hold` file at the directory root
+/// and releases it only once the run's storage and every operation that storage
+/// dispatched have finished, including operations whose futures were dropped
+/// mid-flight. A start on a directory another run still holds blocks, after
+/// logging a warning, until that hold releases. A `Context`, `Storage`, or
+/// `Blob` retained past `start` keeps the hold, so it must be dropped before the
+/// next start on the same directory.
 pub struct Runner {
     cfg: Config,
 }
@@ -485,13 +494,8 @@ impl crate::Runner for Runner {
 
         // Make any storage a prior process left in the page cache crash-durable before we open it,
         // so the data read during init is durable. This runs under the hold, after any straggling
-        // writes from a previous run have landed, so the flush covers them too. A directory holding
-        // no partitions has nothing to flush, so the flush is skipped for it. Freshness is judged
-        // here, under the hold, rather than before acquiring it, so a directory another instance
-        // populated while we waited is not mistaken for empty.
-        if crate::storage::has_partitions(&self.cfg.storage_directory)
-            && let Err(e) = crate::storage::sync(&self.cfg.storage_directory)
-        {
+        // writes from a previous run have landed, so the flush covers them too.
+        if let Err(e) = crate::storage::sync(&self.cfg.storage_directory) {
             panic!(
                 "failed to sync storage filesystem at startup ({}): {e}",
                 self.cfg.storage_directory.display()
@@ -1094,7 +1098,7 @@ mod tests {
     }
 
     #[test]
-    fn test_runner_restart_waits_for_straggling_write() {
+    fn test_runner_restart_after_dropped_write() {
         let cfg = Config::new();
         let storage_directory = cfg.storage_directory().clone();
         const LEN: usize = 64 * 1024 * 1024;

--- a/runtime/src/tokio/runtime.rs
+++ b/runtime/src/tokio/runtime.rs
@@ -167,7 +167,7 @@ pub struct Config {
     catch_panics: bool,
 
     /// Base directory for all storage operations, created at start if missing
-    /// and held for the run (see [Runner]).
+    /// and held for the run.
     storage_directory: PathBuf,
 
     /// Blob layouts accepted by storage.
@@ -415,15 +415,6 @@ impl Drop for TaskGuard {
 }
 
 /// Implementation of [crate::Runner] for the `tokio` runtime.
-///
-/// [crate::Runner::start] holds the configured storage directory for the run:
-/// it takes an exclusive advisory lock on a `.hold` file at the directory root
-/// and releases it only once the run's storage and every operation that storage
-/// dispatched have finished, including operations whose futures were dropped
-/// mid-flight. A start on a directory another run still holds blocks, after
-/// logging a warning, until that hold releases. A `Context`, `Storage`, or
-/// `Blob` retained past `start` keeps the hold, so it must be dropped before the
-/// next start on the same directory.
 pub struct Runner {
     cfg: Config,
 }


### PR DESCRIPTION
Replaces #4196. Dropping a storage operation's future does not cancel it: work already handed to tokio's blocking pool or the io_uring ring runs to completion. A new storage instance on the same directory can therefore see a previous run's operations landing under it, which is how #4196 hit a missing blob at prune. Draining at shutdown (#4501) only helps runs that reach shutdown. A crash, a relaunch while the old process is still unwinding, an escaped handle, or the io_uring ring thread all leave operations in flight with nothing waiting for them.

Each filesystem backend now takes a hold on its storage directory: an advisory lock on an empty `.hold` file, acquired at construction and shared with everything that can still touch the directory. In the tokio backend the blob's file handle carries it, and `open_versioned`, `remove`, and `scan` run as `std::fs` closures through one helper that owns both the filesystem lock and the hold. In the io_uring backend the ring thread carries it. A new instance blocks until every holder is gone, and the OS releases the lock when the process exits, so a crash needs no cleanup. The startup flush now runs under the hold, the `Storage` trait documents the contract, and the `maximum_buffer_size` knob goes away with `tokio::fs`. The rewrite also fixes two latent bugs: a failed header write during blob creation used to return `Ok`, and a dropped `remove` used to release the lock while its unlink was still pending.

Tests cover a removal dropped mid-flight that a successor must not see, construction blocking on a live instance or an open blob, and a second `Runner::start` waiting for a first run to return. All three fail with the lock ablated. A cross-process kill probe (220 runs on macOS and Linux, both backends) never saw a byte land after a successor acquired. Two visible shifts: an operation dropped unstarted at shutdown returns `Closed`, and an unusable storage root fails at construction rather than at the first operation. `reshare setup` now runs before the runner, since the runner creates the storage directory at start.
