### PR TITLE
[storage] Bound `RMap::remove` to overlapping ranges and scan `missing_items` forward

### DIFF
--- a/storage/fuzz/fuzz_targets/rmap_operations.rs
+++ b/storage/fuzz/fuzz_targets/rmap_operations.rs
@@ -3,7 +3,7 @@
 use arbitrary::Arbitrary;
 use commonware_storage::rmap::RMap;
 use libfuzzer_sys::fuzz_target;
-use std::collections::BTreeSet;
+use std::{collections::BTreeSet, num::NonZeroU8};
 
 #[derive(Arbitrary, Debug, Clone)]
 enum RMapOperation {
@@ -11,6 +11,7 @@ enum RMapOperation {
     Remove { start: u64, end: u64 },
     Get(u64),
     NextGap(u64),
+    MissingItems { start: u64, max: NonZeroU8 },
     Iter,
 }
 
@@ -114,6 +115,25 @@ fn fuzz(data: FuzzInput) {
                         "Value {after_start} should exist as it's the start of the next range",
                     );
                 }
+            }
+
+            RMapOperation::MissingItems { start, max } => {
+                let max = usize::from(max.get());
+                let missing = rmap.missing_items(*start, max);
+
+                // Every absent value from `start` up to the last present value is missing.
+                // Nothing past the last range is ever reported.
+                let expected: Vec<u64> = match expected_state.last() {
+                    Some(&last) => (*start..last)
+                        .filter(|value| !expected_state.contains(value))
+                        .take(max)
+                        .collect(),
+                    None => Vec::new(),
+                };
+                assert_eq!(
+                    missing, expected,
+                    "missing_items({start}, {max}) disagrees with reference set",
+                );
             }
 
             RMapOperation::Iter => {

--- a/storage/src/rmap/mod.rs
+++ b/storage/src/rmap/mod.rs
@@ -148,8 +148,8 @@ impl RMap {
     /// # Complexity
     ///
     /// O((M + 1) log N), where N is the number of ranges in the map and M is the number of ranges
-    /// that overlap the removal range. One seek finds the first candidate. Each overlapping range
-    /// then costs one removal and at most two insertions.
+    /// overlapping the removal range. Each overlapping range costs one removal, plus at most two
+    /// insertions in total for the pieces that stick out.
     ///
     /// # Example
     ///
@@ -171,16 +171,10 @@ impl RMap {
             return;
         }
 
-        // Candidates: the range starting at or before `start`, then any starting within `[start, end]`.
-        let first = self
-            .ranges
-            .range(..=start)
-            .next_back()
-            .map_or(start, |(&r_start, _)| r_start);
+        // Every range that overlaps or follows `start`, cut off past `end`.
         let overlapping: Vec<(u64, u64)> = self
-            .ranges
-            .range(first..=end)
-            .filter(|&(_, &r_end)| r_end >= start)
+            .iter_from(start)
+            .take_while(|&(&r_start, _)| r_start <= end)
             .map(|(&r_start, &r_end)| (r_start, r_end))
             .collect();
 
@@ -374,9 +368,8 @@ impl RMap {
     ///
     /// # Complexity
     ///
-    /// O(log N + G + M) where N is the number of ranges in [RMap], G is the number of gaps
-    /// visited (at most N), and M is the number of missing items returned (at most `max`).
-    /// One seek positions the scan. The gaps are then visited in order without further lookups.
+    /// O(log N + M) where N is the number of ranges in [RMap] and M is the number of missing items
+    /// returned (at most `max`).
     ///
     /// # Example
     ///
@@ -405,24 +398,12 @@ impl RMap {
         assert!(max > 0, "max must be greater than 0");
         let mut missing = Vec::with_capacity(max);
 
-        // Step past the range containing `start`, if any.
-        let mut current = match self.ranges.range(..=start).next_back() {
-            Some((_, &end)) if end >= start => match end.checked_add(1) {
-                Some(next) => next,
-                None => return missing,
-            },
-            _ => start,
-        };
-
-        // Each range at or after `current` closes one gap. Collect from it, then step past the range.
-        for (&r_start, &r_end) in self.ranges.range(current..) {
-            if r_start > current {
-                let remaining = (max - missing.len()) as u64;
-                let gap_end = (r_start - 1).min(current.saturating_add(remaining - 1));
-                missing.extend(current..=gap_end);
-                if missing.len() >= max {
-                    break;
-                }
+        // Each range closes the gap before it. The scan then resumes past it.
+        let mut current = start;
+        for (&r_start, &r_end) in self.iter_from(start) {
+            missing.extend((current..r_start).take(max - missing.len()));
+            if missing.len() == max {
+                break;
             }
             let Some(next) = r_end.checked_add(1) else {
                 break;

--- a/storage/src/rmap/mod.rs
+++ b/storage/src/rmap/mod.rs
@@ -148,7 +148,7 @@ impl RMap {
     /// # Complexity
     ///
     /// O((M + 1) log N), where N is the number of ranges in the map and M is the number of ranges
-    /// that overlap the removal range. One seek finds the first candidate; each overlapping range
+    /// that overlap the removal range. One seek finds the first candidate. Each overlapping range
     /// then costs one removal and at most two insertions.
     ///
     /// # Example
@@ -376,7 +376,7 @@ impl RMap {
     ///
     /// O(log N + G + M) where N is the number of ranges in [RMap], G is the number of gaps
     /// visited (at most N), and M is the number of missing items returned (at most `max`).
-    /// One seek positions the scan; the gaps are then visited in order without further lookups.
+    /// One seek positions the scan. The gaps are then visited in order without further lookups.
     ///
     /// # Example
     ///
@@ -414,7 +414,7 @@ impl RMap {
             _ => start,
         };
 
-        // Each range at or after `current` closes one gap: collect from it, then step past the range.
+        // Each range at or after `current` closes one gap. Collect from it, then step past the range.
         for (&r_start, &r_end) in self.ranges.range(current..) {
             if r_start > current {
                 let remaining = (max - missing.len()) as u64;

--- a/storage/src/rmap/mod.rs
+++ b/storage/src/rmap/mod.rs
@@ -147,9 +147,9 @@ impl RMap {
     ///
     /// # Complexity
     ///
-    /// The time complexity is O(M + K log N), where N is the total number of ranges in the map,
-    /// M is the number of ranges that overlap with the removal range (iterate part), and K is the number of
-    /// new ranges created or ranges removed (at most 2 additions and M removals).
+    /// O((M + 1) log N), where N is the number of ranges in the map and M is the number of ranges
+    /// that overlap the removal range. One seek finds the first candidate; each overlapping range
+    /// then costs one removal and at most two insertions.
     ///
     /// # Example
     ///
@@ -171,62 +171,27 @@ impl RMap {
             return;
         }
 
-        // Iterate over ranges that could possibly overlap with the removal range `[start, end]`.
-        // A range (r_start, r_end) overlaps if r_start <= end AND r_end >= start.
-        //
-        // We optimize the BTreeMap iteration by only looking at ranges whose start (r_start)
-        // is less than or equal to the `end` of the removal range. If r_start > end,
-        // then (r_start, r_end) cannot overlap with [start, end].
-        let mut to_add = Vec::new();
-        let mut to_remove = Vec::new();
+        // Candidates: the range starting at or before `start`, then any starting within `[start, end]`.
+        let first = self
+            .ranges
+            .range(..=start)
+            .next_back()
+            .map_or(start, |(&r_start, _)| r_start);
+        let overlapping: Vec<(u64, u64)> = self
+            .ranges
+            .range(first..=end)
+            .filter(|&(_, &r_end)| r_end >= start)
+            .map(|(&r_start, &r_end)| (r_start, r_end))
+            .collect();
 
-        for (&r_start, &r_end) in self.ranges.iter() {
-            // Case 1: No overlap
-            if r_end < start || r_start > end {
-                continue;
-            }
-
-            // Case 2: Removal range completely covers current range
-            if start <= r_start && end >= r_end {
-                to_remove.push(r_start);
-                continue;
-            }
-
-            // Case 3: Current range completely covers removal range (split)
-            if r_start < start && r_end > end {
-                to_remove.push(r_start);
-                to_add.push((r_start, start - 1));
-                to_add.push((end + 1, r_end));
-                continue;
-            }
-
-            // Case 4: Removal range overlaps start of current range
-            if start <= r_start && end < r_end {
-                // and end >= r_start implied by not Case 1
-                to_remove.push(r_start);
-                to_add.push((end + 1, r_end));
-                continue;
-            }
-
-            // Case 5: Removal range overlaps end of current range
-            if start > r_start && end >= r_end {
-                // and start <= r_end implied by not Case 1
-                to_remove.push(r_start);
-                to_add.push((r_start, start - 1));
-                continue;
-            }
-        }
-
-        // Remove anything no longer needed.
-        for r_start in to_remove {
+        // Remove each overlapping range and re-add whatever sticks out on either side.
+        for (r_start, r_end) in overlapping {
             self.ranges.remove(&r_start);
-        }
-
-        // Add anything that is now needed.
-        for (a_start, a_end) in to_add {
-            if a_start <= a_end {
-                // Ensure valid range before adding
-                self.ranges.insert(a_start, a_end);
+            if r_start < start {
+                self.ranges.insert(r_start, start - 1);
+            }
+            if r_end > end {
+                self.ranges.insert(end + 1, r_end);
             }
         }
     }
@@ -409,9 +374,9 @@ impl RMap {
     ///
     /// # Complexity
     ///
-    /// O(G log N + M) where N is the number of ranges in [RMap], G is the number of gaps
+    /// O(log N + G + M) where N is the number of ranges in [RMap], G is the number of gaps
     /// visited (at most N), and M is the number of missing items returned (at most `max`).
-    /// Each gap requires a `next_gap` call (O(log N)) and collecting items (O(items in gap)).
+    /// One seek positions the scan; the gaps are then visited in order without further lookups.
     ///
     /// # Example
     ///
@@ -438,43 +403,33 @@ impl RMap {
     pub fn missing_items(&self, start: u64, max: usize) -> Vec<u64> {
         // Ensure input is valid
         assert!(max > 0, "max must be greater than 0");
-        let mut current = start;
-
-        // Collect missing items
         let mut missing = Vec::with_capacity(max);
-        loop {
-            // If we're inside a range, skip to just after it
-            let (current_range_end, next_range_start) = self.next_gap(current);
-            if let Some(end) = current_range_end {
-                // Check if we can move past this range
-                if end == u64::MAX {
-                    break missing; // No gaps possible after u64::MAX
+
+        // Step past the range containing `start`, if any.
+        let mut current = match self.ranges.range(..=start).next_back() {
+            Some((_, &end)) if end >= start => match end.checked_add(1) {
+                Some(next) => next,
+                None => return missing,
+            },
+            _ => start,
+        };
+
+        // Each range at or after `current` closes one gap: collect from it, then step past the range.
+        for (&r_start, &r_end) in self.ranges.range(current..) {
+            if r_start > current {
+                let remaining = (max - missing.len()) as u64;
+                let gap_end = (r_start - 1).min(current.saturating_add(remaining - 1));
+                missing.extend(current..=gap_end);
+                if missing.len() >= max {
+                    break;
                 }
-                current = end + 1;
-                continue;
             }
-
-            // We're in a gap - check if there's a next range
-            let Some(next_start) = next_range_start else {
-                break missing; // No more ranges, so no more gaps to fill
+            let Some(next) = r_end.checked_add(1) else {
+                break;
             };
-
-            // Collect items from this gap until we hit the next range or have enough
-            let gap_end = next_start - 1; // next_start must be greater than or equal to 1
-            let items_needed = max - missing.len(); // there must be at least one item to collect
-            let gap_end = gap_end.min(current.saturating_add(items_needed as u64 - 1));
-            for index in current..=gap_end {
-                missing.push(index);
-            }
-
-            // If we have enough items, break
-            if missing.len() >= max {
-                break missing;
-            }
-
-            // Move to the start of the next range to check for more gaps
-            current = next_start;
+            current = next;
         }
+        missing
     }
 }
 


### PR DESCRIPTION
## `remove`

The comment above the loop said the traversal was limited to ranges that could overlap `[start, end]`. The loop actually walked every range in the map and skipped the ones that didn't overlap, so each call cost O(N) in the number of stored ranges.

Ranges are disjoint and sorted, so only two kinds of range can overlap the removal: the one containing `start`, and the ones that start inside `[start, end]`. `iter_from(start)` yields exactly those in order (the range containing `start`, if any, then every range starting after it), and `take_while(r_start <= end)` stops the walk at the removal range. Each overlapping range is removed and whatever sticks out on either side is re-added. Only the first can stick out to the left and only the last to the right, so there are at most two insertions. O((M + 1) log N).

## `missing_items`

The old loop called `next_gap` on every iteration, and `next_gap` does two `BTreeMap` seeks. When the cursor landed inside a range, a whole iteration went to stepping past it before another `next_gap` read the gap.

Now `iter_from(start)` walks the ranges forward from `start`. Each range it yields closes one gap: collect from `[current, r_start - 1]`, stop at `max`, otherwise move past the range. Adjacent ranges are always merged, so every range after the first closes a non-empty gap and the walk visits at most M + 1 ranges. O(log N + M).

## Fuzz

`rmap_operations` gains a `MissingItems` operation checked against the `BTreeSet` reference: the expected result is the absent values from `start` up to the last present value, capped at `max`. Before this the only fuzz coverage of `missing_items` compared an `RMap` against another `RMap`.
