### PR TITLE
[storage/qmdb] Move values out of read operations

### DIFF
--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -1721,7 +1721,7 @@ where
         unresolved: Vec<PendingRead<'_, U::Key>>,
         db: &Db<F, E, C, I, H, U, N, S>,
         results: &mut [Option<U::Value>],
-        map: impl Fn(&U, Location<F>) -> T + Send + Sync,
+        map: impl Fn(U, Location<F>) -> T + Send + Sync,
         mut apply: impl FnMut(usize, T) -> U::Value,
     ) -> Result<(), crate::qmdb::Error<F>>
     where
@@ -1787,7 +1787,7 @@ where
             unresolved,
             db,
             &mut results,
-            |data, _| data.value().clone(),
+            |data, _| data.into_value(),
             |_, value| value,
         )
         .await?;
@@ -1880,7 +1880,10 @@ where
             unresolved,
             db,
             &mut results,
-            |data, loc| (data.value().clone(), loc, data.cached()),
+            |data, loc| {
+                let payload = data.cached();
+                (data.into_value(), loc, payload)
+            },
             |slot, (value, loc, payload)| {
                 resolutions[slot] = Some((StagedLoc::Committed(loc), payload));
                 value

--- a/storage/src/qmdb/any/db.rs
+++ b/storage/src/qmdb/any/db.rs
@@ -214,7 +214,7 @@ where
                 panic!("location does not reference update operation. loc={loc}");
             };
             if data.key() == key {
-                result = Some(data.value().clone());
+                result = Some(data.into_value());
                 break;
             }
         }

--- a/storage/src/qmdb/any/db.rs
+++ b/storage/src/qmdb/any/db.rs
@@ -29,6 +29,11 @@ use std::{collections::HashMap, sync::Arc};
 /// keys plus `(global key index, position)` pairs for page-cache misses.
 type ShardReads<T> = (Vec<Option<T>>, Vec<(usize, u64)>);
 
+/// Whether two `(key index, position)` candidates share a position.
+const fn same_position(a: &(usize, u64), b: &(usize, u64)) -> bool {
+    a.1 == b.1
+}
+
 /// Type alias for the authenticated journal used by [Db].
 pub(crate) type AuthenticatedLog<F, E, C, H, S> = authenticated::Journal<F, E, C, H, S>;
 
@@ -229,16 +234,16 @@ where
         &self,
         keys: &[&U::Key],
     ) -> Result<Vec<Option<U::Value>>, crate::qmdb::Error<F>> {
-        self.get_many_map(keys, |data, _| data.value().clone())
-            .await
+        self.get_many_map(keys, |data, _| data.into_value()).await
     }
 
