### PR TITLE
[storage] Batch node reads in merkle proof generation

### DIFF
--- a/storage/src/merkle/verification.rs
+++ b/storage/src/merkle/verification.rs
@@ -20,7 +20,6 @@ use crate::merkle::{
 use ahash::AHashMap;
 use commonware_cryptography::Digest;
 use core::ops::Range;
-use futures::future::try_join_all;
 use std::collections::BTreeSet;
 
 /// A store derived from a [Proof] that can be used to generate proofs over any sub-range of the
@@ -321,17 +320,12 @@ pub async fn historical_range_proof<
 ) -> Result<Proof<F, D>, Error<F>> {
     let bp = Blueprint::new(leaves, inactive_peaks, hasher.root_bagging(), range)?;
 
-    let all_positions: BTreeSet<_> = bp.required_positions().collect();
-
-    let node_futures: Vec<_> = all_positions
-        .into_iter()
-        .map(|pos| async move { merkle.get_node(pos).await.map(|digest| (pos, digest)) })
-        .collect();
-    let fetched = try_join_all(node_futures)
-        .await?
-        .into_iter()
-        .map(|(pos, digest)| digest.ok_or(Error::ElementPruned(pos)).map(|d| (pos, d)))
-        .collect::<Result<AHashMap<_, _>, _>>()?;
+    // `get_nodes` requires strictly increasing positions.
+    let mut positions: Vec<_> = bp.required_positions().collect();
+    positions.sort_unstable();
+    positions.dedup();
+    let digests = merkle.get_nodes(&positions).await?;
+    let fetched: AHashMap<_, _> = positions.into_iter().zip(digests).collect();
 
     bp.build_proof(
         hasher,
@@ -368,20 +362,11 @@ pub async fn multi_proof<F: Family, D: Digest, S: Storage<F, Digest = D>>(
     // Collect all required node positions
     let size = merkle.size();
     let leaves = Location::try_from(size)?;
-    let node_positions: BTreeSet<_> =
-        merkle_proof::nodes_required_for_multi_proof(leaves, inactive_peaks, bagging, locations)?;
-
-    // Fetch all required digests in parallel and collect with positions
-    let node_futures: Vec<_> = node_positions
-        .iter()
-        .map(|&pos| async move { merkle.get_node(pos).await.map(|digest| (pos, digest)) })
-        .collect();
-    // Build the proof, returning error with correct position on pruned nodes.
-    let digests = try_join_all(node_futures)
-        .await?
-        .into_iter()
-        .map(|(pos, digest)| digest.ok_or(Error::ElementPruned(pos)))
-        .collect::<Result<Vec<_>, _>>()?;
+    let positions: Vec<_> =
+        merkle_proof::nodes_required_for_multi_proof(leaves, inactive_peaks, bagging, locations)?
+            .into_iter()
+            .collect();
+    let digests = merkle.get_nodes(&positions).await?;
 
     Ok(Proof {
         leaves,

--- a/storage/src/qmdb/current/grafting.rs
+++ b/storage/src/qmdb/current/grafting.rs
@@ -511,6 +511,44 @@ impl<
         let grafted_pos = ops_to_grafted_pos::<F>(pos, self.grafting_height);
         Ok(self.reconstruct_grafted_node(grafted_pos))
     }
+
+    async fn get_nodes(
+        &self,
+        positions: &[Position<F>],
+    ) -> Result<Vec<H::Digest>, merkle::Error<F>> {
+        let mut nodes = vec![None; positions.len()];
+        let mut ops_positions = Vec::with_capacity(positions.len());
+        let mut missing = None;
+        for (slot, &pos) in nodes.iter_mut().zip(positions) {
+            if F::pos_to_height(pos) < self.grafting_height {
+                ops_positions.push(pos);
+                continue;
+            }
+            let grafted_pos = ops_to_grafted_pos::<F>(pos, self.grafting_height);
+            match self.reconstruct_grafted_node(grafted_pos) {
+                Some(node) => *slot = Some(node),
+                None => {
+                    missing = Some(pos);
+                    break;
+                }
+            }
+        }
+
+        // A pruned ops position below a missing grafted node is the lower one, so read ops first.
+        let ops_nodes = if ops_positions.is_empty() {
+            Vec::new()
+        } else {
+            self.ops_tree.get_nodes(&ops_positions).await?
+        };
+        if let Some(pos) = missing {
+            return Err(merkle::Error::ElementPruned(pos));
+        }
+        let mut ops_nodes = ops_nodes.into_iter();
+        Ok(nodes
+            .into_iter()
+            .map(|node| node.unwrap_or_else(|| ops_nodes.next().expect("one node per ops read")))
+            .collect())
+    }
 }
 
 #[cfg(test)]
@@ -1165,6 +1203,83 @@ mod tests {
                 .await
                 .unwrap();
             assert!(proof.verify_element_inclusion(&verifier, &b5, loc, &grafted_root));
+        });
+    }
+
+    /// The combined storage's `get_nodes` must agree with `get_node` on every available
+    /// position and name the lowest position `get_node` reports as absent.
+    async fn assert_get_nodes_matches_get_node(
+        combined: &impl StorageTrait<mmr::Family, Digest = sha256::Digest>,
+    ) {
+        let all: Vec<Position> = (0..*combined.size()).map(Position::new).collect();
+        let mut available = Vec::new();
+        let mut first_absent = None;
+        for &pos in &all {
+            match combined.get_node(pos).await.unwrap() {
+                Some(node) => available.push((pos, node)),
+                None => {
+                    if first_absent.is_none() {
+                        first_absent = Some(pos);
+                    }
+                }
+            }
+        }
+
+        match (combined.get_nodes(&all).await, first_absent) {
+            (Ok(nodes), None) => assert_eq!(nodes.len(), all.len()),
+            (Err(merkle::Error::ElementPruned(pos)), Some(expected)) => assert_eq!(pos, expected),
+            (other, expected) => panic!("expected first absent {expected:?}, got {other:?}"),
+        }
+
+        // Every available position, then a sparse subset (slot correspondence), then empty.
+        let positions: Vec<_> = available.iter().map(|&(pos, _)| pos).collect();
+        let batched = combined.get_nodes(&positions).await.unwrap();
+        assert_eq!(batched.len(), available.len());
+        for (slot, &(pos, node)) in available.iter().enumerate() {
+            assert_eq!(batched[slot], node, "position {pos}");
+        }
+        let sparse: Vec<_> = positions.iter().copied().step_by(3).collect();
+        let batched = combined.get_nodes(&sparse).await.unwrap();
+        for (slot, &pos) in sparse.iter().enumerate() {
+            let single = combined.get_node(pos).await.unwrap().unwrap();
+            assert_eq!(batched[slot], single, "position {pos}");
+        }
+        assert!(combined.get_nodes(&[]).await.unwrap().is_empty());
+    }
+
+    #[test_traced]
+    fn test_grafted_storage_get_nodes_matches_get_node() {
+        const GRAFTING_HEIGHT: u32 = 1;
+        let executor = deterministic::Runner::default();
+        executor.start(|_| async move {
+            let hasher = qmdb::hasher::<Sha256>();
+            let mut ops_mmr = Mmr::new();
+            let batch = {
+                let mut batch = ops_mmr.new_batch();
+                for i in 0u8..16 {
+                    batch = batch.add(&hasher, &Sha256::fill(i));
+                }
+                batch.merkleize(&ops_mmr, &hasher)
+            };
+            ops_mmr.apply_batch(&batch).unwrap();
+            let chunks: Vec<_> = (0xF0u8..0xF8).map(Sha256::fill).collect();
+            let mut grafted = build_test_grafted_mmr(&hasher, &ops_mmr, &chunks, GRAFTING_HEIGHT);
+
+            // Fully retained, then pruned on each side: a pruned grafted leaf is absent at the
+            // grafting height and a pruned ops leaf is absent below it.
+            let combined =
+                Storage::<mmr::Family, Sha256, _, _>::new(&grafted, GRAFTING_HEIGHT, &ops_mmr);
+            assert_get_nodes_matches_get_node(&combined).await;
+
+            grafted.prune(Location::new(4)).unwrap();
+            let combined =
+                Storage::<mmr::Family, Sha256, _, _>::new(&grafted, GRAFTING_HEIGHT, &ops_mmr);
+            assert_get_nodes_matches_get_node(&combined).await;
+
+            ops_mmr.prune(Location::new(2)).unwrap();
+            let combined =
+                Storage::<mmr::Family, Sha256, _, _>::new(&grafted, GRAFTING_HEIGHT, &ops_mmr);
+            assert_get_nodes_matches_get_node(&combined).await;
         });
     }
 


### PR DESCRIPTION
Proof generation now fetches all the Merkle nodes it needs in one batched call instead of one call per node.

## Why

To build a range proof or multi-proof, we first figure out which node positions we need, then fetch their digests. Today each position gets its own `get_node` future and we `try_join_all` them.

We already have a batched version of this. `Storage::get_nodes` was added in #4465 for the graft-input reads. The proof generators predate it and were never switched over.

## What changed

- `historical_range_proof` and `multi_proof` sort and dedup their positions, then make a single `get_nodes` call.
- The grafted storage adapter in qmdb current now implements `get_nodes`. This matters because the trait's default implementation reads nodes one at a time, sequentially, which is slower on cache misses than the concurrent futures we have today. The qmdb current proof path goes through this adapter, so without an override the switch would have made that path worse. The override sends positions below the grafting height to the ops tree's batch read and reconstructs the rest in memory, then merges the two back in order. If a grafted node turns out to be missing, it reads the ops positions before it first, so the error names the lowest missing position like the trait promises.
- A new test checks that the adapter's `get_nodes` agrees with `get_node` on every position, with both trees intact and with each one pruned in turn.