### PR TITLE
[glue, consensus, storage] Fix replayed-ancestor verdicts, recover boundary re-proposals on leader restart, bound resolver serve backlogs, and strengthen oracles

### DIFF
--- a/bench/src/bin/tests.rs
+++ b/bench/src/bin/tests.rs
@@ -11,6 +11,7 @@ use std::{
     collections::{BTreeMap, HashMap},
     env, fs,
     path::PathBuf,
+    sync::atomic::{AtomicUsize, Ordering},
 };
 
 const FIXTURE: &str = r#"{"module_path":"qmdb_gungraun::qmdb_merkleize::bench_merkleize","id":"any_unordered_fixed_mmr","profiles":[{"tool":"Callgrind","summaries":{"total":{"summary":{"Callgrind":{"Ir":{"metrics":{"Both":[{"Int":1000000},{"Int":900000}]}},"L1hits":{"metrics":{"Both":[{"Int":850000},{"Int":800000}]}},"LLhits":{"metrics":{"Both":[{"Int":120000},{"Int":110000}]}},"RamHits":{"metrics":{"Both":[{"Int":30000},{"Int":25000}]}},"TotalRW":{"metrics":{"Both":[{"Int":300000},{"Int":280000}]}},"EstimatedCycles":{"metrics":{"Both":[{"Int":1450000},{"Int":1300000}]}}}}}}}]}
@@ -431,14 +432,28 @@ fn custom_metric_benchmark() -> Benchmark {
 }
 
 fn unique_temp_dir() -> PathBuf {
+    // Tests run as separate processes at the same instant, so the timestamp
+    // alone can collide and one test would remove another's directory.
+    static COUNTER: AtomicUsize = AtomicUsize::new(0);
     let mut path = env::temp_dir();
     path.push(format!(
-        "benchmark-tracker-{}",
+        "benchmark-tracker-{}-{}-{}",
+        std::process::id(),
         std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
-            .as_nanos()
+            .as_nanos(),
+        COUNTER.fetch_add(1, Ordering::Relaxed)
     ));
     fs::create_dir_all(&path).unwrap();
     path
+}
+
+#[test]
+fn unique_temp_dir_never_repeats() {
+    let first = unique_temp_dir();
+    let second = unique_temp_dir();
+    assert_ne!(first, second);
+    fs::remove_dir_all(first).unwrap();
+    fs::remove_dir_all(second).unwrap();
 }

