### PR TITLE
[deployer] Bound SDK retry attempts to fix per-request stalls

### DIFF
--- a/deployer/src/aws/ec2.rs
+++ b/deployer/src/aws/ec2.rs
@@ -3,7 +3,10 @@
 use super::{METRICS_PORT, SYSTEM_PORT};
 use crate::aws::{
     PortConfig,
-    utils::{DEPLOYER_MAX_PORT, DEPLOYER_MIN_PORT, DEPLOYER_PROTOCOL, RETRY_INTERVAL, exact_cidr},
+    utils::{
+        DEPLOYER_MAX_PORT, DEPLOYER_MIN_PORT, DEPLOYER_PROTOCOL, MAX_SDK_ATTEMPTS, RETRY_INTERVAL,
+        SDK_INITIAL_BACKOFF, SDK_MAX_BACKOFF, exact_cidr,
+    },
 };
 pub use aws_config::Region;
 use aws_config::{BehaviorVersion, retry::RetryConfig};
@@ -74,9 +77,9 @@ const RETRYABLE_LAUNCH_STATUS_CODES: &[u16] = &[500, 502, 503, 504];
 /// Creates an EC2 client for the specified AWS region
 pub async fn create_client(region: Region) -> Ec2Client {
     let retry = aws_config::retry::RetryConfig::adaptive()
-        .with_max_attempts(u32::MAX)
-        .with_initial_backoff(Duration::from_millis(500))
-        .with_max_backoff(Duration::from_secs(30))
+        .with_max_attempts(MAX_SDK_ATTEMPTS)
+        .with_initial_backoff(SDK_INITIAL_BACKOFF)
+        .with_max_backoff(SDK_MAX_BACKOFF)
         .with_reconnect_mode(aws_sdk_ec2::config::retry::ReconnectMode::ReconnectOnTransientError);
     let config = aws_config::defaults(BehaviorVersion::v2026_01_12())
         .region(region)

--- a/deployer/src/aws/s3.rs
+++ b/deployer/src/aws/s3.rs
@@ -1,6 +1,9 @@
 //! AWS S3 SDK function wrappers for caching deployer artifacts
 
-use crate::aws::{Error, InstanceConfig, deployer_directory};
+use crate::aws::{
+    Error, InstanceConfig, deployer_directory,
+    utils::{MAX_SDK_ATTEMPTS, SDK_INITIAL_BACKOFF, SDK_MAX_BACKOFF},
+};
 use aws_config::BehaviorVersion;
 pub use aws_config::Region;
 use aws_sdk_s3::{
@@ -104,9 +107,9 @@ pub const WGET: &str = "wget -q --tries=10 --retry-connrefused --retry-on-http-e
 /// Creates an S3 client for the specified AWS region
 pub async fn create_client(region: Region) -> S3Client {
     let retry = aws_config::retry::RetryConfig::adaptive()
-        .with_max_attempts(u32::MAX)
-        .with_initial_backoff(Duration::from_millis(500))
-        .with_max_backoff(Duration::from_secs(30))
+        .with_max_attempts(MAX_SDK_ATTEMPTS)
+        .with_initial_backoff(SDK_INITIAL_BACKOFF)
+        .with_max_backoff(SDK_MAX_BACKOFF)
         .with_reconnect_mode(ReconnectMode::ReconnectOnTransientError);
     let config = aws_config::defaults(BehaviorVersion::v2026_01_12())
         .region(region)

--- a/deployer/src/aws/utils.rs
+++ b/deployer/src/aws/utils.rs
@@ -19,6 +19,18 @@ pub const MAX_POLL_ATTEMPTS: usize = 30;
 /// Interval between retries
 pub const RETRY_INTERVAL: Duration = Duration::from_secs(15);
 
+/// Maximum attempts the AWS SDK makes per EC2 or S3 request.
+///
+/// With [SDK_INITIAL_BACKOFF] doubling up to [SDK_MAX_BACKOFF], this retries throttled or failing
+/// requests for over two hours.
+pub const MAX_SDK_ATTEMPTS: u32 = 256;
+
+/// Backoff before the first AWS SDK retry (doubles on each subsequent retry)
+pub const SDK_INITIAL_BACKOFF: Duration = Duration::from_millis(500);
+
+/// Upper bound on the backoff between AWS SDK retries
+pub const SDK_MAX_BACKOFF: Duration = Duration::from_secs(30);
+
 /// Protocol for deployer ingress
 pub const DEPLOYER_PROTOCOL: &str = "tcp";
 


### PR DESCRIPTION
## Summary

Every EC2 and S3 request made by `deployer` stalled for about 40 seconds before it was sent, so commands like `aws destroy` across ten regions took many minutes even on a fast connection.

The deployer configured its SDK clients with `RetryConfig::adaptive().with_max_attempts(u32::MAX)`. `aws-smithy-runtime` 1.14 added a "pessimistic" credential-load timeout for the identity cache that, when no explicit timeout is configured, is computed by iterating once per configured retry attempt before every request:

```rust
let total_backoff: f64 = (0..attempts.saturating_sub(1))
    .map(|i| (initial_backoff * 2.0_f64.powi(i as i32)).min(max_backoff))
    .sum();
```

With `u32::MAX` attempts that is 4.3 billion iterations of CPU work per request, and the resulting timeout was nonsensical (`load_timeout=91053306520.625s` in `-v` output).

This PR bounds attempts at `MAX_SDK_ATTEMPTS = 256` and hoists the shared backoff parameters into `SDK_INITIAL_BACKOFF` (500 ms) and `SDK_MAX_BACKOFF` (30 s) alongside it. With that backoff schedule, 256 attempts still retry a throttled or failing request for over two hours, so behavior under throttling is unchanged in practice.

## Validation

- `deployer -v aws destroy` on a built binary: the identity-cache step now begins 0.1 ms after the request starts (previously 41 s), and the derived `load_timeout` is 9,088 s instead of 91 billion.
- `cargo test -p commonware-deployer --features aws` (52 tests) and `cargo +nightly fmt --check` pass.
