### PR TITLE
[consensus/marshal] Remove lock from marshal automaton

### DIFF
--- a/consensus/src/marshal/application/gates.rs
+++ b/consensus/src/marshal/application/gates.rs
@@ -9,7 +9,7 @@ use commonware_utils::{
     channel::{fallible::OneshotExt, oneshot},
     sync::Mutex,
 };
-use std::{collections::HashMap, future::Future, sync::Arc};
+use std::{collections::HashMap, sync::Arc};
 use tracing::debug;
 
 /// A proposal staged for its relay broadcast: the block and the ack that
@@ -210,7 +210,7 @@ pub(crate) async fn forward<T, U>(
 /// A ready verdict is published on `tx`. [`GateOutcome::Recover`] or a dropped sender triggers
 /// `fallback`, whose receiver is awaited and published instead. A consensus-dropped receiver
 /// (`tx.closed()`) abandons the work.
-pub(crate) async fn drive<D, F, Fut>(
+pub(crate) async fn drive<D, F>(
     mut tx: oneshot::Sender<bool>,
     task: oneshot::Receiver<GateOutcome>,
     round: Round,
@@ -218,8 +218,7 @@ pub(crate) async fn drive<D, F, Fut>(
     fallback: F,
 ) where
     D: Digest,
-    F: FnOnce() -> Fut,
-    Fut: Future<Output = oneshot::Receiver<bool>>,
+    F: FnOnce() -> oneshot::Receiver<bool>,
 {
     let result = select! {
         _ = tx.closed() => {
@@ -241,7 +240,7 @@ pub(crate) async fn drive<D, F, Fut>(
                 ?id,
                 "certification gate requires recovery, falling back to embedded context"
             );
-            let fallback = fallback().await;
+            let fallback = fallback();
             let result = select! {
                 _ = tx.closed() => {
                     debug!(
@@ -265,7 +264,6 @@ mod tests {
     use crate::types::{Epoch, View};
     use commonware_cryptography::{Hasher, Sha256, sha256::Digest as Sha256Digest};
     use commonware_runtime::{Runner, Spawner, Supervisor, deterministic};
-    use std::future::ready;
 
     type D = Sha256Digest;
     type TestGates = Gates<D, u64>;
@@ -279,7 +277,7 @@ mod tests {
         rx
     }
 
-    fn no_fallback() -> std::future::Ready<oneshot::Receiver<bool>> {
+    fn no_fallback() -> oneshot::Receiver<bool> {
         unreachable!("certification must not fall back")
     }
 
@@ -448,7 +446,7 @@ mod tests {
             task_tx.send_lossy(GateOutcome::Recover);
             let (fallback_tx, fallback_rx) = oneshot::channel();
             fallback_tx.send_lossy(true);
-            drive(tx, task_rx, round(1), digest, || ready(fallback_rx)).await;
+            drive(tx, task_rx, round(1), digest, || fallback_rx).await;
             assert!(rx.await.expect("fallback verdict published"));
         });
     }
@@ -463,7 +461,7 @@ mod tests {
             drop(task_tx);
             let (fallback_tx, fallback_rx) = oneshot::channel();
             fallback_tx.send_lossy(false);
-            drive(tx, task_rx, round(1), digest, || ready(fallback_rx)).await;
+            drive(tx, task_rx, round(1), digest, || fallback_rx).await;
             assert!(!rx.await.expect("fallback verdict published"));
         });
     }

--- a/consensus/src/marshal/coding/marshaled.rs
+++ b/consensus/src/marshal/coding/marshaled.rs
@@ -117,10 +117,7 @@ use commonware_runtime::{
         traces::TracedExt as _,
     },
 };
-use commonware_utils::{
-    channel::{fallible::OneshotExt, oneshot},
-    sync::TracedAsyncMutex,
-};
+use commonware_utils::channel::{fallible::OneshotExt, oneshot};
 use rand_core::Rng;
 use std::sync::Arc;
 use tracing::{Instrument as _, debug, info_span, warn};
@@ -167,7 +164,7 @@ where
     S: Strategy,
     ES: Epocher,
 {
-    context: Arc<TracedAsyncMutex<E>>,
+    context: Arc<E>,
     application: A,
     marshal: core::Mailbox<Z::Scheme, Coding<B, C, H, <Z::Scheme as Verifier>::PublicKey>>,
     shards: shards::Mailbox<B, C, H, <Z::Scheme as Verifier>::PublicKey>,
@@ -281,7 +278,7 @@ where
         let erasure_encode_duration = Timed::new(erasure_histogram);
 
         Self {
-            context: Arc::new(TracedAsyncMutex::new("marshal.context", context)),
+            context: Arc::new(context),
             application,
             marshal,
             shards,
@@ -315,7 +312,7 @@ where
     /// If `prefetched_block` is provided, it will be used directly instead of fetching from
     /// the marshal. This is useful in `certify` when we've already fetched the block to
     /// extract its embedded context.
-    async fn deferred_verify(
+    fn deferred_verify(
         &mut self,
         consensus_context: Context<Commitment<B, C, H>, <Z::Scheme as Verifier>::PublicKey>,
         commitment: Commitment<B, C, H>,
@@ -331,8 +328,6 @@ where
         let (mut tx, rx) = oneshot::channel();
         let context = self
             .context
-            .lock()
-            .await
             .child("deferred_verify")
             .with_attribute("round", consensus_context.round);
         let span = info_span!(
@@ -483,7 +478,7 @@ where
         rx
     }
 
-    async fn certify_from_embedded_context(
+    fn certify_from_embedded_context(
         &mut self,
         round: Round,
         payload: Commitment<B, C, H>,
@@ -519,12 +514,7 @@ where
         let mut marshaled = self.clone();
         let shards = self.shards.clone();
         let (mut tx, rx) = oneshot::channel();
-        let context = self
-            .context
-            .lock()
-            .await
-            .child("certify")
-            .with_attribute("round", round);
+        let context = self.context.child("certify").with_attribute("round", round);
         context.spawn(move |_| {
             async move {
                 let block = select! {
@@ -583,9 +573,12 @@ where
 
                 // Use the block's embedded context for verification, passing the
                 // prefetched block to avoid fetching it again inside deferred_verify.
-                let verify_rx = marshaled
-                    .deferred_verify(embedded_context, payload, Some(block), Stage::Certified)
-                    .await;
+                let verify_rx = marshaled.deferred_verify(
+                    embedded_context,
+                    payload,
+                    Some(block),
+                    Stage::Certified,
+                );
                 gates::forward(tx, verify_rx, |result| match result {
                     GateOutcome::Ready(result) => Some(result),
                     GateOutcome::Recover => None,
@@ -600,9 +593,7 @@ where
         });
         rx
     }
-
-    #[allow(clippy::async_yields_async)]
-    async fn certify_from_existing_task(
+    fn certify_from_existing_task(
         &mut self,
         round: Round,
         payload: Commitment<B, C, H>,
@@ -622,15 +613,11 @@ where
         let (tx, rx) = oneshot::channel();
         let context = self
             .context
-            .lock()
-            .await
             .child("certify_existing")
             .with_attribute("round", round);
         context.spawn(move |_| {
-            gates::drive(tx, task, round, payload, move || async move {
-                marshaled
-                    .certify_from_embedded_context(round, payload)
-                    .await
+            gates::drive(tx, task, round, payload, move || {
+                marshaled.certify_from_embedded_context(round, payload)
             })
             .instrument(info_span!(
                 "marshal.coding.certify.existing",
@@ -711,8 +698,6 @@ where
         let (mut tx, rx) = oneshot::channel();
         let context = self
             .context
-            .lock()
-            .await
             .child("propose")
             .with_attribute("round", consensus_context.round);
         let span = info_span!(
@@ -983,8 +968,6 @@ where
             let (mut tx, rx) = oneshot::channel();
             let context = self
                 .context
-                .lock()
-                .await
                 .child("verify_reproposal")
                 .with_attribute("round", round);
             context.spawn(move |_| {
@@ -1069,9 +1052,7 @@ where
         // drops the verify receiver without cancelling certification for it, so
         // deferred verification must survive that drop for certify to consume.
         let round = consensus_context.round;
-        let task = self
-            .deferred_verify(consensus_context, payload, None, Stage::Verified)
-            .await;
+        let task = self.deferred_verify(consensus_context, payload, None, Stage::Verified);
         self.gates.insert(round, payload, task);
 
         match scheme.me() {
@@ -1084,8 +1065,6 @@ where
                 let (tx, rx) = oneshot::channel();
                 let context = self
                     .context
-                    .lock()
-                    .await
                     .child("shard_validity_wait")
                     .with_attribute("round", round);
                 context.spawn(move |_| {
@@ -1137,10 +1116,10 @@ where
         // First, check for an in-progress certification gate task.
         let task = self.gates.take(round, payload);
         if let Some(task) = task {
-            return self.certify_from_existing_task(round, payload, task).await;
+            return self.certify_from_existing_task(round, payload, task);
         }
 
-        self.certify_from_embedded_context(round, payload).await
+        self.certify_from_embedded_context(round, payload)
     }
 }
 

--- a/consensus/src/marshal/standard/deferred.rs
+++ b/consensus/src/marshal/standard/deferred.rs
@@ -103,10 +103,7 @@ use commonware_runtime::{
         traces::TracedExt as _,
     },
 };
-use commonware_utils::{
-    channel::{fallible::OneshotExt, oneshot},
-    sync::TracedAsyncMutex,
-};
+use commonware_utils::channel::{fallible::OneshotExt, oneshot};
 use rand_core::Rng;
 use std::sync::Arc;
 use tracing::{Instrument as _, debug, info_span};
@@ -148,7 +145,7 @@ where
     B: CertifiableBlock,
     ES: Epocher,
 {
-    context: Arc<TracedAsyncMutex<E>>,
+    context: Arc<E>,
     application: A,
     marshal: Mailbox<S, Standard<B>>,
     epocher: ES,
@@ -217,7 +214,7 @@ where
         let ancestor_fetch_duration = Timed::new(ancestor_fetch_histogram);
 
         Self {
-            context: Arc::new(TracedAsyncMutex::new("marshal.context", context)),
+            context: Arc::new(context),
             application,
             marshal,
             epocher,
@@ -242,7 +239,7 @@ where
     /// Verification is spawned in a background task and returns a receiver that will contain
     /// the verification result. Valid blocks are reported to the marshal as verified.
     #[inline]
-    async fn deferred_verify(
+    fn deferred_verify(
         &mut self,
         context: <Self as Automaton>::Context,
         block: Arc<B>,
@@ -255,8 +252,6 @@ where
         let ancestor_fetch_duration = self.ancestor_fetch_duration.clone();
         let runtime_context = self
             .context
-            .lock()
-            .await
             .child("deferred_verify")
             .with_attribute("round", context.round);
         let span = info_span!(
@@ -315,7 +310,7 @@ where
         rx
     }
 
-    async fn certify_from_embedded_context(
+    fn certify_from_embedded_context(
         &mut self,
         round: Round,
         digest: B::Digest,
@@ -345,12 +340,7 @@ where
         let mut marshaled = self.clone();
         let epocher = self.epocher.clone();
         let (mut tx, rx) = oneshot::channel();
-        let context = self
-            .context
-            .lock()
-            .await
-            .child("certify")
-            .with_attribute("round", round);
+        let context = self.context.child("certify").with_attribute("round", round);
         context.spawn(move |_| {
             async move {
                 let block = select! {
@@ -413,9 +403,12 @@ where
                     },
                 );
 
-                let verify_rx = marshaled
-                    .deferred_verify(embedded_context, block, parent_request, Stage::Certified)
-                    .await;
+                let verify_rx = marshaled.deferred_verify(
+                    embedded_context,
+                    block,
+                    parent_request,
+                    Stage::Certified,
+                );
                 gates::forward(tx, verify_rx, |result| match result {
                     GateOutcome::Ready(result) => Some(result),
                     GateOutcome::Recover => None,
@@ -430,9 +423,7 @@ where
         });
         rx
     }
-
-    #[allow(clippy::async_yields_async)]
-    async fn certify_from_existing_task(
+    fn certify_from_existing_task(
         &mut self,
         round: Round,
         digest: B::Digest,
@@ -451,13 +442,11 @@ where
         let (tx, rx) = oneshot::channel();
         let context = self
             .context
-            .lock()
-            .await
             .child("certify_existing")
             .with_attribute("round", round);
         context.spawn(move |_| {
-            gates::drive(tx, task, round, digest, move || async move {
-                marshaled.certify_from_embedded_context(round, digest).await
+            gates::drive(tx, task, round, digest, move || {
+                marshaled.certify_from_embedded_context(round, digest)
             })
             .instrument(info_span!(
                 "marshal.deferred.certify.existing",
@@ -518,8 +507,6 @@ where
         let (mut tx, rx) = oneshot::channel();
         let context = self
             .context
-            .lock()
-            .await
             .child("propose")
             .with_attribute("round", consensus_context.round);
         let span = info_span!(
@@ -717,8 +704,6 @@ where
         let (mut tx, rx) = oneshot::channel();
         let runtime_context = self
             .context
-            .lock()
-            .await
             .child("optimistic_verify")
             .with_attribute("round", round);
         runtime_context.spawn(move |_| {
@@ -832,8 +817,7 @@ where
                 // gate owns the deferred work. Nullification keeps that gate
                 // alive, while finalization drops it.
                 let deferred_rx = marshaled
-                    .deferred_verify(context, block, parent_request, Stage::Verified)
-                    .await;
+                    .deferred_verify(context, block, parent_request, Stage::Verified);
                 tx.send_lossy(true);
                 gates::forward(task_tx, deferred_rx, Some).await;
             }
@@ -869,10 +853,10 @@ where
         // Attempt to retrieve the existing certification gate task for this round/digest.
         let task = self.gates.take(round, digest);
         if let Some(task) = task {
-            return self.certify_from_existing_task(round, digest, task).await;
+            return self.certify_from_existing_task(round, digest, task);
         }
 
-        self.certify_from_embedded_context(round, digest).await
+        self.certify_from_embedded_context(round, digest)
     }
 }
 

--- a/consensus/src/marshal/standard/inline.rs
+++ b/consensus/src/marshal/standard/inline.rs
@@ -72,10 +72,7 @@ use commonware_runtime::{
         traces::TracedExt as _,
     },
 };
-use commonware_utils::{
-    channel::{fallible::OneshotExt, oneshot},
-    sync::TracedAsyncMutex,
-};
+use commonware_utils::channel::{fallible::OneshotExt, oneshot};
 use rand_core::Rng;
 use std::sync::Arc;
 use tracing::{Instrument as _, debug, info_span};
@@ -138,7 +135,7 @@ where
     B: Block + Clone,
     ES: Epocher,
 {
-    context: Arc<TracedAsyncMutex<E>>,
+    context: Arc<E>,
     application: A,
     marshal: Mailbox<S, Standard<B>>,
     epocher: ES,
@@ -209,7 +206,7 @@ where
         let ancestor_fetch_duration = Timed::new(ancestor_fetch_histogram);
 
         Self {
-            context: Arc::new(TracedAsyncMutex::new("marshal.context", context)),
+            context: Arc::new(context),
             application,
             marshal,
             epocher,
@@ -263,8 +260,6 @@ where
         let (mut tx, rx) = oneshot::channel();
         let context = self
             .context
-            .lock()
-            .await
             .child("propose")
             .with_attribute("round", consensus_context.round);
         let span = info_span!(
@@ -447,8 +442,6 @@ where
         let (mut tx, rx) = oneshot::channel();
         let runtime_context = self
             .context
-            .lock()
-            .await
             .child("inline_verify")
             .with_attribute("round", round);
         let span = info_span!(
@@ -618,8 +611,6 @@ where
         let (mut tx, rx) = oneshot::channel();
         let context = self
             .context
-            .lock()
-            .await
             .child("inline_certify")
             .with_attribute("round", round);
         context.spawn(move |_| {


### PR DESCRIPTION
`Inline`, `Deferred`, and `Marshaled` held their runtime context behind `Arc<TracedAsyncMutex<E>>`. Every one of the 14 lock sites took the guard only to call `child(...)`, which borrows `&self` and returns an owned context, and released it before spawning. `Supervisor` is `Send + Sync`, so the lock guarded nothing. This replaces the field with `Arc<E>` and calls `child` directly.

Removing the lock also removed the only `.await` from six private helpers (`deferred_verify`, `certify_from_embedded_context`, `certify_from_existing_task` in both `Deferred` and `Marshaled`), so they are now synchronous, and `gates::drive` takes a plain `FnOnce() -> Receiver<bool>` fallback instead of a future-returning one. The `marshal.context` trace span for lock wait time goes away with the lock.

No public API or wire change.