### PR TITLE
[storage] Fold peaks into the root without an intermediate Vec

### DIFF
--- a/storage/src/merkle/hasher.rs
+++ b/storage/src/merkle/hasher.rs
@@ -1,7 +1,6 @@
 //! Shared hasher trait and standard implementation for Merkle-family data structures.
 
 use crate::merkle::{Bagging, Error, Family, Location, Position};
-use alloc::vec::Vec;
 use commonware_cryptography::{Digest, Hasher as CHasher};
 use core::marker::PhantomData;
 
@@ -70,7 +69,7 @@ pub trait Hasher<F: Family>: Clone + Send + Sync {
     ) -> Result<Self::Digest, Error<F>>
     where
         I: IntoIterator<Item = &'a Self::Digest>,
-        I::IntoIter: ExactSizeIterator,
+        I::IntoIter: ExactSizeIterator + DoubleEndedIterator,
     {
         let iter = peak_digests.into_iter();
         let peaks = iter.len();
@@ -93,13 +92,17 @@ pub trait Hasher<F: Family>: Clone + Send + Sync {
     ///
     /// Returns `None` if `inactive_peaks_to_fold` exceeds the number of provided peak digests, or
     /// if a nonzero inactive boundary is requested for an empty tree.
-    fn root_with_folded_peaks<'a>(
+    fn root_with_folded_peaks<'a, I>(
         &self,
         leaves: Location<F>,
         inactive_peaks_to_fold: usize,
         committed_inactive_peaks: usize,
-        peak_digests: impl IntoIterator<Item = &'a Self::Digest>,
-    ) -> Option<Self::Digest> {
+        peak_digests: I,
+    ) -> Option<Self::Digest>
+    where
+        I: IntoIterator<Item = &'a Self::Digest>,
+        I::IntoIter: DoubleEndedIterator,
+    {
         let mut peak_digests = peak_digests.into_iter();
         let Some(first) = peak_digests.next() else {
             return (inactive_peaks_to_fold == 0 && committed_inactive_peaks == 0)
@@ -119,18 +122,11 @@ pub trait Hasher<F: Family>: Clone + Send + Sync {
                 }
                 acc
             }
-            Bagging::BackwardFold => {
-                let (lower, upper) = peak_digests.size_hint();
-                let mut active_peaks = Vec::with_capacity(1 + upper.unwrap_or(lower));
-                active_peaks.push(acc);
-                active_peaks.extend(peak_digests.copied());
-
-                let mut acc = *active_peaks.last().unwrap();
-                for peak in active_peaks.iter().rev().skip(1) {
-                    acc = self.fold(peak, &acc);
-                }
-                acc
-            }
+            Bagging::BackwardFold => peak_digests
+                .rev()
+                .copied()
+                .reduce(|bag, peak| self.fold(&peak, &bag))
+                .map_or(acc, |bag| self.fold(&acc, &bag)),
         };
 
         if committed_inactive_peaks == 0 {
@@ -256,18 +252,22 @@ impl<F: Family, T: Hasher<F>> Hasher<F> for &T {
     ) -> Result<Self::Digest, Error<F>>
     where
         I: IntoIterator<Item = &'a Self::Digest>,
-        I::IntoIter: ExactSizeIterator,
+        I::IntoIter: ExactSizeIterator + DoubleEndedIterator,
     {
         (**self).root(leaves, inactive_peaks, peak_digests)
     }
 
-    fn root_with_folded_peaks<'a>(
+    fn root_with_folded_peaks<'a, I>(
         &self,
         leaves: Location<F>,
         inactive_peaks_to_fold: usize,
         committed_inactive_peaks: usize,
-        peak_digests: impl IntoIterator<Item = &'a Self::Digest>,
-    ) -> Option<Self::Digest> {
+        peak_digests: I,
+    ) -> Option<Self::Digest>
+    where
+        I: IntoIterator<Item = &'a Self::Digest>,
+        I::IntoIter: DoubleEndedIterator,
+    {
         (**self).root_with_folded_peaks(
             leaves,
             inactive_peaks_to_fold,

--- a/storage/src/merkle/mem.rs
+++ b/storage/src/merkle/mem.rs
@@ -153,9 +153,16 @@ impl<F: Family, D: Digest> Mem<F, D> {
     ) -> Result<D, Error<F>> {
         let size = self.size();
         let leaves = Location::try_from(size).expect("invalid merkle size");
-        let peaks: Vec<&D> = F::peaks(size)
-            .map(|(p, _)| self.get_node_unchecked(p))
-            .collect();
+        // A u64 leaf count has at most 64 peaks, so a fixed buffer avoids a heap allocation.
+        let mut peaks = [Position::<F>::default(); 64];
+        let mut count = 0;
+        for (pos, _) in F::peaks(size) {
+            peaks[count] = pos;
+            count += 1;
+        }
+        let peaks = peaks[..count]
+            .iter()
+            .map(|&pos| self.get_node_unchecked(pos));
         hasher.root(leaves, inactive_peaks, peaks)
     }
 

--- a/storage/src/merkle/mod.rs
+++ b/storage/src/merkle/mod.rs
@@ -26,7 +26,6 @@ pub mod storage;
 #[cfg(feature = "std")]
 pub mod verification;
 
-use alloc::vec::Vec;
 use bytes::{Buf, BufMut};
 use commonware_codec::{EncodeSize, Read, Write};
 use commonware_cryptography::Digest;
@@ -133,8 +132,6 @@ pub trait Family: Copy + Clone + Debug + Default + Send + Sync + 'static {
         Self::peaks(prune_pos)
             .filter(move |&(pos, _)| pos < prune_pos)
             .map(|(pos, _)| pos)
-            .collect::<Vec<_>>()
-            .into_iter()
     }
 
     /// Return the positions of the left and right children of the node at `pos` with the

--- a/storage/src/merkle/proof.rs
+++ b/storage/src/merkle/proof.rs
@@ -382,8 +382,7 @@ impl<F: Family, D: Digest> Proof<F, D> {
             return None;
         }
 
-        let pinned_positions: Vec<_> = F::nodes_to_pin(start_loc).collect();
-        if pinned_positions.len() != pinned_nodes.len() {
+        if F::nodes_to_pin(start_loc).count() != pinned_nodes.len() {
             return None;
         }
 
@@ -396,8 +395,7 @@ impl<F: Family, D: Digest> Proof<F, D> {
         )
         .ok()?;
 
-        let mut pinned_map: BTreeMap<Position<F>, D> = pinned_positions
-            .into_iter()
+        let mut pinned_map: BTreeMap<Position<F>, D> = F::nodes_to_pin(start_loc)
             .zip(pinned_nodes.iter().copied())
             .collect();
 

--- a/storage/src/merkle/proof.rs
+++ b/storage/src/merkle/proof.rs
@@ -382,10 +382,6 @@ impl<F: Family, D: Digest> Proof<F, D> {
             return None;
         }
 
-        if F::nodes_to_pin(start_loc).count() != pinned_nodes.len() {
-            return None;
-        }
-
         let end_loc = start_loc.checked_add(elements.len() as u64)?;
         let bp = Blueprint::new(
             self.leaves,
@@ -395,9 +391,15 @@ impl<F: Family, D: Digest> Proof<F, D> {
         )
         .ok()?;
 
-        let mut pinned_map: BTreeMap<Position<F>, D> = F::nodes_to_pin(start_loc)
-            .zip(pinned_nodes.iter().copied())
-            .collect();
+        // Pair each pinned position with its digest, rejecting a count mismatch in either direction.
+        let mut pinned_map = BTreeMap::new();
+        let mut pinned_digests = pinned_nodes.iter();
+        for pos in F::nodes_to_pin(start_loc) {
+            pinned_map.insert(pos, *pinned_digests.next()?);
+        }
+        if pinned_digests.next().is_some() {
+            return None;
+        }
 
         // Fold-prefix peaks of the larger tree may have merged several pins together. Reconstruct
         // each peak's digest by hashing the pins beneath it up to the peak, then compare the


### PR DESCRIPTION
**Backward fold no longer copies the peaks.** `Hasher::root` and `root_with_folded_peaks` now require the peak iterator to be `DoubleEndedIterator` (slice and `Vec` iterators already are). `Bagging::BackwardFold` folds from `.rev()` directly instead of copying the peaks into a `Vec` first. This is QMDB's root bagging, so it runs on every commit, merkleize, and proof verification.

**`Mem::root` collects peak positions into a stack array.** An MMR with a `u64` leaf count has at most 64 peaks, so a `[Position<F>; 64]` replaces the `Vec<&D>`. The MMR peak iterator has no size hint, so the old `Vec` reallocated several times for large trees.

**`Family::nodes_to_pin` returns the lazy iterator.** The chain was already `Send` (it captures only a `Copy` position) and was collected into a `Vec` for no reason. The proof pinned-node check counts and zips the lazy iterator instead of collecting it.