### PR TITLE
[consensus/marshal] Reuse certified coding roots for block fetches

### DIFF
--- a/consensus/src/marshal/coding/mod.rs
+++ b/consensus/src/marshal/coding/mod.rs
@@ -3610,7 +3610,7 @@ mod tests {
             // subscriber alone binds the coding root, so the shared delivery
             // decodes without recomputing it and lands in the finalized archive.
             let mut subscribers = NonEmptyVec::new((
-                handler::Annotation::Ancestry { height },
+                handler::Annotation::Untrusted { height },
                 tracing::Span::none(),
             ));
             subscribers.push((
@@ -3752,7 +3752,10 @@ mod tests {
             assert_eq!(fetches.len(), 2);
             assert!(fetches.iter().all(|fetch| matches!(
                 (&fetch.key, &fetch.subscriber),
-                (handler::Key::Block(_), handler::Annotation::Ancestry { .. })
+                (
+                    handler::Key::Block(_),
+                    handler::Annotation::Untrusted { .. }
+                )
             )));
         });
     }

--- a/consensus/src/marshal/coding/mod.rs
+++ b/consensus/src/marshal/coding/mod.rs
@@ -3905,6 +3905,11 @@ mod tests {
                     .verified(candidate.context().round, candidate.clone())
                     .await
             );
+            let cached = mailbox
+                .subscribe_by_digest(parent.digest(), core::DigestFallback::Wait)
+                .await
+                .unwrap();
+            assert_eq!(cached.commitment(), parent.commitment());
             let shards =
                 start_shard_mailbox(context.child("shards"), participants, provider.clone()).await;
             let application = WalkingVerifyingApp::default();
@@ -4006,80 +4011,102 @@ mod tests {
 
     #[test_traced("WARN")]
     fn test_coding_certified_ancestry_delivery_skips_recoding() {
-        let runner = deterministic::Runner::timed(Duration::from_secs(30));
-        runner.start(|mut context| async move {
-            let Fixture {
-                participants,
-                schemes,
-                ..
-            } = bls12381_threshold_vrf::fixture::<V, _>(&mut context, NAMESPACE, NUM_VALIDATORS);
-            let (mut mailbox, resolver, _actor_handle) = start_coding_actor_with_recording(
-                context.child("validator"),
-                "certified-ancestry-delivery",
-                ConstantProvider::new(schemes[0].clone()),
-                RecordingCodingBuffer::default(),
-            )
-            .await;
-
-            // Build genesis <- grandparent <- parent <- child, verify the child
-            // locally, and have consensus report that it was certified.
-            // Certification implies its ancestors are certified.
-            let mut chain = coding_chain(participants[0].clone(), 3);
-            let (child_round, child) = chain.pop().expect("child");
-            let (_, parent) = chain.pop().expect("parent");
-            let (_, grandparent) = chain.pop().expect("grandparent");
-            assert!(mailbox.verified(child_round, child.clone()).await);
-            let notarization = CodingHarness::make_notarization(
-                Proposal::new(child_round, View::new(2), child.commitment()),
-                &schemes,
-                QUORUM,
-            );
-            mailbox.report(Activity::Certification(notarization));
-
-            // The parent is fetched under certification evidence and arrives lazy.
-            resolver.respond_to_next_fetch(parent.encode());
-            let delivered = mailbox
-                .subscribe_by_commitment(
-                    parent.commitment(),
-                    core::CommitmentFallback::FetchByCommitment {
-                        height: Height::new(2),
-                    },
+        for (cached_parent, by_digest) in [(false, false), (true, false), (true, true)] {
+            let runner = deterministic::Runner::timed(Duration::from_secs(30));
+            runner.start(|mut context| async move {
+                let Fixture {
+                    participants,
+                    schemes,
+                    ..
+                } = bls12381_threshold_vrf::fixture::<V, _>(
+                    &mut context,
+                    NAMESPACE,
+                    NUM_VALIDATORS,
+                );
+                let (mut mailbox, resolver, _actor_handle) = start_coding_actor_with_recording(
+                    context.child("validator"),
+                    "certified-ancestry-delivery",
+                    ConstantProvider::new(schemes[0].clone()),
+                    RecordingCodingBuffer::default(),
                 )
-                .await
-                .expect("parent subscription dropped");
-            assert!(
-                delivered.shard(0).is_none(),
-                "certified parent should not recompute shards"
-            );
-            assert!(resolver.wait_for_delivery_response().await);
+                .await;
 
-            // The delivered parent extends the evidence to the grandparent.
-            resolver.respond_to_next_fetch(grandparent.encode());
-            let delivered = mailbox
-                .subscribe_by_commitment(
-                    grandparent.commitment(),
-                    core::CommitmentFallback::FetchByCommitment {
-                        height: Height::new(1),
-                    },
-                )
-                .await
-                .expect("grandparent subscription dropped");
-            assert!(
-                delivered.shard(0).is_none(),
-                "certified grandparent should not recompute shards"
-            );
-            assert!(resolver.wait_for_delivery_response().await);
+                // Build genesis <- grandparent <- parent <- child, verify the child
+                // locally, and have consensus report that it was certified.
+                // Certification implies its ancestors are certified.
+                let mut chain = coding_chain(participants[0].clone(), 3);
+                let (child_round, child) = chain.pop().expect("child");
+                let (parent_round, parent) = chain.pop().expect("parent");
+                let (_, grandparent) = chain.pop().expect("grandparent");
+                if cached_parent {
+                    assert!(mailbox.verified(parent_round, parent.clone()).await);
+                }
+                assert!(mailbox.verified(child_round, child.clone()).await);
+                let notarization = CodingHarness::make_notarization(
+                    Proposal::new(child_round, View::new(2), child.commitment()),
+                    &schemes,
+                    QUORUM,
+                );
+                mailbox.report(Activity::Certification(notarization));
 
-            let certified: Vec<Height> = resolver
-                .fetches()
-                .iter()
-                .filter_map(|fetch| match fetch.subscriber {
-                    handler::Annotation::Certified { height } => Some(height),
-                    _ => None,
-                })
-                .collect();
-            assert_eq!(certified, vec![Height::new(2), Height::new(1)]);
-        });
+                // Both local retrieval and remote delivery preserve certification evidence
+                if !cached_parent {
+                    resolver.respond_to_next_fetch(parent.encode());
+                }
+                let subscription = if by_digest {
+                    mailbox.subscribe_by_digest(parent.digest(), core::DigestFallback::Wait)
+                } else {
+                    mailbox.subscribe_by_commitment(
+                        parent.commitment(),
+                        core::CommitmentFallback::FetchByCommitment {
+                            height: Height::new(2),
+                        },
+                    )
+                };
+                let delivered = subscription.await.expect("parent subscription dropped");
+                assert!(
+                    delivered.shard(0).is_none(),
+                    "certified parent should not recompute shards"
+                );
+                if cached_parent {
+                    assert!(resolver.fetches().is_empty());
+                } else {
+                    assert!(resolver.wait_for_delivery_response().await);
+                }
+
+                // Resolving the parent extends the evidence to the grandparent
+                resolver.respond_to_next_fetch(grandparent.encode());
+                let delivered = mailbox
+                    .subscribe_by_commitment(
+                        grandparent.commitment(),
+                        core::CommitmentFallback::FetchByCommitment {
+                            height: Height::new(1),
+                        },
+                    )
+                    .await
+                    .expect("grandparent subscription dropped");
+                assert!(
+                    delivered.shard(0).is_none(),
+                    "certified grandparent should not recompute shards"
+                );
+                assert!(resolver.wait_for_delivery_response().await);
+
+                let certified: Vec<Height> = resolver
+                    .fetches()
+                    .iter()
+                    .filter_map(|fetch| match fetch.subscriber {
+                        handler::Annotation::Certified { height } => Some(height),
+                        _ => None,
+                    })
+                    .collect();
+                let expected = if cached_parent {
+                    vec![Height::new(1)]
+                } else {
+                    vec![Height::new(2), Height::new(1)]
+                };
+                assert_eq!(certified, expected);
+            });
+        }
     }
 
     #[test_traced("WARN")]

--- a/consensus/src/marshal/coding/mod.rs
+++ b/consensus/src/marshal/coding/mod.rs
@@ -3381,9 +3381,9 @@ mod tests {
     #[test_traced("WARN")]
     fn test_backfill_block_mismatched_commitment() {
         // Regression: when backfilling by Key::Block(commitment), a peer may return
-        // a coded block with matching inner digest but a different coding commitment.
-        // If a finalization for this digest is already cached, marshal must reject
-        // the block unless V::commitment(block) matches the finalization payload.
+        // a coded block with matching inner digest but a different coding config.
+        // The finalized decode takes the root from the commitment, so the wire
+        // config must still be checked against it and the block rejected.
         let runner = deterministic::Runner::timed(Duration::from_secs(30));
         runner.start(|mut context| async move {
             let Fixture {
@@ -3468,8 +3468,8 @@ mod tests {
             // Report finalization to v0. v0 doesn't have the block:
             //   - it fetches Key::Block(commitment)
             //   - v1 responds with coded_block_b (same digest, wrong commitment)
-            //   - deliver path must reject because the response commitment does not
-            //     match the request key
+            //   - deliver path must reject because the response coding config does
+            //     not match the request key
             CodingHarness::report_finalization(&mut v0_mailbox, finalization).await;
 
             // Wait for the fetch cycle to complete.
@@ -3489,6 +3489,282 @@ mod tests {
                 "finalization should not be archived until matching block is available"
             );
         })
+    }
+
+    #[test_traced("WARN")]
+    fn test_coding_finalized_block_delivery_skips_recoding() {
+        let runner = deterministic::Runner::timed(Duration::from_secs(30));
+        runner.start(|mut context| async move {
+            let Fixture {
+                participants,
+                schemes,
+                ..
+            } = bls12381_threshold_vrf::fixture::<V, _>(&mut context, NAMESPACE, NUM_VALIDATORS);
+            let (mut mailbox, resolver, _actor_handle) = start_coding_actor_with_recording(
+                context.child("validator"),
+                "finalized-block-delivery",
+                ConstantProvider::new(schemes[0].clone()),
+                RecordingCodingBuffer::default(),
+            )
+            .await;
+
+            let (candidate_ctx, candidate) = missing_candidate(participants[0].clone());
+            let commitment = candidate.commitment();
+            let subscription =
+                mailbox.subscribe_by_commitment(commitment, core::CommitmentFallback::Wait);
+            context.sleep(Duration::from_millis(100)).await;
+
+            // The finalization names the commitment, so the fetched block is
+            // rebuilt from it without recomputing the coding root.
+            let finalization = CodingHarness::make_finalization(
+                Proposal::new(candidate_ctx.round, View::zero(), commitment),
+                &schemes,
+                QUORUM,
+            );
+            resolver.respond_to_next_fetch(candidate.encode());
+            CodingHarness::report_finalization(&mut mailbox, finalization).await;
+
+            let delivered = subscription.await.expect("subscription dropped");
+            assert_eq!(delivered.commitment(), commitment);
+            assert!(
+                delivered.shard(0).is_none(),
+                "finalized delivery should not recompute shards"
+            );
+            assert!(
+                resolver.wait_for_delivery_response().await,
+                "finalized delivery should validate"
+            );
+            assert!(
+                resolver.fetches().iter().any(|fetch| matches!(
+                    (&fetch.key, &fetch.subscriber),
+                    (
+                        handler::Key::Block(requested),
+                        handler::Annotation::Finalized(handler::Finalized::ByRound { .. }),
+                    ) if *requested == commitment
+                )),
+                "finalization should fetch the block by commitment"
+            );
+            assert!(mailbox.get_block(Height::new(1)).await.is_some());
+        });
+    }
+
+    #[test_traced("WARN")]
+    fn test_coding_coalesced_block_delivery_trusts_finalized_subscriber() {
+        let runner = deterministic::Runner::timed(Duration::from_secs(30));
+        runner.start(|mut context| async move {
+            let Fixture {
+                participants,
+                schemes,
+                ..
+            } = bls12381_threshold_vrf::fixture::<V, _>(&mut context, NAMESPACE, NUM_VALIDATORS);
+            let (mailbox, resolver, _actor_handle) = start_coding_actor_with_recording(
+                context.child("validator"),
+                "coalesced-block-delivery",
+                ConstantProvider::new(schemes[0].clone()),
+                RecordingCodingBuffer::default(),
+            )
+            .await;
+            let resolver_tx = resolver
+                .sender
+                .clone()
+                .expect("recording resolver should keep its sender");
+
+            let (_, candidate) = missing_candidate(participants[0].clone());
+            let commitment = candidate.commitment();
+            let height = Height::new(1);
+            let subscription =
+                mailbox.subscribe_by_commitment(commitment, core::CommitmentFallback::Wait);
+            context.sleep(Duration::from_millis(100)).await;
+
+            // One key can carry an ancestry subscriber and a finalized-chain
+            // subscriber at once. The finalized subscriber alone binds the
+            // coding root, so the shared delivery decodes without recomputing it
+            // and lands in the finalized archive.
+            let mut subscribers = NonEmptyVec::new((
+                handler::Annotation::Certified { height },
+                tracing::Span::none(),
+            ));
+            subscribers.push((
+                handler::Annotation::Finalized(handler::Finalized::ByHeight { height }),
+                tracing::Span::none(),
+            ));
+            let (response, response_rx) = oneshot::channel();
+            assert!(
+                resolver_tx
+                    .enqueue(handler::Message::Deliver {
+                        delivery: Delivery {
+                            key: handler::Key::Block(commitment),
+                            subscribers,
+                        },
+                        value: candidate.encode(),
+                        response,
+                    })
+                    .accepted()
+            );
+            assert!(
+                response_rx.await.unwrap(),
+                "coalesced delivery should validate"
+            );
+
+            let delivered = subscription.await.expect("subscription dropped");
+            assert_eq!(delivered.commitment(), commitment);
+            assert!(
+                delivered.shard(0).is_none(),
+                "coalesced delivery should not recompute shards"
+            );
+            assert!(mailbox.get_block(height).await.is_some());
+        });
+    }
+
+    #[test_traced("WARN")]
+    fn test_coding_finalized_block_delivery_rejects_digest_mismatch() {
+        let runner = deterministic::Runner::timed(Duration::from_secs(30));
+        runner.start(|mut context| async move {
+            let Fixture {
+                participants,
+                schemes,
+                ..
+            } = bls12381_threshold_vrf::fixture::<V, _>(&mut context, NAMESPACE, NUM_VALIDATORS);
+            let (mut mailbox, resolver, _actor_handle) = start_coding_actor_with_recording(
+                context.child("validator"),
+                "finalized-block-digest-mismatch",
+                ConstantProvider::new(schemes[0].clone()),
+                RecordingCodingBuffer::default(),
+            )
+            .await;
+
+            let (candidate_ctx, candidate) = missing_candidate(participants[0].clone());
+            let commitment = candidate.commitment();
+            let other = make_coding_block(
+                candidate_ctx.clone(),
+                genesis_block().digest(),
+                Height::new(1),
+                101,
+            );
+            let other: TestCodedBlock = CodedBlock::new(
+                other,
+                coding_config_for_participants(NUM_VALIDATORS as u16),
+                &Sequential,
+            );
+            assert_ne!(other.digest(), candidate.digest());
+
+            // The finalized decode skips the root, so the digest check is what
+            // rejects a different block under the same coding config.
+            let finalization = CodingHarness::make_finalization(
+                Proposal::new(candidate_ctx.round, View::zero(), commitment),
+                &schemes,
+                QUORUM,
+            );
+            resolver.respond_to_next_fetch(other.encode());
+            CodingHarness::report_finalization(&mut mailbox, finalization).await;
+            context.sleep(Duration::from_millis(100)).await;
+
+            assert!(
+                !resolver.wait_for_delivery_response().await,
+                "digest mismatch should be rejected"
+            );
+            assert!(mailbox.get_block(Height::new(1)).await.is_none());
+        });
+    }
+
+    #[test_traced("WARN")]
+    fn test_coding_certified_block_delivery_recomputes_root() {
+        let runner = deterministic::Runner::timed(Duration::from_secs(30));
+        runner.start(|mut context| async move {
+            let Fixture {
+                participants,
+                schemes,
+                ..
+            } = bls12381_threshold_vrf::fixture::<V, _>(&mut context, NAMESPACE, NUM_VALIDATORS);
+            let (mailbox, resolver, _actor_handle) = start_coding_actor_with_recording(
+                context.child("validator"),
+                "certified-block-delivery",
+                ConstantProvider::new(schemes[0].clone()),
+                RecordingCodingBuffer::default(),
+            )
+            .await;
+
+            let (_, candidate) = missing_candidate(participants[0].clone());
+            let commitment = candidate.commitment();
+
+            // No finalization names the commitment, so the delivery proves the
+            // coding root by re-encoding the block.
+            resolver.respond_to_next_fetch(candidate.encode());
+            let subscription = mailbox.subscribe_by_commitment(
+                commitment,
+                core::CommitmentFallback::FetchByCommitment {
+                    height: Height::new(1),
+                },
+            );
+
+            let delivered = subscription.await.expect("subscription dropped");
+            assert_eq!(delivered.commitment(), commitment);
+            assert!(
+                delivered.shard(0).is_some(),
+                "ancestry delivery should recompute shards"
+            );
+            assert!(
+                resolver.wait_for_delivery_response().await,
+                "ancestry delivery should validate"
+            );
+            assert!(
+                resolver.fetches().iter().any(|fetch| matches!(
+                    (&fetch.key, &fetch.subscriber),
+                    (
+                        handler::Key::Block(requested),
+                        handler::Annotation::Certified { .. },
+                    ) if *requested == commitment
+                )),
+                "ancestry walk should fetch the block by commitment"
+            );
+        });
+    }
+
+    #[test_traced("WARN")]
+    fn test_coding_notarized_delivery_recomputes_root() {
+        let runner = deterministic::Runner::timed(Duration::from_secs(30));
+        runner.start(|mut context| async move {
+            let Fixture {
+                participants,
+                schemes,
+                ..
+            } = bls12381_threshold_vrf::fixture::<V, _>(&mut context, NAMESPACE, NUM_VALIDATORS);
+            let (mailbox, resolver, _actor_handle) = start_coding_actor_with_recording(
+                context.child("validator"),
+                "notarized-block-delivery",
+                ConstantProvider::new(schemes[0].clone()),
+                RecordingCodingBuffer::default(),
+            )
+            .await;
+
+            let (candidate_ctx, candidate) = missing_candidate(participants[0].clone());
+            let commitment = candidate.commitment();
+            let round = candidate_ctx.round;
+            let notarization = CodingHarness::make_notarization(
+                Proposal::new(round, View::zero(), commitment),
+                &schemes,
+                QUORUM,
+            );
+
+            // A notarization does not bind the coding root to the block, so the
+            // delivery proves it by re-encoding the block.
+            resolver.respond_to_next_fetch((notarization, candidate).encode());
+            let subscription = mailbox.subscribe_by_commitment(
+                commitment,
+                core::CommitmentFallback::FetchByRound { round },
+            );
+
+            let delivered = subscription.await.expect("subscription dropped");
+            assert_eq!(delivered.commitment(), commitment);
+            assert!(
+                delivered.shard(0).is_some(),
+                "notarized delivery should recompute shards"
+            );
+            assert!(
+                resolver.wait_for_delivery_response().await,
+                "notarized delivery should validate"
+            );
+        });
     }
 
     #[test_traced("WARN")]

--- a/consensus/src/marshal/coding/mod.rs
+++ b/consensus/src/marshal/coding/mod.rs
@@ -95,7 +95,7 @@ mod tests {
     use bytes::Bytes;
     use commonware_actor::{Feedback, mailbox};
     use commonware_codec::{Encode, FixedSize};
-    use commonware_coding::{CodecConfig, Config as CodingConfig, ReedSolomon};
+    use commonware_coding::{CodecConfig, Config as CodingConfig, ReedSolomon, Scheme as _};
     use commonware_cryptography::{
         Committable, Digestible, Hasher,
         certificate::{ConstantProvider, Verifier as _, mocks::Fixture},
@@ -107,6 +107,7 @@ mod tests {
     use commonware_resolver::{Delivery, Fetch, Resolver, TargetedResolver};
     use commonware_runtime::{
         Clock, Metrics, Runner, Supervisor as _, buffer::paged::CacheRef, deterministic,
+        utils::reschedule,
     };
     use commonware_storage::archive::immutable;
     use commonware_utils::{
@@ -3704,7 +3705,7 @@ mod tests {
                 schemes,
                 ..
             } = bls12381_threshold_vrf::fixture::<V, _>(&mut context, NAMESPACE, NUM_VALIDATORS);
-            let (mailbox, resolver, _actor_handle) = start_coding_actor_with_recording(
+            let (mut mailbox, resolver, _actor_handle) = start_coding_actor_with_recording(
                 context.child("validator"),
                 "ancestry-block-delivery",
                 ConstantProvider::new(schemes[0].clone()),
@@ -3712,9 +3713,18 @@ mod tests {
             )
             .await;
 
-            // Nothing certified the chain, so each fetch proves its coding root
-            // by re-encoding and none extends certification evidence downward.
-            let mut chain = coding_chain(participants[0].clone(), 2);
+            // Certification persists the candidate before the application verdict.
+            // That write alone must not authenticate its ancestry, so each fetch
+            // below still proves its coding root by re-encoding.
+            let mut chain = coding_chain(participants[0].clone(), 3);
+            let (round, candidate) = chain.pop().expect("candidate");
+            let notarization = CodingHarness::make_notarization(
+                Proposal::new(round, View::new(2), candidate.commitment()),
+                &schemes,
+                QUORUM,
+            );
+            mailbox.report(Activity::Notarization(notarization));
+            assert!(mailbox.certified(round, candidate).await);
             let (_, top) = chain.pop().expect("top");
             let (_, bottom) = chain.pop().expect("bottom");
             for (block, height) in [(top, 2), (bottom, 1)] {
@@ -3870,6 +3880,93 @@ mod tests {
                 "notarized delivery should validate"
             );
         });
+    }
+
+    #[test_traced("WARN")]
+    fn test_coding_untrusted_delivery_rejects_mismatched_root() {
+        for notarized in [false, true] {
+            let runner = deterministic::Runner::timed(Duration::from_secs(30));
+            runner.start(|mut context| async move {
+                let Fixture {
+                    participants,
+                    schemes,
+                    ..
+                } = bls12381_threshold_vrf::fixture::<V, _>(
+                    &mut context,
+                    NAMESPACE,
+                    NUM_VALIDATORS,
+                );
+                let (mailbox, resolver, _actor_handle) = start_coding_actor_with_recording(
+                    context.child("validator"),
+                    "untrusted-delivery-mismatched-root",
+                    ConstantProvider::new(schemes[0].clone()),
+                    RecordingCodingBuffer::default(),
+                )
+                .await;
+
+                let (candidate_ctx, candidate) = missing_candidate(participants[0].clone());
+                let config = candidate.config();
+                let other: TestCodedBlock = CodedBlock::new(
+                    make_coding_block(
+                        candidate_ctx.clone(),
+                        genesis_block().digest(),
+                        Height::new(1),
+                        101,
+                    ),
+                    config,
+                    &Sequential,
+                );
+                let expected = candidate.commitment();
+                let commitment = TestCommitment::from((
+                    expected.block(),
+                    other.commitment().root(),
+                    expected.context(),
+                    config,
+                ));
+                assert_ne!(commitment.root(), expected.root());
+
+                // A leader can obtain notarize votes with valid assigned shards even
+                // though their root encodes different bytes from the named block.
+                for (index, shard) in other.shards(&Sequential).iter().enumerate() {
+                    ReedSolomon::<Sha256>::check(&config, &commitment.root(), index as u16, shard)
+                        .expect("assigned shard should verify against the advertised root");
+                }
+
+                let (value, fallback) = if notarized {
+                    let round = candidate_ctx.round;
+                    let notarization = CodingHarness::make_notarization(
+                        Proposal::new(round, View::zero(), commitment),
+                        &schemes,
+                        QUORUM,
+                    );
+                    (
+                        (notarization, candidate.clone()).encode(),
+                        core::CommitmentFallback::FetchByRound { round },
+                    )
+                } else {
+                    (
+                        candidate.encode(),
+                        core::CommitmentFallback::FetchByCommitment {
+                            height: Height::new(1),
+                        },
+                    )
+                };
+                resolver.respond_to_next_fetch(value);
+                let mut subscription = mailbox.subscribe_by_commitment(commitment, fallback);
+                while resolver.fetches().is_empty() {
+                    reschedule().await;
+                }
+                assert!(
+                    !resolver.wait_for_delivery_response().await,
+                    "mismatched coding root should be rejected (notarized={notarized})"
+                );
+                assert!(matches!(
+                    subscription.try_recv(),
+                    Err(oneshot::error::TryRecvError::Empty)
+                ));
+                assert!(mailbox.get_block(&candidate.digest()).await.is_none());
+            });
+        }
     }
 
     #[test_traced("WARN")]

--- a/consensus/src/marshal/coding/mod.rs
+++ b/consensus/src/marshal/coding/mod.rs
@@ -64,9 +64,9 @@ pub use marshaled::{Marshaled, MarshaledConfig};
 #[cfg(test)]
 mod tests {
     use crate::{
-        Automaton, Block, CertifiableAutomaton, CertifiableBlock, Relay, Reporter,
+        Automaton, Block, CertifiableAutomaton, CertifiableBlock, Heightable, Relay, Reporter,
         marshal::{
-            ancestry::BlockProvider,
+            ancestry::{Ancestry, BlockProvider},
             coding::{
                 Coding, Marshaled, MarshaledConfig, shards,
                 types::{CodedBlock, coding_config_for_participants, hash_context},
@@ -113,6 +113,7 @@ mod tests {
     use commonware_utils::{
         NZU16, NZU64, NZUsize, channel::oneshot, sync::Mutex, vec::NonEmptyVec,
     };
+    use futures::StreamExt;
     use std::{sync::Arc, time::Duration};
 
     type TestCodingVariant = Coding<CodingB, ReedSolomon<Sha256>, Sha256, K>;
@@ -189,6 +190,42 @@ mod tests {
         }
     }
 
+    /// Records the ancestry consumed by verification, accepting only after reaching genesis.
+    #[derive(Clone, Default)]
+    struct WalkingVerifyingApp {
+        blocks: Arc<Mutex<Vec<D>>>,
+    }
+
+    impl crate::Application<deterministic::Context> for WalkingVerifyingApp {
+        type Block = CodingB;
+        type Context = CodingCtx;
+        type SigningScheme = S;
+        type Input = ();
+
+        async fn propose(
+            &mut self,
+            _context: (deterministic::Context, CodingCtx),
+            _ancestry: impl Ancestry<CodingB>,
+            _input: (),
+        ) -> Option<CodingB> {
+            None
+        }
+
+        async fn verify(
+            &mut self,
+            _context: (deterministic::Context, CodingCtx),
+            mut ancestry: impl Ancestry<CodingB>,
+        ) -> bool {
+            while let Some(block) = ancestry.next().await {
+                self.blocks.lock().push(block.digest());
+                if block.height() == Height::zero() {
+                    return true;
+                }
+            }
+            false
+        }
+    }
+
     type CodingFetchRecord = Fetch<handler::Key<TestCommitment>, handler::Annotation>;
     type CodingTargetedFetch = (handler::Key<TestCommitment>, NonEmptyVec<K>);
 
@@ -243,6 +280,28 @@ mod tests {
                 replaced.is_none(),
                 "recording resolver already has an automatic delivery"
             );
+        }
+
+        async fn deliver(&self, fetch: CodingFetchRecord, value: Bytes) -> bool {
+            let (response, receiver) = oneshot::channel();
+            assert!(
+                self.sender
+                    .as_ref()
+                    .expect("resolver sender missing")
+                    .enqueue(handler::Message::Deliver {
+                        delivery: Delivery {
+                            key: fetch.key,
+                            subscribers: NonEmptyVec::new((
+                                fetch.subscriber,
+                                tracing::Span::none()
+                            )),
+                        },
+                        value,
+                        response,
+                    })
+                    .accepted()
+            );
+            receiver.await.expect("delivery response missing")
         }
 
         async fn wait_for_delivery_response(&self) -> bool {
@@ -3761,6 +3820,191 @@ mod tests {
     }
 
     #[test_traced("WARN")]
+    fn test_coding_optimistic_ancestry_conflicts_with_certified_cache() {
+        let runner = deterministic::Runner::timed(Duration::from_secs(30));
+        runner.start(|mut context| async move {
+            let Fixture {
+                participants,
+                schemes,
+                ..
+            } = bls12381_threshold_vrf::fixture::<V, _>(&mut context, NAMESPACE, NUM_VALIDATORS);
+            let provider = ConstantProvider::new(schemes[0].clone());
+            let (mut mailbox, resolver, _actor_handle) = start_coding_actor_with_recording(
+                context.child("validator"),
+                "optimistic-ancestry-conflict",
+                provider.clone(),
+                RecordingCodingBuffer::default(),
+            )
+            .await;
+
+            // Cache a certified ancestor at height 2 without finalizing its branch
+            let mut certified_chain = coding_chain(participants[0].clone(), 3);
+            let (round, certified_child) = certified_chain.pop().unwrap();
+            let (_, certified_ancestor) = certified_chain.pop().unwrap();
+            assert!(mailbox.verified(round, certified_child.clone()).await);
+            mailbox.report(Activity::Certification(CodingHarness::make_notarization(
+                Proposal::new(round, View::new(2), certified_child.commitment()),
+                &schemes,
+                QUORUM,
+            )));
+            resolver.respond_to_next_fetch(certified_ancestor.encode());
+            let certified = mailbox
+                .subscribe_by_commitment(
+                    certified_ancestor.commitment(),
+                    core::CommitmentFallback::FetchByCommitment {
+                        height: certified_ancestor.height(),
+                    },
+                )
+                .await
+                .unwrap();
+            assert!(resolver.wait_for_delivery_response().await);
+            assert!(certified.shard(0).is_none());
+            assert_eq!(
+                resolver.fetches()[0].subscriber,
+                handler::Annotation::Certified {
+                    height: Height::new(2)
+                }
+            );
+
+            // Later views extend a competing branch at the same heights
+            let mut chain = Vec::new();
+            let mut parent_view = View::zero();
+            let mut parent_commitment = genesis_coding_commitment(&genesis_block());
+            for height in 1..=4 {
+                let round = Round::new(Epoch::zero(), View::new(height + 10));
+                let block: TestCodedBlock = CodedBlock::new(
+                    make_coding_block(
+                        CodingCtx {
+                            round,
+                            leader: participants[0].clone(),
+                            parent: (parent_view, parent_commitment),
+                        },
+                        parent_commitment.block(),
+                        Height::new(height),
+                        height * 100,
+                    ),
+                    coding_config_for_participants(NUM_VALIDATORS as u16),
+                    &Sequential,
+                );
+                parent_view = round.view();
+                parent_commitment = block.commitment();
+                chain.push(block);
+            }
+            let candidate = &chain[3];
+            let parent = &chain[2];
+            assert_ne!(chain[1].digest(), certified_ancestor.digest());
+
+            // Only the candidate and immediate parent are available before verification
+            assert!(
+                mailbox
+                    .verified(parent.context().round, parent.clone())
+                    .await
+            );
+            assert!(
+                mailbox
+                    .verified(candidate.context().round, candidate.clone())
+                    .await
+            );
+            let shards =
+                start_shard_mailbox(context.child("shards"), participants, provider.clone()).await;
+            let application = WalkingVerifyingApp::default();
+            let mut marshaled = Marshaled::new(
+                context.child("marshaled"),
+                MarshaledConfig {
+                    application: application.clone(),
+                    marshal: mailbox.clone(),
+                    shards,
+                    scheme_provider: provider,
+                    epocher: FixedEpocher::new(BLOCKS_PER_EPOCH),
+                    strategy: Sequential,
+                },
+            );
+            let _shard_verdict = marshaled
+                .verify(candidate.context(), candidate.commitment())
+                .await;
+
+            // Neither the certified fork nor a cached untrusted child authenticates these fetches
+            for (index, ancestor) in [&chain[1], &chain[0]].into_iter().enumerate() {
+                while resolver.fetches().len() < index + 2 {
+                    reschedule().await;
+                }
+                let fetch = resolver.fetches()[index + 1].clone();
+                assert_eq!(fetch.key, handler::Key::Block(ancestor.commitment()));
+                assert_eq!(
+                    fetch.subscriber,
+                    handler::Annotation::Untrusted {
+                        height: ancestor.height()
+                    }
+                );
+                let mut subscription = mailbox
+                    .subscribe_by_commitment(ancestor.commitment(), core::CommitmentFallback::Wait);
+                let _ = mailbox.get_processed_height().await;
+
+                if index == 0 {
+                    assert!(
+                        !resolver
+                            .deliver(fetch.clone(), certified_ancestor.encode())
+                            .await
+                    );
+                    assert!(matches!(
+                        subscription.try_recv(),
+                        Err(oneshot::error::TryRecvError::Empty)
+                    ));
+                }
+                assert!(resolver.deliver(fetch, ancestor.encode()).await);
+                let delivered = subscription.await.unwrap();
+                assert_eq!(delivered.commitment(), ancestor.commitment());
+                assert!(
+                    delivered.shard(0).is_some(),
+                    "untrusted ancestry must be recoded"
+                );
+            }
+
+            // Both forks survive in storage and are retrieved by their own digests
+            for ancestor in [&certified_ancestor, &chain[1]] {
+                let stored = mailbox
+                    .get_block(&ancestor.digest())
+                    .await
+                    .expect("both ancestors at the same height must remain cached");
+                assert_eq!(stored.commitment(), ancestor.commitment());
+            }
+            assert!(
+                marshaled
+                    .certify(candidate.context().round, candidate.commitment())
+                    .await
+                    .await
+                    .unwrap()
+            );
+            let expected: Vec<_> = chain
+                .iter()
+                .rev()
+                .map(Digestible::digest)
+                .chain(std::iter::once(genesis_block().digest()))
+                .collect();
+            assert_eq!(*application.blocks.lock(), expected);
+
+            // Finalization follows the competing branch despite the certified block at height 2
+            mailbox.report(Activity::Finalization(CodingHarness::make_finalization(
+                Proposal::new(
+                    candidate.context().round,
+                    parent.context().round.view(),
+                    candidate.commitment(),
+                ),
+                &schemes,
+                QUORUM,
+            )));
+            while mailbox.get_processed_height().await != Some(candidate.height()) {
+                reschedule().await;
+            }
+            for block in &chain {
+                let finalized = mailbox.get_block(block.height()).await.unwrap();
+                assert_eq!(finalized.commitment(), block.commitment());
+            }
+            assert_eq!(resolver.fetches().len(), 3);
+        });
+    }
+
+    #[test_traced("WARN")]
     fn test_coding_certified_ancestry_delivery_skips_recoding() {
         let runner = deterministic::Runner::timed(Duration::from_secs(30));
         runner.start(|mut context| async move {
@@ -3835,6 +4079,127 @@ mod tests {
                 })
                 .collect();
             assert_eq!(certified, vec![Height::new(2), Height::new(1)]);
+        });
+    }
+
+    #[test_traced("WARN")]
+    fn test_coding_certification_retention_follows_finalized_tip() {
+        let runner = deterministic::Runner::timed(Duration::from_secs(30));
+        runner.start(|mut context| async move {
+            let Fixture {
+                participants,
+                schemes,
+                ..
+            } = bls12381_threshold_vrf::fixture::<V, _>(&mut context, NAMESPACE, NUM_VALIDATORS);
+            let (mut mailbox, resolver, _actor_handle) = start_coding_actor_with_recording(
+                context.child("validator"),
+                "certification-retention",
+                ConstantProvider::new(schemes[0].clone()),
+                RecordingCodingBuffer::default(),
+            )
+            .await;
+
+            // Start a certified parent fetch before the child is finalized
+            let mut chain = coding_chain(participants[0].clone(), 3);
+            let (round, child) = chain.pop().expect("child");
+            let (_, parent) = chain.pop().expect("parent");
+            let (_, grandparent) = chain.pop().expect("grandparent");
+            assert!(mailbox.verified(round, child.clone()).await);
+            let proposal = Proposal::new(round, View::new(2), child.commitment());
+            let notarization = CodingHarness::make_notarization(proposal.clone(), &schemes, QUORUM);
+            mailbox.report(Activity::Certification(notarization.clone()));
+            let fallback = core::CommitmentFallback::FetchByCommitment {
+                height: parent.height(),
+            };
+            let mut subscriptions =
+                vec![mailbox.subscribe_by_commitment(parent.commitment(), fallback)];
+            let _ = mailbox.get_processed_height().await;
+            let fetch = resolver.fetches().pop().expect("parent fetch missing");
+            assert_eq!(
+                fetch.subscriber,
+                handler::Annotation::Certified {
+                    height: parent.height()
+                }
+            );
+
+            // Finalization advances the tip while missing ancestors hold back processing
+            mailbox.report(Activity::Finalization(CodingHarness::make_finalization(
+                proposal, &schemes, QUORUM,
+            )));
+            assert_eq!(
+                mailbox.get_info(child.height()).await,
+                Some((child.height(), child.digest()))
+            );
+            subscriptions.push(mailbox.subscribe_by_commitment(parent.commitment(), fallback));
+
+            // A late certification must not restore evidence below the tip
+            mailbox.report(Activity::Certification(notarization));
+            subscriptions.push(mailbox.subscribe_by_commitment(parent.commitment(), fallback));
+            let _ = mailbox.get_processed_height().await;
+
+            // The original fetch can still arrive, but must not retain older ancestry evidence
+            let (response, response_rx) = oneshot::channel();
+            assert!(
+                resolver
+                    .sender
+                    .as_ref()
+                    .expect("resolver sender missing")
+                    .enqueue(handler::Message::Deliver {
+                        delivery: Delivery {
+                            key: fetch.key,
+                            subscribers: NonEmptyVec::new((
+                                fetch.subscriber,
+                                tracing::Span::none()
+                            )),
+                        },
+                        value: parent.encode(),
+                        response,
+                    })
+                    .accepted()
+            );
+            assert!(response_rx.await.expect("delivery response missing"));
+            subscriptions.push(mailbox.subscribe_by_commitment(
+                grandparent.commitment(),
+                core::CommitmentFallback::FetchByCommitment {
+                    height: grandparent.height(),
+                },
+            ));
+            assert!(
+                mailbox
+                    .get_processed_height()
+                    .await
+                    .unwrap_or(Height::zero())
+                    < grandparent.height()
+            );
+            let annotations: Vec<_> = resolver
+                .fetches()
+                .into_iter()
+                .filter_map(|fetch| {
+                    matches!(
+                        fetch.subscriber,
+                        handler::Annotation::Certified { .. }
+                            | handler::Annotation::Untrusted { .. }
+                    )
+                    .then_some(fetch.subscriber)
+                })
+                .collect();
+            assert_eq!(
+                annotations,
+                vec![
+                    handler::Annotation::Certified {
+                        height: parent.height()
+                    },
+                    handler::Annotation::Untrusted {
+                        height: parent.height()
+                    },
+                    handler::Annotation::Untrusted {
+                        height: parent.height()
+                    },
+                    handler::Annotation::Untrusted {
+                        height: grandparent.height()
+                    },
+                ]
+            );
         });
     }
 

--- a/consensus/src/marshal/coding/mod.rs
+++ b/consensus/src/marshal/coding/mod.rs
@@ -64,7 +64,7 @@ pub use marshaled::{Marshaled, MarshaledConfig};
 #[cfg(test)]
 mod tests {
     use crate::{
-        Automaton, Block, CertifiableAutomaton, CertifiableBlock, Relay,
+        Automaton, Block, CertifiableAutomaton, CertifiableBlock, Relay, Reporter,
         marshal::{
             ancestry::BlockProvider,
             coding::{
@@ -86,7 +86,9 @@ mod tests {
             resolver::handler,
         },
         simplex::{
-            Plan, scheme::bls12381_threshold::vrf as bls12381_threshold_vrf, types::Proposal,
+            Plan,
+            scheme::bls12381_threshold::vrf as bls12381_threshold_vrf,
+            types::{Activity, Proposal},
         },
         types::{Epoch, Epocher, FixedEpocher, Height, Round, View, ViewDelta, coding::Commitment},
     };
@@ -488,6 +490,32 @@ mod tests {
         let coded_candidate: TestCodedBlock =
             CodedBlock::new(candidate, coding_config, &Sequential);
         (candidate_ctx, coded_candidate)
+    }
+
+    /// Builds `length` coded blocks above genesis, each proposed at the view
+    /// matching its height and naming the block below it as its parent.
+    fn coding_chain(leader: K, length: u64) -> Vec<(Round, TestCodedBlock)> {
+        let coding_config = coding_config_for_participants(NUM_VALIDATORS as u16);
+        let genesis = genesis_block();
+        let mut parent_view = View::zero();
+        let mut parent_commitment = genesis_coding_commitment(&genesis);
+        let mut parent_digest = genesis.digest();
+        let mut chain = Vec::new();
+        for height in 1..=length {
+            let round = Round::new(Epoch::zero(), View::new(height));
+            let ctx = CodingCtx {
+                round,
+                leader: leader.clone(),
+                parent: (parent_view, parent_commitment),
+            };
+            let block = make_coding_block(ctx, parent_digest, Height::new(height), height * 100);
+            let coded: TestCodedBlock = CodedBlock::new(block, coding_config, &Sequential);
+            parent_view = round.view();
+            parent_commitment = coded.commitment();
+            parent_digest = coded.digest();
+            chain.push((round, coded));
+        }
+        chain
     }
 
     #[test_traced("WARN")]
@@ -3576,12 +3604,12 @@ mod tests {
                 mailbox.subscribe_by_commitment(commitment, core::CommitmentFallback::Wait);
             context.sleep(Duration::from_millis(100)).await;
 
-            // One key can carry an ancestry subscriber and a finalized-chain
-            // subscriber at once. The finalized subscriber alone binds the
-            // coding root, so the shared delivery decodes without recomputing it
-            // and lands in the finalized archive.
+            // One key can carry an ancestry subscriber without certification
+            // evidence and a finalized-chain subscriber at once. The finalized
+            // subscriber alone binds the coding root, so the shared delivery
+            // decodes without recomputing it and lands in the finalized archive.
             let mut subscribers = NonEmptyVec::new((
-                handler::Annotation::Certified { height },
+                handler::Annotation::Ancestry { height },
                 tracing::Span::none(),
             ));
             subscribers.push((
@@ -3668,7 +3696,7 @@ mod tests {
     }
 
     #[test_traced("WARN")]
-    fn test_coding_certified_block_delivery_recomputes_root() {
+    fn test_coding_ancestry_block_delivery_recomputes_root() {
         let runner = deterministic::Runner::timed(Duration::from_secs(30));
         runner.start(|mut context| async move {
             let Fixture {
@@ -3678,45 +3706,122 @@ mod tests {
             } = bls12381_threshold_vrf::fixture::<V, _>(&mut context, NAMESPACE, NUM_VALIDATORS);
             let (mailbox, resolver, _actor_handle) = start_coding_actor_with_recording(
                 context.child("validator"),
-                "certified-block-delivery",
+                "ancestry-block-delivery",
                 ConstantProvider::new(schemes[0].clone()),
                 RecordingCodingBuffer::default(),
             )
             .await;
 
-            let (_, candidate) = missing_candidate(participants[0].clone());
-            let commitment = candidate.commitment();
+            // Nothing certified the chain, so each fetch proves its coding root
+            // by re-encoding and none extends certification evidence downward.
+            let mut chain = coding_chain(participants[0].clone(), 2);
+            let (_, top) = chain.pop().expect("top");
+            let (_, bottom) = chain.pop().expect("bottom");
+            for (block, height) in [(top, 2), (bottom, 1)] {
+                resolver.respond_to_next_fetch(block.encode());
+                let delivered = mailbox
+                    .subscribe_by_commitment(
+                        block.commitment(),
+                        core::CommitmentFallback::FetchByCommitment {
+                            height: Height::new(height),
+                        },
+                    )
+                    .await
+                    .expect("subscription dropped");
+                assert_eq!(delivered.commitment(), block.commitment());
+                assert!(
+                    delivered.shard(0).is_some(),
+                    "ancestry delivery should recompute shards"
+                );
+                assert!(
+                    resolver.wait_for_delivery_response().await,
+                    "ancestry delivery should validate"
+                );
+            }
+            let fetches = resolver.fetches();
+            assert_eq!(fetches.len(), 2);
+            assert!(fetches.iter().all(|fetch| matches!(
+                (&fetch.key, &fetch.subscriber),
+                (handler::Key::Block(_), handler::Annotation::Ancestry { .. })
+            )));
+        });
+    }
 
-            // No finalization names the commitment, so the delivery proves the
-            // coding root by re-encoding the block.
-            resolver.respond_to_next_fetch(candidate.encode());
-            let subscription = mailbox.subscribe_by_commitment(
-                commitment,
-                core::CommitmentFallback::FetchByCommitment {
-                    height: Height::new(1),
-                },
-            );
+    #[test_traced("WARN")]
+    fn test_coding_certified_ancestry_delivery_skips_recoding() {
+        let runner = deterministic::Runner::timed(Duration::from_secs(30));
+        runner.start(|mut context| async move {
+            let Fixture {
+                participants,
+                schemes,
+                ..
+            } = bls12381_threshold_vrf::fixture::<V, _>(&mut context, NAMESPACE, NUM_VALIDATORS);
+            let (mut mailbox, resolver, _actor_handle) = start_coding_actor_with_recording(
+                context.child("validator"),
+                "certified-ancestry-delivery",
+                ConstantProvider::new(schemes[0].clone()),
+                RecordingCodingBuffer::default(),
+            )
+            .await;
 
-            let delivered = subscription.await.expect("subscription dropped");
-            assert_eq!(delivered.commitment(), commitment);
-            assert!(
-                delivered.shard(0).is_some(),
-                "ancestry delivery should recompute shards"
+            // Build genesis <- grandparent <- parent <- child, verify the child
+            // locally, and have consensus report that it was certified.
+            // Certification implies its ancestors are certified.
+            let mut chain = coding_chain(participants[0].clone(), 3);
+            let (child_round, child) = chain.pop().expect("child");
+            let (_, parent) = chain.pop().expect("parent");
+            let (_, grandparent) = chain.pop().expect("grandparent");
+            assert!(mailbox.verified(child_round, child.clone()).await);
+            let notarization = CodingHarness::make_notarization(
+                Proposal::new(child_round, View::new(2), child.commitment()),
+                &schemes,
+                QUORUM,
             );
+            mailbox.report(Activity::Certification(notarization));
+
+            // The parent is fetched under certification evidence and arrives lazy.
+            resolver.respond_to_next_fetch(parent.encode());
+            let delivered = mailbox
+                .subscribe_by_commitment(
+                    parent.commitment(),
+                    core::CommitmentFallback::FetchByCommitment {
+                        height: Height::new(2),
+                    },
+                )
+                .await
+                .expect("parent subscription dropped");
             assert!(
-                resolver.wait_for_delivery_response().await,
-                "ancestry delivery should validate"
+                delivered.shard(0).is_none(),
+                "certified parent should not recompute shards"
             );
+            assert!(resolver.wait_for_delivery_response().await);
+
+            // The delivered parent extends the evidence to the grandparent.
+            resolver.respond_to_next_fetch(grandparent.encode());
+            let delivered = mailbox
+                .subscribe_by_commitment(
+                    grandparent.commitment(),
+                    core::CommitmentFallback::FetchByCommitment {
+                        height: Height::new(1),
+                    },
+                )
+                .await
+                .expect("grandparent subscription dropped");
             assert!(
-                resolver.fetches().iter().any(|fetch| matches!(
-                    (&fetch.key, &fetch.subscriber),
-                    (
-                        handler::Key::Block(requested),
-                        handler::Annotation::Certified { .. },
-                    ) if *requested == commitment
-                )),
-                "ancestry walk should fetch the block by commitment"
+                delivered.shard(0).is_none(),
+                "certified grandparent should not recompute shards"
             );
+            assert!(resolver.wait_for_delivery_response().await);
+
+            let certified: Vec<Height> = resolver
+                .fetches()
+                .iter()
+                .filter_map(|fetch| match fetch.subscriber {
+                    handler::Annotation::Certified { height } => Some(height),
+                    _ => None,
+                })
+                .collect();
+            assert_eq!(certified, vec![Height::new(2), Height::new(1)]);
         });
     }
 

--- a/consensus/src/marshal/coding/types.rs
+++ b/consensus/src/marshal/coding/types.rs
@@ -316,12 +316,12 @@ pub struct CodedBlockCfg<B: Block, C: Scheme, H: Hasher> {
     pub inner: <B as Read>::Cfg,
     /// The commitment the decoded block must match.
     pub expected: Commitment<B, C, H>,
-    /// Whether `expected` is bound by the finalized chain.
+    /// Whether this node holds certification evidence for `expected`.
     ///
-    /// The commitment is the payload of a verified finalization or the parent
-    /// commitment of a finalized block. Either way the finalized chain already
-    /// fixes the coding root of the bytes that match the block digest, so
-    /// decoding takes the root from `expected` and defers shard generation to
+    /// The commitment is on the finalized chain, or it is a block this node
+    /// certified or an ancestor of one. Either way the commitment was already
+    /// checked to encode the bytes that match its block digest, so decoding
+    /// takes the root from `expected` and defers shard generation to
     /// [`CodedBlock::shards`]. A notarization is not enough: notarize votes
     /// attest shard validity against the root, not that the root encodes the
     /// block named by the digest.
@@ -361,9 +361,8 @@ impl<B: Block, C: Scheme, H: Hasher> Read for CodedBlock<B, C, H> {
             ));
         }
 
-        // A commitment bound by the finalized chain already fixes the coding
-        // root of these bytes, so recomputing it would only re-derive the root
-        // already in `expected`.
+        // A certified commitment already fixes the coding root of these bytes,
+        // so recomputing it would only re-derive the root already in `expected`.
         if cfg.trusted {
             return Ok(Self::new_trusted(inner, cfg.expected));
         }

--- a/consensus/src/marshal/coding/types.rs
+++ b/consensus/src/marshal/coding/types.rs
@@ -181,12 +181,8 @@ impl<B: Block, C: Scheme, H: Hasher> CodedBlock<B, C, H> {
 
     /// Create a new [`CodedBlock`] from a [`Block`] and trusted [`Commitment`].
     ///
-    /// The caller must know that `commitment` was produced by encoding `inner`,
-    /// for example because a quorum decoded the block under it. That inference
-    /// relies on the unique-commitment guarantee of [`Scheme`]: only the
-    /// commitment produced by [`Scheme::encode`] passes [`Scheme::decode`].
-    /// Shards are generated on demand by [`Self::shards`], which panics if the
-    /// commitment does not encode `inner`.
+    /// `commitment` must encode `inner`. [`Self::shards`] generates shards on
+    /// demand and panics if the coding root does not match.
     pub fn new_trusted(inner: B, commitment: Commitment<B, C, H>) -> Self {
         Self::new_trusted_shared(Arc::new(inner), commitment)
     }

--- a/consensus/src/marshal/coding/types.rs
+++ b/consensus/src/marshal/coding/types.rs
@@ -180,6 +180,13 @@ impl<B: Block, C: Scheme, H: Hasher> CodedBlock<B, C, H> {
     }
 
     /// Create a new [`CodedBlock`] from a [`Block`] and trusted [`Commitment`].
+    ///
+    /// The caller must know that `commitment` was produced by encoding `inner`,
+    /// for example because a quorum decoded the block under it. That inference
+    /// relies on the unique-commitment guarantee of [`Scheme`]: only the
+    /// commitment produced by [`Scheme::encode`] passes [`Scheme::decode`].
+    /// Shards are generated on demand by [`Self::shards`], which panics if the
+    /// commitment does not encode `inner`.
     pub fn new_trusted(inner: B, commitment: Commitment<B, C, H>) -> Self {
         Self::new_trusted_shared(Arc::new(inner), commitment)
     }

--- a/consensus/src/marshal/coding/types.rs
+++ b/consensus/src/marshal/coding/types.rs
@@ -2,6 +2,7 @@
 
 use crate::{
     Block, CertifiableBlock, Heightable,
+    marshal::core::ExpectedCommitment,
     types::{Height, coding::Commitment},
 };
 use commonware_codec::{BufsMut, EncodeSize, Read, ReadExt, Write};
@@ -310,25 +311,15 @@ impl<B: Block, C: Scheme, H: Hasher> EncodeSize for CodedBlock<B, C, H> {
 
 /// Codec configuration for decoding a [`CodedBlock`] from the wire.
 ///
-/// Pairs the inner block's codec config with the [`Commitment`] that the
-/// decoded block must match. The [`Read`] impl rejects a block whose digest or
-/// coding configuration differs from `expected`. Unless `trusted` is set, it
-/// also re-encodes the block and rejects a coding root mismatch.
+/// Decoding checks the expected digest and coding configuration.
+/// [`ExpectedCommitment::Untrusted`] also recomputes the coding root;
+/// [`ExpectedCommitment::Trusted`] reuses it and defers shard generation to
+/// [`CodedBlock::shards`].
 pub struct CodedBlockCfg<B: Block, C: Scheme, H: Hasher> {
     /// Codec configuration for the inner application block.
     pub inner: <B as Read>::Cfg,
-    /// The commitment the decoded block must match.
-    pub expected: Commitment<B, C, H>,
-    /// Whether this node holds certification evidence for `expected`.
-    ///
-    /// The commitment is on the finalized chain, or it is a block this node
-    /// certified or an ancestor of one. Either way the commitment was already
-    /// checked to encode the bytes that match its block digest, so decoding
-    /// takes the root from `expected` and defers shard generation to
-    /// [`CodedBlock::shards`]. A notarization is not enough: notarize votes
-    /// attest shard validity against the root, not that the root encodes the
-    /// block named by the digest.
-    pub trusted: bool,
+    /// The expected commitment and its certification evidence.
+    pub expected: ExpectedCommitment<Commitment<B, C, H>>,
 }
 
 impl<B: Block, C: Scheme, H: Hasher> Clone for CodedBlockCfg<B, C, H> {
@@ -336,7 +327,6 @@ impl<B: Block, C: Scheme, H: Hasher> Clone for CodedBlockCfg<B, C, H> {
         Self {
             inner: self.inner.clone(),
             expected: self.expected,
-            trusted: self.trusted,
         }
     }
 }
@@ -350,14 +340,16 @@ impl<B: Block, C: Scheme, H: Hasher> Read for CodedBlock<B, C, H> {
     ) -> Result<Self, commonware_codec::Error> {
         let inner = B::read_cfg(buf, &cfg.inner)?;
         let config = CodingConfig::read(buf)?;
+        let (ExpectedCommitment::Trusted(expected) | ExpectedCommitment::Untrusted(expected)) =
+            cfg.expected;
 
-        if config != cfg.expected.config() {
+        if config != expected.config() {
             return Err(commonware_codec::Error::Invalid(
                 "CodedBlock",
                 "config mismatch",
             ));
         }
-        if inner.digest() != cfg.expected.block() {
+        if inner.digest() != expected.block() {
             return Err(commonware_codec::Error::Invalid(
                 "CodedBlock",
                 "block digest mismatch",
@@ -366,8 +358,8 @@ impl<B: Block, C: Scheme, H: Hasher> Read for CodedBlock<B, C, H> {
 
         // A certified commitment already fixes the coding root of these bytes,
         // so recomputing it would only re-derive the root already in `expected`.
-        if cfg.trusted {
-            return Ok(Self::new_trusted(inner, cfg.expected));
+        if matches!(cfg.expected, ExpectedCommitment::Trusted(_)) {
+            return Ok(Self::new_trusted(inner, expected));
         }
 
         // Recompute the coding root and require it to match the expected
@@ -383,7 +375,7 @@ impl<B: Block, C: Scheme, H: Hasher> Read for CodedBlock<B, C, H> {
             C::encode(&config, buf.as_slice(), &Sequential).map_err(|_| {
                 commonware_codec::Error::Invalid("CodedBlock", "Failed to re-commit to block")
             })?;
-        if commitment != cfg.expected.root() {
+        if commitment != expected.root() {
             return Err(commonware_codec::Error::Invalid(
                 "CodedBlock",
                 "coding root mismatch",
@@ -692,8 +684,7 @@ mod test {
             encoded,
             &CodedBlockCfg {
                 inner: (),
-                expected: coded_block.commitment(),
-                trusted: false,
+                expected: ExpectedCommitment::Untrusted(coded_block.commitment()),
             },
         )
         .unwrap();
@@ -722,8 +713,7 @@ mod test {
             encoded.as_ref(),
             &CodedBlockCfg {
                 inner: (),
-                expected,
-                trusted: false,
+                expected: ExpectedCommitment::Untrusted(expected),
             },
         ) else {
             panic!("config mismatch should be rejected");
@@ -761,8 +751,7 @@ mod test {
             coded.encode(),
             &CodedBlockCfg {
                 inner: (),
-                expected,
-                trusted: false,
+                expected: ExpectedCommitment::Untrusted(expected),
             },
         ) else {
             panic!("coding root mismatch should be rejected");
@@ -787,8 +776,7 @@ mod test {
             coded.encode(),
             &CodedBlockCfg {
                 inner: (),
-                expected: coded.commitment(),
-                trusted: true,
+                expected: ExpectedCommitment::Trusted(coded.commitment()),
             },
         )
         .unwrap();
@@ -820,8 +808,7 @@ mod test {
             encoded.as_ref(),
             &CodedBlockCfg {
                 inner: (),
-                expected,
-                trusted: true,
+                expected: ExpectedCommitment::Trusted(expected),
             },
         ) else {
             panic!("config mismatch should be rejected");
@@ -850,8 +837,7 @@ mod test {
             encoded.as_ref(),
             &CodedBlockCfg {
                 inner: (),
-                expected,
-                trusted: true,
+                expected: ExpectedCommitment::Trusted(expected),
             },
         ) else {
             panic!("block digest mismatch should be rejected");
@@ -879,8 +865,7 @@ mod test {
             encoded.as_ref(),
             &CodedBlockCfg {
                 inner: (),
-                expected: coded.commitment(),
-                trusted: true,
+                expected: ExpectedCommitment::Trusted(coded.commitment()),
             },
         ) else {
             panic!("trailing bytes should be rejected");
@@ -915,8 +900,7 @@ mod test {
             coded.encode(),
             &CodedBlockCfg {
                 inner: (),
-                expected,
-                trusted: true,
+                expected: ExpectedCommitment::Trusted(expected),
             },
         )
         .unwrap();

--- a/consensus/src/marshal/coding/types.rs
+++ b/consensus/src/marshal/coding/types.rs
@@ -850,34 +850,6 @@ mod test {
     }
 
     #[test]
-    fn test_coded_block_decode_trusted_rejects_trailing_bytes() {
-        const CONFIG: CodingConfig = CodingConfig {
-            minimum_shards: NZU16!(1),
-            extra_shards: NZU16!(2),
-        };
-
-        let block = TestBlock::new(Sha256::hash(&[b"parent"]), Height::new(42), 1_234_567);
-        let coded = CodedBlock::<TestBlock, RS, H>::new(block, CONFIG, &Sequential);
-        let mut encoded = coded.encode().to_vec();
-        encoded.push(0);
-
-        let Err(err) = CodedBlock::<TestBlock, RS, H>::decode_cfg(
-            encoded.as_ref(),
-            &CodedBlockCfg {
-                inner: (),
-                expected: ExpectedCommitment::Trusted(coded.commitment()),
-            },
-        ) else {
-            panic!("trailing bytes should be rejected");
-        };
-
-        assert!(
-            matches!(err, Error::ExtraData(1)),
-            "unexpected error: {err:?}"
-        );
-    }
-
-    #[test]
     #[should_panic(expected = "does not match commitment")]
     fn test_coded_block_trusted_wrong_root_panics_on_shards() {
         const CONFIG: CodingConfig = CodingConfig {

--- a/consensus/src/marshal/coding/types.rs
+++ b/consensus/src/marshal/coding/types.rs
@@ -309,7 +309,7 @@ impl<B: Block, C: Scheme, H: Hasher> EncodeSize for CodedBlock<B, C, H> {
 ///
 /// Pairs the inner block's codec config with the [`Commitment`] that the
 /// decoded block must match. The [`Read`] impl rejects a block whose digest or
-/// coding configuration differs from `expected`. Unless `finalized` is set, it
+/// coding configuration differs from `expected`. Unless `trusted` is set, it
 /// also re-encodes the block and rejects a coding root mismatch.
 pub struct CodedBlockCfg<B: Block, C: Scheme, H: Hasher> {
     /// Codec configuration for the inner application block.
@@ -325,7 +325,7 @@ pub struct CodedBlockCfg<B: Block, C: Scheme, H: Hasher> {
     /// [`CodedBlock::shards`]. A notarization is not enough: notarize votes
     /// attest shard validity against the root, not that the root encodes the
     /// block named by the digest.
-    pub finalized: bool,
+    pub trusted: bool,
 }
 
 impl<B: Block, C: Scheme, H: Hasher> Clone for CodedBlockCfg<B, C, H> {
@@ -333,7 +333,7 @@ impl<B: Block, C: Scheme, H: Hasher> Clone for CodedBlockCfg<B, C, H> {
         Self {
             inner: self.inner.clone(),
             expected: self.expected,
-            finalized: self.finalized,
+            trusted: self.trusted,
         }
     }
 }
@@ -364,7 +364,7 @@ impl<B: Block, C: Scheme, H: Hasher> Read for CodedBlock<B, C, H> {
         // A commitment bound by the finalized chain already fixes the coding
         // root of these bytes, so recomputing it would only re-derive the root
         // already in `expected`.
-        if cfg.finalized {
+        if cfg.trusted {
             return Ok(Self::new_trusted(inner, cfg.expected));
         }
 
@@ -441,7 +441,7 @@ impl<B: Block + Eq, C: Scheme, H: Hasher> Eq for CodedBlock<B, C, H> {}
 /// This type should be preferred for storing verified [`CodedBlock`]s on disk - it
 /// should never be sent over the network. Use [`CodedBlock`] for network transmission.
 /// Its [`Read`] impl recomputes the coding root with [`Scheme::encode`] unless the
-/// expected commitment is finalized (see [`CodedBlockCfg`]).
+/// expected commitment is trusted (see [`CodedBlockCfg`]).
 ///
 /// When reading from storage, we don't need to re-encode the block to compute
 /// the commitment - we stored it alongside the block when we first verified it.
@@ -691,7 +691,7 @@ mod test {
             &CodedBlockCfg {
                 inner: (),
                 expected: coded_block.commitment(),
-                finalized: false,
+                trusted: false,
             },
         )
         .unwrap();
@@ -721,7 +721,7 @@ mod test {
             &CodedBlockCfg {
                 inner: (),
                 expected,
-                finalized: false,
+                trusted: false,
             },
         ) else {
             panic!("config mismatch should be rejected");
@@ -760,7 +760,7 @@ mod test {
             &CodedBlockCfg {
                 inner: (),
                 expected,
-                finalized: false,
+                trusted: false,
             },
         ) else {
             panic!("coding root mismatch should be rejected");
@@ -773,7 +773,7 @@ mod test {
     }
 
     #[test]
-    fn test_coded_block_decode_finalized_is_lazy() {
+    fn test_coded_block_decode_trusted_is_lazy() {
         const CONFIG: CodingConfig = CodingConfig {
             minimum_shards: NZU16!(1),
             extra_shards: NZU16!(2),
@@ -786,7 +786,7 @@ mod test {
             &CodedBlockCfg {
                 inner: (),
                 expected: coded.commitment(),
-                finalized: true,
+                trusted: true,
             },
         )
         .unwrap();
@@ -798,7 +798,7 @@ mod test {
     }
 
     #[test]
-    fn test_coded_block_decode_finalized_rejects_config_mismatch() {
+    fn test_coded_block_decode_trusted_rejects_config_mismatch() {
         const EXPECTED_CONFIG: CodingConfig = CodingConfig {
             minimum_shards: NZU16!(1),
             extra_shards: NZU16!(3),
@@ -819,7 +819,7 @@ mod test {
             &CodedBlockCfg {
                 inner: (),
                 expected,
-                finalized: true,
+                trusted: true,
             },
         ) else {
             panic!("config mismatch should be rejected");
@@ -832,7 +832,7 @@ mod test {
     }
 
     #[test]
-    fn test_coded_block_decode_finalized_rejects_block_digest_mismatch() {
+    fn test_coded_block_decode_trusted_rejects_block_digest_mismatch() {
         const CONFIG: CodingConfig = CodingConfig {
             minimum_shards: NZU16!(1),
             extra_shards: NZU16!(2),
@@ -849,7 +849,7 @@ mod test {
             &CodedBlockCfg {
                 inner: (),
                 expected,
-                finalized: true,
+                trusted: true,
             },
         ) else {
             panic!("block digest mismatch should be rejected");
@@ -862,7 +862,7 @@ mod test {
     }
 
     #[test]
-    fn test_coded_block_decode_finalized_rejects_trailing_bytes() {
+    fn test_coded_block_decode_trusted_rejects_trailing_bytes() {
         const CONFIG: CodingConfig = CodingConfig {
             minimum_shards: NZU16!(1),
             extra_shards: NZU16!(2),
@@ -878,7 +878,7 @@ mod test {
             &CodedBlockCfg {
                 inner: (),
                 expected: coded.commitment(),
-                finalized: true,
+                trusted: true,
             },
         ) else {
             panic!("trailing bytes should be rejected");
@@ -892,14 +892,14 @@ mod test {
 
     #[test]
     #[should_panic(expected = "does not match commitment")]
-    fn test_coded_block_finalized_wrong_root_panics_on_shards() {
+    fn test_coded_block_trusted_wrong_root_panics_on_shards() {
         const CONFIG: CodingConfig = CodingConfig {
             minimum_shards: NZU16!(1),
             extra_shards: NZU16!(2),
         };
 
-        // A finalized commitment is trusted at decode, so a root that does not
-        // encode the block is only caught when shards are generated.
+        // A trusted commitment is not re-encoded at decode, so a root that does
+        // not encode the block is only caught when shards are generated.
         let block = TestBlock::new(Sha256::hash(&[b"parent"]), Height::new(42), 1_234_567);
         let coded = CodedBlock::<TestBlock, RS, H>::new(block, CONFIG, &Sequential);
         let commitment = coded.commitment();
@@ -914,7 +914,7 @@ mod test {
             &CodedBlockCfg {
                 inner: (),
                 expected,
-                finalized: true,
+                trusted: true,
             },
         )
         .unwrap();

--- a/consensus/src/marshal/coding/types.rs
+++ b/consensus/src/marshal/coding/types.rs
@@ -206,6 +206,9 @@ impl<B: Block, C: Scheme, H: Hasher> CodedBlock<B, C, H> {
         self.shards.get_or_init(|| {
             let (commitment, shards) = Self::encode(&self.inner, self.config, strategy);
 
+            // A mismatch means a commitment trusted at construction does not
+            // encode this block, which is a contract violation or a consensus
+            // safety failure. Never serve shards under a different root.
             assert_eq!(
                 commitment, self.commitment,
                 "coded block constructed with trusted commitment does not match commitment"
@@ -305,14 +308,24 @@ impl<B: Block, C: Scheme, H: Hasher> EncodeSize for CodedBlock<B, C, H> {
 /// Codec configuration for decoding a [`CodedBlock`] from the wire.
 ///
 /// Pairs the inner block's codec config with the [`Commitment`] that the
-/// decoded block must match. The [`Read`] impl re-encodes the block and
-/// rejects it unless its block digest, coding configuration, and coding root match
-/// `expected`.
+/// decoded block must match. The [`Read`] impl rejects a block whose digest or
+/// coding configuration differs from `expected`. Unless `finalized` is set, it
+/// also re-encodes the block and rejects a coding root mismatch.
 pub struct CodedBlockCfg<B: Block, C: Scheme, H: Hasher> {
     /// Codec configuration for the inner application block.
     pub inner: <B as Read>::Cfg,
     /// The commitment the decoded block must match.
     pub expected: Commitment<B, C, H>,
+    /// Whether `expected` is bound by the finalized chain.
+    ///
+    /// The commitment is the payload of a verified finalization or the parent
+    /// commitment of a finalized block. Either way the finalized chain already
+    /// fixes the coding root of the bytes that match the block digest, so
+    /// decoding takes the root from `expected` and defers shard generation to
+    /// [`CodedBlock::shards`]. A notarization is not enough: notarize votes
+    /// attest shard validity against the root, not that the root encodes the
+    /// block named by the digest.
+    pub finalized: bool,
 }
 
 impl<B: Block, C: Scheme, H: Hasher> Clone for CodedBlockCfg<B, C, H> {
@@ -320,6 +333,7 @@ impl<B: Block, C: Scheme, H: Hasher> Clone for CodedBlockCfg<B, C, H> {
         Self {
             inner: self.inner.clone(),
             expected: self.expected,
+            finalized: self.finalized,
         }
     }
 }
@@ -345,6 +359,13 @@ impl<B: Block, C: Scheme, H: Hasher> Read for CodedBlock<B, C, H> {
                 "CodedBlock",
                 "block digest mismatch",
             ));
+        }
+
+        // A commitment bound by the finalized chain already fixes the coding
+        // root of these bytes, so recomputing it would only re-derive the root
+        // already in `expected`.
+        if cfg.finalized {
+            return Ok(Self::new_trusted(inner, cfg.expected));
         }
 
         // Recompute the coding root and require it to match the expected
@@ -418,8 +439,9 @@ impl<B: Block + Eq, C: Scheme, H: Hasher> Eq for CodedBlock<B, C, H> {}
 /// A [`CodedBlock`] paired with its [`Commitment`] for efficient storage and retrieval.
 ///
 /// This type should be preferred for storing verified [`CodedBlock`]s on disk - it
-/// should never be sent over the network. Use [`CodedBlock`] for network transmission,
-/// as it re-encodes the block with [`Scheme::encode`] on deserialization to ensure integrity.
+/// should never be sent over the network. Use [`CodedBlock`] for network transmission.
+/// Its [`Read`] impl recomputes the coding root with [`Scheme::encode`] unless the
+/// expected commitment is finalized (see [`CodedBlockCfg`]).
 ///
 /// When reading from storage, we don't need to re-encode the block to compute
 /// the commitment - we stored it alongside the block when we first verified it.
@@ -669,6 +691,7 @@ mod test {
             &CodedBlockCfg {
                 inner: (),
                 expected: coded_block.commitment(),
+                finalized: false,
             },
         )
         .unwrap();
@@ -698,6 +721,7 @@ mod test {
             &CodedBlockCfg {
                 inner: (),
                 expected,
+                finalized: false,
             },
         ) else {
             panic!("config mismatch should be rejected");
@@ -736,6 +760,7 @@ mod test {
             &CodedBlockCfg {
                 inner: (),
                 expected,
+                finalized: false,
             },
         ) else {
             panic!("coding root mismatch should be rejected");
@@ -745,6 +770,156 @@ mod test {
             matches!(err, Error::Invalid("CodedBlock", "coding root mismatch")),
             "unexpected error: {err:?}"
         );
+    }
+
+    #[test]
+    fn test_coded_block_decode_finalized_is_lazy() {
+        const CONFIG: CodingConfig = CodingConfig {
+            minimum_shards: NZU16!(1),
+            extra_shards: NZU16!(2),
+        };
+
+        let block = TestBlock::new(Sha256::hash(&[b"parent"]), Height::new(42), 1_234_567);
+        let coded = CodedBlock::<TestBlock, RS, H>::new(block, CONFIG, &Sequential);
+        let decoded = CodedBlock::<TestBlock, RS, H>::decode_cfg(
+            coded.encode(),
+            &CodedBlockCfg {
+                inner: (),
+                expected: coded.commitment(),
+                finalized: true,
+            },
+        )
+        .unwrap();
+
+        // The root comes from the commitment and shards are generated on demand.
+        assert_eq!(decoded.commitment(), coded.commitment());
+        assert!(decoded.shard(0).is_none());
+        assert_eq!(decoded.shards(&Sequential), coded.shards(&Sequential));
+    }
+
+    #[test]
+    fn test_coded_block_decode_finalized_rejects_config_mismatch() {
+        const EXPECTED_CONFIG: CodingConfig = CodingConfig {
+            minimum_shards: NZU16!(1),
+            extra_shards: NZU16!(3),
+        };
+        const EMBEDDED_CONFIG: CodingConfig = CodingConfig {
+            minimum_shards: NZU16!(2),
+            extra_shards: NZU16!(2),
+        };
+
+        let block = TestBlock::new(Sha256::hash(&[b"parent"]), Height::new(42), 1_234_567);
+        let expected =
+            CodedBlock::<TestBlock, RS, H>::new(block.clone(), EXPECTED_CONFIG, &Sequential)
+                .commitment();
+        let encoded = (block, EMBEDDED_CONFIG).encode();
+
+        let Err(err) = CodedBlock::<TestBlock, RS, H>::decode_cfg(
+            encoded.as_ref(),
+            &CodedBlockCfg {
+                inner: (),
+                expected,
+                finalized: true,
+            },
+        ) else {
+            panic!("config mismatch should be rejected");
+        };
+
+        assert!(
+            matches!(err, Error::Invalid("CodedBlock", "config mismatch")),
+            "unexpected error: {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_coded_block_decode_finalized_rejects_block_digest_mismatch() {
+        const CONFIG: CodingConfig = CodingConfig {
+            minimum_shards: NZU16!(1),
+            extra_shards: NZU16!(2),
+        };
+
+        let block = TestBlock::new(Sha256::hash(&[b"parent"]), Height::new(42), 1_234_567);
+        let other = TestBlock::new(Sha256::hash(&[b"parent"]), Height::new(43), 1_234_567);
+        let expected = CodedBlock::<TestBlock, RS, H>::new(block, CONFIG, &Sequential).commitment();
+        assert_ne!(other.digest(), expected.block());
+        let encoded = (other, CONFIG).encode();
+
+        let Err(err) = CodedBlock::<TestBlock, RS, H>::decode_cfg(
+            encoded.as_ref(),
+            &CodedBlockCfg {
+                inner: (),
+                expected,
+                finalized: true,
+            },
+        ) else {
+            panic!("block digest mismatch should be rejected");
+        };
+
+        assert!(
+            matches!(err, Error::Invalid("CodedBlock", "block digest mismatch")),
+            "unexpected error: {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_coded_block_decode_finalized_rejects_trailing_bytes() {
+        const CONFIG: CodingConfig = CodingConfig {
+            minimum_shards: NZU16!(1),
+            extra_shards: NZU16!(2),
+        };
+
+        let block = TestBlock::new(Sha256::hash(&[b"parent"]), Height::new(42), 1_234_567);
+        let coded = CodedBlock::<TestBlock, RS, H>::new(block, CONFIG, &Sequential);
+        let mut encoded = coded.encode().to_vec();
+        encoded.push(0);
+
+        let Err(err) = CodedBlock::<TestBlock, RS, H>::decode_cfg(
+            encoded.as_ref(),
+            &CodedBlockCfg {
+                inner: (),
+                expected: coded.commitment(),
+                finalized: true,
+            },
+        ) else {
+            panic!("trailing bytes should be rejected");
+        };
+
+        assert!(
+            matches!(err, Error::ExtraData(1)),
+            "unexpected error: {err:?}"
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "does not match commitment")]
+    fn test_coded_block_finalized_wrong_root_panics_on_shards() {
+        const CONFIG: CodingConfig = CodingConfig {
+            minimum_shards: NZU16!(1),
+            extra_shards: NZU16!(2),
+        };
+
+        // A finalized commitment is trusted at decode, so a root that does not
+        // encode the block is only caught when shards are generated.
+        let block = TestBlock::new(Sha256::hash(&[b"parent"]), Height::new(42), 1_234_567);
+        let coded = CodedBlock::<TestBlock, RS, H>::new(block, CONFIG, &Sequential);
+        let commitment = coded.commitment();
+        let expected = Commitment::<TestBlock, RS, H>::from((
+            commitment.block(),
+            Sha256::hash(&[b"wrong root"]),
+            commitment.context(),
+            commitment.config(),
+        ));
+        let decoded = CodedBlock::<TestBlock, RS, H>::decode_cfg(
+            coded.encode(),
+            &CodedBlockCfg {
+                inner: (),
+                expected,
+                finalized: true,
+            },
+        )
+        .unwrap();
+
+        decoded.shards(&Sequential);
     }
 
     #[test]

--- a/consensus/src/marshal/coding/variant.rs
+++ b/consensus/src/marshal/coding/variant.rs
@@ -94,10 +94,12 @@ where
     fn block_cfg(
         block_cfg: &<Self::ApplicationBlock as Read>::Cfg,
         expected: Self::Commitment,
+        finalized: bool,
     ) -> <Self::Block as Read>::Cfg {
         CodedBlockCfg {
             inner: block_cfg.clone(),
             expected,
+            finalized,
         }
     }
 

--- a/consensus/src/marshal/coding/variant.rs
+++ b/consensus/src/marshal/coding/variant.rs
@@ -6,7 +6,7 @@ use crate::{
             shards,
             types::{CodedBlock, CodedBlockCfg, StoredCodedBlock, coding_config_for_participants},
         },
-        core::{Buffer, CommitmentFallback, Mailbox, Retirement, Variant},
+        core::{Buffer, CommitmentFallback, ExpectedCommitment, Mailbox, Retirement, Variant},
     },
     simplex::{scheme::Scheme as SimplexScheme, types::Context},
     types::{Round, coding::Commitment},
@@ -93,13 +93,11 @@ where
 
     fn block_cfg(
         block_cfg: &<Self::ApplicationBlock as Read>::Cfg,
-        expected: Self::Commitment,
-        trusted: bool,
+        expected: ExpectedCommitment<Self::Commitment>,
     ) -> <Self::Block as Read>::Cfg {
         CodedBlockCfg {
             inner: block_cfg.clone(),
             expected,
-            trusted,
         }
     }
 

--- a/consensus/src/marshal/coding/variant.rs
+++ b/consensus/src/marshal/coding/variant.rs
@@ -94,12 +94,12 @@ where
     fn block_cfg(
         block_cfg: &<Self::ApplicationBlock as Read>::Cfg,
         expected: Self::Commitment,
-        finalized: bool,
+        trusted: bool,
     ) -> <Self::Block as Read>::Cfg {
         CodedBlockCfg {
             inner: block_cfg.clone(),
             expected,
-            finalized,
+            trusted,
         }
     }
 

--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -401,6 +401,7 @@ where
             if let Some((height, digest, round)) = tip {
                 application.report(Update::Tip(round, height, digest));
                 self.tip = height;
+                self.certified.retain(height.next());
                 let _ = self.finalized_height.try_set(height.get());
             }
 
@@ -738,12 +739,8 @@ where
                     return self;
                 };
                 let height = block.height();
-                if height > self.tip {
-                    self.certified.insert(height, commitment);
-                }
-                if let Some(parent) = height.previous()
-                    && parent > self.tip
-                {
+                self.certified.insert(height, commitment);
+                if let Some(parent) = height.previous() {
                     self.certified.insert(parent, V::parent_commitment(&block));
                 }
             }
@@ -1524,7 +1521,6 @@ where
                     .iter()
                     .any(|annotation| matches!(annotation, Annotation::Certified { .. }))
                     && let Some(parent) = height.previous()
-                    && parent > self.tip
                 {
                     self.certified.insert(parent, V::parent_commitment(&block));
                 }

--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -1159,7 +1159,7 @@ where
                     Request::untrusted(commitment, height)
                 };
                 self.floor.fetch_if_permitted(resolver, request).ignore();
-                debug!(%height, ?commitment, ?digest, "ancestry block unavailable");
+                debug!(%height, ?commitment, ?digest, "certified ancestry block unavailable");
             }
             CommitmentFallback::Wait => {}
         }
@@ -1552,7 +1552,7 @@ where
                 {
                     self.cache = self
                         .cache
-                        .put_ancestry(
+                        .put_certified(
                             bounds.epoch(),
                             height,
                             digest,
@@ -2558,7 +2558,7 @@ where
         self
     }
 
-    /// Prunes finalized archives and the ancestry cache below the durable floor.
+    /// Prunes finalized archives and height-indexed certified cache data below the durable floor.
     async fn prune_after_floor(mut self: Box<Self>, height: Height) -> Box<Self> {
         (
             self.cache,

--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -2,6 +2,7 @@ use super::{
     Buffer, Retirement, Variant,
     acks::{PendingAck, PendingAcks},
     cache,
+    certified::Certified,
     delivery::PendingVerification,
     durability::{DispatchGate, Durable as _},
     floor::{Floor, State as FloorState},
@@ -140,6 +141,8 @@ where
     tip: Height,
     // Outstanding subscriptions for blocks
     block_subscriptions: Subscriptions<V>,
+    // Commitments known certified above the processed floor
+    certified: Certified<V::Commitment>,
     // Defers application dispatch of finalized-archive writes until a sync
     // covering them completes
     dispatch_gate: DispatchGate,
@@ -263,6 +266,7 @@ where
                 cleared_acks: Vec::new(),
                 tip: Height::zero(),
                 block_subscriptions: Subscriptions::new(),
+                certified: Certified::new(),
                 dispatch_gate: DispatchGate::default(),
                 cache,
                 finalizations_by_height,
@@ -726,6 +730,23 @@ where
                 });
                 ack.send_lossy(handle);
             }
+            Message::Certification { notarization, .. } => {
+                // The engine reports a certification after its own certify verdict,
+                // so the notarization is not re-verified. A certified block arrived
+                // bound to its commitment, and its embedded parent commitment was
+                // checked against a root-bound parent, by this node or by the honest
+                // validators whose certification its notarization required. Later
+                // ancestry fetches can trust both commitments.
+                let commitment = notarization.proposal.payload;
+                let Some(block) = self.find_block_by_commitment(buffer, commitment).await else {
+                    debug!(?commitment, "certified block unavailable locally");
+                    return self;
+                };
+                self.certified.insert(block.height(), commitment);
+                if let Some(parent) = block.height().previous() {
+                    self.certified.insert(parent, V::parent_commitment(&block));
+                }
+            }
             Message::Notarization { notarization, .. } => {
                 let round = notarization.round();
                 let commitment = notarization.proposal.payload;
@@ -1130,12 +1151,19 @@ where
                     }
                 };
 
-                // This path is only for accepted ancestry or finalized repair,
-                // never for a candidate block's immediate parent.
-                self.floor
-                    .fetch_if_permitted(resolver, Request::certified_block(commitment, height))
-                    .ignore();
-                debug!(%height, ?commitment, ?digest, "certified ancestry block unavailable");
+                // This path serves ancestry walks and caller-driven finalized-gap
+                // repair, never a candidate block's immediate parent. Certification
+                // evidence lets the delivery skip recomputing the commitment.
+                // Without it the delivery re-derives the commitment from the block
+                // bytes, since an optimistic ancestry walk can name a commitment
+                // that is only notarized.
+                let request = if self.certified.contains(height, &commitment) {
+                    Request::certified_block(commitment, height)
+                } else {
+                    Request::ancestry_block(commitment, height)
+                };
+                self.floor.fetch_if_permitted(resolver, request).ignore();
+                debug!(%height, ?commitment, ?digest, "ancestry block unavailable");
             }
             CommitmentFallback::Wait => {}
         }
@@ -1447,14 +1475,18 @@ where
 
                 // `Finalized` annotations come only from request sites whose
                 // commitment is the payload of a verified finalization or the
-                // parent commitment of an archived finalized block. Either way
-                // the commitment is already bound to the block, so decoding
-                // need not recompute it. `Certified` annotations come from the
-                // ancestry walk, which can name a commitment this node has only
-                // shard-checked, so those deliveries recompute it.
-                let trusted = annotations
-                    .iter()
-                    .any(|annotation| matches!(annotation, Annotation::Finalized(_)));
+                // parent commitment of an archived finalized block. `Certified`
+                // annotations come only from ancestry fetches for commitments
+                // this node recorded as certified. Either way the commitment is
+                // already bound to the block, so decoding need not recompute it.
+                // `Ancestry` annotations carry no such evidence, so those
+                // deliveries recompute it.
+                let trusted = annotations.iter().any(|annotation| {
+                    matches!(
+                        annotation,
+                        Annotation::Finalized(_) | Annotation::Certified { .. }
+                    )
+                });
                 let block_cfg = V::block_cfg(&self.block_codec_config, commitment, trusted);
                 let Ok(block) = V::Block::decode_cfg(value.as_ref(), &block_cfg) else {
                     response.send_lossy(false);
@@ -1480,6 +1512,16 @@ where
 
                 let height = block.height();
                 let digest = block.digest();
+
+                // A certified block's parent link was checked by the validators
+                // that certified it, so the walk keeps trusting as it descends.
+                if annotations
+                    .iter()
+                    .any(|annotation| matches!(annotation, Annotation::Certified { .. }))
+                    && let Some(parent) = height.previous()
+                {
+                    self.certified.insert(parent, V::parent_commitment(&block));
+                }
 
                 // Round-bound proposal-parent fetches are `Key::Notarized`
                 // deliveries and are handled below. In this block-keyed path,
@@ -1513,14 +1555,15 @@ where
                 } else if annotations.iter().any(|annotation| {
                     matches!(
                         annotation,
-                        Annotation::Certified { height: bound } if height <= *bound
+                        Annotation::Certified { height: bound }
+                        | Annotation::Ancestry { height: bound } if height <= *bound
                     )
                 }) && height > self.floor.processed_height()
                     && let Some(bounds) = self.epocher.containing(height)
                 {
                     self.cache = self
                         .cache
-                        .put_certified(
+                        .put_ancestry(
                             bounds.epoch(),
                             height,
                             digest,
@@ -2389,6 +2432,10 @@ where
 
         // Resolver request retention is independent of caller-owned block subscriptions.
         resolver.retain(handler::above_height_floor::<V::Commitment>(height));
+
+        // Certification evidence at or below the processed height can no longer
+        // gate a fetch.
+        self.certified.prune(height.next());
     }
 
     /// Returns the latest recoverable round at or immediately after the processed height.
@@ -2526,7 +2573,7 @@ where
         self
     }
 
-    /// Prunes finalized archives and height-indexed certified cache data below the durable floor.
+    /// Prunes finalized archives and the ancestry cache below the durable floor.
     async fn prune_after_floor(mut self: Box<Self>, height: Height) -> Box<Self> {
         (
             self.cache,

--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -731,12 +731,7 @@ where
                 ack.send_lossy(handle);
             }
             Message::Certification { notarization, .. } => {
-                // The engine reports a certification after its own certify verdict,
-                // so the notarization is not re-verified. A certified block arrived
-                // bound to its commitment, and its embedded parent commitment was
-                // checked against a root-bound parent, by this node or by the honest
-                // validators whose certification its notarization required. Later
-                // ancestry fetches can trust both commitments.
+                // Certification also authenticates the parent commitment
                 let commitment = notarization.proposal.payload;
                 let Some(block) = self.find_block_by_commitment(buffer, commitment).await else {
                     debug!(?commitment, "certified block unavailable locally");
@@ -1151,12 +1146,8 @@ where
                     }
                 };
 
-                // This path serves ancestry walks and caller-driven finalized-gap
-                // repair, never a candidate block's immediate parent. Certification
-                // evidence lets the delivery skip recomputing the commitment.
-                // Without it the delivery re-derives the commitment from the block
-                // bytes, since an optimistic ancestry walk can name a commitment
-                // that is only notarized.
+                // Ancestry may be only notarized, so skipping commitment recomputation
+                // requires certification evidence
                 let request = if self.certified.contains(height, &commitment) {
                     Request::certified_block(commitment, height)
                 } else {

--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -1121,7 +1121,6 @@ where
             // An ancestor may be certified through a descendant without its own local notification.
             // Its digest binds the parent commitment, so extend certification evidence here.
             if let Some(parent) = block.height().previous()
-                && parent > self.tip
                 && match key {
                     SubscriptionKey::Commitment(commitment) => {
                         self.certified.contains(block.height(), &commitment)

--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -1437,7 +1437,25 @@ where
         } = delivery;
         match key {
             Key::Block(commitment) => {
-                let block_cfg = V::block_cfg(&self.block_codec_config, commitment);
+                // The peer-visible request only says "give me this block".
+                // Local annotations explain why the block was requested, and
+                // therefore how much of the commitment to recompute and where,
+                // if anywhere, the block should be stored.
+                let annotations = subscribers
+                    .map_into(|(annotation, _)| annotation)
+                    .into_vec();
+
+                // `Finalized` annotations come only from request sites whose
+                // commitment is the payload of a verified finalization or the
+                // parent commitment of an archived finalized block. Either way
+                // the commitment is already bound to the block, so decoding
+                // need not recompute it. `Certified` annotations come from the
+                // ancestry walk, which can name a commitment this node has only
+                // shard-checked, so those deliveries recompute it.
+                let finalized = annotations
+                    .iter()
+                    .any(|annotation| matches!(annotation, Annotation::Finalized(_)));
+                let block_cfg = V::block_cfg(&self.block_codec_config, commitment, finalized);
                 let Ok(block) = V::Block::decode_cfg(value.as_ref(), &block_cfg) else {
                     response.send_lossy(false);
                     return self;
@@ -1460,14 +1478,8 @@ where
                     return self;
                 }
 
-                // The peer-visible request only says "give me this block".
-                // Local annotations explain why the block was requested and
-                // therefore where, if anywhere, it should be stored.
                 let height = block.height();
                 let digest = block.digest();
-                let annotations = subscribers
-                    .map_into(|(annotation, _)| annotation)
-                    .into_vec();
 
                 // Round-bound proposal-parent fetches are `Key::Notarized`
                 // deliveries and are handled below. In this block-keyed path,
@@ -1555,14 +1567,9 @@ where
                     return self;
                 };
 
-                // In contrast to the `Block` and `Notarization` deliveries, the finalization delivery
-                // is guaranteed to be certified (assuming the certificate verifies). Because of this,
-                // we can skip broader payload checks and just check that the application block matches
-                // the commitment in the finalization proposal.
-                //
-                // TODO(https://github.com/commonwarexyz/monorepo/issues/3938): Apply this pattern
-                // conditionally to `Request::Block` and `Request::Notarized`, if the requester knows
-                // the requested block is certified.
+                // Once the certificate verifies, the finalization authenticates the application
+                // block, so only the height and digest are checked here. The working block is then
+                // rebuilt from the finalized commitment.
                 let commitment = finalization.proposal.payload;
                 if block.height() != height || block.digest() != V::commitment_to_inner(commitment)
                 {
@@ -1606,12 +1613,16 @@ where
 
                 // Use the notarization payload to derive the block decode config. Below, the
                 // decoded block is checked against the same payload.
+                //
+                // A notarization is not finalization evidence. Notarize votes need not have
+                // reconstructed the block, so the payload may name a block its variant-specific
+                // components do not encode. The decode recomputes those components from the bytes.
                 let commitment = notarization.proposal.payload;
                 if !V::check_payload(scheme.as_ref(), commitment) {
                     response.send_lossy(false);
                     return self;
                 }
-                let block_cfg = V::block_cfg(&self.block_codec_config, commitment);
+                let block_cfg = V::block_cfg(&self.block_codec_config, commitment, false);
                 let Ok(block) = V::Block::decode_cfg(value, &block_cfg) else {
                     response.send_lossy(false);
                     return self;

--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -837,7 +837,7 @@ where
                     self.floor
                         .fetch_if_permitted(
                             resolver,
-                            Request::finalized_block_by_round(commitment, round),
+                            Request::finalized_by_round(commitment, round),
                         )
                         .ignore();
                 }
@@ -1149,9 +1149,9 @@ where
                 // Ancestry may be only notarized, so skipping commitment recomputation
                 // requires certification evidence
                 let request = if self.certified.contains(height, &commitment) {
-                    Request::certified_block(commitment, height)
+                    Request::certified(commitment, height)
                 } else {
-                    Request::ancestry_block(commitment, height)
+                    Request::untrusted(commitment, height)
                 };
                 self.floor.fetch_if_permitted(resolver, request).ignore();
                 debug!(%height, ?commitment, ?digest, "ancestry block unavailable");
@@ -1233,10 +1233,7 @@ where
         debug!(?round, ?commitment, "starting fetch for floor block");
         self.floor.await_anchor(finalization);
         self.floor
-            .fetch_if_permitted(
-                resolver,
-                Request::finalized_block_by_round(commitment, round),
-            )
+            .fetch_if_permitted(resolver, Request::finalized_by_round(commitment, round))
             .ignore();
         self
     }
@@ -1639,12 +1636,8 @@ where
                     return self;
                 }
 
-                // Use the notarization payload to derive the block decode config. Below, the
-                // decoded block is checked against the same payload.
-                //
-                // A notarization is not finalization evidence. Notarize votes need not have
-                // reconstructed the block, so the payload may name a block its variant-specific
-                // components do not encode. The decode recomputes those components from the bytes.
+                // Notarization alone does not prove the commitment encodes the block,
+                // so decoding must recompute it
                 let commitment = notarization.proposal.payload;
                 if !V::check_payload(scheme.as_ref(), commitment) {
                     response.send_lossy(false);
@@ -2316,7 +2309,7 @@ where
                     self.floor
                         .fetch_if_permitted(
                             resolver,
-                            Request::finalized_block_by_height(commitment, last_finalized),
+                            Request::finalized_by_height(commitment, last_finalized),
                         )
                         .ignore();
                 }
@@ -2380,7 +2373,7 @@ where
                     self.floor
                         .fetch_if_permitted(
                             resolver,
-                            Request::finalized_block_by_height(parent_commitment, parent_height),
+                            Request::finalized_by_height(parent_commitment, parent_height),
                         )
                         .ignore();
                     break 'cache_repair;
@@ -2423,7 +2416,7 @@ where
 
         // Certification evidence at or below the processed height can no longer
         // gate a fetch.
-        self.certified.prune(height.next());
+        self.certified.retain(height.next());
     }
 
     /// Returns the latest recoverable round at or immediately after the processed height.

--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -1456,22 +1456,12 @@ where
         } = delivery;
         match key {
             Key::Block(commitment) => {
-                // The peer-visible request only says "give me this block".
-                // Local annotations explain why the block was requested, and
-                // therefore how much of the commitment to recompute and where,
-                // if anywhere, the block should be stored.
+                // Local annotations determine commitment checks and block storage
                 let annotations = subscribers
                     .map_into(|(annotation, _)| annotation)
                     .into_vec();
 
-                // `Finalized` annotations come only from request sites whose
-                // commitment is the payload of a verified finalization or the
-                // parent commitment of an archived finalized block. `Certified`
-                // annotations come only from ancestry fetches for commitments
-                // this node recorded as certified. Either way the commitment is
-                // already bound to the block, so decoding need not recompute it.
-                // `Ancestry` annotations carry no such evidence, so those
-                // deliveries recompute it.
+                // Any `Finalized` or `Certified` subscriber authenticates the shared commitment
                 let expected = if annotations.iter().any(|annotation| {
                     matches!(
                         annotation,

--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -1452,10 +1452,10 @@ where
                 // need not recompute it. `Certified` annotations come from the
                 // ancestry walk, which can name a commitment this node has only
                 // shard-checked, so those deliveries recompute it.
-                let finalized = annotations
+                let trusted = annotations
                     .iter()
                     .any(|annotation| matches!(annotation, Annotation::Finalized(_)));
-                let block_cfg = V::block_cfg(&self.block_codec_config, commitment, finalized);
+                let block_cfg = V::block_cfg(&self.block_codec_config, commitment, trusted);
                 let Ok(block) = V::Block::decode_cfg(value.as_ref(), &block_cfg) else {
                     response.send_lossy(false);
                     return self;

--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -1464,11 +1464,11 @@ where
                     .map_into(|(annotation, _)| annotation)
                     .into_vec();
 
-                // Any `Finalized` or `Certified` subscriber authenticates the shared commitment
+                // Any `Certified` or `Finalized` subscriber authenticates the shared commitment
                 let expected = if annotations.iter().any(|annotation| {
                     matches!(
                         annotation,
-                        Annotation::Finalized(_) | Annotation::Certified { .. }
+                        Annotation::Certified { .. } | Annotation::Finalized(_)
                     )
                 }) {
                     ExpectedCommitment::Trusted(commitment)

--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -1538,7 +1538,7 @@ where
                     matches!(
                         annotation,
                         Annotation::Certified { height: bound }
-                        | Annotation::Ancestry { height: bound } if height <= *bound
+                        | Annotation::Untrusted { height: bound } if height <= *bound
                     )
                 }) && height > self.floor.processed_height()
                     && let Some(bounds) = self.epocher.containing(height)

--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -1121,6 +1121,22 @@ where
             }
         };
         if let Some(block) = block {
+            // Certification of the block's digest also binds its parent commitment
+            if let Some(parent) = block.height().previous()
+                && parent > self.tip
+                && match key {
+                    SubscriptionKey::Commitment(commitment) => {
+                        self.certified.contains(block.height(), &commitment)
+                    }
+                    SubscriptionKey::Digest(digest) => self
+                        .certified
+                        .contains_matching(block.height(), |commitment| {
+                            V::commitment_to_inner(*commitment) == digest
+                        }),
+                }
+            {
+                self.certified.insert(parent, V::parent_commitment(&block));
+            }
             response.send_lossy(block);
             return;
         }

--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -1,5 +1,5 @@
 use super::{
-    Buffer, Retirement, Variant,
+    Buffer, ExpectedCommitment, Retirement, Variant,
     acks::{PendingAck, PendingAcks},
     cache,
     certified::Certified,
@@ -1481,13 +1481,17 @@ where
                 // already bound to the block, so decoding need not recompute it.
                 // `Ancestry` annotations carry no such evidence, so those
                 // deliveries recompute it.
-                let trusted = annotations.iter().any(|annotation| {
+                let expected = if annotations.iter().any(|annotation| {
                     matches!(
                         annotation,
                         Annotation::Finalized(_) | Annotation::Certified { .. }
                     )
-                });
-                let block_cfg = V::block_cfg(&self.block_codec_config, commitment, trusted);
+                }) {
+                    ExpectedCommitment::Trusted(commitment)
+                } else {
+                    ExpectedCommitment::Untrusted(commitment)
+                };
+                let block_cfg = V::block_cfg(&self.block_codec_config, expected);
                 let Ok(block) = V::Block::decode_cfg(value.as_ref(), &block_cfg) else {
                     response.send_lossy(false);
                     return self;
@@ -1665,7 +1669,10 @@ where
                     response.send_lossy(false);
                     return self;
                 }
-                let block_cfg = V::block_cfg(&self.block_codec_config, commitment, false);
+                let block_cfg = V::block_cfg(
+                    &self.block_codec_config,
+                    ExpectedCommitment::Untrusted(commitment),
+                );
                 let Ok(block) = V::Block::decode_cfg(value, &block_cfg) else {
                     response.send_lossy(false);
                     return self;

--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -141,7 +141,7 @@ where
     tip: Height,
     // Outstanding subscriptions for blocks
     block_subscriptions: Subscriptions<V>,
-    // Commitments known certified above the processed floor
+    // Commitments known certified above the finalized tip
     certified: Certified<V::Commitment>,
     // Defers application dispatch of finalized-archive writes until a sync
     // covering them completes
@@ -737,8 +737,13 @@ where
                     debug!(?commitment, "certified block unavailable locally");
                     return self;
                 };
-                self.certified.insert(block.height(), commitment);
-                if let Some(parent) = block.height().previous() {
+                let height = block.height();
+                if height > self.tip {
+                    self.certified.insert(height, commitment);
+                }
+                if let Some(parent) = height.previous()
+                    && parent > self.tip
+                {
                     self.certified.insert(parent, V::parent_commitment(&block));
                 }
             }
@@ -1377,6 +1382,7 @@ where
         if height > self.tip {
             application.report(Update::Tip(round, height, digest));
             self.tip = height;
+            self.certified.retain(height.next());
             let _ = self.finalized_height.try_set(height.get());
         }
 
@@ -1501,6 +1507,7 @@ where
                     .iter()
                     .any(|annotation| matches!(annotation, Annotation::Certified { .. }))
                     && let Some(parent) = height.previous()
+                    && parent > self.tip
                 {
                     self.certified.insert(parent, V::parent_commitment(&block));
                 }
@@ -2145,6 +2152,7 @@ where
         if let Some(round) = round.filter(|_| height > self.tip) {
             application.report(Update::Tip(round, height, digest));
             self.tip = height;
+            self.certified.retain(height.next());
             let _ = self.finalized_height.try_set(height.get());
         }
 
@@ -2413,10 +2421,6 @@ where
 
         // Resolver request retention is independent of caller-owned block subscriptions.
         resolver.retain(handler::above_height_floor::<V::Commitment>(height));
-
-        // Certification evidence at or below the processed height can no longer
-        // gate a fetch.
-        self.certified.retain(height.next());
     }
 
     /// Returns the latest recoverable round at or immediately after the processed height.

--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -1121,7 +1121,8 @@ where
             }
         };
         if let Some(block) = block {
-            // Certification of the block's digest also binds its parent commitment
+            // An ancestor may be certified through a descendant without its own local notification.
+            // Its digest binds the parent commitment, so extend certification evidence here.
             if let Some(parent) = block.height().previous()
                 && parent > self.tip
                 && match key {

--- a/consensus/src/marshal/core/cache.rs
+++ b/consensus/src/marshal/core/cache.rs
@@ -50,9 +50,8 @@ where
     /// Notarized blocks stored by view
     notarized_blocks:
         prunable::Archive<TwoCap, R, <V::Block as Digestible>::Digest, V::StoredBlock>,
-    /// Certified blocks indexed by height and keyed by digest.
-    certified_blocks:
-        prunable::Archive<TwoCap, R, <V::Block as Digestible>::Digest, V::StoredBlock>,
+    /// Blocks fetched by ancestry walks, indexed by height and keyed by digest.
+    ancestry_blocks: prunable::Archive<TwoCap, R, <V::Block as Digestible>::Digest, V::StoredBlock>,
     /// Notarizations stored by view
     notarizations: prunable::Archive<
         TwoCap,
@@ -95,11 +94,11 @@ where
 
     /// Prune height-indexed archives to the given height.
     async fn prune_by_height(mut self, min_height: Height) -> Self {
-        self.certified_blocks = self
-            .certified_blocks
+        self.ancestry_blocks = self
+            .ancestry_blocks
             .prune(min_height.get())
             .await
-            .expect("failed to prune certified blocks");
+            .expect("failed to prune ancestry blocks");
         self
     }
 }
@@ -235,7 +234,7 @@ where
     #[boxed]
     async fn init_epoch(&mut self, epoch: Epoch) {
         let context = self.context.child("cache").with_attribute("epoch", epoch);
-        let (verified_blocks, notarized_blocks, certified_blocks, notarizations, finalizations) = futures::join!(
+        let (verified_blocks, notarized_blocks, ancestry_blocks, notarizations, finalizations) = futures::join!(
             Self::init_archive(
                 &context,
                 &self.cfg,
@@ -250,6 +249,8 @@ where
                 "notarized",
                 self.block_codec_config.clone()
             ),
+            // Renaming a partition is a storage break, so ancestry blocks keep
+            // the `certified` partition.
             Self::init_archive(
                 &context,
                 &self.cfg,
@@ -277,7 +278,7 @@ where
             Cache {
                 verified_blocks,
                 notarized_blocks,
-                certified_blocks,
+                ancestry_blocks,
                 notarizations,
                 finalizations,
             },
@@ -365,8 +366,8 @@ where
         (self, handle.unwrap_or_else(|| Handle::ready(Ok(()))))
     }
 
-    /// Add a certified block to the height-indexed archive.
-    pub(crate) async fn put_certified(
+    /// Add a block fetched by an ancestry walk to the height-indexed archive.
+    pub(crate) async fn put_ancestry(
         mut self,
         epoch: Epoch,
         height: Height,
@@ -377,17 +378,17 @@ where
             .with_epoch(epoch, |mut cache| async move {
                 // A digest determines its height, so scoping the dedup to this height
                 // is exact and avoids fetching values.
-                let exists = match cache.certified_blocks.has_at(height.get(), &digest).await {
+                let exists = match cache.ancestry_blocks.has_at(height.get(), &digest).await {
                     Ok(exists) => exists,
-                    Err(e) => panic!("failed to check certified block: {e}"),
+                    Err(e) => panic!("failed to check ancestry block: {e}"),
                 };
                 if !exists {
-                    cache.certified_blocks = cache
-                        .certified_blocks
+                    cache.ancestry_blocks = cache
+                        .ancestry_blocks
                         .put_multi_sync(height.get(), digest, block)
                         .await
-                        .unwrap_or_else(|e| panic!("failed to insert certified block: {e}"));
-                    debug!(%height, "cached certified block");
+                        .unwrap_or_else(|e| panic!("failed to insert ancestry block: {e}"));
+                    debug!(%height, "cached ancestry block");
                 }
                 (cache, ())
             })
@@ -588,7 +589,7 @@ where
         None
     }
 
-    /// Looks for a block (certified by height, verified, or notarized) that matches `predicate`.
+    /// Looks for a block (verified, notarized, or fetched by an ancestry walk) that matches `predicate`.
     pub(crate) async fn find_block_matching(
         &self,
         digest: <V::Block as Digestible>::Digest,
@@ -618,12 +619,12 @@ where
                 return Some(block);
             }
 
-            // Check certified blocks
+            // Check ancestry blocks
             if let Some(block) = cache
-                .certified_blocks
+                .ancestry_blocks
                 .get(Identifier::Key(&digest))
                 .await
-                .expect("failed to get certified block")
+                .expect("failed to get ancestry block")
                 && predicate(&block)
             {
                 return Some(block);
@@ -646,13 +647,13 @@ where
             let Cache {
                 verified_blocks: vb,
                 notarized_blocks: nb,
-                certified_blocks: cb,
+                ancestry_blocks: ab,
                 notarizations: nv,
                 finalizations: fv,
             } = self.caches.remove(epoch).unwrap();
             vb.destroy().await.expect("failed to destroy vb");
             nb.destroy().await.expect("failed to destroy nb");
-            cb.destroy().await.expect("failed to destroy cb");
+            ab.destroy().await.expect("failed to destroy ab");
             nv.destroy().await.expect("failed to destroy nv");
             fv.destroy().await.expect("failed to destroy fv");
         }
@@ -673,7 +674,7 @@ where
         self
     }
 
-    /// Prune height-indexed certified blocks below the given height.
+    /// Prune height-indexed ancestry blocks below the given height.
     pub(crate) async fn prune_by_height(mut self, height: Height) -> Self {
         for (epoch, cache) in std::mem::take(&mut self.caches) {
             let cache = cache.prune_by_height(height).await;

--- a/consensus/src/marshal/core/cache.rs
+++ b/consensus/src/marshal/core/cache.rs
@@ -101,7 +101,7 @@ where
             .certified_blocks
             .prune(min_height.get())
             .await
-            .expect("failed to prune ancestry blocks");
+            .expect("failed to prune certified blocks");
         self
     }
 }
@@ -367,8 +367,8 @@ where
         (self, handle.unwrap_or_else(|| Handle::ready(Ok(()))))
     }
 
-    /// Add a block fetched by an ancestry walk to the height-indexed archive.
-    pub(crate) async fn put_ancestry(
+    /// Add a block to the height-indexed certified archive.
+    pub(crate) async fn put_certified(
         mut self,
         epoch: Epoch,
         height: Height,
@@ -381,15 +381,15 @@ where
                 // is exact and avoids fetching values.
                 let exists = match cache.certified_blocks.has_at(height.get(), &digest).await {
                     Ok(exists) => exists,
-                    Err(e) => panic!("failed to check ancestry block: {e}"),
+                    Err(e) => panic!("failed to check certified block: {e}"),
                 };
                 if !exists {
                     cache.certified_blocks = cache
                         .certified_blocks
                         .put_multi_sync(height.get(), digest, block)
                         .await
-                        .unwrap_or_else(|e| panic!("failed to insert ancestry block: {e}"));
-                    debug!(%height, "cached ancestry block");
+                        .unwrap_or_else(|e| panic!("failed to insert certified block: {e}"));
+                    debug!(%height, "cached certified block");
                 }
                 (cache, ())
             })
@@ -590,7 +590,7 @@ where
         None
     }
 
-    /// Looks for a block (verified, notarized, or fetched by an ancestry walk) that matches `predicate`.
+    /// Looks for a block in the verified, notarized, or certified archives that matches `predicate`.
     pub(crate) async fn find_block_matching(
         &self,
         digest: <V::Block as Digestible>::Digest,
@@ -620,12 +620,12 @@ where
                 return Some(block);
             }
 
-            // Check ancestry blocks
+            // Check certified blocks
             if let Some(block) = cache
                 .certified_blocks
                 .get(Identifier::Key(&digest))
                 .await
-                .expect("failed to get ancestry block")
+                .expect("failed to get certified block")
                 && predicate(&block)
             {
                 return Some(block);
@@ -648,13 +648,13 @@ where
             let Cache {
                 verified_blocks: vb,
                 notarized_blocks: nb,
-                certified_blocks: ab,
+                certified_blocks: cb,
                 notarizations: nv,
                 finalizations: fv,
             } = self.caches.remove(epoch).unwrap();
             vb.destroy().await.expect("failed to destroy vb");
             nb.destroy().await.expect("failed to destroy nb");
-            ab.destroy().await.expect("failed to destroy ab");
+            cb.destroy().await.expect("failed to destroy cb");
             nv.destroy().await.expect("failed to destroy nv");
             fv.destroy().await.expect("failed to destroy fv");
         }
@@ -675,7 +675,7 @@ where
         self
     }
 
-    /// Prune height-indexed ancestry blocks below the given height.
+    /// Prune height-indexed certified blocks below the given height.
     pub(crate) async fn prune_by_height(mut self, height: Height) -> Self {
         for (epoch, cache) in std::mem::take(&mut self.caches) {
             let cache = cache.prune_by_height(height).await;

--- a/consensus/src/marshal/core/cache.rs
+++ b/consensus/src/marshal/core/cache.rs
@@ -50,8 +50,11 @@ where
     /// Notarized blocks stored by view
     notarized_blocks:
         prunable::Archive<TwoCap, R, <V::Block as Digestible>::Digest, V::StoredBlock>,
-    /// Blocks fetched by ancestry walks, indexed by height and keyed by digest.
-    ancestry_blocks: prunable::Archive<TwoCap, R, <V::Block as Digestible>::Digest, V::StoredBlock>,
+    /// Certified blocks indexed by height and keyed by digest.
+    ///
+    /// Also includes uncertified ancestors fetched during optimistic verification.
+    certified_blocks:
+        prunable::Archive<TwoCap, R, <V::Block as Digestible>::Digest, V::StoredBlock>,
     /// Notarizations stored by view
     notarizations: prunable::Archive<
         TwoCap,
@@ -94,8 +97,8 @@ where
 
     /// Prune height-indexed archives to the given height.
     async fn prune_by_height(mut self, min_height: Height) -> Self {
-        self.ancestry_blocks = self
-            .ancestry_blocks
+        self.certified_blocks = self
+            .certified_blocks
             .prune(min_height.get())
             .await
             .expect("failed to prune ancestry blocks");
@@ -234,7 +237,7 @@ where
     #[boxed]
     async fn init_epoch(&mut self, epoch: Epoch) {
         let context = self.context.child("cache").with_attribute("epoch", epoch);
-        let (verified_blocks, notarized_blocks, ancestry_blocks, notarizations, finalizations) = futures::join!(
+        let (verified_blocks, notarized_blocks, certified_blocks, notarizations, finalizations) = futures::join!(
             Self::init_archive(
                 &context,
                 &self.cfg,
@@ -249,8 +252,6 @@ where
                 "notarized",
                 self.block_codec_config.clone()
             ),
-            // Renaming a partition is a storage break, so ancestry blocks keep
-            // the `certified` partition.
             Self::init_archive(
                 &context,
                 &self.cfg,
@@ -278,7 +279,7 @@ where
             Cache {
                 verified_blocks,
                 notarized_blocks,
-                ancestry_blocks,
+                certified_blocks,
                 notarizations,
                 finalizations,
             },
@@ -378,13 +379,13 @@ where
             .with_epoch(epoch, |mut cache| async move {
                 // A digest determines its height, so scoping the dedup to this height
                 // is exact and avoids fetching values.
-                let exists = match cache.ancestry_blocks.has_at(height.get(), &digest).await {
+                let exists = match cache.certified_blocks.has_at(height.get(), &digest).await {
                     Ok(exists) => exists,
                     Err(e) => panic!("failed to check ancestry block: {e}"),
                 };
                 if !exists {
-                    cache.ancestry_blocks = cache
-                        .ancestry_blocks
+                    cache.certified_blocks = cache
+                        .certified_blocks
                         .put_multi_sync(height.get(), digest, block)
                         .await
                         .unwrap_or_else(|e| panic!("failed to insert ancestry block: {e}"));
@@ -621,7 +622,7 @@ where
 
             // Check ancestry blocks
             if let Some(block) = cache
-                .ancestry_blocks
+                .certified_blocks
                 .get(Identifier::Key(&digest))
                 .await
                 .expect("failed to get ancestry block")
@@ -647,7 +648,7 @@ where
             let Cache {
                 verified_blocks: vb,
                 notarized_blocks: nb,
-                ancestry_blocks: ab,
+                certified_blocks: ab,
                 notarizations: nv,
                 finalizations: fv,
             } = self.caches.remove(epoch).unwrap();

--- a/consensus/src/marshal/core/certified.rs
+++ b/consensus/src/marshal/core/certified.rs
@@ -36,8 +36,8 @@ impl<C: Digest> Certified<C> {
             .is_some_and(|commitments| commitments.contains(commitment))
     }
 
-    /// Drops entries below `min`.
-    pub(super) fn prune(&mut self, min: Height) {
+    /// Retains entries at or above `min`.
+    pub(super) fn retain(&mut self, min: Height) {
         self.entries = self.entries.split_off(&min);
     }
 }
@@ -48,7 +48,7 @@ mod tests {
     use commonware_cryptography::{Hasher as _, Sha256};
 
     #[test]
-    fn contains_is_height_scoped_and_prune_drops_below_min() {
+    fn contains_is_height_scoped_and_retain_keeps_from_min() {
         let mut certified = Certified::new();
         let a = Sha256::hash(&[b"a"]);
         let b = Sha256::hash(&[b"b"]);
@@ -61,7 +61,7 @@ mod tests {
         assert!(!certified.contains(Height::new(6), &a));
         assert!(!certified.contains(Height::new(5), &b));
 
-        certified.prune(Height::new(6));
+        certified.retain(Height::new(6));
         assert!(!certified.contains(Height::new(5), &a));
         assert!(certified.contains(Height::new(6), &c));
         assert!(certified.contains(Height::new(7), &b));

--- a/consensus/src/marshal/core/certified.rs
+++ b/consensus/src/marshal/core/certified.rs
@@ -1,0 +1,69 @@
+//! Commitments this node certified.
+
+use crate::types::Height;
+use commonware_cryptography::Digest;
+use std::collections::{BTreeMap, BTreeSet};
+
+/// Commitments of proposals this node certified, and ancestors of them,
+/// indexed by height.
+///
+/// A certified block arrives bound to its commitment, and its certification,
+/// by this node or by the honest validators consensus required, checked its
+/// embedded parent commitment against a root-bound parent. So recording a
+/// certified block also records its parent, and a block fetched under this
+/// knowledge extends it to that block's parent. Entries at or below the
+/// processed floor are pruned.
+pub(super) struct Certified<C: Digest> {
+    entries: BTreeMap<Height, BTreeSet<C>>,
+}
+
+impl<C: Digest> Certified<C> {
+    pub(super) const fn new() -> Self {
+        Self {
+            entries: BTreeMap::new(),
+        }
+    }
+
+    /// Records `commitment` at `height` as certified.
+    pub(super) fn insert(&mut self, height: Height, commitment: C) {
+        self.entries.entry(height).or_default().insert(commitment);
+    }
+
+    /// Returns true when `commitment` at `height` is known certified.
+    pub(super) fn contains(&self, height: Height, commitment: &C) -> bool {
+        self.entries
+            .get(&height)
+            .is_some_and(|commitments| commitments.contains(commitment))
+    }
+
+    /// Drops entries below `min`.
+    pub(super) fn prune(&mut self, min: Height) {
+        self.entries = self.entries.split_off(&min);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use commonware_cryptography::{Hasher as _, Sha256};
+
+    #[test]
+    fn contains_is_height_scoped_and_prune_drops_below_min() {
+        let mut certified = Certified::new();
+        let a = Sha256::hash(&[b"a"]);
+        let b = Sha256::hash(&[b"b"]);
+        let c = Sha256::hash(&[b"c"]);
+        certified.insert(Height::new(5), a);
+        certified.insert(Height::new(6), c);
+        certified.insert(Height::new(7), b);
+
+        assert!(certified.contains(Height::new(5), &a));
+        assert!(!certified.contains(Height::new(6), &a));
+        assert!(!certified.contains(Height::new(5), &b));
+
+        certified.prune(Height::new(6));
+        assert!(!certified.contains(Height::new(5), &a));
+        assert!(certified.contains(Height::new(6), &c));
+        assert!(certified.contains(Height::new(7), &b));
+    }
+}

--- a/consensus/src/marshal/core/certified.rs
+++ b/consensus/src/marshal/core/certified.rs
@@ -12,20 +12,25 @@ use std::collections::{BTreeMap, BTreeSet};
 /// embedded parent commitment against a root-bound parent. So recording a
 /// certified block also records its parent, and a block fetched under this
 /// knowledge extends it to that block's parent. Entries at or below the
-/// finalized tip are pruned.
+/// finalized tip are pruned and cannot be reinserted.
 pub(super) struct Certified<C: Digest> {
     entries: BTreeMap<Height, BTreeSet<C>>,
+    min: Height,
 }
 
 impl<C: Digest> Certified<C> {
     pub(super) const fn new() -> Self {
         Self {
             entries: BTreeMap::new(),
+            min: Height::new(1),
         }
     }
 
-    /// Records `commitment` at `height` as certified.
+    /// Records `commitment` at `height` as certified unless below the retention minimum.
     pub(super) fn insert(&mut self, height: Height, commitment: C) {
+        if height < self.min {
+            return;
+        }
         self.entries.entry(height).or_default().insert(commitment);
     }
 
@@ -47,8 +52,13 @@ impl<C: Digest> Certified<C> {
             .is_some_and(|commitments| commitments.iter().any(predicate))
     }
 
-    /// Retains entries at or above `min`.
+    /// Retains entries at or above `min` and rejects future inserts below it.
+    /// The retention minimum never decreases.
     pub(super) fn retain(&mut self, min: Height) {
+        if min <= self.min {
+            return;
+        }
+        self.min = min;
         self.entries = self.entries.split_off(&min);
     }
 }
@@ -76,5 +86,16 @@ mod tests {
         assert!(!certified.contains(Height::new(5), &a));
         assert!(certified.contains(Height::new(6), &c));
         assert!(certified.contains(Height::new(7), &b));
+
+        // Late inserts cannot restore pruned heights, even after a stale retain
+        certified.retain(Height::new(4));
+        certified.insert(Height::new(5), a);
+        certified.insert(Height::new(6), a);
+        assert!(!certified.contains(Height::new(5), &a));
+        assert!(certified.contains(Height::new(6), &a));
+
+        let mut certified = Certified::new();
+        certified.insert(Height::zero(), a);
+        assert!(!certified.contains(Height::zero(), &a));
     }
 }

--- a/consensus/src/marshal/core/certified.rs
+++ b/consensus/src/marshal/core/certified.rs
@@ -36,6 +36,17 @@ impl<C: Digest> Certified<C> {
             .is_some_and(|commitments| commitments.contains(commitment))
     }
 
+    /// Returns true when a certified commitment at `height` matches `predicate`.
+    pub(super) fn contains_matching(
+        &self,
+        height: Height,
+        predicate: impl FnMut(&C) -> bool,
+    ) -> bool {
+        self.entries
+            .get(&height)
+            .is_some_and(|commitments| commitments.iter().any(predicate))
+    }
+
     /// Retains entries at or above `min`.
     pub(super) fn retain(&mut self, min: Height) {
         self.entries = self.entries.split_off(&min);

--- a/consensus/src/marshal/core/certified.rs
+++ b/consensus/src/marshal/core/certified.rs
@@ -12,7 +12,7 @@ use std::collections::{BTreeMap, BTreeSet};
 /// embedded parent commitment against a root-bound parent. So recording a
 /// certified block also records its parent, and a block fetched under this
 /// knowledge extends it to that block's parent. Entries at or below the
-/// processed floor are pruned.
+/// finalized tip are pruned.
 pub(super) struct Certified<C: Digest> {
     entries: BTreeMap<Height, BTreeSet<C>>,
 }

--- a/consensus/src/marshal/core/floor.rs
+++ b/consensus/src/marshal/core/floor.rs
@@ -315,7 +315,7 @@ mod tests {
         assert!(matches!(
             floor.fetch_if_permitted(
                 &mut resolver,
-                Request::finalized_block_by_height(digest(1), Height::new(4)),
+                Request::finalized_by_height(digest(1), Height::new(4)),
             ),
             FetchAdmission::Denied
         ));

--- a/consensus/src/marshal/core/mailbox.rs
+++ b/consensus/src/marshal/core/mailbox.rs
@@ -222,10 +222,7 @@ pub(crate) enum Message<S: Scheme, V: Variant> {
         /// The finalization.
         finalization: Finalization<S, V::Commitment>,
     },
-    /// A notarization this node certified, from the consensus engine.
-    ///
-    /// The engine reports it after its own certify verdict, so it is not
-    /// re-verified here.
+    /// A certification from the consensus engine.
     Certification {
         /// The span carried with this request.
         span: Span,

--- a/consensus/src/marshal/core/mailbox.rs
+++ b/consensus/src/marshal/core/mailbox.rs
@@ -276,6 +276,9 @@ pub enum CommitmentFallback {
     /// It is not part of response validity. A fetched block is delivered if its
     /// commitment matches. A matching block above this bound is delivered but
     /// not cached.
+    ///
+    /// The commitment may not be finalized, so deliveries recompute any
+    /// variant-specific commitment material from the block bytes.
     FetchByCommitment { height: Height },
 }
 

--- a/consensus/src/marshal/core/mailbox.rs
+++ b/consensus/src/marshal/core/mailbox.rs
@@ -222,6 +222,16 @@ pub(crate) enum Message<S: Scheme, V: Variant> {
         /// The finalization.
         finalization: Finalization<S, V::Commitment>,
     },
+    /// A notarization this node certified, from the consensus engine.
+    ///
+    /// The engine reports it after its own certify verdict, so it is not
+    /// re-verified here.
+    Certification {
+        /// The span carried with this request.
+        span: Span,
+        /// The certified notarization.
+        notarization: Notarization<S, V::Commitment>,
+    },
 }
 
 /// How a digest-keyed block subscription should behave when the block is missing locally.
@@ -277,8 +287,10 @@ pub enum CommitmentFallback {
     /// commitment matches. A matching block above this bound is delivered but
     /// not cached.
     ///
-    /// The commitment may not be finalized, so deliveries recompute any
-    /// variant-specific commitment material from the block bytes.
+    /// Marshal issues a certified request when it holds certification evidence
+    /// for the commitment and an ancestry request otherwise. Only ancestry
+    /// deliveries recompute variant-specific commitment material from the block
+    /// bytes.
     FetchByCommitment { height: Height },
 }
 
@@ -298,6 +310,7 @@ impl<S: Scheme, V: Variant> Message<S, V> {
             | Self::Certified { span, .. }
             | Self::Notarization { span, .. }
             | Self::Finalization { span, .. }
+            | Self::Certification { span, .. }
             | Self::GetProcessedHeight { span, .. }
             | Self::HintFinalized { span, .. }
             | Self::HintNotarized { span, .. }
@@ -326,6 +339,7 @@ impl<S: Scheme, V: Variant> Message<S, V> {
             Self::Prune { .. } => "prune",
             Self::Notarization { .. } => "notarization",
             Self::Finalization { .. } => "finalization",
+            Self::Certification { .. } => "certification",
         }
     }
 
@@ -363,7 +377,8 @@ impl<S: Scheme, V: Variant> Message<S, V> {
             | Self::SetFloor { .. }
             | Self::Prune { .. }
             | Self::Notarization { .. }
-            | Self::Finalization { .. } => false,
+            | Self::Finalization { .. }
+            | Self::Certification { .. } => false,
         }
     }
 
@@ -386,7 +401,8 @@ impl<S: Scheme, V: Variant> Message<S, V> {
             | Self::SetFloor { .. }
             | Self::Prune { .. }
             | Self::Notarization { .. }
-            | Self::Finalization { .. } => false,
+            | Self::Finalization { .. }
+            | Self::Certification { .. } => false,
         }
     }
 }
@@ -1005,6 +1021,10 @@ impl<S: Scheme, V: Variant> Reporter for Mailbox<S, V> {
             Activity::Finalization(finalization) => Message::Finalization {
                 span: info_span!("marshal.mailbox.finalization", round = %finalization.round()),
                 finalization,
+            },
+            Activity::Certification(notarization) => Message::Certification {
+                span: info_span!("marshal.mailbox.certification", round = %notarization.round()),
+                notarization,
             },
             _ => return Feedback::Ok,
         };

--- a/consensus/src/marshal/core/mailbox.rs
+++ b/consensus/src/marshal/core/mailbox.rs
@@ -283,11 +283,6 @@ pub enum CommitmentFallback {
     /// It is not part of response validity. A fetched block is delivered if its
     /// commitment matches. A matching block above this bound is delivered but
     /// not cached.
-    ///
-    /// Marshal issues a certified request when it holds certification evidence
-    /// for the commitment and an ancestry request otherwise. Only ancestry
-    /// deliveries recompute variant-specific commitment material from the block
-    /// bytes.
     FetchByCommitment { height: Height },
 }
 

--- a/consensus/src/marshal/core/mod.rs
+++ b/consensus/src/marshal/core/mod.rs
@@ -59,4 +59,4 @@ pub use mailbox::{CommitmentFallback, DigestFallback, Mailbox};
 
 mod subscriptions;
 mod variant;
-pub use variant::{Buffer, Retirement, Variant};
+pub use variant::{Buffer, ExpectedCommitment, Retirement, Variant};

--- a/consensus/src/marshal/core/mod.rs
+++ b/consensus/src/marshal/core/mod.rs
@@ -47,6 +47,7 @@ pub use actor::Actor;
 
 mod acks;
 pub(crate) mod cache;
+mod certified;
 mod delivery;
 pub(crate) mod durability;
 mod floor;

--- a/consensus/src/marshal/core/variant.rs
+++ b/consensus/src/marshal/core/variant.rs
@@ -84,7 +84,7 @@ pub trait Variant: Clone + Send + Sync + 'static {
     /// Returns the codec configuration used to decode [`Self::Block`] received over the wire.
     ///
     /// The returned configuration may bind `expected` so that decoding rejects blocks that do
-    /// not match it. `finalized` is true when `expected` is bound by the finalized chain, as the
+    /// not match it. `trusted` is true when `expected` is bound by the finalized chain, as the
     /// payload of a verified finalization or as the parent commitment of a finalized block. The
     /// configuration may then take commitment material from `expected` instead of recomputing
     /// it from the block bytes. Decoding need not check every component of `expected`, so
@@ -92,7 +92,7 @@ pub trait Variant: Clone + Send + Sync + 'static {
     fn block_cfg(
         block_cfg: &<Self::ApplicationBlock as Read>::Cfg,
         expected: Self::Commitment,
-        finalized: bool,
+        trusted: bool,
     ) -> <Self::Block as Read>::Cfg;
 
     /// Converts a working block to an application block.

--- a/consensus/src/marshal/core/variant.rs
+++ b/consensus/src/marshal/core/variant.rs
@@ -31,6 +31,17 @@ pub struct Retirement<C> {
     pub exact_retirements: Vec<C>,
 }
 
+/// A block commitment and the evidence available when decoding it.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ExpectedCommitment<C> {
+    /// A finalized or locally certified block commitment, or an ancestor's.
+    ///
+    /// Decoding may reuse commitment material. Notarization alone is insufficient.
+    Trusted(C),
+    /// A commitment without certification evidence.
+    Untrusted(C),
+}
+
 /// A marker trait describing the types used by a variant of Marshal.
 pub trait Variant: Clone + Send + Sync + 'static {
     /// The working block type of marshal, supporting the consensus commitment.
@@ -83,17 +94,12 @@ pub trait Variant: Clone + Send + Sync + 'static {
 
     /// Returns the codec configuration used to decode [`Self::Block`] received over the wire.
     ///
-    /// The returned configuration may bind `expected` so that decoding rejects blocks that do
-    /// not match it. `trusted` is true when this node holds certification evidence for
-    /// `expected`: it is on the finalized chain, or it is a block this node certified or an
-    /// ancestor of one. The configuration may then take commitment material from `expected`
-    /// instead of recomputing it from the block bytes. Decoding need not check every component
-    /// of `expected`, so callers that need the full commitment to match compare it after
-    /// decoding.
+    /// The configuration may bind `expected` and reuse trusted commitment material.
+    /// Decoding need not check every component, so callers requiring a full commitment
+    /// match must compare it after decoding.
     fn block_cfg(
         block_cfg: &<Self::ApplicationBlock as Read>::Cfg,
-        expected: Self::Commitment,
-        trusted: bool,
+        expected: ExpectedCommitment<Self::Commitment>,
     ) -> <Self::Block as Read>::Cfg;
 
     /// Converts a working block to an application block.

--- a/consensus/src/marshal/core/variant.rs
+++ b/consensus/src/marshal/core/variant.rs
@@ -84,11 +84,12 @@ pub trait Variant: Clone + Send + Sync + 'static {
     /// Returns the codec configuration used to decode [`Self::Block`] received over the wire.
     ///
     /// The returned configuration may bind `expected` so that decoding rejects blocks that do
-    /// not match it. `trusted` is true when `expected` is bound by the finalized chain, as the
-    /// payload of a verified finalization or as the parent commitment of a finalized block. The
-    /// configuration may then take commitment material from `expected` instead of recomputing
-    /// it from the block bytes. Decoding need not check every component of `expected`, so
-    /// callers that need the full commitment to match compare it after decoding.
+    /// not match it. `trusted` is true when this node holds certification evidence for
+    /// `expected`: it is on the finalized chain, or it is a block this node certified or an
+    /// ancestor of one. The configuration may then take commitment material from `expected`
+    /// instead of recomputing it from the block bytes. Decoding need not check every component
+    /// of `expected`, so callers that need the full commitment to match compare it after
+    /// decoding.
     fn block_cfg(
         block_cfg: &<Self::ApplicationBlock as Read>::Cfg,
         expected: Self::Commitment,

--- a/consensus/src/marshal/core/variant.rs
+++ b/consensus/src/marshal/core/variant.rs
@@ -34,7 +34,7 @@ pub struct Retirement<C> {
 /// A block commitment and the evidence available when decoding it.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ExpectedCommitment<C> {
-    /// A finalized or locally certified block commitment, or an ancestor's.
+    /// A locally certified or finalized block commitment, or an ancestor's.
     ///
     /// Decoding may reuse commitment material. Notarization alone is insufficient.
     Trusted(C),

--- a/consensus/src/marshal/core/variant.rs
+++ b/consensus/src/marshal/core/variant.rs
@@ -83,11 +83,16 @@ pub trait Variant: Clone + Send + Sync + 'static {
 
     /// Returns the codec configuration used to decode [`Self::Block`] received over the wire.
     ///
-    /// The returned configuration may bind `expected_commitment` so that decoding rejects
-    /// blocks that do not match the expected commitment.
+    /// The returned configuration may bind `expected` so that decoding rejects blocks that do
+    /// not match it. `finalized` is true when `expected` is bound by the finalized chain, as the
+    /// payload of a verified finalization or as the parent commitment of a finalized block. The
+    /// configuration may then take commitment material from `expected` instead of recomputing
+    /// it from the block bytes. Decoding need not check every component of `expected`, so
+    /// callers that need the full commitment to match compare it after decoding.
     fn block_cfg(
         block_cfg: &<Self::ApplicationBlock as Read>::Cfg,
         expected: Self::Commitment,
+        finalized: bool,
     ) -> <Self::Block as Read>::Cfg;
 
     /// Converts a working block to an application block.

--- a/consensus/src/marshal/resolver/handler.rs
+++ b/consensus/src/marshal/resolver/handler.rs
@@ -176,10 +176,9 @@ impl<D: Digest> Producer for Handler<D> {
 /// Local processing annotation for a resolved key.
 ///
 /// The resolver key is the peer-visible lookup. An annotation is local
-/// metadata attached to that lookup so marshal can decide how to process the
-/// response after validating it against the key. It is not part of peer
-/// response validity. Multiple local annotations may share one peer key when
-/// they depend on the same block.
+/// metadata attached to that lookup so marshal can decide how to validate,
+/// process, and store the response. Peers never see it. Multiple local
+/// annotations may share one peer key when they depend on the same block.
 ///
 /// [`Notarization`](Annotation::Notarization) carries round-bound local
 /// context. [`Certified`](Annotation::Certified) and
@@ -200,8 +199,16 @@ pub enum Annotation {
     /// supplied when the caller has a validated height bound. It must not make
     /// a commitment-matching response invalid. A matching block above this
     /// bound is delivered but not cached.
+    ///
+    /// The commitment may not be finalized, so deliveries recompute any
+    /// variant-specific commitment material from the block bytes.
     Certified { height: Height },
     /// A block requested by commitment for the finalized chain.
+    ///
+    /// On a [`Key::Block`] delivery this means the requester's commitment is
+    /// the payload of a verified finalization or the parent commitment of an
+    /// archived finalized block, so variant-specific commitment material is
+    /// taken from the commitment instead of recomputed from the block bytes.
     Finalized(Finalized),
 }
 
@@ -285,6 +292,10 @@ impl<D: Digest> Request<D> {
     }
 
     /// Fetch a finalized-chain block by commitment when its height is known.
+    ///
+    /// `commitment` must be the payload of a verified finalization or the parent
+    /// commitment of an archived finalized block. Deliveries take variant-specific
+    /// commitment material from it instead of recomputing it from the block bytes.
     pub const fn finalized_block_by_height(commitment: D, height: Height) -> Self {
         Self {
             kind: RequestKind::FinalizedBlockByHeight { commitment, height },
@@ -292,6 +303,10 @@ impl<D: Digest> Request<D> {
     }
 
     /// Fetch a finalized-chain block by commitment when only its finalization round is known.
+    ///
+    /// `commitment` must be the payload of a verified finalization. Deliveries take
+    /// variant-specific commitment material from it instead of recomputing it from the
+    /// block bytes.
     pub const fn finalized_block_by_round(commitment: D, round: Round) -> Self {
         Self {
             kind: RequestKind::FinalizedBlockByRound { commitment, round },

--- a/consensus/src/marshal/resolver/handler.rs
+++ b/consensus/src/marshal/resolver/handler.rs
@@ -181,27 +181,40 @@ impl<D: Digest> Producer for Handler<D> {
 /// annotations may share one peer key when they depend on the same block.
 ///
 /// [`Notarization`](Annotation::Notarization) carries round-bound local
-/// context. [`Certified`](Annotation::Certified) and
-/// [`Finalized`](Annotation::Finalized) describe how block-bearing responses
-/// should be processed locally.
+/// context. [`Ancestry`](Annotation::Ancestry), [`Certified`](Annotation::Certified)
+/// and [`Finalized`](Annotation::Finalized) describe how block-bearing
+/// responses should be validated and stored locally.
 ///
-/// This storage role is part of the annotation because a [`Key::Block`]
-/// only names the peer-visible commitment. The same block-shaped response may
-/// need to update different local stores depending on whether it was fetched
-/// for a certified chain or for the finalized chain.
+/// This role is part of the annotation because a [`Key::Block`] only names
+/// the peer-visible commitment. The same block-shaped response may need to
+/// update different local stores, and may or may not need its variant-specific
+/// commitment material recomputed, depending on the evidence the requester
+/// held for the commitment.
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub enum Annotation {
     /// A notarization requested by round.
     Notarization { round: Round },
-    /// A block requested by commitment for a certified chain.
+    /// A block requested by commitment while walking ancestry without
+    /// certification evidence for the commitment.
     ///
     /// The expected height is local pruning metadata and should only be
     /// supplied when the caller has a validated height bound. It must not make
     /// a commitment-matching response invalid. A matching block above this
     /// bound is delivered but not cached.
     ///
-    /// The commitment may not be finalized, so deliveries recompute any
-    /// variant-specific commitment material from the block bytes.
+    /// Deliveries recompute any variant-specific commitment material from the
+    /// block bytes.
+    Ancestry { height: Height },
+    /// A block requested by commitment that this node certified, or an ancestor
+    /// of one.
+    ///
+    /// A certified block arrives bound to its commitment, and its
+    /// certification, by this node or by the honest validators consensus
+    /// required, checked its embedded parent commitment against a root-bound
+    /// parent. So every ancestor recorded from a certified block encodes its
+    /// commitment. Deliveries take variant-specific commitment material from
+    /// the commitment instead of recomputing it. The height bound behaves as
+    /// for [`Ancestry`](Annotation::Ancestry).
     Certified { height: Height },
     /// A block requested by commitment for the finalized chain.
     ///
@@ -255,7 +268,9 @@ pub(crate) enum RequestKind<D: Digest> {
     Notarized { round: Round },
     /// Fetch a finalization for a height.
     Finalized { height: Height },
-    /// Fetch a certified-chain block by commitment.
+    /// Fetch a block by commitment while walking ancestry without certification evidence.
+    AncestryBlock { commitment: D, height: Height },
+    /// Fetch a block this node certified, or an ancestor of one, by commitment.
     CertifiedBlock { commitment: D, height: Height },
     /// Fetch a finalized-chain block by commitment when its height is known.
     FinalizedBlockByHeight { commitment: D, height: Height },
@@ -284,7 +299,21 @@ impl<D: Digest> Request<D> {
         }
     }
 
-    /// Fetch a certified-chain block by commitment.
+    /// Fetch a block by commitment while walking ancestry without certification
+    /// evidence for `commitment`.
+    ///
+    /// Deliveries recompute variant-specific commitment material from the block
+    /// bytes.
+    pub const fn ancestry_block(commitment: D, height: Height) -> Self {
+        Self {
+            kind: RequestKind::AncestryBlock { commitment, height },
+        }
+    }
+
+    /// Fetch a block this node certified, or an ancestor of one, by commitment.
+    ///
+    /// Deliveries take variant-specific commitment material from `commitment`
+    /// instead of recomputing it from the block bytes.
     pub const fn certified_block(commitment: D, height: Height) -> Self {
         Self {
             kind: RequestKind::CertifiedBlock { commitment, height },
@@ -316,6 +345,7 @@ impl<D: Digest> Request<D> {
     pub(crate) fn above_height_floor(&self, floor: Height) -> bool {
         match self.kind {
             RequestKind::Finalized { height }
+            | RequestKind::AncestryBlock { height, .. }
             | RequestKind::CertifiedBlock { height, .. }
             | RequestKind::FinalizedBlockByHeight { height, .. } => height > floor,
             RequestKind::Notarized { .. } | RequestKind::FinalizedBlockByRound { .. } => true,
@@ -328,6 +358,7 @@ impl<D: Digest> Request<D> {
                 round > floor
             }
             RequestKind::Finalized { .. }
+            | RequestKind::AncestryBlock { .. }
             | RequestKind::CertifiedBlock { .. }
             | RequestKind::FinalizedBlockByHeight { .. } => true,
         }
@@ -342,6 +373,9 @@ impl<D: Digest> Request<D> {
                 Key::Finalized { height },
                 Annotation::Finalized(Finalized::ByHeight { height }),
             ),
+            RequestKind::AncestryBlock { commitment, height } => {
+                (Key::Block(commitment), Annotation::Ancestry { height })
+            }
             RequestKind::CertifiedBlock { commitment, height } => {
                 (Key::Block(commitment), Annotation::Certified { height })
             }
@@ -380,7 +414,8 @@ pub(crate) fn above_height_floor<D: Digest>(
         (Key::Finalized { height: requested }, _) => *requested > height,
         (
             Key::Block(_),
-            Annotation::Certified { height: requested }
+            Annotation::Ancestry { height: requested }
+            | Annotation::Certified { height: requested }
             | Annotation::Finalized(Finalized::ByHeight { height: requested }),
         ) => *requested > height,
         _ => true,
@@ -720,6 +755,12 @@ mod tests {
         let stale_certified = Annotation::Certified {
             height: Height::new(100),
         };
+        let fresh_ancestry = Annotation::Ancestry {
+            height: Height::new(101),
+        };
+        let stale_ancestry = Annotation::Ancestry {
+            height: Height::new(100),
+        };
 
         let predicate = above_height_floor(floor);
         assert!(predicate(
@@ -735,6 +776,7 @@ mod tests {
             }
         ));
         assert!(predicate(&block, &fresh_certified));
+        assert!(predicate(&block, &fresh_ancestry));
 
         let same_height = Key::<D>::Finalized {
             height: Height::new(100),
@@ -747,6 +789,7 @@ mod tests {
         ));
         assert!(!predicate(&block, &stale_finalized));
         assert!(!predicate(&block, &stale_certified));
+        assert!(!predicate(&block, &stale_ancestry));
     }
 
     #[test]

--- a/consensus/src/marshal/resolver/handler.rs
+++ b/consensus/src/marshal/resolver/handler.rs
@@ -207,20 +207,14 @@ pub enum Annotation {
     /// A block requested by commitment that this node certified, or an ancestor
     /// of one.
     ///
-    /// A certified block arrives bound to its commitment, and its
-    /// certification, by this node or by the honest validators consensus
-    /// required, checked its embedded parent commitment against a root-bound
-    /// parent. So every ancestor recorded from a certified block encodes its
-    /// commitment. Deliveries take variant-specific commitment material from
-    /// the commitment instead of recomputing it. The height bound behaves as
-    /// for [`Untrusted`](Annotation::Untrusted).
+    /// Certification binds the block and its ancestors to their commitments,
+    /// so deliveries reuse commitment material. Height bounds match
+    /// [`Untrusted`](Annotation::Untrusted).
     Certified { height: Height },
     /// A block requested by commitment for the finalized chain.
     ///
-    /// On a [`Key::Block`] delivery this means the requester's commitment is
-    /// the payload of a verified finalization or the parent commitment of an
-    /// archived finalized block, so variant-specific commitment material is
-    /// taken from the commitment instead of recomputed from the block bytes.
+    /// For [`Key::Block`], reuse commitment material authenticated by a verified
+    /// finalization or an archived finalized block's parent link.
     Finalized(Finalized),
 }
 

--- a/consensus/src/marshal/resolver/handler.rs
+++ b/consensus/src/marshal/resolver/handler.rs
@@ -336,9 +336,9 @@ impl<D: Digest> Request<D> {
 
     pub(crate) fn above_height_floor(&self, floor: Height) -> bool {
         match self.kind {
-            RequestKind::Finalized { height }
-            | RequestKind::Untrusted { height, .. }
+            RequestKind::Untrusted { height, .. }
             | RequestKind::Certified { height, .. }
+            | RequestKind::Finalized { height }
             | RequestKind::FinalizedByHeight { height, .. } => height > floor,
             RequestKind::Notarized { .. } | RequestKind::FinalizedByRound { .. } => true,
         }
@@ -349,9 +349,9 @@ impl<D: Digest> Request<D> {
             RequestKind::Notarized { round } | RequestKind::FinalizedByRound { round, .. } => {
                 round > floor
             }
-            RequestKind::Finalized { .. }
-            | RequestKind::Untrusted { .. }
+            RequestKind::Untrusted { .. }
             | RequestKind::Certified { .. }
+            | RequestKind::Finalized { .. }
             | RequestKind::FinalizedByHeight { .. } => true,
         }
     }

--- a/consensus/src/marshal/resolver/handler.rs
+++ b/consensus/src/marshal/resolver/handler.rs
@@ -181,7 +181,7 @@ impl<D: Digest> Producer for Handler<D> {
 /// annotations may share one peer key when they depend on the same block.
 ///
 /// [`Notarization`](Annotation::Notarization) carries round-bound local
-/// context. [`Ancestry`](Annotation::Ancestry), [`Certified`](Annotation::Certified)
+/// context. [`Untrusted`](Annotation::Untrusted), [`Certified`](Annotation::Certified)
 /// and [`Finalized`](Annotation::Finalized) describe how block-bearing
 /// responses should be validated and stored locally.
 ///
@@ -194,17 +194,16 @@ impl<D: Digest> Producer for Handler<D> {
 pub enum Annotation {
     /// A notarization requested by round.
     Notarization { round: Round },
-    /// A block requested by commitment while walking ancestry without
-    /// certification evidence for the commitment.
+    /// A block requested by commitment without certification evidence.
     ///
     /// The expected height is local pruning metadata and should only be
     /// supplied when the caller has a validated height bound. It must not make
     /// a commitment-matching response invalid. A matching block above this
     /// bound is delivered but not cached.
     ///
-    /// Deliveries recompute any variant-specific commitment material from the
-    /// block bytes.
-    Ancestry { height: Height },
+    /// Commitment material is recomputed unless another subscriber supplies
+    /// certification evidence.
+    Untrusted { height: Height },
     /// A block requested by commitment that this node certified, or an ancestor
     /// of one.
     ///
@@ -214,7 +213,7 @@ pub enum Annotation {
     /// parent. So every ancestor recorded from a certified block encodes its
     /// commitment. Deliveries take variant-specific commitment material from
     /// the commitment instead of recomputing it. The height bound behaves as
-    /// for [`Ancestry`](Annotation::Ancestry).
+    /// for [`Untrusted`](Annotation::Untrusted).
     Certified { height: Height },
     /// A block requested by commitment for the finalized chain.
     ///
@@ -301,8 +300,8 @@ impl<D: Digest> Request<D> {
 
     /// Fetch a block by commitment without certification evidence.
     ///
-    /// Deliveries recompute variant-specific commitment material from the block
-    /// bytes.
+    /// Commitment material is recomputed unless another subscriber supplies
+    /// certification evidence.
     pub const fn untrusted(commitment: D, height: Height) -> Self {
         Self {
             kind: RequestKind::Untrusted { commitment, height },
@@ -373,7 +372,7 @@ impl<D: Digest> Request<D> {
                 Annotation::Finalized(Finalized::ByHeight { height }),
             ),
             RequestKind::Untrusted { commitment, height } => {
-                (Key::Block(commitment), Annotation::Ancestry { height })
+                (Key::Block(commitment), Annotation::Untrusted { height })
             }
             RequestKind::Certified { commitment, height } => {
                 (Key::Block(commitment), Annotation::Certified { height })
@@ -413,7 +412,7 @@ pub(crate) fn above_height_floor<D: Digest>(
         (Key::Finalized { height: requested }, _) => *requested > height,
         (
             Key::Block(_),
-            Annotation::Ancestry { height: requested }
+            Annotation::Untrusted { height: requested }
             | Annotation::Certified { height: requested }
             | Annotation::Finalized(Finalized::ByHeight { height: requested }),
         ) => *requested > height,
@@ -754,10 +753,10 @@ mod tests {
         let stale_certified = Annotation::Certified {
             height: Height::new(100),
         };
-        let fresh_ancestry = Annotation::Ancestry {
+        let fresh_untrusted = Annotation::Untrusted {
             height: Height::new(101),
         };
-        let stale_ancestry = Annotation::Ancestry {
+        let stale_untrusted = Annotation::Untrusted {
             height: Height::new(100),
         };
 
@@ -775,7 +774,7 @@ mod tests {
             }
         ));
         assert!(predicate(&block, &fresh_certified));
-        assert!(predicate(&block, &fresh_ancestry));
+        assert!(predicate(&block, &fresh_untrusted));
 
         let same_height = Key::<D>::Finalized {
             height: Height::new(100),
@@ -788,7 +787,7 @@ mod tests {
         ));
         assert!(!predicate(&block, &stale_finalized));
         assert!(!predicate(&block, &stale_certified));
-        assert!(!predicate(&block, &stale_ancestry));
+        assert!(!predicate(&block, &stale_untrusted));
     }
 
     #[test]

--- a/consensus/src/marshal/resolver/handler.rs
+++ b/consensus/src/marshal/resolver/handler.rs
@@ -268,14 +268,14 @@ pub(crate) enum RequestKind<D: Digest> {
     Notarized { round: Round },
     /// Fetch a finalization for a height.
     Finalized { height: Height },
-    /// Fetch a block by commitment while walking ancestry without certification evidence.
-    AncestryBlock { commitment: D, height: Height },
+    /// Fetch a block by commitment without certification evidence.
+    Untrusted { commitment: D, height: Height },
     /// Fetch a block this node certified, or an ancestor of one, by commitment.
-    CertifiedBlock { commitment: D, height: Height },
+    Certified { commitment: D, height: Height },
     /// Fetch a finalized-chain block by commitment when its height is known.
-    FinalizedBlockByHeight { commitment: D, height: Height },
+    FinalizedByHeight { commitment: D, height: Height },
     /// Fetch a finalized-chain block by commitment when only its finalization round is known.
-    FinalizedBlockByRound { commitment: D, round: Round },
+    FinalizedByRound { commitment: D, round: Round },
 }
 
 /// A marshal backfill fetch with a request and local processing annotation that match.
@@ -299,14 +299,13 @@ impl<D: Digest> Request<D> {
         }
     }
 
-    /// Fetch a block by commitment while walking ancestry without certification
-    /// evidence for `commitment`.
+    /// Fetch a block by commitment without certification evidence.
     ///
     /// Deliveries recompute variant-specific commitment material from the block
     /// bytes.
-    pub const fn ancestry_block(commitment: D, height: Height) -> Self {
+    pub const fn untrusted(commitment: D, height: Height) -> Self {
         Self {
-            kind: RequestKind::AncestryBlock { commitment, height },
+            kind: RequestKind::Untrusted { commitment, height },
         }
     }
 
@@ -314,9 +313,9 @@ impl<D: Digest> Request<D> {
     ///
     /// Deliveries take variant-specific commitment material from `commitment`
     /// instead of recomputing it from the block bytes.
-    pub const fn certified_block(commitment: D, height: Height) -> Self {
+    pub const fn certified(commitment: D, height: Height) -> Self {
         Self {
-            kind: RequestKind::CertifiedBlock { commitment, height },
+            kind: RequestKind::Certified { commitment, height },
         }
     }
 
@@ -325,9 +324,9 @@ impl<D: Digest> Request<D> {
     /// `commitment` must be the payload of a verified finalization or the parent
     /// commitment of an archived finalized block. Deliveries take variant-specific
     /// commitment material from it instead of recomputing it from the block bytes.
-    pub const fn finalized_block_by_height(commitment: D, height: Height) -> Self {
+    pub const fn finalized_by_height(commitment: D, height: Height) -> Self {
         Self {
-            kind: RequestKind::FinalizedBlockByHeight { commitment, height },
+            kind: RequestKind::FinalizedByHeight { commitment, height },
         }
     }
 
@@ -336,31 +335,31 @@ impl<D: Digest> Request<D> {
     /// `commitment` must be the payload of a verified finalization. Deliveries take
     /// variant-specific commitment material from it instead of recomputing it from the
     /// block bytes.
-    pub const fn finalized_block_by_round(commitment: D, round: Round) -> Self {
+    pub const fn finalized_by_round(commitment: D, round: Round) -> Self {
         Self {
-            kind: RequestKind::FinalizedBlockByRound { commitment, round },
+            kind: RequestKind::FinalizedByRound { commitment, round },
         }
     }
 
     pub(crate) fn above_height_floor(&self, floor: Height) -> bool {
         match self.kind {
             RequestKind::Finalized { height }
-            | RequestKind::AncestryBlock { height, .. }
-            | RequestKind::CertifiedBlock { height, .. }
-            | RequestKind::FinalizedBlockByHeight { height, .. } => height > floor,
-            RequestKind::Notarized { .. } | RequestKind::FinalizedBlockByRound { .. } => true,
+            | RequestKind::Untrusted { height, .. }
+            | RequestKind::Certified { height, .. }
+            | RequestKind::FinalizedByHeight { height, .. } => height > floor,
+            RequestKind::Notarized { .. } | RequestKind::FinalizedByRound { .. } => true,
         }
     }
 
     pub(crate) fn above_round_floor(&self, floor: Round) -> bool {
         match self.kind {
-            RequestKind::Notarized { round } | RequestKind::FinalizedBlockByRound { round, .. } => {
+            RequestKind::Notarized { round } | RequestKind::FinalizedByRound { round, .. } => {
                 round > floor
             }
             RequestKind::Finalized { .. }
-            | RequestKind::AncestryBlock { .. }
-            | RequestKind::CertifiedBlock { .. }
-            | RequestKind::FinalizedBlockByHeight { .. } => true,
+            | RequestKind::Untrusted { .. }
+            | RequestKind::Certified { .. }
+            | RequestKind::FinalizedByHeight { .. } => true,
         }
     }
 
@@ -373,17 +372,17 @@ impl<D: Digest> Request<D> {
                 Key::Finalized { height },
                 Annotation::Finalized(Finalized::ByHeight { height }),
             ),
-            RequestKind::AncestryBlock { commitment, height } => {
+            RequestKind::Untrusted { commitment, height } => {
                 (Key::Block(commitment), Annotation::Ancestry { height })
             }
-            RequestKind::CertifiedBlock { commitment, height } => {
+            RequestKind::Certified { commitment, height } => {
                 (Key::Block(commitment), Annotation::Certified { height })
             }
-            RequestKind::FinalizedBlockByHeight { commitment, height } => (
+            RequestKind::FinalizedByHeight { commitment, height } => (
                 Key::Block(commitment),
                 Annotation::Finalized(Finalized::ByHeight { height }),
             ),
-            RequestKind::FinalizedBlockByRound { commitment, round } => (
+            RequestKind::FinalizedByRound { commitment, round } => (
                 Key::Block(commitment),
                 Annotation::Finalized(Finalized::ByRound { round }),
             ),

--- a/consensus/src/marshal/standard/mod.rs
+++ b/consensus/src/marshal/standard/mod.rs
@@ -2966,6 +2966,7 @@ mod tests {
                             && !matches!(
                                 fetch.subscriber,
                                 handler::Annotation::Certified { height }
+                                | handler::Annotation::Ancestry { height }
                                     if height == Height::new(2)
                             )
                     }),

--- a/consensus/src/marshal/standard/mod.rs
+++ b/consensus/src/marshal/standard/mod.rs
@@ -2966,7 +2966,7 @@ mod tests {
                             && !matches!(
                                 fetch.subscriber,
                                 handler::Annotation::Certified { height }
-                                | handler::Annotation::Ancestry { height }
+                                | handler::Annotation::Untrusted { height }
                                     if height == Height::new(2)
                             )
                     }),

--- a/consensus/src/marshal/standard/variant.rs
+++ b/consensus/src/marshal/standard/variant.rs
@@ -7,7 +7,7 @@ use crate::{
     Block,
     marshal::{
         ancestry::BlockProvider,
-        core::{Buffer, CommitmentFallback, Mailbox, Retirement, Variant},
+        core::{Buffer, CommitmentFallback, ExpectedCommitment, Mailbox, Retirement, Variant},
     },
     simplex::scheme::Scheme as SimplexScheme,
     types::Round,
@@ -62,8 +62,7 @@ where
 
     fn block_cfg(
         block_cfg: &<Self::ApplicationBlock as Read>::Cfg,
-        _expected: Self::Commitment,
-        _trusted: bool,
+        _expected: ExpectedCommitment<Self::Commitment>,
     ) -> <Self::Block as Read>::Cfg {
         block_cfg.clone()
     }

--- a/consensus/src/marshal/standard/variant.rs
+++ b/consensus/src/marshal/standard/variant.rs
@@ -63,7 +63,7 @@ where
     fn block_cfg(
         block_cfg: &<Self::ApplicationBlock as Read>::Cfg,
         _expected: Self::Commitment,
-        _finalized: bool,
+        _trusted: bool,
     ) -> <Self::Block as Read>::Cfg {
         block_cfg.clone()
     }

--- a/consensus/src/marshal/standard/variant.rs
+++ b/consensus/src/marshal/standard/variant.rs
@@ -63,6 +63,7 @@ where
     fn block_cfg(
         block_cfg: &<Self::ApplicationBlock as Read>::Cfg,
         _expected: Self::Commitment,
+        _finalized: bool,
     ) -> <Self::Block as Read>::Cfg {
         block_cfg.clone()
     }

--- a/consensus/src/simplex/actors/voter/mod.rs
+++ b/consensus/src/simplex/actors/voter/mod.rs
@@ -10181,6 +10181,10 @@ mod tests {
                 !certified_before_sync,
                 "resolver observed certification before the section sync completed"
             );
+            assert!(
+                !reporter.certifications.lock().contains_key(&target_view),
+                "reporter observed certification before the section sync completed"
+            );
 
             let mut finalize_constructed = false;
             while let Some(msg) = batcher_receiver.recv().now_or_never().flatten() {
@@ -10262,6 +10266,15 @@ mod tests {
                     },
                 }
             }
+            assert_eq!(
+                reporter
+                    .certifications
+                    .lock()
+                    .get(&target_view)
+                    .map(|certification| &certification.proposal),
+                Some(&proposal),
+                "reporter should receive successful certification"
+            );
 
             // The durable finalize should be broadcast, without another section sync.
             let deadline = context.current() + Duration::from_secs(5);
@@ -10401,6 +10414,15 @@ mod tests {
                 .and_then(|payloads| payloads.get(&proposal.payload))
                 .expect("coalesced finalize should replay after restart");
             assert!(signers.contains(&me));
+            assert_eq!(
+                replay_reporter
+                    .certifications
+                    .lock()
+                    .get(&target_view)
+                    .map(|certification| &certification.proposal),
+                Some(&proposal),
+                "reporter should receive replayed successful certification"
+            );
         });
     }
 
@@ -10555,6 +10577,10 @@ mod tests {
                     },
                 }
             }
+            assert!(
+                !reporter.certifications.lock().contains_key(&target_view),
+                "reporter should not receive failed certification"
+            );
 
             // Let the journal sync.
             context.sleep(Duration::from_millis(50)).await;
@@ -10584,7 +10610,7 @@ mod tests {
                 blocker: oracle.control(me.clone()),
                 automaton: application.clone(),
                 relay: application.clone(),
-                reporter,
+                reporter: reporter.clone(),
                 partition,
                 epoch,
                 floor: Floor::Genesis(mocks::application::genesis::<Sha256>(epoch)),
@@ -10654,6 +10680,10 @@ mod tests {
             assert!(
                 replayed_certified,
                 "resolver should receive Certified(false) during replay for view {target_view}"
+            );
+            assert!(
+                !reporter.certifications.lock().contains_key(&target_view),
+                "reporter should not receive replayed failed certification"
             );
         });
     }

--- a/glue/src/dkg/probe/actor/discovery.rs
+++ b/glue/src/dkg/probe/actor/discovery.rs
@@ -936,6 +936,9 @@ mod tests {
 
             assert_eq!(decoded.height(), Height::new(1));
             assert_eq!(TestCodingVariant::commitment(&decoded), payload);
+
+            // The finalized payload fixes the root, so the probe decodes without re-encoding.
+            assert!(decoded.shard(0).is_none());
         });
     }
 
@@ -997,6 +1000,9 @@ mod tests {
 
             assert_eq!(decoded.height(), Height::new(1));
             assert_eq!(TestCodingVariant::commitment(&decoded), payload);
+
+            // The finalized payload fixes the root, so the probe decodes without re-encoding.
+            assert!(decoded.shard(0).is_none());
         });
     }
 }

--- a/glue/src/dkg/probe/wire.rs
+++ b/glue/src/dkg/probe/wire.rs
@@ -1,7 +1,7 @@
 use bytes::{Buf, BufMut};
 use commonware_codec::{Decode, DecodeExt, EncodeSize, Error, FixedSize, Read, ReadExt, Write};
 use commonware_consensus::{
-    marshal::core::Variant,
+    marshal::core::{ExpectedCommitment, Variant},
     simplex::{scheme::Scheme, types::Finalization},
     types::Epoch,
 };
@@ -237,7 +237,7 @@ pub(crate) fn read_block<V>(
 where
     V: Variant,
 {
-    let block_cfg = V::block_cfg(block_codec_config, commitment, true);
+    let block_cfg = V::block_cfg(block_codec_config, ExpectedCommitment::Trusted(commitment));
     V::Block::decode_cfg(reader, &block_cfg)
 }
 

--- a/glue/src/dkg/probe/wire.rs
+++ b/glue/src/dkg/probe/wire.rs
@@ -228,7 +228,7 @@ where
     }
 }
 
-/// Decode the body of a block response using its authenticated commitment.
+/// Decode the body of a block response using the payload of a verified finalization.
 pub(crate) fn read_block<V>(
     reader: impl Buf,
     commitment: V::Commitment,
@@ -237,7 +237,7 @@ pub(crate) fn read_block<V>(
 where
     V: Variant,
 {
-    let block_cfg = V::block_cfg(block_codec_config, commitment);
+    let block_cfg = V::block_cfg(block_codec_config, commitment, true);
     V::Block::decode_cfg(reader, &block_cfg)
 }
 


### PR DESCRIPTION
Reuse coding roots for fetched blocks backed by finalization or certification evidence, generating shards on demand. `ExpectedCommitment` distinguishes trusted decoding from recomputation; full-commitment checks remain enforced.

Optimistic verification (#3416, August 10, 2026) began fetching uncertified ancestors through the existing `Certified` path. This PR distinguishes `Certified` from `Untrusted` fetches without broadening the cached block categories. Keep `certified_blocks` aligned with the existing `certified` archive partition, documenting that cache membership is not certification evidence.

Track certification evidence separately and prune it at the finalized tip. Wire and storage formats are unchanged.

Validation: eight focused tests, including a retention regression reproduced before the fix; Clippy and formatting pass.

Closes #3938. Supersedes #4273. Closes #4638.