--- a/consensus/fuzz/src/invariants.rs
+++ b/consensus/fuzz/src/invariants.rs
@@ -168,10 +168,12 @@ pub fn check<P: Simplex>(
         // Invariant: no_nullification_in_finalized_view
         // If any replica finalized view v, no replica may have a nullification
         // that covers v (a nullification covers the rest of its term).
-        let finalized_views: HashMap<u64, Sha256Digest> = replicas
+        let finalized_views: HashMap<u64, (Sha256Digest, u64)> = replicas
             .iter()
             .flat_map(|(_, _, finalizations)| {
-                finalizations.iter().map(|(&view, d)| (view, d.payload))
+                finalizations
+                    .iter()
+                    .map(|(&view, d)| (view, (d.payload, d.parent)))
             })
             .collect();
         let nullified: HashSet<u64> = replicas
@@ -188,49 +190,60 @@ pub fn check<P: Simplex>(
         }
 
         // Invariant: no_conflicting_notarization_in_finalized_view
-        // If any replica finalized view v for a digest, no replica may have a notarization for a different digest.
+        // If any replica finalized view v for a proposal, no replica may have a
+        // notarization for a different proposal. Certificates sign the parent
+        // alongside the payload, so a differing parent is a different proposal.
         for (idx, (notarizations, _, _)) in replicas.iter().enumerate() {
             for (&view, data) in notarizations.iter() {
-                if let Some(&finalized_digest) = finalized_views.get(&view) {
+                if let Some(&(finalized_payload, finalized_parent)) = finalized_views.get(&view) {
                     assert_eq!(
-                        finalized_digest, data.payload,
-                        "Invariant violation: replica {idx} notarized view {view} with {:?} but finalized with {finalized_digest:?}",
-                        data.payload
+                        (finalized_payload, finalized_parent),
+                        (data.payload, data.parent),
+                        "Invariant violation: replica {idx} notarized view {view} with ({:?}, {}) but finalized with ({finalized_payload:?}, {finalized_parent})",
+                        data.payload,
+                        data.parent
                     );
                 }
             }
         }
 
         // Invariant: no_conflicting_quorum_notarizations
-        // In any view, there cannot be quorum notarizations for multiple digests.
-        let mut per_view: HashMap<u64, HashSet<Sha256Digest>> = HashMap::new();
+        // In any view, there cannot be quorum notarizations for multiple proposals.
+        let mut per_view: HashMap<u64, HashSet<(Sha256Digest, u64)>> = HashMap::new();
         for (notarizations, _, _) in replicas.iter() {
             for (v, d) in notarizations {
                 let is_quorum = d.signature_count.is_none_or(|c| c >= threshold);
                 if is_quorum {
-                    per_view.entry(*v).or_default().insert(d.payload);
+                    per_view
+                        .entry(*v)
+                        .or_default()
+                        .insert((d.payload, d.parent));
                 }
             }
         }
-        for (v, payloads) in per_view {
+        for (v, proposals) in per_view {
             assert!(
-                payloads.len() <= 1,
-                "Invariant violation: conflicting quorum notarizations in view {v}: {payloads:?}"
+                proposals.len() <= 1,
+                "Invariant violation: conflicting quorum notarizations in view {v}: {proposals:?}"
             );
         }
 
         // Invariant: finalization_requires_notarization
-        // Any finalization must be backed by some notarization for the same (view, payload).
-        let notarized: HashSet<(u64, Sha256Digest)> = replicas
+        // Any finalization must be backed by some notarization for the same
+        // (view, payload, parent).
+        let notarized: HashSet<(u64, Sha256Digest, u64)> = replicas
             .iter()
-            .flat_map(|(notarizations, _, _)| notarizations.iter().map(|(&v, d)| (v, d.payload)))
+            .flat_map(|(notarizations, _, _)| {
+                notarizations.iter().map(|(&v, d)| (v, d.payload, d.parent))
+            })
             .collect();
         for (_, _, finalizations) in replicas.iter() {
             for (&v, d) in finalizations.iter() {
                 assert!(
-                    notarized.contains(&(v, d.payload)),
-                    "Invariant violation: finalization without notarization: view {v}, payload={:?}",
-                    d.payload
+                    notarized.contains(&(v, d.payload, d.parent)),
+                    "Invariant violation: finalization without notarization: view {v}, payload={:?}, parent={}",
+                    d.payload,
+                    d.parent
                 );
             }
         }
@@ -338,6 +351,7 @@ where
                         view.get(),
                         Notarization {
                             payload: cert.proposal.payload,
+                            parent: cert.proposal.parent.get(),
                             signature_count: get_signature_count::<S>(
                                 &cert.certificate,
                                 max_participants,
@@ -418,6 +432,7 @@ mod tests {
             3,
             Notarization {
                 payload,
+                parent: 2,
                 signature_count: Some(3),
             },
         );
@@ -460,6 +475,7 @@ mod tests {
                 3,
                 Notarization {
                     payload,
+                    parent,
                     signature_count: Some(3),
                 },
             );
@@ -539,6 +555,7 @@ mod tests {
                 view,
                 Notarization {
                     payload,
+                    parent,
                     signature_count: Some(3),
                 },
             );
@@ -576,6 +593,7 @@ mod tests {
                 4,
                 Notarization {
                     payload,
+                    parent: 2,
                     signature_count: Some(3),
                 },
             );
@@ -615,6 +633,7 @@ mod tests {
                 11,
                 Notarization {
                     payload,
+                    parent: 3,
                     signature_count: Some(3),
                 },
             );
@@ -712,6 +731,80 @@ mod tests {
         );
         assert!(
             message.contains("finalization without notarization"),
+            "wrong invariant fired: {message}"
+        );
+    }
+
+    #[test]
+    fn notarization_parent_mismatch_with_finalization_fires() {
+        let payload = Sha256Digest::from([11u8; 32]);
+        let mut notarizations = HashMap::new();
+        notarizations.insert(
+            3,
+            Notarization {
+                payload,
+                parent: 1,
+                signature_count: Some(3),
+            },
+        );
+        let mut finalizations = HashMap::new();
+
+        // Parent 2 keeps the ancestry rules satisfied, so the first arm to
+        // fire is the notarization naming a different parent for the same
+        // payload (the unbacked finalization would fire next).
+        finalizations.insert(
+            3,
+            Finalization {
+                payload,
+                parent: 2,
+                signature_count: Some(3),
+            },
+        );
+
+        let message = check_panics(
+            N4F1C3,
+            TermLength::new(NZU32!(5)),
+            vec![(notarizations, HashMap::new(), finalizations)],
+        );
+        assert!(
+            message.contains("notarized view 3"),
+            "wrong invariant fired: {message}"
+        );
+    }
+
+    #[test]
+    fn quorum_notarization_parent_conflict_fires() {
+        let payload = Sha256Digest::from([12u8; 32]);
+        let replica = |parent| {
+            let mut notarizations = HashMap::new();
+            notarizations.insert(
+                3,
+                Notarization {
+                    payload,
+                    parent,
+                    signature_count: Some(3),
+                },
+            );
+            (notarizations, HashMap::new(), HashMap::new())
+        };
+
+        // Without an honest quorum the parent is not trustworthy, so the rule
+        // must not fire (see `parent_mismatch_requires_honest_quorum`).
+        check::<SimplexEd25519>(
+            N4F3C1,
+            TermLength::new(NZU32!(5)),
+            vec![replica(1), replica(2)],
+        );
+
+        // Two quorum notarizations for the same payload but different parents
+        // are different proposals, so they conflict.
+        let message = check_panics(
+            N4F1C3,
+            TermLength::new(NZU32!(5)),
+            vec![replica(1), replica(2)],
+        );
+        assert!(
+            message.contains("conflicting quorum notarizations in view 3"),
             "wrong invariant fired: {message}"
         );
     }

--- a/consensus/fuzz/src/types.rs
+++ b/consensus/fuzz/src/types.rs
@@ -14,6 +14,8 @@ pub enum Message {
 
 pub struct Notarization {
     pub payload: Sha256Digest,
+    /// View of the notarized proposal's parent.
+    pub parent: u64,
     /// None for threshold schemes where count is not exposed.
     pub signature_count: Option<usize>,
 }

--- a/consensus/src/marshal/coding/marshaled.rs
+++ b/consensus/src/marshal/coding/marshaled.rs
@@ -730,14 +730,22 @@ where
                 // block is the only proposal we can broadcast for this round.
                 //
                 // The recovered block is safe to reuse only if its embedded
-                // context matches the context simplex just recovered.
+                // context matches the context simplex just recovered, or if it
+                // is the parent itself: a boundary re-proposal stores the parent
+                // under its original context, whose round is the parent's own.
                 // Otherwise the cached block was built against a different
                 // parent and cannot be broadcast under the current header, so
                 // drop the receiver and let the voter nullify the view via
                 // timeout.
+                let last_in_epoch = epocher
+                    .last(consensus_context.epoch())
+                    .expect("current epoch should exist");
                 if let Some(block) = marshal.get_verified(consensus_context.round).await {
                     let block_context = block.context();
-                    if block_context != consensus_context {
+                    let commitment = block.commitment();
+                    let reproposal =
+                        commitment == consensus_context.parent.1 && block.height() == last_in_epoch;
+                    if !reproposal && block_context != consensus_context {
                         debug!(
                             round = ?consensus_context.round,
                             ?consensus_context,
@@ -750,11 +758,11 @@ where
                     // its shards through the same handshake as a fresh
                     // proposal. The relay-time persist deduplicates against the
                     // pre-crash write, with the handle covering the original.
-                    let commitment = block.commitment();
                     let round = consensus_context.round;
                     debug!(
                         ?round,
                         ?commitment,
+                        reproposal,
                         "reusing verified block from marshal on leader recovery"
                     );
                     gates
@@ -802,9 +810,6 @@ where
                 // Special case: If the parent block is the last block in the epoch,
                 // re-propose it as to not produce any blocks that will be cut out
                 // by the epoch transition.
-                let last_in_epoch = epocher
-                    .last(consensus_context.epoch())
-                    .expect("current epoch should exist");
                 if parent.height() == last_in_epoch {
                     let commitment = parent.commitment();
                     let round = consensus_context.round;
@@ -947,7 +952,7 @@ where
         // original proposal view.
         //
         // Re-proposals also skip shard-validity and deferred verification because:
-        // 1. The block was already verified when originally proposed
+        // 1. Consensus settles the block's validity when certifying the view that first carried it
         // 2. The parent-child height check would fail (parent IS the block)
         // 3. Waiting for shards could stall if the leader doesn't rebroadcast
         if is_reproposal {

--- a/consensus/src/marshal/coding/marshaled.rs
+++ b/consensus/src/marshal/coding/marshaled.rs
@@ -731,8 +731,8 @@ where
                 //
                 // The recovered block is safe to reuse only if its embedded
                 // context matches the context simplex just recovered, or if it
-                // is the parent itself: a boundary re-proposal stores the parent
-                // under its original context, whose round is the parent's own.
+                // is the parent re-proposed at the epoch boundary: that stores the
+                // parent under its original context, whose round is the parent's own.
                 // Otherwise the cached block was built against a different
                 // parent and cannot be broadcast under the current header, so
                 // drop the receiver and let the voter nullify the view via

--- a/consensus/src/marshal/coding/mod.rs
+++ b/consensus/src/marshal/coding/mod.rs
@@ -2910,6 +2910,99 @@ mod tests {
         })
     }
 
+    /// Without a registered gate, certify runs the application against the
+    /// block's embedded context. A live rejection there must reach consensus.
+    #[test_traced("WARN")]
+    fn test_certify_without_prior_verify_honors_application_rejection() {
+        let runner = deterministic::Runner::timed(Duration::from_secs(30));
+        runner.start(|mut context| async move {
+            let Fixture {
+                participants,
+                schemes,
+                ..
+            } = bls12381_threshold_vrf::fixture::<V, _>(&mut context, NAMESPACE, NUM_VALIDATORS);
+            let mut oracle = setup_network_with_participants(
+                context.child("network"),
+                NZUsize!(1),
+                participants.clone(),
+            )
+            .await;
+
+            let me = participants[0].clone();
+            let coding_config = coding_config_for_participants(NUM_VALIDATORS as u16);
+
+            let setup = CodingHarness::setup_validator(
+                context.child("validator").with_attribute("index", 0),
+                &mut oracle,
+                me.clone(),
+                ConstantProvider::new(schemes[0].clone()),
+            )
+            .await;
+            let marshal = setup.mailbox;
+            let shards = setup.extra;
+
+            let genesis_ctx = CodingCtx {
+                round: Round::zero(),
+                leader: default_leader(),
+                parent: (View::zero(), genesis_commitment()),
+            };
+            let genesis = make_coding_block(genesis_ctx, Sha256::hash(&[b""]), Height::zero(), 0);
+
+            let mock_app: MockVerifyingApp<CodingB, S> =
+                MockVerifyingApp::with_verify_result(false);
+            let cfg = MarshaledConfig {
+                application: mock_app,
+                marshal: marshal.clone(),
+                shards: shards.clone(),
+                scheme_provider: ConstantProvider::new(schemes[0].clone()),
+                epocher: FixedEpocher::new(BLOCKS_PER_EPOCH),
+                strategy: Sequential,
+            };
+            let mut marshaled = Marshaled::new(context.child("marshaled"), cfg);
+
+            // Create parent at height 1.
+            let parent_round = Round::new(Epoch::zero(), View::new(1));
+            let parent_ctx = CodingCtx {
+                round: parent_round,
+                leader: default_leader(),
+                parent: (View::zero(), genesis_commitment()),
+            };
+            let parent = make_coding_block(parent_ctx, genesis.digest(), Height::new(1), 100);
+            let coded_parent = CodedBlock::new(parent.clone(), coding_config, &Sequential);
+            let parent_commitment = coded_parent.commitment();
+            shards.proposed(parent_round, coded_parent);
+
+            // Create child at height 2.
+            let child_round = Round::new(Epoch::zero(), View::new(2));
+            let child_ctx = CodingCtx {
+                round: child_round,
+                leader: me.clone(),
+                parent: (View::new(1), parent_commitment),
+            };
+            let child = make_coding_block(child_ctx, parent.digest(), Height::new(2), 200);
+            let coded_child = CodedBlock::new(child, coding_config, &Sequential);
+            let child_commitment = coded_child.commitment();
+            shards.proposed(child_round, coded_child);
+
+            context.sleep(Duration::from_millis(10)).await;
+
+            // No prior verify, so no gate exists and certify falls through to
+            // the embedded-context path.
+            let certify_rx = marshaled.certify(child_round, child_commitment).await;
+            select! {
+                result = certify_rx => {
+                    assert!(
+                        !result.expect("certify result missing"),
+                        "certify must propagate the application rejection"
+                    );
+                },
+                _ = context.sleep(Duration::from_secs(5)) => {
+                    panic!("certify should resolve promptly");
+                },
+            }
+        })
+    }
+
     /// A Byzantine leader can deliver assigned shards to only f+1 honest
     /// validators and form a notarization with its own vote, leaving no peer
     /// able to serve a full-block fetch. A validator that never saw the
@@ -3977,6 +4070,113 @@ mod tests {
                 },
                 _ = verify_started => {
                     panic!("certifying a recovered proposal must not run app verification");
+                },
+            }
+        });
+    }
+
+    /// Regression: a boundary re-proposal stores the parent block itself at
+    /// the re-proposal round, under the parent's original embedded context.
+    /// A leader that crashes after that relay broadcast must recognize the
+    /// cached parent as the re-proposal on restart and propose it again,
+    /// rather than skipping the round because its embedded context names an
+    /// older round.
+    #[test_traced("WARN")]
+    fn test_propose_reuses_reproposed_boundary_block_on_restart() {
+        let runner = deterministic::Runner::timed(Duration::from_secs(60));
+        runner.start(|mut context| async move {
+            let Fixture {
+                participants,
+                schemes,
+                ..
+            } = bls12381_threshold_vrf::fixture::<V, _>(&mut context, NAMESPACE, NUM_VALIDATORS);
+            let mut oracle = setup_network_with_participants(
+                context.child("network"),
+                NZUsize!(1),
+                participants.clone(),
+            )
+            .await;
+
+            let me = participants[0].clone();
+            let coding_config = coding_config_for_participants(NUM_VALIDATORS as u16);
+
+            let setup = CodingHarness::setup_validator(
+                context.child("validator").with_attribute("index", 0),
+                &mut oracle,
+                me.clone(),
+                ConstantProvider::new(schemes[0].clone()),
+            )
+            .await;
+            let marshal = setup.mailbox;
+            let shards = setup.extra;
+
+            let genesis_ctx = CodingCtx {
+                round: Round::zero(),
+                leader: default_leader(),
+                parent: (View::zero(), genesis_commitment()),
+            };
+            let genesis = make_coding_block(genesis_ctx, Sha256::hash(&[b""]), Height::zero(), 0);
+            let genesis_parent_commitment = genesis_coding_commitment(&genesis);
+
+            // Seed the boundary block at the re-proposal round, where the
+            // pre-crash relay broadcast of the re-proposal persisted it.
+            let boundary_height = Height::new(BLOCKS_PER_EPOCH.get() - 1);
+            let boundary_round = Round::new(Epoch::zero(), View::new(boundary_height.get()));
+            let boundary_ctx = CodingCtx {
+                round: boundary_round,
+                leader: default_leader(),
+                parent: (View::zero(), genesis_parent_commitment),
+            };
+            let boundary_block =
+                make_coding_block(boundary_ctx, genesis.digest(), boundary_height, 1900);
+            let coded_boundary: CodedBlock<_, ReedSolomon<Sha256>, Sha256> =
+                CodedBlock::new(boundary_block, coding_config, &Sequential);
+            let boundary_commitment = coded_boundary.commitment();
+            let round = Round::new(Epoch::zero(), View::new(boundary_height.get() + 1));
+            assert!(marshal.verified(round, coded_boundary).await);
+
+            let ctx = CodingCtx {
+                round,
+                leader: me.clone(),
+                parent: (View::new(boundary_height.get()), boundary_commitment),
+            };
+
+            // The app cannot build and its verification never completes, so
+            // the assertions below hold only if the cached parent is
+            // re-proposed as-is.
+            let (mock_app, verify_started, _release_verify): (GatedVerifyingApp<CodingB, S>, _, _) =
+                GatedVerifyingApp::new();
+            let cfg = MarshaledConfig {
+                application: mock_app,
+                marshal: marshal.clone(),
+                shards: shards.clone(),
+                scheme_provider: ConstantProvider::new(schemes[0].clone()),
+                epocher: FixedEpocher::new(BLOCKS_PER_EPOCH),
+                strategy: Sequential,
+            };
+            let mut marshaled = Marshaled::new(context.child("marshaled"), cfg);
+
+            let commitment = marshaled
+                .propose(ctx)
+                .await
+                .await
+                .expect("propose must return a commitment");
+            assert_eq!(
+                commitment, boundary_commitment,
+                "propose must re-propose the boundary block marshal already persisted for this round"
+            );
+
+            let _ = marshaled.broadcast(commitment, Plan::Propose { round });
+            let certify_rx = marshaled.certify(round, commitment).await;
+            select! {
+                result = certify_rx => {
+                    assert!(
+                        result.expect("certify result missing"),
+                        "re-proposed boundary block must certify through the relay handshake"
+                    );
+                },
+                _ = verify_started => {
+                    panic!("certifying a re-proposed boundary block must not run app verification");
                 },
             }
         });

--- a/consensus/src/marshal/core/mailbox.rs
+++ b/consensus/src/marshal/core/mailbox.rs
@@ -164,7 +164,7 @@ pub(crate) enum Message<S: Scheme, V: Variant> {
     Verified {
         /// The span carried with this request.
         span: Span,
-        /// The round in which the block was verified.
+        /// The round of the verify request.
         round: Round,
         /// The block.
         block: Arc<V::Block>,
@@ -176,7 +176,7 @@ pub(crate) enum Message<S: Scheme, V: Variant> {
     Certified {
         /// The span carried with this request.
         span: Span,
-        /// The round in which the block was certified.
+        /// The round of the certify request.
         round: Round,
         /// The block.
         block: Arc<V::Block>,

--- a/consensus/src/marshal/core/mailbox.rs
+++ b/consensus/src/marshal/core/mailbox.rs
@@ -159,24 +159,26 @@ pub(crate) enum Message<S: Scheme, V: Variant> {
         /// A channel sent once the block sync has started.
         ack: oneshot::Sender<Handle<()>>,
     },
-    /// A notification that a block has been verified by the application.
+    /// A notification that a block reached the verify stage. Persisting it
+    /// does not imply application validity.
     Verified {
         /// The span carried with this request.
         span: Span,
         /// The round in which the block was verified.
         round: Round,
-        /// The verified block.
+        /// The block.
         block: Arc<V::Block>,
         /// A channel sent once the block sync has started.
         ack: oneshot::Sender<Handle<()>>,
     },
-    /// A notification that a block has been certified by the application.
+    /// A notification that a block reached the certify stage. Persisting it
+    /// does not imply application validity.
     Certified {
         /// The span carried with this request.
         span: Span,
         /// The round in which the block was certified.
         round: Round,
-        /// The certified block.
+        /// The block.
         block: Arc<V::Block>,
         /// A channel sent once the block and notarization syncs have started; the
         /// handle covers both.
@@ -912,7 +914,7 @@ impl<S: Scheme, V: Variant> Mailbox<S, V> {
         });
     }
 
-    /// Notifies the actor that a block has been verified.
+    /// Notifies the actor that a block reached the verify stage.
     ///
     /// Returns after the block is durably persisted. Mirrors [Self::certified]: the
     /// durable sync is awaited on the caller's task (off the actor), so the actor
@@ -927,7 +929,7 @@ impl<S: Scheme, V: Variant> Mailbox<S, V> {
         handle.durable(round, "verified").await
     }
 
-    /// Notifies the actor that a block has been certified.
+    /// Notifies the actor that a block reached the certify stage.
     ///
     /// Returns after the block is durably persisted.
     #[must_use = "callers must consider block durability before proceeding"]

--- a/consensus/src/marshal/resolver/handler.rs
+++ b/consensus/src/marshal/resolver/handler.rs
@@ -51,7 +51,7 @@ impl<D: Digest> Message<D> {
     }
 }
 
-/// Pending resolver handler messages retained after the mailbox fills.
+/// Deliveries retained while the ready queue is full.
 pub(crate) struct Pending<D: Digest>(VecDeque<Message<D>>);
 
 impl<D: Digest> Default for Pending<D> {
@@ -86,10 +86,14 @@ impl<D: Digest> Policy for Message<D> {
     type Overflow = Pending<D>;
 
     fn handle(overflow: &mut Self::Overflow, message: Self) {
-        if message.response_closed() {
-            return;
+        // Deliveries are retained until the actor has room. Produce requests
+        // are dropped so the serve backlog stays bounded by the ready queue,
+        // and the peer sees the closed response as an error.
+        if let Self::Deliver { response, .. } = &message
+            && !response.is_closed()
+        {
+            overflow.0.push_back(message);
         }
-        overflow.0.push_back(message);
     }
 }
 
@@ -511,50 +515,69 @@ mod tests {
         Hasher as _,
         sha256::{Digest as Sha256Digest, Sha256},
     };
+    use commonware_utils::vec::NonEmptyVec;
     use std::collections::BTreeSet;
 
     type D = Sha256Digest;
 
     #[test]
-    fn handler_drain_skips_closed_responses() {
+    fn handle_retains_open_deliveries_only() {
         let mut overflow = Pending::<D>::default();
+        let deliver = |height: u64, response| Message::Deliver {
+            delivery: Delivery {
+                key: Key::Finalized {
+                    height: Height::new(height),
+                },
+                subscribers: NonEmptyVec::new((
+                    Annotation::Finalized(Finalized::ByHeight {
+                        height: Height::new(height),
+                    }),
+                    tracing::Span::none(),
+                )),
+            },
+            value: Bytes::new(),
+            response,
+        };
 
-        let (closed_response, closed_receiver) = oneshot::channel();
+        // An overflowed produce request is dropped and its requester sees the
+        // closed response.
+        let (response, mut produce) = oneshot::channel();
         Message::handle(
             &mut overflow,
             Message::Produce {
                 key: Key::Finalized {
                     height: Height::new(1),
                 },
-                response: closed_response,
+                response,
             },
         );
-        drop(closed_receiver);
+        assert!(matches!(
+            produce.try_recv(),
+            Err(oneshot::error::TryRecvError::Closed)
+        ));
 
-        let (open_response, _open_receiver) = oneshot::channel();
-        Message::handle(
-            &mut overflow,
-            Message::Produce {
-                key: Key::Finalized {
-                    height: Height::new(2),
-                },
-                response: open_response,
-            },
-        );
+        // Deliveries are retained, and drain skips one whose requester left.
+        let (response, closed) = oneshot::channel();
+        Message::handle(&mut overflow, deliver(2, response));
+        let (response, _open) = oneshot::channel();
+        Message::handle(&mut overflow, deliver(3, response));
+        drop(closed);
 
         let mut messages = Vec::new();
         Overflow::drain(&mut overflow, |message| {
             messages.push(message);
             None
         });
-
         assert_eq!(messages.len(), 1);
         assert!(matches!(
             messages.pop(),
-            Some(Message::Produce {
-                key: Key::Finalized { height },
+            Some(Message::Deliver {
+                delivery: Delivery {
+                    key: Key::Finalized { height },
+                    ..
+                },
                 ..
-            }) if height == Height::new(2)
+            }) if height == Height::new(3)
         ));
     }
 

--- a/consensus/src/marshal/resolver/handler.rs
+++ b/consensus/src/marshal/resolver/handler.rs
@@ -86,14 +86,18 @@ impl<D: Digest> Policy for Message<D> {
     type Overflow = Pending<D>;
 
     fn handle(overflow: &mut Self::Overflow, message: Self) {
-        // Deliveries are retained until the actor has room. Produce requests
-        // are dropped so the serve backlog stays bounded by the ready queue,
-        // and the peer sees the closed response as an error.
-        if let Self::Deliver { response, .. } = &message
-            && !response.is_closed()
-        {
-            overflow.0.push_back(message);
+        // Drop produce requests so the serve backlog stays bounded by the ready
+        // queue. We prefer handling our own responses over serving peers, who can
+        // ask a less loaded peer instead.
+        if matches!(message, Self::Produce { .. }) {
+            return;
         }
+
+        // Retain deliveries that still have a waiting requester.
+        if message.response_closed() {
+            return;
+        }
+        overflow.0.push_back(message);
     }
 }
 

--- a/consensus/src/marshal/standard/deferred.rs
+++ b/consensus/src/marshal/standard/deferred.rs
@@ -539,8 +539,8 @@ where
                 //
                 // The recovered block is safe to reuse only if its embedded
                 // context matches the context simplex just recovered, or if it
-                // is the parent itself: a boundary re-proposal stores the parent
-                // under its original context, whose round is the parent's own.
+                // is the parent re-proposed at the epoch boundary: that stores the
+                // parent under its original context, whose round is the parent's own.
                 // Otherwise the cached block was built against a different
                 // parent and cannot be broadcast under the current header, so
                 // drop the receiver and let the voter nullify the view via

--- a/consensus/src/marshal/standard/deferred.rs
+++ b/consensus/src/marshal/standard/deferred.rs
@@ -538,13 +538,22 @@ where
                 // the only proposal we can broadcast for this round.
                 //
                 // The recovered block is safe to reuse only if its embedded
-                // context matches the context simplex just recovered. Otherwise the
-                // cached block was built against a different parent and cannot be
-                // broadcast under the current header, so drop the receiver
-                // and let the voter nullify the view via timeout.
+                // context matches the context simplex just recovered, or if it
+                // is the parent itself: a boundary re-proposal stores the parent
+                // under its original context, whose round is the parent's own.
+                // Otherwise the cached block was built against a different
+                // parent and cannot be broadcast under the current header, so
+                // drop the receiver and let the voter nullify the view via
+                // timeout.
+                let last_in_epoch = epocher
+                    .last(consensus_context.epoch())
+                    .expect("current epoch should exist");
                 if let Some(block) = marshal.get_verified(consensus_context.round).await {
                     let block_context = block.context();
-                    if block_context != consensus_context {
+                    let digest = block.digest();
+                    let reproposal =
+                        digest == consensus_context.parent.1 && block.height() == last_in_epoch;
+                    if !reproposal && block_context != consensus_context {
                         debug!(
                             round = ?consensus_context.round,
                             ?consensus_context,
@@ -557,10 +566,10 @@ where
                     // it through the same handshake as a fresh proposal. The
                     // relay-time persist deduplicates against the pre-crash
                     // write, with the handle covering the original.
-                    let digest = block.digest();
                     debug!(
                         round = ?consensus_context.round,
                         ?digest,
+                        reproposal,
                         "reusing verified block from marshal on leader recovery"
                     );
                     gates
@@ -614,9 +623,6 @@ where
                 // Special case: If the parent block is the last block in the epoch,
                 // re-propose it as to not produce any blocks that will be cut out
                 // by the epoch transition.
-                let last_in_epoch = epocher
-                    .last(consensus_context.epoch())
-                    .expect("current epoch should exist");
                 if parent.height() == last_in_epoch {
                     let digest = parent.digest();
                     gates
@@ -760,8 +766,9 @@ where
                 // - Re-proposal detection via `digest == context.parent.1`.
                 //
                 // Re-proposals return early and skip normal parent/height checks
-                // because they were already verified when originally proposed and
-                // parent-child checks would fail by construction when parent == block.
+                // because consensus settles their validity when certifying the view
+                // that first carried the block, and parent-child checks would fail by
+                // construction when parent == block.
                 let Some(decision) = precheck_epoch_and_reproposal(
                     &marshaled.epocher,
                     &marshal,
@@ -1523,6 +1530,99 @@ mod tests {
         });
     }
 
+    /// Regression: a boundary re-proposal stores the parent block itself at
+    /// the re-proposal round, under the parent's original embedded context.
+    /// A leader that crashes after that relay broadcast must recognize the
+    /// cached parent as the re-proposal on restart and propose it again,
+    /// rather than skipping the round because its embedded context names an
+    /// older round.
+    #[test_traced("WARN")]
+    fn test_propose_reuses_reproposed_boundary_block_on_restart() {
+        let runner = deterministic::Runner::timed(Duration::from_secs(30));
+        runner.start(|mut context| async move {
+            let Fixture {
+                participants,
+                schemes,
+                ..
+            } = bls12381_threshold_vrf::fixture::<V, _>(&mut context, NAMESPACE, NUM_VALIDATORS);
+            let mut oracle = setup_network_with_participants(
+                context.child("network"),
+                NZUsize!(1),
+                participants.clone(),
+            )
+            .await;
+
+            let me = participants[0].clone();
+            let setup = StandardHarness::setup_validator(
+                context.child("validator").with_attribute("index", 0),
+                &mut oracle,
+                me.clone(),
+                ConstantProvider::new(schemes[0].clone()),
+            )
+            .await;
+            let marshal = setup.mailbox;
+
+            let genesis = make_raw_block(Sha256::hash(&[b""]), Height::zero(), 0);
+
+            // Seed the boundary block at the re-proposal round, where the
+            // pre-crash relay broadcast of the re-proposal persisted it.
+            let boundary_height = Height::new(BLOCKS_PER_EPOCH.get() - 1);
+            let boundary_round = Round::new(Epoch::zero(), View::new(boundary_height.get()));
+            let boundary_block = B::new::<Sha256>(
+                Ctx {
+                    round: boundary_round,
+                    leader: default_leader(),
+                    parent: (View::zero(), genesis.digest()),
+                },
+                genesis.digest(),
+                boundary_height,
+                1900,
+            );
+            let boundary_digest = boundary_block.digest();
+            let round = Round::new(Epoch::zero(), View::new(boundary_height.get() + 1));
+            assert!(marshal.verified(round, boundary_block).await);
+
+            let ctx = Ctx {
+                round,
+                leader: me.clone(),
+                parent: (View::new(boundary_height.get()), boundary_digest),
+            };
+
+            // The app cannot build and its verification never completes, so
+            // the assertions below hold only if the cached parent is
+            // re-proposed as-is.
+            let (mock_app, verify_started, _release_verify): (GatedVerifyingApp<B, S>, _, _) =
+                GatedVerifyingApp::new();
+            let mut marshaled = Deferred::new(
+                context.child("deferred"),
+                mock_app,
+                marshal.clone(),
+                FixedEpocher::new(BLOCKS_PER_EPOCH),
+            );
+
+            let digest_rx = marshaled.propose(ctx).await;
+            let digest = digest_rx.await.expect("propose must return a digest");
+            assert_eq!(
+                digest, boundary_digest,
+                "propose must re-propose the boundary block marshal already persisted for this round"
+            );
+
+            let _ = marshaled.broadcast(digest, Plan::Propose { round });
+            let certify_rx = marshaled.certify(round, digest).await;
+            select! {
+                result = certify_rx => {
+                    assert!(
+                        result.expect("certify result missing"),
+                        "re-proposed boundary block must certify through the relay handshake"
+                    );
+                },
+                _ = verify_started => {
+                    panic!("certifying a re-proposed boundary block must not run app verification");
+                },
+            }
+        });
+    }
+
     /// Regression: if a pre-crash leader persisted a verified block for a
     /// round but the simplex `Notarize` never reached the journal, replay
     /// can recover a `consensus_context` whose parent differs from the one
@@ -1879,6 +1979,37 @@ mod tests {
                 "optimistic verify accepts an available block with a matching context"
             );
 
+            let certify_rx = fixture
+                .marshaled
+                .certify(fixture.round, fixture.digest)
+                .await;
+            select! {
+                result = certify_rx => {
+                    assert!(
+                        !result.expect("certify result missing"),
+                        "certify must propagate the application rejection"
+                    );
+                },
+                _ = context.sleep(Duration::from_secs(5)) => {
+                    panic!("certify should resolve promptly");
+                },
+            }
+        });
+    }
+
+    /// Without a registered gate (never verified locally, or the gate was lost
+    /// to a restart), certification runs the application against the block's
+    /// embedded context. A live rejection there must reach consensus too.
+    #[test_traced("WARN")]
+    fn test_certify_without_prior_verify_honors_application_rejection() {
+        let runner = deterministic::Runner::timed(Duration::from_secs(30));
+        runner.start(|mut context| async move {
+            let mut fixture =
+                equivocation_fixture(&mut context, MockVerifyingApp::with_verify_result(false))
+                    .await;
+
+            // No prior verify, so no gate exists and certify falls through to
+            // the embedded-context path.
             let certify_rx = fixture
                 .marshaled
                 .certify(fixture.round, fixture.digest)

--- a/consensus/src/marshal/standard/deferred.rs
+++ b/consensus/src/marshal/standard/deferred.rs
@@ -126,8 +126,8 @@ use tracing::{Instrument as _, debug, info_span};
 /// - Block height is exactly one greater than the parent's height
 ///
 /// Verifying only the immediate parent is sufficient since the parent itself must have
-/// been notarized by consensus, which guarantees it was verified and accepted by a quorum.
-/// This means the entire ancestry chain back to genesis is transitively validated.
+/// been notarized by consensus, which guarantees a quorum verified its context. This means
+/// the entire ancestry chain back to genesis is transitively validated.
 ///
 /// Applications do not need to re-implement these checks in their own verification logic.
 ///

--- a/consensus/src/marshal/standard/deferred.rs
+++ b/consensus/src/marshal/standard/deferred.rs
@@ -125,9 +125,10 @@ use tracing::{Instrument as _, debug, info_span};
 /// - Parent digest matches the consensus context's expected parent
 /// - Block height is exactly one greater than the parent's height
 ///
-/// Verifying only the immediate parent is sufficient since the parent itself must have
-/// been notarized by consensus, which guarantees a quorum verified its context. This means
-/// the entire ancestry chain back to genesis is transitively validated.
+/// Verifying only the immediate parent is sufficient since the parent was either notarized by
+/// consensus, whose honest voters verified its context, or verified locally before this
+/// participant voted for it (optimistic validation). Either way the entire ancestry chain back
+/// to genesis is transitively validated.
 ///
 /// Applications do not need to re-implement these checks in their own verification logic.
 ///

--- a/consensus/src/marshal/standard/inline.rs
+++ b/consensus/src/marshal/standard/inline.rs
@@ -122,7 +122,8 @@ where
 /// - Parent digest matches consensus context's expected parent
 /// - Child height is exactly parent height plus one
 ///
-/// This is sufficient because the parent must have already been accepted by consensus.
+/// This is sufficient because the parent was either notarized by consensus or verified locally
+/// before this participant voted for it, so its own linkage was already checked.
 ///
 /// # Certifiability
 ///
@@ -484,7 +485,8 @@ where
                 //   not a valid boundary re-proposal.
                 // - Re-proposals are detected when `digest == context.parent.1`.
                 // - Re-proposals skip normal parent/height checks because:
-                //   1) the block was already verified when originally proposed
+                //   1) consensus settles their validity when certifying the view that
+                //      first carried the block
                 //   2) parent-child checks would fail by construction when parent == block
                 let Some(decision) =
                     precheck_epoch_and_reproposal(&epocher, &marshal, &context, digest, block)

--- a/consensus/src/marshal/standard/validation.rs
+++ b/consensus/src/marshal/standard/validation.rs
@@ -90,7 +90,8 @@ where
 
     // Re-proposals are signaled by `digest == context.parent.1`.
     // They skip normal parent/height checks because:
-    // 1. The block was already verified when originally proposed.
+    // 1. Consensus settles the block's validity when certifying the view that
+    //    first carried it, before it certifies the re-proposal.
     // 2. Parent-child checks would fail by construction when parent == block.
     if digest == context.parent.1 {
         if !is_valid_reproposal_at_verify(epocher, block.height(), context.epoch()) {

--- a/consensus/src/simplex/actors/resolver/ingress.rs
+++ b/consensus/src/simplex/actors/resolver/ingress.rs
@@ -325,14 +325,18 @@ impl Policy for HandlerMessage {
     type Overflow = HandlerPending;
 
     fn handle(overflow: &mut Self::Overflow, message: Self) {
-        // Deliveries are retained until the actor has room. Produce requests
-        // are dropped so the serve backlog stays bounded by the ready queue,
-        // and the peer sees the closed response as an error.
-        if let Self::Deliver { response, .. } = &message
-            && !response.is_closed()
-        {
-            overflow.0.push_back(message);
+        // Drop produce requests so the serve backlog stays bounded by the ready
+        // queue. We prefer handling our own responses over serving peers, who can
+        // ask a less loaded peer instead.
+        if matches!(message, Self::Produce { .. }) {
+            return;
         }
+
+        // Retain deliveries that still have a waiting requester.
+        if message.response_closed() {
+            return;
+        }
+        overflow.0.push_back(message);
     }
 }
 

--- a/consensus/src/simplex/actors/resolver/ingress.rs
+++ b/consensus/src/simplex/actors/resolver/ingress.rs
@@ -295,7 +295,7 @@ impl HandlerMessage {
     }
 }
 
-/// Pending resolver handler messages retained after the mailbox fills.
+/// Deliveries retained while the ready queue is full.
 #[derive(Default)]
 pub(crate) struct HandlerPending(VecDeque<HandlerMessage>);
 
@@ -325,10 +325,14 @@ impl Policy for HandlerMessage {
     type Overflow = HandlerPending;
 
     fn handle(overflow: &mut Self::Overflow, message: Self) {
-        if message.response_closed() {
-            return;
+        // Deliveries are retained until the actor has room. Produce requests
+        // are dropped so the serve backlog stays bounded by the ready queue,
+        // and the peer sees the closed response as an error.
+        if let Self::Deliver { response, .. } = &message
+            && !response.is_closed()
+        {
+            overflow.0.push_back(message);
         }
-        overflow.0.push_back(message);
     }
 }
 
@@ -501,38 +505,47 @@ mod tests {
     }
 
     #[test]
-    fn handler_drain_skips_closed_responses() {
+    fn handle_retains_open_deliveries_only() {
         let mut overflow = HandlerPending::default();
+        let deliver = |view: u64, response| HandlerMessage::Deliver {
+            span: Span::none(),
+            view: View::new(view),
+            data: Bytes::new(),
+            asks: NonEmptyVec::new(Ask::backfill()),
+            response,
+        };
 
-        let (closed_response, closed_receiver) = oneshot::channel();
+        // An overflowed produce request is dropped and its requester sees the
+        // closed response.
+        let (response, mut produce) = oneshot::channel();
         HandlerMessage::handle(
             &mut overflow,
             HandlerMessage::Produce {
                 view: View::new(1),
-                response: closed_response,
+                response,
             },
         );
-        drop(closed_receiver);
+        assert!(matches!(
+            produce.try_recv(),
+            Err(oneshot::error::TryRecvError::Closed)
+        ));
 
-        let (open_response, _open_receiver) = oneshot::channel();
-        HandlerMessage::handle(
-            &mut overflow,
-            HandlerMessage::Produce {
-                view: View::new(2),
-                response: open_response,
-            },
-        );
+        // Deliveries are retained, and drain skips one whose requester left.
+        let (response, closed) = oneshot::channel();
+        HandlerMessage::handle(&mut overflow, deliver(2, response));
+        let (response, _open) = oneshot::channel();
+        HandlerMessage::handle(&mut overflow, deliver(3, response));
+        drop(closed);
 
         let mut messages = Vec::new();
         Overflow::drain(&mut overflow, |message| {
             messages.push(message);
             None
         });
-
         assert_eq!(messages.len(), 1);
         assert!(matches!(
             messages.pop(),
-            Some(HandlerMessage::Produce { view, .. }) if view == View::new(2)
+            Some(HandlerMessage::Deliver { view, .. }) if view == View::new(3)
         ));
     }
 

--- a/examples/reshare/src/application.rs
+++ b/examples/reshare/src/application.rs
@@ -107,8 +107,8 @@ where
         _context: (E, Self::Context),
         block: &Self::Block,
         batches: <Self::Databases as DatabaseSet<E>>::Unmerkleized,
-    ) -> <Self::Databases as DatabaseSet<E>>::Merkleized {
-        Self::execute(block.height(), batches).await
+    ) -> Option<<Self::Databases as DatabaseSet<E>>::Merkleized> {
+        Some(Self::execute(block.height(), batches).await)
     }
 
     async fn capture(

--- a/glue/src/dkg/reshare/actor/inclusion.rs
+++ b/glue/src/dkg/reshare/actor/inclusion.rs
@@ -1046,9 +1046,9 @@ where
 
     /// Persist a finalized dealer log from an included block.
     ///
-    /// Invalid logs are ignored because the block has already passed
-    /// application verification. The finalized reporter path is the only place
-    /// where observed dealer logs become durable state.
+    /// Dealer logs are not part of block validity, so a finalized block may
+    /// carry an invalid one. Invalid logs are ignored. The finalized reporter
+    /// path is the only place where observed dealer logs become durable state.
     pub(super) async fn observe_dealer_log(
         public_key: &C::PublicKey,
         info: &Info<V, C::PublicKey>,

--- a/glue/src/dkg/tests/reshare/harness.rs
+++ b/glue/src/dkg/tests/reshare/harness.rs
@@ -425,8 +425,8 @@ impl<E: Rng + Spawner + Metrics + Clock + Storage + BufferPooler> Application<E>
         _context: (E, Self::Context),
         block: &Self::Block,
         batches: <Self::Databases as DatabaseSet<E>>::Unmerkleized,
-    ) -> <Self::Databases as DatabaseSet<E>>::Merkleized {
-        Self::execute(block.height(), batches).await
+    ) -> Option<<Self::Databases as DatabaseSet<E>>::Merkleized> {
+        Some(Self::execute(block.height(), batches).await)
     }
 
     async fn capture(

--- a/glue/src/stateful/actor/core/processing.rs
+++ b/glue/src/stateful/actor/core/processing.rs
@@ -660,8 +660,8 @@ mod tests {
             _context: (deterministic::Context, Self::Context),
             _block: &Self::Block,
             _batches: TestUnmerkleized,
-        ) -> TestMerkleized {
-            TestMerkleized
+        ) -> Option<TestMerkleized> {
+            Some(TestMerkleized)
         }
 
         async fn capture(
@@ -743,8 +743,8 @@ mod tests {
             _context: (deterministic::Context, Self::Context),
             _block: &Self::Block,
             _batches: TestUnmerkleized,
-        ) -> TestMerkleized {
-            TestMerkleized
+        ) -> Option<TestMerkleized> {
+            Some(TestMerkleized)
         }
 
         async fn capture(
@@ -772,6 +772,7 @@ mod tests {
         verify_gate: Arc<Mutex<Option<ApplicationGate>>>,
         finalized_gate: Arc<Mutex<Option<ApplicationGate>>>,
         gate_height: Height,
+        unexecutable: Option<Height>,
         apply_calls: Arc<AtomicUsize>,
         capture_calls: Arc<AtomicUsize>,
         verify_calls: Arc<AtomicUsize>,
@@ -825,8 +826,11 @@ mod tests {
             _context: (deterministic::Context, Self::Context),
             block: &Self::Block,
             _batches: TestUnmerkleized,
-        ) -> TestMerkleized {
+        ) -> Option<TestMerkleized> {
             self.apply_calls.fetch_add(1, Ordering::SeqCst);
+            if self.unexecutable == Some(block.height()) {
+                return None;
+            }
             let gate = (block.height() == self.gate_height)
                 .then(|| self.gates.lock().pop_front())
                 .flatten();
@@ -834,7 +838,7 @@ mod tests {
                 let _ = gate.started.send(());
                 let _ = (&mut gate.release).await;
             }
-            TestMerkleized
+            Some(TestMerkleized)
         }
 
         async fn capture(
@@ -1303,6 +1307,7 @@ mod tests {
                 verify_gate: Arc::default(),
                 finalized_gate: Arc::default(),
                 gate_height: parent.height(),
+                unexecutable: None,
                 apply_calls: apply_calls.clone(),
                 capture_calls: Arc::new(AtomicUsize::new(0)),
                 verify_calls: verify_calls.clone(),
@@ -1357,6 +1362,74 @@ mod tests {
             }
             assert_eq!(apply_calls.load(Ordering::SeqCst), 1);
             assert_eq!(verify_calls.load(Ordering::SeqCst), 2);
+            actor.abort();
+            drop(marshal.guards);
+        });
+    }
+
+    #[test]
+    fn unexecutable_parent_rejects_child() {
+        deterministic::Runner::timed(Duration::from_secs(5)).start(|context| async move {
+            let genesis = TestBlock::new(0, 0);
+            let parent = TestBlock::child(&genesis, 1);
+            let child = TestBlock::child(&parent, 2);
+            let mut signing = context.child("signing");
+            let scheme =
+                scheme_mocks::fixture(&mut signing, b"unexecutable-parent", 1).schemes[0].clone();
+            let marshal = fixtures::marshal_fixture_with_finalized_block(
+                context.child("marshal"),
+                "unexecutable-parent",
+                scheme,
+                &genesis,
+                NZUsize!(1),
+                true,
+            )
+            .await;
+            let apply_calls = Arc::new(AtomicUsize::new(0));
+            let verify_calls = Arc::new(AtomicUsize::new(0));
+            let app = ReplayGatedApp {
+                gates: Arc::default(),
+                verify_gate: Arc::default(),
+                finalized_gate: Arc::default(),
+                gate_height: parent.height(),
+                unexecutable: Some(parent.height()),
+                apply_calls: apply_calls.clone(),
+                capture_calls: Arc::new(AtomicUsize::new(0)),
+                verify_calls: verify_calls.clone(),
+                applied_finalizations: Arc::default(),
+            };
+            let processor = Processor::new(
+                app,
+                test_databases(),
+                anchor(0, 0),
+                StatefulMetrics::new(&context),
+                None,
+            );
+            let (sender, receiver) = actor_mailbox::new(context.child("mailbox"), NZUsize!(8));
+            let mut mailbox = Mailbox::new(sender);
+            let processing = Processing {
+                context: ContextCell::new(context.child("processing")),
+                mailbox: receiver,
+                provider: (),
+                marshal: marshal.mailbox,
+                processor,
+                deferred_verifications: Vec::new(),
+                skip_finalized_until: None,
+            };
+            let actor = context.child("loop").spawn(move |_| processing.start());
+
+            // A parent that cannot be executed invalidates the child's ancestry
+            // before the application is asked to verify the child.
+            assert!(
+                !mailbox
+                    .verify(
+                        (context.child("verify_child"), child.context()),
+                        ancestry::from_iter([Arc::new(child), Arc::new(parent)]),
+                    )
+                    .await
+            );
+            assert_eq!(apply_calls.load(Ordering::SeqCst), 1);
+            assert_eq!(verify_calls.load(Ordering::SeqCst), 0);
             actor.abort();
             drop(marshal.guards);
         });
@@ -1841,6 +1914,7 @@ mod tests {
                 verify_gate: Arc::new(Mutex::new(Some(verify_gate))),
                 finalized_gate: Arc::default(),
                 gate_height: finalized.height(),
+                unexecutable: None,
                 apply_calls: apply_calls.clone(),
                 capture_calls: capture_calls.clone(),
                 verify_calls: Arc::new(AtomicUsize::new(0)),
@@ -1923,6 +1997,7 @@ mod tests {
                 verify_gate: Arc::default(),
                 finalized_gate: Arc::default(),
                 gate_height: genesis.height(),
+                unexecutable: None,
                 apply_calls: apply_calls.clone(),
                 capture_calls: capture_calls.clone(),
                 verify_calls: Arc::new(AtomicUsize::new(0)),
@@ -2077,6 +2152,7 @@ mod tests {
                 verify_gate: Arc::new(Mutex::new(Some(verify_gate))),
                 finalized_gate: Arc::new(Mutex::new(Some(finalized_gate))),
                 gate_height: parent.height(),
+                unexecutable: None,
                 apply_calls: apply_calls.clone(),
                 capture_calls: Arc::new(AtomicUsize::new(0)),
                 verify_calls: verify_calls.clone(),
@@ -2177,6 +2253,7 @@ mod tests {
                 verify_gate: Arc::new(Mutex::new(None)),
                 finalized_gate: Arc::new(Mutex::new(None)),
                 gate_height: finalized.height(),
+                unexecutable: None,
                 apply_calls: apply_calls.clone(),
                 capture_calls: Arc::new(AtomicUsize::new(0)),
                 verify_calls: verify_calls.clone(),
@@ -2272,6 +2349,7 @@ mod tests {
                 verify_gate: verify_gate.clone(),
                 finalized_gate: Arc::new(Mutex::new(None)),
                 gate_height: first.height(),
+                unexecutable: None,
                 apply_calls: apply_calls.clone(),
                 capture_calls: Arc::new(AtomicUsize::new(0)),
                 verify_calls: verify_calls.clone(),
@@ -2380,6 +2458,7 @@ mod tests {
                 verify_gate: Arc::new(Mutex::new(Some(verify_gate))),
                 finalized_gate: Arc::new(Mutex::new(Some(finalized_gate))),
                 gate_height: first.height(),
+                unexecutable: None,
                 apply_calls: Arc::new(AtomicUsize::new(0)),
                 capture_calls: Arc::new(AtomicUsize::new(0)),
                 verify_calls: Arc::new(AtomicUsize::new(0)),
@@ -2495,6 +2574,7 @@ mod tests {
                 verify_gate: Arc::new(Mutex::new(None)),
                 finalized_gate: Arc::new(Mutex::new(None)),
                 gate_height: parent.height(),
+                unexecutable: None,
                 apply_calls: apply_calls.clone(),
                 capture_calls: Arc::new(AtomicUsize::new(0)),
                 verify_calls: verify_calls.clone(),
@@ -2875,6 +2955,7 @@ mod tests {
                 verify_gate: Arc::default(),
                 finalized_gate: Arc::new(Mutex::new(Some(finalized_gate))),
                 gate_height: block1.height(),
+                unexecutable: None,
                 apply_calls: Arc::new(AtomicUsize::new(0)),
                 capture_calls: capture_calls.clone(),
                 verify_calls: Arc::new(AtomicUsize::new(0)),

--- a/glue/src/stateful/actor/core/processing.rs
+++ b/glue/src/stateful/actor/core/processing.rs
@@ -1279,6 +1279,90 @@ mod tests {
     }
 
     #[test]
+    fn replayed_parent_is_not_a_verdict() {
+        deterministic::Runner::timed(Duration::from_secs(5)).start(|context| async move {
+            let genesis = TestBlock::new(0, 0);
+            let parent = TestBlock::child(&genesis, 1);
+            let child = TestBlock::child(&parent, 2);
+            let mut signing = context.child("signing");
+            let scheme =
+                scheme_mocks::fixture(&mut signing, b"replayed-parent", 1).schemes[0].clone();
+            let marshal = fixtures::marshal_fixture_with_finalized_block(
+                context.child("marshal"),
+                "replayed-parent",
+                scheme,
+                &genesis,
+                NZUsize!(1),
+                true,
+            )
+            .await;
+            let apply_calls = Arc::new(AtomicUsize::new(0));
+            let verify_calls = Arc::new(AtomicUsize::new(0));
+            let app = ReplayGatedApp {
+                gates: Arc::default(),
+                verify_gate: Arc::default(),
+                finalized_gate: Arc::default(),
+                gate_height: parent.height(),
+                apply_calls: apply_calls.clone(),
+                capture_calls: Arc::new(AtomicUsize::new(0)),
+                verify_calls: verify_calls.clone(),
+                applied_finalizations: Arc::default(),
+            };
+            let processor = Processor::new(
+                app,
+                test_databases(),
+                anchor(0, 0),
+                StatefulMetrics::new(&context),
+                None,
+            );
+            let (sender, receiver) = actor_mailbox::new(context.child("mailbox"), NZUsize!(8));
+            let mut mailbox = Mailbox::new(sender);
+            let processing = Processing {
+                context: ContextCell::new(context.child("processing")),
+                mailbox: receiver,
+                provider: (),
+                marshal: marshal.mailbox,
+                processor,
+                deferred_verifications: Vec::new(),
+                skip_finalized_until: None,
+            };
+            let actor = context.child("loop").spawn(move |_| processing.start());
+
+            // Verifying the child replays its missing parent through apply.
+            assert!(
+                mailbox
+                    .verify(
+                        (context.child("verify_child"), child.context()),
+                        ancestry::from_iter([Arc::new(child), Arc::new(parent.clone())]),
+                    )
+                    .await
+            );
+            assert_eq!(apply_calls.load(Ordering::SeqCst), 1);
+            assert_eq!(verify_calls.load(Ordering::SeqCst), 1);
+
+            // Replayed state is reusable parent state, not a verdict: verifying the
+            // parent asks the application once and then settles from the cache.
+            for label in ["verify_parent", "verify_parent_again"] {
+                assert!(
+                    mailbox
+                        .verify(
+                            (context.child(label), parent.context()),
+                            ancestry::from_iter([
+                                Arc::new(parent.clone()),
+                                Arc::new(genesis.clone())
+                            ]),
+                        )
+                        .await
+                );
+            }
+            assert_eq!(apply_calls.load(Ordering::SeqCst), 1);
+            assert_eq!(verify_calls.load(Ordering::SeqCst), 2);
+            actor.abort();
+            drop(marshal.guards);
+        });
+    }
+
+    #[test]
     fn conflicting_processed_block_is_rejected() {
         deterministic::Runner::timed(Duration::from_secs(5)).start(|context| async move {
             let (mut mailbox, control, _marshal, actor) =

--- a/glue/src/stateful/actor/processor/mod.rs
+++ b/glue/src/stateful/actor/processor/mod.rs
@@ -914,6 +914,9 @@ where
             None
         } else {
             let batches = self.execution.databases.new_batches().await;
+
+            // A finalized block was certified by a quorum that verified it, so
+            // it always executes.
             let batch = self
                 .app
                 .apply(
@@ -921,7 +924,8 @@ where
                     block,
                     batches,
                 )
-                .await;
+                .await
+                .expect("finalize reconstruction must execute the block");
             assert!(
                 A::Databases::matches_sync_targets(&batch, &sync_targets),
                 "finalize reconstruction must match block commitments",
@@ -1228,8 +1232,9 @@ where
 
     /// Replays one block and caches its commitment-matching state.
     ///
-    /// Cancellation caches nothing. A commitment mismatch or state that cannot
-    /// be cached across active finalization makes the ancestry invalid.
+    /// Cancellation caches nothing. A block that cannot be executed, a
+    /// commitment mismatch, or state that cannot be cached across active
+    /// finalization makes the ancestry invalid.
     async fn replay_block<C>(
         &self,
         app: &mut A,
@@ -1262,6 +1267,10 @@ where
         .await
         else {
             return Err(PrepareBatchesError::Cancelled);
+        };
+        let Some(merkleized) = merkleized else {
+            warn!(?target_digest, block = ?digest, "rebuild replay could not execute block");
+            return Err(PrepareBatchesError::Invalid);
         };
 
         if !A::Databases::matches_sync_targets(&merkleized, &A::sync_targets(&block)) {
@@ -1940,11 +1949,11 @@ mod tests {
             _context: (deterministic::Context, Self::Context),
             block: &Self::Block,
             batches: <Self::Databases as DatabaseSet<deterministic::Context>>::Unmerkleized,
-        ) -> <Self::Databases as DatabaseSet<deterministic::Context>>::Merkleized {
+        ) -> Option<<Self::Databases as DatabaseSet<deterministic::Context>>::Merkleized> {
             if let Some(probe) = &self.apply_probe {
                 probe.call(block.digest()).await;
             }
-            Self::execute(block.height(), block.context.round.view(), batches).await
+            Some(Self::execute(block.height(), block.context.round.view(), batches).await)
         }
 
         async fn capture(

--- a/glue/src/stateful/actor/processor/mod.rs
+++ b/glue/src/stateful/actor/processor/mod.rs
@@ -196,8 +196,6 @@ where
     round: Round,
     parent: PendingDigest<A, E>,
     merkleized: PendingBatches<A, E>,
-    /// Whether the application produced this state through propose or verify
-    /// rather than replay.
     verified: bool,
 }
 
@@ -1088,8 +1086,8 @@ where
     ) -> bool {
         let mut state = self.state.lock();
         if let Some(existing) = state.pending.get_mut(&digest) {
-            debug_assert_eq!(existing.parent, parent, "pending parent changed for digest");
-            debug_assert_eq!(existing.round, round, "pending round changed for digest");
+            assert_eq!(existing.parent, parent, "pending parent changed for digest");
+            assert_eq!(existing.round, round, "pending round changed for digest");
 
             // Verifying a replayed block upgrades its entry to a verdict.
             existing.verified |= verified;

--- a/glue/src/stateful/actor/processor/mod.rs
+++ b/glue/src/stateful/actor/processor/mod.rs
@@ -196,6 +196,9 @@ where
     round: Round,
     parent: PendingDigest<A, E>,
     merkleized: PendingBatches<A, E>,
+    /// Whether the application produced this state through propose or verify
+    /// rather than replay.
+    verified: bool,
 }
 
 /// Speculative state shared by independently-polled verification jobs.
@@ -789,7 +792,7 @@ where
             "proposed state must match block commitments",
         );
         assert!(
-            self.cache_pending(block.digest(), parent_digest, round, merkleized),
+            self.cache_pending(block.digest(), parent_digest, round, merkleized, true),
             "proposal parent must remain compatible until the proposal completes",
         );
         self.execution.update_pending_metric();
@@ -972,9 +975,10 @@ where
         parent: PendingDigest<A, E>,
         round: Round,
         merkleized: PendingBatches<A, E>,
+        verified: bool,
     ) -> bool {
         self.execution
-            .cache_pending(digest, parent, round, merkleized)
+            .cache_pending(digest, parent, round, merkleized, verified)
     }
 }
 
@@ -1049,8 +1053,17 @@ where
         (state.last_processed, state.pending.len())
     }
 
+    #[cfg(test)]
     fn pending_contains(&self, digest: &PendingDigest<A, E>) -> bool {
         self.state.lock().pending.contains_key(digest)
+    }
+
+    fn pending_verified(&self, digest: &PendingDigest<A, E>) -> bool {
+        self.state
+            .lock()
+            .pending
+            .get(digest)
+            .is_some_and(|entry| entry.verified)
     }
 
     fn pending_len(&self) -> usize {
@@ -1067,11 +1080,15 @@ where
         parent: PendingDigest<A, E>,
         round: Round,
         merkleized: PendingBatches<A, E>,
+        verified: bool,
     ) -> bool {
         let mut state = self.state.lock();
-        if let Some(existing) = state.pending.get(&digest) {
+        if let Some(existing) = state.pending.get_mut(&digest) {
             debug_assert_eq!(existing.parent, parent, "pending parent changed for digest");
             debug_assert_eq!(existing.round, round, "pending round changed for digest");
+
+            // Verifying a replayed block upgrades its entry to a verdict.
+            existing.verified |= verified;
             return true;
         }
 
@@ -1113,6 +1130,7 @@ where
                 round,
                 parent,
                 merkleized,
+                verified,
             },
         );
         if state.finalizing.is_some() {
@@ -1208,7 +1226,7 @@ where
         Ok(self.databases.new_batches().await)
     }
 
-    /// Replays one certified block and caches its commitment-matching state.
+    /// Replays one block and caches its commitment-matching state.
     ///
     /// Cancellation caches nothing. A commitment mismatch or state that cannot
     /// be cached across active finalization makes the ancestry invalid.
@@ -1255,7 +1273,7 @@ where
             return Err(PrepareBatchesError::Invalid);
         }
 
-        self.cache_pending(digest, parent_digest, round, merkleized)
+        self.cache_pending(digest, parent_digest, round, merkleized, false)
             .then_some(())
             .ok_or(PrepareBatchesError::Invalid)
     }
@@ -2163,7 +2181,8 @@ mod tests {
                 block.digest(),
                 parent.digest(),
                 round,
-                merkleized
+                merkleized,
+                true,
             ));
             self.provider.insert(block.clone());
             block
@@ -2584,6 +2603,7 @@ mod tests {
                 genesis.digest(),
                 round,
                 initial_batch,
+                true,
             ));
 
             let (gate, started, release) = apply_gate();
@@ -2603,6 +2623,7 @@ mod tests {
                 genesis.digest(),
                 round,
                 during_finalization_batch,
+                true,
             ));
             assert!(!execution.pending_contains(&winner.digest()));
 
@@ -2619,6 +2640,7 @@ mod tests {
                 genesis.digest(),
                 round,
                 after_finalization_batch,
+                true,
             ));
             assert!(!execution.pending_contains(&winner.digest()));
         });
@@ -2958,6 +2980,7 @@ mod tests {
                 genesis.digest(),
                 winner.context().round,
                 merkleized,
+                true,
             ));
 
             let (gate, mut started, release) = apply_gate();
@@ -3127,6 +3150,7 @@ mod tests {
                     loser.digest(),
                     Round::new(Epoch::zero(), late_view),
                     merkleized,
+                    true,
                 ),
                 "completed work on a losing fork must not publish after finalization",
             );

--- a/glue/src/stateful/actor/processor/mod.rs
+++ b/glue/src/stateful/actor/processor/mod.rs
@@ -913,8 +913,8 @@ where
         } else {
             let batches = self.execution.databases.new_batches().await;
 
-            // A finalized block was certified by a quorum that verified it, so
-            // it always executes.
+            // A finalized block was certified by a quorum whose honest voters
+            // verified it, so it always executes.
             let batch = self
                 .app
                 .apply(

--- a/glue/src/stateful/actor/processor/verifier.rs
+++ b/glue/src/stateful/actor/processor/verifier.rs
@@ -118,8 +118,7 @@ where
         };
         let block_digest = block.digest();
 
-        // Replayed state is reusable as a parent but is not a verdict, so only
-        // state that passed verify or came from propose settles the request.
+        // Only skip verification if the application already verified this block.
         if self.execution.pending_verified(&block_digest) {
             timer.observe(context);
             return Some(true);

--- a/glue/src/stateful/actor/processor/verifier.rs
+++ b/glue/src/stateful/actor/processor/verifier.rs
@@ -118,7 +118,7 @@ where
         };
         let block_digest = block.digest();
 
-        // Only skip verification if the application already verified this block.
+        // Only skip verification for blocks the application built or verified.
         if self.execution.pending_verified(&block_digest) {
             timer.observe(context);
             return Some(true);

--- a/glue/src/stateful/actor/processor/verifier.rs
+++ b/glue/src/stateful/actor/processor/verifier.rs
@@ -118,7 +118,9 @@ where
         };
         let block_digest = block.digest();
 
-        if self.execution.pending_contains(&block_digest) {
+        // Replayed state is reusable as a parent but is not a verdict, so only
+        // state that passed verify or came from propose settles the request.
+        if self.execution.pending_verified(&block_digest) {
             timer.observe(context);
             return Some(true);
         }
@@ -371,7 +373,7 @@ where
         }
         if !self
             .execution
-            .cache_pending(block_digest, parent.digest, round, merkleized)
+            .cache_pending(block_digest, parent.digest, round, merkleized, true)
         {
             warn!(
                 parent_digest = ?parent.digest,

--- a/glue/src/stateful/actor/syncer/actor.rs
+++ b/glue/src/stateful/actor/syncer/actor.rs
@@ -380,7 +380,7 @@ mod tests {
             _context: (deterministic::Context, Self::Context),
             _block: &Self::Block,
             _batches: TestUnmerkleized,
-        ) -> TestMerkleized {
+        ) -> Option<TestMerkleized> {
             unreachable!("WedgeApp only serves the syncer harness")
         }
 

--- a/glue/src/stateful/db/current.rs
+++ b/glue/src/stateful/db/current.rs
@@ -715,8 +715,6 @@ mod open {
             },
         },
     };
-    use commonware_utils::Array;
-
     type VConfig<T, F, K, V, S> = VariableConfig<
         T,
         <Operation<F, unordered::Update<K, VariableEncoding<V>>> as Read>::Cfg,
@@ -732,7 +730,7 @@ mod open {
     where
         F: Graftable,
         E: Context + Spawner,
-        K: Array,
+        K: commonware_storage::qmdb::operation::Key,
         V: VariableValue + 'static,
         H: Hasher,
         T: commonware_storage::translator::Translator,
@@ -775,7 +773,7 @@ impl<F, E, K, V, H, T, const N: usize, S> ManagedDb<E>
 where
     F: Graftable,
     E: Context + Spawner,
-    K: Key + Array,
+    K: Key,
     V: value::VariableValue + 'static,
     H: Hasher,
     T: Translator,
@@ -1091,7 +1089,7 @@ impl<F, E, K, V, H, T, R, const N: usize, S> StateSyncDb<E, R>
 where
     F: Graftable,
     E: Context + Spawner,
-    K: Key + Array,
+    K: Key,
     V: value::VariableValue + 'static,
     H: Hasher,
     T: Translator,
@@ -1190,7 +1188,7 @@ mod tests {
         merkle::{full::Config as MerkleConfig, mmr},
         qmdb::current::{
             ordered::{fixed as ordered_fixed, variable as ordered_variable},
-            unordered::fixed,
+            unordered::{fixed, variable},
         },
         translator::TwoCap,
     };
@@ -1238,6 +1236,23 @@ mod tests {
         64,
         Sequential,
     >;
+
+    /// The variable-encoding wrapper accepts variable-length keys.
+    fn _assert_variable_db_accepts_variable_keys() {
+        fn managed<D: ManagedDb<deterministic::Context>>() {}
+        managed::<
+            variable::Db<
+                mmr::Family,
+                deterministic::Context,
+                Vec<u8>,
+                Digest,
+                Sha256,
+                TwoCap,
+                64,
+                Sequential,
+            >,
+        >();
+    }
 
     const PAGE_SIZE: NonZeroU16 = NZU16!(101);
     const PAGE_CACHE_SIZE: NonZeroUsize = NZUsize!(11);

--- a/glue/src/stateful/db/current.rs
+++ b/glue/src/stateful/db/current.rs
@@ -1237,22 +1237,17 @@ mod tests {
         Sequential,
     >;
 
-    /// The variable-encoding wrapper accepts variable-length keys.
-    fn _assert_variable_db_accepts_variable_keys() {
-        fn managed<D: ManagedDb<deterministic::Context>>() {}
-        managed::<
-            variable::Db<
-                mmr::Family,
-                deterministic::Context,
-                Vec<u8>,
-                Digest,
-                Sha256,
-                TwoCap,
-                64,
-                Sequential,
-            >,
-        >();
-    }
+    /// The unordered variable wrapper accepts variable-length keys.
+    type VariableDb = variable::Db<
+        mmr::Family,
+        deterministic::Context,
+        Vec<u8>,
+        Digest,
+        Sha256,
+        TwoCap,
+        64,
+        Sequential,
+    >;
 
     const PAGE_SIZE: NonZeroU16 = NZU16!(101);
     const PAGE_CACHE_SIZE: NonZeroUsize = NZUsize!(11);
@@ -1334,6 +1329,13 @@ mod tests {
         assert_state_sync_db::<OrderedVariableDb, Arc<OrderedVariableDb>>();
         assert_database_set::<Shared<OrderedFixedDb>>();
         assert_database_set::<Shared<OrderedVariableDb>>();
+    }
+
+    #[test]
+    fn variable_current_db_trait_impls_compile() {
+        assert_managed_db::<VariableDb>();
+        assert_state_sync_db::<VariableDb, Arc<VariableDb>>();
+        assert_database_set::<Shared<VariableDb>>();
     }
 
     #[test]

--- a/glue/src/stateful/db/p2p/actor.rs
+++ b/glue/src/stateful/db/p2p/actor.rs
@@ -49,8 +49,7 @@ where
     /// Local database used to serve incoming requests when available.
     pub database: Option<Shared<DB>>,
 
-    /// Maximum size of resolver mailbox backlogs. Peer requests that overflow
-    /// the mailbox are answered with an error rather than queued.
+    /// Maximum size of resolver mailbox backlogs.
     pub mailbox_size: NonZeroUsize,
 
     /// Local node identity if available.

--- a/glue/src/stateful/db/p2p/actor.rs
+++ b/glue/src/stateful/db/p2p/actor.rs
@@ -49,7 +49,8 @@ where
     /// Local database used to serve incoming requests when available.
     pub database: Option<Shared<DB>>,
 
-    /// Maximum size of resolver mailbox backlogs.
+    /// Maximum size of resolver mailbox backlogs. Peer requests that overflow
+    /// the mailbox are answered with an error rather than queued.
     pub mailbox_size: NonZeroUsize,
 
     /// Local node identity if available.

--- a/glue/src/stateful/db/p2p/handler.rs
+++ b/glue/src/stateful/db/p2p/handler.rs
@@ -73,14 +73,18 @@ impl<F: Family> Policy for EngineMessage<F> {
     type Overflow = EnginePending<F>;
 
     fn handle(overflow: &mut Self::Overflow, message: Self) {
-        // Deliveries are retained until the actor has room. Produce requests
-        // are dropped so the serve backlog stays bounded by the ready queue,
-        // and the peer sees the closed response as an error.
-        if let Self::Deliver { response, .. } = &message
-            && !response.is_closed()
-        {
-            overflow.0.push_back(message);
+        // Drop produce requests so the serve backlog stays bounded by the ready
+        // queue. We prefer handling our own responses over serving peers, who can
+        // ask a less loaded peer instead.
+        if matches!(message, Self::Produce { .. }) {
+            return;
         }
+
+        // Retain deliveries that still have a waiting requester.
+        if message.response_closed() {
+            return;
+        }
+        overflow.0.push_back(message);
     }
 }
 

--- a/glue/src/stateful/db/p2p/handler.rs
+++ b/glue/src/stateful/db/p2p/handler.rs
@@ -38,6 +38,7 @@ impl<F: Family> EngineMessage<F> {
     }
 }
 
+/// Deliveries retained while the ready queue is full.
 pub(super) struct EnginePending<F: Family>(VecDeque<EngineMessage<F>>);
 
 impl<F: Family> Default for EnginePending<F> {
@@ -72,10 +73,14 @@ impl<F: Family> Policy for EngineMessage<F> {
     type Overflow = EnginePending<F>;
 
     fn handle(overflow: &mut Self::Overflow, message: Self) {
-        if message.response_closed() {
-            return;
+        // Deliveries are retained until the actor has room. Produce requests
+        // are dropped so the serve backlog stays bounded by the ready queue,
+        // and the peer sees the closed response as an error.
+        if let Self::Deliver { response, .. } = &message
+            && !response.is_closed()
+        {
+            overflow.0.push_back(message);
         }
-        overflow.0.push_back(message);
     }
 }
 
@@ -127,5 +132,63 @@ impl<F: Family> Producer for Handler<F> {
             .sender
             .enqueue(EngineMessage::Produce { key, response });
         receiver
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use commonware_storage::mmr::{self, Location};
+    use commonware_utils::NZU64;
+
+    #[test]
+    fn handle_retains_open_deliveries_only() {
+        let mut overflow = EnginePending::<mmr::Family>::default();
+        let key = Request::Operations {
+            size: Location::new(10),
+            start: Location::new(0),
+            max_ops: NZU64!(1),
+        };
+
+        // An overflowed produce request is dropped and its requester sees the
+        // closed response.
+        let (response, mut produce) = oneshot::channel();
+        EngineMessage::handle(&mut overflow, EngineMessage::Produce { key, response });
+        assert!(matches!(
+            produce.try_recv(),
+            Err(oneshot::error::TryRecvError::Closed)
+        ));
+
+        // Deliveries are retained, and drain skips one whose requester left.
+        let (response, closed) = oneshot::channel();
+        EngineMessage::handle(
+            &mut overflow,
+            EngineMessage::Deliver {
+                key,
+                value: Bytes::new(),
+                response,
+            },
+        );
+        let (response, _open) = oneshot::channel();
+        EngineMessage::handle(
+            &mut overflow,
+            EngineMessage::Deliver {
+                key,
+                value: Bytes::from_static(b"open"),
+                response,
+            },
+        );
+        drop(closed);
+
+        let mut messages = Vec::new();
+        Overflow::drain(&mut overflow, |message| {
+            messages.push(message);
+            None
+        });
+        assert_eq!(messages.len(), 1);
+        assert!(matches!(
+            messages.pop(),
+            Some(EngineMessage::Deliver { value, .. }) if value == Bytes::from_static(b"open")
+        ));
     }
 }

--- a/glue/src/stateful/mod.rs
+++ b/glue/src/stateful/mod.rs
@@ -238,8 +238,10 @@ where
 
     /// Verify a block received from a peer, relative to its ancestry.
     ///
-    /// Called before voting. The implementation should execute the block
-    /// against the provided batches and merkleize them.
+    /// Called before the node votes to finalize the block. Under deferred
+    /// verification the notarize vote may already have been cast. The
+    /// implementation should execute the block against the provided batches
+    /// and merkleize them.
     ///
     /// This future should not resolve until the implementation can produce a
     /// stable verdict. Return [`None`] only when the block is permanently

--- a/glue/src/stateful/mod.rs
+++ b/glue/src/stateful/mod.rs
@@ -81,9 +81,10 @@
 //! to the nearest known ancestor or the finalized tip,
 //! then replays forward via [`Application::apply`] to fill the gap. Each
 //! replayed block is inserted into the pending map immediately so that
-//! partial progress survives timeouts. Replayed state is reusable as parent
-//! state but is never a verification verdict: verifying a replayed block
-//! still runs [`Application::verify`].
+//! partial progress survives timeouts. Consensus may build on a block before
+//! it is certified, so a replayed ancestor is not guaranteed to be valid.
+//! Replayed state is reusable as parent state but is never a verification
+//! verdict: verifying a replayed block still runs [`Application::verify`].
 //!
 //! # Compatibility
 //!
@@ -300,10 +301,11 @@ where
     /// replay result during finalization and cannot re-check block-specific
     /// commitments generically.
     ///
-    /// Return [`None`] if the block cannot be executed. Under optimistic
-    /// validation a replayed ancestor may not have passed
-    /// [`verify`](Self::verify), and the wrapper rejects the ancestry that
-    /// depends on it. A finalized block always executes.
+    /// Return [`None`] if the block cannot be executed. Consensus may ask the
+    /// wrapper to verify or build on a block before its ancestors are certified,
+    /// so a replayed ancestor is not guaranteed to have passed
+    /// [`verify`](Self::verify) anywhere. The wrapper then rejects the ancestry
+    /// that depends on it. A finalized block always executes.
     ///
     /// This future may be cancelled if its originating request is dropped, or
     /// cancelled and retried before finalization or pruning. Cancellation and

--- a/glue/src/stateful/mod.rs
+++ b/glue/src/stateful/mod.rs
@@ -82,7 +82,8 @@
 //! then replays forward via [`Application::apply`] to fill the gap. Each
 //! replayed block is inserted into the pending map immediately so that
 //! partial progress survives timeouts. Consensus may build on a block before
-//! it is certified, so a replayed ancestor is not guaranteed to be valid.
+//! it is certified (for example, with stable leaders), so a replayed ancestor
+//! is not guaranteed to be valid.
 //! Replayed state is reusable as parent state but is never a verification
 //! verdict: verifying a replayed block still runs [`Application::verify`].
 //!
@@ -238,10 +239,9 @@ where
 
     /// Verify a block received from a peer, relative to its ancestry.
     ///
-    /// Called before the node votes to finalize the block. Under deferred
-    /// verification the notarize vote may already have been cast. The
-    /// implementation should execute the block against the provided batches
-    /// and merkleize them.
+    /// Called before the node votes to finalize the block (the notarize vote
+    /// may already have been cast). The implementation should execute the
+    /// block against the provided batches and merkleize them.
     ///
     /// This future should not resolve until the implementation can produce a
     /// stable verdict. Return [`None`] only when the block is permanently

--- a/glue/src/stateful/mod.rs
+++ b/glue/src/stateful/mod.rs
@@ -81,7 +81,9 @@
 //! to the nearest known ancestor or the finalized tip,
 //! then replays forward via [`Application::apply`] to fill the gap. Each
 //! replayed block is inserted into the pending map immediately so that
-//! partial progress survives timeouts.
+//! partial progress survives timeouts. Replayed state is reusable as parent
+//! state but is never a verification verdict: verifying a replayed block
+//! still runs [`Application::verify`].
 //!
 //! # Compatibility
 //!
@@ -283,15 +285,18 @@ where
         batches: <Self::Databases as DatabaseSet<E>>::Unmerkleized,
     ) -> impl Future<Output = Option<<Self::Databases as DatabaseSet<E>>::Merkleized>> + Send;
 
-    /// Apply a previously certified block to reconstruct its merkleized state.
+    /// Apply a block to reconstruct its merkleized state.
     ///
-    /// Called by the wrapper during lazy recovery when pending state for
-    /// an ancestor block is missing (e.g. after a restart). The block is
-    /// known-good (it was previously certified), so the implementation
-    /// should unconditionally execute the block's state transitions.
+    /// Called when the wrapper lacks state for `block`: during lazy recovery
+    /// for a missing ancestor (e.g. after a restart), or during finalization
+    /// for an uncached winner. The implementation should unconditionally
+    /// execute the block's state transitions.
     ///
     /// The returned merkleized state must match what
-    /// [`verify`](Self::verify) accepted for `block`. The wrapper commits this
+    /// [`verify`](Self::verify) accepts for `block`. The wrapper checks it
+    /// against the block's commitments before caching it and reuses it as
+    /// parent state, but never as a verdict: a request to verify the replayed
+    /// block still runs [`verify`](Self::verify). The wrapper commits this
     /// replay result during finalization and cannot re-check block-specific
     /// commitments generically.
     ///
@@ -301,8 +306,11 @@ where
     ///
     /// # Panics
     ///
-    /// Implementations should panic if execution fails, as this indicates
-    /// data corruption or non-determinism.
+    /// Implementations should panic on data corruption or non-determinism,
+    /// but not on an application-invalid block: under deferred voting with
+    /// optimistic validation a replayed ancestor may never have passed
+    /// [`verify`](Self::verify). Return the state its execution yields and
+    /// let the commitment check reject the ancestry.
     fn apply(
         &mut self,
         context: (E, Self::Context),

--- a/glue/src/stateful/mod.rs
+++ b/glue/src/stateful/mod.rs
@@ -289,8 +289,8 @@ where
     ///
     /// Called when the wrapper lacks state for `block`: during lazy recovery
     /// for a missing ancestor (e.g. after a restart), or during finalization
-    /// for an uncached winner. The implementation should unconditionally
-    /// execute the block's state transitions.
+    /// for an uncached winner. The implementation should execute the block's
+    /// state transitions.
     ///
     /// The returned merkleized state must match what
     /// [`verify`](Self::verify) accepts for `block`. The wrapper checks it
@@ -300,23 +300,24 @@ where
     /// replay result during finalization and cannot re-check block-specific
     /// commitments generically.
     ///
+    /// Return [`None`] if the block cannot be executed. Under optimistic
+    /// validation a replayed ancestor may not have passed
+    /// [`verify`](Self::verify), and the wrapper rejects the ancestry that
+    /// depends on it. A finalized block always executes.
+    ///
     /// This future may be cancelled if its originating request is dropped, or
     /// cancelled and retried before finalization or pruning. Cancellation and
     /// retry must not violate invariants or lose durable progress.
     ///
     /// # Panics
     ///
-    /// Implementations should panic on data corruption or non-determinism,
-    /// but not on an application-invalid block: under deferred voting with
-    /// optimistic validation a replayed ancestor may never have passed
-    /// [`verify`](Self::verify). Return the state its execution yields and
-    /// let the commitment check reject the ancestry.
+    /// Implementations should panic if executing a valid block fails.
     fn apply(
         &mut self,
         context: (E, Self::Context),
         block: &Self::Block,
         batches: <Self::Databases as DatabaseSet<E>>::Unmerkleized,
-    ) -> impl Future<Output = <Self::Databases as DatabaseSet<E>>::Merkleized> + Send;
+    ) -> impl Future<Output = Option<<Self::Databases as DatabaseSet<E>>::Merkleized>> + Send;
 
     /// Capture data from winning batches before they are applied.
     ///

--- a/glue/src/stateful/tests/mocks.rs
+++ b/glue/src/stateful/tests/mocks.rs
@@ -341,8 +341,8 @@ impl<
         _context: (E, Self::Context),
         _block: &Self::Block,
         _batches: <Self::Databases as DatabaseSet<E>>::Unmerkleized,
-    ) -> <Self::Databases as DatabaseSet<E>>::Merkleized {
-        TestMerkleized
+    ) -> Option<<Self::Databases as DatabaseSet<E>>::Merkleized> {
+        Some(TestMerkleized)
     }
 
     async fn capture(

--- a/glue/src/stateful/tests/mod.rs
+++ b/glue/src/stateful/tests/mod.rs
@@ -1006,7 +1006,7 @@ impl Application<deterministic::Context> for GatedMultiApp {
         context: (deterministic::Context, Self::Context),
         block: &Self::Block,
         batches: <Self::Databases as DatabaseSet<deterministic::Context>>::Unmerkleized,
-    ) -> <Self::Databases as DatabaseSet<deterministic::Context>>::Merkleized {
+    ) -> Option<<Self::Databases as DatabaseSet<deterministic::Context>>::Merkleized> {
         <MultiApp as Application<deterministic::Context>>::apply(
             &mut self.inner,
             context,

--- a/glue/src/stateful/tests/multi_db_app.rs
+++ b/glue/src/stateful/tests/multi_db_app.rs
@@ -350,8 +350,8 @@ impl<E: Rng + Spawner + StorageContext> Application<E> for App {
         _context: (E, Self::Context),
         block: &Self::Block,
         batches: <Self::Databases as DatabaseSet<E>>::Unmerkleized,
-    ) -> <Self::Databases as DatabaseSet<E>>::Merkleized {
-        Self::execute(block.height(), batches).await
+    ) -> Option<<Self::Databases as DatabaseSet<E>>::Merkleized> {
+        Some(Self::execute(block.height(), batches).await)
     }
 
     async fn capture(

--- a/glue/src/stateful/tests/single_db_app.rs
+++ b/glue/src/stateful/tests/single_db_app.rs
@@ -270,8 +270,8 @@ impl<E: Rng + Spawner + StorageContext> Application<E> for App {
         _context: (E, Self::Context),
         block: &Self::Block,
         batches: <Self::Databases as DatabaseSet<E>>::Unmerkleized,
-    ) -> <Self::Databases as DatabaseSet<E>>::Merkleized {
-        Self::execute(block.height(), batches).await
+    ) -> Option<<Self::Databases as DatabaseSet<E>>::Merkleized> {
+        Some(Self::execute(block.height(), batches).await)
     }
 
     async fn capture(

--- a/storage/fuzz/fuzz_targets/metadata_recovery.rs
+++ b/storage/fuzz/fuzz_targets/metadata_recovery.rs
@@ -5,8 +5,9 @@
 //! Rewrite, overwrite, and remove write paths are crossed with three crash kinds: a failed
 //! write, an unsynced write parked at the delayed durability barrier, and an acked sync that
 //! completes the barrier first. The oracle pins that recovery yields the baseline or the
-//! complete candidate, never a mixture, and that a crash after an acknowledged sync
-//! preserves the acked state exactly.
+//! complete candidate, never a mixture, that a crash after an acknowledged sync preserves
+//! the acked state exactly, and that a first sync smaller than the torn image survives
+//! reopen on the copy init repaired.
 
 use arbitrary::Arbitrary;
 use commonware_codec::Read;
@@ -236,10 +237,10 @@ fn run(input: &FuzzInput, mode: PartialWriteMode) {
             );
         }
 
-        // Prove the repaired store remains writable and that the selected state survives a clean
-        // sync and reopen. Shrink first: a stale tail left behind by an unrepaired mirror would
-        // survive the larger sentinel rewrite, so the first write must be smaller than any
-        // reachable crash image.
+        // Shrink first. The first sync lands on the copy init repaired without adopting, and the
+        // shrunk baseline is smaller than the image that copy held before the crash, so a stale
+        // tail left by an incomplete repair fails its checksum at reopen. Reopen before the next
+        // sync rotates the newest state to the other copy.
         let mut expected = recovered;
         metadata.remove(&U64::new(0));
         expected.remove(&0);
@@ -247,6 +248,17 @@ fn run(input: &FuzzInput, mode: PartialWriteMode) {
             .sync()
             .await
             .expect("post-recovery shrink sync failed");
+        drop(metadata);
+        let mut metadata = Metadata::<_, U64, Vec<u8>>::init(context.child("shrunk"), config())
+            .await
+            .expect("post-shrink reopen failed");
+        assert_eq!(
+            snapshot(&metadata),
+            expected,
+            "reopen lost the post-recovery shrink"
+        );
+
+        // Prove the store remains writable and that a further sync survives a clean reopen.
         let sentinel = vec![0xEF; 32];
         metadata.put(U64::new(SENTINEL_KEY), sentinel.clone());
         expected.insert(SENTINEL_KEY, sentinel);

--- a/storage/fuzz/fuzz_targets/metadata_recovery.rs
+++ b/storage/fuzz/fuzz_targets/metadata_recovery.rs
@@ -6,8 +6,8 @@
 //! write, an unsynced write parked at the delayed durability barrier, and an acked sync that
 //! completes the barrier first. The oracle pins that recovery yields the baseline or the
 //! complete candidate, never a mixture, that a crash after an acknowledged sync preserves
-//! the acked state exactly, and that a first sync smaller than the torn image survives
-//! reopen on the copy init repaired.
+//! the acked state exactly, and that the first sync after a repair survives reopen on the
+//! repaired copy.
 
 use arbitrary::Arbitrary;
 use commonware_codec::Read;
@@ -237,10 +237,10 @@ fn run(input: &FuzzInput, mode: PartialWriteMode) {
             );
         }
 
-        // Shrink first. The first sync lands on the copy init repaired without adopting, and the
-        // shrunk baseline is smaller than the image that copy held before the crash, so a stale
-        // tail left by an incomplete repair fails its checksum at reopen. Reopen before the next
-        // sync rotates the newest state to the other copy.
+        // Shrink first. When init repaired a torn copy, the first sync lands on it, and the shrunk
+        // state is never larger than the image that copy held before the crash, so any stale tail
+        // left by an incomplete repair fails its checksum at reopen. Reopen before the next sync
+        // rotates the newest state to the other copy.
         let mut expected = recovered;
         metadata.remove(&U64::new(0));
         expected.remove(&0);

--- a/storage/src/journal/segmented/fixed.rs
+++ b/storage/src/journal/segmented/fixed.rs
@@ -1323,6 +1323,23 @@ mod tests {
     }
 
     #[test_traced]
+    #[should_panic(expected = "must be replayed before append")]
+    fn test_segmented_fixed_gates_older_section_after_reopen() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = test_cfg(&context);
+            seed(&context, &cfg, 1..=3).await;
+
+            // Every nonempty retained section is append-locked, not only the oldest or the
+            // newest.
+            let journal = Journal::<_, u64>::init(context.child("reopen"), cfg)
+                .await
+                .expect("failed to reopen");
+            journal.append(2, &2).await.unwrap();
+        });
+    }
+
+    #[test_traced]
     fn test_segmented_fixed_floor_preflight_reads_boundary_only() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {

--- a/storage/src/journal/segmented/variable.rs
+++ b/storage/src/journal/segmented/variable.rs
@@ -1065,6 +1065,20 @@ mod tests {
     }
 
     #[test_traced]
+    #[should_panic(expected = "must be replayed before append")]
+    fn test_segmented_variable_gates_clean_older_section() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            const PARTITION: &str = "segmented-variable-gate-clean-older-section";
+
+            // Sections 0 and 2 are intact and section 1 is torn. The oldest section is gated
+            // even though it is neither torn nor the newest.
+            let journal = journal_with_torn_interior_page(&context, PARTITION, true).await;
+            let _ = journal.append(0, &7).await;
+        });
+    }
+
+    #[test_traced]
     fn test_segmented_variable_replay_propagates_read_options() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {

--- a/storage/src/qmdb/current/sync/tests.rs
+++ b/storage/src/qmdb/current/sync/tests.rs
@@ -10,8 +10,9 @@
 //! unordered) x (fixed, variable) database variant, so the shared suite runs twice per variant.
 //!
 //! In addition to the shared harness-based suite, this module contains focused tests for
-//! `current`-specific sync behavior: overlay-state authentication (canonical-root check), pruned
-//! MMB round-trip, and target-update regression coverage.
+//! `current`-specific sync behavior: pruned MMB round-trip (canonical-root reconstruction across
+//! a pruned chunk boundary) and `local_pinned_nodes` returning `None` for targets starting below
+//! the local lower bound.
 
 use crate::qmdb::{
     any::sync::tests::{ConfigOf, SyncTestHarness},
@@ -464,9 +465,9 @@ mod harnesses {
 /// same canonical root, reopens cleanly, and returns the expected value.
 ///
 /// The target DB commits the same key 100 times, forcing the inactivity floor past a full
-/// 256-bit chunk boundary. Without overlay-state in the sync protocol, the receiver
-/// re-derives `pruned_chunks` from `range.start / chunk_bits` and builds a grafted tree
-/// whose pinned nodes don't match the sender's. The canonical roots diverge.
+/// 256-bit chunk boundary. The receiver derives `pruned_chunks` from `range.start` and must
+/// source the grafted pinned nodes for that region from the ops tree (zero-chunk identity).
+/// If those nodes do not match the sender's, the canonical roots diverge.
 #[test_traced("INFO")]
 fn test_current_mmb_sync_with_pruned_full_chunk_reopens() {
     let executor = deterministic::Runner::default();
@@ -523,9 +524,10 @@ fn test_current_mmb_sync_with_pruned_full_chunk_reopens() {
         let client_suffix = context.next_u64().to_string();
         let client_config = variable_config::<crate::translator::TwoCap>(&client_suffix, &context);
         let target_db = std::sync::Arc::new(target_db);
-        // Supply the trusted canonical root so `build_db`'s authentication check actually
-        // runs: this is the success-path coverage for the overlay-state authentication
-        // anchor. A bad-root rejection path test belongs with the focused sync tests.
+
+        // Sync targets the ops root, which is what the engine verifies. `build_db` reconstructs
+        // the canonical root without authenticating it, so the assertions below compare it
+        // against `verification_root`.
         let synced_db: Db = crate::qmdb::sync::sync(crate::qmdb::sync::engine::Config {
             context: context.child("client"),
             db_config: client_config.clone(),

--- a/storage/src/qmdb/store/db.rs
+++ b/storage/src/qmdb/store/db.rs
@@ -102,7 +102,6 @@ use crate::{
 use commonware_codec::{CodecShared, Read};
 use commonware_macros::boxed;
 use commonware_runtime::Handle;
-use commonware_utils::Array;
 use core::{num::NonZeroUsize, ops::Range};
 use std::collections::BTreeMap;
 use tracing::{debug, warn};
@@ -157,7 +156,7 @@ impl<K: Key, V: CodecShared + Clone, const N: usize> From<[(K, Option<V>); N]> f
 pub struct Batch<'a, E, K, V, T>
 where
     E: Context,
-    K: Array,
+    K: Key,
     V: VariableValue,
     T: Translator,
 {
@@ -168,7 +167,7 @@ where
 impl<'a, E, K, V, T> Batch<'a, E, K, V, T>
 where
     E: Context,
-    K: Array,
+    K: Key,
     V: VariableValue,
     T: Translator,
 {
@@ -213,7 +212,7 @@ where
 pub struct Db<E, K, V, T>
 where
     E: Context,
-    K: Array,
+    K: Key,
     V: VariableValue,
     T: Translator,
 {
@@ -251,7 +250,7 @@ where
 impl<E, K, V, T> std::fmt::Debug for Db<E, K, V, T>
 where
     E: Context,
-    K: Array,
+    K: Key,
     V: VariableValue,
     T: Translator,
 {
@@ -266,7 +265,7 @@ where
 impl<E, K, V, T> Db<E, K, V, T>
 where
     E: Context,
-    K: Array,
+    K: Key,
     V: VariableValue,
     T: Translator,
 {
@@ -1361,6 +1360,59 @@ mod test {
             assert_eq!(fetched_value.unwrap(), value);
 
             // Destroy the store
+            db.destroy().await.unwrap();
+        });
+    }
+
+    /// A [Db] keyed by variable-length byte keys.
+    type VecKeyStore = Db<deterministic::Context, Vec<u8>, Vec<u8>, TwoCap>;
+
+    #[test_traced("DEBUG")]
+    fn test_store_variable_length_keys() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            // Configure the operation codec for variable-length keys.
+            let cfg = Config {
+                log: JournalConfig {
+                    partition: "journal".into(),
+                    write_buffer: NZUsize!(64 * 1024),
+                    replay_buffer: NZUsize!(64 * 1024),
+                    compression: None,
+                    codec_config: (((0..=64).into(), ()), ((0..=10000).into(), ())),
+                    items_per_section: NZU64!(7),
+                    page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
+                },
+                translator: TwoCap,
+                init_cache_size: Some(NZUsize!(1024)),
+                init_buffer: NZUsize!(1 << 21),
+            };
+
+            // Commit two keys of different lengths that share a translated prefix.
+            let db = VecKeyStore::init(
+                context.child("store").with_attribute("index", 0),
+                cfg.clone(),
+            )
+            .await
+            .unwrap();
+            let short = b"key".to_vec();
+            let long = b"key-extended".to_vec();
+            let batch = db
+                .new_batch()
+                .update(short.clone(), vec![1])
+                .update(long.clone(), vec![2])
+                .finalize(None);
+            let (db, _) = db.apply_batch(batch).await.unwrap();
+            let db = db.commit().await.unwrap();
+            assert_eq!(db.get(&short).await.unwrap(), Some(vec![1]));
+            assert_eq!(db.get(&long).await.unwrap(), Some(vec![2]));
+            drop(db);
+
+            // Reopen the store and verify both committed values.
+            let db = VecKeyStore::init(context.child("store").with_attribute("index", 1), cfg)
+                .await
+                .unwrap();
+            assert_eq!(db.get(&short).await.unwrap(), Some(vec![1]));
+            assert_eq!(db.get(&long).await.unwrap(), Some(vec![2]));
             db.destroy().await.unwrap();
         });
     }


### PR DESCRIPTION
Fixes for issues found while preparing v2026.9.0. Each code change carries a regression that fails without the fix.

## glue

- **`Stateful` treated replayed ancestors as verified.** The verify fast path returned `true` for any digest in the pending map, including ancestors rebuilt through `Application::apply` during lazy recovery. Under deferred voting with optimistic validation, certifying a replayed parent that the application would reject skipped `Application::verify` entirely. Pending entries now record whether they came from `propose`/`verify` or from replay, only the former short-circuit, and a later successful verify upgrades a replayed entry in place. `Application::apply` now returns `Option<Merkleized>`: `None` means the block cannot be executed (for example because `verify` would reject it), and the wrapper rejects the ancestry that depends on it, the same as a commitment mismatch. Reconstructing a finalized winner treats `None` as a bug, since a quorum verified that block. The docs no longer claim a replayed block was previously certified: under optimistic validation it may not have passed `verify` anywhere, and replayed state is reusable as parent state but never a verdict. The `Stateful::verify` doc now says the notarize vote may already have been cast. Re-caching a pending digest now asserts, rather than debug-asserts, that its parent and round are unchanged.
- **QMDB sync served an unbounded backlog of peer requests.** The resolver relies on the `Producer` to bound serve concurrency, but the sync `Handler` retained every overflowed `Produce` in its overflow queue with the response channel alive, so the backlog grew without bound and the actor kept serving requests their requesters had already abandoned. The overflow `Policy` now retains only open deliveries and drops overflowed produce requests, so the peer gets an error and retries elsewhere and outstanding serve work is bounded by `mailbox_size`.
- **Variable-length keys on the unordered variable `current` wrappers.** `open::variable` and the unordered-variable `ManagedDb`/`StateSyncDb` impls still required `K: Array` while the ordered siblings accept `K: Key`. Relaxed to match, with a compile-time pin.

## consensus

- **Leader recovery skipped its own boundary re-proposal.** At an epoch boundary the leader re-proposes the parent block itself, and marshal persists it under the re-proposal round. After a crash between the relay broadcast and the notarize journal sync, recovery found that block but rejected it because its embedded context is the parent's original round, and dropped the proposal. This only matters when the leader restarts before its peers' leader timeout expires (otherwise the view is nullified either way): a leader that could have re-proposed and kept the view alive instead lost the view under rotating terms, or the rest of the term under stable leaders. `Deferred` and `Marshaled` now reuse the cached block when its context matches or when it is the current parent at the epoch's last height, the same test the fresh path applies. A restart-shaped regression per wrapper fails on the old code with the dropped proposal receiver.
- **Certification through the embedded-context path was unpinned for application rejection.** Every existing rejection test called `verify` before `certify`, so only the registered-gate path was covered. Added `test_certify_without_prior_verify_honors_application_rejection` for both `Deferred` and `coding::Marshaled`. Each fails under a mutant that ignores the verdict on the embedded path while the existing tests stay green.
- **Docs that assumed notarized means application-verified.** Under deferred verification a notarization only guarantees a quorum verified the block's context. Reworded the re-proposal comments in `validation.rs`, `deferred.rs`, `inline.rs` and `marshaled.rs` (validity is settled when consensus certifies the view that first carried the block), the marshal `Verified`/`Certified` message docs (reached the stage, not application-valid), the `Deferred` and `Inline` ancestry-validation docs (parent notarized, or verified locally before this participant voted for it), and the reshare `observe_dealer_log` doc (dealer logs are not part of block validity).
- **Same overflow fix for the marshal resolver handler and the simplex resolver ingress**, which carried the identical retain-everything `Policy`. Each site now has a direct `Policy` test: produce dropped with the response closed, deliveries retained, drain skips a delivery whose requester left.
- **Simplex fuzz oracle ignored the notarized parent.** `check()` compared notarizations and finalizations by payload only, so a notarization and finalization for the same payload but different parents in one view passed every arm. Certificates sign the parent, so the arms now key on `(payload, parent)`.

## storage

- **`qmdb::store::Db` rejected variable-length keys.** `Db` and `Batch` were bounded `K: Array` although the store logs the variable operation codec, which only needs `K: Key`, and `Changeset` in the same file already accepted `K: Key`. Relaxed, with a `Vec<u8>`-keyed regression that fails to compile on the old bounds.
- **Segmented journal append gate was pinned for one section only.** Every existing `should_panic` pin probed the newest retained section, so a gate that covered only the newest section passed every test. Added pins for both journals that a clean interior or older section is gated after reopen.
- **`metadata_recovery` fuzz target could not observe a missing init-time repair.** The shrink-then-sentinel sequence rotated the newest state off the repaired copy before the only reopen, so a stale tail left by an incomplete repair went unobserved. The target now reopens between the shrink sync and the sentinel write.
- **`current` sync test comments** claimed a canonical-root authentication check that `sync()`/`build_db` never perform. Reworded to match the code.

## bench

- **`benchmark-tracker` tests collided on their temp directory.** `unique_temp_dir()` named it by timestamp alone, so two tests starting in the same clock tick under a workspace-wide `just test` shared a directory and the first to finish removed it under the other (`NotFound` on write). The name now includes the process id and a per-process counter, with a pin that consecutive calls never repeat.