-    /// Like [`Self::get_many`] but maps each matched update through `map`, which also
-    /// receives the committed location the update was read from.
+    /// Like [`Self::get_many`] but maps each matched update through `map`, which takes the
+    /// update by value along with the committed location it was read from. A key repeated in
+    /// `keys` receives a clone of its update in every slot but the last.
     pub(crate) async fn get_many_map<T: Send>(
         &self,
         keys: &[&U::Key],
-        map: impl Fn(&U, Location<F>) -> T + Send + Sync,
+        map: impl Fn(U, Location<F>) -> T + Send + Sync,
     ) -> Result<Vec<Option<T>>, crate::qmdb::Error<F>> {
         if keys.is_empty() {
             return Ok(Vec::new());
@@ -282,11 +287,15 @@ where
         misses.sort_unstable_by_key(|&(_, pos)| pos);
         let positions = Self::dedup_positions(&misses);
         let ops = self.log.read_many(&positions).await?;
+        assert_eq!(
+            ops.len(),
+            positions.len(),
+            "read_many returns one operation per position"
+        );
         Self::match_read_ops(
             keys,
             &misses,
-            &positions,
-            |i| Some(&ops[i]),
+            ops.into_iter().map(Some),
             &map,
             &mut results,
             |_, pos| unreachable!("read_many returns one operation per position, pos={pos}"),
@@ -301,7 +310,7 @@ where
     fn resolve_cached<T: Send>(
         &self,
         keys: &[&U::Key],
-        map: &(impl Fn(&U, Location<F>) -> T + Send + Sync),
+        map: &(impl Fn(U, Location<F>) -> T + Send + Sync),
         base: usize,
     ) -> ShardReads<T> {
         // Probe the in-memory index. Each key may map to multiple locations due to hash
@@ -315,13 +324,17 @@ where
         let positions = Self::dedup_positions(&candidates);
 
         let served = self.log.try_read_many_sync(&positions);
+        assert_eq!(
+            served.len(),
+            positions.len(),
+            "try_read_many_sync returns one slot per position"
+        );
         let mut results: Vec<Option<T>> = (0..keys.len()).map(|_| None).collect();
         let mut misses: Vec<(usize, u64)> = Vec::new();
         Self::match_read_ops(
             keys,
             &candidates,
-            &positions,
-            |i| served[i].as_ref(),
+            served.into_iter(),
             map,
             &mut results,
             |key_idx, pos| misses.push((base + key_idx, pos)),
@@ -332,44 +345,50 @@ where
     /// Collapse position-sorted `(key index, position)` candidates into deduplicated positions.
     fn dedup_positions(candidates: &[(usize, u64)]) -> Vec<u64> {
         let mut positions = Vec::with_capacity(candidates.len());
-        for &(_, pos) in candidates {
-            if positions.last() != Some(&pos) {
-                positions.push(pos);
-            }
-        }
+        positions.extend(candidates.chunk_by(same_position).map(|group| group[0].1));
         positions
     }
 
-    /// Match operations read for deduplicated `positions` back to their position-sorted
-    /// `(key index, position)` candidates, filling each unresolved key slot whose operation
-    /// carries its exact key. `op` returns the operation read for a deduplicated position
-    /// index, or `None` when the page cache could not serve it, which is reported to `on_miss`
-    /// with the candidate's key index and position.
-    fn match_read_ops<'o, T>(
+    /// Match the operations read for the deduplicated positions of position-sorted
+    /// `(key index, position)` candidates back to those candidates, filling each unresolved key
+    /// slot whose operation carries its exact key. `ops` yields one slot per deduplicated
+    /// position, in order: the operation read there, or `None` when the page cache could not
+    /// serve it, which is reported to `on_miss` with each candidate's key index and position.
+    fn match_read_ops<T>(
         keys: &[&U::Key],
         candidates: &[(usize, u64)],
-        positions: &[u64],
-        op: impl Fn(usize) -> Option<&'o Operation<F, U>>,
-        map: &impl Fn(&U, Location<F>) -> T,
+        ops: impl Iterator<Item = Option<Operation<F, U>>>,
+        map: &impl Fn(U, Location<F>) -> T,
         results: &mut [Option<T>],
         mut on_miss: impl FnMut(usize, u64),
-    ) where
-        F: 'o,
-        U: 'o,
-    {
-        let mut op_idx = 0;
-        for &(key_idx, pos) in candidates {
-            while positions[op_idx] < pos {
-                op_idx += 1;
-            }
-            match op(op_idx) {
-                Some(Operation::Update(data)) => {
-                    if results[key_idx].is_none() && data.key() == keys[key_idx] {
-                        results[key_idx] = Some(map(data, Location::new(pos)));
-                    }
+    ) {
+        for (group, op) in candidates.chunk_by(same_position).zip(ops) {
+            let pos = group[0].1;
+            let Some(op) = op else {
+                for &(key_idx, _) in group {
+                    on_miss(key_idx, pos);
                 }
-                Some(_) => panic!("location does not reference update operation. loc={pos}"),
-                None => on_miss(key_idx, pos),
+                continue;
+            };
+            let Operation::Update(data) = op else {
+                panic!("location does not reference update operation. loc={pos}");
+            };
+
+            // The candidates sharing this position match the update only for repeated input
+            // keys. Defer each match so every slot but the last takes a clone and the last
+            // takes the update itself.
+            let loc = Location::new(pos);
+            let mut pending = None;
+            for &(key_idx, _) in group {
+                if results[key_idx].is_some() || data.key() != keys[key_idx] {
+                    continue;
+                }
+                if let Some(prev) = pending.replace(key_idx) {
+                    results[prev] = Some(map(data.clone(), loc));
+                }
+            }
+            if let Some(last) = pending {
+                results[last] = Some(map(data, loc));
             }
         }
     }

--- a/storage/src/qmdb/any/operation/update/mod.rs
+++ b/storage/src/qmdb/any/operation/update/mod.rs
@@ -44,6 +44,9 @@ pub trait Update: sealed::Sealed + Clone + Send + Sync + 'static {
     /// The updated value.
     fn value(&self) -> &Self::Value;
 
+    /// Consumes the update and returns its owned value.
+    fn into_value(self) -> Self::Value;
+
     /// Build the cached payload from a resolved update.
     fn cached(&self) -> Self::Cached;
 

--- a/storage/src/qmdb/any/operation/update/ordered.rs
+++ b/storage/src/qmdb/any/operation/update/ordered.rs
@@ -64,6 +64,10 @@ impl<K: Key, V: ValueEncoding> UpdateTrait for Update<K, V> {
         &self.value
     }
 
+    fn into_value(self) -> V::Value {
+        self.value
+    }
+
     fn cached(&self) -> K {
         self.next_key.clone()
     }

--- a/storage/src/qmdb/any/operation/update/unordered.rs
+++ b/storage/src/qmdb/any/operation/update/unordered.rs
@@ -55,6 +55,10 @@ impl<K: Key, V: ValueEncoding> UpdateTrait for Update<K, V> {
         &self.1
     }
 
+    fn into_value(self) -> V::Value {
+        self.1
+    }
+
     fn cached(&self) {}
 
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/storage/src/qmdb/any/unordered/fixed.rs
+++ b/storage/src/qmdb/any/unordered/fixed.rs
@@ -447,6 +447,12 @@ pub(crate) mod test {
             for _ in 0..100 {
                 keys.push(Digest::random(&mut rng));
             }
+
+            // Repeat present and absent keys, some more than once, so one operation resolves
+            // several slots in both the cached pass and the miss fallback.
+            let repeats: Vec<Digest> = keys.iter().step_by(37).copied().collect();
+            keys.extend_from_slice(&repeats);
+            keys.extend_from_slice(&repeats[..20]);
             let refs: Vec<&Digest> = keys.iter().collect();
             let fused = db.get_many(&refs).await.unwrap();
             assert_eq!(fused.len(), keys.len());

--- a/storage/src/qmdb/any/unordered/mod.rs
+++ b/storage/src/qmdb/any/unordered/mod.rs
@@ -41,10 +41,10 @@ where
 
         for loc in locs {
             let op = self.log.read(*loc).await?;
-            match &op {
+            match op {
                 Operation::Update(Update(k, value)) => {
-                    if k == key {
-                        return Ok(Some((value.clone(), loc)));
+                    if k == *key {
+                        return Ok(Some((value, loc)));
                     }
                 }
                 _ => unreachable!("location {loc} does not reference update operation"),

--- a/storage/src/qmdb/immutable/fixed.rs
+++ b/storage/src/qmdb/immutable/fixed.rs
@@ -561,6 +561,7 @@ mod tests {
         test_fixed_prune_after_uncommitted_apply_batch_recovery => run_prune_after_uncommitted_apply_batch_recovery, open;
         test_fixed_rewind_preserves_collision_bucket => run_rewind_preserves_collision_bucket, open;
         test_fixed_get_many => run_get_many, open;
+        test_fixed_get_many_duplicate_keys => run_get_many_duplicate_keys, open;
         test_fixed_get_many_unexpected_data => run_get_many_unexpected_data, open;
         test_fixed_rewind_after_reopen_repeated_key_gap => run_rewind_after_reopen_repeated_key_gap, open;
         test_fixed_rewind_after_reopen_mixed_gap_retained => run_rewind_after_reopen_mixed_gap_retained, open;

--- a/storage/src/qmdb/immutable/mod.rs
+++ b/storage/src/qmdb/immutable/mod.rs
@@ -411,18 +411,22 @@ where
 
         let ops = self.journal.read_many(&positions).await?;
 
-        for &(key_idx, pos) in &candidates {
-            if results[key_idx].is_some() {
-                continue;
-            }
-            let op_idx = positions
-                .binary_search(&pos)
-                .expect("position was deduped from candidates");
-            let Operation::Set(k, v) = &ops[op_idx] else {
-                return Err(Error::UnexpectedData(Location::new(pos)));
+        let groups = candidates.chunk_by(|a, b| a.1 == b.1);
+        for (op, group) in ops.into_iter().zip(groups) {
+            let Operation::Set(k, v) = op else {
+                return Err(Error::UnexpectedData(Location::new(group[0].1)));
             };
-            if k == keys[key_idx] {
-                results[key_idx] = Some(v.clone());
+            let mut pending = None;
+            for &(key_idx, _) in group {
+                if results[key_idx].is_some() || k != *keys[key_idx] {
+                    continue;
+                }
+                if let Some(prev) = pending.replace(key_idx) {
+                    results[prev] = Some(v.clone());
+                }
+            }
+            if let Some(last) = pending {
+                results[last] = Some(v);
             }
         }
 
@@ -3842,6 +3846,37 @@ pub(super) mod tests {
         let child = parent.new_batch::<Sha256>().set(k3, v3_new);
         let results = child.get_many(&[&k1, &k3, &k_missing], &db).await.unwrap();
         assert_eq!(results, vec![Some(v1), Some(v3_new), None]);
+
+        db.destroy().await.unwrap();
+    }
+
+    /// `get_many` fills every slot of a repeated key.
+    #[boxed]
+    pub(crate) async fn run_get_many_duplicate_keys<F: Family, V, C>(
+        context: deterministic::Context,
+        open_db: impl Fn(
+            deterministic::Context,
+        ) -> Pin<Box<dyn Future<Output = TestDb<F, V, C>> + Send>>,
+    ) where
+        V: ValueEncoding<Value = Digest>,
+        C: Mutable<Item = Operation<F, Digest, V>>,
+        C::Item: EncodeShared,
+    {
+        let db = open_db(context.child("db")).await;
+
+        let key = Sha256::fill(1u8);
+        let value = Sha256::fill(11u8);
+        let k_missing = Sha256::fill(99u8);
+        let merkleized = db
+            .new_batch()
+            .set(key, value)
+            .merkleize(&db, None, db.inactivity_floor_loc())
+            .await;
+        let (db, _) = db.apply_batch(merkleized).await.unwrap();
+        let db = db.commit().await.unwrap();
+
+        let results = db.get_many(&[&key, &k_missing, &key, &key]).await.unwrap();
+        assert_eq!(results, vec![Some(value), None, Some(value), Some(value)]);
 
         db.destroy().await.unwrap();
     }

--- a/storage/src/qmdb/immutable/mod.rs
+++ b/storage/src/qmdb/immutable/mod.rs
@@ -402,17 +402,20 @@ where
 
         candidates.sort_unstable_by_key(|&(_, pos)| pos);
 
-        let mut positions: Vec<u64> = Vec::with_capacity(candidates.len());
-        for &(_, pos) in &candidates {
-            if positions.last() != Some(&pos) {
-                positions.push(pos);
-            }
-        }
+        let same_pos = |a: &(usize, u64), b: &(usize, u64)| a.1 == b.1;
+        let positions: Vec<u64> = candidates
+            .chunk_by(same_pos)
+            .map(|group| group[0].1)
+            .collect();
 
         let ops = self.journal.read_many(&positions).await?;
+        assert_eq!(
+            ops.len(),
+            positions.len(),
+            "read_many returns one operation per position"
+        );
 
-        let groups = candidates.chunk_by(|a, b| a.1 == b.1);
-        for (op, group) in ops.into_iter().zip(groups) {
+        for (op, group) in ops.into_iter().zip(candidates.chunk_by(same_pos)) {
             let Operation::Set(k, v) = op else {
                 return Err(Error::UnexpectedData(Location::new(group[0].1)));
             };

--- a/storage/src/qmdb/immutable/variable.rs
+++ b/storage/src/qmdb/immutable/variable.rs
@@ -287,6 +287,7 @@ mod tests {
         test_variable_partial_ancestor_commit => run_partial_ancestor_commit, open;
         test_variable_delayed_merkleize_after_ancestor_apply => run_delayed_merkleize_after_ancestor_apply, open;
         test_variable_get_many => run_get_many, open;
+        test_variable_get_many_duplicate_keys => run_get_many_duplicate_keys, open;
         test_variable_get_many_unexpected_data => run_get_many_unexpected_data, open;
         test_variable_apply_after_ancestor_dropped => run_apply_after_ancestor_dropped, open;
         test_variable_rewind_preserves_collision_bucket => run_rewind_preserves_collision_bucket, open;


### PR DESCRIPTION
QMDB read paths decode an `Operation` they own, but the `Update` trait only has `into_key` and a borrowing `value()`. So `get` and `get_with_loc` cloned the value out of the op and then dropped the op, and the immutable `get_many` did the same through a borrow of an owned `ops` vector. For variable-size values that is a full copy per lookup for nothing.

Changes:
- `Update` trait (`storage/src/qmdb/any/operation/update/mod.rs`) gains `into_value(self) -> Self::Value`, implemented for the unordered and ordered `Update` types.
- `any::Db::get` (`storage/src/qmdb/any/db.rs`) moves the value out with `into_value`.
- unordered `Db::get_with_loc` (`storage/src/qmdb/any/unordered/mod.rs`) matches the op by value and moves, as the ordered variant already does for the whole update.
- immutable `Db::get_many` (`storage/src/qmdb/immutable/mod.rs`) consumes `ops` with `into_iter`, pairing each op with its run of same-position candidates via `chunk_by`. This drops the per-candidate binary search. When the same key appears more than once in the input, every slot but the last still clones. `get_many` now reports a non-`Set` op at any candidate position, even after the key has already resolved, where the old loop skipped positions for resolved keys.