### PR TITLE
chore(deps): replace yanked wnaf and chacha20 crate versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1008,9 +1008,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cipher",
@@ -7053,13 +7053,14 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wnaf"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab12e7090f27e2ffd9322651492942d50c2926094af30601e1964337db39daf1"
+checksum = "795ca18b3fdb5e62bf982199278341ddcf7ebf7d32e25e212ad05d496e95f6fa"
 dependencies = [
  "ff 0.14.0",
  "group 0.14.0",
  "hybrid-array",
+ "primefield",
 ]
 
 [[package]]


### PR DESCRIPTION
## What

`Cargo.lock` pinned `wnaf 0.14.0` and `chacha20 0.10.1`, both yanked from crates.io:

```
warning: package `wnaf v0.14.0` in Cargo.lock is yanked in registry `crates-io`
warning: package `chacha20 v0.10.1` in Cargo.lock is yanked in registry `crates-io`
```

Fixes #4671.

## Fix

Bumped to the next non-yanked patch release of each:

- **wnaf 0.14.0 → 0.14.1.** This release added a new dependency, `primefield` (`^0.14`). This workspace already has `primefield 0.14.0` in its lock file (satisfies the requirement) via other crates, so no new package entry was needed — just adding it to wnaf's own dependency list. Every other dependency wnaf declares (`ff`, `group`, `hybrid-array`) is unchanged between 0.14.0 and 0.14.1.
- **chacha20 0.10.1 → 0.10.2.** Dependency list is identical between the two versions — a pure patch bump.

Both are transitive dependencies (`chacha20` via `chacha20poly1305`, declared directly in the workspace `Cargo.toml`; `wnaf` via one of the cryptography crates), so this only touches `Cargo.lock` — no `Cargo.toml` changes.

## Verification

Verified the new checksums and dependency lists directly against crates.io's API (`https://crates.io/api/v1/crates/<name>/<version>/dependencies`) rather than running `cargo update`, since this workspace requires Cargo >= 1.85 (edition2024) and I only have 1.75 in my sandbox. Please run `cargo check` / confirm no further `cargo update` changes are needed before merging.

Fixes #4671