### PR TITLE
[consensus] Remove redundant simplex voter bookkeeping

### DIFF
--- a/consensus/src/simplex/actors/voter/actor.rs
+++ b/consensus/src/simplex/actors/voter/actor.rs
@@ -448,12 +448,6 @@ impl<
         }
     }
 
-    /// Persists our nullify vote to the journal for crash recovery.
-    async fn handle_nullify(self, nullify: Nullify<S>) -> Self {
-        self.append_journal(nullify.view(), Artifact::Nullify(nullify))
-            .await
-    }
-
     /// Handle a timeout.
     ///
     /// Builds a nullify vote for the current view (as many times as required
@@ -474,7 +468,9 @@ impl<
 
         // Persist the nullify if it is a first attempt
         if !retry {
-            self = self.handle_nullify(nullify.clone()).await;
+            self = self
+                .append_journal(nullify.view(), Artifact::Nullify(nullify.clone()))
+                .await;
             return (self, Some((nullify, None)));
         }
 
@@ -496,12 +492,6 @@ impl<
             return self;
         }
         self.append_journal(view, artifact).await
-    }
-
-    /// Persists our notarize vote to the journal for crash recovery.
-    async fn handle_notarize(self, notarize: Notarize<S, D>) -> Self {
-        self.append_journal(notarize.view(), Artifact::Notarize(notarize))
-            .await
     }
 
     /// Records a notarization certificate and blocks any equivocating leader.
@@ -539,12 +529,6 @@ impl<
         (self, Some(notarization))
     }
 
-    /// Persists our finalize vote to the journal for crash recovery.
-    async fn handle_finalize(self, finalize: Finalize<S, D>) -> Self {
-        self.append_journal(finalize.view(), Artifact::Finalize(finalize))
-            .await
-    }
-
     /// Stores a finalization certificate and guards against leader equivocation.
     ///
     /// The finalization is appended to the journal without an immediate sync.
@@ -570,7 +554,9 @@ impl<
         };
 
         // Record the vote locally before sharing it.
-        self = self.handle_notarize(notarize.clone()).await;
+        self = self
+            .append_journal(notarize.view(), Artifact::Notarize(notarize.clone()))
+            .await;
         (self, Some(notarize))
     }
 
@@ -635,7 +621,9 @@ impl<
         };
 
         // Record the vote locally before sharing it.
-        self = self.handle_finalize(finalize.clone()).await;
+        self = self
+            .append_journal(finalize.view(), Artifact::Finalize(finalize.clone()))
+            .await;
         (self, Some(finalize))
     }
 
@@ -1040,7 +1028,6 @@ impl<
                 self.state.replay(&artifact);
                 match artifact {
                     Artifact::Notarize(notarize) => {
-                        self = self.handle_notarize(notarize.clone()).await;
                         self.reporter.report(Activity::Notarize(notarize));
                     }
                     Artifact::Notarization(notarization) => {
@@ -1061,7 +1048,6 @@ impl<
                         }
                     }
                     Artifact::Nullify(nullify) => {
-                        self = self.handle_nullify(nullify.clone()).await;
                         self.reporter.report(Activity::Nullify(nullify));
                     }
                     Artifact::Nullification(nullification) => {
@@ -1070,7 +1056,6 @@ impl<
                         self.reporter.report(Activity::Nullification(nullification));
                     }
                     Artifact::Finalize(finalize) => {
-                        self = self.handle_finalize(finalize.clone()).await;
                         self.reporter.report(Activity::Finalize(finalize));
                     }
                     Artifact::Finalization(finalization) => {

--- a/consensus/src/simplex/actors/voter/actor.rs
+++ b/consensus/src/simplex/actors/voter/actor.rs
@@ -472,7 +472,9 @@ impl<
 
         // Persist the nullify if it is a first attempt
         if !retry {
-            self = self.append_journal(Artifact::Nullify(nullify.clone())).await;
+            self = self
+                .append_journal(Artifact::Nullify(nullify.clone()))
+                .await;
             return (self, Some((nullify, None)));
         }
 
@@ -553,7 +555,9 @@ impl<
         };
 
         // Record the vote locally before sharing it.
