### PR TITLE
[codec] Remove double bounds checks from fixed-int and varint paths

### DIFF
--- a/codec/src/types/mod.rs
+++ b/codec/src/types/mod.rs
@@ -108,7 +108,7 @@ where
 #[cfg(test)]
 pub(crate) mod tests {
     use crate::{BufsMut, Error, Read, Write};
-    use bytes::{Buf, BufMut, Bytes, BytesMut, buf::UninitSlice};
+    use bytes::{Buf, BufMut, Bytes, BytesMut, TryGetError, buf::UninitSlice};
 
     /// One-byte test type that uses the default aggregate hooks.
     ///
@@ -202,22 +202,22 @@ pub(crate) mod tests {
     /// Test [`Buf`] implementation that records how values are read.
     ///
     /// Specialization-selection tests use this to assert whether a container
-    /// read its payload with one aggregate [`Buf::copy_to_slice`] call or with
-    /// per-element [`Buf::get_u8`] calls.
+    /// read its payload with bulk reads (a slice copy, or a chunk consumed via
+    /// [`Buf::advance`]) or with per-byte reads.
     pub struct TrackingReadBuf {
         inner: Bytes,
-        /// Number of aggregate slice reads.
-        pub copy_to_slice_calls: usize,
+        /// Number of bulk reads.
+        pub bulk_read_calls: usize,
         /// Number of single-byte reads.
-        pub get_u8_calls: usize,
+        pub byte_read_calls: usize,
     }
 
     impl TrackingReadBuf {
         pub fn new(bytes: &'static [u8]) -> Self {
             Self {
                 inner: Bytes::from_static(bytes),
-                copy_to_slice_calls: 0,
-                get_u8_calls: 0,
+                bulk_read_calls: 0,
+                byte_read_calls: 0,
             }
         }
     }
@@ -232,17 +232,28 @@ pub(crate) mod tests {
         }
 
         fn advance(&mut self, cnt: usize) {
+            self.bulk_read_calls += 1;
             self.inner.advance(cnt)
         }
 
         fn copy_to_slice(&mut self, dst: &mut [u8]) {
-            self.copy_to_slice_calls += 1;
+            self.bulk_read_calls += 1;
             self.inner.copy_to_slice(dst);
         }
 
+        fn try_copy_to_slice(&mut self, dst: &mut [u8]) -> Result<(), TryGetError> {
+            self.bulk_read_calls += 1;
+            self.inner.try_copy_to_slice(dst)
+        }
+
         fn get_u8(&mut self) -> u8 {
-            self.get_u8_calls += 1;
+            self.byte_read_calls += 1;
             self.inner.get_u8()
+        }
+
+        fn try_get_u8(&mut self) -> Result<u8, TryGetError> {
+            self.byte_read_calls += 1;
+            self.inner.try_get_u8()
         }
     }
 }

--- a/codec/src/types/mod.rs
+++ b/codec/src/types/mod.rs
@@ -236,16 +236,6 @@ pub(crate) mod tests {
             self.inner.advance(cnt)
         }
 
-        fn copy_to_slice(&mut self, dst: &mut [u8]) {
-            self.bulk_read_calls += 1;
-            self.inner.copy_to_slice(dst);
-        }
-
-        fn try_copy_to_slice(&mut self, dst: &mut [u8]) -> Result<(), TryGetError> {
-            self.bulk_read_calls += 1;
-            self.inner.try_copy_to_slice(dst)
-        }
-
         fn get_u8(&mut self) -> u8 {
             self.byte_read_calls += 1;
             self.inner.get_u8()

--- a/codec/src/types/mod.rs
+++ b/codec/src/types/mod.rs
@@ -206,17 +206,17 @@ pub(crate) mod tests {
     pub struct TrackingReadBuf {
         inner: Bytes,
         /// Number of bulk reads.
-        pub bulk_read_calls: usize,
+        pub bulk_reads: usize,
         /// Number of single-byte reads.
-        pub byte_read_calls: usize,
+        pub byte_reads: usize,
     }
 
     impl TrackingReadBuf {
         pub fn new(bytes: &'static [u8]) -> Self {
             Self {
                 inner: Bytes::from_static(bytes),
-                bulk_read_calls: 0,
-                byte_read_calls: 0,
+                bulk_reads: 0,
+                byte_reads: 0,
             }
         }
     }
@@ -233,22 +233,22 @@ pub(crate) mod tests {
         }
 
         fn advance(&mut self, cnt: usize) {
-            self.bulk_read_calls += 1;
+            self.bulk_reads += 1;
             self.inner.advance(cnt)
         }
 
         fn get_u8(&mut self) -> u8 {
-            self.byte_read_calls += 1;
+            self.byte_reads += 1;
             self.inner.get_u8()
+        }
+
+        fn try_get_u8(&mut self) -> Result<u8, TryGetError> {
+            self.byte_reads += 1;
+            self.inner.try_get_u8()
         }
 
         fn copy_to_bytes(&mut self, len: usize) -> Bytes {
             self.inner.copy_to_bytes(len)
-        }
-
-        fn try_get_u8(&mut self) -> Result<u8, TryGetError> {
-            self.byte_read_calls += 1;
-            self.inner.try_get_u8()
         }
     }
 }

