### PR TITLE
[consensus/marshal] Reject unsupported coding committees

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -9,6 +9,11 @@ BLS multisig certificates form and verify quorum by weight. BLS threshold
 schemes remain count-based and reject non-uniform committees. Certificate
 encoding is unchanged ([#4635]).
 
+### Coding Marshal Committee Guards
+
+The coding marshal declines proposals and rejects payloads when a committee is
+non-uniform or has a participant count outside `4..=u16::MAX` ([#4651]).
+
 ### Crash Recovery
 
 Runtime storage now recovers a blob whose initial header write was interrupted.
@@ -33,6 +38,7 @@ after restart ([#4420]).
 [#4275]: https://github.com/commonwarexyz/monorepo/pull/4275
 [#4420]: https://github.com/commonwarexyz/monorepo/pull/4420
 [#4635]: https://github.com/commonwarexyz/monorepo/pull/4635
+[#4651]: https://github.com/commonwarexyz/monorepo/pull/4651
 
 ## v2026.7.0
 

--- a/consensus/src/marshal/coding/marshaled.rs
+++ b/consensus/src/marshal/coding/marshaled.rs
@@ -915,6 +915,7 @@ where
         };
 
         let committee = scheme.participants();
+        // No payload is valid for a known unsupported committee. Vote false rather than abstaining.
         let Some(coding_config) = coding_config_for_committee(committee) else {
             warn!(
                 round = %consensus_context.round,

--- a/consensus/src/marshal/coding/marshaled.rs
+++ b/consensus/src/marshal/coding/marshaled.rs
@@ -90,7 +90,7 @@ use crate::{
         },
         coding::{
             Coding, shards,
-            types::{CodedBlock, coding_config_for_participants, hash_context},
+            types::{CodedBlock, coding_config_for_committee, hash_context},
             validation::{ProposalError, validate_block, validate_proposal},
         },
         core,
@@ -698,9 +698,17 @@ where
             return rx;
         };
 
-        let n_participants =
-            u16::try_from(scheme.participants().len()).expect("too many participants");
-        let coding_config = coding_config_for_participants(n_participants);
+        let committee = scheme.participants();
+        let Some(coding_config) = coding_config_for_committee(committee) else {
+            warn!(
+                round = %consensus_context.round,
+                participants = committee.len(),
+                uniform = committee.is_uniform(),
+                "coding does not support the epoch committee"
+            );
+            let (_, rx) = oneshot::channel();
+            return rx;
+        };
 
         // Metrics
         let build_duration = self.build_duration.clone();
@@ -906,9 +914,18 @@ where
             return rx;
         };
 
-        let n_participants =
-            u16::try_from(scheme.participants().len()).expect("too many participants");
-        let coding_config = coding_config_for_participants(n_participants);
+        let committee = scheme.participants();
+        let Some(coding_config) = coding_config_for_committee(committee) else {
+            warn!(
+                round = %consensus_context.round,
+                participants = committee.len(),
+                uniform = committee.is_uniform(),
+                "coding does not support the epoch committee"
+            );
+            let (tx, rx) = oneshot::channel();
+            tx.send_lossy(false);
+            return rx;
+        };
         let is_reproposal = payload == consensus_context.parent.1;
 
         // Validate proposal-level invariants:

--- a/consensus/src/marshal/coding/mod.rs
+++ b/consensus/src/marshal/coding/mod.rs
@@ -86,7 +86,11 @@ mod tests {
             resolver::handler,
         },
         simplex::{
-            Plan, scheme::bls12381_threshold::vrf as bls12381_threshold_vrf, types::Proposal,
+            Plan,
+            scheme::{
+                bls12381_threshold::vrf as bls12381_threshold_vrf, ed25519 as simplex_ed25519,
+            },
+            types::Proposal,
         },
         types::{Epoch, Epocher, FixedEpocher, Height, Round, View, ViewDelta, coding::Commitment},
     };
@@ -108,7 +112,8 @@ mod tests {
     };
     use commonware_storage::archive::immutable;
     use commonware_utils::{
-        NZU16, NZU64, NZUsize, channel::oneshot, sync::Mutex, vec::NonEmptyVec,
+        NZU16, NZU64, NZUsize, TryCollect, channel::oneshot, ordered::Committee, sync::Mutex,
+        vec::NonEmptyVec,
     };
     use std::{sync::Arc, time::Duration};
 
@@ -3449,6 +3454,83 @@ mod tests {
             mailbox.set_floor(finalization);
             context.sleep(Duration::from_secs(5)).await;
         })
+    }
+
+    #[test]
+    fn test_coding_check_payload_rejects_non_uniform_committee() {
+        let runner = deterministic::Runner::default();
+        runner.start(|mut context| async move {
+            let fixture = simplex_ed25519::fixture(&mut context, NAMESPACE, NUM_VALIDATORS);
+            let committee = fixture
+                .participants
+                .iter()
+                .cloned()
+                .zip([1, 1, 1, 2])
+                .try_collect::<Committee<_>>()
+                .unwrap();
+            let scheme = simplex_ed25519::Scheme::verifier(NAMESPACE, committee);
+
+            assert!(!<TestCodingVariant as core::Variant>::check_payload(
+                &scheme,
+                genesis_commitment()
+            ));
+        });
+    }
+
+    #[test_traced("WARN")]
+    fn test_marshaled_unsupported_committee_skips_propose_and_rejects_verify() {
+        let runner = deterministic::Runner::timed(Duration::from_secs(30));
+        runner.start(|mut context| async move {
+            let Fixture {
+                participants,
+                schemes,
+                ..
+            } = bls12381_threshold_vrf::fixture::<V, _>(&mut context, NAMESPACE, 3);
+            let mut oracle = setup_network_with_participants(
+                context.child("network"),
+                NZUsize!(1),
+                participants.clone(),
+            )
+            .await;
+            let me = participants[0].clone();
+            let provider = ConstantProvider::new(schemes[0].clone());
+            let setup = CodingHarness::setup_validator(
+                context.child("validator").with_attribute("index", 0),
+                &mut oracle,
+                me.clone(),
+                provider.clone(),
+            )
+            .await;
+            let cfg = MarshaledConfig {
+                application: MockVerifyingApp::<CodingB, S>::new(),
+                marshal: setup.mailbox,
+                shards: setup.extra,
+                scheme_provider: provider,
+                epocher: FixedEpocher::new(BLOCKS_PER_EPOCH),
+                strategy: Sequential,
+            };
+            let mut marshaled = Marshaled::new(context.child("marshaled"), cfg);
+            let consensus_context = CodingCtx {
+                round: Round::new(Epoch::zero(), View::new(1)),
+                leader: me,
+                parent: (View::zero(), genesis_commitment()),
+            };
+
+            assert!(
+                marshaled
+                    .propose(consensus_context.clone())
+                    .await
+                    .await
+                    .is_err()
+            );
+            assert_eq!(
+                marshaled
+                    .verify(consensus_context, genesis_commitment())
+                    .await
+                    .await,
+                Ok(false)
+            );
+        });
     }
 
     /// When the scheme provider has no entry for the current epoch,

--- a/consensus/src/marshal/coding/mod.rs
+++ b/consensus/src/marshal/coding/mod.rs
@@ -5,6 +5,8 @@
 //! The coding marshal couples the consensus pipeline with erasure-coded block broadcast.
 //! Blocks are produced by an application, encoded into [`types::Shard`]s, fanned out to peers, and
 //! later reconstructed when a notarization or finalization proves that the data is needed.
+//! The coding marshal supports uniform committees with `4..=u16::MAX` participants. For other
+//! committees, it declines to propose and rejects every payload.
 //! Compared to [`super::standard`], this variant makes more efficient usage of the network's bandwidth
 //! by spreading the load of block dissemination across all participants.
 //!

--- a/consensus/src/marshal/coding/types.rs
+++ b/consensus/src/marshal/coding/types.rs
@@ -8,7 +8,7 @@ use commonware_codec::{BufsMut, EncodeSize, Read, ReadExt, Write};
 use commonware_coding::{Config as CodingConfig, Scheme};
 use commonware_cryptography::{Committable, Digestible, Hasher};
 use commonware_parallel::{Sequential, Strategy};
-use commonware_utils::{Faults, N3f1, NZU16};
+use commonware_utils::{Faults, N3f1, NZU16, ordered::Committee};
 use std::{
     marker::PhantomData,
     sync::{Arc, OnceLock},
@@ -573,6 +573,18 @@ pub fn coding_config_for_participants(n_participants: u16) -> CodingConfig {
     }
 }
 
+/// Computes the [`CodingConfig`] for a committee supported by the coding marshal.
+///
+/// Returns `None` for non-uniform committees or participant counts outside
+/// `4..=u16::MAX`.
+pub fn coding_config_for_committee<P: Ord>(committee: &Committee<P>) -> Option<CodingConfig> {
+    if !committee.is_uniform() {
+        return None;
+    }
+    let n_participants = u16::try_from(committee.len()).ok()?;
+    (n_participants >= 4).then(|| coding_config_for_participants(n_participants))
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -582,6 +594,7 @@ mod test {
     use commonware_coding::{CodecConfig, ReedSolomon};
     use commonware_cryptography::{Digest, Sha256, sha256::Digest as Sha256Digest};
     use commonware_runtime::{BufferPooler, Runner, deterministic, iobuf::EncodeExt};
+    use commonware_utils::{TryCollect, ordered::Committee};
 
     const MAX_SHARD_SIZE: CodecConfig = CodecConfig {
         maximum_shard_size: 1024 * 1024, // 1 MiB
@@ -632,6 +645,48 @@ mod test {
     #[should_panic(expected = "Need at least 4 participants to maintain fault tolerance")]
     fn test_coding_config_for_participants_panics_for_small_sets() {
         let _ = coding_config_for_participants(3);
+    }
+
+    #[test]
+    fn test_coding_config_for_committee_rejects_unsupported_committees() {
+        let too_small = (0..3u32)
+            .map(|participant| (participant, 1))
+            .try_collect::<Committee<_>>()
+            .unwrap();
+        assert_eq!(coding_config_for_committee(&too_small), None);
+
+        let non_uniform = [(0u32, 1), (1, 1), (2, 1), (3, 2)]
+            .into_iter()
+            .try_collect::<Committee<_>>()
+            .unwrap();
+        assert_eq!(coding_config_for_committee(&non_uniform), None);
+
+        let too_large = (0..=u32::from(u16::MAX))
+            .map(|participant| (participant, 1))
+            .try_collect::<Committee<_>>()
+            .unwrap();
+        assert_eq!(coding_config_for_committee(&too_large), None);
+    }
+
+    #[test]
+    fn test_coding_config_for_committee_accepts_uniform_boundaries() {
+        let minimum = (0..4u32)
+            .map(|participant| (participant, 7))
+            .try_collect::<Committee<_>>()
+            .unwrap();
+        assert_eq!(
+            coding_config_for_committee(&minimum),
+            Some(coding_config_for_participants(4))
+        );
+
+        let maximum = (0..u32::from(u16::MAX))
+            .map(|participant| (participant, 1))
+            .try_collect::<Committee<_>>()
+            .unwrap();
+        assert_eq!(
+            coding_config_for_committee(&maximum),
+            Some(coding_config_for_participants(u16::MAX))
+        );
     }
 
     #[test]

--- a/consensus/src/marshal/coding/variant.rs
+++ b/consensus/src/marshal/coding/variant.rs
@@ -4,7 +4,7 @@ use crate::{
         ancestry::BlockProvider,
         coding::{
             shards,
-            types::{CodedBlock, CodedBlockCfg, StoredCodedBlock, coding_config_for_participants},
+            types::{CodedBlock, CodedBlockCfg, StoredCodedBlock, coding_config_for_committee},
         },
         core::{Buffer, CommitmentFallback, Mailbox, Retirement, Variant},
     },
@@ -86,9 +86,8 @@ where
     where
         S: SimplexScheme<Self::Commitment>,
     {
-        let n_participants = u16::try_from(scheme.participants().len())
-            .expect("scheme must have at most 2^16-1 participants");
-        payload.config() == coding_config_for_participants(n_participants)
+        coding_config_for_committee(scheme.participants())
+            .is_some_and(|config| payload.config() == config)
     }
 
     fn block_cfg(


### PR DESCRIPTION
Stacked on #4635.

Part of #443.

## Summary

- derive marshal coding configuration through one committee-aware helper
- accept uniform committees with `4..=u16::MAX` participants
- decline proposals and reject verification and payload checks for unsupported committees without panicking
- keep count-based coding derivation unchanged; #4598 adds weighted derivation and rollout semantics