-        self = self.append_journal(Artifact::Notarize(notarize.clone())).await;
+        self = self
+            .append_journal(Artifact::Notarize(notarize.clone()))
+            .await;
         (self, Some(notarize))
     }
 
@@ -618,7 +622,9 @@ impl<
         };
 
         // Record the vote locally before sharing it.
-        self = self.append_journal(Artifact::Finalize(finalize.clone())).await;
+        self = self
+            .append_journal(Artifact::Finalize(finalize.clone()))
+            .await;
         (self, Some(finalize))
     }
 

--- a/consensus/src/simplex/actors/voter/actor.rs
+++ b/consensus/src/simplex/actors/voter/actor.rs
@@ -254,8 +254,12 @@ impl<
     /// The append is not immediately durable. All appends in an event loop
     /// iteration target the view being processed and are synced together by
     /// [Self::sync_journal].
-    async fn append_journal(mut self, view: View, artifact: Artifact<S, D>) -> Self {
+    ///
+    /// Inert until replay attaches the journal, so handlers called during
+    /// replay do not re-journal the artifacts they restore.
+    async fn append_journal(mut self, artifact: Artifact<S, D>) -> Self {
         if self.journal.is_some() {
+            let view = artifact.view();
             rebind(&mut self.journal, |journal| {
                 journal.append(view.get(), &artifact)
             })
@@ -468,9 +472,7 @@ impl<
 
         // Persist the nullify if it is a first attempt
         if !retry {
-            self = self
-                .append_journal(nullify.view(), Artifact::Nullify(nullify.clone()))
-                .await;
+            self = self.append_journal(Artifact::Nullify(nullify.clone())).await;
             return (self, Some((nullify, None)));
         }
 
@@ -484,23 +486,21 @@ impl<
 
     /// Tracks a verified nullification certificate if it is new.
     async fn handle_nullification(mut self, nullification: Nullification<S>) -> Self {
-        let view = nullification.view();
         let artifact = Artifact::Nullification(nullification.clone());
 
         // Add verified nullification to journal
         if !self.state.add_nullification(nullification) {
             return self;
         }
-        self.append_journal(view, artifact).await
+        self.append_journal(artifact).await
     }
 
     /// Records a notarization certificate and blocks any equivocating leader.
     async fn handle_notarization(mut self, notarization: Notarization<S, D>) -> Self {
-        let view = notarization.view();
         let artifact = Artifact::Notarization(notarization.clone());
         let (added, equivocator) = self.state.add_notarization(notarization);
         if added {
-            self = self.append_journal(view, artifact).await;
+            self = self.append_journal(artifact).await;
         }
         self.block_equivocator(equivocator);
         self
@@ -524,7 +524,7 @@ impl<
         // iteration's broadcast phase. If lost to a crash before then, certification
         // is re-requested on restart.
         let artifact = Artifact::Certification(Rnd::new(self.state.epoch(), view), success);
-        self = self.append_journal(view, artifact).await;
+        self = self.append_journal(artifact).await;
 
         (self, Some(notarization))
     }
@@ -536,11 +536,10 @@ impl<
     /// gate, replay restores the blocked gate (which is safe) and it heals
     /// again as soon as peers redeliver any covering finalization.
     async fn handle_finalization(mut self, finalization: Finalization<S, D>) -> Self {
-        let view = finalization.view();
         let artifact = Artifact::Finalization(finalization.clone());
         let (added, equivocator) = self.state.add_finalization(finalization);
         if added {
-            self = self.append_journal(view, artifact).await;
+            self = self.append_journal(artifact).await;
         }
         self.block_equivocator(equivocator);
         self
@@ -554,9 +553,7 @@ impl<
         };
 
         // Record the vote locally before sharing it.
-        self = self
-            .append_journal(notarize.view(), Artifact::Notarize(notarize.clone()))
-            .await;
+        self = self.append_journal(Artifact::Notarize(notarize.clone())).await;
         (self, Some(notarize))
     }
 
@@ -621,9 +618,7 @@ impl<
         };
 
         // Record the vote locally before sharing it.
-        self = self
-            .append_journal(finalize.view(), Artifact::Finalize(finalize.clone()))
-            .await;
+        self = self.append_journal(Artifact::Finalize(finalize.clone())).await;
         (self, Some(finalize))
     }
 

