### PR TITLE
[storage] Cover speculative batch proofs that read committed nodes from the base

### DIFF
--- a/storage/src/merkle/batch.rs
+++ b/storage/src/merkle/batch.rs
@@ -1005,6 +1005,35 @@ mod tests {
         });
     }
 
+    /// A proof requested directly from an unmerged, speculative [`MerkleizedBatch`] (i.e. before
+    /// it is applied to `base`) must succeed even when building the Merkle path for one of the
+    /// batch's own newly appended leaves requires sibling nodes that only exist in `base` --
+    /// the batch chain alone does not contain nodes committed before the fork.
+    fn speculative_proof_uses_base_fallback<F: Family>() {
+        let executor = deterministic::Runner::default();
+        executor.start(|_| async move {
+            let hasher: H = Standard::new(ForwardFold);
+            let base = build_reference::<F>(&hasher, 50);
+            let mut batch = base.new_batch();
+            for i in 50u64..55 {
+                let element = hasher.digest(&i.to_be_bytes());
+                batch = batch.add(&hasher, &element);
+            }
+            let m = batch.merkleize(&base, &hasher);
+            let expected_root = batch_root(&base, &m, &hasher);
+
+            let loc = Location::<F>::new(52);
+            let element = hasher.digest(&52u64.to_be_bytes());
+            let proof = m.proof(&base, &hasher, loc, 0).unwrap();
+            assert!(proof.verify_element_inclusion(&hasher, &element, loc, &expected_root));
+
+            let range = Location::<F>::new(50)..Location::<F>::new(55);
+            let elements: Vec<D> = (50u64..55).map(|i| hasher.digest(&i.to_be_bytes())).collect();
+            let rp = m.range_proof(&base, &hasher, range.clone(), 0).unwrap();
+            assert!(rp.verify_range_inclusion(&hasher, &elements, range.start, &expected_root));
+        });
+    }
+
     fn empty_batch<F: Family>() {
         let executor = deterministic::Runner::default();
         executor.start(|_| async move {
@@ -1254,6 +1283,10 @@ mod tests {
         proof_verification::<crate::mmr::Family>();
     }
     #[test]
+    fn mmr_speculative_proof_uses_base_fallback() {
+        speculative_proof_uses_base_fallback::<crate::mmr::Family>();
+    }
+    #[test]
     fn mmr_empty_batch() {
         empty_batch::<crate::mmr::Family>();
     }
@@ -1376,6 +1409,10 @@ mod tests {
     #[test]
     fn mmb_proof_verification() {
         proof_verification::<crate::mmb::Family>();
+    }
+    #[test]
+    fn mmb_speculative_proof_uses_base_fallback() {
+        speculative_proof_uses_base_fallback::<crate::mmb::Family>();
     }
     #[test]
     fn mmb_empty_batch() {

--- a/storage/src/merkle/batch.rs
+++ b/storage/src/merkle/batch.rs
@@ -1005,10 +1005,9 @@ mod tests {
         });
     }
 
-    /// A proof requested directly from an unmerged, speculative [`MerkleizedBatch`] (i.e. before
-    /// it is applied to `base`) must succeed even when building the Merkle path for one of the
-    /// batch's own newly appended leaves requires sibling nodes that only exist in `base` --
-    /// the batch chain alone does not contain nodes committed before the fork.
+    /// A proof requested directly from a speculative [`MerkleizedBatch`], before it is applied to
+    /// `base`, must succeed even when the Merkle path needs nodes that only exist in `base`. The
+    /// batch chain alone does not contain nodes committed before the fork.
     fn speculative_proof_uses_base_fallback<F: Family>() {
         let executor = deterministic::Runner::default();
         executor.start(|_| async move {
@@ -1022,15 +1021,29 @@ mod tests {
             let m = batch.merkleize(&base, &hasher);
             let expected_root = batch_root(&base, &m, &hasher);
 
+            // A newly appended leaf: the path needs the committed peaks.
             let loc = Location::<F>::new(52);
             let element = hasher.digest(&52u64.to_be_bytes());
             let proof = m.proof(&base, &hasher, loc, 0).unwrap();
             assert!(proof.verify_element_inclusion(&hasher, &element, loc, &expected_root));
 
-            let range = Location::<F>::new(50)..Location::<F>::new(55);
-            let elements: Vec<D> = (50u64..55).map(|i| hasher.digest(&i.to_be_bytes())).collect();
-            let rp = m.range_proof(&base, &hasher, range.clone(), 0).unwrap();
-            assert!(rp.verify_range_inclusion(&hasher, &elements, range.start, &expected_root));
+            // A committed leaf: the path needs committed siblings as well as committed peaks.
+            let loc = Location::<F>::new(49);
+            let element = hasher.digest(&49u64.to_be_bytes());
+            let proof = m.proof(&base, &hasher, loc, 0).unwrap();
+            assert!(proof.verify_element_inclusion(&hasher, &element, loc, &expected_root));
+
+            // A range of new leaves and a range spanning the fork boundary.
+            for range in [
+                Location::<F>::new(50)..Location::<F>::new(55),
+                Location::<F>::new(45)..Location::<F>::new(55),
+            ] {
+                let elements: Vec<D> = (*range.start..*range.end)
+                    .map(|i| hasher.digest(&i.to_be_bytes()))
+                    .collect();
+                let rp = m.range_proof(&base, &hasher, range.clone(), 0).unwrap();
+                assert!(rp.verify_range_inclusion(&hasher, &elements, range.start, &expected_root));
+            }
         });
     }
 


### PR DESCRIPTION
Closes #3686.

## Summary

#3686 reported that `MerkleizedBatch::proof()` and `range_proof()` in `storage/src/merkle/batch.rs` only walked the batch chain and never fell back to the committed `Mem`, so a proof that needed a committed node returned a spurious `Error::ElementPruned`.

That was fixed in #4618, where `range_proof` resolves each position through the batch chain first and then through `base`. The behavior is exercised indirectly by the `operations_match_applied_log` tests in `qmdb`, which prove batch items through the authenticated journal's `speculative_proof`. This PR adds a direct test at the merkle layer, `speculative_proof_uses_base_fallback`, registered for both the `mmr` and `mmb` families, so a regression is caught where it originates.

The test forks a batch from a committed base, appends leaves, and without applying the batch proves a newly appended leaf, a committed leaf, a range of new leaves, and a range spanning the fork boundary against the batch's root. Removing the `base` fallback makes it fail with `ElementPruned`.

No production code is changed.
