### PR TITLE
[storage/qmdb] Export batch artifacts

### DIFF
--- a/storage/src/journal/authenticated.rs
+++ b/storage/src/journal/authenticated.rs
@@ -687,6 +687,30 @@ where
             .map_err(Error::Merkle)
     }
 
+    /// Merkle frontier at the first item `batch` appends ([`Family::nodes_to_pin`]).
+    ///
+    /// Nodes below the batch chain are read from this journal's
+    /// [Merkle store][crate::merkle::mem::Mem], which retains them at least until
+    /// the batch's changes are flushed.
+    pub fn speculative_pinned_nodes(
+        &self,
+        batch: &MerkleizedBatch<F, H::Digest, C::Item, S>,
+    ) -> Result<Vec<H::Digest>, Error<F>> {
+        let start = Location::new(batch.size() - batch.items().len() as u64);
+        self.merkle
+            .with_mem(|mem| {
+                F::nodes_to_pin(start)
+                    .map(|pos| {
+                        batch
+                            .get_node(pos)
+                            .or_else(|| mem.get_node(pos))
+                            .ok_or(merkle::Error::ElementPruned(pos))
+                    })
+                    .collect::<Result<Vec<_>, _>>()
+            })
+            .map_err(Error::Merkle)
+    }
+
     /// Generate a historical proof with respect to the state of the Merkle structure when it had
     /// `historical_leaves` leaves.
     ///

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -2625,11 +2625,20 @@ where
 
     /// Inclusion proof for the operations returned by [`Self::operations`], anchored at
     /// this batch's tip. The pair verifies against [`Self::root`] via
-    /// [`crate::qmdb::verify_proof`].
+    /// [`crate::qmdb::verify_proof`]. Together with [`Self::pinned_nodes`] they verify via
+    /// [`crate::qmdb::verify_proof_and_pinned_nodes`].
     ///
-    /// Nodes below this batch chain are read from `db`'s
+    /// Nodes of unapplied ancestors are read through the chain, so those ancestors must still be
+    /// alive. Nodes below the chain are read from `db`'s
     /// [Merkle store][crate::merkle::mem::Mem], which retains them at least until
     /// this batch's changes are flushed (by a commit or sync after apply).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::merkle::Error::ElementPruned`] if a required node has been pruned or
+    /// belongs to a dropped unapplied ancestor and
+    /// [`crate::merkle::Error::Empty`] if the batch has no operations (a [`Db::to_batch`]
+    /// snapshot).
     pub fn proof<E, C, I, H, const N: usize>(
         &self,
         db: &Db<F, E, C, I, H, U, N, S>,
@@ -2643,6 +2652,35 @@ where
         let inactive_peaks = F::inactive_peaks(self.bounds.tip.size, self.bounds.inactivity_floor);
         db.log
             .speculative_proof(&self.journal_batch, inactive_peaks)
+            .map_err(Into::into)
+    }
+
+    /// The Merkle frontier at the first operation returned by [`Self::operations`]
+    /// ([`Family::nodes_to_pin`]), which lets a consumer holding only this batch's base rebuild
+    /// compact state and replay the operations. The operations, [`Self::proof`], and pinned
+    /// nodes verify against [`Self::root`] via [`crate::qmdb::verify_proof_and_pinned_nodes`].
+    ///
+    /// Nodes of unapplied ancestors are read through the chain, so those ancestors must still be
+    /// alive. Nodes below the chain are read from `db`'s
+    /// [Merkle store][crate::merkle::mem::Mem], which retains them at least until
+    /// this batch's changes are flushed (by a commit or sync after apply).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::merkle::Error::ElementPruned`] if a required node has been pruned or
+    /// belongs to a dropped unapplied ancestor.
+    pub fn pinned_nodes<E, C, I, H, const N: usize>(
+        &self,
+        db: &Db<F, E, C, I, H, U, N, S>,
+    ) -> Result<Vec<D>, crate::qmdb::Error<F>>
+    where
+        E: Context,
+        C: Contiguous<Item = Operation<F, U>>,
+        I: UnorderedIndex<Value = Location<F>>,
+        H: Hasher<Digest = D>,
+    {
+        db.log
+            .speculative_pinned_nodes(&self.journal_batch)
             .map_err(Into::into)
     }
 
