### PR TITLE
[consensus/aggregation] Support weighted committees

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1444,7 +1444,6 @@ dependencies = [
  "rand_core 0.10.1",
  "rand_distr",
  "rayon",
- "rstest",
  "thiserror 2.0.18",
  "tracing",
  "tracing-subscriber",

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -9,6 +9,11 @@ BLS multisig certificates form and verify quorum by weight. BLS threshold
 schemes remain count-based and reject non-uniform committees. Certificate
 encoding is unchanged ([#4635]).
 
+### Weighted Aggregation Committees
+
+Aggregation forms certificates and advances its safe tip by committee weight.
+Uniform committees retain their existing behavior ([#4649]).
+
 ### Crash Recovery
 
 Runtime storage now recovers a blob whose initial header write was interrupted.
@@ -33,6 +38,7 @@ after restart ([#4420]).
 [#4275]: https://github.com/commonwarexyz/monorepo/pull/4275
 [#4420]: https://github.com/commonwarexyz/monorepo/pull/4420
 [#4635]: https://github.com/commonwarexyz/monorepo/pull/4635
+[#4649]: https://github.com/commonwarexyz/monorepo/pull/4649
 
 ## v2026.7.0
 

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -52,7 +52,6 @@ commonware-runtime = { workspace = true, features = ["test-utils"] }
 paste.workspace = true
 rand = { workspace = true, features = ["alloc"] }
 rand_chacha.workspace = true
-rstest.workspace = true
 tracing-subscriber.workspace = true
 
 [package.metadata.cargo-udeps.ignore]

--- a/consensus/src/aggregation/engine.rs
+++ b/consensus/src/aggregation/engine.rs
@@ -31,7 +31,6 @@ use commonware_utils::{
     N3f1, PrioritySet,
     futures::{Pool as FuturesPool, rebind},
     non_empty,
-    ordered::Quorum,
 };
 use futures::future::{self, Either};
 use rand_core::CryptoRng;
@@ -52,6 +51,14 @@ enum Pending<S: Scheme, D: Digest> {
 
     /// Verified by the automaton. Now stores the digest.
     Verified(D, BTreeMap<Epoch, BTreeMap<Participant, Ack<S, D>>>),
+}
+
+fn has_quorum_weight<S: Scheme, D: Digest>(scheme: &S, acks: &[&Ack<S, D>]) -> bool {
+    let participants = scheme.participants();
+    let weight = participants
+        .sum_ordered_weights(acks.iter().map(|ack| ack.attestation.signer))
+        .expect("stored acknowledgements must have unique ordered signers");
+    weight >= participants.quorum_weight::<N3f1>()
 }
 
 /// The type returned by the `pending` pool, used by the application to return which digest is
@@ -492,7 +499,6 @@ impl<
     /// inapplicable (e.g. unknown scheme, non-pending height, digest mismatch).
     /// Duplicate acks are accepted as no-ops.
     async fn handle_ack(mut self, ack: &Ack<P::Scheme, D>) -> (Self, bool) {
-        // Get the quorum (from scheme participants for the ack's epoch)
         let scheme = match self.scheme(ack.epoch) {
             Ok(scheme) => scheme,
             Err(err) => {
@@ -500,8 +506,6 @@ impl<
                 return (self, false);
             }
         };
-        let quorum = scheme.participants().quorum_count::<N3f1>() as usize;
-
         // Get the acks and check digest consistency
         let acks_by_epoch = match self.pending.get_mut(&ack.item.height) {
             None => {
@@ -533,9 +537,7 @@ impl<
             .values()
             .filter(|a| a.item.digest == ack.item.digest)
             .collect::<Vec<_>>();
-        if filtered.len() >= quorum {
-            // Every stored acknowledgement is verified and signer-unique, so a same-item quorum
-            // satisfies the certificate scheme's assembly contract.
+        if has_quorum_weight(&*scheme, &filtered) {
             let certificate =
                 Certificate::from_acks(&*scheme, non_empty![@filtered], &self.strategy)
                     .expect("verified acknowledgement quorum must assemble");
@@ -990,7 +992,7 @@ mod tests {
     use commonware_runtime::{
         Runner as _, Supervisor as _, buffer::paged::CacheRef, deterministic,
     };
-    use commonware_utils::{NZU16, NZUsize, NonZeroDuration};
+    use commonware_utils::{NZU16, NZUsize, NonZeroDuration, TryCollect, ordered::Committee};
 
     #[derive(Clone)]
     struct NoopBlocker;
@@ -1001,6 +1003,80 @@ mod tests {
         fn block(&mut self, _peer: Self::PublicKey) -> Feedback {
             Feedback::Ok
         }
+    }
+
+    fn weighted_fixture(weights: &[u64]) -> Fixture<ed25519::Scheme> {
+        let mut rng = commonware_utils::test_rng();
+        let Fixture {
+            participants,
+            private_keys,
+            ..
+        } = ed25519::fixture(
+            &mut rng,
+            b"aggregation-weighted-quorum",
+            u32::try_from(weights.len()).expect("test committee must fit in u32"),
+        );
+        let committee: Committee<_> = participants
+            .iter()
+            .cloned()
+            .zip(weights.iter().copied())
+            .try_collect()
+            .expect("test committee must be valid");
+        let schemes = private_keys
+            .iter()
+            .cloned()
+            .map(|private_key| {
+                ed25519::Scheme::signer(
+                    b"aggregation-weighted-quorum",
+                    committee.clone(),
+                    private_key,
+                )
+                .expect("private key must belong to test committee")
+            })
+            .collect();
+        let verifier = ed25519::Scheme::verifier(b"aggregation-weighted-quorum", committee);
+
+        Fixture {
+            participants,
+            private_keys,
+            schemes,
+            verifier,
+        }
+    }
+
+    #[test]
+    fn acknowledgement_quorum_uses_weight() {
+        let epoch = Epoch::new(111);
+        let item = Item {
+            height: Height::new(7),
+            digest: Sha256::hash(&[b"payload"]),
+        };
+
+        let light_majority = weighted_fixture(&[1, 1, 1, 6]);
+        let acks: Vec<_> = light_majority
+            .schemes
+            .iter()
+            .map(|scheme| Ack::sign(scheme, epoch, item.clone()).unwrap())
+            .collect();
+        assert!(!has_quorum_weight(
+            &light_majority.verifier,
+            &[&acks[0], &acks[1], &acks[2]],
+        ));
+        assert!(has_quorum_weight(
+            &light_majority.verifier,
+            &[&acks[0], &acks[1], &acks[2], &acks[3]],
+        ));
+
+        let heavy_quorum = weighted_fixture(&[4, 1, 1, 1]);
+        let acks: Vec<_> = heavy_quorum
+            .schemes
+            .iter()
+            .map(|scheme| Ack::sign(scheme, epoch, item.clone()).unwrap())
+            .collect();
+        assert!(has_quorum_weight(
+            &heavy_quorum.verifier,
+            &[&acks[0], &acks[1]],
+        ));
     }
 
     #[test]

--- a/consensus/src/aggregation/engine.rs
+++ b/consensus/src/aggregation/engine.rs
@@ -537,6 +537,7 @@ impl<
             .values()
             .filter(|a| a.item.digest == ack.item.digest)
             .collect::<Vec<_>>();
+        // BTreeMap iteration preserves the signer order required by sum_ordered_weights.
         if has_quorum_weight(&*scheme, &filtered) {
             let certificate =
                 Certificate::from_acks(&*scheme, non_empty![@filtered], &self.strategy)

--- a/consensus/src/aggregation/mod.rs
+++ b/consensus/src/aggregation/mod.rs
@@ -119,8 +119,9 @@ mod tests {
         deterministic::{self, Context},
     };
     use commonware_utils::{
-        NZU16, NZUsize, NonZeroDuration, TestRng,
+        NZU16, NZUsize, NonZeroDuration, TestRng, TryCollect,
         channel::{fallible::OneshotExt, oneshot},
+        ordered::Committee,
         probability, test_rng,
     };
     use futures::future::join_all;
@@ -241,6 +242,43 @@ mod tests {
         link_participants(&mut oracle, &fixture.participants, link).await;
 
         (oracle, registrations)
+    }
+
+    fn weighted_ed25519_fixture(
+        rng: &mut deterministic::Context,
+        weights: &[u64],
+    ) -> Fixture<ed25519::Scheme> {
+        let Fixture {
+            participants,
+            private_keys,
+            ..
+        } = ed25519::fixture(
+            rng,
+            TEST_NAMESPACE,
+            u32::try_from(weights.len()).expect("test committee must fit in u32"),
+        );
+        let committee: Committee<_> = participants
+            .iter()
+            .cloned()
+            .zip(weights.iter().copied())
+            .try_collect()
+            .expect("test committee must be valid");
+        let schemes = private_keys
+            .iter()
+            .cloned()
+            .map(|private_key| {
+                ed25519::Scheme::signer(TEST_NAMESPACE, committee.clone(), private_key)
+                    .expect("private key must belong to test committee")
+            })
+            .collect();
+        let verifier = ed25519::Scheme::verifier(TEST_NAMESPACE, committee);
+
+        Fixture {
+            participants,
+            private_keys,
+            schemes,
+            verifier,
+        }
     }
 
     /// Spawn aggregation engines for all validators.
@@ -409,6 +447,40 @@ mod tests {
     }
 
     test_for_all_fixtures!(slow all_online);
+
+    #[test_traced("INFO")]
+    fn test_weighted_quorum_finalizes() {
+        let runner = deterministic::Runner::timed(Duration::from_secs(30));
+
+        runner.start(|mut context| async move {
+            let mut fixture = weighted_ed25519_fixture(&mut context, &[4, 1, 1, 1]);
+            let epoch = Epoch::new(111);
+
+            // A weight-4 participant and one weight-1 participant form a quorum of 5.
+            fixture.participants.truncate(2);
+            fixture.schemes.truncate(2);
+
+            let (mut oracle, mut registrations) =
+                initialize_simulation(context.child("simulation"), &fixture, RELIABLE_LINK).await;
+            let reporters = spawn_validator_engines(
+                context.child("validator"),
+                &fixture,
+                &mut registrations,
+                &mut oracle,
+                epoch,
+                Duration::from_secs(5),
+                vec![],
+            );
+
+            await_reporters(
+                context.child("reporter"),
+                &reporters,
+                Height::new(20),
+                epoch,
+            )
+            .await;
+        });
+    }
 
     /// Test consensus resilience to Byzantine behavior.
     fn byzantine_proposer<S, F>(fixture: F)

--- a/consensus/src/aggregation/mod.rs
+++ b/consensus/src/aggregation/mod.rs
@@ -31,7 +31,7 @@
 //! - Requesting externally synchronized [commonware_cryptography::Digest]s
 //! - Signing said digests with the configured scheme's signature type
 //! - Multicasting signatures/shares to other validators
-//! - Assembling certificates from a quorum of signatures
+//! - Assembling certificates from a quorum weight of signatures
 //! - Monitoring recovery progress and notifying the application layer of recoveries
 //!
 //! The engine interacts with four main components:
@@ -59,9 +59,11 @@
 //! In aggregation, participants never gossip recovered certificates. Rather, they gossip [types::TipAck]s
 //! with signatures over some height and their latest tip. This approach reduces the overhead of running aggregation
 //! concurrently with a consensus mechanism and consistently results in local recovery on stable networks. To increase
-//! the likelihood of local recovery, participants should tune the [Config::activity_timeout] to a value larger than the expected
-//! drift of online participants (even if all participants are synchronous the tip advancement logic will advance to the `f+1`th highest
-//! reported tip and drop all work below that tip minus the [Config::activity_timeout]).
+//! the likelihood of local recovery, participants should tune the [Config::activity_timeout] to a
+//! value larger than the expected drift of online participants. Even if all participants are
+//! synchronous, tip advancement may skip to the greatest height reported by more than the maximum
+//! faulty committee weight and drop all work below that tip minus the
+//! [Config::activity_timeout].
 //!
 //! ## Epoch-Independent Signatures
 //!

--- a/consensus/src/aggregation/safe_tip.rs
+++ b/consensus/src/aggregation/safe_tip.rs
@@ -2,9 +2,8 @@ use crate::types::Height;
 use commonware_cryptography::PublicKey;
 use commonware_utils::{N3f1, ordered::Committee};
 use std::{
-    cmp::Ordering,
-    collections::{HashMap, hash_map::RandomState},
-    hash::BuildHasher,
+    collections::{BTreeMap, HashMap, btree_map::Entry},
+    ops::Bound::{Excluded, Unbounded},
 };
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -16,7 +15,12 @@ struct Tip {
 /// Tracks the greatest height reported by more than the maximum faulty weight.
 pub struct SafeTip<P: PublicKey> {
     tips: HashMap<P, Tip>,
-    heights: WeightedHeights,
+    /// Total committee weight at each reported height.
+    heights: BTreeMap<Height, u64>,
+    /// Greatest height reported by more than the maximum faulty weight.
+    safe: Height,
+    /// Total committee weight strictly above `safe`.
+    above_safe: u64,
     max_fault_weight: u64,
 }
 
@@ -24,7 +28,9 @@ impl<P: PublicKey> Default for SafeTip<P> {
     fn default() -> Self {
         Self {
             tips: HashMap::new(),
-            heights: WeightedHeights::default(),
+            heights: BTreeMap::new(),
+            safe: Height::zero(),
+            above_safe: 0,
             max_fault_weight: 0,
         }
     }
@@ -33,37 +39,12 @@ impl<P: PublicKey> Default for SafeTip<P> {
 impl<P: PublicKey> SafeTip<P> {
     /// Initializes an instance with the given committee.
     pub fn init(&mut self, committee: &Committee<P>) {
-        let max_fault_weight = committee.max_fault_weight::<N3f1>();
-        self.tips = committee
-            .iter()
-            .zip(committee.weights())
-            .map(|(participant, &weight)| {
-                (
-                    participant.clone(),
-                    Tip {
-                        height: Height::zero(),
-                        weight,
-                    },
-                )
-            })
-            .collect();
-        self.heights = WeightedHeights::default();
-        self.heights.add(Height::zero(), committee.total_weight());
-        self.max_fault_weight = max_fault_weight;
+        self.tips.clear();
+        self.reconcile(committee);
     }
 
     /// Updates the committee, preserving retained participants' heights.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the new committee does not have the same participant count.
     pub fn reconcile(&mut self, committee: &Committee<P>) {
-        assert_eq!(
-            committee.len(),
-            self.tips.len(),
-            "committee participant count mismatch"
-        );
-
         let tips = committee
             .iter()
             .zip(committee.weights())
@@ -76,14 +57,39 @@ impl<P: PublicKey> SafeTip<P> {
             })
             .collect::<HashMap<_, _>>();
 
-        let mut heights = WeightedHeights::default();
+        let mut heights = BTreeMap::new();
         for tip in tips.values() {
-            heights.add(tip.height, tip.weight);
+            let weight = heights.entry(tip.height).or_insert(0u64);
+            *weight = weight
+                .checked_add(tip.weight)
+                .expect("height weight overflow");
         }
+
+        let max_fault_weight = committee.max_fault_weight::<N3f1>();
+        let mut above_safe = 0u64;
+        let safe = heights
+            .iter()
+            .rev()
+            .find_map(|(&height, &weight)| {
+                if above_safe
+                    .checked_add(weight)
+                    .expect("height weight overflow")
+                    > max_fault_weight
+                {
+                    return Some(height);
+                }
+                above_safe = above_safe
+                    .checked_add(weight)
+                    .expect("height weight overflow");
+                None
+            })
+            .expect("empty committee");
 
         self.tips = tips;
         self.heights = heights;
-        self.max_fault_weight = committee.max_fault_weight::<N3f1>();
+        self.safe = safe;
+        self.above_safe = above_safe;
+        self.max_fault_weight = max_fault_weight;
     }
 
     /// Updates a participant's tip, returning its previous height.
@@ -106,192 +112,49 @@ impl<P: PublicKey> SafeTip<P> {
             },
         );
 
-        self.heights.remove(old, weight);
-        self.heights.add(new, weight);
+        match self.heights.entry(old) {
+            Entry::Occupied(mut entry) => {
+                let remaining = entry
+                    .get()
+                    .checked_sub(weight)
+                    .expect("insufficient height weight");
+                if remaining == 0 {
+                    entry.remove();
+                } else {
+                    *entry.get_mut() = remaining;
+                }
+            }
+            Entry::Vacant(_) => panic!("cannot remove missing height weight"),
+        }
+        let new_weight = self.heights.entry(new).or_insert(0);
+        *new_weight = new_weight
+            .checked_add(weight)
+            .expect("height weight overflow");
+
+        if old <= self.safe && new > self.safe {
+            self.above_safe = self
+                .above_safe
+                .checked_add(weight)
+                .expect("height weight overflow");
+        }
+        while self.above_safe > self.max_fault_weight {
+            let (&next, &weight) = self
+                .heights
+                .range((Excluded(self.safe), Unbounded))
+                .next()
+                .expect("weight above safe height must have a reported height");
+            self.safe = next;
+            self.above_safe = self
+                .above_safe
+                .checked_sub(weight)
+                .expect("height weight underflow");
+        }
         Some(old)
     }
 
     /// Returns the greatest height reached by weight greater than `f`.
-    pub fn get(&self) -> Height {
-        self.heights
-            .nth_highest(
-                self.max_fault_weight
-                    .checked_add(1)
-                    .expect("fault weight cannot reach u64::MAX"),
-            )
-            .expect("empty committee")
-    }
-}
-
-#[derive(Default)]
-struct WeightedHeights {
-    root: Option<Box<Node>>,
-    hasher: RandomState,
-}
-
-impl WeightedHeights {
-    fn add(&mut self, height: Height, weight: u64) {
-        assert!(weight > 0, "height weight must be positive");
-        let priority = self.hasher.hash_one(height);
-        self.root = Some(Node::insert(self.root.take(), height, weight, priority));
-    }
-
-    fn remove(&mut self, height: Height, weight: u64) {
-        assert!(weight > 0, "height weight must be positive");
-        self.root = Node::remove(self.root.take(), height, weight);
-    }
-
-    fn nth_highest(&self, weight: u64) -> Option<Height> {
-        self.root
-            .as_deref()
-            .and_then(|root| root.nth_highest(weight))
-    }
-}
-
-struct Node {
-    height: Height,
-    weight: u64,
-    subtree_weight: u64,
-    priority: u64,
-    left: Option<Box<Self>>,
-    right: Option<Box<Self>>,
-}
-
-impl Node {
-    fn new(height: Height, weight: u64, priority: u64) -> Box<Self> {
-        Box::new(Self {
-            height,
-            weight,
-            subtree_weight: weight,
-            priority,
-            left: None,
-            right: None,
-        })
-    }
-
-    fn subtree_weight(node: &Option<Box<Self>>) -> u64 {
-        node.as_ref().map_or(0, |node| node.subtree_weight)
-    }
-
-    fn refresh(&mut self) {
-        self.subtree_weight = Self::subtree_weight(&self.left)
-            .checked_add(self.weight)
-            .and_then(|weight| weight.checked_add(Self::subtree_weight(&self.right)))
-            .expect("height weight overflow");
-    }
-
-    fn higher_priority_than(&self, other: &Self) -> bool {
-        (self.priority, self.height) > (other.priority, other.height)
-    }
-
-    fn insert(root: Option<Box<Self>>, height: Height, weight: u64, priority: u64) -> Box<Self> {
-        let Some(mut root) = root else {
-            return Self::new(height, weight, priority);
-        };
-
-        match height.cmp(&root.height) {
-            Ordering::Less => {
-                root.left = Some(Self::insert(root.left.take(), height, weight, priority));
-                if root
-                    .left
-                    .as_ref()
-                    .is_some_and(|left| left.higher_priority_than(&root))
-                {
-                    return Self::rotate_right(root);
-                }
-            }
-            Ordering::Greater => {
-                root.right = Some(Self::insert(root.right.take(), height, weight, priority));
-                if root
-                    .right
-                    .as_ref()
-                    .is_some_and(|right| right.higher_priority_than(&root))
-                {
-                    return Self::rotate_left(root);
-                }
-            }
-            Ordering::Equal => {
-                root.weight = root
-                    .weight
-                    .checked_add(weight)
-                    .expect("height weight overflow");
-            }
-        }
-        root.refresh();
-        root
-    }
-
-    fn remove(root: Option<Box<Self>>, height: Height, weight: u64) -> Option<Box<Self>> {
-        let mut root = root.expect("cannot remove missing height weight");
-        match height.cmp(&root.height) {
-            Ordering::Less => root.left = Self::remove(root.left.take(), height, weight),
-            Ordering::Greater => root.right = Self::remove(root.right.take(), height, weight),
-            Ordering::Equal => {
-                root.weight = root
-                    .weight
-                    .checked_sub(weight)
-                    .expect("insufficient height weight");
-                if root.weight == 0 {
-                    return Self::merge(root.left, root.right);
-                }
-            }
-        }
-        root.refresh();
-        Some(root)
-    }
-
-    fn merge(left: Option<Box<Self>>, right: Option<Box<Self>>) -> Option<Box<Self>> {
-        match (left, right) {
-            (None, right) => right,
-            (left, None) => left,
-            (Some(mut left), Some(mut right)) => {
-                if left.higher_priority_than(&right) {
-                    left.right = Self::merge(left.right.take(), Some(right));
-                    left.refresh();
-                    Some(left)
-                } else {
-                    right.left = Self::merge(Some(left), right.left.take());
-                    right.refresh();
-                    Some(right)
-                }
-            }
-        }
-    }
-
-    fn rotate_left(mut root: Box<Self>) -> Box<Self> {
-        let mut pivot = root.right.take().expect("missing right child");
-        root.right = pivot.left.take();
-        root.refresh();
-        pivot.left = Some(root);
-        pivot.refresh();
-        pivot
-    }
-
-    fn rotate_right(mut root: Box<Self>) -> Box<Self> {
-        let mut pivot = root.left.take().expect("missing left child");
-        root.left = pivot.right.take();
-        root.refresh();
-        pivot.right = Some(root);
-        pivot.refresh();
-        pivot
-    }
-
-    fn nth_highest(&self, weight: u64) -> Option<Height> {
-        if weight == 0 || weight > self.subtree_weight {
-            return None;
-        }
-
-        let right_weight = Self::subtree_weight(&self.right);
-        if weight <= right_weight {
-            return self.right.as_deref()?.nth_highest(weight);
-        }
-        let weight = weight.checked_sub(right_weight).expect("weight underflow");
-        if weight <= self.weight {
-            return Some(self.height);
-        }
-        self.left
-            .as_deref()?
-            .nth_highest(weight.checked_sub(self.weight).expect("weight underflow"))
+    pub const fn get(&self) -> Height {
+        self.safe
     }
 }
 
@@ -302,7 +165,8 @@ mod tests {
         Signer,
         ed25519::{PrivateKey, PublicKey},
     };
-    use commonware_utils::TryCollect;
+    use commonware_utils::{TryCollect, test_rng};
+    use rand::RngExt as _;
 
     fn key(seed: u64) -> PublicKey {
         PrivateKey::from_seed(seed).public_key()
@@ -342,15 +206,17 @@ mod tests {
             .unwrap()
     }
 
-    fn assert_weight(safe_tip: &SafeTip<PublicKey>) {
+    fn assert_invariants(safe_tip: &SafeTip<PublicKey>) {
         let expected = safe_tip.tips.values().map(|tip| tip.weight).sum::<u64>();
+        assert_eq!(safe_tip.heights.values().sum::<u64>(), expected);
+        assert!(safe_tip.heights.values().all(|&weight| weight > 0));
         assert_eq!(
             safe_tip
                 .heights
-                .root
-                .as_ref()
-                .map_or(0, |root| root.subtree_weight),
-            expected
+                .range((Excluded(safe_tip.safe), Unbounded))
+                .map(|(_, weight)| weight)
+                .sum::<u64>(),
+            safe_tip.above_safe
         );
     }
 
@@ -386,8 +252,7 @@ mod tests {
         safe_tip.update(heavy, Height::new(10));
 
         assert_eq!(safe_tip.get(), Height::new(10));
-        assert_eq!(safe_tip.heights.nth_highest(2), Some(Height::new(10)));
-        assert_eq!(safe_tip.heights.nth_highest(3), Some(Height::new(10)));
+        assert_eq!(safe_tip.heights[&Height::new(10)], 5);
     }
 
     #[test]
@@ -432,28 +297,44 @@ mod tests {
     }
 
     #[test]
-    fn reconcile_replaces_members_at_height_zero() {
+    fn reconcile_supports_committee_size_changes() {
         let (mut safe_tip, old) = setup(&[(1, 1), (2, 1), (3, 1), (4, 1)]);
         for participant in old.iter().cloned() {
             safe_tip.update(participant, Height::new(10));
         }
         let retained = old.iter().skip(2).cloned().collect::<Vec<_>>();
-        let replacement = vec![
+        let smaller = vec![
             (retained[0].clone(), 1),
             (retained[1].clone(), 1),
-            (key(5), 1),
-            (key(6), 1),
+            (key(5), 2),
         ]
         .try_into()
         .unwrap();
 
-        safe_tip.reconcile(&replacement);
+        safe_tip.reconcile(&smaller);
+
+        assert_eq!(safe_tip.tips[&retained[0]].height, Height::new(10));
+        assert_eq!(safe_tip.tips[&retained[1]].height, Height::new(10));
+        assert_eq!(safe_tip.tips[&key(5)].height, Height::zero());
+        assert_eq!(safe_tip.get(), Height::new(10));
+
+        let larger = vec![
+            (retained[0].clone(), 1),
+            (retained[1].clone(), 1),
+            (key(5), 2),
+            (key(6), 4),
+            (key(7), 4),
+        ]
+        .try_into()
+        .unwrap();
+        safe_tip.reconcile(&larger);
 
         assert_eq!(safe_tip.tips[&retained[0]].height, Height::new(10));
         assert_eq!(safe_tip.tips[&retained[1]].height, Height::new(10));
         assert_eq!(safe_tip.tips[&key(5)].height, Height::zero());
         assert_eq!(safe_tip.tips[&key(6)].height, Height::zero());
-        assert_eq!(safe_tip.get(), Height::new(10));
+        assert_eq!(safe_tip.tips[&key(7)].height, Height::zero());
+        assert_eq!(safe_tip.get(), Height::zero());
     }
 
     #[test]
@@ -510,7 +391,7 @@ mod tests {
                             }
                         }
                         assert_eq!(safe_tip.get(), oracle(&committee, &heights));
-                        assert_weight(&safe_tip);
+                        assert_invariants(&safe_tip);
                     }
                 }
             }
@@ -518,9 +399,54 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "committee participant count mismatch")]
-    fn reconcile_requires_same_participant_count() {
-        let (mut safe_tip, _) = setup(&[(1, 1), (2, 1), (3, 1), (4, 1)]);
-        safe_tip.reconcile(&committee(&[(1, 1), (2, 1), (3, 1)]));
+    fn randomized_updates_and_reconciles_match_oracle() {
+        let mut rng = test_rng();
+        let entries = (1..=32)
+            .map(|seed| (seed, rng.random_range(1..=20)))
+            .collect::<Vec<_>>();
+        let (mut safe_tip, mut committee) = setup(&entries);
+        let mut heights = committee
+            .iter()
+            .cloned()
+            .map(|participant| (participant, Height::zero()))
+            .collect::<HashMap<_, _>>();
+
+        for step in 0..500 {
+            if step > 0 && step % 100 == 0 {
+                let (start, count) = match step {
+                    100 => (1, 24),
+                    200 => (1, 40),
+                    300 => (9, 32),
+                    _ => (1, 36),
+                };
+                let entries = (start..start + count)
+                    .map(|seed| (seed, rng.random_range(1..=20)))
+                    .collect::<Vec<_>>();
+                let next = self::committee(&entries);
+                heights = next
+                    .iter()
+                    .cloned()
+                    .map(|participant| {
+                        let height = heights
+                            .get(&participant)
+                            .copied()
+                            .unwrap_or_else(Height::zero);
+                        (participant, height)
+                    })
+                    .collect();
+                safe_tip.reconcile(&next);
+                committee = next;
+            } else {
+                let index = rng.random_range(0..committee.len());
+                let participant = committee[index].clone();
+                let old = heights[&participant];
+                let new = Height::new(old.get() + rng.random_range(1..=25));
+                assert_eq!(safe_tip.update(participant.clone(), new), Some(old));
+                heights.insert(participant, new);
+            }
+
+            assert_eq!(safe_tip.get(), oracle(&committee, &heights));
+            assert_invariants(&safe_tip);
+        }
     }
 }

--- a/consensus/src/aggregation/safe_tip.rs
+++ b/consensus/src/aggregation/safe_tip.rs
@@ -1,247 +1,297 @@
 use crate::types::Height;
 use commonware_cryptography::PublicKey;
-use commonware_utils::{
-    N3f1,
-    ordered::{Quorum, Set},
+use commonware_utils::{N3f1, ordered::Committee};
+use std::{
+    cmp::Ordering,
+    collections::{HashMap, hash_map::RandomState},
+    hash::BuildHasher,
 };
-use std::collections::{BTreeMap, HashMap, btree_map};
 
-/// A data structure that keeps track of the reported tip for each validator.
-/// It can efficiently query the `f`th highest tip, where `f` is the maximum number of faults
-/// that can be tolerated for the given set of validators.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct Tip {
+    height: Height,
+    weight: u64,
+}
+
+/// Tracks the greatest height reported by more than the maximum faulty weight.
 pub struct SafeTip<P: PublicKey> {
-    /// For each validator, the maximum tip that it has reported.
-    tips: HashMap<P, Height>,
-
-    /// The `f` highest tips, stored as a map from height to number of validators.
-    ///
-    /// We assume that all of these values could have been reported by faulty validators.
-    hi: BTreeMap<Height, usize>,
-
-    /// The `n-f` lowest tips, stored as a map from height to number of validators.
-    ///
-    /// Treat the highest value as the safe tip, which is the tip that at least one honest validator
-    /// has reached.
-    lo: BTreeMap<Height, usize>,
+    tips: HashMap<P, Tip>,
+    heights: WeightedHeights,
+    max_fault_weight: u64,
 }
 
 impl<P: PublicKey> Default for SafeTip<P> {
     fn default() -> Self {
         Self {
             tips: HashMap::new(),
-            hi: BTreeMap::new(),
-            lo: BTreeMap::new(),
+            heights: WeightedHeights::default(),
+            max_fault_weight: 0,
         }
     }
 }
 
 impl<P: PublicKey> SafeTip<P> {
-    /// Initializes an instance with the given validators.
+    /// Initializes an instance with the given committee.
+    pub fn init(&mut self, committee: &Committee<P>) {
+        let max_fault_weight = committee.max_fault_weight::<N3f1>();
+        self.tips = committee
+            .iter()
+            .zip(committee.weights())
+            .map(|(participant, &weight)| {
+                (
+                    participant.clone(),
+                    Tip {
+                        height: Height::zero(),
+                        weight,
+                    },
+                )
+            })
+            .collect();
+        self.heights = WeightedHeights::default();
+        self.heights.add(Height::zero(), committee.total_weight());
+        self.max_fault_weight = max_fault_weight;
+    }
+
+    /// Updates the committee, preserving retained participants' heights.
     ///
     /// # Panics
     ///
-    /// Panics if the validator set is empty.
-    pub fn init(&mut self, validators: &Set<P>) {
-        // Ensure the validator set is not empty
-        assert!(!validators.is_empty());
+    /// Panics if the new committee does not have the same participant count.
+    pub fn reconcile(&mut self, committee: &Committee<P>) {
+        assert_eq!(
+            committee.len(),
+            self.tips.len(),
+            "committee participant count mismatch"
+        );
 
-        // Get the number of validators and the maximum number of faults
-        let n = validators.len();
-        let f = validators.max_faults_count::<N3f1>() as usize;
+        let tips = committee
+            .iter()
+            .zip(committee.weights())
+            .map(|(participant, &weight)| {
+                let height = self
+                    .tips
+                    .get(participant)
+                    .map_or(Height::zero(), |tip| tip.height);
+                (participant.clone(), Tip { height, weight })
+            })
+            .collect::<HashMap<_, _>>();
 
-        // Initialize the tips map
-        let mut tips = HashMap::with_capacity(n);
-        for validator in validators {
-            tips.insert(validator.clone(), Height::default());
-        }
-
-        // Initialize the heaps
-        let mut lo = BTreeMap::new();
-        lo.insert(Height::default(), n - f);
-        let mut hi = BTreeMap::new();
-        if f > 0 {
-            hi.insert(Height::default(), f);
+        let mut heights = WeightedHeights::default();
+        for tip in tips.values() {
+            heights.add(tip.height, tip.weight);
         }
 
         self.tips = tips;
-        self.hi = hi;
-        self.lo = lo;
+        self.heights = heights;
+        self.max_fault_weight = committee.max_fault_weight::<N3f1>();
     }
 
-    /// Updates the validator set. New validators are added with a default tip of 0.
+    /// Updates a participant's tip, returning its previous height.
     ///
-    /// # Panics
-    ///
-    /// Panics if the new validator set is not the same size as the existing set.
-    pub fn reconcile(&mut self, validators: &Set<P>) {
-        // Verify the new validator set size
-        assert!(
-            validators.len() == self.tips.len(),
-            "Validator set size mismatch"
-        );
-
-        // Get the set of exiting validators.
-        let mut exiting_vals = Vec::new();
-        for val in self.tips.keys() {
-            if validators.position(val).is_none() {
-                exiting_vals.push(val.clone());
-            }
-        }
-
-        // Remove validators that are no longer in the set.
-        // Their old tip value gets set to the default value.
-        for val in exiting_vals {
-            // Remove the validator from the set of validators.
-            let old = self.tips.remove(&val).unwrap();
-            let new = Height::default();
-
-            // Update the heaps. Since the value is decreasing (or stays at 0), there are four
-            // cases, which we check in order-of-preference:
-            // 1. No-op. The value was already `0`.
-            // 2. The value can remain in the `lo` heap.
-            // 3. The value can remain in the `hi` heap.
-            // 4. The value must be moved from the `hi` heap to the `lo` heap.
-
-            // Case 1: No-op
-            if old == new {
-                continue;
-            }
-
-            // Case 2: The value can remain in the `lo` heap.
-            if self.lo.contains_key(&old) {
-                dec(self.lo.entry(old));
-                inc(self.lo.entry(new));
-                continue;
-            }
-
-            // At this point, we know that the old value is in the `hi` heap. If every single value
-            // in the `lo` heap is less-than-or-equal-to the new value, then the value can remain in
-            // the `hi` heap.
-            let stay_in_hi: bool = self
-                .lo
-                .last_entry()
-                .map(|e| *e.key())
-                .is_none_or(|max_lo| max_lo <= new);
-
-            // Case 3: The value can remain in the `hi` heap.
-            if stay_in_hi {
-                dec(self.hi.entry(old));
-                inc(self.hi.entry(new));
-                continue;
-            }
-
-            // Case 4: The value must be moved from the `hi` heap to the `lo` heap.
-            dec(self.hi.entry(old));
-            inc(self.lo.entry(new));
-
-            // Move the maximum value from the `lo` heap to the `hi` heap.
-            let max_lo = *self.lo.last_entry().expect("Empty lo heap").key();
-            assert!(max_lo > new); // Sanity-check
-            dec(self.lo.entry(max_lo));
-            inc(self.hi.entry(max_lo));
-        }
-
-        // Add new validators with default height
-        for new_val in validators {
-            self.tips.entry(new_val.clone()).or_default();
-        }
-    }
-
-    /// Updates the tip for the given validator.
-    ///
-    /// Returns `None` if the validator is not in the set of validators.
-    ///
-    /// Returns `None` if the new tip is not higher than the old tip.
-    ///
-    /// Otherwise, returns the old tip.
+    /// Returns `None` for an unknown participant or a non-increasing update.
     pub fn update(&mut self, public_key: P, new: Height) -> Option<Height> {
-        // Update the tip for the given validator. Return early if the validator is not in the set.
-        let &old = self.tips.get(&public_key)?;
-
-        // If the new tip is not higher than the old tip, this is a no-op.
+        let &Tip {
+            height: old,
+            weight,
+        } = self.tips.get(&public_key)?;
         if old >= new {
             return None;
         }
 
-        // Update the tip for the given validator
-        self.tips.insert(public_key, new);
+        self.tips.insert(
+            public_key,
+            Tip {
+                height: new,
+                weight,
+            },
+        );
 
-        // Update the heaps. Since the value is strictly increasing, there are three cases, which we
-        // check in order-of-preference:
-        // 1. The value can remain in the `hi` heap.
-        // 2. The value can remain in the `lo` heap.
-        // 3. The value must be moved from the `lo` heap to the `hi` heap.
-
-        // Case 1: The value can remain in the `hi` heap.
-        if self.hi.contains_key(&old) {
-            dec(self.hi.entry(old));
-            inc(self.hi.entry(new));
-            return Some(old);
-        }
-
-        // At this point, we know that the old value is in the `lo` heap. If every single value in
-        // the `hi` heap is greater-than-or-equal-to the new value, then the value can remain in the
-        // `lo` heap.
-        let stay_in_lo: bool = self
-            .hi
-            .first_entry()
-            .map(|e| *e.key())
-            .is_none_or(|min_hi| min_hi >= new);
-
-        // Case 2: The value can remain in the `lo` heap.
-        if stay_in_lo {
-            dec(self.lo.entry(old));
-            inc(self.lo.entry(new));
-            return Some(old);
-        }
-
-        // Case 3: The value must be moved from the `lo` heap to the `hi` heap.
-        dec(self.lo.entry(old));
-        inc(self.hi.entry(new));
-
-        // Move the minimum value from the `hi` heap to the `lo` heap.
-        let min_hi = *self.hi.first_entry().expect("Empty hi heap").key();
-        assert!(min_hi < new); // Sanity-check
-        dec(self.hi.entry(min_hi));
-        inc(self.lo.entry(min_hi));
-
+        self.heights.remove(old, weight);
+        self.heights.add(new, weight);
         Some(old)
     }
 
-    /// Returns the `f`th highest tip.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the set of validators is empty.
+    /// Returns the greatest height reached by weight greater than `f`.
     pub fn get(&self) -> Height {
-        self.lo
-            .last_key_value()
-            .map(|(k, _)| *k)
-            .expect("Empty validator set")
+        self.heights
+            .nth_highest(
+                self.max_fault_weight
+                    .checked_add(1)
+                    .expect("fault weight cannot reach u64::MAX"),
+            )
+            .expect("empty committee")
     }
 }
 
-/// Increments the value of the entry in the map.
-///
-/// If the entry does not exist, it is created with a value of 1.
-fn inc(entry: btree_map::Entry<'_, Height, usize>) {
-    *entry.or_default() += 1;
+#[derive(Default)]
+struct WeightedHeights {
+    root: Option<Box<Node>>,
+    hasher: RandomState,
 }
 
-/// Decrements the value of the entry in the map.
-///
-/// If the value reaches zero, the entry is removed from the map.
-///
-/// # Panics
-///
-/// Panics if the entry is [btree_map::Entry::Vacant].
-fn dec(entry: btree_map::Entry<'_, Height, usize>) {
-    let btree_map::Entry::Occupied(mut value) = entry else {
-        panic!("Cannot decrement a non-existent entry");
-    };
-    *value.get_mut() -= 1;
-    if *value.get() == 0 {
-        value.remove();
+impl WeightedHeights {
+    fn add(&mut self, height: Height, weight: u64) {
+        assert!(weight > 0, "height weight must be positive");
+        let priority = self.hasher.hash_one(height);
+        self.root = Some(Node::insert(self.root.take(), height, weight, priority));
+    }
+
+    fn remove(&mut self, height: Height, weight: u64) {
+        assert!(weight > 0, "height weight must be positive");
+        self.root = Node::remove(self.root.take(), height, weight);
+    }
+
+    fn nth_highest(&self, weight: u64) -> Option<Height> {
+        self.root
+            .as_deref()
+            .and_then(|root| root.nth_highest(weight))
+    }
+}
+
+struct Node {
+    height: Height,
+    weight: u64,
+    subtree_weight: u64,
+    priority: u64,
+    left: Option<Box<Self>>,
+    right: Option<Box<Self>>,
+}
+
+impl Node {
+    fn new(height: Height, weight: u64, priority: u64) -> Box<Self> {
+        Box::new(Self {
+            height,
+            weight,
+            subtree_weight: weight,
+            priority,
+            left: None,
+            right: None,
+        })
+    }
+
+    fn subtree_weight(node: &Option<Box<Self>>) -> u64 {
+        node.as_ref().map_or(0, |node| node.subtree_weight)
+    }
+
+    fn refresh(&mut self) {
+        self.subtree_weight = Self::subtree_weight(&self.left)
+            .checked_add(self.weight)
+            .and_then(|weight| weight.checked_add(Self::subtree_weight(&self.right)))
+            .expect("height weight overflow");
+    }
+
+    fn higher_priority_than(&self, other: &Self) -> bool {
+        (self.priority, self.height) > (other.priority, other.height)
+    }
+
+    fn insert(root: Option<Box<Self>>, height: Height, weight: u64, priority: u64) -> Box<Self> {
+        let Some(mut root) = root else {
+            return Self::new(height, weight, priority);
+        };
+
+        match height.cmp(&root.height) {
+            Ordering::Less => {
+                root.left = Some(Self::insert(root.left.take(), height, weight, priority));
+                if root
+                    .left
+                    .as_ref()
+                    .is_some_and(|left| left.higher_priority_than(&root))
+                {
+                    return Self::rotate_right(root);
+                }
+            }
+            Ordering::Greater => {
+                root.right = Some(Self::insert(root.right.take(), height, weight, priority));
+                if root
+                    .right
+                    .as_ref()
+                    .is_some_and(|right| right.higher_priority_than(&root))
+                {
+                    return Self::rotate_left(root);
+                }
+            }
+            Ordering::Equal => {
+                root.weight = root
+                    .weight
+                    .checked_add(weight)
+                    .expect("height weight overflow");
+            }
+        }
+        root.refresh();
+        root
+    }
+
+    fn remove(root: Option<Box<Self>>, height: Height, weight: u64) -> Option<Box<Self>> {
+        let mut root = root.expect("cannot remove missing height weight");
+        match height.cmp(&root.height) {
+            Ordering::Less => root.left = Self::remove(root.left.take(), height, weight),
+            Ordering::Greater => root.right = Self::remove(root.right.take(), height, weight),
+            Ordering::Equal => {
+                root.weight = root
+                    .weight
+                    .checked_sub(weight)
+                    .expect("insufficient height weight");
+                if root.weight == 0 {
+                    return Self::merge(root.left, root.right);
+                }
+            }
+        }
+        root.refresh();
+        Some(root)
+    }
+
+    fn merge(left: Option<Box<Self>>, right: Option<Box<Self>>) -> Option<Box<Self>> {
+        match (left, right) {
+            (None, right) => right,
+            (left, None) => left,
+            (Some(mut left), Some(mut right)) => {
+                if left.higher_priority_than(&right) {
+                    left.right = Self::merge(left.right.take(), Some(right));
+                    left.refresh();
+                    Some(left)
+                } else {
+                    right.left = Self::merge(Some(left), right.left.take());
+                    right.refresh();
+                    Some(right)
+                }
+            }
+        }
+    }
+
+    fn rotate_left(mut root: Box<Self>) -> Box<Self> {
+        let mut pivot = root.right.take().expect("missing right child");
+        root.right = pivot.left.take();
+        root.refresh();
+        pivot.left = Some(root);
+        pivot.refresh();
+        pivot
+    }
+
+    fn rotate_right(mut root: Box<Self>) -> Box<Self> {
+        let mut pivot = root.left.take().expect("missing left child");
+        root.left = pivot.right.take();
+        root.refresh();
+        pivot.right = Some(root);
+        pivot.refresh();
+        pivot
+    }
+
+    fn nth_highest(&self, weight: u64) -> Option<Height> {
+        if weight == 0 || weight > self.subtree_weight {
+            return None;
+        }
+
+        let right_weight = Self::subtree_weight(&self.right);
+        if weight <= right_weight {
+            return self.right.as_deref()?.nth_highest(weight);
+        }
+        let weight = weight.checked_sub(right_weight).expect("weight underflow");
+        if weight <= self.weight {
+            return Some(self.height);
+        }
+        self.left
+            .as_deref()?
+            .nth_highest(weight.checked_sub(self.weight).expect("weight underflow"))
     }
 }
 
@@ -253,445 +303,224 @@ mod tests {
         ed25519::{PrivateKey, PublicKey},
     };
     use commonware_utils::TryCollect;
-    use rstest::rstest;
 
-    fn key(i: u64) -> PublicKey {
-        PrivateKey::from_seed(i).public_key()
+    fn key(seed: u64) -> PublicKey {
+        PrivateKey::from_seed(seed).public_key()
     }
 
-    fn setup_safe_tip(validator_count: usize) -> (SafeTip<PublicKey>, Set<PublicKey>) {
-        let mut safe_tip = SafeTip::<PublicKey>::default();
-        let validators = (1..=validator_count)
-            .map(|i| key(i as u64))
-            .try_collect::<Set<_>>()
+    fn committee(entries: &[(u64, u64)]) -> Committee<PublicKey> {
+        entries
+            .iter()
+            .map(|&(seed, weight)| (key(seed), weight))
+            .try_collect()
+            .unwrap()
+    }
+
+    fn setup(entries: &[(u64, u64)]) -> (SafeTip<PublicKey>, Committee<PublicKey>) {
+        let committee = committee(entries);
+        let mut safe_tip = SafeTip::default();
+        safe_tip.init(&committee);
+        (safe_tip, committee)
+    }
+
+    fn oracle(committee: &Committee<PublicKey>, heights: &HashMap<PublicKey, Height>) -> Height {
+        let f = committee.max_fault_weight::<N3f1>();
+        heights
+            .values()
+            .copied()
+            .filter(|&candidate| {
+                committee
+                    .iter()
+                    .zip(committee.weights())
+                    .filter(|(participant, _)| heights[*participant] >= candidate)
+                    .fold(0u64, |weight, (_, participant_weight)| {
+                        weight.checked_add(*participant_weight).unwrap()
+                    })
+                    > f
+            })
+            .max()
+            .unwrap()
+    }
+
+    fn assert_weight(safe_tip: &SafeTip<PublicKey>) {
+        let expected = safe_tip.tips.values().map(|tip| tip.weight).sum::<u64>();
+        assert_eq!(
+            safe_tip
+                .heights
+                .root
+                .as_ref()
+                .map_or(0, |root| root.subtree_weight),
+            expected
+        );
+    }
+
+    #[test]
+    fn uniform_weights_match_count_based_safe_tip() {
+        for count in 1..=8 {
+            let entries = (1..=count).map(|seed| (seed, 1)).collect::<Vec<_>>();
+            let (mut safe_tip, committee) = setup(&entries);
+            let mut heights = committee
+                .iter()
+                .cloned()
+                .map(|participant| (participant, Height::zero()))
+                .collect::<HashMap<_, _>>();
+
+            for (index, participant) in committee.iter().cloned().enumerate() {
+                let height = Height::new((index + 1) as u64);
+                safe_tip.update(participant.clone(), height);
+                heights.insert(participant, height);
+                assert_eq!(safe_tip.get(), oracle(&committee, &heights));
+            }
+        }
+    }
+
+    #[test]
+    fn participant_weight_can_span_the_safe_tip_boundary() {
+        let (mut safe_tip, committee) = setup(&[(1, 5), (2, 2), (3, 1)]);
+        let heavy = committee
+            .iter()
+            .find(|participant| committee.weights()[committee.position(participant).unwrap()] == 5)
+            .unwrap()
+            .clone();
+
+        safe_tip.update(heavy, Height::new(10));
+
+        assert_eq!(safe_tip.get(), Height::new(10));
+        assert_eq!(safe_tip.heights.nth_highest(2), Some(Height::new(10)));
+        assert_eq!(safe_tip.heights.nth_highest(3), Some(Height::new(10)));
+    }
+
+    #[test]
+    fn weighted_safety_uses_weight_strictly_greater_than_f() {
+        let (mut safe_tip, committee) = setup(&[(1, 3), (2, 2), (3, 2)]);
+        let mut by_weight = committee
+            .iter()
+            .cloned()
+            .zip(committee.weights().iter().copied())
+            .collect::<Vec<_>>();
+        by_weight.sort_by_key(|(_, weight)| *weight);
+
+        safe_tip.update(by_weight[0].0.clone(), Height::new(100));
+        assert_eq!(safe_tip.get(), Height::zero());
+        safe_tip.update(by_weight[2].0.clone(), Height::new(20));
+        assert_eq!(safe_tip.get(), Height::new(20));
+    }
+
+    #[test]
+    fn reconcile_applies_weight_changes_without_losing_heights() {
+        let (mut safe_tip, old) = setup(&[(1, 1), (2, 1), (3, 1), (4, 1)]);
+        for (index, participant) in old.iter().cloned().enumerate() {
+            safe_tip.update(participant, Height::new((index + 1) as u64 * 10));
+        }
+        let highest = old.iter().last().unwrap().clone();
+        let changed = old
+            .iter()
+            .map(|participant| {
+                (
+                    participant.clone(),
+                    if participant == &highest { 4 } else { 1 },
+                )
+            })
+            .try_collect::<Committee<_>>()
             .unwrap();
-        safe_tip.init(&validators);
-        (safe_tip, validators)
+
+        safe_tip.reconcile(&changed);
+
+        assert_eq!(safe_tip.tips[&highest].height, Height::new(40));
+        assert_eq!(safe_tip.tips[&highest].weight, 4);
+        assert_eq!(safe_tip.get(), Height::new(40));
     }
 
-    fn setup_with_tips(
-        validator_count: usize,
-        tips: &[u64],
-    ) -> (SafeTip<PublicKey>, Set<PublicKey>) {
-        let (mut safe_tip, validators) = setup_safe_tip(validator_count);
-        for (i, &tip) in tips.iter().enumerate() {
-            if i < validators.len() && tip > 0 {
-                safe_tip.update(validators[i].clone(), Height::new(tip));
-            }
+    #[test]
+    fn reconcile_replaces_members_at_height_zero() {
+        let (mut safe_tip, old) = setup(&[(1, 1), (2, 1), (3, 1), (4, 1)]);
+        for participant in old.iter().cloned() {
+            safe_tip.update(participant, Height::new(10));
         }
-        (safe_tip, validators)
-    }
+        let retained = old.iter().skip(2).cloned().collect::<Vec<_>>();
+        let replacement = vec![
+            (retained[0].clone(), 1),
+            (retained[1].clone(), 1),
+            (key(5), 1),
+            (key(6), 1),
+        ]
+        .try_into()
+        .unwrap();
 
-    #[test]
-    fn test_init() {
-        let (safe_tip, _) = setup_safe_tip(4);
-        assert_eq!(safe_tip.tips.len(), 4);
-        assert_eq!(safe_tip.get(), Height::zero());
-    }
+        safe_tip.reconcile(&replacement);
 
-    #[test]
-    fn test_validation_failures() {
-        // Test init with empty validator set
-        let mut safe_tip = SafeTip::<PublicKey>::default();
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            safe_tip.init(&[].try_into().unwrap());
-        }));
-        assert!(result.is_err());
-
-        // Test reconcile with size mismatch
-        let mut safe_tip = SafeTip::<PublicKey>::default();
-        safe_tip.init(&[key(1), key(2), key(3), key(4)].try_into().unwrap());
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            safe_tip.reconcile(&[key(1), key(2), key(3)].try_into().unwrap());
-        }));
-        assert!(result.is_err());
-
-        // Test dec function with non-existent entry
-        let mut map = BTreeMap::new();
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            dec(map.entry(Height::new(42)));
-        }));
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_update_and_get() {
-        let (mut safe_tip, validators) = setup_safe_tip(4);
-
-        // Valid update
-        assert_eq!(
-            safe_tip.update(validators[0].clone(), Height::new(10)),
-            Some(Height::zero())
-        );
-        assert_eq!(safe_tip.get(), Height::zero());
-
-        // Update with lower tip - no-op
-        assert_eq!(safe_tip.update(validators[0].clone(), Height::new(5)), None);
-        assert_eq!(safe_tip.get(), Height::zero());
-
-        // Update with same tip - no-op
-        assert_eq!(
-            safe_tip.update(validators[0].clone(), Height::new(10)),
-            None
-        );
-        assert_eq!(safe_tip.get(), Height::zero());
-
-        // Update remaining validators
-        assert_eq!(
-            safe_tip.update(validators[1].clone(), Height::new(20)),
-            Some(Height::zero())
-        );
+        assert_eq!(safe_tip.tips[&retained[0]].height, Height::new(10));
+        assert_eq!(safe_tip.tips[&retained[1]].height, Height::new(10));
+        assert_eq!(safe_tip.tips[&key(5)].height, Height::zero());
+        assert_eq!(safe_tip.tips[&key(6)].height, Height::zero());
         assert_eq!(safe_tip.get(), Height::new(10));
+    }
+
+    #[test]
+    fn zero_fault_weight_tracks_the_highest_tip() {
+        let (mut safe_tip, committee) = setup(&[(1, 1), (2, 1), (3, 1)]);
+        assert_eq!(safe_tip.max_fault_weight, 0);
+
+        safe_tip.update(committee[0].clone(), Height::new(4));
+        safe_tip.update(committee[1].clone(), Height::new(9));
+        assert_eq!(safe_tip.get(), Height::new(9));
+    }
+
+    #[test]
+    fn rejects_unknown_and_non_increasing_updates() {
+        let (mut safe_tip, committee) = setup(&[(1, 1), (2, 1), (3, 1), (4, 1)]);
+        assert_eq!(safe_tip.update(key(99), Height::new(1)), None);
         assert_eq!(
-            safe_tip.update(validators[2].clone(), Height::new(30)),
+            safe_tip.update(committee[0].clone(), Height::new(5)),
             Some(Height::zero())
         );
-        assert_eq!(safe_tip.get(), Height::new(20));
-        assert_eq!(
-            safe_tip.update(validators[3].clone(), Height::new(40)),
-            Some(Height::zero())
-        );
-        assert_eq!(safe_tip.get(), Height::new(30));
+        assert_eq!(safe_tip.update(committee[0].clone(), Height::new(5)), None);
+        assert_eq!(safe_tip.update(committee[0].clone(), Height::new(4)), None);
     }
 
     #[test]
-    fn test_reconcile() {
-        let mut safe_tip = SafeTip::<PublicKey>::default();
-        let old_validators = &[key(1), key(2), key(3), key(4)];
-        safe_tip.init(&old_validators.try_into().unwrap());
+    fn matches_small_brute_force_oracle() {
+        let (mut safe_tip, committee) = setup(&[(1, 1), (2, 2), (3, 3)]);
+        let participants = committee.iter().cloned().collect::<Vec<_>>();
+        let orders = [
+            [0, 1, 2],
+            [0, 2, 1],
+            [1, 0, 2],
+            [1, 2, 0],
+            [2, 0, 1],
+            [2, 1, 0],
+        ];
 
-        safe_tip.update(key(1), Height::new(10));
-        safe_tip.update(key(2), Height::new(20));
-        safe_tip.update(key(3), Height::new(30));
-        safe_tip.update(key(4), Height::new(40));
+        for first in 0..=3 {
+            for second in 0..=3 {
+                for third in 0..=3 {
+                    let values = [first, second, third];
+                    let mut heights = HashMap::new();
+                    for (participant, &value) in participants.iter().zip(&values) {
+                        let height = Height::new(value);
+                        heights.insert(participant.clone(), height);
+                    }
 
-        assert_eq!(safe_tip.get(), Height::new(30));
-
-        // Reconcile with a new set of validators
-        let new_validators = &[key(3), key(4), key(5), key(6)];
-        safe_tip.reconcile(&new_validators.try_into().unwrap());
-
-        assert_eq!(safe_tip.tips.len(), 4);
-        assert!(safe_tip.tips.contains_key(&key(3)));
-        assert!(safe_tip.tips.contains_key(&key(4)));
-        assert!(safe_tip.tips.contains_key(&key(5)));
-        assert!(safe_tip.tips.contains_key(&key(6)));
-        assert_eq!(*safe_tip.tips.get(&key(3)).unwrap(), Height::new(30));
-        assert_eq!(*safe_tip.tips.get(&key(4)).unwrap(), Height::new(40));
-        assert_eq!(*safe_tip.tips.get(&key(5)).unwrap(), Height::zero());
-        assert_eq!(*safe_tip.tips.get(&key(6)).unwrap(), Height::zero());
-        assert_eq!(safe_tip.get(), Height::new(30));
-    }
-
-    #[test]
-    fn test_reconcile_identical() {
-        let mut safe_tip = SafeTip::<PublicKey>::default();
-        let validators = &[key(1), key(2), key(3), key(4)];
-        safe_tip.init(&validators.try_into().unwrap());
-
-        // Set some initial tips
-        safe_tip.update(key(1), Height::new(10));
-        safe_tip.update(key(2), Height::new(20));
-        safe_tip.update(key(3), Height::new(30));
-
-        let initial_safe_tip = safe_tip.get();
-        let initial_tips = safe_tip.tips.clone();
-        let initial_hi = safe_tip.hi.clone();
-        let initial_lo = safe_tip.lo.clone();
-
-        // Reconcile with identical validator set - should be a no-op
-        safe_tip.reconcile(&validators.try_into().unwrap());
-
-        // Verify nothing changed
-        assert_eq!(safe_tip.get(), initial_safe_tip);
-        assert_eq!(safe_tip.tips, initial_tips);
-        assert_eq!(safe_tip.hi, initial_hi);
-        assert_eq!(safe_tip.lo, initial_lo);
-    }
-
-    #[test]
-    fn test_update_nonexistent_validator() {
-        let (mut safe_tip, _) = setup_with_tips(4, &[10, 20, 0, 0]);
-
-        let initial_safe_tip = safe_tip.get();
-        let initial_tips = safe_tip.tips.clone();
-
-        // Test multiple non-existent validators
-        for nonexistent_key in [key(100), key(200), key(300)] {
-            assert_eq!(safe_tip.update(nonexistent_key, Height::new(50)), None);
-        }
-
-        // State should remain unchanged
-        assert_eq!(safe_tip.get(), initial_safe_tip);
-        assert_eq!(safe_tip.tips, initial_tips);
-    }
-
-    #[rstest]
-    #[case::single_validator_no_faults_possible(1, 0)]
-    #[case::two_validators_no_faults_possible(2, 0)]
-    #[case::three_validators_no_faults_possible(3, 0)]
-    #[case::four_validators_one_fault_possible(4, 1)]
-    #[case::seven_validators_two_faults_possible(7, 2)]
-    fn test_edge_cases_for_f(#[case] n: usize, #[case] f: usize) {
-        let (mut safe_tip, validators) = setup_safe_tip(n);
-
-        // Initial state checks
-        assert_eq!(safe_tip.get(), Height::zero());
-
-        if f == 0 {
-            assert_eq!(safe_tip.hi.len(), 0,);
-            assert_eq!(safe_tip.lo.len(), 1,);
-
-            // When f=0, updates should immediately change safe tip
-            safe_tip.update(validators[0].clone(), Height::new(10));
-            assert_eq!(safe_tip.get(), Height::new(10),);
-        } else {
-            assert_eq!(safe_tip.hi.len(), 1,);
-            assert_eq!(safe_tip.lo.len(), 1,);
-
-            if n == 7 && f == 2 {
-                assert_eq!(safe_tip.hi.get(&Height::zero()), Some(&2),);
-                assert_eq!(safe_tip.lo.get(&Height::zero()), Some(&5),);
+                    for order in orders {
+                        safe_tip.init(&committee);
+                        for index in order {
+                            let value = values[index];
+                            if value > 0 {
+                                safe_tip.update(participants[index].clone(), Height::new(value));
+                            }
+                        }
+                        assert_eq!(safe_tip.get(), oracle(&committee, &heights));
+                        assert_weight(&safe_tip);
+                    }
+                }
             }
         }
     }
 
     #[test]
-    fn test_dec_inc_internal() {
-        // Test inc function
-        let mut map = BTreeMap::new();
-
-        // Test inc on non-existent entry
-        inc(map.entry(Height::new(10)));
-        assert_eq!(map.get(&Height::new(10)), Some(&1));
-
-        // Test inc on existing entry
-        inc(map.entry(Height::new(10)));
-        assert_eq!(map.get(&Height::new(10)), Some(&2));
-
-        // Test inc on different keys
-        inc(map.entry(Height::new(20)));
-        inc(map.entry(Height::new(30)));
-        assert_eq!(map.get(&Height::new(20)), Some(&1));
-        assert_eq!(map.get(&Height::new(30)), Some(&1));
-        assert_eq!(map.len(), 3);
-
-        // Test dec function
-        // Test dec on existing entry
-        dec(map.entry(Height::new(10)));
-        assert_eq!(map.get(&Height::new(10)), Some(&1));
-
-        // Test dec that removes entry (value becomes 0)
-        dec(map.entry(Height::new(10)));
-        assert_eq!(map.get(&Height::new(10)), None);
-        assert_eq!(map.len(), 2);
-
-        // Test dec on other entries
-        dec(map.entry(Height::new(20)));
-        assert_eq!(map.get(&Height::new(20)), None);
-        assert_eq!(map.len(), 1);
-
-        dec(map.entry(Height::new(30)));
-        assert_eq!(map.get(&Height::new(30)), None);
-        assert_eq!(map.len(), 0);
-    }
-
-    #[test]
-    fn test_reconcile_overall_behavior_lo_heap() {
-        // Test overall reconcile behavior when removing validator from lo heap
-        let (mut safe_tip, _) = setup_with_tips(7, &[5, 10, 15, 20, 25, 30, 35]);
-        assert_eq!(safe_tip.get(), Height::new(25));
-
-        // Remove validator with tip 10 (in lo heap), replace with new validator
-        let new_validators = &[key(1), key(8), key(3), key(4), key(5), key(6), key(7)];
-        safe_tip.reconcile(&new_validators.try_into().unwrap());
-
-        assert_eq!(safe_tip.get(), Height::new(25)); // Should remain the same
-        assert_eq!(*safe_tip.tips.get(&key(8)).unwrap(), Height::zero()); // New validator starts at 0
-    }
-
-    #[test]
-    fn test_reconcile_overall_behavior_hi_heap() {
-        // Test overall reconcile behavior when removing validator from hi heap
-        let (mut safe_tip, _) = setup_with_tips(7, &[5, 10, 15, 20, 25, 30, 35]);
-        assert_eq!(safe_tip.get(), Height::new(25));
-
-        // Remove validator with tip 30 (in hi heap), replace with new validator
-        let new_validators = &[key(1), key(2), key(3), key(4), key(5), key(8), key(7)];
-        safe_tip.reconcile(&new_validators.try_into().unwrap());
-
-        // When a validator with tip 30 is removed and replaced with one at tip 0,
-        // the max of lo heap should drop from 25 to 20
-        assert_eq!(safe_tip.get(), Height::new(20));
-        assert_eq!(*safe_tip.tips.get(&key(8)).unwrap(), Height::zero());
-    }
-
-    #[test]
-    fn test_reconcile_overall_behavior_with_rebalancing() {
-        // Test overall reconcile behavior when heap rebalancing occurs
-        let (mut safe_tip, validators) = setup_with_tips(4, &[10, 20, 30, 0]);
-        assert_eq!(safe_tip.get(), Height::new(20));
-
-        // Remove validator with tip 30 (validators[2] in hi heap), causing rebalancing
-        let new_validators = &[
-            validators[0].clone(),
-            validators[1].clone(),
-            key(8),
-            validators[3].clone(),
-        ];
-        safe_tip.reconcile(&new_validators.try_into().unwrap());
-
-        assert_eq!(*safe_tip.tips.get(&key(8)).unwrap(), Height::zero());
-        // After removing validator with tip 30 and adding one with tip 0,
-        // the safe tip should now be 10 (with tips [10, 20, 0, 0], lo heap has [0, 0, 10])
-        assert_eq!(safe_tip.get(), Height::new(10));
-    }
-
-    #[test]
-    fn test_reconcile_internal_case_1_noop() {
-        // Test Case 1: No-op when validator already has tip 0
-        let (mut safe_tip, validators) = setup_with_tips(4, &[0, 10, 20, 30]);
-
-        let initial_hi = safe_tip.hi.clone();
-        let initial_lo = safe_tip.lo.clone();
-
-        // Remove validator that already has tip 0 (validators[0])
-        let new_validators = &[
-            key(8),
-            validators[1].clone(),
-            validators[2].clone(),
-            validators[3].clone(),
-        ];
-        safe_tip.reconcile(&new_validators.try_into().unwrap());
-
-        // Heaps should be unchanged since removing 0 -> 0 is a no-op
-        assert_eq!(safe_tip.hi, initial_hi);
-        assert_eq!(safe_tip.lo, initial_lo);
-        assert_eq!(safe_tip.get(), Height::new(20));
-    }
-
-    #[test]
-    fn test_reconcile_internal_case_2_remains_in_lo() {
-        // Test Case 2: Value remains in lo heap
-        let (mut safe_tip, validators) = setup_with_tips(4, &[5, 15, 25, 30]);
-        assert_eq!(safe_tip.get(), Height::new(25));
-
-        // Verify initial heap state: with n=4, f=1, we have 1 in hi, 3 in lo
-        // Tips [5, 15, 25, 30] -> hi has [30], lo has [5, 15, 25]
-        assert!(safe_tip.lo.contains_key(&Height::new(5)));
-        assert!(safe_tip.lo.contains_key(&Height::new(15)));
-        assert!(safe_tip.lo.contains_key(&Height::new(25)));
-        assert!(safe_tip.hi.contains_key(&Height::new(30)));
-
-        // Remove validator with tip 5 (validators[0] in lo heap)
-        let new_validators = &[
-            key(8),
-            validators[1].clone(),
-            validators[2].clone(),
-            validators[3].clone(),
-        ];
-        safe_tip.reconcile(&new_validators.try_into().unwrap());
-
-        // The removed tip 5 should be replaced with 0, both in lo heap
-        assert!(safe_tip.lo.contains_key(&Height::zero()));
-        assert!(!safe_tip.lo.contains_key(&Height::new(5)));
-        assert_eq!(safe_tip.get(), Height::new(25)); // Safe tip unchanged
-    }
-
-    #[test]
-    fn test_reconcile_internal_case_3_remains_in_hi() {
-        // Test Case 3: Value remains in hi heap when new value >= max(lo)
-        let (safe_tip, _) = setup_with_tips(4, &[5, 15, 25, 35]);
-        assert_eq!(safe_tip.get(), Height::new(25));
-
-        // Verify tip 35 is in hi heap
-        assert!(safe_tip.hi.contains_key(&Height::new(35)));
-
-        // Create a scenario where removed value can stay in hi:
-        // Remove validator with tip 35, all lo values (5,15,25) <= 0 is false
-        // But we can test by removing and replacing with a value that satisfies the condition
-
-        // Actually, let's test the condition directly by creating the right setup
-        let (mut safe_tip, _) = setup_with_tips(7, &[0, 0, 0, 0, 0, 10, 20]);
-        assert_eq!(safe_tip.get(), Height::zero());
-
-        // With n=7, f=2: hi has [10, 20], lo has [0, 0, 0, 0, 0]
-        // Remove validator with tip 10 (in hi), max_lo is 0, so 0 <= 0 is true
-        let new_validators = &[key(1), key(2), key(3), key(4), key(5), key(8), key(7)];
-        safe_tip.reconcile(&new_validators.try_into().unwrap());
-
-        // Value should remain in hi heap as 0, since max_lo (0) <= new (0)
-        assert!(safe_tip.hi.contains_key(&Height::zero()) || safe_tip.hi.is_empty());
-        assert_eq!(safe_tip.get(), Height::zero());
-    }
-
-    #[test]
-    fn test_reconcile_internal_case_4_move_hi_to_lo() {
-        // Test Case 4: Value must move from hi to lo heap with rebalancing
-        let (mut safe_tip, validators) = setup_with_tips(4, &[10, 20, 30, 40]);
-        assert_eq!(safe_tip.get(), Height::new(30));
-
-        // With n=4, f=1: hi has [40], lo has [10, 20, 30]
-        // Remove validator with tip 40 (validators[3] in hi), max_lo is 30, so 30 > 0, condition fails
-        let new_validators = &[
-            validators[0].clone(),
-            validators[1].clone(),
-            validators[2].clone(),
-            key(8),
-        ];
-        safe_tip.reconcile(&new_validators.try_into().unwrap());
-
-        // This should trigger Case 4: move from hi to lo with rebalancing
-        // The 0 goes to lo, and max_lo (30) moves to hi
-        assert!(safe_tip.hi.contains_key(&Height::new(30)));
-        assert!(safe_tip.lo.contains_key(&Height::zero()));
-        assert_eq!(safe_tip.get(), Height::new(20)); // New max of lo heap
-    }
-
-    #[test]
-    fn test_update_internal_case_2_remains_in_lo() {
-        // Test Case 2 in update: Value remains in lo heap
-        let (mut safe_tip, validators) = setup_with_tips(4, &[5, 15, 25, 35]);
-        assert_eq!(safe_tip.get(), Height::new(25));
-
-        // With n=4, f=1: hi has [35], lo has [5, 15, 25]
-        // Update validators[0]'s tip from 5 to 10 - both should stay in lo since min_hi (35) >= 10
-        assert!(safe_tip.lo.contains_key(&Height::new(5)));
-        safe_tip.update(validators[0].clone(), Height::new(10));
-
-        assert!(safe_tip.lo.contains_key(&Height::new(10)));
-        assert!(!safe_tip.lo.contains_key(&Height::new(5)));
-        assert_eq!(safe_tip.get(), Height::new(25)); // Safe tip unchanged
-    }
-
-    #[test]
-    fn test_update_internal_case_3_move_lo_to_hi() {
-        // Test Case 3 in update: Value must move from lo to hi heap with rebalancing
-        let (mut safe_tip, validators) = setup_with_tips(4, &[5, 15, 25, 35]);
-        assert_eq!(safe_tip.get(), Height::new(25));
-
-        // With n=4, f=1: hi has [35], lo has [5, 15, 25]
-        // Update tip 5 to 40 - should move to hi and cause rebalancing
-        safe_tip.update(validators[0].clone(), Height::new(40));
-
-        // The 40 goes to hi, min_hi (35) moves to lo
-        assert!(safe_tip.hi.contains_key(&Height::new(40)));
-        assert!(safe_tip.lo.contains_key(&Height::new(35)));
-        assert_eq!(safe_tip.get(), Height::new(35)); // New max of lo heap
-    }
-
-    #[test]
-    fn test_update_edge_cases() {
-        let (mut safe_tip, validators) = setup_with_tips(7, &[0, 0, 0, 0, 0, 10, 20]);
-
-        // Test updating when hi heap might be empty after rebalancing
-        // With n=7, f=2: initially hi has [10, 20], lo has [0, 0, 0, 0, 0]
-
-        // Update one of the 0s to a very high value
-        safe_tip.update(validators[0].clone(), Height::new(100));
-
-        // This should cause rebalancing
-        assert!(safe_tip.hi.contains_key(&Height::new(100)));
-        assert_eq!(safe_tip.get(), Height::new(10)); // Should now be higher than 0
+    #[should_panic(expected = "committee participant count mismatch")]
+    fn reconcile_requires_same_participant_count() {
+        let (mut safe_tip, _) = setup(&[(1, 1), (2, 1), (3, 1), (4, 1)]);
+        safe_tip.reconcile(&committee(&[(1, 1), (2, 1), (3, 1)]));
     }
 }


### PR DESCRIPTION
Stacked on #4635.

Part of #443.

## Summary

- form aggregation certificates when acknowledgements reach quorum weight
- track the safe tip as the greatest height reported by more than the maximum faulty weight
- advance the safe tip over a height-to-weight map with amortized logarithmic updates within an epoch
- rebuild safe-tip state when epoch membership or weights change while preserving retained participant tips

Tests cover count/weight disagreement, exact boundaries, reconciliation, and engine-level weighted finalization.