--- a/codec/src/types/primitives.rs
+++ b/codec/src/types/primitives.rs
@@ -47,8 +47,8 @@ macro_rules! impl_numeric {
                 buf.$try_read_method().map_err(|_| Error::EndOfBuffer)
             }
 
-            // Since the upfront size check guarantees the buffer contains every requested
-            // value, elements are read directly without per-element bounds checks.
+            // The upfront check bounds the allocation and lets the infallible getters
+            // below run without panicking.
             #[inline]
             fn read_vec(buf: &mut impl Buf, len: usize, _: &()) -> Result<Vec<Self>, Error> {
                 at_least_items(buf, len, Self::SIZE)?;
@@ -113,14 +113,7 @@ impl Read for u8 {
     fn read_vec(buf: &mut impl Buf, len: usize, _: &()) -> Result<Vec<Self>, Error> {
         at_least(buf, len)?;
         let mut values = Vec::with_capacity(len);
-        let mut remaining = len;
-        while remaining > 0 {
-            let chunk = buf.chunk();
-            let n = chunk.len().min(remaining);
-            values.extend_from_slice(&chunk[..n]);
-            buf.advance(n);
-            remaining -= n;
-        }
+        values.put(buf.take(len));
         Ok(values)
     }
 

--- a/codec/src/types/primitives.rs
+++ b/codec/src/types/primitives.rs
@@ -562,15 +562,15 @@ mod tests {
         let mut buf = TrackingReadBuf::new(&[0x01, 0x02, 0x03]);
         let value = <[u8; 3]>::read_cfg(&mut buf, &()).unwrap();
         assert_eq!(value, [1, 2, 3]);
-        assert_eq!(buf.copy_to_slice_calls, 1);
-        assert_eq!(buf.get_u8_calls, 0);
+        assert_eq!(buf.bulk_read_calls, 1);
+        assert_eq!(buf.byte_read_calls, 0);
 
         // Other array element types still read one element at a time.
         let mut buf = TrackingReadBuf::new(&[0x01, 0x02, 0x03]);
         let value = <[Byte; 3]>::read_cfg(&mut buf, &()).unwrap();
         assert_eq!(value, [Byte(1), Byte(2), Byte(3)]);
-        assert_eq!(buf.copy_to_slice_calls, 0);
-        assert_eq!(buf.get_u8_calls, 3);
+        assert_eq!(buf.bulk_read_calls, 0);
+        assert_eq!(buf.byte_read_calls, 3);
     }
 
     #[test]

--- a/codec/src/types/primitives.rs
+++ b/codec/src/types/primitives.rs
@@ -24,7 +24,7 @@ use crate::{
     varint::UInt,
 };
 #[cfg(not(feature = "std"))]
-use alloc::{vec, vec::Vec};
+use alloc::vec::Vec;
 use bytes::{Buf, BufMut};
 use core::num::{NonZeroU16, NonZeroU32, NonZeroU64};
 #[cfg(feature = "std")]
@@ -32,7 +32,7 @@ use std::vec::Vec;
 
 // Numeric types implementation
 macro_rules! impl_numeric {
-    ($type:ty, $read_method:ident, $write_method:ident) => {
+    ($type:ty, $try_read_method:ident, $read_method:ident, $write_method:ident) => {
         impl Write for $type {
             #[inline]
             fn write(&self, buf: &mut impl BufMut) {
@@ -44,8 +44,7 @@ macro_rules! impl_numeric {
             type Cfg = ();
             #[inline]
             fn read_cfg(buf: &mut impl Buf, _: &()) -> Result<Self, Error> {
-                at_least(buf, core::mem::size_of::<$type>())?;
-                Ok(buf.$read_method())
+                buf.$try_read_method().map_err(|_| Error::EndOfBuffer)
             }
 
             // Since the upfront size check guarantees the buffer contains every requested
@@ -73,17 +72,17 @@ macro_rules! impl_numeric {
     };
 }
 
-impl_numeric!(u16, get_u16, put_u16);
-impl_numeric!(u32, get_u32, put_u32);
-impl_numeric!(u64, get_u64, put_u64);
-impl_numeric!(u128, get_u128, put_u128);
-impl_numeric!(i8, get_i8, put_i8);
-impl_numeric!(i16, get_i16, put_i16);
-impl_numeric!(i32, get_i32, put_i32);
-impl_numeric!(i64, get_i64, put_i64);
-impl_numeric!(i128, get_i128, put_i128);
-impl_numeric!(f32, get_f32, put_f32);
-impl_numeric!(f64, get_f64, put_f64);
+impl_numeric!(u16, try_get_u16, get_u16, put_u16);
+impl_numeric!(u32, try_get_u32, get_u32, put_u32);
+impl_numeric!(u64, try_get_u64, get_u64, put_u64);
+impl_numeric!(u128, try_get_u128, get_u128, put_u128);
+impl_numeric!(i8, try_get_i8, get_i8, put_i8);
+impl_numeric!(i16, try_get_i16, get_i16, put_i16);
+impl_numeric!(i32, try_get_i32, get_i32, put_i32);
+impl_numeric!(i64, try_get_i64, get_i64, put_i64);
+impl_numeric!(i128, try_get_i128, get_i128, put_i128);
+impl_numeric!(f32, try_get_f32, get_f32, put_f32);
+impl_numeric!(f64, try_get_f64, get_f64, put_f64);
 
 impl Write for u8 {
     #[inline]
@@ -107,23 +106,29 @@ impl Read for u8 {
 
     #[inline]
     fn read_cfg(buf: &mut impl Buf, _: &()) -> Result<Self, Error> {
-        at_least(buf, 1)?;
-        Ok(buf.get_u8())
+        buf.try_get_u8().map_err(|_| Error::EndOfBuffer)
     }
 
     #[inline]
     fn read_vec(buf: &mut impl Buf, len: usize, _: &()) -> Result<Vec<Self>, Error> {
         at_least(buf, len)?;
-        let mut values = vec![0; len];
-        buf.copy_to_slice(&mut values);
+        let mut values = Vec::with_capacity(len);
+        let mut remaining = len;
+        while remaining > 0 {
+            let chunk = buf.chunk();
+            let n = chunk.len().min(remaining);
+            values.extend_from_slice(&chunk[..n]);
+            buf.advance(n);
+            remaining -= n;
+        }
         Ok(values)
     }
 
     #[inline]
     fn read_array<const N: usize>(buf: &mut impl Buf, _: &()) -> Result<[Self; N], Error> {
-        at_least(buf, N)?;
         let mut values = [0; N];
-        buf.copy_to_slice(&mut values);
+        buf.try_copy_to_slice(&mut values)
+            .map_err(|_| Error::EndOfBuffer)?;
         Ok(values)
     }
 }

--- a/codec/src/types/primitives.rs
+++ b/codec/src/types/primitives.rs
@@ -109,6 +109,7 @@ impl Read for u8 {
         buf.try_get_u8().map_err(|_| Error::EndOfBuffer)
     }
 
+    // The upfront check bounds the allocation and guarantees `take` yields exactly `len` bytes.
     #[inline]
     fn read_vec(buf: &mut impl Buf, len: usize, _: &()) -> Result<Vec<Self>, Error> {
         at_least(buf, len)?;
@@ -576,15 +577,15 @@ mod tests {
         let mut buf = TrackingReadBuf::new(&[0x01, 0x02, 0x03]);
         let value = <[u8; 3]>::read_cfg(&mut buf, &()).unwrap();
         assert_eq!(value, [1, 2, 3]);
-        assert_eq!(buf.bulk_read_calls, 1);
-        assert_eq!(buf.byte_read_calls, 0);
+        assert_eq!(buf.bulk_reads, 1);
+        assert_eq!(buf.byte_reads, 0);
 
         // Other array element types still read one element at a time.
         let mut buf = TrackingReadBuf::new(&[0x01, 0x02, 0x03]);
         let value = <[Byte; 3]>::read_cfg(&mut buf, &()).unwrap();
         assert_eq!(value, [Byte(1), Byte(2), Byte(3)]);
-        assert_eq!(buf.bulk_read_calls, 0);
-        assert_eq!(buf.byte_read_calls, 3);
+        assert_eq!(buf.bulk_reads, 0);
+        assert_eq!(buf.byte_reads, 3);
     }
 
     #[test]

--- a/codec/src/types/vec.rs
+++ b/codec/src/types/vec.rs
@@ -226,15 +226,15 @@ mod tests {
         let mut buf = TrackingReadBuf::new(&[0x03, 0x01, 0x02, 0x03]);
         let value = Vec::<u8>::read_cfg(&mut buf, &((..).into(), ())).unwrap();
         assert_eq!(value, vec![1, 2, 3]);
-        assert_eq!(buf.copy_to_slice_calls, 1);
-        assert_eq!(buf.get_u8_calls, 1);
+        assert_eq!(buf.bulk_read_calls, 1);
+        assert_eq!(buf.byte_read_calls, 1);
 
         // Other element types still read one element at a time.
         let mut buf = TrackingReadBuf::new(&[0x03, 0x01, 0x02, 0x03]);
         let value = Vec::<Byte>::read_cfg(&mut buf, &((..).into(), ())).unwrap();
         assert_eq!(value, vec![Byte(1), Byte(2), Byte(3)]);
-        assert_eq!(buf.copy_to_slice_calls, 0);
-        assert_eq!(buf.get_u8_calls, 4);
+        assert_eq!(buf.bulk_read_calls, 0);
+        assert_eq!(buf.byte_read_calls, 4);
     }
 
     #[test]

--- a/codec/src/types/vec.rs
+++ b/codec/src/types/vec.rs
@@ -226,15 +226,15 @@ mod tests {
         let mut buf = TrackingReadBuf::new(&[0x03, 0x01, 0x02, 0x03]);
         let value = Vec::<u8>::read_cfg(&mut buf, &((..).into(), ())).unwrap();
         assert_eq!(value, vec![1, 2, 3]);
-        assert_eq!(buf.bulk_read_calls, 1);
-        assert_eq!(buf.byte_read_calls, 1);
+        assert_eq!(buf.bulk_reads, 1);
+        assert_eq!(buf.byte_reads, 1);
 
         // Other element types still read one element at a time.
         let mut buf = TrackingReadBuf::new(&[0x03, 0x01, 0x02, 0x03]);
         let value = Vec::<Byte>::read_cfg(&mut buf, &((..).into(), ())).unwrap();
         assert_eq!(value, vec![Byte(1), Byte(2), Byte(3)]);
-        assert_eq!(buf.bulk_read_calls, 0);
-        assert_eq!(buf.byte_read_calls, 4);
+        assert_eq!(buf.bulk_reads, 0);
+        assert_eq!(buf.byte_reads, 4);
     }
 
     #[test]

--- a/codec/src/varint.rs
+++ b/codec/src/varint.rs
@@ -29,7 +29,7 @@
 //! assert_eq!(decoded, -3);
 //! ```
 
-use crate::{EncodeSize, Error, FixedSize, Read, ReadExt, Write};
+use crate::{EncodeSize, Error, FixedSize, Read, Write};
 use bytes::{Buf, BufMut};
 use core::{fmt::Debug, mem::size_of};
 use sealed::{SPrim, UPrim};
@@ -376,12 +376,16 @@ fn write<T: UPrim>(value: T, buf: &mut impl BufMut) {
         return;
     }
 
+    let mut bytes = [0u8; MAX_U128_VARINT_SIZE];
+    let mut len = 0;
     let mut val = value;
     while val >= continuation_threshold {
-        buf.put_u8((val.as_u8()) | CONTINUATION_BIT_MASK);
+        bytes[len] = val.as_u8() | CONTINUATION_BIT_MASK;
+        len += 1;
         val >>= 7;
     }
-    buf.put_u8(val.as_u8());
+    bytes[len] = val.as_u8();
+    buf.put_slice(&bytes[..=len]);
 }
 
 /// Decodes an unsigned integer from a varint.
@@ -390,13 +394,18 @@ fn write<T: UPrim>(value: T, buf: &mut impl BufMut) {
 /// - The varint is invalid (too long or malformed)
 /// - The buffer ends while reading
 fn read<T: UPrim>(buf: &mut impl Buf) -> Result<T, Error> {
+    // Fast path for single-byte values.
+    let mut byte = buf.try_get_u8().map_err(|_| Error::EndOfBuffer)?;
+    if byte & CONTINUATION_BIT_MASK == 0 {
+        return Ok(T::from(byte));
+    }
+
     let mut decoder = Decoder::<T>::new();
     loop {
-        // Read the next byte.
-        let byte = u8::read(buf)?;
         if let Some(value) = decoder.feed(byte)? {
             return Ok(value);
         }
+        byte = buf.try_get_u8().map_err(|_| Error::EndOfBuffer)?;
     }
 }
 

--- a/codec/src/varint.rs
+++ b/codec/src/varint.rs
@@ -376,6 +376,7 @@ fn write<T: UPrim>(value: T, buf: &mut impl BufMut) {
         return;
     }
 
+    // Stage the encoded bytes on the stack so the buffer receives a single bulk write.
     let mut bytes = [0u8; MAX_U128_VARINT_SIZE];
     let mut len = 0;
     let mut val = value;
@@ -400,6 +401,8 @@ fn read<T: UPrim>(buf: &mut impl Buf) -> Result<T, Error> {
         return Ok(T::from(byte));
     }
 
+    // The decoder enforces canonical encodings and rejects overflow for multi-byte values,
+    // starting with the byte already read.
     let mut decoder = Decoder::<T>::new();
     loop {
         if let Some(value) = decoder.feed(byte)? {


### PR DESCRIPTION
Removes redundant bounds checks and per-byte writes from the codec's integer and varint paths.

## Why

These functions sit under every integer, length prefix, `Vec<u8>` and `Bytes` in the wire and storage formats. Each one was doing slightly more work than it needed to:

- **Fixed-width reads** (`u16` through `u128`, signed ints, floats) called `at_least(buf, N)` and then `buf.get_uN()`. In `bytes` 1.12.1, `get_uN` is `try_get_uN().unwrap_or_else(panic)`, and `try_get_uN` starts with its own `remaining() < N` check. So every read checked the length twice and went through a closure.
- **Varint reads** went through `u8::read` per byte (the same double check) and built a `Decoder` even for one-byte values, which is nearly every length prefix. The write side already had a `value < 0x80` fast path; the read side did not.
- **Varint writes** called `put_u8` once per byte. `BytesMut` does not override `put_u8`, so each call ran the default `put_slice(&[n])`: a capacity check, `chunk_mut`, a copy, and `advance_mut`.
- **`u8::read_vec`** did `vec![0; len]` followed by `copy_to_slice`, so a memset then a memcpy, with `copy_to_slice` checking the length again.

## Change

- Fixed-width `read_cfg` now calls `try_get_*` directly and maps the error to `Error::EndOfBuffer`. The `read_vec` and `read_array` paths keep their single up-front size check and are unchanged.
- Varint `read` pulls the first byte and returns `T::from(byte)` when the continuation bit is clear. Multi-byte values go through the same `Decoder` as before, so the canonicality checks are untouched.
- Varint `write` encodes into a `[u8; MAX_U128_VARINT_SIZE]` stack buffer and calls `put_slice` once.
- `u8::read_vec` allocates with `Vec::with_capacity` and fills it with a single `put(buf.take(len))`, which copies chunk by chunk without the memset. `u8::read_array` uses `try_copy_to_slice` instead of a separate check followed by `copy_to_slice`.
