### PR TITLE
[storage/qmdb] Move ownership of fetched operations to journal

### DIFF
--- a/storage/src/qmdb/sync/engine.rs
+++ b/storage/src/qmdb/sync/engine.rs
@@ -506,12 +506,12 @@ where
             };
 
             // Remove the batch of operations that contains the next operation to apply.
-            let operations = self.fetched_operations.remove(&range_start_loc).unwrap();
+            let mut operations = self.fetched_operations.remove(&range_start_loc).unwrap();
             assert!(!operations.is_empty());
             // Skip operations that are before the next location. The containment check when
             // selecting the range (`next_loc <= range_end`) guarantees at least one operation
             // at or after it, so the batch is never empty.
-            let operations = &operations[(next_loc - *range_start_loc) as usize..];
+            operations.drain(..(next_loc - *range_start_loc) as usize);
             next_loc += operations.len() as u64;
             self.journal = self.journal.append(operations).await?;
         }
@@ -874,7 +874,7 @@ mod tests {
             self.size
         }
 
-        async fn append(mut self, ops: &[Self::Op]) -> Result<Self, Self::Error> {
+        async fn append(mut self, ops: Vec<Self::Op>) -> Result<Self, Self::Error> {
             self.size += ops.len() as u64;
             Ok(self)
         }

--- a/storage/src/qmdb/sync/journal.rs
+++ b/storage/src/qmdb/sync/journal.rs
@@ -44,7 +44,7 @@ pub trait Journal<F: Family>: Sized + Send {
     fn size(&self) -> u64;
 
     /// Append a non-empty batch of operations.
-    fn append(self, ops: &[Self::Op]) -> impl Future<Output = Result<Self, Self::Error>> + Send;
+    fn append(self, ops: Vec<Self::Op>) -> impl Future<Output = Result<Self, Self::Error>> + Send;
 }
 
 impl<F, E, V> Journal<F> for crate::journal::contiguous::variable::Journal<E, V>
@@ -83,8 +83,8 @@ where
         Contiguous::bounds(self).end
     }
 
-    async fn append(self, ops: &[Self::Op]) -> Result<Self, Self::Error> {
-        let (journal, _) = self.append_many(Many::Flat(ops)).await?;
+    async fn append(self, ops: Vec<Self::Op>) -> Result<Self, Self::Error> {
+        let (journal, _) = self.append_many(Many::Flat(&ops)).await?;
         Ok(journal)
     }
 }
@@ -151,8 +151,8 @@ where
         Contiguous::bounds(self).end
     }
 
-    async fn append(self, ops: &[Self::Op]) -> Result<Self, Self::Error> {
-        let (journal, _) = self.append_many(Many::Flat(ops)).await?;
+    async fn append(self, ops: Vec<Self::Op>) -> Result<Self, Self::Error> {
+        let (journal, _) = self.append_many(Many::Flat(&ops)).await?;
         Ok(journal)
     }
 }
@@ -175,7 +175,7 @@ impl<F, E, Op> Journal<F> for Memory<F, E, Op>
 where
     F: Family,
     E: Send,
-    Op: Clone + Send + Sync,
+    Op: Send + Sync,
 {
     type Context = E;
     type Config = ();
@@ -213,8 +213,8 @@ where
         *self.start + self.ops.len() as u64
     }
 
-    async fn append(mut self, ops: &[Self::Op]) -> Result<Self, Self::Error> {
-        self.ops.extend_from_slice(ops);
+    async fn append(mut self, ops: Vec<Self::Op>) -> Result<Self, Self::Error> {
+        self.ops.extend(ops);
         Ok(self)
     }
 }
@@ -270,7 +270,7 @@ mod tests {
             assert_eq!(journal.size(), 10);
 
             // Appends extend the size.
-            let journal = journal.append(&[1, 2, 3]).await.unwrap();
+            let journal = journal.append(vec![1, 2, 3]).await.unwrap();
             assert_eq!(journal.size(), 13);
 
             // A resize within the retained ops drains the prefix.
@@ -284,7 +284,7 @@ mod tests {
             let journal = <Mem as Journal<F>>::new((), (), range.clone())
                 .await
                 .unwrap();
-            let journal = journal.append(&[1, 2]).await.unwrap();
+            let journal = journal.append(vec![1, 2]).await.unwrap();
             let journal = journal.resize(Location::new(15)).await.unwrap();
             assert_eq!(journal.size(), 15);
             let (start, ops) = journal.into_parts();
@@ -293,7 +293,7 @@ mod tests {
 
             // A resize before the start clears.
             let journal = <Mem as Journal<F>>::new((), (), range).await.unwrap();
-            let journal = journal.append(&[1]).await.unwrap();
+            let journal = journal.append(vec![1]).await.unwrap();
             let journal = journal.resize(Location::new(5)).await.unwrap();
             assert_eq!(journal.size(), 5);
             let (start, ops) = journal.into_parts();


### PR DESCRIPTION
`sync::Journal::append` took `&[Op]`. The engine owns the fetched batch it appends. It removes the batch from `fetched_operations` and drops it right after, so the in-memory journal used by the compact databases cloned every synced operation only to drop the original. The disk-backed journals borrow the slice and were unaffected.

`append` now takes `Vec<Op>`. The engine drains the already-applied prefix and moves the rest. The in-memory journal extends from the vector, and the contiguous journals pass `Many::Flat(&ops)` as before. The memory journal no longer needs `Op: Clone`.