### PR TITLE
[consensus/marshal] Support weighted coding committees

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -669,6 +669,14 @@ participant-index based. Simplex also logs and exports committee quorum diagnost
 when it installs an epoch. The stateful recovery probe selects its floor after reply
 weight exceeds the solicited committee's fault budget ([#4639]).
 
+### Weighted Coding Committees
+
+The coding marshal derives its minimum shard count from committee weights and
+rejects participant counts outside `4..=u16::MAX` or configurations that the
+coding scheme cannot support. This changes coding commitments for unit-weight
+committees whose size is not `3f + 1` and requires a coordinated, drained
+upgrade ([#4652]).
+
 ### Crash Recovery
 
 Runtime storage now recovers a blob whose initial header write was interrupted.
@@ -694,6 +702,7 @@ after restart ([#4420]).
 [#4420]: https://github.com/commonwarexyz/monorepo/pull/4420
 [#4635]: https://github.com/commonwarexyz/monorepo/pull/4635
 [#4639]: https://github.com/commonwarexyz/monorepo/pull/4639
+[#4652]: https://github.com/commonwarexyz/monorepo/pull/4652
 
 ## v2026.7.0
 

--- a/coding/src/lib.rs
+++ b/coding/src/lib.rs
@@ -169,6 +169,9 @@ commonware_macros::stability_scope!(ALPHA {
         /// The type of errors that can occur during encoding, checking, and decoding.
         type Error: std::fmt::Debug + Send;
 
+        /// Returns an error if this scheme does not support `config`.
+        fn validate_config(config: &Config) -> Result<(), Self::Error>;
+
         /// Encode a piece of data, returning a commitment, along with shards, and proofs.
         ///
         /// Each shard and proof is intended for exactly one participant. The number of shards returned
@@ -305,6 +308,9 @@ commonware_macros::stability_scope!(ALPHA {
         /// The type of errors that can occur during encoding, weakening, checking, and decoding.
         type Error: std::fmt::Debug + Send;
 
+        /// Returns an error if this scheme does not support `config`.
+        fn validate_config(config: &Config) -> Result<(), Self::Error>;
+
         /// Encode a piece of data, returning a commitment, along with shards, and proofs.
         ///
         /// Each shard and proof is intended for exactly one participant. The number of shards returned
@@ -419,6 +425,10 @@ commonware_macros::stability_scope!(ALPHA {
         type Shard = P::StrongShard;
         type CheckedShard = PhasedCheckedShard<P>;
         type Error = PhasedAsSchemeError<P::Error>;
+
+        fn validate_config(config: &Config) -> Result<(), Self::Error> {
+            P::validate_config(config).map_err(PhasedAsSchemeError::Scheme)
+        }
 
         fn encode(
             config: &Config,

--- a/coding/src/reed_solomon.rs
+++ b/coding/src/reed_solomon.rs
@@ -51,6 +51,19 @@ fn total_shards(config: &Config) -> Result<u16, Error> {
         .map_err(|_| Error::TooManyTotalShards(total))
 }
 
+fn validate_config(config: &Config) -> Result<u16, Error> {
+    let total = total_shards(config)?;
+    let original_count = usize::from(config.minimum_shards.get());
+    let recovery_count = usize::from(config.extra_shards.get());
+    if !Encoder::supports(original_count, recovery_count) {
+        return Err(Error::ReedSolomon(RsError::UnsupportedShardCount {
+            original_count,
+            recovery_count,
+        }));
+    }
+    Ok(total)
+}
+
 /// A piece of data from a Reed-Solomon encoded object.
 #[derive(Debug, Clone)]
 pub struct Chunk<D: Digest> {
@@ -1149,13 +1162,17 @@ impl<H: Hasher> Scheme for ReedSolomon<H> {
     type CheckedShard = CheckedChunk<H::Digest>;
     type Error = Error;
 
+    fn validate_config(config: &Config) -> Result<(), Self::Error> {
+        validate_config(config).map(|_| ())
+    }
+
     fn encode(
         config: &Config,
         data: impl Buf,
         strategy: &impl Strategy,
     ) -> Result<(Self::Commitment, Vec<Self::Shard>), Self::Error> {
         encode::<H, _>(
-            total_shards(config)?,
+            validate_config(config)?,
             config.minimum_shards.get(),
             data,
             strategy,
@@ -1190,7 +1207,7 @@ impl<H: Hasher> Scheme for ReedSolomon<H> {
         strategy: &impl Strategy,
     ) -> Result<Vec<u8>, Self::Error> {
         decode::<H, _>(
-            total_shards(config)?,
+            validate_config(config)?,
             config.minimum_shards.get(),
             commitment,
             shards,
@@ -2239,6 +2256,27 @@ mod tests {
             )
             .is_err()
         )
+    }
+
+    #[test]
+    fn test_validate_config_shard_count_boundary() {
+        let supported = Config {
+            minimum_shards: NZU16!(32_768),
+            extra_shards: NZU16!(32_767),
+        };
+        assert!(RS::validate_config(&supported).is_ok());
+
+        let config = Config {
+            minimum_shards: NZU16!(32_766),
+            extra_shards: NZU16!(32_769),
+        };
+        assert!(matches!(
+            RS::validate_config(&config),
+            Err(Error::ReedSolomon(RsError::UnsupportedShardCount {
+                original_count: 32_766,
+                recovery_count: 32_769,
+            }))
+        ));
     }
 
     #[test]

--- a/coding/src/zoda/mod.rs
+++ b/coding/src/zoda/mod.rs
@@ -524,6 +524,10 @@ impl<H: Hasher> PhasedScheme for Zoda<H> {
     type CheckedShard = CheckedShard;
     type Error = Error;
 
+    fn validate_config(_config: &Config) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
     fn encode(
         namespace: &[u8],
         config: &Config,

--- a/consensus/src/marshal/coding/marshaled.rs
+++ b/consensus/src/marshal/coding/marshaled.rs
@@ -90,7 +90,7 @@ use crate::{
         },
         coding::{
             Coding, shards,
-            types::{CodedBlock, coding_config_for_participants, hash_context},
+            types::{CodedBlock, coding_config_for_committee, hash_context},
             validation::{ProposalError, validate_block, validate_proposal},
         },
         core,
@@ -698,9 +698,19 @@ where
             return rx;
         };
 
-        let n_participants =
-            u16::try_from(scheme.participants().len()).expect("too many participants");
-        let coding_config = coding_config_for_participants(n_participants);
+        let committee = scheme.participants();
+        // No proposal can be encoded for an unsupported committee. Drop the sender so the voter
+        // treats the round as a missing proposal.
+        let Some(coding_config) = coding_config_for_committee::<C, _>(committee) else {
+            warn!(
+                round = %consensus_context.round,
+                participants = committee.len(),
+                total_weight = committee.total_weight(),
+                "coding does not support the epoch committee"
+            );
+            let (_, rx) = oneshot::channel();
+            return rx;
+        };
 
         // Metrics
         let build_duration = self.build_duration.clone();
@@ -862,7 +872,18 @@ where
                 build_timer.observe(&runtime_context);
 
                 let erasure_timer = erasure_encode_duration.timer(&runtime_context);
-                let coded_block = CodedBlock::<B, C, H>::new(built_block, coding_config, &strategy);
+                let coded_block =
+                    match CodedBlock::<B, C, H>::try_new(built_block, coding_config, &strategy) {
+                        Ok(block) => block,
+                        Err(error) => {
+                            warn!(
+                                round = %consensus_context.round,
+                                ?error,
+                                "failed to encode proposed block"
+                            );
+                            return;
+                        }
+                    };
                 erasure_timer.observe(&runtime_context);
 
                 let commitment = coded_block.commitment();
@@ -911,9 +932,19 @@ where
             return rx;
         };
 
-        let n_participants =
-            u16::try_from(scheme.participants().len()).expect("too many participants");
-        let coding_config = coding_config_for_participants(n_participants);
+        let committee = scheme.participants();
+        // No payload is valid for a known unsupported committee. Vote false rather than abstaining.
+        let Some(coding_config) = coding_config_for_committee::<C, _>(committee) else {
+            warn!(
+                round = %consensus_context.round,
+                participants = committee.len(),
+                total_weight = committee.total_weight(),
+                "coding does not support the epoch committee"
+            );
+            let (tx, rx) = oneshot::channel();
+            tx.send_lossy(false);
+            return rx;
+        };
         let is_reproposal = payload == consensus_context.parent.1;
 
         // Validate proposal-level invariants:

--- a/consensus/src/marshal/coding/mod.rs
+++ b/consensus/src/marshal/coding/mod.rs
@@ -8,6 +8,20 @@
 //! Compared to [`super::standard`], this variant makes more efficient usage of the network's bandwidth
 //! by spreading the load of block dissemination across all participants.
 //!
+//! # Committees
+//!
+//! The coding marshal supports committees with `4..=u16::MAX` participants when the coding scheme
+//! accepts the derived shard configuration. The marshal derives the minimum shard count by summing
+//! participant weights from greatest to least until the sum reaches the quorum weight minus the
+//! maximum faulty weight. For unsupported committees, the marshal declines to propose and rejects
+//! every payload.
+//!
+//! The threshold depends on absolute weight because fault bounds use integer rounding. For example,
+//! five equal weights of one require three shards, while five equal weights of two require two.
+//!
+//! The derived configuration is embedded in coding commitments, so changing the derivation requires
+//! a coordinated, drained upgrade. Rolling and mid-epoch activation are unsupported.
+//!
 //! # Components
 //!
 //! - [`crate::marshal::core::Actor`]: The unified marshal actor that orders finalized blocks,
@@ -69,7 +83,10 @@ mod tests {
             ancestry::{Ancestry, BlockProvider},
             coding::{
                 Coding, Marshaled, MarshaledConfig, shards,
-                types::{CodedBlock, coding_config_for_participants, hash_context},
+                types::{
+                    CodedBlock, coding_config_for_committee, coding_config_for_participants,
+                    hash_context,
+                },
             },
             config::{Config, Start},
             core,
@@ -87,7 +104,9 @@ mod tests {
         },
         simplex::{
             Plan,
-            scheme::bls12381_threshold::vrf as bls12381_threshold_vrf,
+            scheme::{
+                bls12381_threshold::vrf as bls12381_threshold_vrf, ed25519 as simplex_ed25519,
+            },
             types::{Activity, Proposal},
         },
         types::{Epoch, Epocher, FixedEpocher, Height, Round, View, ViewDelta, coding::Commitment},
@@ -98,7 +117,7 @@ mod tests {
     use commonware_coding::{CodecConfig, Config as CodingConfig, ReedSolomon, Scheme as _};
     use commonware_cryptography::{
         Committable, Digestible, Hasher,
-        certificate::{ConstantProvider, Verifier as _, mocks::Fixture},
+        certificate::{ConstantProvider, Scheme as _, Verifier as _, mocks::Fixture},
         sha256::Sha256,
     };
     use commonware_macros::{select, test_group, test_traced};
@@ -111,7 +130,8 @@ mod tests {
     };
     use commonware_storage::archive::immutable;
     use commonware_utils::{
-        NZU16, NZU64, NZUsize, channel::oneshot, sync::Mutex, vec::NonEmptyVec,
+        NZU16, NZU64, NZUsize, TryCollect, channel::oneshot, ordered::Committee, sync::Mutex,
+        vec::NonEmptyVec,
     };
     use futures::StreamExt;
     use std::{sync::Arc, time::Duration};
@@ -4415,6 +4435,100 @@ mod tests {
             mailbox.set_floor(finalization);
             context.sleep(Duration::from_secs(5)).await;
         })
+    }
+
+    #[test]
+    fn test_coding_check_payload_uses_weighted_config() {
+        let runner = deterministic::Runner::default();
+        runner.start(|mut context| async move {
+            let fixture = simplex_ed25519::fixture(&mut context, NAMESPACE, NUM_VALIDATORS);
+            let committee = fixture
+                .participants
+                .iter()
+                .cloned()
+                .zip([4, 1, 1, 1])
+                .try_collect::<Committee<_>>()
+                .unwrap();
+            let scheme = simplex_ed25519::Scheme::verifier(NAMESPACE, committee);
+            let config =
+                coding_config_for_committee::<ReedSolomon<Sha256>, _>(scheme.participants())
+                    .unwrap();
+            let genesis = genesis_commitment();
+            let weighted =
+                Commitment::from((genesis.block(), genesis.root(), genesis.context(), config));
+
+            assert!(<TestCodingVariant as core::Variant>::check_payload(
+                &scheme, weighted
+            ));
+
+            // Four unit-weight validators commit to the count-based config, which this
+            // committee no longer accepts.
+            let unit = Commitment::from((
+                genesis.block(),
+                genesis.root(),
+                genesis.context(),
+                coding_config_for_participants(NUM_VALIDATORS as u16),
+            ));
+            assert!(!<TestCodingVariant as core::Variant>::check_payload(
+                &scheme, unit
+            ));
+        });
+    }
+
+    #[test_traced("WARN")]
+    fn test_marshaled_unsupported_committee_skips_propose_and_rejects_verify() {
+        let runner = deterministic::Runner::timed(Duration::from_secs(30));
+        runner.start(|mut context| async move {
+            let Fixture {
+                participants,
+                schemes,
+                ..
+            } = bls12381_threshold_vrf::fixture::<V, _>(&mut context, NAMESPACE, 3);
+            let mut oracle = setup_network_with_participants(
+                context.child("network"),
+                NZUsize!(1),
+                participants.clone(),
+            )
+            .await;
+            let me = participants[0].clone();
+            let provider = ConstantProvider::new(schemes[0].clone());
+            let setup = CodingHarness::setup_validator(
+                context.child("validator").with_attribute("index", 0),
+                &mut oracle,
+                me.clone(),
+                provider.clone(),
+            )
+            .await;
+            let cfg = MarshaledConfig {
+                application: MockVerifyingApp::<CodingB, S>::new(),
+                marshal: setup.mailbox,
+                shards: setup.extra,
+                scheme_provider: provider,
+                epocher: FixedEpocher::new(BLOCKS_PER_EPOCH),
+                strategy: Sequential,
+            };
+            let mut marshaled = Marshaled::new(context.child("marshaled"), cfg);
+            let consensus_context = CodingCtx {
+                round: Round::new(Epoch::zero(), View::new(1)),
+                leader: me,
+                parent: (View::zero(), genesis_commitment()),
+            };
+
+            assert!(
+                marshaled
+                    .propose(consensus_context.clone())
+                    .await
+                    .await
+                    .is_err()
+            );
+            assert_eq!(
+                marshaled
+                    .verify(consensus_context, genesis_commitment())
+                    .await
+                    .await,
+                Ok(false)
+            );
+        });
     }
 
     /// When the scheme provider has no entry for the current epoch,

--- a/consensus/src/marshal/coding/shards/engine.rs
+++ b/consensus/src/marshal/coding/shards/engine.rs
@@ -1890,7 +1890,10 @@ where
 mod tests {
     use super::*;
     use crate::{
-        marshal::{coding::types::coding_config_for_participants, mocks::block::EmptyBlock},
+        marshal::{
+            coding::types::{coding_config_for_committee, coding_config_for_participants},
+            mocks::block::EmptyBlock,
+        },
         types::{Epoch, Height, View},
     };
     use bytes::Bytes;
@@ -2089,6 +2092,8 @@ mod tests {
         link: Link,
         /// Per-peer capacity for shards received before leader discovery.
         peer_buffer_size: NonZeroUsize,
+        /// Participant weights in participant-key order.
+        weights: Option<Vec<u64>>,
         /// Marker for the coding scheme type parameter.
         _marker: PhantomData<S>,
     }
@@ -2102,6 +2107,7 @@ mod tests {
                 additional_scheme_epochs: Vec::new(),
                 link: DEFAULT_LINK,
                 peer_buffer_size: NZUsize!(64),
+                weights: None,
                 _marker: PhantomData,
             }
         }
@@ -2127,14 +2133,14 @@ mod tests {
                 private_keys.sort_by_key(|s| s.public_key());
                 let peer_keys: Vec<P> = private_keys.iter().map(|c| c.public_key()).collect();
 
-                let participants = Committee::try_from(
-                    peer_keys
-                        .iter()
-                        .cloned()
-                        .map(|participant| (participant, 1))
-                        .collect::<Vec<_>>(),
-                )
-                .expect("test participants form a committee");
+                let weights = self
+                    .weights
+                    .clone()
+                    .unwrap_or_else(|| vec![1; peer_keys.len()]);
+                assert_eq!(weights.len(), peer_keys.len());
+                let participants =
+                    Committee::try_from(peer_keys.iter().cloned().zip(weights).collect::<Vec<_>>())
+                        .expect("test participants form a committee");
 
                 let mut np_private_keys = (0..self.num_secondary_peers)
                     .map(|i| PrivateKey::from_seed((self.num_primary_peers + i) as u64))
@@ -2183,8 +2189,8 @@ mod tests {
                     }
                 }
 
-                let coding_config =
-                    coding_config_for_participants(u16::try_from(self.num_primary_peers).unwrap());
+                let coding_config = coding_config_for_committee::<S, _>(&participants)
+                    .expect("test committee must support coding");
 
                 let mut peers = Vec::with_capacity(self.num_primary_peers);
                 for (idx, peer_key) in peer_keys.iter().enumerate() {
@@ -3840,7 +3846,7 @@ mod tests {
         // Test that shards buffered in pending_shards are batch-validated once
         // the minimum shard threshold is met, enabling reconstruction.
         //
-        // With 10 peers: minimum_shards = (10-1)/3 + 1 = 4
+        // With 10 unit-weight peers: minimum_shards = 10 - 2 * 3 = 4
         // The leader (peer 0) sends peer 3 their own-index shard (verified
         // immediately). Peers 1, 2, 4 send their own shards (buffered in
         // pending_shards). Once the leader's shard + 3 pending shards >= 4,
@@ -4096,6 +4102,55 @@ mod tests {
                     oracle.blocked().await.unwrap().is_empty(),
                     "valid sender-indexed shards should not block peers"
                 );
+            },
+        );
+    }
+
+    #[test_traced]
+    fn test_weighted_committee_reconstructs_from_derived_minimum_shards() {
+        let fixture: Fixture<C> = Fixture {
+            weights: Some(vec![1, 7, 1, 1]),
+            ..Default::default()
+        };
+
+        fixture.start(
+            |config, context, _, mut peers, _, coding_config| async move {
+                assert_eq!(coding_config.minimum_shards.get(), 1);
+                assert_eq!(coding_config.extra_shards.get(), 3);
+
+                let inner = B::new(Sha256Digest::EMPTY, Height::new(1), 100);
+                let coded_block = CodedBlock::<B, C, H>::new(inner, coding_config, &STRATEGY);
+                let commitment = coded_block.commitment();
+                let round = Round::new(Epoch::zero(), View::new(1));
+                let dominant_idx = 1usize;
+                let receiver_idx = 3usize;
+                let receiver = peers[receiver_idx].public_key.clone();
+                let block_sub = peers[receiver_idx].mailbox.subscribe(commitment);
+
+                let shard = coded_block
+                    .shard(peers[dominant_idx].index.get() as u16)
+                    .expect("missing dominant participant shard")
+                    .encode();
+                peers[dominant_idx]
+                    .sender
+                    .send(Recipients::One(receiver), shard, true);
+                context.sleep(config.link.latency * 2).await;
+
+                assert!(peers[receiver_idx].mailbox.get(commitment).await.is_none());
+                peers[receiver_idx].mailbox.notarized(commitment, round);
+
+                select! {
+                    _ = block_sub => {},
+                    _ = context.sleep(Duration::from_secs(5)) => {
+                        panic!("dominant participant shard did not reconstruct notarized block");
+                    },
+                }
+
+                let reconstructed =
+                    peers[receiver_idx].mailbox.get(commitment).await.expect(
+                        "notarized block should reconstruct from dominant participant shard",
+                    );
+                assert_eq!(reconstructed.commitment(), commitment);
             },
         );
     }

--- a/consensus/src/marshal/coding/types.rs
+++ b/consensus/src/marshal/coding/types.rs
@@ -9,9 +9,12 @@ use commonware_codec::{BufsMut, EncodeSize, Read, ReadExt, Write};
 use commonware_coding::{Config as CodingConfig, Scheme};
 use commonware_cryptography::{Committable, Digestible, Hasher};
 use commonware_parallel::{Sequential, Strategy};
-use commonware_utils::{Faults, N3f1, NZU16};
+#[cfg(any(test, feature = "mocks"))]
+use commonware_utils::{Faults, NZU16};
+use commonware_utils::{N3f1, ordered::Committee};
 use std::{
     marker::PhantomData,
+    num::NonZeroU16,
     sync::{Arc, OnceLock},
 };
 
@@ -154,30 +157,42 @@ pub struct CodedBlock<B: Block, C: Scheme, H: Hasher> {
     _hasher: PhantomData<H>,
 }
 
+type Encoding<C> = (<C as Scheme>::Commitment, Vec<<C as Scheme>::Shard>);
+
 impl<B: Block, C: Scheme, H: Hasher> CodedBlock<B, C, H> {
     /// Erasure codes the block.
     fn encode(
         inner: &B,
         config: CodingConfig,
         strategy: &impl Strategy,
-    ) -> (C::Commitment, Vec<C::Shard>) {
+    ) -> Result<Encoding<C>, C::Error> {
         let mut buf = Vec::with_capacity(inner.encode_size() + config.encode_size());
         inner.write(&mut buf);
         config.write(&mut buf);
 
-        C::encode(&config, buf.as_slice(), strategy).expect("must encode block successfully")
+        C::encode(&config, buf.as_slice(), strategy)
     }
 
-    /// Create a new [`CodedBlock`] from a [`Block`] and a configuration.
-    pub fn new(inner: B, config: CodingConfig, strategy: &impl Strategy) -> Self {
-        let (commitment, shards) = Self::encode(&inner, config, strategy);
-        Self {
+    /// Creates a new [`CodedBlock`] from a [`Block`] and a configuration.
+    pub fn try_new(
+        inner: B,
+        config: CodingConfig,
+        strategy: &impl Strategy,
+    ) -> Result<Self, C::Error> {
+        let (commitment, shards) = Self::encode(&inner, config, strategy)?;
+        Ok(Self {
             inner: Arc::new(inner),
             config,
             commitment,
             shards: OnceLock::from(Arc::<[C::Shard]>::from(shards)),
             _hasher: PhantomData,
-        }
+        })
+    }
+
+    /// Creates a new [`CodedBlock`] for tests.
+    #[cfg(any(test, feature = "mocks"))]
+    pub fn new(inner: B, config: CodingConfig, strategy: &impl Strategy) -> Self {
+        Self::try_new(inner, config, strategy).expect("test block must encode")
     }
 
     /// Create a new [`CodedBlock`] from a [`Block`] and trusted [`Commitment`].
@@ -208,7 +223,8 @@ impl<B: Block, C: Scheme, H: Hasher> CodedBlock<B, C, H> {
     /// If the shards have not yet been generated, they will be created via [`Scheme::encode`].
     pub fn shards(&self, strategy: &impl Strategy) -> &[C::Shard] {
         self.shards.get_or_init(|| {
-            let (commitment, shards) = Self::encode(&self.inner, self.config, strategy);
+            let (commitment, shards) = Self::encode(&self.inner, self.config, strategy)
+                .expect("trusted coded block must remain encodable");
 
             // A mismatch means a commitment trusted at construction does not
             // encode this block, which is a contract violation or a consensus
@@ -572,9 +588,10 @@ impl<B: Block + PartialEq, C: Scheme, H: Hasher> PartialEq for StoredCodedBlock<
 
 impl<B: Block + Eq, C: Scheme, H: Hasher> Eq for StoredCodedBlock<B, C, H> {}
 
-/// Compute the [`CodingConfig`] for a given number of participants.
+/// Computes the [`CodingConfig`] for a unit-weight participant set.
 ///
 /// Panics if `n_participants < 4`.
+#[cfg(any(test, feature = "mocks"))]
 pub fn coding_config_for_participants(n_participants: u16) -> CodingConfig {
     let max_faults = N3f1::max_faults(u64::from(n_participants));
     assert!(
@@ -582,11 +599,40 @@ pub fn coding_config_for_participants(n_participants: u16) -> CodingConfig {
         "Need at least 4 participants to maintain fault tolerance"
     );
     let max_faults = u16::try_from(max_faults).expect("max_faults must fit in u16");
-    let minimum_shards = NZU16!(max_faults + 1);
+    let minimum_shards = NZU16!(n_participants - 2 * max_faults);
     CodingConfig {
         minimum_shards,
         extra_shards: NZU16!(n_participants - minimum_shards.get()),
     }
+}
+
+/// Computes the [`CodingConfig`] for a committee supported by `C`.
+///
+/// The minimum shard count uses absolute integer weights and is not invariant under uniform
+/// rescaling. For five equal participants, weight one yields three minimum shards, while weight
+/// two yields two.
+///
+/// Returns `None` when the participant count is outside `4..=u16::MAX` or the
+/// derived configuration is unsupported by `C`.
+pub fn coding_config_for_committee<C: Scheme, P: Ord>(
+    committee: &Committee<P>,
+) -> Option<CodingConfig> {
+    let n_participants = u16::try_from(committee.len()).ok()?;
+    if n_participants < 4 {
+        return None;
+    }
+
+    let target = committee
+        .quorum_weight::<N3f1>()
+        .checked_sub(committee.max_fault_weight::<N3f1>())?;
+    let minimum_shards = u16::try_from(committee.minimum_cardinality(target)?).ok()?;
+
+    let config = CodingConfig {
+        minimum_shards: NonZeroU16::new(minimum_shards)?,
+        extra_shards: NonZeroU16::new(n_participants.checked_sub(minimum_shards)?)?,
+    };
+    C::validate_config(&config).ok()?;
+    Some(config)
 }
 
 #[cfg(test)]
@@ -598,6 +644,7 @@ mod test {
     use commonware_coding::{CodecConfig, ReedSolomon};
     use commonware_cryptography::{Digest, Sha256, sha256::Digest as Sha256Digest};
     use commonware_runtime::{BufferPooler, Runner, deterministic, iobuf::EncodeExt};
+    use commonware_utils::{TryCollect, ordered::Committee};
 
     const MAX_SHARD_SIZE: CodecConfig = CodecConfig {
         maximum_shard_size: 1024 * 1024, // 1 MiB
@@ -651,6 +698,118 @@ mod test {
     }
 
     #[test]
+    fn test_coding_config_for_committee_rejects_unsupported_sizes() {
+        let too_small = (0..3u32)
+            .map(|participant| (participant, 1))
+            .try_collect::<Committee<_>>()
+            .unwrap();
+        assert_eq!(coding_config_for_committee::<RS, _>(&too_small), None);
+
+        let too_large = (0..=u32::from(u16::MAX))
+            .map(|participant| (participant, 1))
+            .try_collect::<Committee<_>>()
+            .unwrap();
+        assert_eq!(coding_config_for_committee::<RS, _>(&too_large), None);
+    }
+
+    #[test]
+    fn test_coding_config_for_committee_preserves_unit_weight_equivalence() {
+        for n in 4u16..=16 {
+            let committee = (0..u32::from(n))
+                .map(|participant| (participant, 1))
+                .try_collect::<Committee<_>>()
+                .unwrap();
+            assert_eq!(
+                coding_config_for_committee::<RS, _>(&committee),
+                Some(coding_config_for_participants(n))
+            );
+        }
+    }
+
+    #[test]
+    fn test_coding_config_for_committee_uses_absolute_weight_scale() {
+        let unit = (0..5u32)
+            .map(|participant| (participant, 1))
+            .try_collect::<Committee<_>>()
+            .unwrap();
+        let doubled = (0..5u32)
+            .map(|participant| (participant, 2))
+            .try_collect::<Committee<_>>()
+            .unwrap();
+
+        assert_eq!(
+            coding_config_for_committee::<RS, _>(&unit)
+                .unwrap()
+                .minimum_shards,
+            NZU16!(3)
+        );
+        assert_eq!(
+            coding_config_for_committee::<RS, _>(&doubled)
+                .unwrap()
+                .minimum_shards,
+            NZU16!(2)
+        );
+    }
+
+    #[test]
+    fn test_coding_config_for_committee_matches_subset_oracle() {
+        for n in 4usize..=6 {
+            for encoded in 0..3usize.pow(u32::try_from(n).unwrap()) {
+                let mut remaining = encoded;
+                let weights = (0..n)
+                    .map(|participant| {
+                        let weight = u64::try_from(remaining % 3 + 1).unwrap();
+                        remaining /= 3;
+                        (u32::try_from(participant).unwrap(), weight)
+                    })
+                    .collect::<Vec<_>>();
+                let committee = weights
+                    .iter()
+                    .copied()
+                    .try_collect::<Committee<_>>()
+                    .unwrap();
+                let target =
+                    committee.quorum_weight::<N3f1>() - committee.max_fault_weight::<N3f1>();
+                let oracle = (1usize..1usize << n)
+                    .filter_map(|subset| {
+                        let weight = weights
+                            .iter()
+                            .enumerate()
+                            .filter(|(index, _)| subset & (1 << index) != 0)
+                            .map(|(_, (_, weight))| weight)
+                            .sum::<u64>();
+                        (weight >= target).then(|| subset.count_ones())
+                    })
+                    .min()
+                    .unwrap();
+
+                let config = coding_config_for_committee::<RS, _>(&committee).unwrap();
+                assert_eq!(u32::from(config.minimum_shards.get()), oracle);
+            }
+        }
+    }
+
+    #[test]
+    fn test_coding_config_for_committee_checks_reed_solomon_rate() {
+        let maximum_supported = (0..49_155u32)
+            .map(|participant| (participant, 1))
+            .try_collect::<Committee<_>>()
+            .unwrap();
+        let config = coding_config_for_committee::<RS, _>(&maximum_supported).unwrap();
+        assert_eq!(config.minimum_shards.get(), 16_387);
+        assert_eq!(config.extra_shards.get(), 32_768);
+
+        let first_unsupported = (0..49_156u32)
+            .map(|participant| (participant, 1))
+            .try_collect::<Committee<_>>()
+            .unwrap();
+        assert_eq!(
+            coding_config_for_committee::<RS, _>(&first_unsupported),
+            None
+        );
+    }
+
+    #[test]
     fn test_shard_codec_roundtrip() {
         const MOCK_BLOCK_DATA: &[u8] = b"deadc0de";
         const CONFIG: CodingConfig = CodingConfig {
@@ -677,7 +836,8 @@ mod test {
         };
 
         let block = TestBlock::new(Sha256::hash(&[b"parent"]), Height::new(42), 1_234_567);
-        let coded_block = CodedBlock::<TestBlock, RS, H>::new(block, CONFIG, &Sequential);
+        let coded_block =
+            CodedBlock::<TestBlock, RS, H>::try_new(block, CONFIG, &Sequential).unwrap();
 
         let encoded = coded_block.encode();
         let decoded = CodedBlock::<TestBlock, RS, H>::decode_cfg(
@@ -705,7 +865,8 @@ mod test {
 
         let block = TestBlock::new(Sha256::hash(&[b"parent"]), Height::new(42), 1_234_567);
         let expected =
-            CodedBlock::<TestBlock, RS, H>::new(block.clone(), EXPECTED_CONFIG, &Sequential)
+            CodedBlock::<TestBlock, RS, H>::try_new(block.clone(), EXPECTED_CONFIG, &Sequential)
+                .unwrap()
                 .commitment();
         let encoded = (block, EMBEDDED_CONFIG).encode();
 
@@ -734,7 +895,7 @@ mod test {
 
         // Build an expected commitment that differs only in its coding root.
         let block = TestBlock::new(Sha256::hash(&[b"parent"]), Height::new(42), 1_234_567);
-        let coded = CodedBlock::<TestBlock, RS, H>::new(block, CONFIG, &Sequential);
+        let coded = CodedBlock::<TestBlock, RS, H>::try_new(block, CONFIG, &Sequential).unwrap();
         let commitment = coded.commitment();
         let wrong_root = Sha256::hash(&[b"wrong root"]);
         assert_ne!(wrong_root, commitment.root());
@@ -888,7 +1049,8 @@ mod test {
         };
 
         let block = TestBlock::new(Sha256::hash(&[b"parent"]), Height::new(42), 1_234_567);
-        let coded_block = CodedBlock::<TestBlock, RS, H>::new(block, CONFIG, &Sequential);
+        let coded_block =
+            CodedBlock::<TestBlock, RS, H>::try_new(block, CONFIG, &Sequential).unwrap();
         let cloned = coded_block.clone();
 
         assert!(Arc::ptr_eq(&coded_block.inner, &cloned.inner));
@@ -906,7 +1068,8 @@ mod test {
         };
 
         let block = TestBlock::new(Sha256::hash(&[b"parent"]), Height::new(42), 1_234_567);
-        let coded_block = CodedBlock::<TestBlock, RS, H>::new(block, CONFIG, &Sequential);
+        let coded_block =
+            CodedBlock::<TestBlock, RS, H>::try_new(block, CONFIG, &Sequential).unwrap();
         let stored = StoredCodedBlock::<TestBlock, RS, H>::new(coded_block.clone());
 
         assert_eq!(stored.commitment(), coded_block.commitment());
@@ -930,7 +1093,8 @@ mod test {
         };
 
         let block = TestBlock::new(Sha256::hash(&[b"parent"]), Height::new(42), 1_234_567);
-        let coded_block = CodedBlock::<TestBlock, RS, H>::new(block, CONFIG, &Sequential);
+        let coded_block =
+            CodedBlock::<TestBlock, RS, H>::try_new(block, CONFIG, &Sequential).unwrap();
         let original_commitment = coded_block.commitment();
         let original_digest = coded_block.digest();
 
@@ -951,7 +1115,8 @@ mod test {
         };
 
         let block = TestBlock::new(Sha256::hash(&[b"parent"]), Height::new(42), 1_234_567);
-        let coded_block = CodedBlock::<TestBlock, RS, H>::new(block, CONFIG, &Sequential);
+        let coded_block =
+            CodedBlock::<TestBlock, RS, H>::try_new(block, CONFIG, &Sequential).unwrap();
         let stored = StoredCodedBlock::<TestBlock, RS, H>::new(coded_block);
 
         let mut encoded = stored.encode().to_vec();

--- a/consensus/src/marshal/coding/variant.rs
+++ b/consensus/src/marshal/coding/variant.rs
@@ -4,7 +4,7 @@ use crate::{
         ancestry::BlockProvider,
         coding::{
             shards,
-            types::{CodedBlock, CodedBlockCfg, StoredCodedBlock, coding_config_for_participants},
+            types::{CodedBlock, CodedBlockCfg, StoredCodedBlock, coding_config_for_committee},
         },
         core::{Buffer, CommitmentFallback, ExpectedCommitment, Mailbox, Retirement, Variant},
     },
@@ -86,9 +86,8 @@ where
     where
         S: SimplexScheme<Self::Commitment>,
     {
-        let n_participants = u16::try_from(scheme.participants().len())
-            .expect("scheme must have at most 2^16-1 participants");
-        payload.config() == coding_config_for_participants(n_participants)
+        coding_config_for_committee::<C, _>(scheme.participants())
+            .is_some_and(|config| payload.config() == config)
     }
 
     fn block_cfg(
@@ -311,7 +310,9 @@ mod tests {
         type TestVariant = Coding<NoCloneBlock, TestScheme, Sha256, PublicKey>;
 
         let block = no_clone_block(CONFIG);
-        let coded = CodedBlock::<NoCloneBlock, TestScheme, Sha256>::new(block, CONFIG, &Sequential);
+        let coded =
+            CodedBlock::<NoCloneBlock, TestScheme, Sha256>::try_new(block, CONFIG, &Sequential)
+                .unwrap();
         let expected = coded.commitment();
         let stored = StoredCodedBlock::new(coded);
 

--- a/utils/src/ordered.rs
+++ b/utils/src/ordered.rs
@@ -329,35 +329,35 @@ impl<P: Ord> Committee<P> {
         Ok(sum)
     }
 
-    /// Returns quorum diagnostics for the selected fault model.
-    pub fn profile<M: Faults>(&self) -> Profile {
-        let max_faults = self.max_fault_weight::<M>();
-        let quorum = self.quorum_weight::<M>();
+    /// Returns the fewest participants whose combined weight reaches `target`.
+    ///
+    /// Returns `None` if `target` exceeds the total committee weight.
+    pub fn minimum_cardinality(&self, target: u64) -> Option<u32> {
+        if target > self.total_weight {
+            return None;
+        }
         let mut weights = self.weights().to_vec();
         weights.sort_unstable_by(|left, right| right.cmp(left));
-        let max_weight = weights[0];
         let mut accumulated = 0u64;
-        let mut minimum_quorum_cardinality = 0u32;
-        for weight in weights {
-            accumulated = accumulated
-                .checked_add(weight)
-                .expect("committee weights cannot exceed total weight");
-            minimum_quorum_cardinality += 1;
-            if accumulated >= quorum {
-                break;
-            }
+        let mut cardinality = 0u32;
+        while accumulated < target {
+            accumulated += weights[cardinality as usize];
+            cardinality += 1;
         }
-        assert!(
-            accumulated >= quorum,
-            "the full committee must reach quorum"
-        );
+        Some(cardinality)
+    }
 
+    /// Returns quorum diagnostics for the selected fault model.
+    pub fn profile<M: Faults>(&self) -> Profile {
+        let quorum = self.quorum_weight::<M>();
         Profile {
             total_weight: self.total_weight,
-            max_fault_weight: max_faults,
+            max_fault_weight: self.max_fault_weight::<M>(),
             quorum_weight: quorum,
-            max_weight,
-            minimum_quorum_cardinality,
+            max_weight: *self.weights().iter().max().expect("committee is not empty"),
+            minimum_quorum_cardinality: self
+                .minimum_cardinality(quorum)
+                .expect("the full committee reaches quorum"),
         }
     }
 }
@@ -1138,6 +1138,16 @@ mod test {
         assert_eq!(profile.quorum_weight, 10);
         assert_eq!(profile.max_weight, 7);
         assert_eq!(profile.minimum_quorum_cardinality, 2);
+    }
+
+    #[test]
+    fn test_minimum_cardinality_takes_heaviest_first() {
+        let committee = Committee::try_from_iter([('c', 7), ('a', 2), ('b', 5)]).unwrap();
+        assert_eq!(committee.minimum_cardinality(0), Some(0));
+        assert_eq!(committee.minimum_cardinality(7), Some(1));
+        assert_eq!(committee.minimum_cardinality(8), Some(2));
+        assert_eq!(committee.minimum_cardinality(14), Some(3));
+        assert_eq!(committee.minimum_cardinality(15), None);
     }
 
     #[test]


### PR DESCRIPTION
Stacked on #4639.

Part of #443. Closes #4598.

## Summary

- derive the minimum shard count from committee weights, with one shard per participant
- validate derived configurations against the coding scheme
- decline proposals and reject payloads for unsupported committee configurations
- recover finalized blocks using the configuration embedded in each commitment

Tests cover unsupported committee sizes, Reed-Solomon rate limits, subset-oracle shard bounds, unit-weight configurations, and weight scaling.

The derivation changes commitments for some unit-weight committees too. Activation requires a coordinated, drained upgrade because the configuration is embedded in coding commitments. Rolling and mid-epoch activation remain unsupported.