--- a/consensus/src/simplex/actors/voter/mod.rs
+++ b/consensus/src/simplex/actors/voter/mod.rs
@@ -5713,7 +5713,7 @@ mod tests {
     /// When the voter is the leader of a view and builds its own proposal, it
     /// must not subsequently ask the automaton to verify that same proposal.
     ///
-    /// This is guarded by `Slot::built` (which sets `status = Verified` and
+    /// This is guarded by `Slot::record_verified` (which sets `status = Verified` and
     /// `requested_verify = true`) and by `Round::verify_ready` short-circuiting
     /// for leader-owned views. This test asserts the end-to-end invariant on
     /// the live path (no restart): after calling `automaton.propose`, the voter

--- a/consensus/src/simplex/actors/voter/round.rs
+++ b/consensus/src/simplex/actors/voter/round.rs
@@ -399,7 +399,7 @@ impl<S: Scheme, D: Digest> Round<S, D> {
         if self.broadcast_nullify {
             return false;
         }
-        self.proposal.built(proposal);
+        self.proposal.record_verified(proposal);
         self.proposed_at = Some(now);
         self.leader_deadline = None;
         true
@@ -741,26 +741,8 @@ impl<S: Scheme, D: Digest> Round<S, D> {
                     "replaying notarize from another signer"
                 );
 
-                // Replaying our local notarize restores a verified proposal and
-                // the fact that we already voted. For leader-owned rounds, the
-                // proposal was built locally; follower rounds also journal local
-                // notarize votes over other leaders' proposals.
-                //
-                // A vote for the current view replays after the certificate for
-                // `v - 1` (journal replay is append-ordered), which seeds this
-                // round's leader. An optimistic vote replays with no leader set
-                // (the parent certificate did not exist when it was journaled),
-                // so a leader-owned optimistic round takes the `notarized`
-                // branch; the two branches restore the same slot state.
-                if self
-                    .leader
-                    .as_ref()
-                    .is_some_and(|leader| self.is_signer(leader.idx))
-                {
-                    self.proposal.built(notarize.proposal.clone());
-                } else {
-                    self.proposal.notarized(notarize.proposal.clone());
-                }
+                // Our journaled notarize records a locally verified proposal.
+                self.proposal.record_verified(notarize.proposal.clone());
                 self.broadcast_notarize = true;
             }
             Artifact::Nullify(nullify) => {

--- a/consensus/src/simplex/actors/voter/round.rs
+++ b/consensus/src/simplex/actors/voter/round.rs
@@ -1295,7 +1295,7 @@ mod tests {
         round.set_leader(Participant::new(0));
         round.replay(&Artifact::Notarize(notarize_local));
 
-        // Proposal should be restored as verified (we are the leader).
+        // Proposal should be restored as verified.
         assert_eq!(round.proposal.proposal(), Some(&proposal));
         assert_eq!(round.proposal.status(), ProposalStatus::Verified);
         assert!(round.broadcast_notarize);

--- a/consensus/src/simplex/actors/voter/slot.rs
+++ b/consensus/src/simplex/actors/voter/slot.rs
@@ -95,7 +95,7 @@ where
     ///
     /// Additional observations of the same proposal are ignored here.
     /// Conflicting proposals are handled separately as equivocation.
-    fn verified(&mut self, proposal: Proposal<D>) {
+    pub fn record_verified(&mut self, proposal: Proposal<D>) {
         if let Some(existing) = &self.proposal {
             // This can happen if we receive a certificate for a conflicting proposal. Normally,
             // we would ignore this case but it is required to support [Twins](https://arxiv.org/abs/2004.10617) testing.
@@ -112,16 +112,6 @@ where
         self.status = Status::Verified;
         self.requested_build = true;
         self.requested_verify = true;
-    }
-
-    /// Records a proposal built locally by this participant.
-    pub fn built(&mut self, proposal: Proposal<D>) {
-        self.verified(proposal);
-    }
-
-    /// Records a proposal we verified and voted for, but did not build locally.
-    pub fn notarized(&mut self, proposal: Proposal<D>) {
-        self.verified(proposal);
     }
 
     pub const fn request_verify(&mut self) -> bool {
@@ -218,7 +208,7 @@ mod tests {
         let mut slot = Slot::<Sha256Digest>::new();
         let round = Rnd::new(Epoch::new(7), View::new(3));
         let proposal = Proposal::new(round, View::new(2), Sha256Digest::from([1u8; 32]));
-        slot.built(proposal);
+        slot.record_verified(proposal);
         assert!(!slot.should_build());
     }
 
@@ -229,7 +219,7 @@ mod tests {
 
         let round = Rnd::new(Epoch::new(9), View::new(1));
         let proposal = Proposal::new(round, View::new(0), Sha256Digest::from([2u8; 32]));
-        slot.built(proposal.clone());
+        slot.record_verified(proposal.clone());
 
         match slot.proposal() {
             Some(stored) => assert_eq!(stored, &proposal),
@@ -241,27 +231,13 @@ mod tests {
     }
 
     #[test]
-    fn records_and_prevents_duplicate_build() {
-        let mut slot = Slot::<Sha256Digest>::new();
-        let round = Rnd::new(Epoch::new(1), View::new(2));
-        let proposal = Proposal::new(round, View::new(1), Sha256Digest::from([10u8; 32]));
-
-        slot.built(proposal.clone());
-
-        assert_eq!(slot.proposal(), Some(&proposal));
-        assert_eq!(slot.status(), Status::Verified);
-        assert!(!slot.should_build());
-        assert!(!slot.request_verify());
-    }
-
-    #[test]
     fn replay_allows_existing_proposal() {
         let mut slot = Slot::<Sha256Digest>::new();
         let round = Rnd::new(Epoch::new(17), View::new(6));
         let proposal = Proposal::new(round, View::new(5), Sha256Digest::from([11u8; 32]));
 
-        slot.built(proposal.clone());
-        slot.built(proposal.clone());
+        slot.record_verified(proposal.clone());
+        slot.record_verified(proposal.clone());
 
         assert!(!slot.should_build());
         assert_eq!(slot.status(), Status::Verified);
@@ -328,7 +304,7 @@ mod tests {
         // Once we finally finish proposing our honest payload, the slot should just
         // ignore it (the equivocation was already detected when the certificate
         // arrived).
-        slot.built(honest);
+        slot.record_verified(honest);
         assert_eq!(slot.status(), Status::Unverified);
         assert_eq!(slot.proposal(), Some(&compromised));
     }


### PR DESCRIPTION
The voter had two proposal-slot methods with identical behavior and a replay branch that selected between them. Replay also cloned each local vote and called a journal wrapper even though the journal is not attached until replay finishes, so those calls did nothing.

- Replace `Slot::built` and `Slot::notarized` with `record_verified`, and restore journaled notarize proposals directly. This removes the leader check and the comment explaining why both branches have the same effect.
- Remove the no-op vote journal calls during replay and inline the three vote-persistence wrappers at their remaining live call sites. Derive the journal section from `artifact.view()` inside `append_journal`, removing the redundant view argument and preventing a mismatch between the section and artifact. Journal sections and sync ordering stay the same.
- Delete `records_and_prevents_duplicate_build`, which made one recording call and repeated the assertions in `records_proposal_with_flags`. Keep the test that actually records a proposal twice, along with the recovery and equivocation tests.
- Update comments for the consolidated slot method and document why journal appends are inactive during replay.
