### PR TITLE
[storage/journal] Decode journal items from owned buffers

### DIFF
--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -31,6 +31,7 @@ use crate::{
         },
     },
 };
+use bytes::Bytes;
 use commonware_codec::{Codec, CodecShared, varint::MAX_U32_VARINT_SIZE};
 use commonware_macros::boxed;
 use commonware_runtime::{
@@ -68,22 +69,20 @@ const DATA_SUFFIX: &str = "_data";
 /// Suffix appended to the base partition name for the offsets journal.
 const OFFSETS_SUFFIX: &str = "_offsets";
 
-/// Decode one varint-framed item from the head of `bytes`, whose encoded length must be exactly
-/// `frame_len` (the gap to the next frame's offset). Returns `None` on any mismatch or decode
-/// failure. The async read path reports such errors.
+/// Decode one varint-framed item from `bytes`, whose length must be exactly the frame's encoded
+/// length (the gap to the next frame's offset). Returns `None` on any mismatch or decode failure.
+/// The async read path reports such errors.
 fn decode_frame_from_span<V: CodecShared>(
-    bytes: &[u8],
-    frame_len: usize,
+    bytes: Bytes,
     codec_config: &V::Cfg,
     compressed: bool,
 ) -> Option<V> {
-    let mut cursor = Cursor::new(bytes);
+    let mut cursor = Cursor::new(bytes.as_ref());
     let (size, varint_len) = decode_length_prefix(&mut cursor).ok()?;
-    let actual_len = size.checked_add(varint_len)?;
-    if actual_len != frame_len || frame_len > bytes.len() {
+    if size.checked_add(varint_len)? != bytes.len() {
         return None;
     }
-    decode_item::<V>(&bytes[varint_len..frame_len], codec_config, compressed).ok()
+    decode_item::<V>(bytes.slice(varint_len..), codec_config, compressed).ok()
 }
 
 /// One step of walking varint frames over a blob's bytes during recovery.
@@ -494,8 +493,7 @@ impl<'a, E: Context, V: CodecShared> Reader<'a, E, V> {
         let start = offsets[0];
         let end = offsets[offsets.len() - 1];
         let range_len = usize::try_from(end - start).map_err(|_| Error::OffsetOverflow)?;
-        let bytes = blob_handle.read_at(start, range_len).await?.coalesce();
-        let bytes = bytes.as_ref();
+        let bytes = Bytes::from(blob_handle.read_at(start, range_len).await?.coalesce());
 
         let mut items = Vec::with_capacity(offsets.len());
         let mut local_offset = 0usize;
@@ -526,7 +524,7 @@ impl<'a, E: Context, V: CodecShared> Reader<'a, E, V> {
                 .checked_add(item_len)
                 .ok_or(Error::OffsetOverflow)?;
             items.push(decode_item::<V>(
-                &bytes[data_start..data_end],
+                bytes.slice(data_start..data_end),
                 &self.codec_config,
                 self.compressed,
             )?);
@@ -540,7 +538,7 @@ impl<'a, E: Context, V: CodecShared> Reader<'a, E, V> {
 
     /// Read the varint-framed item for `position` at byte `offset` from cached bytes, returning
     /// `None` on any miss.
-    fn try_read_frame_sync(&self, position: u64, offset: u64, buf: &mut Vec<u8>) -> Option<V> {
+    fn try_read_frame_sync(&self, position: u64, offset: u64) -> Option<V> {
         let blob = self
             .data
             .get(position_to_blob(position, self.items_per_blob.get()))?;
@@ -585,12 +583,12 @@ impl<'a, E: Context, V: CodecShared> Reader<'a, E, V> {
         }
 
         // Otherwise try reading the full item from cache.
-        buf.resize(item_len, 0);
-        if !blob.try_read_sync_into(buf, offset) {
+        let mut buf = vec![0u8; item_len];
+        if !blob.try_read_sync_into(&mut buf, offset) {
             return None;
         }
         decode_item::<V>(
-            &buf[varint_len..varint_len + data_len],
+            Bytes::from(buf).slice(varint_len..),
             &self.codec_config,
             self.compressed,
         )
@@ -795,7 +793,6 @@ impl<'a, E: Context, V: CodecShared> Reader<'a, E, V> {
             }
         }
 
-        let mut buf = Vec::new();
         let mut hits = 0u64;
 
         // Serve known-extent frames: one batched cache read per data blob group.
@@ -819,19 +816,20 @@ impl<'a, E: Context, V: CodecShared> Reader<'a, E, V> {
                 .map(|&(_, offset, len)| (offset, len))
                 .collect();
             let total: usize = ranges.iter().map(|&(_, len)| len).sum();
-            buf.resize(total, 0);
+            let mut buf = vec![0u8; total];
             let missed = blob.try_read_ranges_sync_into(&mut buf, &ranges);
+            let buf = Bytes::from(buf);
             let mut missed = missed.into_iter().peekable();
             let mut local = 0usize;
             for (range_idx, &(idx, _, len)) in group.iter().enumerate() {
-                let slot = &buf[local..local + len];
+                let slot = buf.slice(local..local + len);
                 local += len;
                 if missed.peek() == Some(&range_idx) {
                     missed.next();
                     continue;
                 }
                 if let Some(item) =
-                    decode_frame_from_span(slot, len, &self.codec_config, self.compressed)
+                    decode_frame_from_span(slot, &self.codec_config, self.compressed)
                 {
                     out[idx] = Some(item);
                     hits += 1;
@@ -840,9 +838,8 @@ impl<'a, E: Context, V: CodecShared> Reader<'a, E, V> {
         }
 
         // Per-frame path for frames whose extent is unknown.
-        let mut frame_buf = Vec::new();
         for (idx, offset) in singles {
-            if let Some(item) = self.try_read_frame_sync(positions[idx], offset, &mut frame_buf) {
+            if let Some(item) = self.try_read_frame_sync(positions[idx], offset) {
                 out[idx] = Some(item);
                 hits += 1;
             }
@@ -972,13 +969,12 @@ impl<E: Context, V: CodecShared> super::Contiguous for Reader<'_, E, V> {
         // possible. On a data-frame miss the resolved offset is reused by the async path so the
         // offsets journal is not consulted twice.
         let cached_offset = self.offsets.try_read_sync(position);
-        if let Some(offset) = cached_offset {
-            let mut buf = Vec::new();
-            if let Some(item) = self.try_read_frame_sync(position, offset, &mut buf) {
-                self.metrics.cache_hits.inc();
-                self.metrics.items_read.inc();
-                return Ok(item);
-            }
+        if let Some(offset) = cached_offset
+            && let Some(item) = self.try_read_frame_sync(position, offset)
+        {
+            self.metrics.cache_hits.inc();
+            self.metrics.items_read.inc();
+            return Ok(item);
         }
 
         let _timer = self.metrics.read_timer();
@@ -1010,8 +1006,7 @@ impl<E: Context, V: CodecShared> super::Contiguous for Reader<'_, E, V> {
     fn try_read_sync(&self, position: u64) -> Option<V> {
         self.validate_readable(position).ok()?;
         let offset = self.offsets.try_read_sync(position)?;
-        let mut buf = Vec::new();
-        let item = self.try_read_frame_sync(position, offset, &mut buf)?;
+        let item = self.try_read_frame_sync(position, offset)?;
         self.metrics.cache_hits.inc();
         self.metrics.items_read.inc();
         Some(item)

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -587,12 +587,9 @@ impl<'a, E: Context, V: CodecShared> Reader<'a, E, V> {
         if !blob.try_read_sync_into(&mut buf, offset) {
             return None;
         }
-        decode_item::<V>(
-            Bytes::from(buf).slice(varint_len..),
-            &self.codec_config,
-            self.compressed,
-        )
-        .ok()
+        let mut buf = Bytes::from(buf);
+        buf.advance(varint_len);
+        decode_item::<V>(buf, &self.codec_config, self.compressed).ok()
     }
 
     /// Build one replay state for each data blob touched by `[start_pos, bounds.end)`.

--- a/storage/src/journal/frame.rs
+++ b/storage/src/journal/frame.rs
@@ -4,6 +4,7 @@
 //! zstd-compressed) encoded item.
 
 use super::Error;
+use bytes::Bytes;
 use commonware_codec::{
     Codec, EncodeSize, ReadExt as _, Write as _,
     varint::{MAX_U32_VARINT_SIZE, UInt},
@@ -117,7 +118,7 @@ pub(super) fn decode_item<V: Codec>(
     if compressed {
         let decompressed =
             decode_all(item_data.reader()).map_err(|_| Error::DecompressionFailed)?;
-        V::decode_cfg(decompressed.as_ref(), cfg).map_err(Error::Codec)
+        V::decode_cfg(Bytes::from(decompressed), cfg).map_err(Error::Codec)
     } else {
         V::decode_cfg(item_data, cfg).map_err(Error::Codec)
     }
@@ -137,7 +138,7 @@ pub(super) async fn read_frame_at<V: Codec>(
             IoBufMut::with_capacity(MAX_U32_VARINT_SIZE),
         )
         .await?;
-    let buf = buf.freeze();
+    let buf = Bytes::from(buf.freeze());
     let mut cursor = Cursor::new(buf.slice(..available));
     let (next_offset, item_info) = find_frame(&mut cursor, offset)?;
 
@@ -164,6 +165,7 @@ pub(super) async fn read_frame_at<V: Codec>(
                 .and_then(|offset| offset.checked_add(prefix_len as u64))
                 .ok_or(Error::OffsetOverflow)?;
             let remainder = reader.read_at(read_offset, total_len - prefix_len).await?;
+            let remainder = Bytes::from(remainder.coalesce());
             let decoded = decode_item::<V>(prefix.chain(remainder), cfg, compressed)?;
             (total_len as u32, decoded)
         }

--- a/storage/src/journal/segmented/glob.rs
+++ b/storage/src/journal/segmented/glob.rs
@@ -28,6 +28,7 @@
 
 use super::manager::{Config as ManagerConfig, Manager, WriteFactory};
 use crate::{Context, journal::Error};
+use bytes::Bytes;
 use commonware_codec::{Codec, CodecShared, FixedSize};
 use commonware_cryptography::{Crc32, crc32};
 #[cfg(any(test, feature = "test-utils"))]
@@ -123,7 +124,7 @@ impl<E: Context, V: CodecShared> Inner<E, V> {
             .ok_or(Error::SectionOutOfRange(section))?;
 
         // Read via buffered writer (handles read-through for buffered data)
-        let buf = writer.read_at(offset, size as usize).await?.coalesce();
+        let buf = Bytes::from(writer.read_at(offset, size as usize).await?.coalesce());
 
         // Entry format: [compressed_data] [crc32 (4 bytes)]
         if buf.len() < CHECKSUM_SIZE {
@@ -131,7 +132,7 @@ impl<E: Context, V: CodecShared> Inner<E, V> {
         }
 
         let data_len = buf.len() - CHECKSUM_SIZE;
-        let compressed_data = &buf.as_ref()[..data_len];
+        let compressed_data = buf.slice(..data_len);
         let stored_checksum = u32::from_be_bytes(
             buf.as_ref()[data_len..]
                 .try_into()
@@ -139,16 +140,16 @@ impl<E: Context, V: CodecShared> Inner<E, V> {
         );
 
         // Verify checksum
-        let checksum = Crc32::checksum(compressed_data);
+        let checksum = Crc32::checksum(&compressed_data);
         if checksum != stored_checksum {
             return Err(Error::ChecksumMismatch(stored_checksum, checksum));
         }
 
         // Decompress if needed and decode
         let value = if self.compression.is_some() {
-            let decompressed =
-                decode_all(Cursor::new(compressed_data)).map_err(|_| Error::DecompressionFailed)?;
-            V::decode_cfg(decompressed.as_ref(), &self.codec_config).map_err(Error::Codec)?
+            let decompressed = decode_all(Cursor::new(&compressed_data))
+                .map_err(|_| Error::DecompressionFailed)?;
+            V::decode_cfg(Bytes::from(decompressed), &self.codec_config).map_err(Error::Codec)?
         } else {
             V::decode_cfg(compressed_data, &self.codec_config).map_err(Error::Codec)?
         };

--- a/storage/src/journal/segmented/glob.rs
+++ b/storage/src/journal/segmented/glob.rs
@@ -294,7 +294,10 @@ impl<E: Context, V: CodecShared> Glob<E, V> {
     /// Read value at offset with known size (from index entry).
     ///
     /// The offset should be the byte offset returned by `append()`.
-    /// Reads directly from blob without any caching.
+    /// Reads directly from blob without any caching. The byte fields of the
+    /// returned value are views of the read buffer, so a retained value keeps
+    /// that buffer alive (and, for an unflushed entry, forces the write tip to
+    /// copy on its next append).
     pub async fn get(&self, section: u64, offset: u64, size: u32) -> Result<V, Error> {
         self.0.get(section, offset, size).await
     }

--- a/storage/src/journal/segmented/glob.rs
+++ b/storage/src/journal/segmented/glob.rs
@@ -294,10 +294,7 @@ impl<E: Context, V: CodecShared> Glob<E, V> {
     /// Read value at offset with known size (from index entry).
     ///
     /// The offset should be the byte offset returned by `append()`.
-    /// Reads directly from blob without any caching. The byte fields of the
-    /// returned value are views of the read buffer, so a retained value keeps
-    /// that buffer alive (and, for an unflushed entry, forces the write tip to
-    /// copy on its next append).
+    /// Reads directly from blob without any caching.
     pub async fn get(&self, section: u64, offset: u64, size: u32) -> Result<V, Error> {
         self.0.get(section, offset, size).await
     }

--- a/storage/src/journal/segmented/variable.rs
+++ b/storage/src/journal/segmented/variable.rs
@@ -87,6 +87,7 @@ use crate::journal::{
         FrameInfo, decode_item, decode_length_prefix, encode_frame_into, find_frame, read_frame_at,
     },
 };
+use bytes::Bytes;
 use commonware_codec::{Codec, CodecShared, varint::MAX_U32_VARINT_SIZE};
 use commonware_runtime::{
     Blob, Buf, Error as RError, Handle, IoBuf, Metrics, ReadOptions, Storage,
@@ -304,7 +305,7 @@ impl<E: Storage + Metrics, V: CodecShared> Inner<E, V> {
             return None;
         }
         decode_item::<V>(
-            &buf[varint_len..varint_len + data_len],
+            Bytes::from(buf).slice(varint_len..),
             &self.codec_config,
             compressed,
         )

--- a/storage/src/journal/segmented/variable.rs
+++ b/storage/src/journal/segmented/variable.rs
@@ -304,12 +304,9 @@ impl<E: Storage + Metrics, V: CodecShared> Inner<E, V> {
         if !blob.try_read_sync_into(&mut buf, offset) {
             return None;
         }
-        decode_item::<V>(
-            Bytes::from(buf).slice(varint_len..),
-            &self.codec_config,
-            compressed,
-        )
-        .ok()
+        let mut buf = Bytes::from(buf);
+        buf.advance(varint_len);
+        decode_item::<V>(buf, &self.codec_config, compressed).ok()
     }
 
     /// See [Journal::size].
@@ -1190,6 +1187,37 @@ mod tests {
             // Check metrics
             let buffer = context.encode();
             assert!(buffer.contains("second_tracked 1"));
+        });
+    }
+
+    #[test_traced]
+    fn test_journal_try_get_sync() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "test-partition".into(),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
+                write_buffer: NZUsize!(1024),
+            };
+            let mut journal = Journal::<_, u64>::init(context.child("first"), cfg)
+                .await
+                .expect("Failed to initialize journal");
+
+            // A u64 frame is longer than the varint header window, so the hit
+            // path reads the whole item from the cache.
+            let section = 1u64;
+            let data = 0x0102_0304_0506_0708u64;
+            let offset;
+            (journal, offset, _) = journal
+                .append(section, &data)
+                .await
+                .expect("Failed to append data");
+
+            assert_eq!(journal.try_get_sync(section, offset), Some(data));
+            assert_eq!(journal.try_get_sync(section, offset + 1), None);
+            assert_eq!(journal.try_get_sync(section + 1, offset), None);
         });
     }
 


### PR DESCRIPTION
Journal reads decoded items from borrowed slices or slices of a pool-owned `IoBuf`, incurring per-field allocations for `Bytes`, `Lazy`, and `IoBuf`. Borrowed sources copied field data; pooled sources boxed owners for shared slices. Reading an archived block therefore allocated for each lazily decoded transaction.

This converts each read buffer to `Bytes` once before decoding, allowing `Bytes` and `Lazy` fields to share its backing storage instead of allocating for every field. `IoBuf` fields still allocate one external owner each. The change covers glob reads, async frame reads, synchronous cache-hit paths in both variable journals, batched and consecutive reads, and decompressed payloads. The synchronous single-frame paths use `advance` to skip the header without cloning the buffer.

A counting-allocator microbenchmark with 100 `Lazy<u64>` fields measured glob `get` allocations falling from 101 to 2, and contiguous journal `read` allocations from 103 to 4 on both cache hits and misses. These measurements establish the allocation reduction for that workload. They do not measure end-to-end latency or retained memory.

Shared ownership changes memory lifetime. Retaining one item from a batched read can keep the entire blob-group or span buffer alive. Async reads can retain a pooled allocation, including capacity beyond the item's logical bytes, until the last shared field drops. An uncompressed glob value read directly from the write tip can keep that tip shared and require a copy on a later append. Compressed values instead share the decompression buffer.

The contiguous synchronous read pass also allocates a buffer per blob group and per single-frame read instead of reusing scratch storage. This trades scratch reuse for shareable results, so workloads without sharing-capable fields may incur additional allocations. The encoded journal format is unchanged.
