### PR TITLE
fix(runtime): guard iouring offset+len against u64 overflow

### DIFF
--- a/runtime/src/iouring/mod.rs
+++ b/runtime/src/iouring/mod.rs
@@ -404,6 +404,15 @@ impl Handle {
         cache: Cache,
     ) -> Result<IoBufMut, (IoBufMut, Error)> {
         assert!(len <= buf.capacity(), "read_at len exceeds buffer capacity");
+
+        // Reject up front if `offset + len` cannot be represented as a `u64`.
+        // Each retry after a partial read advances the SQE offset by
+        // `offset + read` (`read <= len`), so bounding `offset + len` here
+        // guarantees that arithmetic can never wrap.
+        if offset.checked_add(len as u64).is_none() {
+            return Err((buf, Error::OffsetOverflow));
+        }
+
         let (tx, rx) = oneshot::channel();
         let request = Request::ReadAt(ReadAtRequest {
             file,
@@ -444,6 +453,14 @@ impl Handle {
         options: WriteOptions,
         cache: Cache,
     ) -> Result<(), Error> {
+        // Reject up front if `offset + bufs.len()` cannot be represented as a
+        // `u64`. Each retry after a partial write advances the SQE offset by
+        // `offset + written` (`written <= bufs.len()`), so bounding
+        // `offset + bufs.len()` here guarantees that arithmetic can never wrap.
+        if offset.checked_add(bufs.len() as u64).is_none() {
+            return Err(Error::OffsetOverflow);
+        }
+
         let state = if !options.contains(WriteOptions::SYNC) {
             WriteAtState::Writing
         } else if bufs.chunk_count() <= IOVEC_BATCH_SIZE {
@@ -3166,6 +3183,55 @@ mod tests {
         assert!(iouring.waiters.is_empty());
         assert_eq!(ring.submission().len(), 0);
         assert_eq!(iouring.timeout_wheel.next_deadline(), None);
+    }
+
+    #[tokio::test]
+    async fn test_read_at_rejects_offset_plus_len_overflow() {
+        // `offset + len` overflowing `u64` would let a later partial-read
+        // retry's `offset + read` SQE computation wrap around, redirecting
+        // the read to an unintended file position. This must be rejected
+        // before the request is ever enqueued for submission.
+        let mut registry = Registry::default();
+        let (handle, _iouring) = IoUringLoop::new(Config::default(), &mut registry);
+        let (sock_left, _sock_right) = UnixStream::pair().unwrap();
+        // SAFETY: `sock_left` is a valid owned fd and is transferred into `File`.
+        let file = unsafe { std::fs::File::from_raw_fd(sock_left.into_raw_fd()) };
+
+        let result = handle
+            .read_at(
+                Arc::new(file),
+                u64::MAX - 1,
+                4,
+                IoBufMut::with_capacity(4),
+                Cache::Enabled,
+            )
+            .await;
+
+        assert!(matches!(result, Err((_, Error::OffsetOverflow))));
+    }
+
+    #[tokio::test]
+    async fn test_write_at_rejects_offset_plus_len_overflow() {
+        // Same reasoning as the read_at case above, but for the write path's
+        // `offset + written` SQE computation.
+        let mut registry = Registry::default();
+        let (handle, _iouring) = IoUringLoop::new(Config::default(), &mut registry);
+        let (sock_left, _sock_right) = UnixStream::pair().unwrap();
+        // SAFETY: `sock_left` is a valid owned fd and is transferred into `File`.
+        let file = unsafe { std::fs::File::from_raw_fd(sock_left.into_raw_fd()) };
+        let bufs = IoBufs::from(IoBuf::from(vec![0u8; 4]));
+
+        let result = handle
+            .write_at(
+                Arc::new(file),
+                u64::MAX - 1,
+                bufs,
+                WriteOptions::default(),
+                Cache::Enabled,
+            )
+            .await;
+
+        assert!(matches!(result, Err(Error::OffsetOverflow)));
     }
 
     #[tokio::test]


### PR DESCRIPTION
Fixes #3288.

`Handle::read_at`/`write_at` advance each retry SQE's offset with unchecked `u64` addition (`offset + read` / `offset + written`, now in `iouring/request.rs`'s `build_sqe`). If `offset` is supplied near `u64::MAX`, that addition can wrap in a release build, redirecting I/O to an unintended earlier file position.

This rejects up front, before the request is ever enqueued, if `offset + len` (read) or `offset + bufs.len()` (write) does not fit in a `u64`. Since `read <= len` and `written <= bufs.len()` throughout the retry loop, this bounds every later `offset + read/written` computation and makes the wrap impossible — fixed once at the entry point rather than deep in the SQE-building hot loop.

A prior attempt at this (#3291) was closed as stale, not rejected on its approach — happy to take a different direction if a maintainer prefers plumbing the check through `build_sqe` instead.

- Full `commonware-runtime` suite: 947 tests pass, plus 2 new regression tests.
- Failing-first confirmed: without the guard, both calls hang indefinitely instead of returning (the request is enqueued but never serviced in the test); with the guard, they return `Err(OffsetOverflow)` immediately.
- `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` clean.