### PR TITLE
[storage] Install pruned overwrites into pinned nodes when applying a batch

### DIFF
--- a/storage/src/merkle/batch.rs
+++ b/storage/src/merkle/batch.rs
@@ -63,8 +63,10 @@
 //! applied. Invalid batches must not be used: their methods may return incorrect data rather than
 //! erroring.
 //!
-//! Pruning the base after a batch was forked does not invalidate it: applying the batch then
-//! yields the same state as applying it before the prune (see [`Mem::apply_batch`]).
+//! Pruning the base after a batch has been merkleized does not invalidate it: applying the batch
+//! then yields the same state as applying it before the prune (see [`Mem::apply_batch`]). An
+//! unmerkleized batch still reads sibling digests from the base while merkleizing, so it must be
+//! merkleized before the base is pruned past any leaf it updates.
 //!
 //! # Example (MMR)
 //!

--- a/storage/src/merkle/batch.rs
+++ b/storage/src/merkle/batch.rs
@@ -63,6 +63,9 @@
 //! applied. Invalid batches must not be used: their methods may return incorrect data rather than
 //! erroring.
 //!
+//! Pruning the base after a batch was forked does not invalidate it: applying the batch then
+//! yields the same state as applying it before the prune (see [`Mem::apply_batch`]).
+//!
 //! # Example (MMR)
 //!
 //! ```ignore

--- a/storage/src/merkle/batch.rs
+++ b/storage/src/merkle/batch.rs
@@ -63,10 +63,10 @@
 //! applied. Invalid batches must not be used: their methods may return incorrect data rather than
 //! erroring.
 //!
-//! Pruning the base after a batch has been merkleized does not invalidate it: applying the batch
-//! then yields the same state as applying it before the prune (see [`Mem::apply_batch`]). An
-//! unmerkleized batch still reads sibling digests from the base while merkleizing, so it must be
-//! merkleized before the base is pruned past any leaf it updates.
+//! Pruning the base after a batch has been merkleized does not invalidate it: prune and apply
+//! commute (see [`Mem::apply_batch`]). An unmerkleized batch still reads sibling digests from the
+//! base while merkleizing, so it must be merkleized before the base is pruned past any leaf it
+//! updates.
 //!
 //! # Example (MMR)
 //!

--- a/storage/src/merkle/mem.rs
+++ b/storage/src/merkle/mem.rs
@@ -389,7 +389,7 @@ impl<F: Family, D: Digest> Mem<F, D> {
     }
 
     /// Overwrite the node at `pos`, which may have been pruned since the batch carrying the
