### PR TITLE
[storage] Never prune the Current bitmap past the retained log

### DIFF
--- a/glue/src/stateful/db/current.rs
+++ b/glue/src/stateful/db/current.rs
@@ -1621,6 +1621,100 @@ mod tests {
         });
     }
 
+    /// A 32-byte-chunk Current database, so 384-key generations straddle several bitmap chunks.
+    type FixedDb32 = fixed::Db<
+        mmr::Family,
+        deterministic::Context,
+        Digest,
+        Digest,
+        Sha256,
+        TwoCap,
+        32,
+        Sequential,
+    >;
+
+    /// Pruning to the oldest retained target must keep every retained target rewindable, so a
+    /// restart whose marshal anchor lags the database reconciles by rewinding instead of failing.
+    #[test]
+    fn database_set_current_prune_keeps_recovery_targets_rewindable() {
+        deterministic::Runner::default().start(|context| async move {
+            type DbSet = Shared<FixedDb32>;
+            let config = fixed_config("current-prune-recovery-window", &context);
+            let databases = <DbSet as crate::stateful::db::DatabaseSet<_>>::init(
+                context.child("db"),
+                config.clone(),
+            )
+            .await;
+
+            // Three generations rewriting the same keys. H1 and H2 become durable; H3 is applied
+            // with no barrier of its own when the prune to H1 runs.
+            let mut targets = Vec::new();
+            for generation in 0..3u64 {
+                let mut batch = databases.new_batch_for_test::<_>().await;
+                for i in 0..384u64 {
+                    batch = batch.write(
+                        Sha256::hash(&[&i.to_be_bytes()]),
+                        Some(Sha256::hash(&[&(generation * 1_000 + i).to_le_bytes()])),
+                    );
+                }
+                let batch = crate::stateful::db::Unmerkleized::merkleize(batch)
+                    .await
+                    .unwrap();
+                <DbSet as crate::stateful::db::DatabaseSet<_>>::apply(&databases, batch).await;
+                if generation < 2 {
+                    assert!(
+                        <DbSet as crate::stateful::db::DatabaseSet<_>>::finalize(&databases)
+                            .await
+                            .durable()
+                            .await
+                    );
+                }
+                targets.push(
+                    <DbSet as crate::stateful::db::DatabaseSet<_>>::committed_targets(&databases)
+                        .await,
+                );
+            }
+            <DbSet as crate::stateful::db::DatabaseSet<_>>::prune(&databases, &targets[0]).await;
+            drop(databases);
+
+            // Reopen recovers H3, which the prune committed. Reconciling to H2, then to H1, must
+            // succeed: both stay inside the retained window.
+            let reopened = <DbSet as crate::stateful::db::DatabaseSet<_>>::init(
+                context.child("reopen_h2"),
+                config.clone(),
+            )
+            .await;
+            assert_eq!(
+                <DbSet as crate::stateful::db::DatabaseSet<_>>::committed_targets(&reopened).await,
+                targets[2]
+            );
+            <DbSet as crate::stateful::db::DatabaseSet<_>>::rewind_to_targets(
+                &reopened,
+                targets[1].clone(),
+            )
+            .await;
+            assert_eq!(
+                <DbSet as crate::stateful::db::DatabaseSet<_>>::committed_targets(&reopened).await,
+                targets[1]
+            );
+            drop(reopened);
+            let reopened = <DbSet as crate::stateful::db::DatabaseSet<_>>::init(
+                context.child("reopen_h1"),
+                config,
+            )
+            .await;
+            <DbSet as crate::stateful::db::DatabaseSet<_>>::rewind_to_targets(
+                &reopened,
+                targets[0].clone(),
+            )
+            .await;
+            assert_eq!(
+                <DbSet as crate::stateful::db::DatabaseSet<_>>::committed_targets(&reopened).await,
+                targets[0]
+            );
+        });
+    }
+
     #[test]
     fn managed_db_matches_sync_target_rejects_wrong_ops_root_and_range() {
         deterministic::Runner::default().start(|context| async move {

--- a/glue/src/stateful/db/mod.rs
+++ b/glue/src/stateful/db/mod.rs
@@ -409,12 +409,9 @@ pub trait ManagedDb<E>: Send + Sync + Sized {
 
     /// Prune the database to a previously finalized sync target.
     ///
-    /// The caller resolves every handle returned by [`Self::finalize`] before pruning. Only history
-    /// older than `target` may be discarded: `target` and every sync target finalized after it
-    /// must remain valid for [`Self::rewind_to_target`], since startup reconciles a database that
-    /// persisted further than marshal by rewinding to marshal's anchor. Databases that do not
-    /// retain pruneable operation history can rely on the default no-op. Any pruning effects must
-    /// be durable before returning.
+    /// The caller resolves every handle returned by [`Self::finalize`] before pruning. Databases
+    /// that do not retain pruneable operation history can rely on the default no-op. Any pruning
+    /// effects must be durable before returning.
     fn prune(
         self,
         _target: &Self::SyncTarget,

--- a/glue/src/stateful/db/mod.rs
+++ b/glue/src/stateful/db/mod.rs
@@ -409,9 +409,12 @@ pub trait ManagedDb<E>: Send + Sync + Sized {
 
     /// Prune the database to a previously finalized sync target.
     ///
-    /// The caller resolves every handle returned by [`Self::finalize`] before pruning. Databases
-    /// that do not retain pruneable operation history can rely on the default no-op. Any pruning
-    /// effects must be durable before returning.
+    /// The caller resolves every handle returned by [`Self::finalize`] before pruning. Only history
+    /// older than `target` may be discarded: `target` and every sync target finalized after it
+    /// must remain valid for [`Self::rewind_to_target`], since startup reconciles a database that
+    /// persisted further than marshal by rewinding to marshal's anchor. Databases that do not
+    /// retain pruneable operation history can rely on the default no-op. Any pruning effects must
+    /// be durable before returning.
     fn prune(
         self,
         _target: &Self::SyncTarget,

--- a/storage/src/journal/authenticated.rs
+++ b/storage/src/journal/authenticated.rs
@@ -3203,6 +3203,33 @@ mod tests {
         executor.start(test_speculative_batch_sequential_inner::<mmb::Family>);
     }
 
+    /// The trait-level `prune_boundary` predicts the boundary `prune` establishes, including
+    /// the capped and no-op cases.
+    async fn test_prune_boundary_matches_prune_inner<F: Family + PartialEq>(context: Context) {
+        let mut journal = create_journal_with_ops::<F>(context, "prune-boundary", 17).await;
+        for target in [0u64, 3, 5, 12, 11, 17, 40] {
+            let predicted =
+                crate::journal::contiguous::Mutable::prune_boundary(&journal, target).unwrap();
+            let boundary;
+            (journal, boundary) = journal.prune(Location::<F>::new(target)).await.unwrap();
+            assert_eq!(*boundary, predicted, "target={target}");
+            assert_eq!(journal.bounds().start, predicted, "target={target}");
+        }
+        journal.destroy().await.unwrap();
+    }
+
+    #[test_traced("INFO")]
+    fn test_prune_boundary_matches_prune_mmr() {
+        let executor = deterministic::Runner::default();
+        executor.start(test_prune_boundary_matches_prune_inner::<mmr::Family>);
+    }
+
+    #[test_traced("INFO")]
+    fn test_prune_boundary_matches_prune_mmb() {
+        let executor = deterministic::Runner::default();
+        executor.start(test_prune_boundary_matches_prune_inner::<mmb::Family>);
+    }
+
     async fn test_stale_batch_sibling_inner<F: Family + PartialEq>(context: Context) {
         let mut journal = create_empty_journal::<F>(context.child("open"), "stale-sibling").await;
         let op_a = create_operation::<F>(1);

--- a/storage/src/journal/authenticated.rs
+++ b/storage/src/journal/authenticated.rs
@@ -602,6 +602,21 @@ where
         Ok((journal, boundary))
     }
 
+    /// Return the pruning boundary that [`Self::prune`] with `prune_loc` would establish, without
+    /// pruning anything.
+    pub fn prune_boundary(&self, prune_loc: Location<F>) -> Result<Location<F>, Error<F>> {
+        let bounds = self.journal.bounds();
+        // An empty structure prunes nothing, matching `prune`.
+        if self.merkle.size() == 0 {
+            return Ok(Location::new(bounds.start));
+        }
+        let boundary = self
+            .journal
+            .prune_boundary((*prune_loc).min(bounds.end))
+            .map_err(Error::Journal)?;
+        Ok(Location::new(boundary))
+    }
+
     async fn prune_inner(
         mut self,
         prune_loc: Location<F>,
@@ -1030,6 +1045,12 @@ where
             }
         }
         Ok((self, last_pos))
+    }
+
+    fn prune_boundary(&self, min_position: u64) -> Result<u64, JournalError> {
+        Self::prune_boundary(self, Location::new(min_position))
+            .map(|boundary| *boundary)
+            .map_err(Self::map_error)
     }
 
     async fn prune(self, min_position: u64) -> Result<(Self, bool), JournalError> {

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -1073,17 +1073,18 @@ impl<E: Context, A: CodecFixedShared> Inner<E, A> {
         self.bounds.start
     }
 
+    /// See [Journal::prune_boundary].
+    pub(crate) fn prune_boundary(&self, min_item_pos: u64) -> Result<u64, Error> {
+        super::prune_boundary(min_item_pos, &self.bounds, self.items_per_blob.get())
+    }
+
     /// See [Journal::prune].
     pub(crate) async fn prune(
         mut self: Box<Self>,
         min_item_pos: u64,
     ) -> Result<(Box<Self>, bool), Error> {
-        // Calculate the blob that would contain min_item_pos, capped to the tail (which is
-        // guaranteed to exist by our invariant).
-        let target_blob = super::position_to_blob(min_item_pos, self.items_per_blob.get());
-        let tail_blob = super::position_to_blob(self.bounds.end, self.items_per_blob.get());
-        let min_blob = std::cmp::min(target_blob, tail_blob);
-
+        let new_boundary = self.prune_boundary(min_item_pos)?;
+        let min_blob = super::position_to_blob(new_boundary, self.items_per_blob.get());
         if min_blob <= self.blobs.oldest_blob_index() {
             return Ok((self, false));
         }
@@ -1099,7 +1100,6 @@ impl<E: Context, A: CodecFixedShared> Inner<E, A> {
         sync.await?;
         self.barrier.mark_durable(self.bounds.end);
 
-        let new_boundary = super::blob_first_position(min_blob, self.items_per_blob.get())?;
         self.blobs.prune(min_blob).await?;
         self.bounds.start = new_boundary;
 
@@ -1364,6 +1364,12 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
         let (inner, pruned) = self.0.prune(min_item_pos).await?;
         self.0 = inner;
         Ok((self, pruned))
+    }
+
+    /// Return the boundary that [`Self::prune`] with `min_item_pos` would establish, without
+    /// pruning anything.
+    pub fn prune_boundary(&self, min_item_pos: u64) -> Result<u64, Error> {
+        self.0.prune_boundary(min_item_pos)
     }
 
     /// Remove any persisted data created by the journal.
@@ -1711,6 +1717,10 @@ impl<E: Context, A: CodecFixedShared> Mutable for Journal<E, A> {
 
     async fn prune(self, min_position: u64) -> Result<(Self, bool), Error> {
         Self::prune(self, min_position).await
+    }
+
+    fn prune_boundary(&self, min_position: u64) -> Result<u64, Error> {
+        Self::prune_boundary(self, min_position)
     }
 
     async fn rewind(self, size: u64) -> Result<Self, Error> {
@@ -6329,6 +6339,33 @@ mod tests {
 
             drop(snapshot);
             drop(fresh);
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    /// `prune_boundary` predicts the start `prune` establishes, including the capped and no-op
+    /// cases.
+    #[test_traced]
+    fn test_prune_boundary_matches_prune() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = test_cfg(&context, NZU64!(5));
+            let mut journal = Journal::<_, Digest>::init(context.child("j"), cfg)
+                .await
+                .unwrap();
+            for i in 0..17u64 {
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
+            }
+            journal = journal.sync().await.unwrap();
+            for target in [0u64, 3, 5, 12, 11, 17, 40] {
+                let predicted = journal.prune_boundary(target).unwrap();
+                (journal, _) = journal.prune(target).await.unwrap();
+                assert_eq!(
+                    crate::journal::contiguous::Contiguous::bounds(&journal).start,
+                    predicted,
+                    "target={target}"
+                );
+            }
             journal.destroy().await.unwrap();
         });
     }

--- a/storage/src/journal/contiguous/mod.rs
+++ b/storage/src/journal/contiguous/mod.rs
@@ -60,6 +60,23 @@ fn blob_first_position(blob: u64, items_per_blob: u64) -> Result<u64, Error> {
         .ok_or(Error::OffsetOverflow)
 }
 
+/// Return the start of `bounds` that pruning to `min_position` would establish: the first
+/// position of the blob containing `min_position`, capped at the tail blob and never below the
+/// current start.
+fn prune_boundary(
+    min_position: u64,
+    bounds: &Range<u64>,
+    items_per_blob: u64,
+) -> Result<u64, Error> {
+    let target_blob = position_to_blob(min_position, items_per_blob);
+    let tail_blob = position_to_blob(bounds.end, items_per_blob);
+    let min_blob = target_blob.min(tail_blob);
+    if min_blob <= position_to_blob(bounds.start, items_per_blob) {
+        return Ok(bounds.start);
+    }
+    blob_first_position(min_blob, items_per_blob)
+}
+
 /// Return the exclusive logical end for `blob`, clamped to `end`.
 const fn blob_end_position(blob: u64, items_per_blob: u64, end: u64) -> u64 {
     // No positions exist, so `end - 1` would underflow
@@ -277,6 +294,17 @@ pub trait Mutable: Contiguous + Sized {
         self,
         min_position: u64,
     ) -> impl std::future::Future<Output = Result<(Self, bool), Error>> + Send;
+
+    /// Return the start of [`Contiguous::bounds`] that [`Self::prune`] with `min_position` would
+    /// establish, without pruning anything.
+    ///
+    /// Like [`Self::prune`], the result may fall short of `min_position` because of section/blob
+    /// alignment, and it never precedes the current start.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the boundary is not representable.
+    fn prune_boundary(&self, min_position: u64) -> Result<u64, Error>;
 
     /// Rewind the journal to the given size, discarding items from the end.
     ///

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -1524,24 +1524,21 @@ impl<E: Context, V: CodecShared> Inner<E, V> {
         self.bounds.end
     }
 
+    /// See [Journal::prune_boundary].
+    pub(crate) fn prune_boundary(&self, min_position: u64) -> Result<u64, Error> {
+        super::prune_boundary(min_position, &self.bounds, self.items_per_blob.get())
+    }
+
     /// See [Journal::prune].
     pub(crate) async fn prune(
         mut self: Box<Self>,
         min_position: u64,
     ) -> Result<(Box<Self>, bool), Error> {
-        let items_per_blob = self.items_per_blob.get();
-
-        // Calculate the blob that would contain min_position, capped to the tail (which is
-        // guaranteed to exist by our invariant).
-        let target_blob = position_to_blob(min_position, items_per_blob);
-        let tail_blob = position_to_blob(self.bounds.end, items_per_blob);
-        let min_blob = target_blob.min(tail_blob);
-
+        let new_boundary = self.prune_boundary(min_position)?;
+        let min_blob = position_to_blob(new_boundary, self.items_per_blob.get());
         if min_blob <= self.blobs.oldest_blob_index() {
             return Ok((self, false));
         }
-
-        let new_boundary = blob_first_position(min_blob, items_per_blob)?;
 
         // Make all data durable before removing any: the prune target may be justified by an
         // appended-but-unflushed item (e.g. a consumer's commit record), and removals are
@@ -2317,6 +2314,12 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
         Ok((self, pruned))
     }
 
+    /// Return the boundary that [`Self::prune`] with `min_position` would establish, without
+    /// pruning anything.
+    pub fn prune_boundary(&self, min_position: u64) -> Result<u64, Error> {
+        self.0.prune_boundary(min_position)
+    }
+
     /// Persist data blobs so committed data survives a crash.
     ///
     /// Does not advance the recovery watermark, so reopen may replay entries above it.
@@ -2445,6 +2448,10 @@ impl<E: Context, V: CodecShared> Mutable for Journal<E, V> {
 
     async fn prune(self, min_position: u64) -> Result<(Self, bool), Error> {
         Self::prune(self, min_position).await
+    }
+
+    fn prune_boundary(&self, min_position: u64) -> Result<u64, Error> {
+        Self::prune_boundary(self, min_position)
     }
 
     async fn rewind(self, size: u64) -> Result<Self, Error> {
@@ -2591,6 +2598,41 @@ mod tests {
     // Larger page sizes for tests that need more buffer space.
     const LARGE_PAGE_SIZE: NonZeroU16 = NZU16!(1024);
     const SMALL_PAGE_SIZE: NonZeroU16 = NZU16!(512);
+
+    /// `prune_boundary` predicts the start `prune` establishes, including the capped and no-op
+    /// cases.
+    #[test_traced]
+    fn test_prune_boundary_matches_prune() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let cfg = Config {
+                partition: "variable-prune-boundary".into(),
+                items_per_section: NZU64!(5),
+                compression: None,
+                codec_config: (),
+                page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, NZUsize!(8)),
+                write_buffer: NZUsize!(1024),
+                replay_buffer: NZUsize!(1024),
+            };
+            let mut journal = Journal::<_, u64>::init(context.child("journal"), cfg)
+                .await
+                .unwrap();
+            for item in 0..17u64 {
+                (journal, _) = journal.append(&item).await.unwrap();
+            }
+            journal = journal.sync().await.unwrap();
+            for target in [0u64, 3, 5, 12, 11, 17, 40] {
+                let predicted = journal.prune_boundary(target).unwrap();
+                (journal, _) = journal.prune(target).await.unwrap();
+                assert_eq!(
+                    crate::journal::contiguous::Contiguous::bounds(&journal).start,
+                    predicted,
+                    "target={target}"
+                );
+            }
+            journal.destroy().await.unwrap();
+        });
+    }
 
     #[test_traced]
     fn test_replay_and_writable_tip_request_dont_cache() {

--- a/storage/src/qmdb/any/db.rs
+++ b/storage/src/qmdb/any/db.rs
@@ -110,6 +110,8 @@ pub struct Db<
     /// - `bitmap[i] == 0` implies location `i` is inactive (false negatives are forbidden).
     /// - CommitFloor: only the current `last_commit_loc` carries bit = 1; earlier commits
     ///   are 0.
+    /// - `bitmap.pruned_bits() <= log.bounds().start`: the bitmap is never pruned past the
+    ///   retained log, so rewinding to any retained commit can restore its active bits.
     pub(crate) bitmap: Arc<Shared<N>>,
 
     /// Metrics for this database.
@@ -417,10 +419,27 @@ where
     S: Strategy,
     Operation<F, U>: Codec,
 {
-    /// Prune the bitmap to `prune_loc`, rounded down to a chunk boundary. Skips the
-    /// inactivity-floor check.
-    pub(crate) fn prune_bitmap(&mut self, prune_loc: Location<F>) {
-        self.bitmap.write().prune_to_bit(*prune_loc);
+    /// Prune the bitmap to the boundary the operations log lands on when pruned to `prune_loc`,
+    /// and return that boundary. The bitmap never advances past the retained log: rewinding to a
+    /// commit restores the activity bits within its active range, so every commit the log
+    /// retains stays a valid rewind target.
+    ///
+    /// # Errors
+    ///
+    /// - Returns [crate::qmdb::Error::PruneBeyondMinRequired] if `prune_loc` > inactivity floor.
+    pub(crate) fn prune_bitmap_to_log_boundary(
+        &mut self,
+        prune_loc: Location<F>,
+    ) -> Result<Location<F>, crate::qmdb::Error<F>> {
+        if prune_loc > self.inactivity_floor_loc {
+            return Err(crate::qmdb::Error::PruneBeyondMinRequired(
+                prune_loc,
+                self.inactivity_floor_loc,
+            ));
+        }
+        let boundary = self.log.prune_boundary(prune_loc)?;
+        self.bitmap.write().prune_to_bit(*boundary);
+        Ok(boundary)
     }
 
     /// Prune the operations log to `prune_loc`. Does not touch the bitmap.
@@ -447,11 +466,18 @@ where
 
         let boundary;
         (self.log, boundary) = self.log.prune(prune_loc).await?;
+        debug_assert!(
+            self.bitmap.write().pruned_bits() <= *boundary,
+            "bitmap pruned past the retained log"
+        );
         Ok((self, boundary))
     }
 
     /// Prune historical operations prior to `prune_loc`. This does not affect the db's root or
     /// snapshot.
+    ///
+    /// The bitmap is pruned no further than the operations log, so every commit the log retains
+    /// remains a valid target for [`Self::rewind`].
     ///
     /// `prune` requires no prior commit. After a crash, the database remains recoverable;
     /// uncommitted operations are not guaranteed to survive.
@@ -468,8 +494,13 @@ where
     pub async fn prune(self, prune_loc: Location<F>) -> Result<Self, crate::qmdb::Error<F>> {
         let _timer = self.metrics.prune_timer();
         self.metrics.prune_calls.inc();
-        let (mut db, actual_pruned) = self.prune_log(prune_loc).await?;
-        db.prune_bitmap(actual_pruned);
+        let mut db = self;
+        let boundary = db.prune_bitmap_to_log_boundary(prune_loc)?;
+        let (db, pruned_to) = db.prune_log(prune_loc).await?;
+        debug_assert_eq!(
+            pruned_to, boundary,
+            "log and bitmap pruned to different boundaries"
+        );
         db.update_metrics();
         Ok(db)
     }

--- a/storage/src/qmdb/any/db.rs
+++ b/storage/src/qmdb/any/db.rs
@@ -466,7 +466,7 @@ where
 
         let boundary;
         (self.log, boundary) = self.log.prune(prune_loc).await?;
-        debug_assert!(
+        assert!(
             self.bitmap.write().pruned_bits() <= *boundary,
             "bitmap pruned past the retained log"
         );
@@ -497,7 +497,7 @@ where
         let mut db = self;
         let boundary = db.prune_bitmap_to_log_boundary(prune_loc)?;
         let (db, pruned_to) = db.prune_log(prune_loc).await?;
-        debug_assert_eq!(
+        assert_eq!(
             pruned_to, boundary,
             "log and bitmap pruned to different boundaries"
         );

--- a/storage/src/qmdb/any/db.rs
+++ b/storage/src/qmdb/any/db.rs
@@ -110,8 +110,10 @@ pub struct Db<
     /// - `bitmap[i] == 0` implies location `i` is inactive (false negatives are forbidden).
     /// - CommitFloor: only the current `last_commit_loc` carries bit = 1; earlier commits
     ///   are 0.
-    /// - `bitmap.pruned_bits() <= log.bounds().start`: the bitmap is never pruned past the
-    ///   retained log, so rewinding to any retained commit can restore its active bits.
+    /// - Pruning never advances `bitmap.pruned_bits()` past `log.bounds().start`, so every commit
+    ///   the log retains after a prune stays rewindable. State sync and recovery from an
+    ///   interrupted `current` prune may leave the bitmap ahead of the log; the bits in between
+    ///   are inactive and stay zero.
     pub(crate) bitmap: Arc<Shared<N>>,
 
     /// Metrics for this database.
@@ -420,9 +422,10 @@ where
     Operation<F, U>: Codec,
 {
     /// Prune the bitmap to the boundary the operations log lands on when pruned to `prune_loc`,
-    /// and return that boundary. The bitmap never advances past the retained log: rewinding to a
-    /// commit restores the activity bits within its active range, so every commit the log
-    /// retains stays a valid rewind target.
+    /// and return that boundary. Pruning never advances the bitmap past the retained log:
+    /// rewinding to a commit restores the activity bits within its active range, so every commit
+    /// the log retains after a prune stays a valid rewind target. A bitmap already ahead of the
+    /// log (after state sync or an interrupted `current` prune) is left where it is.
     ///
     /// # Errors
     ///
@@ -466,10 +469,6 @@ where
 
         let boundary;
         (self.log, boundary) = self.log.prune(prune_loc).await?;
-        assert!(
-            self.bitmap.write().pruned_bits() <= *boundary,
-            "bitmap pruned past the retained log"
-        );
         Ok((self, boundary))
     }
 

--- a/storage/src/qmdb/any/mod.rs
+++ b/storage/src/qmdb/any/mod.rs
@@ -2811,7 +2811,8 @@ pub(crate) mod test {
 #[cfg(test)]
 mod bitmap_tests {
     //! Regression tests for activity-bitmap maintenance in `any::Db`. The mutation code in
-    //! `apply_batch`, `prune_bitmap`, and `rewind` is independent of the snapshot index variant,
+    //! `apply_batch`, `prune_bitmap_to_log_boundary`, and `rewind` is independent of the snapshot
+    //! index variant,
     //! so one variant (`unordered::variable`) suffices as the test bed.
     use crate::qmdb::any::unordered::variable::test::{AnyTest, create_test_config};
     use commonware_cryptography::{Hasher as _, Sha256};

--- a/storage/src/qmdb/bitmap.rs
+++ b/storage/src/qmdb/bitmap.rs
@@ -33,7 +33,7 @@ impl<const N: usize> Shared<N> {
     }
 
     /// Acquire an exclusive write guard. By convention only the inner-`any` mutators
-    /// (`apply_batch`, `prune_bitmap`, `rewind`) hold the write lock.
+    /// (`apply_batch`, `prune_bitmap_to_log_boundary`, `rewind`) hold the write lock.
     pub(crate) fn write(&self) -> RwLockWriteGuard<'_, bitmap::Prunable<N>> {
         self.inner.write()
     }

--- a/storage/src/qmdb/current/db.rs
+++ b/storage/src/qmdb/current/db.rs
@@ -541,12 +541,11 @@ where
     /// `prune` requires no prior commit. After a crash, the database remains recoverable;
     /// uncommitted operations are not guaranteed to survive.
     ///
-    /// `prune_loc` must be at most [`Self::sync_boundary`]: the ops log's lower bound must not
-    /// advance past the point where the grafting overlay has been pruned. The bitmap and grafted
-    /// tree are pruned only as far as the ops log, never to the sync boundary. Rewinding to a
-    /// commit restores the activity bits within that commit's active range, so pruning the bitmap
-    /// past the retained log would make every commit between the log's start and the sync
-    /// boundary unrewindable even though the log still retains it.
+    /// `prune_loc` must be at most [`Self::sync_boundary`], the youngest boundary at which the
+    /// grafted tree can be pruned safely. The bitmap and grafted tree are then pruned only as far
+    /// as the ops log lands, never further: rewinding to a commit restores the activity bits
+    /// within that commit's active range, so pruning the bitmap past the retained log would make
+    /// every commit the log still holds unrewindable.
     ///
     /// # Errors
     ///
@@ -1633,7 +1632,14 @@ mod tests {
             assert_eq!(db.bounds(), bounds);
             assert_eq!(db.inactivity_floor_loc(), floor);
             assert_eq!(db.root(), root);
-            assert!(db.any.bitmap.pruned_bits() > *durable_floor);
+            let pruned_bits = db.any.bitmap.pruned_bits();
+            assert!(pruned_bits > *durable_floor);
+
+            // The persisted bitmap boundary sits ahead of the unpruned log. A later prune that
+            // lands below it leaves the bitmap where it is instead of failing.
+            let db = db.prune(Location::new(1)).await.unwrap();
+            assert_eq!(db.any.bitmap.pruned_bits(), pruned_bits);
+            assert_eq!(db.bounds().start, Location::new(0));
             db.destroy().await.unwrap();
         });
     }

--- a/storage/src/qmdb/current/db.rs
+++ b/storage/src/qmdb/current/db.rs
@@ -543,7 +543,10 @@ where
     ///
     /// `prune_loc` must be at most [`Self::sync_boundary`]: the ops log's lower bound must not
     /// advance past the point where the grafting overlay has been pruned. The bitmap and grafted
-    /// tree advance to the sync boundary regardless of `prune_loc`.
+    /// tree are pruned only as far as the ops log, never to the sync boundary. Rewinding to a
+    /// commit restores the activity bits within that commit's active range, so pruning the bitmap
+    /// past the retained log would make every commit between the log's start and the sync
+    /// boundary unrewindable even though the log still retains it.
     ///
     /// # Errors
     ///
@@ -569,8 +572,11 @@ where
         // initialize the bitmap.
         self.any.log = self.any.log.commit().await?;
 
-        // Prune the bitmap to the sync boundary (most aggressive safe location).
-        self.any.prune_bitmap(sync_boundary);
+        // Prune the bitmap only as far as the ops log will be pruned, never to the sync
+        // boundary. Every bit below the sync boundary is inactive at the current tip, but
+        // rewinding to an earlier commit flips the bits of its active range back on, and those
+        // chunks must still exist for every commit the log retains.
+        let boundary = self.any.prune_bitmap_to_log_boundary(prune_loc)?;
         self.prune_grafted_tree_to_bitmap()?;
 
         // Persist grafted tree pruning state before pruning the ops log. If the subsequent
@@ -585,7 +591,12 @@ where
             std::future::pending::<()>().await;
         }
 
-        (self.any, _) = self.any.prune_log(prune_loc).await?;
+        let pruned_to;
+        (self.any, pruned_to) = self.any.prune_log(prune_loc).await?;
+        debug_assert_eq!(
+            pruned_to, boundary,
+            "log and bitmap pruned to different boundaries"
+        );
         self.any.update_metrics();
         self.update_metrics();
         Ok(self)

--- a/storage/src/qmdb/current/db.rs
+++ b/storage/src/qmdb/current/db.rs
@@ -593,7 +593,7 @@ where
 
         let pruned_to;
         (self.any, pruned_to) = self.any.prune_log(prune_loc).await?;
-        debug_assert_eq!(
+        assert_eq!(
             pruned_to, boundary,
             "log and bitmap pruned to different boundaries"
         );

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -2118,7 +2118,7 @@ pub mod tests {
     fn test_current_rewind_recovery_pruned_repeated_updates() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            const COMMITS: u64 = 96;
+            const COMMITS: u64 = 200;
 
             let partition = "current-rewind-pruned-recovery";
             let ctx = context.child("db");
@@ -2145,11 +2145,19 @@ pub mod tests {
                 ));
             }
 
-            // Keep most ops-log history, but force bitmap pruning so rewind uses pinned-node
-            // reconstruction (`pruned_chunks > 0` path).
-            let db = db.prune(Location::new(1)).await.unwrap();
+            // Prune to the chunk boundary below the floor of a commit three rounds back: the log
+            // keeps the last few commits, and the whole chunks below them leave the bitmap, so
+            // rewind must reconstruct pinned nodes (`pruned_chunks > 0` path).
+            const CHUNK_BITS: u64 = 32 * 8;
+            let (_, older_floor, _, _, _) = history[history.len() - 4];
+            let prune_loc = Location::new(*older_floor / CHUNK_BITS * CHUNK_BITS);
+            db = db.prune(prune_loc).await.unwrap();
             let pruned_bits = db.pruned_bits();
-            assert!(pruned_bits > 0, "expected bitmap pruning for rewind test");
+            assert!(
+                pruned_bits > 0,
+                "expected bitmap pruning for rewind test: prune_loc={prune_loc} bounds={:?}",
+                db.bounds()
+            );
             let bounds = db.bounds();
 
             let (target_size, target_root, target_ops_root, target_value) = history
@@ -3026,63 +3034,129 @@ pub mod tests {
         });
     }
 
+    /// State observed after one generation of [`build_generations`].
+    struct Generation {
+        size: Location<mmr::Family>,
+        floor: Location<mmr::Family>,
+        sync_boundary: Location<mmr::Family>,
+        root: Digest,
+    }
+
+    /// Apply `generations` batches that each rewrite the same 384 keys, so every generation's
+    /// floor advances past the previous one's writes and its sync boundary moves by whole chunks.
+    async fn build_generations(
+        ctx: &Context,
+        partition: &str,
+        generations: u64,
+    ) -> (UnorderedFixedDb, Vec<Generation>) {
+        let mut db: UnorderedFixedDb =
+            UnorderedFixedDb::init(ctx.child("storage"), fixed_config::<OneCap>(partition, ctx))
+                .await
+                .unwrap();
+        let mut history = Vec::new();
+        for generation in 0..generations {
+            let mut batch = db.new_batch();
+            for i in 0..384 {
+                batch = batch.write(key(i), Some(val(generation * 1_000 + i)));
+            }
+            let batch = batch.merkleize(&db, None).await.unwrap();
+            (db, _) = db.apply_batch(batch).await.unwrap();
+            history.push(Generation {
+                size: db.bounds().end,
+                floor: db.inactivity_floor_loc(),
+                sync_boundary: db.sync_boundary(),
+                root: db.root(),
+            });
+        }
+        (db, history)
+    }
+
+    /// A retained commit whose floor precedes the bitmap pruning boundary is not rewindable: its
+    /// active range needs bitmap chunks that are gone even though the log still holds the commit.
     #[test_traced("INFO")]
     fn test_current_rewind_rejects_target_below_bitmap_floor() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
-            const COMMITS: u64 = 96;
-
-            let partition = "current-rewind-bitmap-floor";
             let ctx = context.child("db");
-            let mut db: UnorderedVariableDb =
-                UnorderedVariableDb::init(ctx.child("storage"), variable_config::<OneCap>(partition, &ctx))
-                    .await
-                    .unwrap();
+            let (db, history) = build_generations(&ctx, "current-rewind-bitmap-floor", 4).await;
+            let target = &history[1];
 
-            let mut history = Vec::new();
-            for round in 0..COMMITS {
-                (db, _) = commit_writes_with_metadata(
-                    db,
-                    [(key(0), Some(val(10_000 + round)))],
-                    None,
-                )
-                .await;
-                history.push((db.bounds().end, db.inactivity_floor_loc()));
-            }
-            assert!(db.inactivity_floor_loc() > Location::new(64));
-
-            // Intentionally prune less than the inactivity floor: log retains older ops, but the
-            // bitmap still prunes to inactivity floor.
-            let prune_loc = Location::new(1);
-            let db = db.prune(prune_loc).await.unwrap();
+            // Prune to just below the target commit: the log keeps the commit, but whole chunks
+            // of its active range fall below the bitmap boundary.
+            let db = db.prune(Location::new(*target.size - 1)).await.unwrap();
             let pruned_bits = db.pruned_bits();
-            assert!(pruned_bits > 0);
-            let retained_start = db.bounds().start;
+            assert!(
+                db.bounds().start < target.size,
+                "target commit must stay in the log"
+            );
+            assert!(
+                *target.floor < pruned_bits,
+                "target floor must fall below the bitmap boundary: floor={:?} pruned_bits={pruned_bits}",
+                target.floor
+            );
 
-            // Pick a historical commit that is still within retained log bounds but whose floor is
-            // below the bitmap pruning boundary.
-            let rewind_target = history
-                .iter()
-                .find_map(|(size, floor)| {
-                    if *size > *retained_start
-                        && *size >= pruned_bits
-                        && *floor >= *retained_start
-                        && *floor < pruned_bits
-                    {
-                        Some(*size)
-                    } else {
-                        None
-                    }
-                })
-                .unwrap_or_else(|| {
-                    panic!(
-                        "expected rewind target below bitmap boundary. retained_start={retained_start:?}, pruned_bits={pruned_bits}, latest_floor={:?}, history={history:?}",
-                        db.inactivity_floor_loc()
-                    )
-                });
-
-            let Err(err) = db.rewind(rewind_target).await else {
+            let Err(err) = db.rewind(target.size).await else {
                 panic!("expected rewind rejection below bitmap floor");
+            };
+            assert!(
+                matches!(
+                    err,
+                    Error::Journal(crate::journal::Error::ItemPruned(loc)) if loc == *target.floor
+                ),
+                "unexpected rewind error: {err:?}"
+            );
+        });
+    }
+
+    /// After a prune, every commit the ops log still retains must remain a rewind target: the
+    /// bitmap must not be pruned past the log even though everything below the sync boundary is
+    /// inactive at the tip.
+    #[test_traced("INFO")]
+    fn test_current_prune_keeps_retained_commits_rewindable() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            // Pruning to H1's boundary keeps both H1 and H2 rewindable, including across reopen.
+            let ctx = context.child("keep");
+            let partition = "current-prune-keeps-rewindable";
+            let (db, history) = build_generations(&ctx, partition, 4).await;
+            let (h1, h2, h3) = (&history[1], &history[2], &history[3]);
+            assert!(
+                h1.sync_boundary > Location::new(0),
+                "the prune must drop history"
+            );
+            assert!(
+                h1.sync_boundary < h2.sync_boundary,
+                "each generation must advance the sync boundary"
+            );
+            let db = db.prune(h1.sync_boundary).await.unwrap();
+            assert!(db.pruned_bits() <= *db.bounds().start);
+            assert_eq!(db.root(), h3.root);
+            let db = db.rewind(h2.size).await.unwrap();
+            assert_eq!(db.root(), h2.root);
+            let db = db.commit().await.unwrap();
+            drop(db);
+            let db: UnorderedFixedDb = UnorderedFixedDb::init(
+                ctx.child("reopen"),
+                fixed_config::<OneCap>(partition, &ctx),
+            )
+            .await
+            .unwrap();
+            assert_eq!(db.root(), h2.root);
+            let db = db.rewind(h1.size).await.unwrap();
+            assert_eq!(db.root(), h1.root);
+            db.destroy().await.unwrap();
+
+            // Pruning to H2's boundary keeps H2 rewindable while H1, whose active range is gone,
+            // is refused.
+            let ctx = context.child("window");
+            let (db, history) = build_generations(&ctx, "current-prune-window", 4).await;
+            let (h1, h2) = (&history[1], &history[2]);
+            let db = db.prune(h2.sync_boundary).await.unwrap();
+            assert!(db.pruned_bits() <= *db.bounds().start);
+            let db = db.rewind(h2.size).await.unwrap();
+            assert_eq!(db.root(), h2.root);
+            let Err(err) = db.rewind(h1.size).await else {
+                panic!("expected H1 to be unrewindable after pruning to H2's boundary");
             };
             assert!(
                 matches!(err, Error::Journal(crate::journal::Error::ItemPruned(_))),

--- a/storage/src/qmdb/current/sync/tests.rs
+++ b/storage/src/qmdb/current/sync/tests.rs
@@ -783,6 +783,92 @@ macro_rules! current_sync_tests_for_harness {
     };
 }
 
+/// A sync that reuses a client's existing journal seeds the bitmap from the chunk-aligned
+/// `range.start` while the journal keeps the blob floor below it, so the bitmap sits ahead of the
+/// log. The prune glue issues right after the sync must leave that state alone rather than fail.
+#[test_traced]
+fn test_prune_after_sync_reusing_journal() {
+    use crate::{
+        merkle::mmr,
+        qmdb::{
+            any::{
+                operation::{Unordered as Op, update::Unordered as Update},
+                sync::tests::SyncTestHarness as _,
+                value::FixedEncoding,
+            },
+            sync::{self, Target, engine::Config},
+        },
+    };
+    use commonware_cryptography::Hasher as _;
+    use harnesses::UnorderedFixedMmrHarness as Harness;
+    use std::sync::Arc;
+
+    type Db = <Harness as crate::qmdb::any::sync::tests::SyncTestHarness>::Db;
+
+    fn generation(g: u64) -> Vec<Op<mmr::Family, Digest, FixedEncoding<Digest>>> {
+        (0..384u64)
+            .map(|i| {
+                Op::Update(Update(
+                    Sha256::hash(&[&i.to_be_bytes()]),
+                    Sha256::hash(&[&(g * 1_000 + i).to_be_bytes()]),
+                ))
+            })
+            .collect()
+    }
+
+    deterministic::Runner::default().start(|mut context| async move {
+        let mut target_db: Db = Harness::init_db(context.child("target")).await;
+        let sync_db_config = Harness::config(&context.next_u64().to_string(), &context);
+        let client_context = context.child("client");
+        let mut sync_db: Db =
+            Harness::init_db_with_config(client_context.child("client"), sync_db_config.clone())
+                .await;
+        // Both sides apply the same generations, then the target moves one commit ahead.
+        for g in 0..4u64 {
+            target_db = Harness::apply_ops(target_db, generation(g)).await;
+            sync_db = Harness::apply_ops(sync_db, generation(g)).await;
+        }
+        drop(sync_db);
+        target_db = Harness::apply_ops(
+            target_db,
+            vec![Op::Update(Update(
+                Sha256::hash(&[b"extra".as_slice()]),
+                Sha256::hash(&[b"v".as_slice()]),
+            ))],
+        )
+        .await;
+
+        let lower_bound = target_db.sync_boundary();
+        let upper_bound = target_db.bounds().end;
+        let target_db = Arc::new(target_db);
+        let synced_db: Db = sync::sync(Config {
+            db_config: sync_db_config,
+            fetch_batch_size: NZU64!(10),
+            target: Target {
+                root: Harness::sync_target_root(&target_db),
+                range: non_empty_range!(lower_bound, upper_bound),
+            },
+            context: client_context.child("sync"),
+            source: target_db.clone(),
+            apply_batch_size: NZU64!(1024),
+            max_outstanding_requests: 1,
+            update_rx: None,
+            finish_rx: None,
+            reached_target_tx: None,
+            max_retained_roots: 8,
+        })
+        .await
+        .unwrap();
+        let pruned_bits = synced_db.any.bitmap.pruned_bits();
+
+        // Glue prunes to the target's range start right after a sync.
+        let synced_db = synced_db.prune(lower_bound).await.unwrap();
+        assert!(synced_db.bounds().start <= lower_bound);
+        assert_eq!(synced_db.any.bitmap.pruned_bits(), pruned_bits);
+        synced_db.destroy().await.unwrap();
+    });
+}
+
 current_sync_tests_for_harness!(harnesses::UnorderedFixedMmrHarness, unordered_fixed_mmr);
 current_sync_tests_for_harness!(harnesses::UnorderedFixedMmbHarness, unordered_fixed_mmb);
 current_sync_tests_for_harness!(


### PR DESCRIPTION
## Summary

`Current::prune` pruned the operations log to the requested location but advanced the activity bitmap and grafted tree to the live `sync_boundary` regardless. Every bit below the sync boundary is inactive at the tip, so this looked free, but `Current::rewind` rebuilds a target commit's activity bits by truncating the bitmap and flipping the bits of that commit's active range back on, and it refuses any target below the bitmap's pruned prefix. The result was that every commit between the log's start and the sync boundary became unrewindable even though the log still retained it.

Stateful depends on that window. It keeps the last `max_pending_acks + 1` finalized targets and prunes to the oldest one so that a restart whose marshal anchor lags the database can reconcile by rewinding. With Current, a maintenance prune to the oldest target committed the whole live log (including a suffix with no barrier yet), pruned the bitmap to the live boundary, and left every retained target below it. A later restart then hit `ItemPruned` from the reconciliation rewind, which the database wrapper treats as fatal, on every boot until the node was rebuilt or state-synced. Any never had this problem because its `prune` trims the bitmap only to what the log actually dropped.

## Fix

Make Current behave like Any, and have them share the rule so they cannot diverge again:

- The contiguous journals gain `Mutable::prune_boundary`, a dry-run that returns the start `prune` would establish, computed by the same code as the prune itself.
- The any layer prunes the bitmap only to the boundary the log will land on, and both `Any::prune` and `Current::prune` go through that one path. Current keeps its crash-safety ordering (commit, bitmap, grafted tree, metadata, then log), which is why it needs to know the boundary before the log is pruned.
- The rule and its reason are documented on `Any::prune`, `Current::prune`, and the bitmap invariants.

## Tests

- `test_prune_boundary_matches_prune` in both contiguous journals checks the dry-run against the real prune, including the capped and no-op cases.
- `test_current_prune_keeps_retained_commits_rewindable` builds generations that rewrite the same keys, prunes to an older generation's boundary, and rewinds to the two retained generations across a reopen. It also checks that pruning to a later boundary refuses the generation whose active range is gone. It fails against the old bitmap behavior.
- `test_current_rewind_recovery_pruned_repeated_updates` and `test_current_rewind_rejects_target_below_bitmap_floor` no longer depend on the bitmap being pruned past the log. The latter now uses a commit with a wide active range, the only shape in which a retained commit's floor can precede the bitmap boundary.
- `database_set_current_prune_keeps_recovery_targets_rewindable` in glue drives `DatabaseSet` through the finalize, prune, reopen, and reconcile sequence and asserts the rewinds to both retained targets succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


