### PR TITLE
[storage] Make authenticated journal rewinds durable before returning

### DIFF
--- a/storage/src/journal/authenticated.rs
+++ b/storage/src/journal/authenticated.rs
@@ -579,10 +579,16 @@ where
         Ok(self)
     }
 
-    /// Rewind the journal and Merkle structure.
+    /// Rewind the journal and Merkle structure to `size` items.
+    ///
+    /// The rewind is durable before this method returns, so no item above `size` can survive a
+    /// crash and be paired with the leaves of a later history appended at the same locations.
     #[boxed]
     pub async fn rewind(mut self, size: u64) -> Result<Self, Error<F>> {
-        self.journal = self.journal.rewind(size).await?;
+        // The Merkle structure persists its own truncation and recovery aligns the two components
+        // by length alone, so a journal whose truncation was lost in a crash would pair its old
+        // items with the new leaves.
+        self.journal = self.journal.rewind(size).await?.sync().await?;
 
         let leaves = *self.merkle.leaves();
         if leaves > size {
@@ -1099,7 +1105,7 @@ mod tests {
         },
         utils::detached::{DropMonitor, block_strategy},
     };
-    use commonware_codec::Encode;
+    use commonware_codec::{Encode, FixedSize};
     use commonware_cryptography::{Sha256, sha256::Digest};
     use commonware_macros::test_traced;
     use commonware_parallel::{Manual, Rayon, Sequential};
@@ -1921,6 +1927,69 @@ mod tests {
     fn test_rewind_mmb() {
         let executor = deterministic::Runner::default();
         executor.start(test_rewind_inner::<mmb::Family>);
+    }
+
+    /// A rewind must survive a crash on its own. Pages are sized to one item so the truncation
+    /// lands on a page boundary, the shape a crash can lose when it is not synced. Seven items
+    /// fill and seal the first blob, so the rewind also demotes a sealed blob back to the tail.
+    fn test_rewind_survives_crash_inner<F: Family + PartialEq>() {
+        let page_size = NonZeroU16::new(TestOp::<F>::SIZE as u16).unwrap();
+        let open = move |context: Context| async move {
+            let merkle_cfg = merkle_config("rewind-crash", &context);
+            let mut journal_cfg = journal_config("rewind-crash", &context);
+            journal_cfg.page_cache = CacheRef::from_pooler(&context, page_size, PAGE_CACHE_SIZE);
+            TestJournal::<F>::new(
+                context,
+                merkle_cfg,
+                journal_cfg,
+                |op: &TestOp<F>| op.is_commit(),
+                ForwardFold,
+            )
+            .await
+            .unwrap()
+        };
+
+        let (root, checkpoint) =
+            deterministic::Runner::default().start_and_recover(|context| async move {
+                let mut journal = open(context.child("first")).await;
+                for i in 0..2 {
+                    (journal, _) = journal.append(&create_operation::<F>(i)).await.unwrap();
+                }
+                (journal, _) = journal
+                    .append(&TestOp::<F>::CommitFloor(None, Location::<F>::new(0)))
+                    .await
+                    .unwrap();
+                for i in 3..6 {
+                    (journal, _) = journal.append(&create_operation::<F>(i)).await.unwrap();
+                }
+                (journal, _) = journal
+                    .append(&TestOp::<F>::CommitFloor(None, Location::<F>::new(0)))
+                    .await
+                    .unwrap();
+                journal = journal.sync().await.unwrap();
+
+                journal = journal.rewind(3).await.unwrap();
+                assert_eq!(journal.size(), 3);
+                let root = journal_root(&journal);
+                drop(journal);
+                root
+            });
+
+        deterministic::Runner::from(checkpoint).start(|context| async move {
+            let journal = open(context.child("second")).await;
+            assert_eq!(journal.size(), 3);
+            assert_eq!(journal_root(&journal), root);
+        });
+    }
+
+    #[test_traced("INFO")]
+    fn test_rewind_survives_crash_mmr() {
+        test_rewind_survives_crash_inner::<mmr::Family>();
+    }
+
+    #[test_traced("INFO")]
+    fn test_rewind_survives_crash_mmb() {
+        test_rewind_survives_crash_inner::<mmb::Family>();
     }
 
     /// Verify that append() increments the operation count, returns correct locations, and

--- a/storage/src/qmdb/any/db.rs
+++ b/storage/src/qmdb/any/db.rs
@@ -544,9 +544,7 @@ where
     /// all in-memory structures are rebuilt. Callers must drop this database handle after any `Err`
     /// from `rewind` and reopen from storage.
     ///
-    /// A successful rewind is not restart-stable until a subsequent [`Db::commit`] or
-    /// [`Db::sync`] completes, or until the handle returned by a subsequent [`Db::start_sync`]
-    /// completes.
+    /// The journal rewind is durable before this method returns.
     #[tracing::instrument(
         name = "qmdb.any.db.rewind",
         level = "info",
@@ -641,8 +639,7 @@ where
             (rewind_floor, undos, active_keys_delta)
         };
 
-        // Journal rewind happens before in-memory undo application. This step is not
-        // restart-stable until a later commit/sync.
+        // Journal rewind happens before in-memory undo application.
         self.log = self.log.rewind(rewind_size).await?;
 
         // Drop bitmap bits for ops at or above the rewind target. Restored locs below

--- a/storage/src/qmdb/current/db.rs
+++ b/storage/src/qmdb/current/db.rs
@@ -609,9 +609,7 @@ where
     /// underlying Any database before this Current overlay finishes rebuilding. Callers must drop
     /// this database handle after any `Err` from `rewind` and reopen from storage.
     ///
-    /// A successful rewind is not restart-stable until a subsequent [`Db::commit`] or
-    /// [`Db::sync`] completes, or until the handle returned by a subsequent [`Db::start_sync`]
-    /// completes.
+    /// The journal rewind is durable before this method returns.
     #[tracing::instrument(name = "qmdb.current.db.rewind", level = "info", skip_all)]
     #[boxed]
     pub async fn rewind(mut self, size: Location<F>) -> Result<Self, Error<F>> {

--- a/storage/src/qmdb/immutable/mod.rs
+++ b/storage/src/qmdb/immutable/mod.rs
@@ -567,9 +567,7 @@ where
     /// before this method finishes rebuilding in-memory rewind state. Callers must drop this
     /// database handle after any `Err` from `rewind` and reopen from storage.
     ///
-    /// A successful rewind is not restart-stable until a subsequent [`Immutable::commit`] or
-    /// [`Immutable::sync`] completes, or until the handle returned by a subsequent
-    /// [`Immutable::start_sync`] completes.
+    /// The journal rewind is durable before this method returns.
     #[tracing::instrument(name = "qmdb.immutable.db.rewind", level = "info", skip_all)]
     #[boxed]
     pub async fn rewind(mut self, size: Location<F>) -> Result<Self, Error<F>> {

--- a/storage/src/qmdb/keyless/fixed.rs
+++ b/storage/src/qmdb/keyless/fixed.rs
@@ -76,7 +76,7 @@ mod tests {
         BufferPooler, Metrics as _, Runner as _, Spawner as _, Strategizer as _, Supervisor as _,
         buffer::paged::CacheRef,
         deterministic,
-        mocks::{DelayedSyncContext, PendingSyncs, drive_pending_syncs},
+        mocks::{DelayedSyncContext, PendingSyncs, drive_pending_syncs, next_pending_sync},
         reschedule,
     };
     use commonware_utils::{NZU16, NZU64, NZUsize, sequence::U64};
@@ -202,6 +202,86 @@ mod tests {
             .await;
         let (db, range) = db.apply_batch(batch).await.unwrap();
         (db, range.start)
+    }
+
+    /// Rewinding a durable history and applying an equal-length sibling, then crashing after
+    /// only the Merkle half of `start_sync` lands, must reopen to a single history: the rewound
+    /// state, never the old operations under the sibling's root.
+    #[test_traced]
+    fn test_keyless_fixed_rebranch_survives_partial_sync() {
+        // A fixed U64 operation is 18 bytes. One record per page makes the rewind a pure blob
+        // truncation, and seven records per blob keeps every record in one blob.
+        fn open(
+            context: &deterministic::Context,
+            label: &'static str,
+            pending: &PendingSyncs,
+        ) -> impl Future<Output = Result<DelayedDb, Error<mmr::Family>>> {
+            let mut cfg = db_config("rebranch", context, Sequential);
+            cfg.log.page_cache = CacheRef::from_pooler(context, NZU16!(18), PAGE_CACHE_SIZE);
+            DelayedDb::init(
+                DelayedSyncContext {
+                    inner: context.child(label),
+                    pending: pending.clone(),
+                },
+                cfg,
+            )
+        }
+
+        let (root_rewound, checkpoint) =
+            deterministic::Runner::default().start_and_recover(|ctx| async move {
+                let pending = PendingSyncs::default();
+                let open = open(&ctx, "first", &pending);
+                let mut db = drive_pending_syncs(&pending, open).await.unwrap();
+
+                // Durably store the first history, then rewind to the initial commit.
+                let floor = db.inactivity_floor_loc();
+                (db, _) = apply_append(db, U64::new(11), floor).await;
+                db = drive_pending_syncs(&pending, db.sync()).await.unwrap();
+                let root_a = db.root();
+                db = drive_pending_syncs(&pending, db.rewind(Location::new(1)))
+                    .await
+                    .unwrap();
+                let root_rewound = db.root();
+
+                // Apply an equal-length sibling and start a sync.
+                let floor = db.inactivity_floor_loc();
+                (db, _) = apply_append(db, U64::new(22), floor).await;
+                assert_eq!(db.bounds().end, Location::new(3));
+                assert_ne!(db.root(), root_a);
+                let starts_before = pending.starts();
+                let completions_before = pending.completions();
+                let handle;
+                (db, handle) = db.start_sync().await.unwrap();
+                assert_eq!(pending.starts() - starts_before, 2);
+
+                // Let only the Merkle sync land, then crash.
+                let _journal_sync = next_pending_sync(&pending);
+                let merkle_sync = next_pending_sync(&pending);
+                let _waiter = ctx.child("partial_sync").spawn(|_| handle);
+                merkle_sync.release.send(Ok(())).unwrap();
+                while pending.completions() < completions_before + 1 {
+                    reschedule().await;
+                }
+                drop(db);
+                root_rewound
+            });
+
+        deterministic::Runner::from(checkpoint).start(|ctx| async move {
+            let pending = PendingSyncs::default();
+            let open = open(&ctx, "second", &pending);
+            let db = drive_pending_syncs(&pending, open).await.unwrap();
+
+            // Only the rewound history is recoverable, and its proofs verify against its root.
+            assert_eq!(db.bounds().end, Location::new(1));
+            assert_eq!(db.root(), root_rewound);
+            let (proof, ops) = db.proof(Location::new(0), NZU64!(3)).await.unwrap();
+            assert!(crate::qmdb::verify_proof::<Sha256, _, _>(
+                &proof,
+                Location::new(0),
+                &ops,
+                &db.root(),
+            ));
+        });
     }
 
     /// A sync handle must not block database use while the backend sync is pending.

--- a/storage/src/qmdb/keyless/mod.rs
+++ b/storage/src/qmdb/keyless/mod.rs
@@ -418,9 +418,7 @@ where
     /// before this method finishes updating in-memory rewind state. Callers must drop this
     /// database handle after any `Err` from `rewind` and reopen from storage.
     ///
-    /// A successful rewind is not restart-stable until a subsequent [`Self::commit`] or
-    /// [`Self::sync`] completes, or until the handle returned by a subsequent
-    /// [`Self::start_sync`] completes.
+    /// The journal rewind is durable before this method returns.
     #[tracing::instrument(name = "qmdb.keyless.db.rewind", level = "info", skip_all)]
     #[boxed]
     pub async fn rewind(mut self, size: Location<F>) -> Result<Self, Error<F>> {
@@ -2802,8 +2800,8 @@ pub(crate) mod tests {
         assert_eq!(db.inactivity_floor_loc(), floor_a);
         assert_eq!(db.last_commit_loc(), Location::new(3));
 
-        // Commit the rewind so it's durable, then reopen and confirm the floor again.
-        db.commit().await.unwrap();
+        // Reopen and confirm the floor again.
+        drop(db);
         let db = reopen(context.child("reopen").with_attribute("index", 2)).await;
         assert_eq!(db.inactivity_floor_loc(), floor_a);
 

--- a/storage/src/qmdb/keyless/variable.rs
+++ b/storage/src/qmdb/keyless/variable.rs
@@ -86,7 +86,7 @@ where
 mod tests {
     use super::*;
     use crate::{
-        merkle::{mmb, mmr},
+        merkle::{Location, mmb, mmr},
         qmdb::keyless::tests::{self, keyless_tests},
     };
     use commonware_cryptography::Sha256;
@@ -173,6 +173,60 @@ mod tests {
 
     fn reopen<F: Family>() -> tests::Reopen<TestDb<F>> {
         Box::new(|ctx| Box::pin(open_db(ctx)))
+    }
+
+    /// A rewind must survive a crash on its own. Three items per section put the rewind target
+    /// at the start of a sealed section, so the rewind empties that section's blob, a
+    /// truncation a crash can lose when it is not synced.
+    #[test_traced]
+    fn test_keyless_variable_rewind_survives_crash() {
+        fn config(
+            context: &deterministic::Context,
+        ) -> Config<(commonware_codec::RangeCfg<usize>, ()), Sequential> {
+            let mut cfg = db_config("rewind-crash", context);
+            cfg.log.items_per_section = NZU64!(3);
+            cfg
+        }
+
+        let (root, checkpoint) =
+            deterministic::Runner::default().start_and_recover(|ctx| async move {
+                let db = TestDb::<mmr::Family>::init(ctx.child("first"), config(&ctx))
+                    .await
+                    .unwrap();
+                let floor = db.inactivity_floor_loc();
+
+                // Commits at 2, 5, and 6 fill the first two sections and open a third.
+                let batch = db
+                    .new_batch()
+                    .append(vec![1])
+                    .merkleize(&db, None, floor)
+                    .await;
+                let (db, _) = db.apply_batch(batch).await.unwrap();
+                let batch = db
+                    .new_batch()
+                    .append(vec![2])
+                    .append(vec![3])
+                    .merkleize(&db, None, floor)
+                    .await;
+                let (db, _) = db.apply_batch(batch).await.unwrap();
+                let batch = db.new_batch().merkleize(&db, None, floor).await;
+                let (db, _) = db.apply_batch(batch).await.unwrap();
+                assert_eq!(db.bounds().end, Location::new(7));
+                let db = db.sync().await.unwrap();
+
+                let db = db.rewind(Location::new(3)).await.unwrap();
+                let root = db.root();
+                drop(db);
+                root
+            });
+
+        deterministic::Runner::from(checkpoint).start(|ctx| async move {
+            let db = TestDb::<mmr::Family>::init(ctx.child("second"), config(&ctx))
+                .await
+                .unwrap();
+            assert_eq!(db.bounds().end, Location::new(3));
+            assert_eq!(db.root(), root);
+        });
     }
 
     keyless_tests! {


### PR DESCRIPTION
## Summary

`authenticated::Journal` pairs a contiguous operation journal with a persisted Merkle structure, and recovery requires operation `i` to be the preimage of leaf `i`. `rewind` restored both components to an earlier size but only the Merkle side made its truncation durable: `full::Merkle::rewind` syncs its node journal, while the contiguous journals durably lower their recovery watermark and then shrink the blob without a sync, as their contract documents. The next `start_sync` (or `sync`) runs the two component syncs independently, and `align` on reopen compares only lengths.

A rewind followed by an equal-length sibling history and a crash after the Merkle sync landed, but before the operation-journal sync did, therefore reopened cleanly with the old branch's operations under the new branch's root. `get` returned the old value, `root` advertised the new history, and proofs generated by the same database failed verification. Every family over `authenticated::Journal` (keyless, any, immutable, current) with either contiguous journal was exposed at the storage API. The glue adapters were not, because they sync immediately after every rewind.

## Fix

`authenticated::Journal::rewind` syncs the operation journal after rewinding it, before returning. No operation above the rewind target can then survive a crash, so whichever component's sync lands first afterwards, recovery sees a prefix of one history. The Merkle side and the compact witness journal already behaved this way. The rewind docs on the four families now state that the journal rewind is durable on return instead of deferring restart stability to the next commit or sync.

Rewind is a reorg-path operation, so the added fsyncs (data plus checkpoint for the fixed journal, data plus offsets for the variable journal) are not on a hot path. The glue adapters' `sync` after `rewind_to_target` is now redundant for durability and is left in place.

## Tests

Each of these fails without the fix.

- `test_rewind_survives_crash_{mmr,mmb}` in `journal::authenticated` sizes pages to one operation so the truncation lands on a page boundary, rewinds a synced seven-item journal to three (demoting a sealed blob), drops it without syncing, crash-recovers, and asserts the rewound size and root reopen. Without the fix the journal reopens at seven.
- `test_keyless_fixed_rebranch_survives_partial_sync` in `qmdb::keyless::fixed` is the reported scenario: rewind a durable history to the initial commit, apply an equal-length sibling, start a sync, let only the Merkle half complete, crash. Reopen must have exactly the rewound history, its root, and a proof that verifies against `root()`. Without the fix it reopens at size three with the old operation under the sibling's root.
- `test_keyless_variable_rewind_survives_crash` in `qmdb::keyless::variable` puts the rewind target at the start of a sealed section so the rewind empties that section's blob, then crashes without syncing. Without the fix it reopens at six instead of three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
