### PR TITLE
[storage/journal/fixed] Remove allocation on cached reads

### DIFF
--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -162,9 +162,9 @@ use std::{
 };
 use tracing::warn;
 
-// Reusable scratch for [`Reader::probe_items`], grown to the largest probe served on the
-// thread. Probes run per shard on the hot read path, where a fresh zeroed allocation per call
-// contends under the pool's fan-out.
+// Reusable scratch for the synchronous read paths ([`Reader::try_read_sync`] and
+// [`Reader::probe_items`]), grown to the largest probe served on the thread. Both run on the
+// hot read path, where a fresh zeroed allocation per call contends under the pool's fan-out.
 commonware_utils::thread_local_cache!(static PROBE_SCRATCH: Vec<u8>);
 
 /// Items encoded for a deferred append, created by [`Journal::prepare_append`] and consumed by
@@ -1591,12 +1591,17 @@ impl<E: Context, A: CodecFixedShared> super::Contiguous for Reader<'_, E, A> {
     }
 
     fn try_read_sync(&self, pos: u64) -> Option<A> {
-        let mut buf = vec![0u8; A::SIZE];
-        let item = match self.locate(pos) {
-            Ok((blob, offset)) if blob.try_read_sync_into(&mut buf, offset) => {
-                A::decode(&buf[..]).ok()
-            }
-            _ => None,
+        let (blob, offset) = self.locate(pos).ok()?;
+        let mut scratch =
+            Cached::take(&PROBE_SCRATCH, || Ok::<_, ()>(Vec::new()), |_| Ok(())).unwrap();
+        if scratch.len() < A::SIZE {
+            scratch.resize(A::SIZE, 0);
+        }
+        let buf = &mut scratch[..A::SIZE];
+        let item = if blob.try_read_sync_into(buf, offset) {
+            A::decode(&buf[..]).ok()
+        } else {
+            None
         };
         if item.is_some() {
             self.metrics.cache_hits.inc();

--- a/storage/src/journal/segmented/fixed.rs
+++ b/storage/src/journal/segmented/fixed.rs
@@ -29,13 +29,17 @@ use commonware_runtime::{
     Blob, Error as RError, Handle, Metrics, ReadOptions, Storage,
     buffer::paged::{CacheRef, Replay as BlobReplay, Writer},
 };
-use commonware_utils::NZUsize;
+use commonware_utils::{Cached, NZUsize};
 use std::{
     collections::{BTreeMap, BTreeSet, VecDeque},
     marker::PhantomData,
     num::{NonZeroU16, NonZeroUsize},
 };
 use tracing::{trace, warn};
+
+// Reusable scratch for [`Inner::try_get_sync`], sized to one item. A fresh zeroed allocation per
+// synchronous read contends under the pool's fan-out.
+commonware_utils::thread_local_cache!(static READ_SCRATCH: Vec<u8>);
 
 /// State for replaying a single section's blob.
 struct SectionReplay<B: Blob> {
@@ -427,8 +431,13 @@ impl<E: Storage + Metrics, A: CodecFixedShared> Inner<E, A> {
         if remaining < Self::CHUNK_SIZE_U64 {
             return None;
         }
-        let mut buf = vec![0u8; Self::CHUNK_SIZE];
-        if !blob.try_read_sync_into(&mut buf, offset) {
+        let mut scratch =
+            Cached::take(&READ_SCRATCH, || Ok::<_, ()>(Vec::new()), |_| Ok(())).unwrap();
+        if scratch.len() < Self::CHUNK_SIZE {
+            scratch.resize(Self::CHUNK_SIZE, 0);
+        }
+        let buf = &mut scratch[..Self::CHUNK_SIZE];
+        if !blob.try_read_sync_into(buf, offset) {
             return None;
         }
         A::decode(&buf[..]).ok()

--- a/storage/src/journal/segmented/fixed.rs
+++ b/storage/src/journal/segmented/fixed.rs
@@ -37,8 +37,7 @@ use std::{
 };
 use tracing::{trace, warn};
 
-// Reusable scratch for [`Inner::try_get_sync`], sized to one item. A fresh zeroed allocation per
-// synchronous read contends under the pool's fan-out.
+// Reusable scratch for [`Inner::try_get_sync`], sized to one item.
 commonware_utils::thread_local_cache!(static READ_SCRATCH: Vec<u8>);
 
 /// State for replaying a single section's blob.


### PR DESCRIPTION
`Reader::try_read_sync` in the contiguous fixed journal allocated a fresh zeroed `Vec` of `A::SIZE` bytes on every call, decoded into it, and freed it. It is the first thing `read()` does before falling back to the async path, and the variable journal calls it on its offsets journal for every `read()` and `try_read_sync()` of its own, so every page-cache hit on a fixed journal, and every variable-journal read, paid one malloc, one memset, and one free for an 8 to 64 byte buffer. `probe_items`, the batched form of the same probe, already avoided this with the `PROBE_SCRATCH` thread-local. The segmented fixed journal's `try_get_sync` had the same allocation.

This serves both single-item probes from a thread-local scratch too. The contiguous reader reuses `PROBE_SCRATCH` (both callers hold it only across synchronous code that never re-enters the journal, so the one-guard-per-thread rule of `Cached` holds). The segmented journal gets its own `READ_SCRATCH`. The buffer is only decoded when `try_read_sync_into` reports a full hit, so stale bytes from an earlier, larger probe are never read. A stack array is not an option here because `A::SIZE` is an associated const of a type parameter.