@@ -3670,6 +3708,7 @@ mod tests {
             let (seed_start, seed_ops) = seed.operations();
             let seed_root = seed.root();
             let seed_proof = seed.proof(&db).unwrap();
+            let seed_pins = seed.pinned_nodes(&db).unwrap();
             let (db, seed_range) = db.apply_batch(seed).await.unwrap();
             assert_eq!(seed_start, seed_range.start);
             assert_eq!(*seed_start + seed_ops.len() as u64, *seed_range.end);
@@ -3693,6 +3732,10 @@ mod tests {
             let (parent_root, child_root) = (parent.root(), child.root());
             let (parent_proof, child_proof) =
                 (parent.proof(&db).unwrap(), child.proof(&db).unwrap());
+            let (parent_pins, child_pins) = (
+                parent.pinned_nodes(&db).unwrap(),
+                child.pinned_nodes(&db).unwrap(),
+            );
             let (db, parent_range) = db.apply_batch(parent).await.unwrap();
             let (db, child_range) = db.apply_batch(child).await.unwrap();
             assert_eq!(parent_start, parent_range.start);
@@ -3704,17 +3747,24 @@ mod tests {
             let empty = db.new_batch().merkleize(&db, None).await.unwrap();
             let (empty_start, empty_ops) = empty.operations();
             let (empty_root, empty_proof) = (empty.root(), empty.proof(&db).unwrap());
+            let empty_pins = empty.pinned_nodes(&db).unwrap();
             let (db, empty_range) = db.apply_batch(empty).await.unwrap();
             assert_eq!(empty_start, empty_range.start);
             assert_eq!(*empty_start + empty_ops.len() as u64, *empty_range.end);
 
             // Every captured delta and proof must match what the log recovers for its
-            // range, and verify against the batch's own root.
-            for (start, ops, proof, root) in [
-                (seed_start, seed_ops, seed_proof, seed_root),
-                (parent_start, parent_ops, parent_proof, parent_root),
-                (child_start, child_ops, child_proof, child_root),
-                (empty_start, empty_ops, empty_proof, empty_root),
+            // range, and verify against the batch's own root with and without the pins.
+            for (start, ops, proof, pins, root) in [
+                (seed_start, seed_ops, seed_proof, seed_pins, seed_root),
+                (
+                    parent_start,
+                    parent_ops,
+                    parent_proof,
+                    parent_pins,
+                    parent_root,
+                ),
+                (child_start, child_ops, child_proof, child_pins, child_root),
+                (empty_start, empty_ops, empty_proof, empty_pins, empty_root),
             ] {
                 let len = core::num::NonZeroU64::new(ops.len() as u64).unwrap();
                 let end = Location::new(*start + ops.len() as u64);
@@ -3724,25 +3774,58 @@ mod tests {
                 assert!(crate::qmdb::verify_proof::<Sha256, _, _>(
                     &proof, start, &ops, &root
                 ));
+                assert!(crate::qmdb::verify_proof_and_pinned_nodes::<Sha256, _, _>(
+                    &proof, start, &ops, &pins, &root
+                ));
             }
 
-            // After the batch's changes are flushed, proof is a verifying proof or an
-            // error, never a wrong proof.
+            // Flushing the applied batch prunes the store to its peaks. The late batch's base is
+            // mid-mountain, so its artifacts are refused rather than returned unverifiable.
             let late = db
                 .new_batch()
                 .write(key_a, Some(Sha256::hash(&[b"late-a"])))
                 .merkleize(&db, None)
                 .await
                 .unwrap();
-            let (late_start, late_ops) = late.operations();
-            let late_root = late.root();
             let (db, _) = db.apply_batch(Arc::clone(&late)).await.unwrap();
             let db = db.commit().await.unwrap();
-            if let Ok(proof) = late.proof(&db) {
-                assert!(crate::qmdb::verify_proof::<Sha256, _, _>(
-                    &proof, late_start, &late_ops, &late_root
-                ));
-            }
+            assert!(matches!(
+                late.proof(&db),
+                Err(crate::qmdb::Error::Merkle(
+                    crate::merkle::Error::ElementPruned(_)
+                ))
+            ));
+            assert!(matches!(
+                late.pinned_nodes(&db),
+                Err(crate::qmdb::Error::Merkle(
+                    crate::merkle::Error::ElementPruned(_)
+                ))
+            ));
+
+            // A batch built on the flushed store reads every node below it from the pinned peaks.
+            let flushed = db
+                .new_batch()
+                .write(key_b, Some(Sha256::hash(&[b"flushed-b"])))
+                .merkleize(&db, None)
+                .await
+                .unwrap();
+            let (flushed_start, flushed_ops) = flushed.operations();
+            let flushed_root = flushed.root();
+            let flushed_proof = flushed.proof(&db).unwrap();
+            let flushed_pins = flushed.pinned_nodes(&db).unwrap();
+            assert!(crate::qmdb::verify_proof_and_pinned_nodes::<Sha256, _, _>(
+                &flushed_proof,
+                flushed_start,
+                &flushed_ops,
+                &flushed_pins,
+                &flushed_root
+            ));
+            let (db, flushed_range) = db.apply_batch(flushed).await.unwrap();
+            assert_eq!(flushed_start, flushed_range.start);
+            assert_eq!(
+                *flushed_start + flushed_ops.len() as u64,
+                *flushed_range.end
+            );
 
             db.destroy().await.unwrap();
         });

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -2636,9 +2636,8 @@ where
     /// # Errors
     ///
     /// Returns [`crate::merkle::Error::ElementPruned`] if a required node has been pruned or
-    /// belongs to a dropped unapplied ancestor and
-    /// [`crate::merkle::Error::Empty`] if the batch has no operations (a [`Db::to_batch`]
-    /// snapshot).
+    /// belongs to a dropped unapplied ancestor, and [`crate::merkle::Error::Empty`] if the batch
+    /// has no operations (a [`Db::to_batch`] snapshot).
     pub fn proof<E, C, I, H, const N: usize>(
         &self,
         db: &Db<F, E, C, I, H, U, N, S>,

--- a/storage/src/qmdb/compact/batch.rs
+++ b/storage/src/qmdb/compact/batch.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 pub(crate) async fn merkleize_ops<F, H, S, Op>(
     merkle: &compact::Merkle<F, H::Digest, S>,
     batch: compact::UnmerkleizedBatch<F, H::Digest, S>,
-    ops: Vec<Op>,
+    ops: impl Into<Arc<Vec<Op>>>,
     inactive_peaks: usize,
 ) -> Result<(Arc<batch::MerkleizedBatch<F, H::Digest, S>>, H::Digest), merkle::Error<F>>
 where
@@ -29,6 +29,7 @@ where
     S: Strategy,
     Op: EncodeShared + 'static,
 {
+    let ops = ops.into();
     let first_leaf = batch.leaves();
     let ancestors = batch.retain_ancestors();
     let mem = merkle.snapshot();
@@ -74,10 +75,14 @@ mod tests {
             compact::Merkle::<F, <Sha256 as Hasher>::Digest, Sequential>::new(Sequential);
 
         // Build a speculative suffix over a prefix that will be committed independently.
-        let (prefix, _) =
-            merkleize_ops::<F, Sha256, _, _>(&merkle, merkle.new_batch(), (0..8u64).collect(), 0)
-                .await
-                .unwrap();
+        let (prefix, _) = merkleize_ops::<F, Sha256, _, _>(
+            &merkle,
+            merkle.new_batch(),
+            (0..8u64).collect::<Vec<_>>(),
+            0,
+        )
+        .await
+        .unwrap();
         let (pending, _) = merkleize_ops::<F, Sha256, _, _>(
             &merkle,
             compact::UnmerkleizedBatch::wrap(prefix.new_batch()),

--- a/storage/src/qmdb/current/batch.rs
+++ b/storage/src/qmdb/current/batch.rs
@@ -1066,9 +1066,9 @@ impl<F: Graftable, D: Digest, U: update::Update, const N: usize, S: Strategy>
     /// Return the operations this batch appends to the ops log and the location of the first.
     ///
     /// Delegates to the wrapped ops-level batch. The bitmap state contributes to the
-    /// canonical root but appends no log operations. There is no matching proof method:
-    /// an ops-level proof verifies only against [`Self::ops_root`], never the grafted
-    /// [`Self::root`] that blocks commit to.
+    /// canonical root but appends no log operations. There are no matching proof or
+    /// pinned-node methods: an ops-level proof verifies only against [`Self::ops_root`],
+    /// never the grafted [`Self::root`] that blocks commit to.
     pub fn operations(&self) -> (Location<F>, Arc<Vec<Operation<F, U>>>) {
         self.inner.operations()
     }

--- a/storage/src/qmdb/immutable/batch.rs
+++ b/storage/src/qmdb/immutable/batch.rs
@@ -339,11 +339,18 @@ where
 
     /// Inclusion proof for the operations returned by [`Self::operations`], anchored at
     /// this batch's tip. The pair verifies against [`Self::root`] via
-    /// [`crate::qmdb::verify_proof`].
+    /// [`crate::qmdb::verify_proof`]. Together with [`Self::pinned_nodes`] they verify via
+    /// [`crate::qmdb::verify_proof_and_pinned_nodes`].
     ///
-    /// Nodes below this batch chain are read from `db`'s
+    /// Nodes of unapplied ancestors are read through the chain, so those ancestors must still be
+    /// alive. Nodes below the chain are read from `db`'s
     /// [Merkle store][crate::merkle::mem::Mem], which retains them at least until
     /// this batch's changes are flushed (by a commit or sync after apply).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::merkle::Error::ElementPruned`] if a required node has been pruned or
+    /// belongs to a dropped unapplied ancestor.
     pub fn proof<E, C, H, T>(
         &self,
         db: &Immutable<F, E, K, V, C, H, T, S>,
@@ -357,6 +364,35 @@ where
         let inactive_peaks = F::inactive_peaks(self.bounds.tip.size, self.bounds.inactivity_floor);
         db.journal
             .speculative_proof(&self.journal_batch, inactive_peaks)
+            .map_err(Into::into)
+    }
+
+    /// The Merkle frontier at the first operation returned by [`Self::operations`]
+    /// ([`Family::nodes_to_pin`]), which lets a consumer holding only this batch's base rebuild
+    /// compact state and replay the operations. The operations, [`Self::proof`], and pinned
+    /// nodes verify against [`Self::root`] via [`crate::qmdb::verify_proof_and_pinned_nodes`].
+    ///
+    /// Nodes of unapplied ancestors are read through the chain, so those ancestors must still be
+    /// alive. Nodes below the chain are read from `db`'s
+    /// [Merkle store][crate::merkle::mem::Mem], which retains them at least until
+    /// this batch's changes are flushed (by a commit or sync after apply).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::merkle::Error::ElementPruned`] if a required node has been pruned or
+    /// belongs to a dropped unapplied ancestor.
+    pub fn pinned_nodes<E, C, H, T>(
+        &self,
+        db: &Immutable<F, E, K, V, C, H, T, S>,
+    ) -> Result<Vec<D>, Error<F>>
+    where
+        E: Context,
+        C: Mutable<Item = Operation<F, K, V>>,
+        H: Hasher<Digest = D>,
+        T: Translator,
+    {
+        db.journal
+            .speculative_pinned_nodes(&self.journal_batch)
             .map_err(Into::into)
     }
 

--- a/storage/src/qmdb/immutable/compact.rs
+++ b/storage/src/qmdb/immutable/compact.rs
@@ -226,10 +226,6 @@ where
     }
 
     /// Create a new speculative batch with this one as its parent.
-    ///
-    /// All unapplied ancestors in the chain must be kept alive until the child (or any
-    /// descendant) is merkleized. Dropping an unapplied ancestor causes data loss detected at
-    /// `apply_batch` time.
     pub fn new_batch<H>(self: &Arc<Self>) -> UnmerkleizedBatch<F, H, K, V, S>
     where
         H: Hasher<Digest = D>,

--- a/storage/src/qmdb/immutable/compact.rs
+++ b/storage/src/qmdb/immutable/compact.rs
@@ -4,7 +4,8 @@
 //! Mirrors the API of [`crate::qmdb::immutable::Immutable`] (`new_batch -> merkleize ->
 //! apply_batch -> commit / sync / start_sync`, pipelined batch chains, `StaleBatch` validation)
 //! but is backed by the peak-only [`crate::merkle::compact`]. Because history is discarded,
-//! there are no `get` / `proof` / `bounds` methods. Use the full variant if you need them.
+//! the db has no `get` / `proof` / `bounds` methods. A merkleized batch can prove only its own
+//! operations, and only until it is applied. Use the full variant for historical proofs.
 //!
 //! # Witness journal
 //!
@@ -28,7 +29,7 @@ pub use crate::qmdb::compact::Config;
 use crate::{
     Context,
     journal::contiguous::variable::{self, Config as JournalConfig},
-    merkle::{Family, Location, batch, compact as compact_merkle},
+    merkle::{Family, Location, Proof, batch, compact as compact_merkle},
     qmdb::{
         self, Error,
         any::value::ValueEncoding,
@@ -117,6 +118,7 @@ where
     Operation<F, K, V>: EncodeShared,
 {
     pub(super) merkle_batch: Arc<batch::MerkleizedBatch<F, D, S>>,
+    operations: Arc<Vec<Operation<F, K, V>>>,
     pub(super) commit_metadata: Option<V::Value>,
     pub(super) parent: Option<Weak<Self>>,
     pub(super) bounds: batch_chain::Bounds<F, D>,
@@ -146,7 +148,88 @@ where
         &self.bounds
     }
 
+    /// Return the operations this batch appends to the log and the location of the first.
+    #[allow(clippy::type_complexity)]
+    pub fn operations(&self) -> (Location<F>, Arc<Vec<Operation<F, K, V>>>) {
+        (self.bounds.base.size, Arc::clone(&self.operations))
+    }
+
+    /// Inclusion proof for the operations returned by [`Self::operations`], anchored at
+    /// this batch's tip. The operations and proof verify against [`Self::root`] via
+    /// [`crate::qmdb::verify_proof`]. Together with [`Self::pinned_nodes`] they verify via
+    /// [`crate::qmdb::verify_proof_and_pinned_nodes`].
+    ///
+    /// Nodes below this batch's own operations are read from its unapplied ancestors, which must
+    /// still be alive, and from `db`'s [Merkle store][crate::merkle::mem::Mem]. Applying this
+    /// batch or a descendant prunes that store to its frontier, so capture the proof first.
+    /// Applying ancestors is safe.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::merkle::Error::ElementPruned`] if a required node has been pruned or
+    /// belongs to a dropped unapplied ancestor, and [`crate::merkle::Error::Empty`] if the batch
+    /// has no operations (a [`Db::to_batch`] snapshot).
+    pub fn proof<E, C, H>(&self, db: &Db<F, E, K, V, H, C, S>) -> Result<Proof<F, D>, Error<F>>
+    where
+        E: Context,
+        H: Hasher<Digest = D>,
+        C: Clone + Send + Sync + 'static,
+        Operation<F, K, V>: Read<Cfg = C>,
+    {
+        let inactive_peaks = F::inactive_peaks(self.bounds.tip.size, self.bounds.inactivity_floor);
+        let hasher = qmdb::hasher::<H>();
+        db.merkle
+            .with_mem(|base| {
+                self.merkle_batch.range_proof(
+                    base,
+                    &hasher,
+                    self.bounds.base.size..self.bounds.tip.size,
+                    inactive_peaks,
+                )
+            })
+            .map_err(Into::into)
+    }
+
+    /// The Merkle frontier at the first operation returned by [`Self::operations`]
+    /// ([`Family::nodes_to_pin`]), which lets a consumer holding only this batch's base rebuild
+    /// compact state and replay the operations. The operations, [`Self::proof`], and pinned
+    /// nodes verify against [`Self::root`] via [`crate::qmdb::verify_proof_and_pinned_nodes`].
+    ///
+    /// Nodes below this batch's own operations are read from its unapplied ancestors, which must
+    /// still be alive, and from `db`'s [Merkle store][crate::merkle::mem::Mem]. Applying this
+    /// batch or a descendant prunes that store to its frontier, so capture the pinned nodes first.
+    /// Applying ancestors is safe.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::merkle::Error::ElementPruned`] if a required node has been pruned or
+    /// belongs to a dropped unapplied ancestor.
+    pub fn pinned_nodes<E, C, H>(&self, db: &Db<F, E, K, V, H, C, S>) -> Result<Vec<D>, Error<F>>
+    where
+        E: Context,
+        H: Hasher<Digest = D>,
+        C: Clone + Send + Sync + 'static,
+        Operation<F, K, V>: Read<Cfg = C>,
+    {
+        db.merkle
+            .with_mem(|base| {
+                F::nodes_to_pin(self.bounds.base.size)
+                    .map(|pos| {
+                        self.merkle_batch
+                            .get_node(pos)
+                            .or_else(|| base.get_node(pos))
+                            .ok_or(crate::merkle::Error::ElementPruned(pos))
+                    })
+                    .collect::<Result<Vec<_>, _>>()
+            })
+            .map_err(Into::into)
+    }
+
     /// Create a new speculative batch with this one as its parent.
+    ///
+    /// All unapplied ancestors in the chain must be kept alive until the child (or any
+    /// descendant) is merkleized. Dropping an unapplied ancestor causes data loss detected at
+    /// `apply_batch` time.
     pub fn new_batch<H>(self: &Arc<Self>) -> UnmerkleizedBatch<F, H, K, V, S>
     where
         H: Hasher<Digest = D>,
@@ -238,12 +321,13 @@ where
         }
         ops.push(Operation::Commit(metadata.clone(), inactivity_floor));
 
-        let total_size = self.base.size + ops.len() as u64;
+        let operations = Arc::new(ops);
+        let total_size = self.base.size + operations.len() as u64;
         let inactive_peaks = F::inactive_peaks(total_size, inactivity_floor);
         let (merkle, root) = compact_batch::merkleize_ops::<F, H, S, _>(
             &db.merkle,
             self.merkle_batch,
-            ops,
+            Arc::clone(&operations),
             inactive_peaks,
         )
         .await
@@ -257,6 +341,7 @@ where
 
         Arc::new(MerkleizedBatch {
             merkle_batch: merkle,
+            operations,
             commit_metadata: metadata,
             parent: self.parent.as_ref().map(Arc::downgrade),
             bounds: batch_chain::Bounds {
@@ -430,6 +515,7 @@ where
     {
         Arc::new(MerkleizedBatch {
             merkle_batch: self.merkle.to_batch(),
+            operations: Arc::new(Vec::new()),
             commit_metadata: self.last_commit_metadata.clone(),
             parent: None,
             bounds: batch_chain::Bounds::from_db(self.commitment(), self.inactivity_floor_loc),
@@ -641,8 +727,11 @@ where
 mod tests {
     use super::*;
     use crate::{
-        merkle::mmr,
-        qmdb::{any::value::FixedEncoding, compact::witness},
+        merkle::{mmb, mmr},
+        qmdb::{
+            any::value::FixedEncoding, compact::witness, verify_proof,
+            verify_proof_and_pinned_nodes,
+        },
     };
     use commonware_cryptography::{Sha256, sha256::Digest};
     use commonware_macros::test_traced;
@@ -682,6 +771,197 @@ mod tests {
         Db::init_from_merkle(merkle, context.child("witness"), witness_cfg, ())
             .await
             .unwrap()
+    }
+
+    /// Batch artifacts (operations, range proof, pinned frontier) verify against the batch root,
+    /// survive applying and dropping ancestors, and are refused once the batch itself is applied
+    /// and the compact store is pruned past them.
+    async fn compact_operations_and_proof_inner<F: Family>(context: deterministic::Context) {
+        let db = open_db::<F>(context.child("db"), "immutable-operations-and-proof").await;
+        let value = |key: u8| Sha256::fill(key.wrapping_add(100));
+
+        // Seed committed state so the chain below forks above a pruned frontier.
+        let mut seed = db.new_batch();
+        for key in 1u8..=6 {
+            seed = seed.set(Sha256::fill(key), value(key));
+        }
+        let seed = seed
+            .merkleize(&db, Some(Sha256::fill(7)), Location::new(0))
+            .await;
+        let (db, _) = db.apply_batch(seed).await.unwrap();
+        let db = db.sync().await.unwrap();
+        let floor = db.size();
+        assert_eq!(floor, Location::new(8));
+
+        // A snapshot batch has no operations to prove.
+        assert!(matches!(
+            db.to_batch().proof(&db),
+            Err(Error::Merkle(crate::merkle::Error::Empty))
+        ));
+
+        // A two-deep unapplied chain: the child's artifacts read the parent's nodes through the
+        // live chain.
+        let mut parent = db.new_batch();
+        for key in 8u8..=12 {
+            parent = parent.set(Sha256::fill(key), value(key));
+        }
+        let parent = parent.merkleize(&db, Some(Sha256::fill(13)), floor).await;
+        let child = parent
+            .new_batch::<Sha256>()
+            .set(Sha256::fill(14), value(14))
+            .merkleize(&db, Some(Sha256::fill(15)), floor)
+            .await;
+
+        // The operation suffix is the batch's own sets plus its commit, handed out zero-copy.
+        let (child_start, child_ops) = child.operations();
+        let (_, child_ops_again) = child.operations();
+        let child_end = child.bounds().tip.size;
+        assert!(Arc::ptr_eq(&child_ops, &child_ops_again));
+        assert_eq!(child_start, parent.bounds().tip.size);
+        assert_eq!(*child_start + child_ops.len() as u64, *child_end);
+        assert_eq!(child_end, Location::new(16));
+        assert!(matches!(
+            child_ops.as_slice(),
+            [Operation::Set(key, set_value), Operation::Commit(Some(metadata), operation_floor)]
+                if key == &Sha256::fill(14)
+                    && set_value == &value(14)
+                    && metadata == &Sha256::fill(15)
+                    && operation_floor == &floor
+        ));
+
+        // The proof is anchored at the batch tip and verifies with or without the pins.
+        let child_root = child.root();
+        let child_proof = child.proof(&db).unwrap();
+        let child_pins = child.pinned_nodes(&db).unwrap();
+        assert_eq!(child_proof.leaves, child_end);
+        assert_eq!(
+            child_proof.inactive_peaks,
+            F::inactive_peaks(child_end, floor),
+        );
+        assert!(verify_proof::<Sha256, _, _>(
+            &child_proof,
+            child_start,
+            &child_ops,
+            &child_root
+        ));
+        assert!(verify_proof_and_pinned_nodes::<Sha256, _, _>(
+            &child_proof,
+            child_start,
+            &child_ops,
+            &child_pins,
+            &child_root
+        ));
+
+        // The pins are order-sensitive.
+        assert!(child_pins.len() > 1);
+        let mut reordered_child_pins = child_pins.clone();
+        reordered_child_pins.swap(0, 1);
+        assert!(!verify_proof_and_pinned_nodes::<Sha256, _, _>(
+            &child_proof,
+            child_start,
+            &child_ops,
+            &reordered_child_pins,
+            &child_root
+        ));
+
+        // Pipelined consumer: applying the parent prunes the store to the parent's tip, which is
+        // exactly the frontier the child's base pins, so the artifacts survive dropping the
+        // parent.
+        let (db, _) = db.apply_batch(parent).await.unwrap();
+        let child_proof_after = child.proof(&db).unwrap();
+        assert_eq!(child.pinned_nodes(&db).unwrap(), child_pins);
+        assert!(verify_proof_and_pinned_nodes::<Sha256, _, _>(
+            &child_proof_after,
+            child_start,
+            &child_ops,
+            &child_pins,
+            &child_root
+        ));
+        let (db, child_range) = db.apply_batch(child).await.unwrap();
+        assert_eq!(child_range, child_start..child_end);
+
+        // A commit-only batch proves exactly its commit operation.
+        let commit_floor = db.size();
+        let commit_only = db
+            .new_batch()
+            .merkleize(&db, Some(Sha256::fill(16)), commit_floor)
+            .await;
+        let (commit_start, commit_ops) = commit_only.operations();
+        let commit_end = commit_only.bounds().tip.size;
+        let commit_root = commit_only.root();
+        let commit_proof = commit_only.proof(&db).unwrap();
+        let commit_pins = commit_only.pinned_nodes(&db).unwrap();
+        assert_eq!(commit_start, commit_floor);
+        assert!(matches!(
+            commit_ops.as_slice(),
+            [Operation::Commit(Some(metadata), operation_floor)]
+                if metadata == &Sha256::fill(16) && operation_floor == &commit_floor
+        ));
+        assert_eq!(*commit_start + commit_ops.len() as u64, *commit_end);
+        assert_eq!(commit_proof.leaves, commit_end);
+        assert_eq!(
+            commit_proof.inactive_peaks,
+            F::inactive_peaks(commit_end, commit_floor)
+        );
+        assert!(verify_proof_and_pinned_nodes::<Sha256, _, _>(
+            &commit_proof,
+            commit_start,
+            &commit_ops,
+            &commit_pins,
+            &commit_root
+        ));
+        let (db, commit_range) = db.apply_batch(commit_only).await.unwrap();
+        assert_eq!(commit_range, commit_start..commit_end);
+        let db = db.sync().await.unwrap();
+
+        // Applying a batch that forked mid-mountain prunes its own artifacts. The accessors
+        // refuse rather than returning a proof that fails to verify, while a child merkleized
+        // before the apply still finds its base frontier in the store.
+        let late_parent = db
+            .new_batch()
+            .set(Sha256::fill(17), value(17))
+            .merkleize(&db, Some(Sha256::fill(18)), db.size())
+            .await;
+        let late = late_parent
+            .new_batch::<Sha256>()
+            .set(Sha256::fill(19), value(19))
+            .merkleize(&db, Some(Sha256::fill(20)), db.size())
+            .await;
+        let (db, _) = db.apply_batch(Arc::clone(&late_parent)).await.unwrap();
+        assert!(matches!(
+            late_parent.proof(&db),
+            Err(Error::Merkle(crate::merkle::Error::ElementPruned(_)))
+        ));
+        assert!(matches!(
+            late_parent.pinned_nodes(&db),
+            Err(Error::Merkle(crate::merkle::Error::ElementPruned(_)))
+        ));
+        drop(late_parent);
+
+        let (late_start, late_ops) = late.operations();
+        let late_root = late.root();
+        let late_proof = late.proof(&db).unwrap();
+        let late_pins = late.pinned_nodes(&db).unwrap();
+        assert!(verify_proof_and_pinned_nodes::<Sha256, _, _>(
+            &late_proof,
+            late_start,
+            &late_ops,
+            &late_pins,
+            &late_root
+        ));
+        let (db, _) = db.apply_batch(late).await.unwrap();
+
+        db.destroy().await.unwrap();
+    }
+
+    #[test_traced]
+    fn test_compact_operations_and_proof_mmr() {
+        deterministic::Runner::default().start(compact_operations_and_proof_inner::<mmr::Family>);
+    }
+
+    #[test_traced]
+    fn test_compact_operations_and_proof_mmb() {
+        deterministic::Runner::default().start(compact_operations_and_proof_inner::<mmb::Family>);
     }
 
     /// Open the persisted witness journal directly so tests can corrupt the tip entry.

--- a/storage/src/qmdb/immutable/compact.rs
+++ b/storage/src/qmdb/immutable/compact.rs
@@ -155,14 +155,14 @@ where
     }
 
     /// Inclusion proof for the operations returned by [`Self::operations`], anchored at
-    /// this batch's tip. The operations and proof verify against [`Self::root`] via
+    /// this batch's tip. The pair verifies against [`Self::root`] via
     /// [`crate::qmdb::verify_proof`]. Together with [`Self::pinned_nodes`] they verify via
     /// [`crate::qmdb::verify_proof_and_pinned_nodes`].
     ///
-    /// Nodes below this batch's own operations are read from its unapplied ancestors, which must
-    /// still be alive, and from `db`'s [Merkle store][crate::merkle::mem::Mem]. Applying this
-    /// batch or a descendant prunes that store to its frontier, so capture the proof first.
-    /// Applying ancestors is safe.
+    /// Nodes of unapplied ancestors are read through the chain, so those ancestors must still be
+    /// alive. Nodes below the chain are read from `db`'s
+    /// [Merkle store][crate::merkle::mem::Mem], which retains them at least until this batch's
+    /// changes are applied (applying it or a descendant prunes the store to its frontier).
     ///
     /// # Errors
     ///
@@ -195,10 +195,10 @@ where
     /// compact state and replay the operations. The operations, [`Self::proof`], and pinned
     /// nodes verify against [`Self::root`] via [`crate::qmdb::verify_proof_and_pinned_nodes`].
     ///
-    /// Nodes below this batch's own operations are read from its unapplied ancestors, which must
-    /// still be alive, and from `db`'s [Merkle store][crate::merkle::mem::Mem]. Applying this
-    /// batch or a descendant prunes that store to its frontier, so capture the pinned nodes first.
-    /// Applying ancestors is safe.
+    /// Nodes of unapplied ancestors are read through the chain, so those ancestors must still be
+    /// alive. Nodes below the chain are read from `db`'s
+    /// [Merkle store][crate::merkle::mem::Mem], which retains them at least until this batch's
+    /// changes are applied (applying it or a descendant prunes the store to its frontier).
     ///
     /// # Errors
     ///

--- a/storage/src/qmdb/immutable/mod.rs
+++ b/storage/src/qmdb/immutable/mod.rs
@@ -872,7 +872,7 @@ pub(super) mod tests {
     use super::*;
     use crate::{
         merkle::{Family, Location},
-        qmdb::verify_proof,
+        qmdb::{verify_proof, verify_proof_and_pinned_nodes},
         translator::TwoCap,
     };
     use commonware_codec::EncodeShared;
@@ -1240,6 +1240,7 @@ pub(super) mod tests {
         let (seed_start, seed_ops) = seed.operations();
         let seed_root = seed.root();
         let seed_proof = seed.proof(&db).unwrap();
+        let seed_pins = seed.pinned_nodes(&db).unwrap();
         let (db, seed_range) = db.apply_batch(seed).await.unwrap();
         assert_eq!(seed_start, seed_range.start);
         assert_eq!(*seed_start + seed_ops.len() as u64, *seed_range.end);
@@ -1258,6 +1259,10 @@ pub(super) mod tests {
         let (parent_start, parent_ops) = parent.operations();
         let (child_start, child_ops) = child.operations();
         let (parent_root, child_root) = (parent.root(), child.root());
+        let (parent_pins, child_pins) = (
+            parent.pinned_nodes(&db).unwrap(),
+            child.pinned_nodes(&db).unwrap(),
+        );
         let (parent_proof, child_proof) = (parent.proof(&db).unwrap(), child.proof(&db).unwrap());
         let (db, parent_range) = db.apply_batch(parent).await.unwrap();
         let (db, child_range) = db.apply_batch(child).await.unwrap();
@@ -1273,17 +1278,24 @@ pub(super) mod tests {
             .await;
         let (empty_start, empty_ops) = empty.operations();
         let (empty_root, empty_proof) = (empty.root(), empty.proof(&db).unwrap());
+        let empty_pins = empty.pinned_nodes(&db).unwrap();
         let (db, empty_range) = db.apply_batch(empty).await.unwrap();
         assert_eq!(empty_start, empty_range.start);
         assert_eq!(*empty_start + empty_ops.len() as u64, *empty_range.end);
 
         // Every captured delta and proof must match what the log recovers for its
-        // range, and verify against the batch's own root.
-        for (start, ops, proof, root) in [
-            (seed_start, seed_ops, seed_proof, seed_root),
-            (parent_start, parent_ops, parent_proof, parent_root),
-            (child_start, child_ops, child_proof, child_root),
-            (empty_start, empty_ops, empty_proof, empty_root),
+        // range, and verify against the batch's own root with and without the pins.
+        for (start, ops, proof, pins, root) in [
+            (seed_start, seed_ops, seed_proof, seed_pins, seed_root),
+            (
+                parent_start,
+                parent_ops,
+                parent_proof,
+                parent_pins,
+                parent_root,
+            ),
+            (child_start, child_ops, child_proof, child_pins, child_root),
+            (empty_start, empty_ops, empty_proof, empty_pins, empty_root),
         ] {
             let len = core::num::NonZeroU64::new(ops.len() as u64).unwrap();
             let end = Location::new(*start + ops.len() as u64);
@@ -1291,24 +1303,56 @@ pub(super) mod tests {
             assert_eq!(log_ops, *ops);
             assert_eq!(log_proof, proof);
             assert!(verify_proof::<Sha256, _, _>(&proof, start, &ops, &root));
+            assert!(verify_proof_and_pinned_nodes::<Sha256, _, _>(
+                &proof, start, &ops, &pins, &root
+            ));
         }
 
-        // After the batch's changes are flushed, proof is a verifying proof or an
-        // error, never a wrong proof.
+        // Flushing the applied batch prunes the store to its peaks. The late batch's base is
+        // mid-mountain, so its artifacts are refused rather than returned unverifiable.
         let late = db
             .new_batch()
             .set(Sha256::fill(5u8), Sha256::fill(15u8))
             .merkleize(&db, None, db.inactivity_floor_loc())
             .await;
-        let (late_start, late_ops) = late.operations();
-        let late_root = late.root();
         let (db, _) = db.apply_batch(Arc::clone(&late)).await.unwrap();
         let db = db.commit().await.unwrap();
-        if let Ok(proof) = late.proof(&db) {
-            assert!(verify_proof::<Sha256, _, _>(
-                &proof, late_start, &late_ops, &late_root
-            ));
-        }
+        assert!(matches!(
+            late.proof(&db),
+            Err(crate::qmdb::Error::Merkle(
+                crate::merkle::Error::ElementPruned(_)
+            ))
+        ));
+        assert!(matches!(
+            late.pinned_nodes(&db),
+            Err(crate::qmdb::Error::Merkle(
+                crate::merkle::Error::ElementPruned(_)
+            ))
+        ));
+
+        // A batch built on the flushed store reads every node below it from the pinned peaks.
+        let flushed = db
+            .new_batch()
+            .set(Sha256::fill(6u8), Sha256::fill(16u8))
+            .merkleize(&db, None, db.inactivity_floor_loc())
+            .await;
+        let (flushed_start, flushed_ops) = flushed.operations();
+        let flushed_root = flushed.root();
+        let flushed_proof = flushed.proof(&db).unwrap();
+        let flushed_pins = flushed.pinned_nodes(&db).unwrap();
+        assert!(verify_proof_and_pinned_nodes::<Sha256, _, _>(
+            &flushed_proof,
+            flushed_start,
+            &flushed_ops,
+            &flushed_pins,
+            &flushed_root
+        ));
+        let (db, flushed_range) = db.apply_batch(flushed).await.unwrap();
+        assert_eq!(flushed_start, flushed_range.start);
+        assert_eq!(
+            *flushed_start + flushed_ops.len() as u64,
+            *flushed_range.end
+        );
 
         db.destroy().await.unwrap();
     }

--- a/storage/src/qmdb/keyless/batch.rs
+++ b/storage/src/qmdb/keyless/batch.rs
@@ -355,9 +355,8 @@ where
     /// # Errors
     ///
     /// Returns [`crate::merkle::Error::ElementPruned`] if a required node has been pruned or
-    /// belongs to a dropped unapplied ancestor and
-    /// [`crate::merkle::Error::Empty`] if the batch has no operations (a [`Keyless::to_batch`]
-    /// snapshot).
+    /// belongs to a dropped unapplied ancestor, and [`crate::merkle::Error::Empty`] if the batch
+    /// has no operations (a [`Keyless::to_batch`] snapshot).
     pub fn proof<E, C, H>(&self, db: &Keyless<F, E, V, C, H, S>) -> Result<Proof<F, D>, Error<F>>
     where
         E: Context,

--- a/storage/src/qmdb/keyless/batch.rs
+++ b/storage/src/qmdb/keyless/batch.rs
@@ -344,11 +344,20 @@ where
 
     /// Inclusion proof for the operations returned by [`Self::operations`], anchored at
     /// this batch's tip. The pair verifies against [`Self::root`] via
-    /// [`crate::qmdb::verify_proof`].
+    /// [`crate::qmdb::verify_proof`]. Together with [`Self::pinned_nodes`] they verify via
+    /// [`crate::qmdb::verify_proof_and_pinned_nodes`].
     ///
-    /// Nodes below this batch chain are read from `db`'s
+    /// Nodes of unapplied ancestors are read through the chain, so those ancestors must still be
+    /// alive. Nodes below the chain are read from `db`'s
     /// [Merkle store][crate::merkle::mem::Mem], which retains them at least until
     /// this batch's changes are flushed (by a commit or sync after apply).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::merkle::Error::ElementPruned`] if a required node has been pruned or
+    /// belongs to a dropped unapplied ancestor and
+    /// [`crate::merkle::Error::Empty`] if the batch has no operations (a [`Keyless::to_batch`]
+    /// snapshot).
     pub fn proof<E, C, H>(&self, db: &Keyless<F, E, V, C, H, S>) -> Result<Proof<F, D>, Error<F>>
     where
         E: Context,
@@ -358,6 +367,31 @@ where
         let inactive_peaks = F::inactive_peaks(self.bounds.tip.size, self.bounds.inactivity_floor);
         db.journal
             .speculative_proof(&self.journal_batch, inactive_peaks)
+            .map_err(Into::into)
+    }
+
+    /// The Merkle frontier at the first operation returned by [`Self::operations`]
+    /// ([`Family::nodes_to_pin`]), which lets a consumer holding only this batch's base rebuild
+    /// compact state and replay the operations. The operations, [`Self::proof`], and pinned
+    /// nodes verify against [`Self::root`] via [`crate::qmdb::verify_proof_and_pinned_nodes`].
+    ///
+    /// Nodes of unapplied ancestors are read through the chain, so those ancestors must still be
+    /// alive. Nodes below the chain are read from `db`'s
+    /// [Merkle store][crate::merkle::mem::Mem], which retains them at least until
+    /// this batch's changes are flushed (by a commit or sync after apply).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::merkle::Error::ElementPruned`] if a required node has been pruned or
+    /// belongs to a dropped unapplied ancestor.
+    pub fn pinned_nodes<E, C, H>(&self, db: &Keyless<F, E, V, C, H, S>) -> Result<Vec<D>, Error<F>>
+    where
+        E: Context,
+        C: Mutable<Item = Operation<F, V>>,
+        H: Hasher<Digest = D>,
+    {
+        db.journal
+            .speculative_pinned_nodes(&self.journal_batch)
             .map_err(Into::into)
     }
 

--- a/storage/src/qmdb/keyless/compact.rs
+++ b/storage/src/qmdb/keyless/compact.rs
@@ -144,14 +144,14 @@ where
     }
 
     /// Inclusion proof for the operations returned by [`Self::operations`], anchored at
-    /// this batch's tip. The operations and proof verify against [`Self::root`] via
+    /// this batch's tip. The pair verifies against [`Self::root`] via
     /// [`crate::qmdb::verify_proof`]. Together with [`Self::pinned_nodes`] they verify via
     /// [`crate::qmdb::verify_proof_and_pinned_nodes`].
     ///
-    /// Nodes below this batch's own operations are read from its unapplied ancestors, which must
-    /// still be alive, and from `db`'s [Merkle store][crate::merkle::mem::Mem]. Applying this
-    /// batch or a descendant prunes that store to its frontier, so capture the proof first.
-    /// Applying ancestors is safe.
+    /// Nodes of unapplied ancestors are read through the chain, so those ancestors must still be
+    /// alive. Nodes below the chain are read from `db`'s
+    /// [Merkle store][crate::merkle::mem::Mem], which retains them at least until this batch's
+    /// changes are applied (applying it or a descendant prunes the store to its frontier).
     ///
     /// # Errors
     ///
@@ -184,10 +184,10 @@ where
     /// compact state and replay the operations. The operations, [`Self::proof`], and pinned
     /// nodes verify against [`Self::root`] via [`crate::qmdb::verify_proof_and_pinned_nodes`].
     ///
-    /// Nodes below this batch's own operations are read from its unapplied ancestors, which must
-    /// still be alive, and from `db`'s [Merkle store][crate::merkle::mem::Mem]. Applying this
-    /// batch or a descendant prunes that store to its frontier, so capture the pinned nodes first.
-    /// Applying ancestors is safe.
+    /// Nodes of unapplied ancestors are read through the chain, so those ancestors must still be
+    /// alive. Nodes below the chain are read from `db`'s
+    /// [Merkle store][crate::merkle::mem::Mem], which retains them at least until this batch's
+    /// changes are applied (applying it or a descendant prunes the store to its frontier).
     ///
     /// # Errors
     ///

--- a/storage/src/qmdb/keyless/compact.rs
+++ b/storage/src/qmdb/keyless/compact.rs
@@ -4,7 +4,8 @@
 //! Mirrors the API of [`crate::qmdb::keyless::Keyless`] (`new_batch -> merkleize ->
 //! apply_batch -> commit / sync / start_sync`, pipelined batch chains, `StaleBatch` validation)
 //! but is backed by the peak-only [`crate::merkle::compact`]. Because history is discarded,
-//! there are no `get` / `proof` / `bounds` methods. Use the full variant if you need them.
+//! the db has no `get` / `proof` / `bounds` methods. A merkleized batch can prove only its own
+//! operations, and only until it is applied. Use the full variant for historical proofs.
 //!
 //! # Witness journal
 //!
@@ -28,7 +29,7 @@ pub use crate::qmdb::compact::Config;
 use crate::{
     Context,
     journal::contiguous::variable::{self, Config as JournalConfig},
-    merkle::{Family, Location, batch, compact as compact_merkle},
+    merkle::{Family, Location, Proof, batch, compact as compact_merkle},
     qmdb::{
         self, Error,
         any::value::ValueEncoding,
@@ -108,6 +109,7 @@ where
     Operation<F, V>: EncodeShared,
 {
     pub(super) merkle_batch: Arc<batch::MerkleizedBatch<F, D, S>>,
+    operations: Arc<Vec<Operation<F, V>>>,
     pub(super) commit_metadata: Option<V::Value>,
     pub(super) parent: Option<Weak<Self>>,
     pub(super) bounds: batch_chain::Bounds<F, D>,
@@ -136,7 +138,87 @@ where
         &self.bounds
     }
 
+    /// Return the operations this batch appends to the log and the location of the first.
+    pub fn operations(&self) -> (Location<F>, Arc<Vec<Operation<F, V>>>) {
+        (self.bounds.base.size, Arc::clone(&self.operations))
+    }
+
+    /// Inclusion proof for the operations returned by [`Self::operations`], anchored at
+    /// this batch's tip. The operations and proof verify against [`Self::root`] via
+    /// [`crate::qmdb::verify_proof`]. Together with [`Self::pinned_nodes`] they verify via
+    /// [`crate::qmdb::verify_proof_and_pinned_nodes`].
+    ///
+    /// Nodes below this batch's own operations are read from its unapplied ancestors, which must
+    /// still be alive, and from `db`'s [Merkle store][crate::merkle::mem::Mem]. Applying this
+    /// batch or a descendant prunes that store to its frontier, so capture the proof first.
+    /// Applying ancestors is safe.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::merkle::Error::ElementPruned`] if a required node has been pruned or
+    /// belongs to a dropped unapplied ancestor, and [`crate::merkle::Error::Empty`] if the batch
+    /// has no operations (a [`Db::to_batch`] snapshot).
+    pub fn proof<E, C, H>(&self, db: &Db<F, E, V, H, C, S>) -> Result<Proof<F, D>, Error<F>>
+    where
+        E: Context,
+        H: Hasher<Digest = D>,
+        C: Clone + Send + Sync + 'static,
+        Operation<F, V>: Read<Cfg = C>,
+    {
+        let inactive_peaks = F::inactive_peaks(self.bounds.tip.size, self.bounds.inactivity_floor);
+        let hasher = qmdb::hasher::<H>();
+        db.merkle
+            .with_mem(|base| {
+                self.merkle_batch.range_proof(
+                    base,
+                    &hasher,
+                    self.bounds.base.size..self.bounds.tip.size,
+                    inactive_peaks,
+                )
+            })
+            .map_err(Into::into)
+    }
+
+    /// The Merkle frontier at the first operation returned by [`Self::operations`]
+    /// ([`Family::nodes_to_pin`]), which lets a consumer holding only this batch's base rebuild
+    /// compact state and replay the operations. The operations, [`Self::proof`], and pinned
+    /// nodes verify against [`Self::root`] via [`crate::qmdb::verify_proof_and_pinned_nodes`].
+    ///
+    /// Nodes below this batch's own operations are read from its unapplied ancestors, which must
+    /// still be alive, and from `db`'s [Merkle store][crate::merkle::mem::Mem]. Applying this
+    /// batch or a descendant prunes that store to its frontier, so capture the pinned nodes first.
+    /// Applying ancestors is safe.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`crate::merkle::Error::ElementPruned`] if a required node has been pruned or
+    /// belongs to a dropped unapplied ancestor.
+    pub fn pinned_nodes<E, C, H>(&self, db: &Db<F, E, V, H, C, S>) -> Result<Vec<D>, Error<F>>
+    where
+        E: Context,
+        H: Hasher<Digest = D>,
+        C: Clone + Send + Sync + 'static,
+        Operation<F, V>: Read<Cfg = C>,
+    {
+        db.merkle
+            .with_mem(|base| {
+                F::nodes_to_pin(self.bounds.base.size)
+                    .map(|pos| {
+                        self.merkle_batch
+                            .get_node(pos)
+                            .or_else(|| base.get_node(pos))
+                            .ok_or(crate::merkle::Error::ElementPruned(pos))
+                    })
+                    .collect::<Result<Vec<_>, _>>()
+            })
+            .map_err(Into::into)
+    }
+
     /// Create a new speculative batch with this one as its parent.
+    ///
+    /// All unapplied ancestors in the chain must be kept alive until the child (or any
+    /// descendant) is merkleized. Dropping an unapplied ancestor causes data loss detected at
+    /// `apply_batch` time.
     pub fn new_batch<H>(self: &Arc<Self>) -> UnmerkleizedBatch<F, H, V, S>
     where
         H: Hasher<Digest = D>,
@@ -227,12 +309,13 @@ where
         }
         ops.push(Operation::Commit(metadata.clone(), inactivity_floor));
 
-        let total_size = self.base.size + ops.len() as u64;
+        let operations = Arc::new(ops);
+        let total_size = self.base.size + operations.len() as u64;
         let inactive_peaks = F::inactive_peaks(total_size, inactivity_floor);
         let (merkle, root) = compact_batch::merkleize_ops::<F, H, S, _>(
             &db.merkle,
             self.merkle_batch,
-            ops,
+            Arc::clone(&operations),
             inactive_peaks,
         )
         .await
@@ -246,6 +329,7 @@ where
 
         Arc::new(MerkleizedBatch {
             merkle_batch: merkle,
+            operations,
             commit_metadata: metadata,
             parent: self.parent.as_ref().map(Arc::downgrade),
             bounds: batch_chain::Bounds {
@@ -415,6 +499,7 @@ where
     {
         Arc::new(MerkleizedBatch {
             merkle_batch: self.merkle.to_batch(),
+            operations: Arc::new(Vec::new()),
             commit_metadata: self.last_commit_metadata.clone(),
             parent: None,
             bounds: batch_chain::Bounds::from_db(self.commitment(), self.inactivity_floor_loc),
@@ -616,8 +701,11 @@ where
 mod tests {
     use super::*;
     use crate::{
-        merkle::mmr,
-        qmdb::{any::value::FixedEncoding, compact::witness},
+        merkle::{mmb, mmr},
+        qmdb::{
+            any::value::FixedEncoding, compact::witness, verify_proof,
+            verify_proof_and_pinned_nodes,
+        },
     };
     use commonware_cryptography::{Sha256, sha256::Digest};
     use commonware_macros::test_traced;
@@ -657,6 +745,195 @@ mod tests {
         Db::init_from_merkle(merkle, context.child("witness"), witness_cfg, ())
             .await
             .unwrap()
+    }
+
+    /// Batch artifacts (operations, range proof, pinned frontier) verify against the batch root,
+    /// survive applying and dropping ancestors, and are refused once the batch itself is applied
+    /// and the compact store is pruned past them.
+    async fn compact_operations_and_proof_inner<F: Family>(context: deterministic::Context) {
+        let db = open_db::<F>(context.child("db"), "keyless-operations-and-proof").await;
+
+        // Seed committed state so the chain below forks above a pruned frontier.
+        let mut seed = db.new_batch();
+        for value in 1u64..=6 {
+            seed = seed.append(U64::new(value));
+        }
+        let seed = seed
+            .merkleize(&db, Some(U64::new(7)), Location::new(0))
+            .await;
+        let (db, _) = db.apply_batch(seed).await.unwrap();
+        let db = db.sync().await.unwrap();
+        let floor = db.size();
+        assert_eq!(floor, Location::new(8));
+
+        // A snapshot batch has no operations to prove.
+        assert!(matches!(
+            db.to_batch().proof(&db),
+            Err(Error::Merkle(crate::merkle::Error::Empty))
+        ));
+
+        // A two-deep unapplied chain: the child's artifacts read the parent's nodes through the
+        // live chain.
+        let mut parent = db.new_batch();
+        for value in 8u64..=12 {
+            parent = parent.append(U64::new(value));
+        }
+        let parent = parent.merkleize(&db, Some(U64::new(13)), floor).await;
+        let child = parent
+            .new_batch::<Sha256>()
+            .append(U64::new(14))
+            .merkleize(&db, Some(U64::new(15)), floor)
+            .await;
+
+        // The operation suffix is the batch's own appends plus its commit, handed out zero-copy.
+        let (child_start, child_ops) = child.operations();
+        let (_, child_ops_again) = child.operations();
+        let child_end = child.bounds().tip.size;
+        assert!(Arc::ptr_eq(&child_ops, &child_ops_again));
+        assert_eq!(child_start, parent.bounds().tip.size);
+        assert_eq!(*child_start + child_ops.len() as u64, *child_end);
+        assert_eq!(child_end, Location::new(16));
+        assert!(matches!(
+            child_ops.as_slice(),
+            [Operation::Append(value), Operation::Commit(Some(metadata), operation_floor)]
+                if value == &U64::new(14)
+                    && metadata == &U64::new(15)
+                    && operation_floor == &floor
+        ));
+
+        // The proof is anchored at the batch tip and verifies with or without the pins.
+        let child_root = child.root();
+        let child_proof = child.proof(&db).unwrap();
+        let child_pins = child.pinned_nodes(&db).unwrap();
+        assert_eq!(child_proof.leaves, child_end);
+        assert_eq!(
+            child_proof.inactive_peaks,
+            F::inactive_peaks(child_end, floor),
+        );
+        assert!(verify_proof::<Sha256, _, _>(
+            &child_proof,
+            child_start,
+            &child_ops,
+            &child_root
+        ));
+        assert!(verify_proof_and_pinned_nodes::<Sha256, _, _>(
+            &child_proof,
+            child_start,
+            &child_ops,
+            &child_pins,
+            &child_root
+        ));
+
+        // The pins are order-sensitive.
+        assert!(child_pins.len() > 1);
+        let mut reordered_child_pins = child_pins.clone();
+        reordered_child_pins.swap(0, 1);
+        assert!(!verify_proof_and_pinned_nodes::<Sha256, _, _>(
+            &child_proof,
+            child_start,
+            &child_ops,
+            &reordered_child_pins,
+            &child_root
+        ));
+
+        // Pipelined consumer: applying the parent prunes the store to the parent's tip, which is
+        // exactly the frontier the child's base pins, so the artifacts survive dropping the
+        // parent.
+        let (db, _) = db.apply_batch(parent).await.unwrap();
+        let child_proof_after = child.proof(&db).unwrap();
+        assert_eq!(child.pinned_nodes(&db).unwrap(), child_pins);
+        assert!(verify_proof_and_pinned_nodes::<Sha256, _, _>(
+            &child_proof_after,
+            child_start,
+            &child_ops,
+            &child_pins,
+            &child_root
+        ));
+        let (db, child_range) = db.apply_batch(child).await.unwrap();
+        assert_eq!(child_range, child_start..child_end);
+
+        // A commit-only batch proves exactly its commit operation.
+        let commit_floor = db.size();
+        let commit_only = db
+            .new_batch()
+            .merkleize(&db, Some(U64::new(16)), commit_floor)
+            .await;
+        let (commit_start, commit_ops) = commit_only.operations();
+        let commit_end = commit_only.bounds().tip.size;
+        let commit_root = commit_only.root();
+        let commit_proof = commit_only.proof(&db).unwrap();
+        let commit_pins = commit_only.pinned_nodes(&db).unwrap();
+        assert_eq!(commit_start, commit_floor);
+        assert!(matches!(
+            commit_ops.as_slice(),
+            [Operation::Commit(Some(metadata), operation_floor)]
+                if metadata == &U64::new(16) && operation_floor == &commit_floor
+        ));
+        assert_eq!(*commit_start + commit_ops.len() as u64, *commit_end);
+        assert_eq!(commit_proof.leaves, commit_end);
+        assert_eq!(
+            commit_proof.inactive_peaks,
+            F::inactive_peaks(commit_end, commit_floor)
+        );
+        assert!(verify_proof_and_pinned_nodes::<Sha256, _, _>(
+            &commit_proof,
+            commit_start,
+            &commit_ops,
+            &commit_pins,
+            &commit_root
+        ));
+        let (db, commit_range) = db.apply_batch(commit_only).await.unwrap();
+        assert_eq!(commit_range, commit_start..commit_end);
+        let db = db.sync().await.unwrap();
+
+        // Applying a batch that forked mid-mountain prunes its own artifacts. The accessors
+        // refuse rather than returning a proof that fails to verify, while a child merkleized
+        // before the apply still finds its base frontier in the store.
+        let late_parent = db
+            .new_batch()
+            .append(U64::new(17))
+            .merkleize(&db, Some(U64::new(18)), db.size())
+            .await;
+        let late = late_parent
+            .new_batch::<Sha256>()
+            .append(U64::new(19))
+            .merkleize(&db, Some(U64::new(20)), db.size())
+            .await;
+        let (db, _) = db.apply_batch(Arc::clone(&late_parent)).await.unwrap();
+        assert!(matches!(
+            late_parent.proof(&db),
+            Err(Error::Merkle(crate::merkle::Error::ElementPruned(_)))
+        ));
+        assert!(matches!(
+            late_parent.pinned_nodes(&db),
+            Err(Error::Merkle(crate::merkle::Error::ElementPruned(_)))
+        ));
+        drop(late_parent);
+
+        let (late_start, late_ops) = late.operations();
+        let late_root = late.root();
+        let late_proof = late.proof(&db).unwrap();
+        let late_pins = late.pinned_nodes(&db).unwrap();
+        assert!(verify_proof_and_pinned_nodes::<Sha256, _, _>(
+            &late_proof,
+            late_start,
+            &late_ops,
+            &late_pins,
+            &late_root
+        ));
+        let (db, _) = db.apply_batch(late).await.unwrap();
+
+        db.destroy().await.unwrap();
+    }
+
+    #[test_traced]
+    fn test_compact_operations_and_proof_mmr() {
+        deterministic::Runner::default().start(compact_operations_and_proof_inner::<mmr::Family>);
+    }
+
+    #[test_traced]
+    fn test_compact_operations_and_proof_mmb() {
+        deterministic::Runner::default().start(compact_operations_and_proof_inner::<mmb::Family>);
     }
 
     /// Open the persisted witness journal directly so tests can corrupt the tip entry.

--- a/storage/src/qmdb/keyless/compact.rs
+++ b/storage/src/qmdb/keyless/compact.rs
@@ -215,10 +215,6 @@ where
     }
 
     /// Create a new speculative batch with this one as its parent.
-    ///
-    /// All unapplied ancestors in the chain must be kept alive until the child (or any
-    /// descendant) is merkleized. Dropping an unapplied ancestor causes data loss detected at
-    /// `apply_batch` time.
     pub fn new_batch<H>(self: &Arc<Self>) -> UnmerkleizedBatch<F, H, V, S>
     where
         H: Hasher<Digest = D>,

--- a/storage/src/qmdb/keyless/mod.rs
+++ b/storage/src/qmdb/keyless/mod.rs
@@ -622,7 +622,7 @@ where
 #[cfg(test)]
 pub(crate) mod tests {
     use super::*;
-    use crate::qmdb::verify_proof;
+    use crate::qmdb::{verify_proof, verify_proof_and_pinned_nodes};
     use commonware_cryptography::Sha256;
     use commonware_parallel::Strategy;
     use commonware_runtime::{Supervisor as _, deterministic};
@@ -767,6 +767,7 @@ pub(crate) mod tests {
         let (seed_start, seed_ops) = seed.operations();
         let seed_root = seed.root();
         let seed_proof = seed.proof(&db).unwrap();
+        let seed_pins = seed.pinned_nodes(&db).unwrap();
         let (db, seed_range) = db.apply_batch(seed).await.unwrap();
         assert_eq!(seed_start, seed_range.start);
         assert_eq!(*seed_start + seed_ops.len() as u64, *seed_range.end);
@@ -785,6 +786,10 @@ pub(crate) mod tests {
         let (parent_start, parent_ops) = parent.operations();
         let (child_start, child_ops) = child.operations();
         let (parent_root, child_root) = (parent.root(), child.root());
+        let (parent_pins, child_pins) = (
+            parent.pinned_nodes(&db).unwrap(),
+            child.pinned_nodes(&db).unwrap(),
+        );
         let (parent_proof, child_proof) = (parent.proof(&db).unwrap(), child.proof(&db).unwrap());
         let (db, parent_range) = db.apply_batch(parent).await.unwrap();
         let (db, child_range) = db.apply_batch(child).await.unwrap();
@@ -800,17 +805,24 @@ pub(crate) mod tests {
             .await;
         let (empty_start, empty_ops) = empty.operations();
         let (empty_root, empty_proof) = (empty.root(), empty.proof(&db).unwrap());
+        let empty_pins = empty.pinned_nodes(&db).unwrap();
         let (db, empty_range) = db.apply_batch(empty).await.unwrap();
         assert_eq!(empty_start, empty_range.start);
         assert_eq!(*empty_start + empty_ops.len() as u64, *empty_range.end);
 
         // Every captured delta and proof must match what the log recovers for its
-        // range, and verify against the batch's own root.
-        for (start, ops, proof, root) in [
-            (seed_start, seed_ops, seed_proof, seed_root),
-            (parent_start, parent_ops, parent_proof, parent_root),
-            (child_start, child_ops, child_proof, child_root),
-            (empty_start, empty_ops, empty_proof, empty_root),
+        // range, and verify against the batch's own root with and without the pins.
+        for (start, ops, proof, pins, root) in [
+            (seed_start, seed_ops, seed_proof, seed_pins, seed_root),
+            (
+                parent_start,
+                parent_ops,
+                parent_proof,
+                parent_pins,
+                parent_root,
+            ),
+            (child_start, child_ops, child_proof, child_pins, child_root),
+            (empty_start, empty_ops, empty_proof, empty_pins, empty_root),
         ] {
             let len = core::num::NonZeroU64::new(ops.len() as u64).unwrap();
             let end = Location::new(*start + ops.len() as u64);
@@ -818,24 +830,56 @@ pub(crate) mod tests {
             assert_eq!(log_ops, *ops);
             assert_eq!(log_proof, proof);
             assert!(verify_proof::<H, _, _>(&proof, start, &ops, &root));
+            assert!(verify_proof_and_pinned_nodes::<H, _, _>(
+                &proof, start, &ops, &pins, &root
+            ));
         }
 
-        // After the batch's changes are flushed, proof is a verifying proof or an
-        // error, never a wrong proof.
+        // Flushing the applied batch prunes the store to its peaks. The late batch's base is
+        // mid-mountain, so its artifacts are refused rather than returned unverifiable.
         let late = db
             .new_batch()
             .append(V::Value::make(5))
             .merkleize(&db, None, db.inactivity_floor_loc())
             .await;
-        let (late_start, late_ops) = late.operations();
-        let late_root = late.root();
         let (db, _) = db.apply_batch(Arc::clone(&late)).await.unwrap();
         let db = db.commit().await.unwrap();
-        if let Ok(proof) = late.proof(&db) {
-            assert!(verify_proof::<H, _, _>(
-                &proof, late_start, &late_ops, &late_root
-            ));
-        }
+        assert!(matches!(
+            late.proof(&db),
+            Err(crate::qmdb::Error::Merkle(
+                crate::merkle::Error::ElementPruned(_)
+            ))
+        ));
+        assert!(matches!(
+            late.pinned_nodes(&db),
+            Err(crate::qmdb::Error::Merkle(
+                crate::merkle::Error::ElementPruned(_)
+            ))
+        ));
+
+        // A batch built on the flushed store reads every node below it from the pinned peaks.
+        let flushed = db
+            .new_batch()
+            .append(V::Value::make(6))
+            .merkleize(&db, None, db.inactivity_floor_loc())
+            .await;
+        let (flushed_start, flushed_ops) = flushed.operations();
+        let flushed_root = flushed.root();
+        let flushed_proof = flushed.proof(&db).unwrap();
+        let flushed_pins = flushed.pinned_nodes(&db).unwrap();
+        assert!(verify_proof_and_pinned_nodes::<H, _, _>(
+            &flushed_proof,
+            flushed_start,
+            &flushed_ops,
+            &flushed_pins,
+            &flushed_root
+        ));
+        let (db, flushed_range) = db.apply_batch(flushed).await.unwrap();
+        assert_eq!(flushed_start, flushed_range.start);
+        assert_eq!(
+            *flushed_start + flushed_ops.len() as u64,
+            *flushed_range.end
+        );
 
         db.destroy().await.unwrap();
     }


### PR DESCRIPTION
Exposes the operation suffix, range proof, and pinned frontier nodes of a merkleized batch so a downstream consumer (an indexer, for example) can authenticate the batch against its root and replay it from the batch's base without holding state.

- The compact variants (`keyless::compact`, `immutable::compact`) gain `operations()` and `proof(&db)`, matching the journal-backed variants from #4618. Operations are shared as an `Arc` with the merkleize job instead of dropped.
- Every batch type with `proof()` (`any`, `keyless`, `immutable`, and both compact variants) gains `pinned_nodes(&db)`: the Merkle frontier at the batch's base (`Family::nodes_to_pin`). Operations and proof verify with `verify_proof`. With the pins they verify with `verify_proof_and_pinned_nodes`, and a consumer holding only the base can rebuild compact state and replay. Journal-backed variants share `Journal::speculative_pinned_nodes` next to `speculative_proof`.
- `compact::merkleize_ops` accepts `impl Into<Arc<Vec<Op>>>` so both compact variants share the ops they now retain.

After this every QMDB batch type exposes `operations()`, and every one except `current` (whose root includes the bitmap) exposes `proof()` and `pinned_nodes()`.

Artifacts must be captured before the batch is applied. For the compact variants, applying the batch (or a descendant) prunes the store to its frontier. For the journal-backed variants, the next flush does. Applying ancestors is safe, since the frontier at an ancestor's tip is exactly what the child's base pins. Unapplied ancestors must still be alive when capturing, which is the existing batch-chain contract. The docs on every accessor state both rules.

Tests: the compact tests cover ops content, proofs with and without pins, pin order sensitivity, artifacts surviving an applied and dropped parent, a commit-only batch, `Empty` for a snapshot batch, and `ElementPruned` after the batch's own apply, for mmr and mmb. The journal-backed `operations_match_applied_log` tests now verify pins for every batch shape, assert refusal after a flush, and cover the steady state of building and exporting a batch on a flushed store.

Alternative to #4637, which bundles the same compact keyless export with a redesign of Merkle ancestor retention. The export does not depend on that redesign, so this PR lands the artifact surface alone and leaves the retention change to be judged on its own.