-    /// overwrite was forked. A pinned node takes the new digest so the root and the proofs of
+    /// overwrite was merkleized. A pinned node takes the new digest so the root and the proofs of
     /// retained leaves reflect it. Any other pruned node no longer contributes to either, so its
     /// digest is discarded.
     fn overwrite(&mut self, pos: Position<F>, digest: D) {
@@ -403,8 +403,8 @@ impl<F: Family, D: Digest> Mem<F, D> {
 
     /// Apply a merkleized batch. Already-committed ancestors are skipped automatically.
     ///
-    /// Pruning this structure after the batch was forked does not invalidate the batch: applying
-    /// it yields the same state as applying it before the prune.
+    /// Pruning this structure after the batch was merkleized does not invalidate the batch:
+    /// applying it yields the same state as applying it before the prune.
     ///
     /// # Errors
     ///

--- a/storage/src/merkle/mem.rs
+++ b/storage/src/merkle/mem.rs
@@ -388,7 +388,29 @@ impl<F: Family, D: Digest> Mem<F, D> {
         root.new_batch()
     }
 
+    /// Overwrite the node at `pos`, which may have been pruned since the batch carrying the
+    /// overwrite was forked. A pinned node takes the new digest so the root and the proofs of
+    /// retained leaves reflect it. Any other pruned node no longer contributes to either, so its
+    /// digest is discarded.
+    fn overwrite(&mut self, pos: Position<F>, digest: D) {
+        if pos >= self.pruning_boundary {
+            let index = self.pos_to_index(pos);
+            self.nodes[index] = digest;
+        } else if let Some(pinned) = self.pinned_nodes.get_mut(&pos) {
+            *pinned = digest;
+        }
+    }
+
     /// Apply a merkleized batch. Already-committed ancestors are skipped automatically.
+    ///
+    /// Pruning this structure after the batch was forked does not invalidate the batch: applying
+    /// it yields the same state as applying it before the prune.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::StaleBatch`] if the structure has diverged from the batch's ancestor chain
+    /// and [`Error::AncestorDropped`] if an unapplied ancestor was dropped before the batch was
+    /// merkleized.
     pub fn apply_batch<S: Strategy>(
         &mut self,
         batch: &batch::MerkleizedBatch<F, D, S>,
@@ -437,11 +459,7 @@ impl<F: Family, D: Digest> Mem<F, D> {
                 continue;
             }
             for (&pos, &digest) in overwrites.iter() {
-                if pos < self.pruning_boundary {
-                    continue;
-                }
-                let index = self.pos_to_index(pos);
-                self.nodes[index] = digest;
+                self.overwrite(pos, digest);
             }
             for &digest in appended.iter() {
                 self.nodes.push_back(digest);
@@ -450,11 +468,7 @@ impl<F: Family, D: Digest> Mem<F, D> {
 
         // Apply this batch's own data.
         for (&pos, &digest) in batch.overwrites.iter() {
-            if skip_ancestors && pos < self.pruning_boundary {
-                continue;
-            }
-            let index = self.pos_to_index(pos);
-            self.nodes[index] = digest;
+            self.overwrite(pos, digest);
         }
         for &digest in batch.appended.iter() {
             self.nodes.push_back(digest);
@@ -1283,6 +1297,132 @@ mod tests {
         );
     }
 
+    /// Assert `actual` is observably identical to `expected` and has the given root.
+    fn assert_same_state<F: Family>(
+        hasher: &H,
+        actual: &Mem<F, D>,
+        expected: &Mem<F, D>,
+        root: D,
+        context: &str,
+    ) {
+        assert_eq!(plain_root(actual, hasher), root, "{context}: root");
+        assert_eq!(actual.size(), expected.size(), "{context}: size");
+        assert_eq!(actual.bounds(), expected.bounds(), "{context}: bounds");
+        assert_eq!(
+            actual.pinned_nodes(),
+            expected.pinned_nodes(),
+            "{context}: pinned nodes"
+        );
+        for pos in 0..*expected.size() {
+            let pos = Position::<F>::new(pos);
+            assert_eq!(
+                actual.get_node(pos),
+                expected.get_node(pos),
+                "{context}: node {pos}"
+            );
+        }
+    }
+
+    /// Pruning past a leaf that a forked batch overwrites must not change what applying the
+    /// batch installs: the result must match applying the batch first and pruning afterward.
+    fn apply_batch_after_prune_matches_prune_after_apply<F: Family>() {
+        let hasher: H = Standard::new(ForwardFold);
+        for n in 1..=12u64 {
+            let mem = build_raw::<F>(&hasher, n);
+            for update_loc in 0..n {
+                for append in [false, true] {
+                    let batch = {
+                        let batch = mem
+                            .new_batch()
+                            .update_leaf(&hasher, Location::new(update_loc), b"new")
+                            .unwrap();
+                        let batch = if append {
+                            batch.add(&hasher, b"appended")
+                        } else {
+                            batch
+                        };
+                        batch.merkleize(&mem, &hasher)
+                    };
+                    let root = batch.root(&mem, &hasher, 0).unwrap();
+                    let case = format!("n={n} update={update_loc} append={append}");
+
+                    for prune_to in (update_loc + 1)..=n {
+                        let prune_to = Location::new(prune_to);
+                        let mut expected = mem.clone();
+                        expected.apply_batch(&batch).unwrap();
+                        expected.prune(prune_to).unwrap();
+
+                        let mut actual = mem.clone();
+                        actual.prune(prune_to).unwrap();
+                        actual.apply_batch(&batch).unwrap();
+
+                        let context = format!("{case} prune={prune_to}");
+                        assert_same_state(&hasher, &actual, &expected, root, &context);
+                    }
+                }
+            }
+        }
+    }
+
+    /// Pruning between applying a parent and applying its child must not drop overwrites below
+    /// the new boundary, whether they belong to the child or to an unapplied overwrite-only
+    /// ancestor in between.
+    fn apply_batch_chain_after_prune_matches_prune_after_apply<F: Family>() {
+        let hasher: H = Standard::new(ForwardFold);
+        for n in 1..=12u64 {
+            let mem = build_raw::<F>(&hasher, n);
+            for update_loc in 0..n {
+                for (middle, append) in [(false, false), (false, true), (true, false), (true, true)]
+                {
+                    // Chain: Mem -> parent (append) [-> middle (overwrite only)] -> child.
+                    let parent = mem
+                        .new_batch()
+                        .add(&hasher, b"parent")
+                        .merkleize(&mem, &hasher);
+                    let child_parent = if middle {
+                        parent
+                            .new_batch()
+                            .update_leaf(&hasher, Location::new(0), b"middle")
+                            .unwrap()
+                            .merkleize(&mem, &hasher)
+                    } else {
+                        parent.clone()
+                    };
+                    let child = {
+                        let batch = child_parent
+                            .new_batch()
+                            .update_leaf(&hasher, Location::new(update_loc), b"child")
+                            .unwrap();
+                        let batch = if append {
+                            batch.add(&hasher, b"appended")
+                        } else {
+                            batch
+                        };
+                        batch.merkleize(&mem, &hasher)
+                    };
+                    let root = child.root(&mem, &hasher, 0).unwrap();
+                    let case = format!("n={n} update={update_loc} middle={middle} append={append}");
+
+                    for prune_to in 1..=(n + 1) {
+                        let prune_to = Location::new(prune_to);
+                        let mut expected = mem.clone();
+                        expected.apply_batch(&parent).unwrap();
+                        expected.apply_batch(&child).unwrap();
+                        expected.prune(prune_to).unwrap();
+
+                        let mut actual = mem.clone();
+                        actual.apply_batch(&parent).unwrap();
+                        actual.prune(prune_to).unwrap();
+                        actual.apply_batch(&child).unwrap();
+
+                        let context = format!("{case} prune={prune_to}");
+                        assert_same_state(&hasher, &actual, &expected, root, &context);
+                    }
+                }
+            }
+        }
+    }
+
     fn split_root_matches_recompute<F: Family>() {
         let hasher: H = Standard::new(ForwardFold);
         let plain = build::<F>(&hasher, 49);
@@ -1397,6 +1537,14 @@ mod tests {
         apply_batch_overwrite_only_ancestor::<crate::mmr::Family>();
     }
     #[test]
+    fn mmr_apply_batch_after_prune_matches_prune_after_apply() {
+        apply_batch_after_prune_matches_prune_after_apply::<crate::mmr::Family>();
+    }
+    #[test]
+    fn mmr_apply_batch_chain_after_prune_matches_prune_after_apply() {
+        apply_batch_chain_after_prune_matches_prune_after_apply::<crate::mmr::Family>();
+    }
+    #[test]
     fn mmr_split_root_matches_recompute() {
         split_root_matches_recompute::<crate::mmr::Family>();
     }
@@ -1502,6 +1650,14 @@ mod tests {
     #[test]
     fn mmb_apply_batch_overwrite_only_ancestor() {
         apply_batch_overwrite_only_ancestor::<crate::mmb::Family>();
+    }
+    #[test]
+    fn mmb_apply_batch_after_prune_matches_prune_after_apply() {
+        apply_batch_after_prune_matches_prune_after_apply::<crate::mmb::Family>();
+    }
+    #[test]
+    fn mmb_apply_batch_chain_after_prune_matches_prune_after_apply() {
+        apply_batch_chain_after_prune_matches_prune_after_apply::<crate::mmb::Family>();
     }
     #[test]
     fn mmb_split_root_matches_recompute() {

--- a/storage/src/merkle/mem.rs
+++ b/storage/src/merkle/mem.rs
@@ -403,8 +403,8 @@ impl<F: Family, D: Digest> Mem<F, D> {
 
     /// Apply a merkleized batch. Already-committed ancestors are skipped automatically.
     ///
-    /// Pruning this structure after the batch was merkleized does not invalidate the batch:
-    /// applying it yields the same state as applying it before the prune.
+    /// Pruning this structure after the batch was merkleized does not invalidate the batch: prune
+    /// and apply commute.
     ///
     /// # Errors
     ///
@@ -1366,57 +1366,73 @@ mod tests {
 
     /// Pruning between applying a parent and applying its child must not drop overwrites below
     /// the new boundary, whether they belong to the child or to an unapplied overwrite-only
-    /// ancestor in between.
+    /// ancestor in between. An applied overwrite-only parent leaves the size unchanged, so the
+    /// child cannot tell it was applied and re-applies it, which must not change the state.
     fn apply_batch_chain_after_prune_matches_prune_after_apply<F: Family>() {
         let hasher: H = Standard::new(ForwardFold);
         for n in 1..=12u64 {
             let mem = build_raw::<F>(&hasher, n);
             for update_loc in 0..n {
-                for (middle, append) in [(false, false), (false, true), (true, false), (true, true)]
-                {
-                    // Chain: Mem -> parent (append) [-> middle (overwrite only)] -> child.
-                    let parent = mem
-                        .new_batch()
-                        .add(&hasher, b"parent")
-                        .merkleize(&mem, &hasher);
-                    let child_parent = if middle {
-                        parent
-                            .new_batch()
-                            .update_leaf(&hasher, Location::new(0), b"middle")
-                            .unwrap()
-                            .merkleize(&mem, &hasher)
-                    } else {
-                        parent.clone()
-                    };
-                    let child = {
-                        let batch = child_parent
-                            .new_batch()
-                            .update_leaf(&hasher, Location::new(update_loc), b"child")
-                            .unwrap();
-                        let batch = if append {
-                            batch.add(&hasher, b"appended")
-                        } else {
-                            batch
+                for parent_append in [false, true] {
+                    for (middle, append) in
+                        [(false, false), (false, true), (true, false), (true, true)]
+                    {
+                        // Chain: Mem -> parent (append or overwrite only) [-> middle (overwrite
+                        // only)] -> child.
+                        let parent = {
+                            let batch = mem.new_batch();
+                            let batch = if parent_append {
+                                batch.add(&hasher, b"parent")
+                            } else {
+                                batch
+                                    .update_leaf(&hasher, Location::new(0), b"parent")
+                                    .unwrap()
+                            };
+                            batch.merkleize(&mem, &hasher)
                         };
-                        batch.merkleize(&mem, &hasher)
-                    };
-                    let root = child.root(&mem, &hasher, 0).unwrap();
-                    let case = format!("n={n} update={update_loc} middle={middle} append={append}");
+                        let child_parent = if middle {
+                            parent
+                                .new_batch()
+                                .update_leaf(&hasher, Location::new(0), b"middle")
+                                .unwrap()
+                                .merkleize(&mem, &hasher)
+                        } else {
+                            parent.clone()
+                        };
+                        let child = {
+                            let batch = child_parent
+                                .new_batch()
+                                .update_leaf(&hasher, Location::new(update_loc), b"child")
+                                .unwrap();
+                            let batch = if append {
+                                batch.add(&hasher, b"appended")
+                            } else {
+                                batch
+                            };
+                            batch.merkleize(&mem, &hasher)
+                        };
+                        let root = child.root(&mem, &hasher, 0).unwrap();
+                        let case = format!(
+                            "n={n} update={update_loc} parent_append={parent_append} \
+                             middle={middle} append={append}"
+                        );
 
-                    for prune_to in 1..=(n + 1) {
-                        let prune_to = Location::new(prune_to);
-                        let mut expected = mem.clone();
-                        expected.apply_batch(&parent).unwrap();
-                        expected.apply_batch(&child).unwrap();
-                        expected.prune(prune_to).unwrap();
+                        let leaves = n + u64::from(parent_append);
+                        for prune_to in 1..=leaves {
+                            let prune_to = Location::new(prune_to);
+                            let mut expected = mem.clone();
+                            expected.apply_batch(&parent).unwrap();
+                            expected.apply_batch(&child).unwrap();
+                            expected.prune(prune_to).unwrap();
 
-                        let mut actual = mem.clone();
-                        actual.apply_batch(&parent).unwrap();
-                        actual.prune(prune_to).unwrap();
-                        actual.apply_batch(&child).unwrap();
+                            let mut actual = mem.clone();
+                            actual.apply_batch(&parent).unwrap();
+                            actual.prune(prune_to).unwrap();
+                            actual.apply_batch(&child).unwrap();
 
-                        let context = format!("{case} prune={prune_to}");
-                        assert_same_state(&hasher, &actual, &expected, root, &context);
+                            let context = format!("{case} prune={prune_to}");
+                            assert_same_state(&hasher, &actual, &expected, root, &context);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary

Applying a merkleized batch after the `Mem` was pruned past a leaf that the batch overwrites was broken in two ways. A batch applied directly panicked while translating the pruned position into the retained-node deque. A child batch whose parent had already been committed returned `Ok(())` but skipped every overwrite below the new boundary, so the pinned peaks kept their old digests and the committed root differed from the root already computed for the batch.

## Fix

`Mem::apply_batch` now routes every overwrite, its own and each replayed ancestor's, through a single helper. Positions at or above the pruning boundary write the retained deque as before. Positions below it update the pinned node when one exists and are discarded otherwise, since a pruned node that is not pinned no longer contributes to the root or to any proof. Pruning after a batch has been merkleized therefore no longer invalidates it: prune and apply commute, and this is now documented on `apply_batch` and in the batch module docs. An unmerkleized batch still reads sibling digests from the base while merkleizing, so it must be merkleized before the base is pruned past any leaf it updates.

Installing rather than rejecting is deliberate. At apply time a committed overwrite-only ancestor, which is legitimately re-applied because it does not change the size, is indistinguishable from an unapplied one, so erroring on any below-boundary overwrite would reject the valid sequence "apply parent, prune, apply child". Updating the pinned node is correct in both cases and keeps the guarantee that `Ok(())` means the structure's root equals the batch's root.

## Reachability

No QMDB variant can reach the broken branches today, so this is not a production incident fix. The journal-backed and compact wrappers are append-only and never carry overwrites, which covers `any`, `keyless`, and `immutable`. The only in-tree `Mem` that receives overwrites is the `current` grafted tree, and two invariants keep every unapplied overwrite at or above its boundary: a batch only clears bits at locations that were active in its parent state, all at or above that state's inactivity floor, and `Current::prune` rejects targets past `sync_boundary` and prunes the bitmap and grafted tree to `sync_boundary` regardless of the requested location. The fork, prune, apply ordering itself is routine in glue (a block verified before a maintenance prune and finalized after it), but the only overwrites that land below the boundary there are re-applied committed ancestors, which the old skip and the new pinned-node write both leave unchanged.

The fix therefore removes `Mem`'s dependence on invariants that live two layers up, and closes the path through the raw `Mem` API, where the ordering is reachable directly.

## Tests

`apply_batch_after_prune_matches_prune_after_apply` and `apply_batch_chain_after_prune_matches_prune_after_apply` in `merkle::mem`, registered for both MMR and MMB, use "apply then prune" as the oracle for "prune then apply" across leaf counts, every overwritten leaf, every boundary past it, with and without appends, and with an unapplied overwrite-only ancestor in the chain. The chain test also runs with an overwrite-only parent, the shape glue produces: the parent leaves the size unchanged, so the child re-applies it through the pinned-node branch and the result must be identical. They compare the root, size, bounds, pinned set, and every node. Both failed before the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
