### PR TITLE
[runtime, storage, glue] Make rewinds durable when they return

### DIFF
--- a/glue/src/stateful/db/any.rs
+++ b/glue/src/stateful/db/any.rs
@@ -570,7 +570,6 @@ where
 
     async fn rewind_to_target(self, target: Self::SyncTarget) -> Result<Self, Error<F>> {
         let db = self.rewind(target.range.end()).await?;
-        let db = db.sync().await?;
 
         let rewound_target = db.sync_target();
         assert_eq!(
@@ -678,7 +677,6 @@ where
 
     async fn rewind_to_target(self, target: Self::SyncTarget) -> Result<Self, Error<F>> {
         let db = self.rewind(target.range.end()).await?;
-        let db = db.sync().await?;
 
         let rewound_target = db.sync_target();
         assert_eq!(

--- a/glue/src/stateful/db/current.rs
+++ b/glue/src/stateful/db/current.rs
@@ -1621,6 +1621,9 @@ mod tests {
         });
     }
 
+    /// A rewind to the already-applied target is durable on its own: after `rewind_to_target`
+    /// with an unfinalized applied state and a crash with no further sync, the reopened database
+    /// reports that target.
     #[test]
     fn managed_db_rewind_current_target_survives_crash() {
         let (target, checkpoint) =
@@ -1646,7 +1649,7 @@ mod tests {
                     .unwrap();
                 let target = <FixedDb as ManagedDb<_>>::sync_target(&database);
 
-                // An unchanged target still needs to persist its unfinalized checkpoint
+                // A target equal to the applied state persists its unfinalized checkpoint.
                 let database =
                     <FixedDb as ManagedDb<_>>::rewind_to_target(database, target.clone())
                         .await

--- a/glue/src/stateful/db/current.rs
+++ b/glue/src/stateful/db/current.rs
@@ -1621,6 +1621,51 @@ mod tests {
         });
     }
 
+    #[test]
+    fn managed_db_rewind_current_target_survives_crash() {
+        let (target, checkpoint) =
+            deterministic::Runner::default().start_and_recover(|context| async move {
+                let db = FixedDb::init(
+                    context.child("db"),
+                    fixed_config("rewind-current-crash", &context),
+                )
+                .await
+                .unwrap();
+                let db = Shared::new("test", db);
+                let batch = db
+                    .new_batch_for_test::<_>()
+                    .await
+                    .write(Sha256::hash(&[b"key"]), Some(Sha256::hash(&[b"value"])))
+                    .with_metadata(Sha256::hash(&[b"metadata"]));
+                let batch = crate::stateful::db::Unmerkleized::merkleize(batch)
+                    .await
+                    .unwrap();
+                let (slot, database) = db.write().await;
+                let database = <FixedDb as ManagedDb<_>>::apply(database, batch)
+                    .await
+                    .unwrap();
+                let target = <FixedDb as ManagedDb<_>>::sync_target(&database);
+
+                // An unchanged target still needs to persist its unfinalized checkpoint
+                let database =
+                    <FixedDb as ManagedDb<_>>::rewind_to_target(database, target.clone())
+                        .await
+                        .unwrap();
+                slot.put(database);
+                target
+            });
+
+        deterministic::Runner::from(checkpoint).start(|context| async move {
+            let db = FixedDb::init(
+                context.child("db"),
+                fixed_config("rewind-current-crash", &context),
+            )
+            .await
+            .unwrap();
+            assert_eq!(<FixedDb as ManagedDb<_>>::sync_target(&db), target);
+        });
+    }
+
     /// A rewind is durable on its own: after `rewind_to_target` and a crash with no further
     /// sync, the reopened database reports the rewound target.
     #[test]

--- a/glue/src/stateful/db/current.rs
+++ b/glue/src/stateful/db/current.rs
@@ -571,7 +571,6 @@ where
 
     async fn rewind_to_target(self, target: Self::SyncTarget) -> Result<Self, Error<F>> {
         let db = self.rewind(target.range.end()).await?;
-        let db = db.sync().await?;
 
         let rewound_target = db.sync_target();
         assert_eq!(
@@ -676,7 +675,6 @@ where
 
     async fn rewind_to_target(self, target: Self::SyncTarget) -> Result<Self, Error<F>> {
         let db = self.rewind(target.range.end()).await?;
-        let db = db.sync().await?;
 
         let rewound_target = db.sync_target();
         assert_eq!(
@@ -857,7 +855,6 @@ where
 
     async fn rewind_to_target(self, target: Self::SyncTarget) -> Result<Self, Error<F>> {
         let db = self.rewind(target.range.end()).await?;
-        let db = db.sync().await?;
 
         let rewound_target = db.sync_target();
         assert_eq!(
@@ -967,7 +964,6 @@ where
 
     async fn rewind_to_target(self, target: Self::SyncTarget) -> Result<Self, Error<F>> {
         let db = self.rewind(target.range.end()).await?;
-        let db = db.sync().await?;
 
         let rewound_target = db.sync_target();
         assert_eq!(
@@ -1175,6 +1171,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use commonware_codec::FixedSize;
     use commonware_cryptography::{Sha256, sha256::Digest};
     use commonware_macros::boxed;
     use commonware_parallel::Sequential;
@@ -1186,9 +1183,12 @@ mod tests {
             fixed::Config as FixedJournalConfig, variable::Config as VariableJournalConfig,
         },
         merkle::{full::Config as MerkleConfig, mmr},
-        qmdb::current::{
-            ordered::{fixed as ordered_fixed, variable as ordered_variable},
-            unordered::{fixed, variable},
+        qmdb::{
+            any::unordered::fixed::Operation as FixedOperation,
+            current::{
+                ordered::{fixed as ordered_fixed, variable as ordered_variable},
+                unordered::{fixed, variable},
+            },
         },
         translator::TwoCap,
     };
@@ -1618,6 +1618,91 @@ mod tests {
                 <OrderedFixedDb as ManagedDb<_>>::sync_target(&guard)
             };
             assert_eq!(target_after_rewind, target_after_first);
+        });
+    }
+
+    /// A rewind is durable on its own: after `rewind_to_target` and a crash with no further
+    /// sync, the reopened database reports the rewound target.
+    #[test]
+    fn managed_db_rewind_to_target_survives_crash() {
+        // One operation per log page puts the rewind's truncation on a page boundary, the shape
+        // a crash can lose when the truncation is not synced. The alias mirrors `FixedDb`'s key
+        // and value types.
+        type FixedOp = FixedOperation<mmr::Family, Digest, Digest>;
+        fn config(pooler: &impl BufferPooler) -> FixedConfig<TwoCap, Sequential> {
+            let page_size = NonZeroU16::new(<FixedOp as FixedSize>::SIZE as u16).unwrap();
+            let mut config = fixed_config("rewind-crash", pooler);
+            config.journal_config.page_cache =
+                CacheRef::from_pooler(pooler, page_size, PAGE_CACHE_SIZE);
+            config
+        }
+
+        let (target_after_first, checkpoint) =
+            deterministic::Runner::default().start_and_recover(|context| async move {
+                let db = FixedDb::init(context.child("db"), config(&context))
+                    .await
+                    .unwrap();
+                let db = Shared::new("test", db);
+
+                let key1 = Sha256::hash(&[b"key1"]);
+                let value1 = Sha256::hash(&[b"value1"]);
+                let metadata1 = Sha256::hash(&[b"metadata1"]);
+                let batch1 = db
+                    .new_batch_for_test::<_>()
+                    .await
+                    .write(key1, Some(value1))
+                    .with_metadata(metadata1);
+                let merkleized1 = crate::stateful::db::Unmerkleized::merkleize(batch1)
+                    .await
+                    .unwrap();
+                {
+                    let (slot, database) = db.write().await;
+                    slot.put(apply_and_finalize::<FixedDb>(database, merkleized1).await);
+                }
+                let target_after_first = {
+                    let guard = db.read().await;
+                    <FixedDb as ManagedDb<_>>::sync_target(&guard)
+                };
+
+                let key2 = Sha256::hash(&[b"key2"]);
+                let value2 = Sha256::hash(&[b"value2"]);
+                let metadata2 = Sha256::hash(&[b"metadata2"]);
+                let batch2 = db
+                    .new_batch_for_test::<_>()
+                    .await
+                    .write(key2, Some(value2))
+                    .with_metadata(metadata2);
+                let merkleized2 = crate::stateful::db::Unmerkleized::merkleize(batch2)
+                    .await
+                    .unwrap();
+                {
+                    let (slot, database) = db.write().await;
+                    slot.put(apply_and_finalize::<FixedDb>(database, merkleized2).await);
+                }
+
+                // Rewind, then crash without syncing.
+                {
+                    let (slot, database) = db.write().await;
+                    slot.put(
+                        <FixedDb as ManagedDb<_>>::rewind_to_target(
+                            database,
+                            target_after_first.clone(),
+                        )
+                        .await
+                        .unwrap(),
+                    );
+                }
+                target_after_first
+            });
+
+        deterministic::Runner::from(checkpoint).start(|context| async move {
+            let db = FixedDb::init(context.child("db"), config(&context))
+                .await
+                .unwrap();
+            assert_eq!(
+                <FixedDb as ManagedDb<_>>::sync_target(&db),
+                target_after_first
+            );
         });
     }
 

--- a/glue/src/stateful/db/current.rs
+++ b/glue/src/stateful/db/current.rs
@@ -1621,9 +1621,8 @@ mod tests {
         });
     }
 
-    /// A rewind to the already-applied target is durable on its own: after `rewind_to_target`
-    /// with an unfinalized applied state and a crash with no further sync, the reopened database
-    /// reports that target.
+    /// Apply without finalizing, rewind to the same target, then crash without another sync.
+    /// Recovery must retain the applied target.
     #[test]
     fn managed_db_rewind_current_target_survives_crash() {
         let (target, checkpoint) =
@@ -1649,7 +1648,7 @@ mod tests {
                     .unwrap();
                 let target = <FixedDb as ManagedDb<_>>::sync_target(&database);
 
-                // A target equal to the applied state persists its unfinalized checkpoint.
+                // Rewind the applied target without finalizing it
                 let database =
                     <FixedDb as ManagedDb<_>>::rewind_to_target(database, target.clone())
                         .await
@@ -1669,13 +1668,11 @@ mod tests {
         });
     }
 
-    /// A rewind is durable on its own: after `rewind_to_target` and a crash with no further
-    /// sync, the reopened database reports the rewound target.
+    /// Finalize two batches, rewind to the first, then crash without another sync.
+    /// Recovery must report the first batch's target.
     #[test]
     fn managed_db_rewind_to_target_survives_crash() {
-        // One operation per log page puts the rewind's truncation on a page boundary, the shape
-        // a crash can lose when the truncation is not synced. The alias mirrors `FixedDb`'s key
-        // and value types.
+        // One operation per page makes the rewind target page aligned
         type FixedOp = FixedOperation<mmr::Family, Digest, Digest>;
         fn config(pooler: &impl BufferPooler) -> FixedConfig<TwoCap, Sequential> {
             let page_size = NonZeroU16::new(<FixedOp as FixedSize>::SIZE as u16).unwrap();
@@ -1728,7 +1725,7 @@ mod tests {
                     slot.put(apply_and_finalize::<FixedDb>(database, merkleized2).await);
                 }
 
-                // Rewind, then crash without syncing.
+                // Crash after rewind without another sync
                 {
                     let (slot, database) = db.write().await;
                     slot.put(

--- a/glue/src/stateful/db/immutable/standard.rs
+++ b/glue/src/stateful/db/immutable/standard.rs
@@ -354,7 +354,6 @@ where
 
     async fn rewind_to_target(self, target: Self::SyncTarget) -> Result<Self, Error<F>> {
         let db = self.rewind(target.range.end()).await?;
-        let db = db.sync().await?;
 
         let rewound_target = db.sync_target();
         assert_eq!(
@@ -450,7 +449,6 @@ where
 
     async fn rewind_to_target(self, target: Self::SyncTarget) -> Result<Self, Error<F>> {
         let db = self.rewind(target.range.end()).await?;
-        let db = db.sync().await?;
 
         let rewound_target = db.sync_target();
         assert_eq!(

--- a/glue/src/stateful/db/keyless/standard.rs
+++ b/glue/src/stateful/db/keyless/standard.rs
@@ -322,7 +322,6 @@ where
 
     async fn rewind_to_target(self, target: Self::SyncTarget) -> Result<Self, Error<F>> {
         let db = self.rewind(target.range.end()).await?;
-        let db = db.sync().await?;
 
         let rewound_target = db.sync_target();
         assert_eq!(
@@ -411,7 +410,6 @@ where
 
     async fn rewind_to_target(self, target: Self::SyncTarget) -> Result<Self, Error<F>> {
         let db = self.rewind(target.range.end()).await?;
-        let db = db.sync().await?;
 
         let rewound_target = db.sync_target();
         assert_eq!(

--- a/glue/src/stateful/db/mod.rs
+++ b/glue/src/stateful/db/mod.rs
@@ -427,7 +427,7 @@ pub trait ManagedDb<E>: Send + Sync + Sized {
     /// Rewind applied state to `target`.
     ///
     /// Implementations must ensure rewind effects are durable before returning
-    /// the database (for example by committing after rewind).
+    /// the database.
     fn rewind_to_target(
         self,
         target: Self::SyncTarget,

--- a/glue/src/stateful/db/mod.rs
+++ b/glue/src/stateful/db/mod.rs
@@ -426,8 +426,8 @@ pub trait ManagedDb<E>: Send + Sync + Sized {
 
     /// Rewind applied state to `target`.
     ///
-    /// Implementations must ensure rewind effects are durable before returning
-    /// the database.
+    /// The target must be durable before returning the database, including when it already
+    /// matches the applied state.
     fn rewind_to_target(
         self,
         target: Self::SyncTarget,

--- a/runtime/src/utils/buffer/mod.rs
+++ b/runtime/src/utils/buffer/mod.rs
@@ -1183,17 +1183,18 @@ mod tests {
             assert_eq!(durable.as_slice(), b"abcdefgh");
             assert_eq!(full_syncs, 1);
 
-            // A shrink is durable on return: the truncation reaches the durable image with a
-            // full sync, leaving nothing for a caller's sync.
+            // Shrink with an empty buffer; one full sync persists the truncation
             writer.resize(4).await.unwrap();
             let (durable, _, full_syncs, _) = blob.snapshot();
             assert_eq!(durable.as_slice(), b"abcd");
             assert_eq!(full_syncs, 2);
+
+            // A subsequent sync has no remaining work
             writer.sync().await.unwrap();
             let (_, _, full_syncs, _) = blob.snapshot();
             assert_eq!(full_syncs, 2);
 
-            // Buffered bytes the shrink retains are flushed and covered by the same sync.
+            // Shrink within the buffer and persist its retained prefix with the truncation
             writer.write_at(4, b"wxyz").await.unwrap();
             writer.resize(6).await.unwrap();
             let (durable, _, full_syncs, _) = blob.snapshot();
@@ -1201,7 +1202,7 @@ mod tests {
             assert_eq!(full_syncs, 3);
             assert_eq!(writer.size(), 6);
 
-            // A shrink below the buffered range discards the buffer and still syncs.
+            // Shrink below the buffer, discarding it while still persisting the truncation
             writer.write_at(6, b"pq").await.unwrap();
             writer.resize(2).await.unwrap();
             let (durable, _, full_syncs, _) = blob.snapshot();

--- a/runtime/src/utils/buffer/mod.rs
+++ b/runtime/src/utils/buffer/mod.rs
@@ -171,7 +171,7 @@ mod tests {
         telemetry::metrics::Registry,
     };
     use commonware_macros::test_traced;
-    use commonware_utils::{NZU32, NZUsize, probability, sync::Mutex};
+    use commonware_utils::{NZU32, NZUsize, sync::Mutex};
     use futures::FutureExt;
     use std::sync::Arc;
 
@@ -1247,63 +1247,6 @@ mod tests {
             assert_eq!(durable.as_slice(), b"abcdef\0\0");
             assert_eq!(full_syncs, 6);
         });
-    }
-
-    fn assert_write_synced_shrink_then_resize_survives_crash(resize_to: u64) {
-        // Keep unsynced writes and drop unsynced resizes at the crash
-        let config = deterministic::Config::default().with_storage_fault_config(
-            deterministic::FaultConfig::default()
-                .write(deterministic::WriteConfig {
-                    failure_rate: probability!(0.0),
-                    retention_rate: probability!(1.0),
-                    mode: deterministic::PartialWriteMode::Prefix,
-                })
-                .resize(deterministic::ResizeConfig {
-                    failure_rate: probability!(0.0),
-                    partial_rate: probability!(0.0),
-                }),
-        );
-        let (_, checkpoint) =
-            deterministic::Runner::new(config).start_and_recover(move |context| async move {
-                let (blob, size) = context.open("partition", b"resize_crash").await.unwrap();
-
-                // A one-byte buffer sends the replacement write directly to the blob
-                let mut writer = Write::from_pooler(&context, blob, size, NZUsize!(1));
-                writer.write_at(0, b"abcdefgh").await.unwrap();
-                writer.sync().await.unwrap();
-
-                // Persist the shrink before an unsynced resize and write reuse its range
-                writer.resize(4).await.unwrap();
-                writer.sync().await.unwrap();
-                writer.resize(resize_to).await.unwrap();
-                writer.write_at(4, b"XY").await.unwrap();
-                drop(writer);
-            });
-
-        deterministic::Runner::from(checkpoint).start(|context| async move {
-            let (blob, size) = context.open("partition", b"resize_crash").await.unwrap();
-
-            // Inspect the raw recovered image before any repair or explicit sync
-            assert_eq!(size, 6, "the discarded tail survived the crash");
-            let bytes = blob
-                .read_at(0, size as usize, ReadOptions::default())
-                .await
-                .unwrap()
-                .coalesce();
-            assert_eq!(bytes.as_ref(), b"abcdXY");
-        });
-    }
-
-    /// An unsynced equal-size resize and replacement write must not undo a durable shrink.
-    #[test_traced]
-    fn test_write_synced_shrink_then_equal_resize_survives_crash() {
-        assert_write_synced_shrink_then_resize_survives_crash(4);
-    }
-
-    /// Unsynced growth and a replacement write must not resurrect the discarded tail.
-    #[test_traced]
-    fn test_write_synced_shrink_then_grow_resize_survives_crash() {
-        assert_write_synced_shrink_then_resize_survives_crash(6);
     }
 
     #[test_traced]

--- a/runtime/src/utils/buffer/mod.rs
+++ b/runtime/src/utils/buffer/mod.rs
@@ -1172,6 +1172,49 @@ mod tests {
     }
 
     #[test_traced]
+    fn test_write_resize_shrink_is_durable() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let blob = SyncTrackingBlob::new();
+            let mut writer = Write::from_pooler(&context, blob.clone(), 0, NZUsize!(8));
+            writer.write_at(0, b"abcdefgh").await.unwrap();
+            writer.sync().await.unwrap();
+            let (durable, _, full_syncs, _) = blob.snapshot();
+            assert_eq!(durable.as_slice(), b"abcdefgh");
+            assert_eq!(full_syncs, 1);
+
+            // A shrink is durable on return: the truncation reaches the durable image with a
+            // full sync, leaving nothing for a caller's sync.
+            writer.resize(4).await.unwrap();
+            let (durable, _, full_syncs, _) = blob.snapshot();
+            assert_eq!(durable.as_slice(), b"abcd");
+            assert_eq!(full_syncs, 2);
+            writer.sync().await.unwrap();
+            let (_, _, full_syncs, _) = blob.snapshot();
+            assert_eq!(full_syncs, 2);
+
+            // Buffered bytes the shrink retains are flushed and covered by the same sync.
+            writer.write_at(4, b"wxyz").await.unwrap();
+            writer.resize(6).await.unwrap();
+            let (durable, _, full_syncs, _) = blob.snapshot();
+            assert_eq!(durable.as_slice(), b"abcdwx");
+            assert_eq!(full_syncs, 3);
+            assert_eq!(writer.size(), 6);
+
+            // A shrink below the buffered range discards the buffer and still syncs.
+            writer.write_at(6, b"pq").await.unwrap();
+            writer.resize(2).await.unwrap();
+            let (durable, _, full_syncs, _) = blob.snapshot();
+            assert_eq!(durable.as_slice(), b"ab");
+            assert_eq!(full_syncs, 4);
+            assert_eq!(writer.size(), 2);
+            writer.sync().await.unwrap();
+            let (_, _, full_syncs, _) = blob.snapshot();
+            assert_eq!(full_syncs, 4);
+        });
+    }
+
+    #[test_traced]
     fn test_write_read_at_on_writer() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {

--- a/runtime/src/utils/buffer/mod.rs
+++ b/runtime/src/utils/buffer/mod.rs
@@ -171,7 +171,7 @@ mod tests {
         telemetry::metrics::Registry,
     };
     use commonware_macros::test_traced;
-    use commonware_utils::{NZU32, NZUsize, sync::Mutex};
+    use commonware_utils::{NZU32, NZUsize, probability, sync::Mutex};
     use futures::FutureExt;
     use std::sync::Arc;
 
@@ -1172,7 +1172,7 @@ mod tests {
     }
 
     #[test_traced]
-    fn test_write_resize_shrink_is_durable() {
+    fn test_write_resize_requires_sync() {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let blob = SyncTrackingBlob::new();
@@ -1183,8 +1183,12 @@ mod tests {
             assert_eq!(durable.as_slice(), b"abcdefgh");
             assert_eq!(full_syncs, 1);
 
-            // Shrink with an empty buffer; one full sync persists the truncation
+            // Shrink with an empty buffer, then explicitly persist the truncation
             writer.resize(4).await.unwrap();
+            let (durable, _, full_syncs, _) = blob.snapshot();
+            assert_eq!(durable.as_slice(), b"abcdefgh");
+            assert_eq!(full_syncs, 1);
+            writer.sync().await.unwrap();
             let (durable, _, full_syncs, _) = blob.snapshot();
             assert_eq!(durable.as_slice(), b"abcd");
             assert_eq!(full_syncs, 2);
@@ -1198,6 +1202,10 @@ mod tests {
             writer.write_at(4, b"wxyz").await.unwrap();
             writer.resize(6).await.unwrap();
             let (durable, _, full_syncs, _) = blob.snapshot();
+            assert_eq!(durable.as_slice(), b"abcd");
+            assert_eq!(full_syncs, 2);
+            writer.sync().await.unwrap();
+            let (durable, _, full_syncs, _) = blob.snapshot();
             assert_eq!(durable.as_slice(), b"abcdwx");
             assert_eq!(full_syncs, 3);
             assert_eq!(writer.size(), 6);
@@ -1206,13 +1214,96 @@ mod tests {
             writer.write_at(6, b"pq").await.unwrap();
             writer.resize(2).await.unwrap();
             let (durable, _, full_syncs, _) = blob.snapshot();
+            assert_eq!(durable.as_slice(), b"abcdwx");
+            assert_eq!(full_syncs, 3);
+            writer.sync().await.unwrap();
+            let (durable, _, full_syncs, _) = blob.snapshot();
             assert_eq!(durable.as_slice(), b"ab");
             assert_eq!(full_syncs, 4);
             assert_eq!(writer.size(), 2);
             writer.sync().await.unwrap();
             let (_, _, full_syncs, _) = blob.snapshot();
             assert_eq!(full_syncs, 4);
+
+            // An equal-size resize flushes buffered bytes without making them durable
+            writer.write_at(2, b"cd").await.unwrap();
+            writer.resize(4).await.unwrap();
+            let (durable, _, full_syncs, _) = blob.snapshot();
+            assert_eq!(durable.as_slice(), b"ab");
+            assert_eq!(full_syncs, 4);
+            writer.sync().await.unwrap();
+            let (durable, _, full_syncs, _) = blob.snapshot();
+            assert_eq!(durable.as_slice(), b"abcd");
+            assert_eq!(full_syncs, 5);
+
+            // Growth needs a sync for both the buffered bytes and the zero-filled extension
+            writer.write_at(4, b"ef").await.unwrap();
+            writer.resize(8).await.unwrap();
+            let (durable, _, full_syncs, _) = blob.snapshot();
+            assert_eq!(durable.as_slice(), b"abcd");
+            assert_eq!(full_syncs, 5);
+            writer.sync().await.unwrap();
+            let (durable, _, full_syncs, _) = blob.snapshot();
+            assert_eq!(durable.as_slice(), b"abcdef\0\0");
+            assert_eq!(full_syncs, 6);
         });
+    }
+
+    fn assert_write_synced_shrink_then_resize_survives_crash(resize_to: u64) {
+        // Keep unsynced writes and drop unsynced resizes at the crash
+        let config = deterministic::Config::default().with_storage_fault_config(
+            deterministic::FaultConfig::default()
+                .write(deterministic::WriteConfig {
+                    failure_rate: probability!(0.0),
+                    retention_rate: probability!(1.0),
+                    mode: deterministic::PartialWriteMode::Prefix,
+                })
+                .resize(deterministic::ResizeConfig {
+                    failure_rate: probability!(0.0),
+                    partial_rate: probability!(0.0),
+                }),
+        );
+        let (_, checkpoint) =
+            deterministic::Runner::new(config).start_and_recover(move |context| async move {
+                let (blob, size) = context.open("partition", b"resize_crash").await.unwrap();
+
+                // A one-byte buffer sends the replacement write directly to the blob
+                let mut writer = Write::from_pooler(&context, blob, size, NZUsize!(1));
+                writer.write_at(0, b"abcdefgh").await.unwrap();
+                writer.sync().await.unwrap();
+
+                // Persist the shrink before an unsynced resize and write reuse its range
+                writer.resize(4).await.unwrap();
+                writer.sync().await.unwrap();
+                writer.resize(resize_to).await.unwrap();
+                writer.write_at(4, b"XY").await.unwrap();
+                drop(writer);
+            });
+
+        deterministic::Runner::from(checkpoint).start(|context| async move {
+            let (blob, size) = context.open("partition", b"resize_crash").await.unwrap();
+
+            // Inspect the raw recovered image before any repair or explicit sync
+            assert_eq!(size, 6, "the discarded tail survived the crash");
+            let bytes = blob
+                .read_at(0, size as usize, ReadOptions::default())
+                .await
+                .unwrap()
+                .coalesce();
+            assert_eq!(bytes.as_ref(), b"abcdXY");
+        });
+    }
+
+    /// An unsynced equal-size resize and replacement write must not undo a durable shrink.
+    #[test_traced]
+    fn test_write_synced_shrink_then_equal_resize_survives_crash() {
+        assert_write_synced_shrink_then_resize_survives_crash(4);
+    }
+
+    /// Unsynced growth and a replacement write must not resurrect the discarded tail.
+    #[test_traced]
+    fn test_write_synced_shrink_then_grow_resize_survives_crash() {
+        assert_write_synced_shrink_then_resize_survives_crash(6);
     }
 
     #[test_traced]

--- a/runtime/src/utils/buffer/paged/writer.rs
+++ b/runtime/src/utils/buffer/paged/writer.rs
@@ -1214,11 +1214,8 @@ impl<B: Blob> Writer<B> {
                 .await;
         }
 
-        // Finish a page-aligned shrink, which needs no CRC-slot rewrite. Sync the truncation
-        // before the freed range can be reused: a later append rewrites those pages, and a
-        // crash that dropped an unsynced truncation while keeping some of the rewritten pages
-        // would stitch them together with the pre-shrink pages still on disk into a
-        // checksum-valid sequence that was never written.
+        // A page-aligned shrink has no CRC-slot rewrite to persist the truncation. Sync before
+        // reuse so a crash cannot join new pages with an old suffix into a checksum-valid history.
         self.sync_state.sync(&self.blob).await?;
         self.partial_page_state = None;
         self.durable_page_state = None;
@@ -5564,15 +5561,15 @@ mod tests {
             append.append(&data).await.unwrap();
             append.sync().await.unwrap();
 
-            // Shrinking to a page boundary resizes the blob but does not rewrite CRC metadata.
-            // The shrink itself makes the resize durable with a full sync.
+            // A page-aligned shrink persists the resize with a full sync, without rewriting
+            // CRC metadata
             append.resize(PAGE_SIZE.get() as u64).await.unwrap();
             let (_, writes, full_syncs, range_syncs) = blob.snapshot();
             assert_eq!(writes, 1);
             assert_eq!(full_syncs, 2);
             assert_eq!(range_syncs, 1);
 
-            // Nothing is left for a caller's sync to persist.
+            // A subsequent sync has no remaining work
             append.sync().await.unwrap();
             let (_, writes, full_syncs, range_syncs) = blob.snapshot();
             assert_eq!(writes, 1);

--- a/runtime/src/utils/buffer/paged/writer.rs
+++ b/runtime/src/utils/buffer/paged/writer.rs
@@ -1134,11 +1134,13 @@ impl<B: Blob> Writer<B> {
     /// This truncates the blob to contain only `size` logical bytes. The physical blob size will
     /// be adjusted to include the necessary CRC records for the remaining pages.
     ///
+    /// A shrink, and every byte it retains, is durable when this returns. Growth appends zeros
+    /// that are not durable until the next sync.
+    ///
     /// # Warning
     ///
     /// - Concurrent mutable operations (append, resize) are not supported and will cause data loss.
     /// - Concurrent readers which try to read past the new size during the resize may error.
-    /// - The resize is not guaranteed durable until the next sync.
     pub async fn resize(&mut self, size: u64) -> Result<(), Error> {
         let current_size = self.buffer.size();
         if size == current_size {
@@ -1212,7 +1214,12 @@ impl<B: Blob> Writer<B> {
                 .await;
         }
 
-        // Shrink the blob to a page boundary, which requires no CRC-slot rewrite.
+        // Finish a page-aligned shrink, which needs no CRC-slot rewrite. Sync the truncation
+        // before the freed range can be reused: a later append rewrites those pages, and a
+        // crash that dropped an unsynced truncation while keeping some of the rewritten pages
+        // would stitch them together with the pre-shrink pages still on disk into a
+        // checksum-valid sequence that was never written.
+        self.sync_state.sync(&self.blob).await?;
         self.partial_page_state = None;
         self.durable_page_state = None;
         self.current_page = full_pages;
@@ -5558,10 +5565,15 @@ mod tests {
             append.sync().await.unwrap();
 
             // Shrinking to a page boundary resizes the blob but does not rewrite CRC metadata.
+            // The shrink itself makes the resize durable with a full sync.
             append.resize(PAGE_SIZE.get() as u64).await.unwrap();
-            append.sync().await.unwrap();
+            let (_, writes, full_syncs, range_syncs) = blob.snapshot();
+            assert_eq!(writes, 1);
+            assert_eq!(full_syncs, 2);
+            assert_eq!(range_syncs, 1);
 
-            // Only the resize needs a full sync, no additional writes are emitted by the shrink.
+            // Nothing is left for a caller's sync to persist.
+            append.sync().await.unwrap();
             let (_, writes, full_syncs, range_syncs) = blob.snapshot();
             assert_eq!(writes, 1);
             assert_eq!(full_syncs, 2);

--- a/runtime/src/utils/buffer/write.rs
+++ b/runtime/src/utils/buffer/write.rs
@@ -219,16 +219,14 @@ impl<B: Blob> Write<B> {
     pub async fn resize(&mut self, len: u64) -> Result<(), Error> {
         let shrink = len < self.buffer.size();
 
-        // Flush buffered data to the underlying blob.
-        //
-        // This can only happen if the new size is at least the current size.
+        // Equal-size resizes and growth flush the entire buffer
         if let Some((buf, offset)) = self.buffer.resize(len) {
             self.sync_state
                 .write_at(&self.blob, offset, buf, WriteOptions::default())
                 .await?;
         }
 
-        // A shrink flushes the buffered bytes it retains so one sync below covers them too.
+        // Flush the retained prefix before syncing a shrink
         if shrink && let Some((buf, offset)) = self.buffer.take() {
             self.sync_state
                 .write_at(&self.blob, offset, buf, WriteOptions::default())
@@ -237,9 +235,7 @@ impl<B: Blob> Write<B> {
 
         self.sync_state.resize(&self.blob, len).await?;
 
-        // Sync a truncation before the freed range can be reused: a later write over those
-        // bytes, combined with a crash that dropped the unsynced truncation, would leave the
-        // pre-shrink bytes past the write in place as if they were never truncated.
+        // Persist the truncation before later writes can reuse the discarded range
         if shrink {
             self.sync_state.sync(&self.blob).await?;
         }

--- a/runtime/src/utils/buffer/write.rs
+++ b/runtime/src/utils/buffer/write.rs
@@ -212,19 +212,37 @@ impl<B: Blob> Write<B> {
 
     /// Resize the logical blob to `len`.
     ///
-    /// If buffered data exists and the resize extends beyond current size, buffered data is flushed
-    /// before resizing the underlying blob.
+    /// Buffered data the resize keeps is flushed to the underlying blob before it is resized.
+    ///
+    /// A shrink, and every byte it retains, is durable when this returns. Growth is not durable
+    /// until the next sync.
     pub async fn resize(&mut self, len: u64) -> Result<(), Error> {
+        let shrink = len < self.buffer.size();
+
         // Flush buffered data to the underlying blob.
         //
-        // This can only happen if the new size is greater than the current size.
+        // This can only happen if the new size is at least the current size.
         if let Some((buf, offset)) = self.buffer.resize(len) {
             self.sync_state
                 .write_at(&self.blob, offset, buf, WriteOptions::default())
                 .await?;
         }
 
+        // A shrink flushes the buffered bytes it retains so one sync below covers them too.
+        if shrink && let Some((buf, offset)) = self.buffer.take() {
+            self.sync_state
+                .write_at(&self.blob, offset, buf, WriteOptions::default())
+                .await?;
+        }
+
         self.sync_state.resize(&self.blob, len).await?;
+
+        // Sync a truncation before the freed range can be reused: a later write over those
+        // bytes, combined with a crash that dropped the unsynced truncation, would leave the
+        // pre-shrink bytes past the write in place as if they were never truncated.
+        if shrink {
+            self.sync_state.sync(&self.blob).await?;
+        }
 
         Ok(())
     }

--- a/runtime/src/utils/buffer/write.rs
+++ b/runtime/src/utils/buffer/write.rs
@@ -212,13 +212,10 @@ impl<B: Blob> Write<B> {
 
     /// Resize the logical blob to `len`.
     ///
-    /// Buffered data the resize keeps is flushed to the underlying blob before it is resized.
+    /// Resizing to the current size or larger flushes buffered data to the blob first.
     ///
-    /// A shrink, and every byte it retains, is durable when this returns. Growth is not durable
-    /// until the next sync.
+    /// Call [Self::sync] to make the resize and retained data durable.
     pub async fn resize(&mut self, len: u64) -> Result<(), Error> {
-        let shrink = len < self.buffer.size();
-
         // Equal-size resizes and growth flush the entire buffer
         if let Some((buf, offset)) = self.buffer.resize(len) {
             self.sync_state
@@ -226,20 +223,7 @@ impl<B: Blob> Write<B> {
                 .await?;
         }
 
-        // Flush the retained prefix before syncing a shrink
-        if shrink && let Some((buf, offset)) = self.buffer.take() {
-            self.sync_state
-                .write_at(&self.blob, offset, buf, WriteOptions::default())
-                .await?;
-        }
-
         self.sync_state.resize(&self.blob, len).await?;
-
-        // Persist the truncation before later writes can reuse the discarded range
-        if shrink {
-            self.sync_state.sync(&self.blob).await?;
-        }
-
         Ok(())
     }
 

--- a/storage/conformance.toml
+++ b/storage/conformance.toml
@@ -52,11 +52,11 @@ hash = "13b3e99a8c74b50dc18150194a92306de670b94e6642758feb6d9b6e9881f827"
 
 ["commonware_storage::journal::conformance::StorageConformance<AuthenticatedMmbWorkload>"]
 n_cases = 256
-hash = "74d03c4e36ba59834df32aa131bc6ad659dc55b1dab5e5926b9aa033d0ed821f"
+hash = "2675b86804b50839a5fece0a10a5935bd51dccd5f6d993bd58c75f0b11bc6579"
 
 ["commonware_storage::journal::conformance::StorageConformance<AuthenticatedMmrWorkload>"]
 n_cases = 256
-hash = "9eec5df6e9016f6d3fb2317bc0d1e0a969ee3ef6efa4ee6a04770a1e533116b8"
+hash = "0a4cadc64a4e926952671ff89ae3571c9f7d8e0b89f67c7e298ca166e73c3d24"
 
 ["commonware_storage::journal::conformance::StorageConformance<ContiguousFixedWorkload>"]
 n_cases = 512
@@ -92,11 +92,11 @@ hash = "4078ce1f5e242f8edb1d41575d51e166af620404036124f8094fc74d4b401047"
 
 ["commonware_storage::merkle::conformance::tests::StorageConformance<MmbFullWorkload>"]
 n_cases = 256
-hash = "e1bb3e91b15311352a0696ab40600747292876fcaf3f8e1188d071d603761b7d"
+hash = "f089403c8337467e351c0dec35af803506ca6592d1845f3f58844c44283b8a37"
 
 ["commonware_storage::merkle::conformance::tests::StorageConformance<MmrFullWorkload>"]
 n_cases = 256
-hash = "a6e586229899a2361b90cb2a208953ecaec6b23c98ec356d4a50c57be5eeb645"
+hash = "5ed9d0108c674f2c694183bdd7ce7744b64ec52c3387a3ed050ec4053c53bc13"
 
 ["commonware_storage::merkle::mmr::proof::tests::conformance::CodecConformance<Proof<Family,Sha256Digest>>"]
 n_cases = 65536
@@ -300,67 +300,67 @@ hash = "d6b0f89534be60d85f5754c16574536d84899fce930dfc182ef973475d3078e4"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<AnyMmbOrderedFixedStorage>"]
 n_cases = 64
-hash = "8865dbff79b343e15be6248f7c9b9ecbcee4ce62fc6ce6ad74a10aeba0b037ca"
+hash = "6e6b05817be8df8af9688cdf01d3b6be280908985c3b5e2ce68c572ba19df56b"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<AnyMmbOrderedVariableStorage>"]
 n_cases = 64
-hash = "08fa4a62f53a26a2bdebd93302dcf961aab3f50b11a576239b9e65cfb135a7e0"
+hash = "8289433526d6079ffcd98ddc87cc8904cabb4802e93d974be5a40390fe578a95"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<AnyMmbUnorderedFixedStorage>"]
 n_cases = 64
-hash = "e27ea4efaa3ca3fb1a9bda6e1e4989f6636f9b064aabbbca70dbaab906f0bc01"
+hash = "61cb0470f94f878248f4c12b616f8f8e956f0c18582801e261c7f659f8bf3d35"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<AnyMmbUnorderedVariableStorage>"]
 n_cases = 64
-hash = "4bcfc84a06a52c0a27de3d1bf87ffce490a0fe2150bd5350908c49020c5e820d"
+hash = "d73d3fe2da3651f0fccc54723b6758c399fe73f2360a1c2332b22414622207d6"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<AnyMmrOrderedFixedStorage>"]
 n_cases = 64
-hash = "2c31e793a22f349c713cbe43fae4494ee39b9eb91e7085ee1ba9add1509c1b6b"
+hash = "f066608b66cf252a48fc1d60fd4677df98d1059fdb1624f6ec24265dca47e115"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<AnyMmrOrderedVariableStorage>"]
 n_cases = 64
-hash = "45cb75ee32c6455b2cbefbc9e6c791f782f1992e39713b548c7d61894597a4d8"
+hash = "b8afc94dbc81309e599ddf24d662312631b22c2a072d7d25167f17fb679f7df2"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<AnyMmrUnorderedFixedStorage>"]
 n_cases = 64
-hash = "6ec3a1e38743976cf2132583e80dce3429ea8cc59b8a765a7eb293eaeddb3055"
+hash = "d3f22a74b07362952d46475df6109f3c2b6e5f2e94d43ceeb03ccaba1e326a06"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<AnyMmrUnorderedVariableStorage>"]
 n_cases = 64
-hash = "3025d50d87c472227cc38a59c939454f2c9ca07d5c4b8fe614a9a54d961c3f45"
+hash = "b1912c37b1cf41c4e601f7fbe045134283f31eca6874971d4b5a38b14c4d3b2e"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<CurrentMmbOrderedFixedStorage>"]
 n_cases = 64
-hash = "52203c4160810631e6f8f02697970ed2db6a15be433be848eeb3de311a5ca1ac"
+hash = "c9085a554e9d72b61ee81ca13307af87530786e82eb15a8b5dac85c4991585bb"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<CurrentMmbOrderedVariableStorage>"]
 n_cases = 64
-hash = "9b859e3d42869a0305e538584d914b691fc7a236de01ce3da68093eb26111aba"
+hash = "ebe8728a1ce5059eff49b21000b1265bd762d513ba16ba1f6087e7d754608e69"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<CurrentMmbUnorderedFixedStorage>"]
 n_cases = 64
-hash = "a33d79be75ae3db4f7c8f706cbb9707326adf070cb67ddf673fabcd17afab6eb"
+hash = "a267dedb8fe69dbb9ce05c386b58f765f9a3a0756e2e81ded36db9c38ab570da"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<CurrentMmbUnorderedVariableStorage>"]
 n_cases = 64
-hash = "244811c362aa673e3f573f233b58c379671c64c26784acbb49343a3144fb90b0"
+hash = "4401b37287f55252580d7aaa88d1e058ffa90cd1b2fc577064b006cbcb5f3cb2"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<CurrentMmrOrderedFixedStorage>"]
 n_cases = 64
-hash = "abb6e4b1281d59e7fb5a223bc906c1989b3fd652533c2f94bea14c1b8cf4de08"
+hash = "238192bc26358e23c7e1c305a8a4c6c0e3c5349da5b26612401b90557a3d6e61"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<CurrentMmrOrderedVariableStorage>"]
 n_cases = 64
-hash = "f2f7bd0129408519e54778487759de2e8ea7dedc239229cf389529f5e1621179"
+hash = "b417c1fa2e6627dca728992889c5422802034233e79a590228b8d086861c4baa"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<CurrentMmrUnorderedFixedStorage>"]
 n_cases = 64
-hash = "7bf844eb896054ec13e2912e53c26f464fa56ac7431e1f7200cd6a8a4dcec944"
+hash = "372705b830a3ef4f47c064e75f9616de11121af9aab0f44fd0019f952acbe770"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<CurrentMmrUnorderedVariableStorage>"]
 n_cases = 64
-hash = "02d3fa9305fed943c9ade46fe6c6e9eba9c06621aa120f02bbd79b3f81589540"
+hash = "e56bda477ffe0801da7c3a3c88cda394274d3151c10e55de8904be44d489e80c"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<ImmutableMmbCompactFixedStorage>"]
 n_cases = 64
@@ -372,11 +372,11 @@ hash = "dd8ad8b953f1c44c056e4a5e1b4341ebcbc0160e9b26eceea13235bbf6e31352"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<ImmutableMmbFixedStorage>"]
 n_cases = 64
-hash = "312105a085f950c933da73418c5bb1e7595247d27e52a2c3c7589ac4db75cdeb"
+hash = "fa5e1d683dfafb12871ea88ca37e71c82a3f86f24b00558e13a7e1492ca3c7d3"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<ImmutableMmbVariableStorage>"]
 n_cases = 64
-hash = "83a12aee531340131135b182651b53de86325e71122796be29b6b9708acfdaa9"
+hash = "6741c07032cfc7a69b7ee258c63dc5f7534689b7234996410c97ba706c4f1b3c"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<ImmutableMmrCompactFixedStorage>"]
 n_cases = 64
@@ -388,11 +388,11 @@ hash = "af8dc663527f741d06688ff0793bc17f0161f3082b642e5b272b0745da843202"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<ImmutableMmrFixedStorage>"]
 n_cases = 64
-hash = "3cf7ae2e5798fc7c78699f59c835552b49ee8b4355f4e8d49cd9659ba20bfd21"
+hash = "ff9b98f5da3e7e6f80024f467c3eb963f7a3edcddf204456235a9b4b40fc4b22"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<ImmutableMmrVariableStorage>"]
 n_cases = 64
-hash = "9f48c1fa5f420774726c6271f3f1180ab293c5fdb39cfd3e7e1c3be3551d57fe"
+hash = "e43469bd257e12717438ef52719d2167640ee852baf81bcd297a21feab46bbd9"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<KeylessMmbCompactFixedStorage>"]
 n_cases = 64
@@ -404,11 +404,11 @@ hash = "c9abedeb9fc50df256226e1c8be766d4618aaa245465dfdcaa67e8c149ed70c4"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<KeylessMmbFixedStorage>"]
 n_cases = 64
-hash = "46bb0f05abd856a34be672ee5ef1a319a1fc4bc724d9f45439b4490d43e071b8"
+hash = "9b468f333c830d1af726848aef4ec32fb29697c7669b69364f1461eafda18298"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<KeylessMmbVariableStorage>"]
 n_cases = 64
-hash = "98f24f75150d38e7c7151887dc0deb4ad5eb1190d1790ba304aaf78141e970f8"
+hash = "345d066c7b665045b066fce96764bd41b8c4e6d5acfc3883cc42d813ad1fbf41"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<KeylessMmrCompactFixedStorage>"]
 n_cases = 64
@@ -420,11 +420,11 @@ hash = "68df6042dc1de7d1d96e70b4da71c723f210328f1b360988d5cade2ee1b38ffc"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<KeylessMmrFixedStorage>"]
 n_cases = 64
-hash = "182b01f2749b189e6a4c14c3a5c10e1c06600c6aedf01496c119cd01fbd5ba0e"
+hash = "d3923382e525ff5fe2cefa96993738fb3b3b8eba2b0085eed5565fbfc5dba3f1"
 
 ["commonware_storage::qmdb::conformance::tests::StorageConformance<KeylessMmrVariableStorage>"]
 n_cases = 64
-hash = "a023b1399b8656e8e113787f935d10013606440d43c8cb7c818749f6f09fc2fd"
+hash = "83ffdcf25e37272bcf38d9aba3f5e596b74e8e43fcbfcba1985eb0468f4d78d4"
 
 ["commonware_storage::qmdb::current::ordered::tests::conformance::CodecConformance<ExclusionProof<mmb::Family,U64,FixedEncoding<U64>\n,Sha256Digest,32>>"]
 n_cases = 65536

--- a/storage/fuzz/fuzz_targets/journal_contiguous_recovery.rs
+++ b/storage/fuzz/fuzz_targets/journal_contiguous_recovery.rs
@@ -285,8 +285,7 @@ impl Expected {
         self.durable_prune = bounds.start;
         self.max_prune = bounds.start;
 
-        // The barrier pins every recorded value exactly, so no failed-append alternate remains
-        // admissible.
+        // The barrier pins recorded values exactly, ruling out failed-append alternatives
         self.candidates.clear();
     }
 
@@ -296,13 +295,11 @@ impl Expected {
         self.durable_len = size;
         self.max_size = size;
 
-        // The barrier pins every recorded value exactly, so no failed-append alternate remains
-        // admissible.
+        // The barrier pins recorded values exactly, ruling out failed-append alternatives
         self.candidates.clear();
     }
 
-    /// Successful rewind: the truncation is durable when `rewind` returns, so the recovered size
-    /// is at most `target` until later appends raise it, and no truncated value can resurface.
+    /// A successful rewind durably caps recovery at `target` until later appends.
     fn rewound(&mut self, target: u64) {
         self.durable_len = self.durable_len.min(target);
         self.max_size = target;

--- a/storage/fuzz/fuzz_targets/journal_contiguous_recovery.rs
+++ b/storage/fuzz/fuzz_targets/journal_contiguous_recovery.rs
@@ -285,8 +285,8 @@ impl Expected {
         self.durable_prune = bounds.start;
         self.max_prune = bounds.start;
 
-        // The barrier makes prior truncations durable and every recorded value exact, so no
-        // alternate values remain admissible.
+        // The barrier pins every recorded value exactly, so no failed-append alternate remains
+        // admissible.
         self.candidates.clear();
     }
 
@@ -296,8 +296,8 @@ impl Expected {
         self.durable_len = size;
         self.max_size = size;
 
-        // The barrier makes prior truncations durable and every recorded value exact, so no
-        // alternate values remain admissible.
+        // The barrier pins every recorded value exactly, so no failed-append alternate remains
+        // admissible.
         self.candidates.clear();
     }
 

--- a/storage/fuzz/fuzz_targets/journal_contiguous_recovery.rs
+++ b/storage/fuzz/fuzz_targets/journal_contiguous_recovery.rs
@@ -32,10 +32,11 @@
 //!
 //! A crash can land anywhere in a range, so `Expected` tracks conservative bounds (a
 //! guaranteed-durable prefix plus size/pruning ceilings), not an exact state. Retained positions
-//! above the durable prefix are still content-checked: every readable frame is CRC-gated and
-//! composed of old or new bytes only, so a recovered item must be one of the values recorded at
-//! that position (see `candidates`). `assert_matches_expected` checks recovery falls within
-//! them. `to_expected` then snapshots it as the next cycle's start.
+//! above the durable prefix are still content-checked: every readable frame is CRC-gated, and a
+//! rewind's truncation is durable before an append can reuse its range, so a recovered item must
+//! be the latest value appended at that position or a failed append that persisted (see
+//! `candidates`). `assert_matches_expected` checks recovery falls within them. `to_expected`
+//! then snapshots it as the next cycle's start.
 //!
 //! # Faults
 //!
@@ -244,9 +245,8 @@ struct Expected {
     max_prune: u64,
     /// Latest value appended at each position (index == position).
     values: Vec<Item>,
-    /// Alternate values a crash may legally retain at a position: values displaced by a rewind
-    /// whose truncation is not yet durable, and values whose append failed after possibly
-    /// persisting. Cleared by every barrier that pins content exactly.
+    /// Alternate values a crash may legally retain at a position: values whose append failed
+    /// after possibly persisting. Cleared by every barrier that pins content exactly.
     candidates: HashMap<u64, Vec<Item>>,
 }
 
@@ -301,21 +301,15 @@ impl Expected {
         self.candidates.clear();
     }
 
-    /// Successful rewind: the truncated tail may or may not persist, so recovered size is in
-    /// `[target, prev]`. Until a durability barrier a crash can resurface the pre-rewind bytes,
-    /// so each truncated value stays admissible at the position it held.
-    fn rewound(&mut self, target: u64, prev_size: u64) {
+    /// Successful rewind: the truncation is durable when `rewind` returns, so the recovered size
+    /// is at most `target` until later appends raise it, and no truncated value can resurface.
+    fn rewound(&mut self, target: u64) {
         self.durable_len = self.durable_len.min(target);
-        self.max_size = self.max_size.max(prev_size);
-        for (offset, item) in self.values.drain(target as usize..).enumerate() {
-            self.candidates
-                .entry(target + offset as u64)
-                .or_default()
-                .push(item);
-        }
+        self.max_size = target;
+        self.values.truncate(target as usize);
     }
 
-    /// Failed rewind: like a successful one it may or may not have truncated, but no value was
+    /// Failed rewind: the truncation may or may not have become durable, but no value was
     /// recorded afterward (the cycle ends), so surviving positions keep their exact content.
     fn rewind_failed(&mut self, target: u64, prev_size: u64) {
         self.durable_len = self.durable_len.min(target);
@@ -591,8 +585,7 @@ async fn assert_matches_expected<J: FuzzJournal>(journal: &J, expected: &Expecte
 
     // Within [boundary, size) every position is readable. The durable prefix must hold exactly
     // the recorded content. Every retained position above it must hold a value the run actually
-    // wrote there: the latest recorded append, or an alternate the crash may legally surface (a
-    // value displaced by a non-durable rewind, or a failed append that persisted). Items are
+    // wrote there: the latest recorded append, or a failed append that persisted. Items are
     // saved for the replay cross-check below.
     let mut read_items = Vec::with_capacity((size - boundary) as usize);
     for pos in boundary..size {
@@ -815,7 +808,7 @@ async fn run_ops<J: FuzzJournal>(
                     };
                     match journal.rewind(target).await {
                         Ok(journal) => {
-                            expected.rewound(target, bounds.end);
+                            expected.rewound(target);
                             journal
                         }
                         // Any error ends the cycle. Validation errors reject before

--- a/storage/fuzz/fuzz_targets/journal_oversized_recovery.rs
+++ b/storage/fuzz/fuzz_targets/journal_oversized_recovery.rs
@@ -5,9 +5,9 @@
 //!
 //! The oracle derives each section's retained prefix from the raw crash image (see
 //! `recover_expected` for the per-mode rules and marker-floor invariants). It asserts that
-//! entries covered by a completed sync survive, that recovery removes orphan value sections
-//! and truncates each value glob to the last retained entry, that a second recovery mutates
-//! nothing, and that sentinel appends land at the repaired tail and reopen intact.
+//! entries covered by a completed sync or rewind survive, that recovery removes orphan value
+//! sections and truncates each value glob to the last retained entry, that a second recovery
+//! mutates nothing, and that sentinel appends land at the repaired tail and reopen intact.
 
 use arbitrary::Arbitrary;
 use commonware_codec::{DecodeExt as _, FixedSize, Read, ReadExt as _, Write};
@@ -123,7 +123,8 @@ struct FuzzInput {
     routes: [u8; 24],
     /// Per-entry action applied after its append: pipeline a sync of its section, release one
     /// held completion, settle everything held, sync one section, or sync everything. Tracked
-    /// mode adds an empty flush that publishes marker debt, a prune, and a section rewind.
+    /// mode adds an empty flush that publishes marker debt, a prune, and section or global
+    /// rewinds, including to the current size.
     /// These ops complete before the fault window opens, so the marker-before-data ordering
     /// inside rewind is not falsifiable here. Prune's ordering is made falsifiable by the
     /// interrupted-prune final op and by the remove faults armed around every prune.
@@ -571,29 +572,36 @@ fn fuzz(input: FuzzInput) {
                                 }
                             }
                         } else {
-                            // Rewind one live section below its current length: its tracked floor
-                            // durably lowers before the freed index and value ranges can be reused.
+                            // Rewind a live section, optionally removing later sections. Retained
+                            // records become durable even when the target size already matches
                             let live: Vec<u64> = counts.keys().copied().collect();
                             if let Some(&section) =
                                 live.get(usize::from(op >> 4) % live.len().max(1))
                             {
                                 let count = counts[&section];
-                                let keep = count * u64::from(op >> 6) / 4;
-                                oversized = drive_pending_syncs(
-                                    &pending,
-                                    oversized
-                                        .rewind_section(section, keep * TestEntry::SIZE as u64),
-                                )
+                                let keep = count * u64::from(op >> 6) / 3;
+                                let remove_later = op & 0x20 != 0;
+                                oversized = drive_pending_syncs(&pending, async move {
+                                    let size = keep * TestEntry::SIZE as u64;
+                                    if remove_later {
+                                        oversized.rewind(section, size).await
+                                    } else {
+                                        oversized.rewind_section(section, size).await
+                                    }
+                                })
                                 .await
                                 .expect("rewind failed");
+                                if remove_later {
+                                    counts.retain(|&candidate, _| candidate <= section);
+                                    model.retain(|&candidate, _| candidate <= section);
+                                    durable.retain(|&candidate, _| candidate <= section);
+                                }
                                 counts.insert(section, keep);
                                 model
                                     .get_mut(&section)
                                     .expect("rewound section is modeled")
                                     .truncate(keep as usize);
-                                if let Some(durable) = durable.get_mut(&section) {
-                                    *durable = (*durable).min(keep);
-                                }
+                                durable.insert(section, keep);
                             }
                         }
                     }
@@ -778,13 +786,13 @@ fn fuzz(input: FuzzInput) {
                     .expect("recovery failed")
             };
 
-            // Entries covered by a completed sync must survive, and a crash that retained every
-            // faulted byte after flushing everything loses nothing at all.
+            // Entries covered by a completed sync or rewind must survive, and a crash that
+            // retained every faulted byte after flushing everything loses nothing at all
             for (section, &count) in &durable {
                 let retained = expected.get(section).map_or(0, Vec::len) as u64;
                 assert!(
                     retained >= count,
-                    "section {section} lost entries covered by a completed sync"
+                    "section {section} lost entries covered by a completed sync or rewind"
                 );
             }
             if retention_percent == 100 && flushed_all {

--- a/storage/fuzz/fuzz_targets/journal_oversized_recovery.rs
+++ b/storage/fuzz/fuzz_targets/journal_oversized_recovery.rs
@@ -124,10 +124,10 @@ struct FuzzInput {
     /// Per-entry action applied after its append: pipeline a sync of its section, release one
     /// held completion, settle everything held, sync one section, or sync everything. Tracked
     /// mode adds an empty flush that publishes marker debt, a prune, and section or global
-    /// rewinds, including to the current size.
-    /// These ops complete before the fault window opens, so the marker-before-data ordering
-    /// inside rewind is not falsifiable here. Prune's ordering is made falsifiable by the
-    /// interrupted-prune final op and by the remove faults armed around every prune.
+    /// rewinds, including to the current size. These ops complete before the fault window
+    /// opens, so the marker-before-data ordering inside rewind is not falsifiable here. Prune's
+    /// ordering is made falsifiable by the interrupted-prune final op and by the remove faults
+    /// armed around every prune.
     ops: [u8; 24],
     /// Shape of the faulted crash: flush everything then abandon the requests (also the
     /// fallback for the prune arm when untracked), interrupt a blocking sync of every

--- a/storage/src/journal/authenticated.rs
+++ b/storage/src/journal/authenticated.rs
@@ -581,8 +581,7 @@ where
 
     /// Rewind the journal and Merkle structure to `size` items.
     ///
-    /// The rewind is durable before this method returns, so no item above `size` can survive a
-    /// crash and be paired with the leaves of a later history appended at the same locations.
+    /// The truncation of both structures is durable when this returns.
     #[boxed]
     pub async fn rewind(mut self, size: u64) -> Result<Self, Error<F>> {
         self.journal = self.journal.rewind(size).await?;

--- a/storage/src/journal/authenticated.rs
+++ b/storage/src/journal/authenticated.rs
@@ -579,7 +579,10 @@ where
         Ok(self)
     }
 
-    /// Rewind the journal and Merkle structure.
+    /// Rewind the journal and Merkle structure to `size` items.
+    ///
+    /// The rewind is durable before this method returns, so no item above `size` can survive a
+    /// crash and be paired with the leaves of a later history appended at the same locations.
     #[boxed]
     pub async fn rewind(mut self, size: u64) -> Result<Self, Error<F>> {
         self.journal = self.journal.rewind(size).await?;

--- a/storage/src/journal/contiguous/checkpoint.rs
+++ b/storage/src/journal/contiguous/checkpoint.rs
@@ -9,9 +9,7 @@
 //!   [Journal::init_at_size](super::fixed::Journal::init_at_size)): recovery needs the exact
 //!   position where the oldest blob's items begin.
 //! - The recovery watermark: a floor on the journal size that has been durably recorded. Items
-//!   below the watermark must survive a crash; items above it may be replayed, discarded, or (after
-//!   an in-place rewind followed by new appends) decode to a value from neither the pre- nor
-//!   post-rewind history.
+//!   below the watermark must survive a crash. Items above it may be replayed or discarded.
 //! - The clear target, while a clear/reset is in progress: the target is recorded before any
 //!   blob is deleted, so a crash mid-clear is finished on reopen instead of being misread as
 //!   corruption.

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -510,7 +510,6 @@ impl<E: Context, A: CodecFixedShared> Inner<E, A> {
                 "truncating to recoverable item prefix"
             );
             writer.resize(valid).await?;
-            writer.sync().await?;
         }
 
         let RecoveredBounds {
@@ -534,9 +533,9 @@ impl<E: Context, A: CodecFixedShared> Inner<E, A> {
             )
             .await?;
 
-        // Apply repair (if any). The short blob becomes the new tail; blobs strictly newer
-        // than it are removed (newest-first) and the truncation is synced, so the repair is
-        // durable before sealing.
+        // Apply repair (if any). The short blob becomes the new tail. Blobs strictly newer
+        // than it are removed (newest-first) and the truncation is durable when `resize`
+        // returns, so the repair is durable before sealing.
         let tail_blob = super::position_to_blob(size, cfg.items_per_blob.get());
         if let Some(truncate_to) = repair {
             while let Some((&newest, _)) = pending.last_key_value() {
@@ -550,7 +549,6 @@ impl<E: Context, A: CodecFixedShared> Inner<E, A> {
                 && truncate_to < writer.size()
             {
                 writer.resize(truncate_to).await?;
-                writer.sync().await?;
             }
         }
 
@@ -2972,6 +2970,95 @@ mod tests {
                 "stale blobs beyond the repair point should be removed"
             );
 
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    /// The truncation a recovery repair applies to a short non-tail blob survives a crash that
+    /// follows the repair without any sync: the repaired blob reopens at the repaired size.
+    #[test_traced]
+    fn test_fixed_journal_repair_truncation_survives_crash() {
+        // A 64-byte page makes the four-item repair target page aligned, the shape a crash can
+        // lose when the shrink is not synced.
+        const PAGE_SIZE: NonZeroU16 = NZU16!(64);
+        const REPAIRED: u64 = 4 * Digest::SIZE as u64;
+        fn cfg(pooler: &impl BufferPooler) -> Config {
+            Config {
+                partition: "repair-truncation-crash".into(),
+                items_per_blob: NZU64!(5),
+                page_cache: CacheRef::from_pooler(pooler, PAGE_SIZE, PAGE_CACHE_SIZE),
+                write_buffer: NZUsize!(2048),
+                replay_buffer: NZUsize!(2048),
+            }
+        }
+
+        let executor = deterministic::Runner::default();
+        let (_, checkpoint) = executor.start_and_recover(|context| async move {
+            let cfg = cfg(&context);
+            let mut journal = Journal::<_, Digest>::init(context.child("first"), cfg.clone())
+                .await
+                .unwrap();
+            for i in 0..15u64 {
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
+            }
+            let mut journal = journal.sync().await.unwrap();
+
+            // Lower the watermark to what the repair will recover, as a crash between the
+            // checkpoint persist and the repair would leave it.
+            journal.0.checkpoint = journal
+                .0
+                .checkpoint
+                .persist(cfg.items_per_blob.get(), 0, 9)
+                .await
+                .unwrap();
+            drop(journal);
+
+            // Leave blob 1 with four items and a valid 10-byte prefix of a fifth, so recovery
+            // repairs it to four.
+            {
+                let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE);
+                let (blob, blob_size) = context
+                    .open(&blob_partition(&cfg), &1u64.to_be_bytes())
+                    .await
+                    .unwrap();
+                let mut writer = Writer::new(blob, blob_size, 2048, cache_ref).await.unwrap();
+                writer.resize(REPAIRED + 10).await.unwrap();
+                writer.sync().await.unwrap();
+            }
+
+            // Pin the crash policy: unsynced resizes are dropped, so the repair's truncation
+            // survives the crash only if the repair synced it.
+            *context.storage_fault_config().write() = deterministic::FaultConfig {
+                resize_rate: Some(deterministic::ResizeConfig {
+                    failure_rate: probability!(0.0),
+                    partial_rate: probability!(0.0),
+                }),
+                ..Default::default()
+            };
+            let journal = Journal::<_, Digest>::init(context.child("repair"), cfg)
+                .await
+                .unwrap();
+            assert_eq!(journal.bounds(), 0..9);
+            drop(journal);
+        });
+
+        deterministic::Runner::from(checkpoint).start(|context| async move {
+            *context.storage_fault_config().write() = deterministic::FaultConfig::default();
+            let cfg = cfg(&context);
+            {
+                let cache_ref = CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE);
+                let (blob, blob_size) = context
+                    .open(&blob_partition(&cfg), &1u64.to_be_bytes())
+                    .await
+                    .unwrap();
+                let writer = Writer::new(blob, blob_size, 2048, cache_ref).await.unwrap();
+                assert_eq!(writer.size(), REPAIRED, "repair truncation did not survive");
+            }
+            let journal = Journal::<_, Digest>::init(context.child("recover"), cfg)
+                .await
+                .unwrap();
+            assert_eq!(journal.bounds(), 0..9);
+            assert_eq!(journal.test_newest_blob(), Some(1));
             journal.destroy().await.unwrap();
         });
     }

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -1335,10 +1335,13 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
     /// Returns [Error::InvalidRewind] if `size` is larger than current size.
     /// Returns [Error::ItemPruned] if `size` is smaller than the pruning boundary.
     ///
+    /// # Durability
+    ///
+    /// The truncation is durable when this returns. Items appended afterward are not durable
+    /// until `commit` or `sync`.
+    ///
     /// # Warnings
     ///
-    /// * The truncation is durable when this returns. Items appended afterward are not durable
-    ///   until `commit` or `sync`.
     /// * This operation is not atomic. Its on-disk updates are ordered (blobs removed
     ///   newest-to-oldest) so that restart recovery always rebuilds a contiguous retained prefix.
     /// * Readers returned by [`snapshot`](Self::snapshot) may observe unspecified contents if this

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -85,9 +85,6 @@
 //! The recovery watermark is therefore an external recovery checkpoint, not a complete record of
 //! every item that may have become durable through `commit` or storage behavior.
 //!
-//! A rewind's truncation is durable before `rewind` returns, so recovery never stitches bytes
-//! appended afterward onto the pre-rewind bytes they replaced.
-//!
 //! # Watermark advancement
 //!
 //! The watermark must never exceed what is durably on disk. `sync()` completes its data sync
@@ -533,9 +530,8 @@ impl<E: Context, A: CodecFixedShared> Inner<E, A> {
             )
             .await?;
 
-        // Apply repair (if any). The short blob becomes the new tail. Blobs strictly newer
-        // than it are removed (newest-first) and the truncation is durable when `resize`
-        // returns, so the repair is durable before sealing.
+        // Make the short blob the new tail, removing newer blobs newest-first. Its resize
+        // makes the repair durable before sealing.
         let tail_blob = super::position_to_blob(size, cfg.items_per_blob.get());
         if let Some(truncate_to) = repair {
             while let Some((&newest, _)) = pending.last_key_value() {
@@ -2977,12 +2973,11 @@ mod tests {
         });
     }
 
-    /// The truncation a recovery repair applies to a short non-tail blob survives a crash that
-    /// follows the repair without any sync: the repaired blob reopens at the repaired size.
+    /// Repair a short non-tail blob, then crash without another sync.
+    /// The repaired blob must reopen at the truncated size.
     #[test_traced]
     fn test_fixed_journal_repair_truncation_survives_crash() {
-        // A 64-byte page makes the four-item repair target page aligned, the shape a crash can
-        // lose when the shrink is not synced.
+        // A 64-byte page makes the four-item repair target page aligned
         const PAGE_SIZE: NonZeroU16 = NZU16!(64);
         const REPAIRED: u64 = 4 * Digest::SIZE as u64;
         fn cfg(pooler: &impl BufferPooler) -> Config {
@@ -3029,8 +3024,7 @@ mod tests {
                 writer.sync().await.unwrap();
             }
 
-            // Pin the crash policy: unsynced resizes are dropped, so the repair's truncation
-            // survives the crash only if the repair synced it.
+            // Drop unsynced resizes at the crash
             *context.storage_fault_config().write() = deterministic::FaultConfig {
                 resize_rate: Some(deterministic::ResizeConfig {
                     failure_rate: probability!(0.0),
@@ -5594,11 +5588,8 @@ mod tests {
         });
     }
 
-    /// A rewind's truncation survives a crash even when a later unsynced append reuses the freed
-    /// range. A crash that dropped an unsynced truncation while keeping the append's pages would
-    /// otherwise stitch those pages onto the pre-rewind bytes still on disk. Here the page-aligned
-    /// bulk write of two re-appended items ends inside the second item, so the pre-rewind history
-    /// would supply that item's remaining bytes and resurrect the third item behind it.
+    /// Rewind and append two replacements, then crash with the second only partly written.
+    /// Old bytes must neither complete it nor restore the discarded tail.
     #[test_traced]
     fn test_fixed_journal_rewind_truncation_survives_crash() {
         // A 24-byte page splits 32-byte digests across pages, and the two-page write buffer
@@ -5625,8 +5616,7 @@ mod tests {
             }
             let journal = journal.sync().await.unwrap();
 
-            // The crash keeps every unsynced write and drops every unsynced resize, so the
-            // truncation survives it only if `rewind` synced it.
+            // Keep unsynced writes and drop unsynced resizes at the crash
             *context.storage_fault_config().write() = deterministic::FaultConfig {
                 write_rate: Some(deterministic::WriteConfig {
                     failure_rate: probability!(0.0),

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -85,6 +85,9 @@
 //! The recovery watermark is therefore an external recovery checkpoint, not a complete record of
 //! every item that may have become durable through `commit` or storage behavior.
 //!
+//! A rewind's truncation is durable before `rewind` returns, so recovery never stitches bytes
+//! appended afterward onto the pre-rewind bytes they replaced.
+//!
 //! # Watermark advancement
 //!
 //! The watermark must never exceed what is durably on disk. `sync()` completes its data sync
@@ -1336,7 +1339,8 @@ impl<E: Context, A: CodecFixedShared> Journal<E, A> {
     ///
     /// # Warnings
     ///
-    /// * This operation is not guaranteed to survive restarts until `commit` or `sync` is called.
+    /// * The truncation is durable when this returns. Items appended afterward are not durable
+    ///   until `commit` or `sync`.
     /// * This operation is not atomic. Its on-disk updates are ordered (blobs removed
     ///   newest-to-oldest) so that restart recovery always rebuilds a contiguous retained prefix.
     /// * Readers returned by [`snapshot`](Self::snapshot) may observe unspecified contents if this
@@ -5496,6 +5500,74 @@ mod tests {
             for i in 3..8u64 {
                 assert_eq!(journal.read(i).await.unwrap(), test_digest(i));
             }
+            journal.destroy().await.unwrap();
+        });
+    }
+
+    /// A rewind's truncation survives a crash even when a later unsynced append reuses the freed
+    /// range. A crash that dropped an unsynced truncation while keeping the append's pages would
+    /// otherwise stitch those pages onto the pre-rewind bytes still on disk. Here the page-aligned
+    /// bulk write of two re-appended items ends inside the second item, so the pre-rewind history
+    /// would supply that item's remaining bytes and resurrect the third item behind it.
+    #[test_traced]
+    fn test_fixed_journal_rewind_truncation_survives_crash() {
+        // A 24-byte page splits 32-byte digests across pages, and the two-page write buffer
+        // floor sends a two-item append down the direct path: two full pages are written and
+        // the 16-byte suffix stays buffered.
+        const PAGE_SIZE: NonZeroU16 = NZU16!(24);
+        fn cfg(pooler: &impl BufferPooler) -> Config {
+            Config {
+                partition: "rewind-truncation-crash".into(),
+                items_per_blob: NZU64!(10),
+                page_cache: CacheRef::from_pooler(pooler, PAGE_SIZE, PAGE_CACHE_SIZE),
+                write_buffer: NZUsize!(1),
+                replay_buffer: NZUsize!(2048),
+            }
+        }
+
+        let executor = deterministic::Runner::default();
+        let (_, checkpoint) = executor.start_and_recover(|context| async move {
+            let mut journal = Journal::<_, Digest>::init(context.child("first"), cfg(&context))
+                .await
+                .unwrap();
+            for i in 0..3u64 {
+                (journal, _) = journal.append(&test_digest(i)).await.unwrap();
+            }
+            let journal = journal.sync().await.unwrap();
+
+            // The crash keeps every unsynced write and drops every unsynced resize, so the
+            // truncation survives it only if `rewind` synced it.
+            *context.storage_fault_config().write() = deterministic::FaultConfig {
+                write_rate: Some(deterministic::WriteConfig {
+                    failure_rate: probability!(0.0),
+                    retention_rate: probability!(1.0),
+                    mode: deterministic::PartialWriteMode::Prefix,
+                }),
+                resize_rate: Some(deterministic::ResizeConfig {
+                    failure_rate: probability!(0.0),
+                    partial_rate: probability!(0.0),
+                }),
+                ..Default::default()
+            };
+            let journal = journal.rewind(0).await.unwrap();
+            let (journal, _) = journal
+                .append_many(Many::Flat(&[test_digest(10), test_digest(11)]))
+                .await
+                .unwrap();
+            drop(journal);
+        });
+
+        deterministic::Runner::from(checkpoint).start(|context| async move {
+            *context.storage_fault_config().write() = deterministic::FaultConfig::default();
+            let journal = Journal::<_, Digest>::init(context.child("recover"), cfg(&context))
+                .await
+                .unwrap();
+            assert_eq!(
+                journal.bounds(),
+                0..1,
+                "pre-rewind bytes survived the rewind"
+            );
+            assert_eq!(journal.read(0).await.unwrap(), test_digest(10));
             journal.destroy().await.unwrap();
         });
     }

--- a/storage/src/journal/contiguous/mod.rs
+++ b/storage/src/journal/contiguous/mod.rs
@@ -291,10 +291,10 @@ pub trait Mutable: Contiguous + Sized {
     /// - This operation is not atomic, but implementations guarantee the journal is left in a
     ///   recoverable state if a crash occurs during rewinding
     ///
-    /// # Warnings
+    /// # Durability
     ///
-    /// - This operation is not guaranteed to survive restarts until the next commit or sync
-    ///   completes.
+    /// - The truncation is durable when this returns. Items appended afterward are not durable
+    ///   until the next commit or sync completes.
     ///
     /// # Errors
     ///
@@ -340,10 +340,9 @@ pub trait Mutable: Contiguous + Sized {
     /// size. If no item matches, the journal is rewound to the pruning boundary, discarding
     /// all unpruned items.
     ///
-    /// # Warnings
+    /// # Durability
     ///
-    /// - This operation is not guaranteed to survive restarts until the next commit or sync
-    ///   completes.
+    /// - The rewind, if any, is durable when this returns.
     fn rewind_to<P>(
         mut self,
         predicate: P,

--- a/storage/src/journal/contiguous/mod.rs
+++ b/storage/src/journal/contiguous/mod.rs
@@ -293,8 +293,8 @@ pub trait Mutable: Contiguous + Sized {
     ///
     /// # Durability
     ///
-    /// - The truncation is durable when this returns. Items appended afterward are not durable
-    ///   until the next commit or sync completes.
+    /// The truncation is durable when this returns. Items appended afterward are not durable
+    /// until the next commit or sync completes.
     ///
     /// # Errors
     ///
@@ -342,7 +342,7 @@ pub trait Mutable: Contiguous + Sized {
     ///
     /// # Durability
     ///
-    /// - The rewind, if any, is durable when this returns.
+    /// The rewind, if any, is durable when this returns.
     fn rewind_to<P>(
         mut self,
         predicate: P,

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -2231,10 +2231,14 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
     ///
     /// Returns [Error::InvalidRewind] if `size` is larger than current size.
     /// Returns [Error::ItemPruned] if `size` is smaller than the pruning boundary.
+    ///
+    /// # Durability
+    ///
+    /// The truncation is durable when this returns. Items appended afterward are not durable
+    /// until `commit` or `sync`.
+    ///
     /// # Warning
     ///
-    /// - The truncation is durable when this returns. Items appended afterward are not durable
-    ///   until `commit` or `sync`.
     /// - Readers returned by [`snapshot`](Self::snapshot) may observe unspecified contents if this
     ///   rewind truncates into their range.
     pub async fn rewind(mut self, size: u64) -> Result<Self, Error> {

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -1119,7 +1119,6 @@ impl<E: Context, V: CodecShared> Inner<E, V> {
             }
             warn!(blob, valid, size, "truncating to last well-formed page");
             writer.resize(valid).await?;
-            writer.sync().await?;
         }
 
         // Validate and align the offsets journal to match the data blobs.
@@ -1722,7 +1721,6 @@ impl<E: Context, V: CodecShared> Inner<E, V> {
                     "crash repair: truncating trailing bytes"
                 );
                 writer.resize(scan.valid_size).await?;
-                writer.sync().await?;
             }
             if scan.items > 0 {
                 items_in_newest = scan.items;
@@ -2071,7 +2069,6 @@ impl<E: Context, V: CodecShared> Inner<E, V> {
                         "crash repair: truncating trailing bytes"
                     );
                     writer.resize(valid_size).await?;
-                    writer.sync().await?;
                 }
                 // A short blob ends the contiguous data-backed prefix: any newer blobs are
                 // unreachable and removed.

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -2239,8 +2239,8 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
     ///
     /// # Warning
     ///
-    /// - Readers returned by [`snapshot`](Self::snapshot) may observe unspecified contents if this
-    ///   rewind truncates into their range.
+    /// Readers returned by [`snapshot`](Self::snapshot) may observe unspecified contents if this
+    /// rewind truncates into their range.
     pub async fn rewind(mut self, size: u64) -> Result<Self, Error> {
         self.0 = self.0.rewind(size).await?;
         Ok(self)

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -2236,7 +2236,8 @@ impl<E: Context, V: CodecShared> Journal<E, V> {
     /// Returns [Error::ItemPruned] if `size` is smaller than the pruning boundary.
     /// # Warning
     ///
-    /// - This operation is not guaranteed to survive restarts until `commit` or `sync` is called.
+    /// - The truncation is durable when this returns. Items appended afterward are not durable
+    ///   until `commit` or `sync`.
     /// - Readers returned by [`snapshot`](Self::snapshot) may observe unspecified contents if this
     ///   rewind truncates into their range.
     pub async fn rewind(mut self, size: u64) -> Result<Self, Error> {

--- a/storage/src/journal/segmented/fixed.rs
+++ b/storage/src/journal/segmented/fixed.rs
@@ -298,8 +298,9 @@ impl<E: Storage + Metrics, A: CodecFixedShared> Inner<E, A> {
         };
         let mut manager = Manager::init(context, manager_cfg).await?;
         if let Some((section, size)) = restore {
-            // The checkpoint preflight authorized this exact truncation. Make it durable before
-            // the paired value journal can release any corresponding bytes.
+            // The checkpoint preflight authorized this exact truncation, which `rewind` makes
+            // durable before the paired value journal can release any corresponding bytes. The
+            // sync persists the retained section whether or not anything was truncated.
             manager.rewind(section, size).await?;
             manager.sync(section).await?;
             return Ok(Self {

--- a/storage/src/journal/segmented/fixed.rs
+++ b/storage/src/journal/segmented/fixed.rs
@@ -298,10 +298,8 @@ impl<E: Storage + Metrics, A: CodecFixedShared> Inner<E, A> {
         };
         let mut manager = Manager::init(context, manager_cfg).await?;
         if let Some((section, size)) = restore {
-            // The checkpoint preflight authorized this exact truncation, and it is durable when
-            // `rewind` returns, before the paired value journal can release any corresponding
-            // bytes. The sync covers the case where nothing was truncated: on real filesystems
-            // the adopted bytes may have been readable but not yet synced.
+            // The checkpoint preflight authorized this exact truncation. Make it durable before
+            // the paired value journal can release any corresponding bytes.
             manager.rewind(section, size).await?;
             manager.sync(section).await?;
             return Ok(Self {

--- a/storage/src/journal/segmented/fixed.rs
+++ b/storage/src/journal/segmented/fixed.rs
@@ -1037,8 +1037,8 @@ impl<E: Storage + Metrics, A: CodecFixedShared> Replay<E, A> {
     }
 }
 
-/// Truncate a replayed section. The shrink is durable when `resize` returns, so new appends
-/// cannot reuse the freed range before the repair is durable.
+/// Truncate `section`'s blob to `size`. The shrink is durable when `resize` returns, so a later
+/// append cannot reuse the freed range before the repair is durable.
 async fn repair_blob<E: Storage + Metrics, A: CodecFixed>(
     journal: &mut Journal<E, A>,
     section: u64,

--- a/storage/src/journal/segmented/fixed.rs
+++ b/storage/src/journal/segmented/fixed.rs
@@ -298,9 +298,8 @@ impl<E: Storage + Metrics, A: CodecFixedShared> Inner<E, A> {
         };
         let mut manager = Manager::init(context, manager_cfg).await?;
         if let Some((section, size)) = restore {
-            // The checkpoint preflight authorized this exact truncation, which `rewind` makes
-            // durable before the paired value journal can release any corresponding bytes. The
-            // sync persists the retained section whether or not anything was truncated.
+            // Persist the authorized index boundary before releasing paired values. Rewind
+            // persists any truncation; sync covers the retained section even without a shrink.
             manager.rewind(section, size).await?;
             manager.sync(section).await?;
             return Ok(Self {
@@ -1036,8 +1035,7 @@ impl<E: Storage + Metrics, A: CodecFixedShared> Replay<E, A> {
     }
 }
 
-/// Truncate `section`'s blob to `size`. The shrink is durable when `resize` returns, so a later
-/// append cannot reuse the freed range before the repair is durable.
+/// Durably truncate `section`'s blob to `size`.
 async fn repair_blob<E: Storage + Metrics, A: CodecFixed>(
     journal: &mut Journal<E, A>,
     section: u64,

--- a/storage/src/journal/segmented/fixed.rs
+++ b/storage/src/journal/segmented/fixed.rs
@@ -298,8 +298,10 @@ impl<E: Storage + Metrics, A: CodecFixedShared> Inner<E, A> {
         };
         let mut manager = Manager::init(context, manager_cfg).await?;
         if let Some((section, size)) = restore {
-            // The checkpoint preflight authorized this exact truncation. Make it durable before
-            // the paired value journal can release any corresponding bytes.
+            // The checkpoint preflight authorized this exact truncation, and it is durable when
+            // `rewind` returns, before the paired value journal can release any corresponding
+            // bytes. The sync covers the case where nothing was truncated: on real filesystems
+            // the adopted bytes may have been readable but not yet synced.
             manager.rewind(section, size).await?;
             manager.sync(section).await?;
             return Ok(Self {
@@ -791,7 +793,7 @@ impl<E: Storage + Metrics, A: CodecFixedShared> Journal<E, A> {
     /// Rewind the journal to a specific section and byte size.
     ///
     /// This truncates the section to the given size. All sections
-    /// after `section` are removed.
+    /// after `section` are removed. The rewind is durable when this returns.
     pub async fn rewind(mut self, section: u64, size: u64) -> Result<Self, Error> {
         self.0.rewind(section, size).await?;
         Ok(self)
@@ -799,7 +801,8 @@ impl<E: Storage + Metrics, A: CodecFixedShared> Journal<E, A> {
 
     /// Rewind only the given section to a specific byte offset.
     ///
-    /// Unlike `rewind`, this does not affect other sections.
+    /// Unlike `rewind`, this does not affect other sections. The truncation is durable when
+    /// this returns.
     pub async fn rewind_section(mut self, section: u64, size: u64) -> Result<Self, Error> {
         self.0.rewind_section(section, size).await?;
         Ok(self)
@@ -1034,15 +1037,14 @@ impl<E: Storage + Metrics, A: CodecFixedShared> Replay<E, A> {
     }
 }
 
-/// Truncate a replayed section and make the repair durable before allowing new appends.
+/// Truncate a replayed section. The shrink is durable when `resize` returns, so new appends
+/// cannot reuse the freed range before the repair is durable.
 async fn repair_blob<E: Storage + Metrics, A: CodecFixed>(
     journal: &mut Journal<E, A>,
     section: u64,
     size: u64,
 ) -> Result<(), Error> {
-    let blob = journal.0.writer(section);
-    blob.resize(size).await?;
-    blob.sync().await?;
+    journal.0.writer(section).resize(size).await?;
     Ok(())
 }
 

--- a/storage/src/journal/segmented/glob.rs
+++ b/storage/src/journal/segmented/glob.rs
@@ -695,6 +695,40 @@ mod tests {
         });
     }
 
+    /// Rewind into a buffered suffix, then crash without another sync.
+    /// Recovery must retain the kept frame and discard the frame beyond the rewind target.
+    #[test_traced]
+    fn test_glob_rewind_persists_retained_buffered_values() {
+        // Keep the last two frames buffered so rewind must flush the retained prefix
+        let cfg = || Config {
+            write_buffer: NZUsize!(1024),
+            ..test_cfg()
+        };
+        let ((first, second), checkpoint) =
+            deterministic::Runner::default().start_and_recover(|context| async move {
+                let glob: Glob<_, i32> = Glob::init(context.child("first"), cfg()).await.unwrap();
+                let (glob, first_offset, first_size) = glob.append(1, &1).await.unwrap();
+                let glob = glob.sync(1).await.unwrap();
+                let (glob, second_offset, second_size) = glob.append(1, &2).await.unwrap();
+                let (glob, _, _) = glob.append(1, &3).await.unwrap();
+
+                let glob = glob
+                    .rewind_section(1, second_offset + u64::from(second_size))
+                    .await
+                    .unwrap();
+                drop(glob);
+                ((first_offset, first_size), (second_offset, second_size))
+            });
+
+        deterministic::Runner::from(checkpoint).start(|context| async move {
+            let glob: Glob<_, i32> = Glob::init(context.child("reopen"), cfg()).await.unwrap();
+            assert_eq!(glob.size(1).unwrap(), second.0 + u64::from(second.1));
+            assert_eq!(glob.get(1, first.0, first.1).await.unwrap(), 1);
+            assert_eq!(glob.get(1, second.0, second.1).await.unwrap(), 2);
+            glob.destroy().await.unwrap();
+        });
+    }
+
     #[test_traced]
     fn test_glob_persistence() {
         let executor = deterministic::Runner::default();

--- a/storage/src/journal/segmented/glob.rs
+++ b/storage/src/journal/segmented/glob.rs
@@ -641,14 +641,13 @@ mod tests {
         });
     }
 
-    /// A rewind's truncation survives a crash even when a later unsynced append reuses the freed
-    /// range: the crash keeps the append but must not resurrect the rewound bytes behind it.
+    /// Rewind a section and reuse its discarded range with an unsynced append, then crash.
+    /// Recovery must retain the new frame without restoring the old frames behind it.
     #[test_traced]
     fn test_glob_rewind_truncation_survives_crash() {
         let executor = deterministic::Runner::default();
 
-        // A write buffer smaller than one 8-byte frame makes every append a direct unsynced
-        // write, so the append after the rewind reaches the blob before the crash.
+        // A buffer smaller than one 8-byte frame sends each append directly to the blob
         let cfg = || Config {
             write_buffer: NZUsize!(4),
             ..test_cfg()
@@ -661,8 +660,7 @@ mod tests {
             (glob, _, _) = glob.append(1, &2).await.expect("Failed to append");
             glob = glob.sync(1).await.expect("Failed to sync");
 
-            // The crash keeps every unsynced write and drops every unsynced resize, so the
-            // truncation survives it only if `rewind_section` synced it.
+            // Keep unsynced writes and drop unsynced resizes at the crash
             *context.storage_fault_config().write() = deterministic::FaultConfig {
                 write_rate: Some(deterministic::WriteConfig {
                     failure_rate: probability!(0.0),

--- a/storage/src/journal/segmented/glob.rs
+++ b/storage/src/journal/segmented/glob.rs
@@ -349,7 +349,8 @@ impl<E: Context, V: CodecShared> Glob<E, V> {
 
     /// Rewind to a specific section and size.
     ///
-    /// Truncates the section to the given size and removes all sections after it.
+    /// Truncates the section to the given size and removes all sections after it. The rewind is
+    /// durable when this returns.
     pub async fn rewind(mut self, section: u64, size: u64) -> Result<Self, Error> {
         self.0.rewind(section, size).await?;
         Ok(self)
@@ -357,7 +358,8 @@ impl<E: Context, V: CodecShared> Glob<E, V> {
 
     /// Rewind only the given section to a specific size.
     ///
-    /// Unlike `rewind`, this does not affect other sections.
+    /// Unlike `rewind`, this does not affect other sections. The truncation is durable when this
+    /// returns.
     pub async fn rewind_section(mut self, section: u64, size: u64) -> Result<Self, Error> {
         self.0.rewind_section(section, size).await?;
         Ok(self)
@@ -434,7 +436,7 @@ mod tests {
     use super::*;
     use commonware_macros::test_traced;
     use commonware_runtime::{Runner, Supervisor as _, deterministic};
-    use commonware_utils::NZUsize;
+    use commonware_utils::{NZUsize, probability};
 
     fn test_cfg() -> Config<()> {
         Config {
@@ -635,6 +637,62 @@ mod tests {
             let result = glob.get(1, fourth_offset, fourth_size).await;
             assert!(result.is_err());
 
+            glob.destroy().await.expect("Failed to destroy");
+        });
+    }
+
+    /// A rewind's truncation survives a crash even when a later unsynced append reuses the freed
+    /// range: the crash keeps the append but must not resurrect the rewound bytes behind it.
+    #[test_traced]
+    fn test_glob_rewind_truncation_survives_crash() {
+        let executor = deterministic::Runner::default();
+
+        // A write buffer smaller than one 8-byte frame makes every append a direct unsynced
+        // write, so the append after the rewind reaches the blob before the crash.
+        let cfg = || Config {
+            write_buffer: NZUsize!(4),
+            ..test_cfg()
+        };
+        let (expected, checkpoint) = executor.start_and_recover(|context| async move {
+            let mut glob: Glob<_, i32> = Glob::init(context.child("first"), cfg())
+                .await
+                .expect("Failed to init glob");
+            (glob, _, _) = glob.append(1, &1).await.expect("Failed to append");
+            (glob, _, _) = glob.append(1, &2).await.expect("Failed to append");
+            glob = glob.sync(1).await.expect("Failed to sync");
+
+            // The crash keeps every unsynced write and drops every unsynced resize, so the
+            // truncation survives it only if `rewind_section` synced it.
+            *context.storage_fault_config().write() = deterministic::FaultConfig {
+                write_rate: Some(deterministic::WriteConfig {
+                    failure_rate: probability!(0.0),
+                    retention_rate: probability!(1.0),
+                    mode: deterministic::PartialWriteMode::Prefix,
+                }),
+                resize_rate: Some(deterministic::ResizeConfig {
+                    failure_rate: probability!(0.0),
+                    partial_rate: probability!(0.0),
+                }),
+                ..Default::default()
+            };
+            glob = glob.rewind_section(1, 0).await.expect("Failed to rewind");
+            let (glob, offset, size) = glob.append(1, &3).await.expect("Failed to append");
+            drop(glob);
+            (offset, size)
+        });
+
+        deterministic::Runner::from(checkpoint).start(|context| async move {
+            *context.storage_fault_config().write() = deterministic::FaultConfig::default();
+            let glob: Glob<_, i32> = Glob::init(context.child("second"), cfg())
+                .await
+                .expect("Failed to reinit glob");
+            let (offset, size) = expected;
+            assert_eq!(
+                glob.size(1).expect("size"),
+                offset + u64::from(size),
+                "rewound bytes survived the rewind"
+            );
+            assert_eq!(glob.get(1, offset, size).await.expect("get"), 3);
             glob.destroy().await.expect("Failed to destroy");
         });
     }

--- a/storage/src/journal/segmented/manager.rs
+++ b/storage/src/journal/segmented/manager.rs
@@ -506,9 +506,7 @@ impl<E: Storage + Metrics, F: BufferFactory<E::Blob>> Manager<E, F> {
             debug!(section = s, "removed blob during rewind");
         }
 
-        // If the section exists, truncate it to the given size. No explicit sync is needed
-        // here: the buffer waits for any in-flight sync before mutating the blob and makes the
-        // truncation durable before returning.
+        // The buffer orders the shrink after pending syncs and makes it durable
         if let Some(blob) = self.blobs.get_mut(&section) {
             let current_size = blob.size();
             if size < current_size {

--- a/storage/src/journal/segmented/manager.rs
+++ b/storage/src/journal/segmented/manager.rs
@@ -62,8 +62,7 @@ pub trait SectionBuffer: Send + Sync {
 
     /// Resize the logical size of the buffer.
     ///
-    /// A shrink, and every byte it retains, is durable when this returns. Growth is not durable
-    /// until the next sync.
+    /// A shrink and all retained bytes are durable when this returns.
     fn resize(&mut self, len: u64) -> impl Future<Output = Result<(), RError>> + Send;
 }
 
@@ -107,7 +106,9 @@ impl<B: Blob> SectionBuffer for Write<B> {
     }
 
     async fn resize(&mut self, len: u64) -> Result<(), RError> {
-        Self::resize(self, len).await
+        // Raw resizes need an explicit sync to meet the section buffer's durability guarantee
+        Self::resize(self, len).await?;
+        Self::sync(self).await
     }
 }
 

--- a/storage/src/journal/segmented/manager.rs
+++ b/storage/src/journal/segmented/manager.rs
@@ -61,6 +61,9 @@ pub trait SectionBuffer: Send + Sync {
     fn wait_for_sync(&mut self) -> impl Future<Output = Result<(), RError>> + Send;
 
     /// Resize the logical size of the buffer.
+    ///
+    /// A shrink, and every byte it retains, is durable when this returns. Growth is not durable
+    /// until the next sync.
     fn resize(&mut self, len: u64) -> impl Future<Output = Result<(), RError>> + Send;
 }
 
@@ -503,8 +506,9 @@ impl<E: Storage + Metrics, F: BufferFactory<E::Blob>> Manager<E, F> {
             debug!(section = s, "removed blob during rewind");
         }
 
-        // If the section exists, truncate it to the given size. No explicit sync barrier is
-        // needed here: the buffer waits for any in-flight sync before mutating the blob.
+        // If the section exists, truncate it to the given size. No explicit sync is needed
+        // here: the buffer waits for any in-flight sync before mutating the blob and makes the
+        // truncation durable before returning.
         if let Some(blob) = self.blobs.get_mut(&section) {
             let current_size = blob.size();
             if size < current_size {

--- a/storage/src/journal/segmented/oversized.rs
+++ b/storage/src/journal/segmented/oversized.rs
@@ -984,9 +984,9 @@ impl<E: Context, I: Record + Send + Sync, V: CodecShared> Oversized<E, I, V> {
         self.prepare_rewind(section, index_size, true).await?;
 
         // Rewind the index first (this also removes sections after `section`). Its truncation
-        // is durable when `index.rewind` returns, so by the time rewinding the values frees
-        // their ranges for reuse by later appends, no dropped index entry can survive a crash
-        // and be adopted referencing whatever bytes a later append placed at its offsets.
+        // is durable when `index.rewind` returns, so once the values rewind frees ranges for
+        // later appends, no dropped index entry can survive a crash and be adopted referencing
+        // whatever bytes a later append placed at its offsets.
         self.index = self.index.rewind(section, index_size).await?;
 
         // Derive value size from last entry (section may not exist if empty)

--- a/storage/src/journal/segmented/oversized.rs
+++ b/storage/src/journal/segmented/oversized.rs
@@ -976,23 +976,20 @@ impl<E: Context, I: Record + Send + Sync, V: CodecShared> Oversized<E, I, V> {
     /// This rewinds the section to the given index size and removes all sections
     /// after the given section. The value size is derived from the last entry.
     ///
-    /// The resulting state of `section` is durable before this returns, including when the
-    /// target size already matches. Each journal removes its later sections (newest first)
-    /// before truncating `section`, and those removals carry the storage layer's removal
-    /// durability.
+    /// The retained section is durable on return, including when its size already matches.
+    /// Each journal removes later sections newest-first before truncating `section`, with the
+    /// storage layer's removal durability.
     pub async fn rewind(mut self, section: u64, index_size: u64) -> Result<Self, Error> {
         self.prepare_rewind(section, index_size, true).await?;
 
-        // Rewind the index before freeing referenced value ranges.
+        // Persist the index before freeing values. Sync both journals to cover retained data
+        // even when their sizes already match.
         self.index = self.index.rewind(section, index_size).await?;
 
-        // Derive value size from last entry (section may not exist if empty)
         let value_size = self.rewound_value_end(section, index_size).await?;
 
-        // The section may retain unsynced entries even when its index size already matches.
         self.index = self.index.sync(section).await?;
 
-        // Rewind values and persist retained bytes even when their size already matches.
         self.values = self.values.rewind(section, value_size).await?;
         self.values = self.values.sync(section).await?;
         Ok(self)
@@ -1003,21 +1000,17 @@ impl<E: Context, I: Record + Send + Sync, V: CodecShared> Oversized<E, I, V> {
     /// Unlike `rewind`, this does not affect other sections.
     /// The value size is derived from the last entry after rewinding the index.
     ///
-    /// The resulting state of `section` is durable before this returns, including when the
-    /// target size already matches.
+    /// The retained section is durable on return, including when its size already matches.
     pub async fn rewind_section(mut self, section: u64, index_size: u64) -> Result<Self, Error> {
         self.prepare_rewind(section, index_size, false).await?;
 
-        // Rewind the index before freeing referenced value ranges.
+        // Persist the index before freeing values; sync both even when sizes already match
         self.index = self.index.rewind_section(section, index_size).await?;
 
-        // Derive value size from last entry (section may not exist if empty)
         let value_size = self.rewound_value_end(section, index_size).await?;
 
-        // The section may retain unsynced entries even when its index size already matches.
         self.index = self.index.sync(section).await?;
 
-        // Rewind values and persist retained bytes even when their size already matches.
         self.values = self.values.rewind_section(section, value_size).await?;
         self.values = self.values.sync(section).await?;
         Ok(self)

--- a/storage/src/journal/segmented/oversized.rs
+++ b/storage/src/journal/segmented/oversized.rs
@@ -382,9 +382,7 @@ impl<E: Context, I: Record + Send + Sync, V: CodecShared> Oversized<E, I, V> {
                 let index = preflight.finish().await?;
 
                 // The index truncation is already durable. Release its unreferenced values only
-                // after that proof, preserving the index-first crash-recovery order. The sync
-                // covers the case where nothing was released: on real filesystems the adopted
-                // value bytes may have been readable but not yet synced.
+                // after that proof, preserving the index-first crash-recovery order.
                 let values = values.rewind(section, value_size).await?;
                 (index, values.sync(section).await?)
             }
@@ -646,6 +644,8 @@ impl<E: Context, I: Record + Send + Sync, V: CodecShared> Oversized<E, I, V> {
             .take()
             .expect("tracked replay preserves its recovery state");
 
+        // Startup-readable bytes are durable by the runtime contract, and recovery
+        // truncations are durable before their retained boundaries are published
         let mut dirty = false;
         for section in self.index.sections() {
             let items = self.index.section_len(section)?;
@@ -976,24 +976,25 @@ impl<E: Context, I: Record + Send + Sync, V: CodecShared> Oversized<E, I, V> {
     /// This rewinds the section to the given index size and removes all sections
     /// after the given section. The value size is derived from the last entry.
     ///
-    /// Both of `section`'s truncations are durable before this returns: a crash recovers
-    /// `section` to either its pre-rewind or its post-rewind state. Each journal removes
-    /// its later sections (newest first) before truncating `section`, and those removals
-    /// carry the storage layer's removal durability.
+    /// The resulting state of `section` is durable before this returns, including when
+    /// the target size already matches. Each journal removes its later
+    /// sections (newest first) before truncating `section`, and those removals carry the
+    /// storage layer's removal durability.
     pub async fn rewind(mut self, section: u64, index_size: u64) -> Result<Self, Error> {
         self.prepare_rewind(section, index_size, true).await?;
 
-        // Rewind the index first (this also removes sections after `section`). Its truncation
-        // is durable when `index.rewind` returns, so once the values rewind frees ranges for
-        // later appends, no dropped index entry can survive a crash and be adopted referencing
-        // whatever bytes a later append placed at its offsets.
+        // Rewind the index before freeing referenced value ranges
         self.index = self.index.rewind(section, index_size).await?;
 
         // Derive value size from last entry (section may not exist if empty)
         let value_size = self.rewound_value_end(section, index_size).await?;
 
-        // Rewind values (this also removes sections after `section`)
+        // A matching index size may still contain unsynced retained entries
+        self.index = self.index.sync(section).await?;
+
+        // Rewind values and persist retained bytes even when their size already matches
         self.values = self.values.rewind(section, value_size).await?;
+        self.values = self.values.sync(section).await?;
         Ok(self)
     }
 
@@ -1002,19 +1003,23 @@ impl<E: Context, I: Record + Send + Sync, V: CodecShared> Oversized<E, I, V> {
     /// Unlike `rewind`, this does not affect other sections.
     /// The value size is derived from the last entry after rewinding the index.
     ///
-    /// Both truncations are durable before this returns (see [Self::rewind]).
+    /// The resulting section state is durable before this returns, including when the
+    /// target size already matches (see [Self::rewind]).
     pub async fn rewind_section(mut self, section: u64, index_size: u64) -> Result<Self, Error> {
         self.prepare_rewind(section, index_size, false).await?;
 
-        // Rewind the index first (see Self::rewind for why its durable truncation must precede
-        // the values rewind).
+        // Rewind the index before freeing referenced value ranges
         self.index = self.index.rewind_section(section, index_size).await?;
 
         // Derive value size from last entry (section may not exist if empty)
         let value_size = self.rewound_value_end(section, index_size).await?;
 
-        // Rewind values
+        // A matching index size may still contain unsynced retained entries
+        self.index = self.index.sync(section).await?;
+
+        // Rewind values and persist retained bytes even when their size already matches
         self.values = self.values.rewind_section(section, value_size).await?;
+        self.values = self.values.sync(section).await?;
         Ok(self)
     }
 
@@ -1195,6 +1200,7 @@ mod tests {
         mocks::{DelayedSyncContext, PendingSyncs, SyncFaultContext, drive_pending_syncs},
     };
     use commonware_utils::{NZU16, NZUsize};
+    use rstest::rstest;
 
     /// Convert offset + size to byte end position (for truncation tests).
     fn byte_end(offset: u64, size: u32) -> u64 {
@@ -1497,6 +1503,62 @@ mod tests {
                 entry.id
             );
         }
+    }
+
+    #[rstest]
+    #[case::all_sections(true)]
+    #[case::single_section(false)]
+    fn test_oversized_rewind_current_size_is_durable(#[case] all_sections: bool) {
+        let (_, checkpoint) =
+            deterministic::Runner::default().start_and_recover(move |context| async move {
+                let mut journal: Oversized<_, TestEntry, TestValue> =
+                    Oversized::init(context.child("initial"), test_cfg(&context))
+                        .await
+                        .unwrap();
+                for section in 1..=2 {
+                    (journal, _, _, _) = journal
+                        .append(section, TestEntry::new(section, 0, 0), &[section as u8; 16])
+                        .await
+                        .unwrap();
+                }
+
+                // Keep the target section buffered while making the later section durable
+                journal = journal.sync(2).await.unwrap();
+                let size = journal.size(1).unwrap();
+                journal = if all_sections {
+                    journal.rewind(1, size).await.unwrap()
+                } else {
+                    journal.rewind_section(1, size).await.unwrap()
+                };
+                assert_eq!(journal.size(1).unwrap(), size);
+                drop(journal);
+            });
+
+        deterministic::Runner::from(checkpoint).start(move |context| async move {
+            let journal: Oversized<_, TestEntry, TestValue> =
+                Oversized::init(context.child("reopen"), test_cfg(&context))
+                    .await
+                    .unwrap();
+            assert_eq!(journal.size(1).unwrap(), TestEntry::SIZE as u64);
+            assert_eq!(
+                journal.size(2).unwrap(),
+                if all_sections {
+                    0
+                } else {
+                    TestEntry::SIZE as u64
+                }
+            );
+            let entry = journal.get(1, 0).await.unwrap();
+            assert_eq!(entry.id, 1);
+            assert_eq!(
+                journal
+                    .get_value(1, entry.value_offset, entry.value_size)
+                    .await
+                    .unwrap(),
+                [1; 16]
+            );
+            journal.destroy().await.unwrap();
+        });
     }
 
     #[test_traced]

--- a/storage/src/journal/segmented/oversized.rs
+++ b/storage/src/journal/segmented/oversized.rs
@@ -982,14 +982,15 @@ impl<E: Context, I: Record + Send + Sync, V: CodecShared> Oversized<E, I, V> {
     pub async fn rewind(mut self, section: u64, index_size: u64) -> Result<Self, Error> {
         self.prepare_rewind(section, index_size, true).await?;
 
-        // Persist the index before freeing values. Sync both journals to cover retained data
-        // even when their sizes already match.
         self.index = self.index.rewind(section, index_size).await?;
 
+        // Keep values through the last retained index entry, or none for an empty section
         let value_size = self.rewound_value_end(section, index_size).await?;
 
+        // Persist the index before freeing values, even if its size did not change
         self.index = self.index.sync(section).await?;
 
+        // Persist retained value bytes even if the rewind does not truncate
         self.values = self.values.rewind(section, value_size).await?;
         self.values = self.values.sync(section).await?;
         Ok(self)
@@ -1004,13 +1005,15 @@ impl<E: Context, I: Record + Send + Sync, V: CodecShared> Oversized<E, I, V> {
     pub async fn rewind_section(mut self, section: u64, index_size: u64) -> Result<Self, Error> {
         self.prepare_rewind(section, index_size, false).await?;
 
-        // Persist the index before freeing values; sync both even when sizes already match
         self.index = self.index.rewind_section(section, index_size).await?;
 
+        // Keep values through the last retained index entry, or none for an empty section
         let value_size = self.rewound_value_end(section, index_size).await?;
 
+        // Persist the index before freeing values, even if its size did not change
         self.index = self.index.sync(section).await?;
 
+        // Persist retained value bytes even if the rewind does not truncate
         self.values = self.values.rewind_section(section, value_size).await?;
         self.values = self.values.sync(section).await?;
         Ok(self)

--- a/storage/src/journal/segmented/oversized.rs
+++ b/storage/src/journal/segmented/oversized.rs
@@ -982,6 +982,7 @@ impl<E: Context, I: Record + Send + Sync, V: CodecShared> Oversized<E, I, V> {
     pub async fn rewind(mut self, section: u64, index_size: u64) -> Result<Self, Error> {
         self.prepare_rewind(section, index_size, true).await?;
 
+        // Rewind the index before deriving the retained value boundary
         self.index = self.index.rewind(section, index_size).await?;
 
         // Keep values through the last retained index entry, or none for an empty section
@@ -1005,6 +1006,7 @@ impl<E: Context, I: Record + Send + Sync, V: CodecShared> Oversized<E, I, V> {
     pub async fn rewind_section(mut self, section: u64, index_size: u64) -> Result<Self, Error> {
         self.prepare_rewind(section, index_size, false).await?;
 
+        // Rewind the index before deriving the retained value boundary
         self.index = self.index.rewind_section(section, index_size).await?;
 
         // Keep values through the last retained index entry, or none for an empty section

--- a/storage/src/journal/segmented/oversized.rs
+++ b/storage/src/journal/segmented/oversized.rs
@@ -382,7 +382,9 @@ impl<E: Context, I: Record + Send + Sync, V: CodecShared> Oversized<E, I, V> {
                 let index = preflight.finish().await?;
 
                 // The index truncation is already durable. Release its unreferenced values only
-                // after that proof, preserving the index-first crash-recovery order.
+                // after that proof, preserving the index-first crash-recovery order. The sync
+                // covers the case where nothing was released: on real filesystems the adopted
+                // value bytes may have been readable but not yet synced.
                 let values = values.rewind(section, value_size).await?;
                 (index, values.sync(section).await?)
             }
@@ -427,8 +429,6 @@ impl<E: Context, I: Record + Send + Sync, V: CodecShared> Oversized<E, I, V> {
         let chunk_size = FixedJournal::<E, I>::CHUNK_SIZE as u64;
         let sections: Vec<u64> = self.index.sections().collect();
 
-        let mut rewound_index = Vec::new();
-        let mut rewound_values = Vec::new();
         for section in sections {
             let index_size = self.index.size(section)?;
             let glob_size = match self.values.size(section) {
@@ -456,7 +456,6 @@ impl<E: Context, I: Record + Send + Sync, V: CodecShared> Oversized<E, I, V> {
                     index_size, aligned_size, "trailing bytes detected: truncating"
                 );
                 self.index = self.index.rewind_section(section, aligned_size).await?;
-                rewound_index.push(section);
             }
 
             // Values are reachable only through index entries.
@@ -464,7 +463,6 @@ impl<E: Context, I: Record + Send + Sync, V: CodecShared> Oversized<E, I, V> {
                 if glob_size > 0 {
                     debug!(section, glob_size, "truncating orphaned value bytes");
                     self.values = self.values.rewind_section(section, 0).await?;
-                    rewound_values.push(section);
                 }
                 continue;
             }
@@ -479,7 +477,6 @@ impl<E: Context, I: Record + Send + Sync, V: CodecShared> Oversized<E, I, V> {
                 let valid_size = valid_count * chunk_size;
                 debug!(section, entry_count, valid_count, "rewinding index");
                 self.index = self.index.rewind_section(section, valid_size).await?;
-                rewound_index.push(section);
             }
 
             // Truncate glob trailing garbage (can occur when value was written but
@@ -490,17 +487,8 @@ impl<E: Context, I: Record + Send + Sync, V: CodecShared> Oversized<E, I, V> {
                     glob_size, glob_target, "truncating glob trailing garbage"
                 );
                 self.values = self.values.rewind_section(section, glob_target).await?;
-                rewound_values.push(section);
             }
         }
-
-        // Make the truncations durable before appends can reuse the freed value ranges. A
-        // dropped index entry that stayed durable would be adopted by a later recovery
-        // referencing whatever bytes a subsequent append placed at its offsets, and stale
-        // glob bytes that stayed durable would satisfy a later entry's range with another
-        // record's frame.
-        self.values = self.values.sync(&rewound_values).await?;
-        self.index = self.index.sync(&rewound_index).await?;
 
         // Clean up orphan value sections that don't exist in index
         self.cleanup_orphan_value_sections().await
@@ -598,7 +586,6 @@ impl<E: Context, I: Record + Send + Sync, V: CodecShared> Oversized<E, I, V> {
     /// Truncate value suffixes that became unreachable while fixed replay repaired index pages.
     async fn align_values_to_index(mut self) -> Result<Self, Error> {
         let sections = self.index.sections().collect::<Vec<_>>();
-        let mut rewound = Vec::new();
         for section in sections {
             let target = Self::boundary_value_end(section, &self.index.last(section).await?)?;
             let retained = self.values.size(section)?;
@@ -609,10 +596,8 @@ impl<E: Context, I: Record + Send + Sync, V: CodecShared> Oversized<E, I, V> {
             }
             if retained > target {
                 self.values = self.values.rewind_section(section, target).await?;
-                rewound.push(section);
             }
         }
-        self.values = self.values.sync(&rewound).await?;
         self.cleanup_orphan_value_sections().await
     }
 
@@ -998,21 +983,17 @@ impl<E: Context, I: Record + Send + Sync, V: CodecShared> Oversized<E, I, V> {
     pub async fn rewind(mut self, section: u64, index_size: u64) -> Result<Self, Error> {
         self.prepare_rewind(section, index_size, true).await?;
 
-        // Rewind index first (this also removes sections after `section`)
+        // Rewind the index first (this also removes sections after `section`). Its truncation
+        // is durable when `index.rewind` returns, so by the time rewinding the values frees
+        // their ranges for reuse by later appends, no dropped index entry can survive a crash
+        // and be adopted referencing whatever bytes a later append placed at its offsets.
         self.index = self.index.rewind(section, index_size).await?;
 
         // Derive value size from last entry (section may not exist if empty)
         let value_size = self.rewound_value_end(section, index_size).await?;
 
-        // Make the index truncation durable before the values are rewound: rewinding the
-        // values frees their ranges for reuse by later appends, and a dropped index entry
-        // that stayed durable would be adopted referencing whatever bytes a later append
-        // placed at its offsets.
-        self.index = self.index.sync(section).await?;
-
         // Rewind values (this also removes sections after `section`)
         self.values = self.values.rewind(section, value_size).await?;
-        self.values = self.values.sync(section).await?;
         Ok(self)
     }
 
@@ -1021,22 +1002,19 @@ impl<E: Context, I: Record + Send + Sync, V: CodecShared> Oversized<E, I, V> {
     /// Unlike `rewind`, this does not affect other sections.
     /// The value size is derived from the last entry after rewinding the index.
     ///
-    /// Both truncations are made durable before returning (see [Self::rewind]).
+    /// Both truncations are durable before this returns (see [Self::rewind]).
     pub async fn rewind_section(mut self, section: u64, index_size: u64) -> Result<Self, Error> {
         self.prepare_rewind(section, index_size, false).await?;
 
-        // Rewind index first
+        // Rewind the index first (see Self::rewind for why its durable truncation must precede
+        // the values rewind).
         self.index = self.index.rewind_section(section, index_size).await?;
 
         // Derive value size from last entry (section may not exist if empty)
         let value_size = self.rewound_value_end(section, index_size).await?;
 
-        // Make the index truncation durable before the values are rewound (see Self::rewind).
-        self.index = self.index.sync(section).await?;
-
         // Rewind values
         self.values = self.values.rewind_section(section, value_size).await?;
-        self.values = self.values.sync(section).await?;
         Ok(self)
     }
 

--- a/storage/src/journal/segmented/oversized.rs
+++ b/storage/src/journal/segmented/oversized.rs
@@ -645,7 +645,7 @@ impl<E: Context, I: Record + Send + Sync, V: CodecShared> Oversized<E, I, V> {
             .expect("tracked replay preserves its recovery state");
 
         // Startup-readable bytes are durable by the runtime contract, and recovery
-        // truncations are durable before their retained boundaries are published
+        // truncations are durable before their retained boundaries are published.
         let mut dirty = false;
         for section in self.index.sections() {
             let items = self.index.section_len(section)?;
@@ -976,23 +976,23 @@ impl<E: Context, I: Record + Send + Sync, V: CodecShared> Oversized<E, I, V> {
     /// This rewinds the section to the given index size and removes all sections
     /// after the given section. The value size is derived from the last entry.
     ///
-    /// The resulting state of `section` is durable before this returns, including when
-    /// the target size already matches. Each journal removes its later
-    /// sections (newest first) before truncating `section`, and those removals carry the
-    /// storage layer's removal durability.
+    /// The resulting state of `section` is durable before this returns, including when the
+    /// target size already matches. Each journal removes its later sections (newest first)
+    /// before truncating `section`, and those removals carry the storage layer's removal
+    /// durability.
     pub async fn rewind(mut self, section: u64, index_size: u64) -> Result<Self, Error> {
         self.prepare_rewind(section, index_size, true).await?;
 
-        // Rewind the index before freeing referenced value ranges
+        // Rewind the index before freeing referenced value ranges.
         self.index = self.index.rewind(section, index_size).await?;
 
         // Derive value size from last entry (section may not exist if empty)
         let value_size = self.rewound_value_end(section, index_size).await?;
 
-        // A matching index size may still contain unsynced retained entries
+        // The section may retain unsynced entries even when its index size already matches.
         self.index = self.index.sync(section).await?;
 
-        // Rewind values and persist retained bytes even when their size already matches
+        // Rewind values and persist retained bytes even when their size already matches.
         self.values = self.values.rewind(section, value_size).await?;
         self.values = self.values.sync(section).await?;
         Ok(self)
@@ -1003,21 +1003,21 @@ impl<E: Context, I: Record + Send + Sync, V: CodecShared> Oversized<E, I, V> {
     /// Unlike `rewind`, this does not affect other sections.
     /// The value size is derived from the last entry after rewinding the index.
     ///
-    /// The resulting section state is durable before this returns, including when the
-    /// target size already matches (see [Self::rewind]).
+    /// The resulting state of `section` is durable before this returns, including when the
+    /// target size already matches.
     pub async fn rewind_section(mut self, section: u64, index_size: u64) -> Result<Self, Error> {
         self.prepare_rewind(section, index_size, false).await?;
 
-        // Rewind the index before freeing referenced value ranges
+        // Rewind the index before freeing referenced value ranges.
         self.index = self.index.rewind_section(section, index_size).await?;
 
         // Derive value size from last entry (section may not exist if empty)
         let value_size = self.rewound_value_end(section, index_size).await?;
 
-        // A matching index size may still contain unsynced retained entries
+        // The section may retain unsynced entries even when its index size already matches.
         self.index = self.index.sync(section).await?;
 
-        // Rewind values and persist retained bytes even when their size already matches
+        // Rewind values and persist retained bytes even when their size already matches.
         self.values = self.values.rewind_section(section, value_size).await?;
         self.values = self.values.sync(section).await?;
         Ok(self)

--- a/storage/src/journal/segmented/variable.rs
+++ b/storage/src/journal/segmented/variable.rs
@@ -550,11 +550,11 @@ impl<E: Storage + Metrics, V: CodecShared> Journal<E, V> {
 
     /// Rewinds the journal to the given `section` and `size`.
     ///
-    /// This removes any data beyond the specified `section` and `size`.
+    /// This removes any data beyond the specified `section` and `size`. The rewind is durable
+    /// when this returns. Items appended afterward are not durable until sync is called.
     ///
     /// # Warnings
     ///
-    /// * This operation is not guaranteed to survive restarts until sync is called.
     /// * This operation is not atomic, but it will always leave the journal in a consistent state
     ///   in the event of failure since blobs are always removed in reverse order of section.
     pub async fn rewind(mut self, section: u64, size: u64) -> Result<Self, Error> {
@@ -565,10 +565,7 @@ impl<E: Storage + Metrics, V: CodecShared> Journal<E, V> {
     /// Rewinds the `section` to the given `size`.
     ///
     /// Unlike [Self::rewind], this method does not modify anything other than the given `section`.
-    ///
-    /// # Warning
-    ///
-    /// This operation is not guaranteed to survive restarts until sync is called.
+    /// The truncation is durable when this returns.
     pub async fn rewind_section(mut self, section: u64, size: u64) -> Result<Self, Error> {
         self.0.rewind_section(section, size).await?;
         Ok(self)
@@ -947,15 +944,13 @@ impl<E: Storage + Metrics, V: CodecShared> Replay<E, V> {
     }
 }
 
-/// Truncates `section`'s blob to `size` and makes the truncation durable.
+/// Truncates `section`'s blob to `size`. The shrink is durable when `resize` returns.
 async fn repair_blob<E: Storage + Metrics, V: Codec>(
     journal: &mut Journal<E, V>,
     section: u64,
     size: u64,
 ) -> Result<(), Error> {
-    let blob = journal.0.writer(section);
-    blob.resize(size).await?;
-    blob.sync().await?;
+    journal.0.writer(section).resize(size).await?;
     Ok(())
 }
 

--- a/storage/src/journal/segmented/variable.rs
+++ b/storage/src/journal/segmented/variable.rs
@@ -944,7 +944,8 @@ impl<E: Storage + Metrics, V: CodecShared> Replay<E, V> {
     }
 }
 
-/// Truncates `section`'s blob to `size`. The shrink is durable when `resize` returns.
+/// Truncate `section`'s blob to `size`. The shrink is durable when `resize` returns, so a later
+/// append cannot reuse the freed range before the repair is durable.
 async fn repair_blob<E: Storage + Metrics, V: Codec>(
     journal: &mut Journal<E, V>,
     section: u64,

--- a/storage/src/journal/segmented/variable.rs
+++ b/storage/src/journal/segmented/variable.rs
@@ -944,8 +944,7 @@ impl<E: Storage + Metrics, V: CodecShared> Replay<E, V> {
     }
 }
 
-/// Truncate `section`'s blob to `size`. The shrink is durable when `resize` returns, so a later
-/// append cannot reuse the freed range before the repair is durable.
+/// Durably truncate `section`'s blob to `size`.
 async fn repair_blob<E: Storage + Metrics, V: Codec>(
     journal: &mut Journal<E, V>,
     section: u64,

--- a/storage/src/journal/segmented/variable.rs
+++ b/storage/src/journal/segmented/variable.rs
@@ -553,10 +553,10 @@ impl<E: Storage + Metrics, V: CodecShared> Journal<E, V> {
     /// This removes any data beyond the specified `section` and `size`. The rewind is durable
     /// when this returns. Items appended afterward are not durable until sync is called.
     ///
-    /// # Warnings
+    /// # Warning
     ///
-    /// * This operation is not atomic, but it will always leave the journal in a consistent state
-    ///   in the event of failure since blobs are always removed in reverse order of section.
+    /// This operation is not atomic, but it will always leave the journal in a consistent state
+    /// in the event of failure since blobs are always removed in reverse order of section.
     pub async fn rewind(mut self, section: u64, size: u64) -> Result<Self, Error> {
         self.0.rewind(section, size).await?;
         Ok(self)

--- a/storage/src/merkle/persisted/full.rs
+++ b/storage/src/merkle/persisted/full.rs
@@ -973,7 +973,8 @@ impl<F: Family, E: Context, D: Digest, S: Strategy> Merkle<F, E, D, S> {
             return Err(Error::ElementPruned(new_size));
         }
 
-        // Rewind the journal if needed.
+        // Rewind the journal if needed. The truncation is durable when `rewind` returns. The
+        // sync raises the recovery watermark and covers retained nodes not yet synced.
         let journal_size = Position::<F>::new(self.journal.size());
         if new_size < journal_size {
             self.journal = self.journal.rewind(*new_size).await?.sync().await?;

--- a/storage/src/merkle/persisted/full.rs
+++ b/storage/src/merkle/persisted/full.rs
@@ -171,9 +171,6 @@ pub struct Merkle<F: Family, E: Context, D: Digest, S: Strategy> {
     /// contents change only when the pruning boundary moves.
     pub(crate) metadata: Metadata<E, U64, Vec<u8>>,
 
-    /// True while the journal may contain flushed nodes that have not yet been made durable.
-    pub(crate) journal_dirty: bool,
-
     /// The strategy to use for parallelization.
     pub(crate) strategy: S,
 }
@@ -302,7 +299,6 @@ impl<F: Family, E: Context, D: Digest, S: Strategy> Merkle<F, E, D, S> {
                 pruned_to_pos: Position::new(0),
                 journal,
                 metadata,
-                journal_dirty: false,
                 strategy: cfg.strategy,
             });
         }
@@ -442,7 +438,6 @@ impl<F: Family, E: Context, D: Digest, S: Strategy> Merkle<F, E, D, S> {
             pruned_to_pos: effective_prune_pos,
             journal,
             metadata,
-            journal_dirty: false,
             strategy: cfg.strategy,
         })
     }
@@ -592,7 +587,6 @@ impl<F: Family, E: Context, D: Digest, S: Strategy> Merkle<F, E, D, S> {
             pruned_to_pos: prune_pos,
             journal,
             metadata,
-            journal_dirty: false,
             strategy: cfg.config.strategy,
         })
     }
@@ -712,12 +706,8 @@ impl<F: Family, E: Context, D: Digest, S: Strategy> Merkle<F, E, D, S> {
     pub async fn sync(mut self) -> Result<Self, Error<F>> {
         self = self.flush_internal().await?;
 
-        // Sync the journal to ensure durability before returning. This covers nodes appended by
-        // the flush above as well as nodes left non-durable by earlier [Self::flush] calls.
-        if self.journal_dirty {
-            self.journal = self.journal.sync().await?;
-            self.journal_dirty = false;
-        }
+        // The journal tracks pending data, recovery metadata, and unobserved sync failures
+        self.journal = self.journal.sync().await?;
 
         Ok(self)
     }
@@ -728,8 +718,6 @@ impl<F: Family, E: Context, D: Digest, S: Strategy> Merkle<F, E, D, S> {
     /// The handle covers only nodes flushed so far. A later [Self::sync] still performs a full
     /// durable sync.
     pub async fn start_sync(mut self) -> Result<(Self, Handle<()>), Error<F>> {
-        // `journal_dirty` is deliberately not cleared: the started sync covers only nodes
-        // flushed so far, and sync() remains the durability authority.
         self = self.flush_internal().await?;
         let (journal, handle) = self.journal.start_sync().await?;
         self.journal = journal;
@@ -737,8 +725,7 @@ impl<F: Family, E: Context, D: Digest, S: Strategy> Merkle<F, E, D, S> {
     }
 
     /// Append nodes cached in the in-memory structure that are missing from the journal, then
-    /// prune them from the in-memory structure. Sets [Self::journal_dirty] when nodes are
-    /// appended.
+    /// prune them from the in-memory structure.
     async fn flush_internal(mut self) -> Result<Self, Error<F>> {
         let journal_size = Position::<F>::new(self.journal.size());
 
@@ -774,7 +761,6 @@ impl<F: Family, E: Context, D: Digest, S: Strategy> Merkle<F, E, D, S> {
 
         // Append missing nodes to the journal.
         (self.journal, _) = self.journal.append_prepared(encoded).await?;
-        self.journal_dirty = true;
 
         // Now that the missing nodes are readable from the journal, it's safe to prune them from
         // the mem. We prune to the previously captured leaf count.
@@ -1175,7 +1161,10 @@ mod tests {
     use commonware_macros::test_traced;
     use commonware_parallel::Sequential;
     use commonware_runtime::{
-        BufferPooler, Runner, Supervisor as _, buffer::paged::CacheRef, deterministic,
+        BufferPooler, Runner, Supervisor as _,
+        buffer::paged::CacheRef,
+        deterministic,
+        mocks::{DelayedSyncContext, PendingSyncs, drive_pending_syncs, fail_pending_syncs},
     };
     use commonware_utils::{NZU16, NZU64, NZUsize, non_empty_range, sequence::prefixed_u64::U64};
     use std::{
@@ -1612,6 +1601,35 @@ mod tests {
         mmr = mmr.sync().await.unwrap();
 
         mmr.destroy().await.unwrap();
+    }
+
+    #[test_traced]
+    fn test_full_sync_observes_clean_start_sync_failure() {
+        deterministic::Runner::default().start(|context| async move {
+            let pending = PendingSyncs::default();
+            let hasher: Standard<Sha256> = Standard::new(ForwardFold);
+            let cfg = test_config(&context);
+            let context = DelayedSyncContext {
+                inner: context,
+                pending: pending.clone(),
+            };
+            let merkle = drive_pending_syncs(
+                &pending,
+                Merkle::<mmr::Family, _, Digest, Sequential>::init(context, &hasher, cfg),
+            )
+            .await
+            .unwrap();
+
+            // No nodes were appended, but the opened journal can still start a blob sync
+            let (merkle, handle) = merkle.start_sync().await.unwrap();
+            assert!(!pending.lock().is_empty());
+            fail_pending_syncs(&pending);
+            drop(handle);
+
+            // A full sync must observe the unobserved failure even with nothing new to flush
+            let error = merkle.sync().await.expect_err("sync failure was lost");
+            assert!(matches!(error, Error::Journal(JError::Runtime(_))));
+        });
     }
 
     #[test_traced]

--- a/storage/src/merkle/persisted/full.rs
+++ b/storage/src/merkle/persisted/full.rs
@@ -973,8 +973,7 @@ impl<F: Family, E: Context, D: Digest, S: Strategy> Merkle<F, E, D, S> {
             return Err(Error::ElementPruned(new_size));
         }
 
-        // Rewind the journal if needed. The truncation is durable when `rewind` returns. The
-        // sync raises the recovery watermark and covers retained nodes not yet synced.
+        // Sync retained nodes and advance the recovery watermark after truncation
         let journal_size = Position::<F>::new(self.journal.size());
         if new_size < journal_size {
             self.journal = self.journal.rewind(*new_size).await?.sync().await?;

--- a/storage/src/qmdb/any/db.rs
+++ b/storage/src/qmdb/any/db.rs
@@ -642,6 +642,8 @@ where
             (rewind_floor, undos, active_keys_delta)
         };
 
+        // Make the log rewind durable before applying in-memory undo so recovery can
+        // rebuild the derived state from the retained log
         self.log = self.log.rewind(rewind_size).await?;
 
         // Drop bitmap bits for ops at or above the rewind target. Restored locs below

--- a/storage/src/qmdb/any/db.rs
+++ b/storage/src/qmdb/any/db.rs
@@ -545,7 +545,8 @@ where
     /// from `rewind` and reopen from storage.
     ///
     /// The rewind of the operations journal and its Merkle structure is durable before this
-    /// method returns.
+    /// method returns. A `size` equal to the current size truncates nothing and instead makes the
+    /// applied state durable, so a completed rewind always leaves `size` durable.
     #[tracing::instrument(
         name = "qmdb.any.db.rewind",
         level = "info",
@@ -560,8 +561,9 @@ where
         let rewind_size = *size;
         let current_size = *self.last_commit_loc + 1;
 
+        // Nothing to truncate, but the applied state may still be unsynced.
         if rewind_size == current_size {
-            return Ok(self);
+            return self.sync().await;
         }
         if rewind_size == 0 || rewind_size > current_size {
             return Err(Error::Journal(JournalError::InvalidRewind(rewind_size)));

--- a/storage/src/qmdb/any/db.rs
+++ b/storage/src/qmdb/any/db.rs
@@ -544,9 +544,8 @@ where
     /// all in-memory structures are rebuilt. Callers must drop this database handle after any `Err`
     /// from `rewind` and reopen from storage.
     ///
-    /// A successful rewind is not restart-stable until a subsequent [`Db::commit`] or
-    /// [`Db::sync`] completes, or until the handle returned by a subsequent [`Db::start_sync`]
-    /// completes.
+    /// The rewind of the operations journal and its Merkle structure is durable before this
+    /// method returns.
     #[tracing::instrument(
         name = "qmdb.any.db.rewind",
         level = "info",
@@ -641,8 +640,7 @@ where
             (rewind_floor, undos, active_keys_delta)
         };
 
-        // Journal rewind happens before in-memory undo application. This step is not
-        // restart-stable until a later commit/sync.
+        // Journal rewind happens before in-memory undo application.
         self.log = self.log.rewind(rewind_size).await?;
 
         // Drop bitmap bits for ops at or above the rewind target. Restored locs below

--- a/storage/src/qmdb/any/db.rs
+++ b/storage/src/qmdb/any/db.rs
@@ -544,9 +544,7 @@ where
     /// all in-memory structures are rebuilt. Callers must drop this database handle after any `Err`
     /// from `rewind` and reopen from storage.
     ///
-    /// The rewind of the operations journal and its Merkle structure is durable before this
-    /// method returns. A `size` equal to the current size truncates nothing and makes the applied
-    /// state durable, so a completed rewind always leaves the state at `size` durable.
+    /// The state at `size` is durable on return, including when `size` already matches.
     #[tracing::instrument(
         name = "qmdb.any.db.rewind",
         level = "info",
@@ -561,7 +559,7 @@ where
         let rewind_size = *size;
         let current_size = *self.last_commit_loc + 1;
 
-        // Nothing to truncate, but the applied state may still be unsynced.
+        // An equal target may still have unsynced applied state
         if rewind_size == current_size {
             return self.sync().await;
         }
@@ -642,8 +640,7 @@ where
             (rewind_floor, undos, active_keys_delta)
         };
 
-        // Make the log rewind durable before applying in-memory undo so recovery can
-        // rebuild the derived state from the retained log
+        // Persist the log rewind before applying undo; recovery rebuilds state from the log
         self.log = self.log.rewind(rewind_size).await?;
 
         // Drop bitmap bits for ops at or above the rewind target. Restored locs below

--- a/storage/src/qmdb/any/db.rs
+++ b/storage/src/qmdb/any/db.rs
@@ -545,8 +545,8 @@ where
     /// from `rewind` and reopen from storage.
     ///
     /// The rewind of the operations journal and its Merkle structure is durable before this
-    /// method returns. A `size` equal to the current size truncates nothing and instead makes the
-    /// applied state durable, so a completed rewind always leaves `size` durable.
+    /// method returns. A `size` equal to the current size truncates nothing and makes the applied
+    /// state durable, so a completed rewind always leaves the state at `size` durable.
     #[tracing::instrument(
         name = "qmdb.any.db.rewind",
         level = "info",
@@ -642,7 +642,6 @@ where
             (rewind_floor, undos, active_keys_delta)
         };
 
-        // Journal rewind happens before in-memory undo application.
         self.log = self.log.rewind(rewind_size).await?;
 
         // Drop bitmap bits for ops at or above the rewind target. Restored locs below

--- a/storage/src/qmdb/any/mod.rs
+++ b/storage/src/qmdb/any/mod.rs
@@ -1635,6 +1635,53 @@ pub(crate) mod test {
         (db, range)
     }
 
+    /// A rewind to the current size makes applied but uncommitted state durable: after such a
+    /// rewind and a crash with no commit or sync, the reopened db reports the applied state.
+    #[test_traced("INFO")]
+    fn test_any_rewind_current_size_makes_applied_state_durable() {
+        // Sections large enough that no append seals a blob, whose sync would make the applied
+        // state durable on its own.
+        fn config(ctx: &Context) -> VariableConfig<OneCap, ((), ()), Sequential> {
+            let mut config = variable_db_config::<OneCap>("rcs", ctx);
+            config.journal_config.items_per_section = NZU64!(1000);
+            config.merkle_config.items_per_blob = NZU64!(1000);
+            config
+        }
+
+        let ((size, root), checkpoint) =
+            deterministic::Runner::default().start_and_recover(|context| async move {
+                let ctx = context.child("db");
+                let db: UnorderedVariable =
+                    UnorderedVariableDb::init(ctx.child("storage"), config(&ctx))
+                        .await
+                        .unwrap();
+                let (db, _) = commit_writes(db, [(key(0), Some(val(0)))], None).await;
+
+                // Apply a batch without committing, then rewind to the size it produced.
+                let batch = db.new_batch().write(key(1), Some(val(1)));
+                let merkleized = batch.merkleize(&db, None).await.unwrap();
+                let (db, _) = db.apply_batch(merkleized).await.unwrap();
+                let size = db.bounds().end;
+                let root = db.root();
+                let db = db.rewind(size).await.unwrap();
+                assert_eq!(db.root(), root);
+                drop(db);
+                (size, root)
+            });
+
+        deterministic::Runner::from(checkpoint).start(|context| async move {
+            let ctx = context.child("db");
+            let db: UnorderedVariable =
+                UnorderedVariableDb::init(ctx.child("reopen"), config(&ctx))
+                    .await
+                    .unwrap();
+            assert_eq!(db.bounds().end, size);
+            assert_eq!(db.root(), root);
+            assert_eq!(db.get(&key(1)).await.unwrap(), Some(val(1)));
+            db.destroy().await.unwrap();
+        });
+    }
+
     /// An empty batch (no mutations) still produces a valid commit.
     #[test_traced("INFO")]
     fn test_any_batch_empty() {

--- a/storage/src/qmdb/any/mod.rs
+++ b/storage/src/qmdb/any/mod.rs
@@ -1635,12 +1635,11 @@ pub(crate) mod test {
         (db, range)
     }
 
-    /// A rewind to the current size makes applied but uncommitted state durable: after such a
-    /// rewind and a crash with no commit or sync, the reopened db reports the applied state.
+    /// Apply an uncommitted batch, rewind to its size, then crash without another sync.
+    /// Recovery must retain the batch's state.
     #[test_traced("INFO")]
     fn test_any_rewind_current_size_makes_applied_state_durable() {
-        // Sections large enough that no append seals a blob, whose sync would make the applied
-        // state durable on its own.
+        // Avoid rollover so sealing cannot hide a missing rewind sync
         fn config(ctx: &Context) -> VariableConfig<OneCap, ((), ()), Sequential> {
             let mut config = variable_db_config::<OneCap>("rcs", ctx);
             config.journal_config.items_per_section = NZU64!(1000);
@@ -1657,7 +1656,7 @@ pub(crate) mod test {
                         .unwrap();
                 let (db, _) = commit_writes(db, [(key(0), Some(val(0)))], None).await;
 
-                // Apply a batch without committing, then rewind to the size it produced.
+                // Leave the batch uncommitted so the equal-size rewind must persist it
                 let batch = db.new_batch().write(key(1), Some(val(1)));
                 let merkleized = batch.merkleize(&db, None).await.unwrap();
                 let (db, _) = db.apply_batch(merkleized).await.unwrap();

--- a/storage/src/qmdb/compact/witness.rs
+++ b/storage/src/qmdb/compact/witness.rs
@@ -327,8 +327,8 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
         .await
     }
 
-    /// Shared body of [`Self::commit`] and [`Self::sync`]: apply the current state, then make
-    /// every uncommitted witness durable according to `durability`.
+    /// Shared body of [`Self::commit`] and [`Self::sync`]: apply the current state, then persist
+    /// the journal according to `durability`.
     async fn persist<H, S>(
         mut self,
         merkle: &compact::Merkle<F, D, S>,
@@ -346,19 +346,19 @@ impl<E: Context, F: Family, D: Digest> Store<E, F, D> {
             .apply::<H, S>(merkle, inactivity_floor_loc, last_commit_op_bytes)
             .await?;
 
-        // A commit leaves `pending_sync` set so the next full sync still persists all metadata.
+        // Sync must persist recovery metadata even when a commit already made every witness durable
         match durability {
             Durability::Commit if self.uncommitted => {
                 self.journal = self.journal.commit().await?;
                 self.uncommitted = false;
             }
-            Durability::Sync if self.uncommitted || self.pending_sync.is_some() => {
+            Durability::Sync => {
                 let journal = self.journal.sync().await?;
                 self.pending_sync = None;
                 self.uncommitted = false;
                 self.journal = journal;
             }
-            Durability::Commit | Durability::Sync => {}
+            Durability::Commit => {}
         }
         Ok(self)
     }

--- a/storage/src/qmdb/current/db.rs
+++ b/storage/src/qmdb/current/db.rs
@@ -609,9 +609,8 @@ where
     /// underlying Any database before this Current overlay finishes rebuilding. Callers must drop
     /// this database handle after any `Err` from `rewind` and reopen from storage.
     ///
-    /// A successful rewind is not restart-stable until a subsequent [`Db::commit`] or
-    /// [`Db::sync`] completes, or until the handle returned by a subsequent [`Db::start_sync`]
-    /// completes.
+    /// The rewind of the operations journal and its Merkle structure is durable before this
+    /// method returns.
     #[tracing::instrument(name = "qmdb.current.db.rewind", level = "info", skip_all)]
     #[boxed]
     pub async fn rewind(mut self, size: Location<F>) -> Result<Self, Error<F>> {

--- a/storage/src/qmdb/current/db.rs
+++ b/storage/src/qmdb/current/db.rs
@@ -610,16 +610,18 @@ where
     /// this database handle after any `Err` from `rewind` and reopen from storage.
     ///
     /// The rewind of the operations journal and its Merkle structure is durable before this
-    /// method returns.
+    /// method returns. A `size` equal to the current size truncates nothing and instead makes the
+    /// applied state durable, so a completed rewind always leaves `size` durable.
     #[tracing::instrument(name = "qmdb.current.db.rewind", level = "info", skip_all)]
     #[boxed]
     pub async fn rewind(mut self, size: Location<F>) -> Result<Self, Error<F>> {
         let rewind_size = *size;
         let current_size = *self.any.last_commit_loc + 1;
-        // No-op short-circuit. Avoids the post-rewind grafted-tree rebuild and the validation
-        // and journal-read overhead below. Validation runs after this on the non-no-op path.
+
+        // Nothing to truncate, but the applied state may still be unsynced. This also skips the
+        // grafted-tree rebuild and the validation and journal reads below.
         if rewind_size == current_size {
-            return Ok(self);
+            return self.sync().await;
         }
         // Reject zero / out-of-range up front: lines below compute `rewind_size - 1`, which
         // underflows when `rewind_size == 0`. `any::Db::rewind` would catch these, but it isn't

--- a/storage/src/qmdb/current/db.rs
+++ b/storage/src/qmdb/current/db.rs
@@ -610,8 +610,8 @@ where
     /// this database handle after any `Err` from `rewind` and reopen from storage.
     ///
     /// The rewind of the operations journal and its Merkle structure is durable before this
-    /// method returns. A `size` equal to the current size truncates nothing and instead makes the
-    /// applied state durable, so a completed rewind always leaves `size` durable.
+    /// method returns. A `size` equal to the current size truncates nothing and makes the applied
+    /// state durable, so a completed rewind always leaves the state at `size` durable.
     #[tracing::instrument(name = "qmdb.current.db.rewind", level = "info", skip_all)]
     #[boxed]
     pub async fn rewind(mut self, size: Location<F>) -> Result<Self, Error<F>> {

--- a/storage/src/qmdb/current/db.rs
+++ b/storage/src/qmdb/current/db.rs
@@ -609,17 +609,14 @@ where
     /// underlying Any database before this Current overlay finishes rebuilding. Callers must drop
     /// this database handle after any `Err` from `rewind` and reopen from storage.
     ///
-    /// The rewind of the operations journal and its Merkle structure is durable before this
-    /// method returns. A `size` equal to the current size truncates nothing and makes the applied
-    /// state durable, so a completed rewind always leaves the state at `size` durable.
+    /// The state at `size` is durable on return, including when `size` already matches.
     #[tracing::instrument(name = "qmdb.current.db.rewind", level = "info", skip_all)]
     #[boxed]
     pub async fn rewind(mut self, size: Location<F>) -> Result<Self, Error<F>> {
         let rewind_size = *size;
         let current_size = *self.any.last_commit_loc + 1;
 
-        // Nothing to truncate, but the applied state may still be unsynced. This also skips the
-        // grafted-tree rebuild and the validation and journal reads below.
+        // An equal target may still have unsynced applied state
         if rewind_size == current_size {
             return self.sync().await;
         }

--- a/storage/src/qmdb/current/unordered/fixed.rs
+++ b/storage/src/qmdb/current/unordered/fixed.rs
@@ -546,9 +546,8 @@ pub mod test {
         });
     }
 
-    /// A page-aligned rewind followed by a replacement branch that crashes before it is
-    /// committed recovers exactly that branch: the durable truncation leaves no pre-rewind
-    /// operations behind the new ones for recovery to splice into a hybrid history.
+    /// Rewind a committed branch, apply a shorter replacement without committing, then crash.
+    /// Recovery must yield the replacement without splicing in the discarded branch's tail.
     #[test_traced]
     fn test_current_unordered_fixed_rewind_then_rebranch_crash_recovers_branch() {
         fn key(i: u8) -> Digest {
@@ -559,8 +558,7 @@ pub mod test {
             bytes[31] = i;
             Digest::from(bytes)
         }
-        // One operation per page puts every rewind target on a page boundary, and one blob
-        // keeps the pre-rewind tail in the same file the replacement branch writes into.
+        // Align rewind targets to pages and keep both branches in one blob so their writes overlap
         fn db_config(ctx: &deterministic::Context) -> FixedConfig<TwoCap, Sequential> {
             let page_size = std::num::NonZeroU16::new(
                 <Operation<mmr::Family, Digest, Digest> as FixedSize>::SIZE as u16,
@@ -591,7 +589,7 @@ pub mod test {
             }
         }
 
-        // The crash keeps every unsynced write in full and drops every unsynced resize.
+        // Keep unsynced writes and drop unsynced resizes at the crash
         let runtime = DeterministicConfig::default().with_storage_fault_config(
             FaultConfig::default().write(WriteConfig {
                 failure_rate: probability!(0.0),
@@ -605,7 +603,7 @@ pub mod test {
                     .await
                     .unwrap();
 
-                // A: create k1..k100 and commit.
+                // A: create k1..k100 and commit
                 let mut batch = db.new_batch();
                 for i in 1..=100 {
                     batch = batch.write(key(i), Some(value(1, i)));
@@ -616,7 +614,7 @@ pub mod test {
                 assert_eq!(*db.bounds().end, 103);
                 let root_a = db.root();
 
-                // B: update k2..k50 and commit.
+                // B: update k2..k50 and commit
                 let mut batch = db.new_batch();
                 for i in 2..=50 {
                     batch = batch.write(key(i), Some(value(2, i)));
@@ -627,8 +625,7 @@ pub mod test {
                 assert_eq!(*db.bounds().end, 203);
                 let root_b = db.root();
 
-                // Rewind to A, then apply the replacement branch N over B's old pages without
-                // committing, and crash.
+                // Rewind to A, append the shorter branch N over B, then crash without committing
                 let db = db.rewind(Location::new(103)).await.unwrap();
                 assert_eq!(db.root(), root_a);
                 let mut batch = db.new_batch();
@@ -652,7 +649,7 @@ pub mod test {
                 .await
                 .unwrap();
 
-            // Recovery yields N and nothing from B's discarded tail.
+            // Recover N without B's discarded tail
             assert_eq!(*db.bounds().end, 191);
             assert_eq!(db.root(), root_n);
             assert_ne!(db.root(), root_a);

--- a/storage/src/qmdb/current/unordered/fixed.rs
+++ b/storage/src/qmdb/current/unordered/fixed.rs
@@ -110,18 +110,28 @@ pub mod partitioned {
 pub mod test {
     use super::*;
     use crate::{
+        journal::contiguous::fixed::Config as JournalConfig,
+        merkle::full::Config as MerkleConfig,
         mmr,
         qmdb::current::{
+            FixedConfig,
             tests::{fixed_config, fixed_config_partitioned},
             unordered::tests as shared,
         },
         translator::{OneCap, TwoCap},
     };
+    use commonware_codec::FixedSize;
     use commonware_cryptography::{Sha256, sha256::Digest};
     use commonware_macros::test_traced;
     use commonware_parallel::Sequential;
-    use commonware_runtime::{Metrics, Runner as _, Supervisor as _, deterministic};
-    use commonware_utils::TestRng;
+    use commonware_runtime::{
+        Metrics, Runner as _, Supervisor as _,
+        buffer::paged::CacheRef,
+        deterministic::{
+            self, Config as DeterministicConfig, FaultConfig, PartialWriteMode, WriteConfig,
+        },
+    };
+    use commonware_utils::{NZU16, NZU64, NZUsize, TestRng, probability};
     use rand::Rng as _;
     use std::collections::HashMap;
 
@@ -541,18 +551,6 @@ pub mod test {
     /// operations behind the new ones for recovery to splice into a hybrid history.
     #[test_traced]
     fn test_current_unordered_fixed_rewind_then_rebranch_crash_recovers_branch() {
-        use crate::{
-            journal::contiguous::fixed::Config as JournalConfig,
-            merkle::{Location, full::Config as MerkleConfig},
-            qmdb::current::FixedConfig,
-        };
-        use commonware_codec::FixedSize;
-        use commonware_runtime::{
-            buffer::paged::CacheRef,
-            deterministic::{Config, FaultConfig, PartialWriteMode, WriteConfig},
-        };
-        use commonware_utils::{NZU16, NZU64, NZUsize, probability};
-
         fn key(i: u8) -> Digest {
             Digest::from([i; 32])
         }
@@ -594,13 +592,13 @@ pub mod test {
         }
 
         // The crash keeps every unsynced write in full and drops every unsynced resize.
-        let runtime = Config::default().with_storage_fault_config(FaultConfig::default().write(
-            WriteConfig {
+        let runtime = DeterministicConfig::default().with_storage_fault_config(
+            FaultConfig::default().write(WriteConfig {
                 failure_rate: probability!(0.0),
                 retention_rate: probability!(1.0),
                 mode: PartialWriteMode::Prefix,
-            },
-        ));
+            }),
+        );
         let ((root_a, root_b, root_n), checkpoint) = deterministic::Runner::new(runtime)
             .start_and_recover(|ctx| async move {
                 let db = CurrentTest::init(ctx.child("initial"), db_config(&ctx))

--- a/storage/src/qmdb/current/unordered/fixed.rs
+++ b/storage/src/qmdb/current/unordered/fixed.rs
@@ -535,4 +535,140 @@ pub mod test {
             .await;
         });
     }
+
+    /// A page-aligned rewind followed by a replacement branch that crashes before it is
+    /// committed recovers exactly that branch: the durable truncation leaves no pre-rewind
+    /// operations behind the new ones for recovery to splice into a hybrid history.
+    #[test_traced]
+    fn test_current_unordered_fixed_rewind_then_rebranch_crash_recovers_branch() {
+        use crate::{
+            journal::contiguous::fixed::Config as JournalConfig,
+            merkle::{Location, full::Config as MerkleConfig},
+            qmdb::current::FixedConfig,
+        };
+        use commonware_codec::FixedSize;
+        use commonware_runtime::{
+            buffer::paged::CacheRef,
+            deterministic::{Config, FaultConfig, PartialWriteMode, WriteConfig},
+        };
+        use commonware_utils::{NZU16, NZU64, NZUsize, probability};
+
+        fn key(i: u8) -> Digest {
+            Digest::from([i; 32])
+        }
+        fn value(branch: u8, i: u8) -> Digest {
+            let mut bytes = [branch; 32];
+            bytes[31] = i;
+            Digest::from(bytes)
+        }
+        // One operation per page puts every rewind target on a page boundary, and one blob
+        // keeps the pre-rewind tail in the same file the replacement branch writes into.
+        fn db_config(ctx: &deterministic::Context) -> FixedConfig<TwoCap, Sequential> {
+            let page_size = std::num::NonZeroU16::new(
+                <Operation<mmr::Family, Digest, Digest> as FixedSize>::SIZE as u16,
+            )
+            .unwrap();
+            FixedConfig {
+                merkle_config: MerkleConfig {
+                    journal_partition: "rebranch-merkle-journal".into(),
+                    metadata_partition: "rebranch-merkle-metadata".into(),
+                    items_per_blob: NZU64!(100_000),
+                    write_buffer: NZUsize!(4096),
+                    replay_buffer: NZUsize!(4096),
+                    strategy: Sequential,
+                    page_cache: CacheRef::from_pooler(ctx, NZU16!(1024), NZUsize!(64)),
+                },
+                journal_config: JournalConfig {
+                    partition: "rebranch-ops-journal".into(),
+                    items_per_blob: NZU64!(100_000),
+                    page_cache: CacheRef::from_pooler(ctx, page_size, NZUsize!(64)),
+                    write_buffer: NZUsize!(1300),
+                    replay_buffer: NZUsize!(4096),
+                },
+                grafted_metadata_partition: "rebranch-current-metadata".into(),
+                translator: TwoCap,
+                init_cache_size: Some(NZUsize!(1024)),
+                init_buffer: NZUsize!(1 << 16),
+                init_concurrency: (),
+            }
+        }
+
+        // The crash keeps every unsynced write in full and drops every unsynced resize.
+        let runtime = Config::default().with_storage_fault_config(FaultConfig::default().write(
+            WriteConfig {
+                failure_rate: probability!(0.0),
+                retention_rate: probability!(1.0),
+                mode: PartialWriteMode::Prefix,
+            },
+        ));
+        let ((root_a, root_b, root_n), checkpoint) = deterministic::Runner::new(runtime)
+            .start_and_recover(|ctx| async move {
+                let db = CurrentTest::init(ctx.child("initial"), db_config(&ctx))
+                    .await
+                    .unwrap();
+
+                // A: create k1..k100 and commit.
+                let mut batch = db.new_batch();
+                for i in 1..=100 {
+                    batch = batch.write(key(i), Some(value(1, i)));
+                }
+                let batch = batch.merkleize(&db, None).await.unwrap();
+                let (db, _) = db.apply_batch(batch).await.unwrap();
+                let db = db.commit().await.unwrap();
+                assert_eq!(*db.bounds().end, 103);
+                let root_a = db.root();
+
+                // B: update k2..k50 and commit.
+                let mut batch = db.new_batch();
+                for i in 2..=50 {
+                    batch = batch.write(key(i), Some(value(2, i)));
+                }
+                let batch = batch.merkleize(&db, None).await.unwrap();
+                let (db, _) = db.apply_batch(batch).await.unwrap();
+                let db = db.commit().await.unwrap();
+                assert_eq!(*db.bounds().end, 203);
+                let root_b = db.root();
+
+                // Rewind to A, then apply the replacement branch N over B's old pages without
+                // committing, and crash.
+                let db = db.rewind(Location::new(103)).await.unwrap();
+                assert_eq!(db.root(), root_a);
+                let mut batch = db.new_batch();
+                for i in 68..=100 {
+                    batch = batch.write(key(i), Some(value(3, i)));
+                }
+                for i in 1..=20 {
+                    batch = batch.write(key(100 + i), Some(value(4, i)));
+                }
+                let batch = batch.merkleize(&db, None).await.unwrap();
+                let root_n = batch.root();
+                let (db, range) = db.apply_batch(batch).await.unwrap();
+                assert_eq!((*range.start, *range.end), (103, 191));
+                drop(db);
+
+                (root_a, root_b, root_n)
+            });
+
+        deterministic::Runner::from(checkpoint).start(|ctx| async move {
+            let db = CurrentTest::init(ctx.child("reopen"), db_config(&ctx))
+                .await
+                .unwrap();
+
+            // Recovery yields N and nothing from B's discarded tail.
+            assert_eq!(*db.bounds().end, 191);
+            assert_eq!(db.root(), root_n);
+            assert_ne!(db.root(), root_a);
+            assert_ne!(db.root(), root_b);
+            for i in 1..=67 {
+                assert_eq!(db.get(&key(i)).await.unwrap(), Some(value(1, i)));
+            }
+            for i in 68..=100 {
+                assert_eq!(db.get(&key(i)).await.unwrap(), Some(value(3, i)));
+            }
+            for i in 1..=20 {
+                assert_eq!(db.get(&key(100 + i)).await.unwrap(), Some(value(4, i)));
+            }
+            db.destroy().await.unwrap();
+        });
+    }
 }

--- a/storage/src/qmdb/immutable/compact.rs
+++ b/storage/src/qmdb/immutable/compact.rs
@@ -724,6 +724,7 @@ mod tests {
     use super::*;
     use crate::{
         merkle::{mmb, mmr},
+        metadata::{Config as MetadataConfig, Metadata},
         qmdb::{
             any::value::FixedEncoding, compact::witness, verify_proof,
             verify_proof_and_pinned_nodes,
@@ -738,7 +739,7 @@ mod tests {
         deterministic,
         mocks::{DelayedSyncContext, PendingSyncs, drive_pending_syncs},
     };
-    use commonware_utils::{NZU16, NZU64, NZUsize};
+    use commonware_utils::{NZU16, NZU64, NZUsize, sequence::VecU64};
     use core::future::Future;
     use futures::FutureExt as _;
     use std::num::{NonZeroU16, NonZeroUsize};
@@ -1600,10 +1601,24 @@ mod tests {
                     .await;
                 let (db, _) = db.apply_batch(batch).await.unwrap();
                 let db = db.commit().await.unwrap();
-                // The commit already made the state durable, so this is a no-op.
+                // Commit persists witness data; sync must also persist recovery metadata
                 let db = db.sync().await.unwrap();
                 db.root()
             };
+
+            // Check the watermark before reopening can rebuild the offsets journal
+            let metadata = Metadata::<_, u64, VecU64>::init(
+                context.child("checkpoint"),
+                MetadataConfig {
+                    partition: format!("{partition}-witness_offsets-metadata"),
+                    codec_config: (),
+                },
+            )
+            .await
+            .unwrap();
+            // Key 3 records the durable prefix: the bootstrap witness and the applied batch
+            assert_eq!(metadata.get(&3).copied().map(u64::from), Some(2));
+            drop(metadata);
 
             let db = open_db::<mmr::Family>(context.child("second"), partition).await;
             assert_eq!(db.root(), root);

--- a/storage/src/qmdb/immutable/fixed.rs
+++ b/storage/src/qmdb/immutable/fixed.rs
@@ -124,6 +124,40 @@ mod tests {
         Db::init(context, cfg).await.unwrap()
     }
 
+    /// A rewind to the current size makes applied but uncommitted state durable: after such a
+    /// rewind and a crash with no commit or sync, the reopened db reports the applied state.
+    #[test_traced]
+    fn test_immutable_fixed_rewind_current_size_makes_applied_state_durable() {
+        let key = Sha256::hash(&[b"key"]);
+        let value = Sha256::fill(7u8);
+        let ((size, root), checkpoint) =
+            deterministic::Runner::default().start_and_recover(|context| async move {
+                let db = open_db::<mmr::Family>(context.child("db")).await;
+
+                // Apply a batch without committing, then rewind to the size it produced.
+                let merkleized = db
+                    .new_batch()
+                    .set(key, value)
+                    .merkleize(&db, None, db.inactivity_floor_loc())
+                    .await;
+                let (db, _) = db.apply_batch(merkleized).await.unwrap();
+                let size = db.bounds().end;
+                let root = db.root();
+                let db = db.rewind(size).await.unwrap();
+                assert_eq!(db.root(), root);
+                drop(db);
+                (size, root)
+            });
+
+        deterministic::Runner::from(checkpoint).start(|context| async move {
+            let db = open_db::<mmr::Family>(context.child("reopen")).await;
+            assert_eq!(db.bounds().end, size);
+            assert_eq!(db.root(), root);
+            assert_eq!(db.get(&key).await.unwrap(), Some(value));
+            db.destroy().await.unwrap();
+        });
+    }
+
     async fn open_compact<F: Family>(
         context: deterministic::Context,
     ) -> CompactDb<F, deterministic::Context, Digest, Digest, Sha256, Sequential> {

--- a/storage/src/qmdb/immutable/fixed.rs
+++ b/storage/src/qmdb/immutable/fixed.rs
@@ -124,12 +124,11 @@ mod tests {
         Db::init(context, cfg).await.unwrap()
     }
 
-    /// A rewind to the current size makes applied but uncommitted state durable: after such a
-    /// rewind and a crash with no commit or sync, the reopened db reports the applied state.
+    /// Apply an uncommitted batch, rewind to its size, then crash without another sync.
+    /// Recovery must retain the batch's state.
     #[test_traced]
     fn test_immutable_fixed_rewind_current_size_makes_applied_state_durable() {
-        // Blobs large enough that no append seals one, whose sync would make the applied state
-        // durable on its own.
+        // Avoid rollover so sealing cannot hide a missing rewind sync
         async fn open(
             context: deterministic::Context,
         ) -> Db<mmr::Family, deterministic::Context, Digest, Digest, Sha256, TwoCap, Sequential>
@@ -146,7 +145,7 @@ mod tests {
             deterministic::Runner::default().start_and_recover(|context| async move {
                 let db = open(context.child("db")).await;
 
-                // Apply a batch without committing, then rewind to the size it produced.
+                // Leave the batch uncommitted so the equal-size rewind must persist it
                 let merkleized = db
                     .new_batch()
                     .set(key, value)

--- a/storage/src/qmdb/immutable/fixed.rs
+++ b/storage/src/qmdb/immutable/fixed.rs
@@ -128,11 +128,23 @@ mod tests {
     /// rewind and a crash with no commit or sync, the reopened db reports the applied state.
     #[test_traced]
     fn test_immutable_fixed_rewind_current_size_makes_applied_state_durable() {
+        // Blobs large enough that no append seals one, whose sync would make the applied state
+        // durable on its own.
+        async fn open(
+            context: deterministic::Context,
+        ) -> Db<mmr::Family, deterministic::Context, Digest, Digest, Sha256, TwoCap, Sequential>
+        {
+            let mut cfg = config("rcs", &context);
+            cfg.log.items_per_blob = NZU64!(1000);
+            cfg.merkle_config.items_per_blob = NZU64!(1000);
+            Db::init(context, cfg).await.unwrap()
+        }
+
         let key = Sha256::hash(&[b"key"]);
         let value = Sha256::fill(7u8);
         let ((size, root), checkpoint) =
             deterministic::Runner::default().start_and_recover(|context| async move {
-                let db = open_db::<mmr::Family>(context.child("db")).await;
+                let db = open(context.child("db")).await;
 
                 // Apply a batch without committing, then rewind to the size it produced.
                 let merkleized = db
@@ -150,7 +162,7 @@ mod tests {
             });
 
         deterministic::Runner::from(checkpoint).start(|context| async move {
-            let db = open_db::<mmr::Family>(context.child("reopen")).await;
+            let db = open(context.child("reopen")).await;
             assert_eq!(db.bounds().end, size);
             assert_eq!(db.root(), root);
             assert_eq!(db.get(&key).await.unwrap(), Some(value));

--- a/storage/src/qmdb/immutable/mod.rs
+++ b/storage/src/qmdb/immutable/mod.rs
@@ -567,16 +567,14 @@ where
     /// before this method finishes rebuilding in-memory rewind state. Callers must drop this
     /// database handle after any `Err` from `rewind` and reopen from storage.
     ///
-    /// The rewind of the operations journal and its Merkle structure is durable before this
-    /// method returns. A `size` equal to the current size truncates nothing and makes the applied
-    /// state durable, so a completed rewind always leaves the state at `size` durable.
+    /// The state at `size` is durable on return, including when `size` already matches.
     #[tracing::instrument(name = "qmdb.immutable.db.rewind", level = "info", skip_all)]
     #[boxed]
     pub async fn rewind(mut self, size: Location<F>) -> Result<Self, Error<F>> {
         let rewind_size = *size;
         let current_size = *self.last_commit_loc + 1;
 
-        // Nothing to truncate, but the applied state may still be unsynced.
+        // An equal target may still have unsynced applied state
         if rewind_size == current_size {
             return self.sync().await;
         }

--- a/storage/src/qmdb/immutable/mod.rs
+++ b/storage/src/qmdb/immutable/mod.rs
@@ -567,9 +567,8 @@ where
     /// before this method finishes rebuilding in-memory rewind state. Callers must drop this
     /// database handle after any `Err` from `rewind` and reopen from storage.
     ///
-    /// A successful rewind is not restart-stable until a subsequent [`Immutable::commit`] or
-    /// [`Immutable::sync`] completes, or until the handle returned by a subsequent
-    /// [`Immutable::start_sync`] completes.
+    /// The rewind of the operations journal and its Merkle structure is durable before this
+    /// method returns.
     #[tracing::instrument(name = "qmdb.immutable.db.rewind", level = "info", skip_all)]
     #[boxed]
     pub async fn rewind(mut self, size: Location<F>) -> Result<Self, Error<F>> {

--- a/storage/src/qmdb/immutable/mod.rs
+++ b/storage/src/qmdb/immutable/mod.rs
@@ -568,8 +568,8 @@ where
     /// database handle after any `Err` from `rewind` and reopen from storage.
     ///
     /// The rewind of the operations journal and its Merkle structure is durable before this
-    /// method returns. A `size` equal to the current size truncates nothing and instead makes the
-    /// applied state durable, so a completed rewind always leaves `size` durable.
+    /// method returns. A `size` equal to the current size truncates nothing and makes the applied
+    /// state durable, so a completed rewind always leaves the state at `size` durable.
     #[tracing::instrument(name = "qmdb.immutable.db.rewind", level = "info", skip_all)]
     #[boxed]
     pub async fn rewind(mut self, size: Location<F>) -> Result<Self, Error<F>> {

--- a/storage/src/qmdb/immutable/mod.rs
+++ b/storage/src/qmdb/immutable/mod.rs
@@ -568,14 +568,17 @@ where
     /// database handle after any `Err` from `rewind` and reopen from storage.
     ///
     /// The rewind of the operations journal and its Merkle structure is durable before this
-    /// method returns.
+    /// method returns. A `size` equal to the current size truncates nothing and instead makes the
+    /// applied state durable, so a completed rewind always leaves `size` durable.
     #[tracing::instrument(name = "qmdb.immutable.db.rewind", level = "info", skip_all)]
     #[boxed]
     pub async fn rewind(mut self, size: Location<F>) -> Result<Self, Error<F>> {
         let rewind_size = *size;
         let current_size = *self.last_commit_loc + 1;
+
+        // Nothing to truncate, but the applied state may still be unsynced.
         if rewind_size == current_size {
-            return Ok(self);
+            return self.sync().await;
         }
         if rewind_size == 0 || rewind_size > current_size {
             return Err(Error::Journal(crate::journal::Error::InvalidRewind(

--- a/storage/src/qmdb/keyless/compact.rs
+++ b/storage/src/qmdb/keyless/compact.rs
@@ -698,6 +698,7 @@ mod tests {
     use super::*;
     use crate::{
         merkle::{mmb, mmr},
+        metadata::{Config as MetadataConfig, Metadata},
         qmdb::{
             any::value::FixedEncoding, compact::witness, verify_proof,
             verify_proof_and_pinned_nodes,
@@ -713,7 +714,10 @@ mod tests {
         mocks::{DelayedSyncContext, PendingSyncs, drive_pending_syncs, fail_pending_syncs},
         reschedule,
     };
-    use commonware_utils::{NZU16, NZU64, NZUsize, sequence::U64};
+    use commonware_utils::{
+        NZU16, NZU64, NZUsize,
+        sequence::{U64, VecU64},
+    };
     use core::future::Future;
     use futures::FutureExt as _;
     use std::num::{NonZeroU16, NonZeroUsize};
@@ -2012,10 +2016,24 @@ mod tests {
                     .await;
                 let (db, _) = db.apply_batch(batch).await.unwrap();
                 let db = db.commit().await.unwrap();
-                // The commit already made the state durable, so this is a no-op.
+                // Commit persists witness data; sync must also persist recovery metadata
                 let db = db.sync().await.unwrap();
                 db.root()
             };
+
+            // Check the watermark before reopening can rebuild the offsets journal
+            let metadata = Metadata::<_, u64, VecU64>::init(
+                context.child("checkpoint"),
+                MetadataConfig {
+                    partition: format!("{partition}-witness_offsets-metadata"),
+                    codec_config: (),
+                },
+            )
+            .await
+            .unwrap();
+            // Key 3 records the durable prefix: the bootstrap witness and the applied batch
+            assert_eq!(metadata.get(&3).copied().map(u64::from), Some(2));
+            drop(metadata);
 
             let db = open_db::<mmr::Family>(context.child("second"), partition).await;
             assert_eq!(db.root(), root);

--- a/storage/src/qmdb/keyless/fixed.rs
+++ b/storage/src/qmdb/keyless/fixed.rs
@@ -132,9 +132,18 @@ mod tests {
     /// rewind and a crash with no commit or sync, the reopened db reports the applied state.
     #[test_traced]
     fn test_keyless_fixed_rewind_current_size_makes_applied_state_durable() {
+        // Blobs large enough that no append seals one, whose sync would make the applied state
+        // durable on its own.
+        async fn open(context: deterministic::Context) -> TestDb<mmr::Family> {
+            let mut cfg = db_config("rcs", &context, Sequential);
+            cfg.log.items_per_blob = NZU64!(1000);
+            cfg.merkle.items_per_blob = NZU64!(1000);
+            TestDb::init(context, cfg).await.unwrap()
+        }
+
         let ((size, root), checkpoint) =
             deterministic::Runner::default().start_and_recover(|context| async move {
-                let db = open_db_with_suffix::<mmr::Family>("rcs", context.child("db")).await;
+                let db = open(context.child("db")).await;
 
                 // Apply a batch without committing, then rewind to the size it produced.
                 let merkleized = db
@@ -152,7 +161,7 @@ mod tests {
             });
 
         deterministic::Runner::from(checkpoint).start(|context| async move {
-            let db = open_db_with_suffix::<mmr::Family>("rcs", context.child("reopen")).await;
+            let db = open(context.child("reopen")).await;
             assert_eq!(db.bounds().end, size);
             assert_eq!(db.root(), root);
             assert_eq!(db.get(Location::new(1)).await.unwrap(), Some(U64::new(7)));

--- a/storage/src/qmdb/keyless/fixed.rs
+++ b/storage/src/qmdb/keyless/fixed.rs
@@ -128,12 +128,11 @@ mod tests {
         TestDb::init(context, cfg).await.unwrap()
     }
 
-    /// A rewind to the current size makes applied but uncommitted state durable: after such a
-    /// rewind and a crash with no commit or sync, the reopened db reports the applied state.
+    /// Apply an uncommitted batch, rewind to its size, then crash without another sync.
+    /// Recovery must retain the batch's state.
     #[test_traced]
     fn test_keyless_fixed_rewind_current_size_makes_applied_state_durable() {
-        // Blobs large enough that no append seals one, whose sync would make the applied state
-        // durable on its own.
+        // Avoid rollover so sealing cannot hide a missing rewind sync
         async fn open(context: deterministic::Context) -> TestDb<mmr::Family> {
             let mut cfg = db_config("rcs", &context, Sequential);
             cfg.log.items_per_blob = NZU64!(1000);
@@ -145,7 +144,7 @@ mod tests {
             deterministic::Runner::default().start_and_recover(|context| async move {
                 let db = open(context.child("db")).await;
 
-                // Apply a batch without committing, then rewind to the size it produced.
+                // Leave the batch uncommitted so the equal-size rewind must persist it
                 let merkleized = db
                     .new_batch()
                     .append(U64::new(7))

--- a/storage/src/qmdb/keyless/fixed.rs
+++ b/storage/src/qmdb/keyless/fixed.rs
@@ -128,6 +128,38 @@ mod tests {
         TestDb::init(context, cfg).await.unwrap()
     }
 
+    /// A rewind to the current size makes applied but uncommitted state durable: after such a
+    /// rewind and a crash with no commit or sync, the reopened db reports the applied state.
+    #[test_traced]
+    fn test_keyless_fixed_rewind_current_size_makes_applied_state_durable() {
+        let ((size, root), checkpoint) =
+            deterministic::Runner::default().start_and_recover(|context| async move {
+                let db = open_db_with_suffix::<mmr::Family>("rcs", context.child("db")).await;
+
+                // Apply a batch without committing, then rewind to the size it produced.
+                let merkleized = db
+                    .new_batch()
+                    .append(U64::new(7))
+                    .merkleize(&db, None, db.inactivity_floor_loc())
+                    .await;
+                let (db, _) = db.apply_batch(merkleized).await.unwrap();
+                let size = db.bounds().end;
+                let root = db.root();
+                let db = db.rewind(size).await.unwrap();
+                assert_eq!(db.root(), root);
+                drop(db);
+                (size, root)
+            });
+
+        deterministic::Runner::from(checkpoint).start(|context| async move {
+            let db = open_db_with_suffix::<mmr::Family>("rcs", context.child("reopen")).await;
+            assert_eq!(db.bounds().end, size);
+            assert_eq!(db.root(), root);
+            assert_eq!(db.get(Location::new(1)).await.unwrap(), Some(U64::new(7)));
+            db.destroy().await.unwrap();
+        });
+    }
+
     async fn open_rayon_db<F: Family>(context: deterministic::Context) -> TestRayonDb<F> {
         let strategy = context.strategy(NZUsize!(2));
         let cfg = db_config("rayon", &context, strategy);

--- a/storage/src/qmdb/keyless/mod.rs
+++ b/storage/src/qmdb/keyless/mod.rs
@@ -419,8 +419,8 @@ where
     /// database handle after any `Err` from `rewind` and reopen from storage.
     ///
     /// The rewind of the operations journal and its Merkle structure is durable before this
-    /// method returns. A `size` equal to the current size truncates nothing and instead makes the
-    /// applied state durable, so a completed rewind always leaves `size` durable.
+    /// method returns. A `size` equal to the current size truncates nothing and makes the applied
+    /// state durable, so a completed rewind always leaves the state at `size` durable.
     #[tracing::instrument(name = "qmdb.keyless.db.rewind", level = "info", skip_all)]
     #[boxed]
     pub async fn rewind(mut self, size: Location<F>) -> Result<Self, Error<F>> {

--- a/storage/src/qmdb/keyless/mod.rs
+++ b/storage/src/qmdb/keyless/mod.rs
@@ -418,9 +418,8 @@ where
     /// before this method finishes updating in-memory rewind state. Callers must drop this
     /// database handle after any `Err` from `rewind` and reopen from storage.
     ///
-    /// A successful rewind is not restart-stable until a subsequent [`Self::commit`] or
-    /// [`Self::sync`] completes, or until the handle returned by a subsequent
-    /// [`Self::start_sync`] completes.
+    /// The rewind of the operations journal and its Merkle structure is durable before this
+    /// method returns.
     #[tracing::instrument(name = "qmdb.keyless.db.rewind", level = "info", skip_all)]
     #[boxed]
     pub async fn rewind(mut self, size: Location<F>) -> Result<Self, Error<F>> {

--- a/storage/src/qmdb/keyless/mod.rs
+++ b/storage/src/qmdb/keyless/mod.rs
@@ -418,16 +418,14 @@ where
     /// before this method finishes updating in-memory rewind state. Callers must drop this
     /// database handle after any `Err` from `rewind` and reopen from storage.
     ///
-    /// The rewind of the operations journal and its Merkle structure is durable before this
-    /// method returns. A `size` equal to the current size truncates nothing and makes the applied
-    /// state durable, so a completed rewind always leaves the state at `size` durable.
+    /// The state at `size` is durable on return, including when `size` already matches.
     #[tracing::instrument(name = "qmdb.keyless.db.rewind", level = "info", skip_all)]
     #[boxed]
     pub async fn rewind(mut self, size: Location<F>) -> Result<Self, Error<F>> {
         let rewind_size = *size;
         let current_size = *self.last_commit_loc + 1;
 
-        // Nothing to truncate, but the applied state may still be unsynced.
+        // An equal target may still have unsynced applied state
         if rewind_size == current_size {
             return self.sync().await;
         }

--- a/storage/src/qmdb/keyless/mod.rs
+++ b/storage/src/qmdb/keyless/mod.rs
@@ -419,14 +419,17 @@ where
     /// database handle after any `Err` from `rewind` and reopen from storage.
     ///
     /// The rewind of the operations journal and its Merkle structure is durable before this
-    /// method returns.
+    /// method returns. A `size` equal to the current size truncates nothing and instead makes the
+    /// applied state durable, so a completed rewind always leaves `size` durable.
     #[tracing::instrument(name = "qmdb.keyless.db.rewind", level = "info", skip_all)]
     #[boxed]
     pub async fn rewind(mut self, size: Location<F>) -> Result<Self, Error<F>> {
         let rewind_size = *size;
         let current_size = *self.last_commit_loc + 1;
+
+        // Nothing to truncate, but the applied state may still be unsynced.
         if rewind_size == current_size {
-            return Ok(self);
+            return self.sync().await;
         }
         if rewind_size == 0 || rewind_size > current_size {
             return Err(Error::Journal(crate::journal::Error::InvalidRewind(


### PR DESCRIPTION
Closes #4682. Closes #4690.

Make journal rewinds durable before returning so a crash after rewind and append cannot combine replacement data with a discarded tail. This prevents recovery from accepting unwritten items or rebuilding QMDB from mixed histories.

- Sync paged buffer shrinks and raw journal rewinds, including retained buffered bytes.
- Make equal-target rewinds durable in standard QMDB databases and preserve Oversized index/value syncs.
- Remove redundant caller syncs and document the durability contracts.
- Always sync the Merkle node journal in `Merkle::sync` and persist recovery metadata on every compact witness `sync`, so a started sync's failure and the recovery checkpoint are never skipped when nothing new was flushed.

The last item regenerates 28 storage conformance hashes (authenticated journal, Merkle, and every QMDB workload). The on-disk format is unchanged: a clean checkpoint persist writes the metadata store's lagging mirror blob, so the audited durable image differs. The cost is bounded to one catch-up write per prior change.

Validation: original repros, deterministic crash regressions, and fuzz runs pass; formatting and clippy pass for runtime, storage, storage-fuzz, and glue.

