### PR TITLE
[consensus] Reject one-block epochs and document the genesis epoch expectation

### DIFF
--- a/consensus/src/marshal/core/floor.rs
+++ b/consensus/src/marshal/core/floor.rs
@@ -64,6 +64,13 @@ impl<S: Scheme, C: Digest> State<S, C> {
         }
     }
 
+    /// Returns the inclusive height floor. Finalized data at or below it is
+    /// neither stored nor repaired.
+    ///
+    /// Nothing processed maps to zero because height zero is genesis, which is
+    /// anchored at startup or sits below a floor anchor and never carries a
+    /// finalization. Delivery uses the stream cursor, which keeps that state
+    /// distinct.
     pub(super) const fn processed_height(&self) -> Height {
         match self.height {
             Some(height) => height,

--- a/consensus/src/types.rs
+++ b/consensus/src/types.rs
@@ -149,7 +149,7 @@ impl From<Epoch> for U64 {
 
 /// Represents a sequential position in a chain or sequence.
 ///
-/// Height is a monotonically increasing counter.
+/// Height is a monotonically increasing counter. Height zero is the genesis block.
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct Height(u64);
@@ -740,6 +740,9 @@ impl EpochInfo {
 }
 
 /// Mechanism for determining epoch boundaries.
+///
+/// Genesis is not produced by any epoch, so every epoch must contain at least one
+/// height above [`Height::zero`].
 pub trait Epocher: Clone + Send + Sync + 'static {
     /// Returns the information about an epoch containing the given block height.
     ///
@@ -758,11 +761,18 @@ pub trait Epocher: Clone + Send + Sync + 'static {
 }
 
 /// Implementation of [`Epocher`] for fixed epoch lengths.
+///
+/// Epoch `e` spans heights `e * length..(e + 1) * length`, so epoch zero includes
+/// genesis.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct FixedEpocher(u64);
 
 impl FixedEpocher {
     /// Creates a new fixed epoch strategy.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `length` is one, since epoch zero would contain only genesis.
     ///
     /// # Example
     /// ```rust
@@ -771,6 +781,7 @@ impl FixedEpocher {
     /// let strategy = FixedEpocher::new(NZU64!(60_480));
     /// ```
     pub const fn new(length: NonZeroU64) -> Self {
+        assert!(length.get() > 1, "epoch length must exceed one");
         Self(length.get())
     }
 
@@ -2150,6 +2161,12 @@ mod tests {
     }
 
     #[test]
+    #[should_panic(expected = "epoch length must exceed one")]
+    fn test_fixed_epocher_rejects_length_one() {
+        let _ = FixedEpocher::new(NZU64!(1));
+    }
+
+    #[test]
     fn test_fixed_epocher_overflow() {
         // Test that containing() returns None when last() would overflow
         let epocher = FixedEpocher::new(NZU64!(100));
@@ -2196,8 +2213,8 @@ mod tests {
         assert!(result.is_some());
         assert_eq!(result.unwrap().last(), Height::new(u64::MAX));
 
-        // Test with epoch length 1 (every height is its own epoch)
-        let epocher = FixedEpocher::new(NZU64!(1));
+        // Test with the smallest epoch length (the final epoch ends exactly at u64::MAX)
+        let epocher = FixedEpocher::new(NZU64!(2));
         let result = epocher.containing(Height::new(u64::MAX));
         assert!(result.is_some());
         assert_eq!(result.unwrap().last(), Height::new(u64::MAX));

--- a/glue/src/dkg/reshare/application.rs
+++ b/glue/src/dkg/reshare/application.rs
@@ -771,7 +771,7 @@ mod tests {
                 >(
                     context.child("mailbox"), NZUsize!(1)
                 );
-                let mut app = Application::new(inner.clone(), Mailbox::new(sender), NZU64!(1));
+                let mut app = Application::new(inner.clone(), Mailbox::new(sender), NZU64!(2));
                 let mut verify = Box::pin(app.verify(
                     (context.child("app"), block_context(&parent, 1)),
                     ancestry::from_iter([tip, parent]),


### PR DESCRIPTION
## Summary

Height zero is the genesis block. It exists before consensus runs, so no epoch produces it, and an epoch that contains only genesis has nothing to produce. `FixedEpocher::new(NZU64!(1))` shaped epoch zero exactly that way and nothing rejected it.

- `Height` documents that height zero is the genesis block. Marshal already asserts this at startup, but the generic types never stated it.
- `Epocher` documents the expectation for every implementation: genesis is not produced by any epoch, so every epoch must contain a height above `Height::zero`.
- `FixedEpocher` documents its span (`e * length..(e + 1) * length`, so epoch zero includes genesis) and `new` panics on a length of one.
- `FloorState::processed_height` documents why nothing processed maps to a floor of zero and that delivery uses the stream cursor instead.

No behavior change for any length of two or more. The shipped DKG already requires four blocks per epoch.

## Context

With a one-block first epoch, the boundary re-proposal rule re-proposes genesis itself and a correct committee certifies it. Marshal has nowhere to put that certificate: height zero sits at or below every processed floor, so the row is dropped, `Latest` stays empty, and height-zero fetches from peers go unanswered. A fresh node handed that certificate as `Start::Floor` stalls permanently: the anchor is treated as already processed and never stored, repair starts at height one, and dispatch waits forever for a block at height zero. Rejecting the schedule at construction removes both.

The `None -> Height::zero()` mapping in `FloorState::processed_height` is not involved. Every gate compares against zero and decides identically for `None` and `Some(0)`, and `Some(0)` is reached at startup once genesis is dispatched and acknowledged. Its new doc comment records why.

## Testing

- `just check-fmt`
- `just clippy -p commonware-consensus`
- `just check-docs -p commonware-consensus`
- `just test -p commonware-consensus fixed_epocher` (new `should_panic` test plus the overflow test moved from length one to two)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kzg8GiQuEHi4MJZbGc8vpi
