### PR TITLE
[storage] Reject batches whose chain does not match the structure's state

### DIFF
--- a/storage/src/journal/authenticated.rs
+++ b/storage/src/journal/authenticated.rs
@@ -545,6 +545,11 @@ where
             .into());
         };
 
+        // Confirm the Merkle structure really is at one of the chain's states before any item
+        // is appended, so a stale batch mutates nothing.
+        self.merkle
+            .with_mem(|mem| mem.validate_batch(&batch.inner))?;
+
         // Apply ancestor item batches in root-to-tip order. Already-committed
         // batches are skipped by tracking cumulative leaf count.
         // Batches are collected into a single append_many call to acquire the
@@ -3294,6 +3299,62 @@ mod tests {
 
         assert_eq!(journal_root(&journal), expected_root);
         assert_eq!(*journal.size(), 2);
+    }
+
+    async fn test_stale_batch_interior_fork_inner<F: Family + PartialEq>(context: Context) {
+        let mut journal =
+            create_journal_with_ops::<F>(context.child("open"), "stale-interior", 4).await;
+        let commit_op = TestOp::<F>::CommitFloor(None, Location::<F>::new(0));
+
+        // Chain A -> B is retained while a same-length sibling of A wins.
+        let batch_a = journal
+            .new_batch()
+            .add(create_operation::<F>(10))
+            .add(commit_op.clone());
+        let a = journal.merkle.with_mem(|mem| batch_a.merkleize(mem));
+        let batch_b = a.new_batch::<Sha256>().add(create_operation::<F>(20));
+        let b = journal.merkle.with_mem(|mem| batch_b.merkleize(mem));
+        let op_sibling = create_operation::<F>(30);
+        let batch_sibling = journal.new_batch().add(op_sibling.clone()).add(commit_op);
+        let sibling = journal.merkle.with_mem(|mem| batch_sibling.merkleize(mem));
+        journal = journal.apply_batch(&sibling).await.unwrap();
+        journal = journal.sync().await.unwrap();
+        let root = journal_root(&journal);
+        let size = journal.size();
+
+        // The journal is strictly inside B's chain by size, but B's ancestor is not what was
+        // applied: reusing B must be rejected rather than desynchronizing items and root.
+        let result = journal.apply_batch(&b).await;
+        assert!(
+            matches!(
+                result,
+                Err(super::Error::Merkle(merkle::Error::StaleBatch { .. }))
+            ),
+            "expected StaleBatch, got {result:?}"
+        );
+
+        // The eager reject mutated nothing: reopening recovers exactly the sibling's state.
+        let journal = create_empty_journal::<F>(context.child("reopen"), "stale-interior").await;
+        assert_eq!(journal_root(&journal), root);
+        assert_eq!(journal.size(), size);
+        let (_, ops) = journal
+            .proof(Location::<F>::new(4), NZU64!(1), 0)
+            .await
+            .unwrap();
+        assert_eq!(ops, vec![op_sibling]);
+        journal.destroy().await.unwrap();
+    }
+
+    #[test_traced("INFO")]
+    fn test_stale_batch_interior_fork_mmr() {
+        let executor = deterministic::Runner::default();
+        executor.start(test_stale_batch_interior_fork_inner::<mmr::Family>);
+    }
+
+    #[test_traced("INFO")]
+    fn test_stale_batch_interior_fork_mmb() {
+        let executor = deterministic::Runner::default();
+        executor.start(test_stale_batch_interior_fork_inner::<mmb::Family>);
     }
 
     #[test_traced("INFO")]

--- a/storage/src/merkle/batch.rs
+++ b/storage/src/merkle/batch.rs
@@ -61,7 +61,9 @@
 //!
 //! A batch becomes _invalid_ when an unapplied ancestor is dropped, or a sibling fork has been
 //! applied. Invalid batches must not be used: their methods may return incorrect data rather than
-//! erroring.
+//! erroring. Applying one is rejected, though: each batch records the peak digests of every state
+//! its chain passes through, and [`Mem::apply_batch`] refuses a structure whose peaks match none
+//! of them, so a sibling fork of the same size cannot be mistaken for an applied ancestor.
 //!
 //! Pruning the base after a batch has been merkleized does not invalidate it: prune and apply
 //! commute (see [`Mem::apply_batch`]). An unmerkleized batch still reads sibling digests from the
@@ -391,9 +393,14 @@ impl<F: Family, D: Digest, S: Strategy> UnmerkleizedBatch<F, D, S> {
             self.merkleize_bucket(base, hasher, positions, height as u32);
         }
 
+        // Record the peaks of the state this batch represents so `apply_batch` can tell it
+        // apart from another fork of the same size.
+        let tip_peaks: Vec<D> = F::peaks(self.size())
+            .map(|(pos, _)| self.get_node(base, pos).expect("peak missing"))
+            .collect();
+
         // Collect ancestor data by walking the parent chain (strong Arc + Weak walk).
-        let (ancestor_base_size, ancestor_appended, ancestor_overwrites) =
-            collect_ancestor_batches(&self.parent);
+        let ancestors = collect_ancestor_batches(&self.parent);
 
         let parent_size = self.parent.size();
         Arc::new(MerkleizedBatch {
@@ -402,10 +409,15 @@ impl<F: Family, D: Digest, S: Strategy> UnmerkleizedBatch<F, D, S> {
             overwrites: Arc::new(self.overwrites),
             parent_size,
             base_size: self.parent.base_size,
-            ancestor_base_size,
+            ancestor_base_size: ancestors.base_size,
             pruning_boundary: self.parent.pruning_boundary(),
-            ancestor_appended,
-            ancestor_overwrites,
+            base_peaks: Arc::clone(&self.parent.base_peaks),
+            parent_peaks: self.parent.tip_peaks.clone(),
+            tip_peaks,
+            ancestor_base_peaks: ancestors.base_peaks,
+            ancestor_appended: ancestors.appended,
+            ancestor_overwrites: ancestors.overwrites,
+            ancestor_tip_peaks: ancestors.tip_peaks,
             strategy: self.parent.strategy.clone(),
         })
     }
@@ -480,37 +492,57 @@ impl<F: Family, D: Digest, S: Strategy> UnmerkleizedBatch<F, D, S> {
     }
 }
 
-/// Collect ancestor batch data by walking the parent + its Weak chain.
-/// Returns the size before the oldest retained ancestor followed by its appended nodes and
-/// overwrites in root-to-tip order. Skips empty batches (e.g. root batches from `from_mem`).
-#[allow(clippy::type_complexity)]
+/// Data retained from the live ancestors of a batch, in root-to-tip order.
+struct Ancestors<F: Family, D: Digest> {
+    /// Number of nodes before the oldest retained ancestor.
+    base_size: Position<F>,
+    /// Peak digests at `base_size`.
+    base_peaks: Vec<D>,
+    /// Each ancestor's appended nodes.
+    appended: Vec<Arc<Vec<D>>>,
+    /// Each ancestor's overwrites.
+    overwrites: Vec<Arc<Overwrites<F, D>>>,
+    /// Each ancestor's peak digests at its tip.
+    tip_peaks: Vec<Vec<D>>,
+}
+
+/// Collect ancestor batch data by walking the parent + its Weak chain. Skips empty batches (e.g.
+/// root batches from `from_mem`).
 fn collect_ancestor_batches<F: Family, D: Digest, S: Strategy>(
     parent: &Arc<MerkleizedBatch<F, D, S>>,
-) -> (Position<F>, Vec<Arc<Vec<D>>>, Vec<Arc<Overwrites<F, D>>>) {
-    let mut appended = Vec::new();
-    let mut overwrites = Vec::new();
-    let mut base_size = parent.parent_size;
+) -> Ancestors<F, D> {
+    let mut ancestors = Ancestors {
+        base_size: parent.parent_size,
+        base_peaks: parent.parent_peaks.clone(),
+        appended: Vec::new(),
+        overwrites: Vec::new(),
+        tip_peaks: Vec::new(),
+    };
 
     // Parent is alive (strong Arc held by UnmerkleizedBatch).
     if !parent.appended.is_empty() || !parent.overwrites.is_empty() {
-        appended.push(Arc::clone(&parent.appended));
-        overwrites.push(Arc::clone(&parent.overwrites));
+        ancestors.appended.push(Arc::clone(&parent.appended));
+        ancestors.overwrites.push(Arc::clone(&parent.overwrites));
+        ancestors.tip_peaks.push(parent.tip_peaks.clone());
     }
 
     // Walk Weak chain for grandparents+.
     let mut current = parent.parent.as_ref().and_then(Weak::upgrade);
     while let Some(batch) = current {
-        base_size = batch.parent_size;
+        ancestors.base_size = batch.parent_size;
+        ancestors.base_peaks = batch.parent_peaks.clone();
         if !batch.appended.is_empty() || !batch.overwrites.is_empty() {
-            appended.push(Arc::clone(&batch.appended));
-            overwrites.push(Arc::clone(&batch.overwrites));
+            ancestors.appended.push(Arc::clone(&batch.appended));
+            ancestors.overwrites.push(Arc::clone(&batch.overwrites));
+            ancestors.tip_peaks.push(batch.tip_peaks.clone());
         }
         current = batch.parent.as_ref().and_then(Weak::upgrade);
     }
 
-    appended.reverse();
-    overwrites.reverse();
-    (base_size, appended, overwrites)
+    ancestors.appended.reverse();
+    ancestors.overwrites.reverse();
+    ancestors.tip_peaks.reverse();
+    ancestors
 }
 
 // ---------------------------------------------------------------------------
@@ -544,6 +576,20 @@ pub struct MerkleizedBatch<F: Family, D: Digest, S: Strategy> {
     /// unchanged by all descendants, like `base_size`.
     pruning_boundary: Location<F>,
 
+    /// Peak digests of the [`Mem`] when the batch chain was forked. Inherited unchanged by all
+    /// descendants, like `base_size`.
+    pub(crate) base_peaks: Arc<Vec<D>>,
+
+    /// Peak digests of the parent's state, at `parent_size`.
+    parent_peaks: Vec<D>,
+
+    /// Peak digests of the state this batch represents, at `size()`.
+    pub(crate) tip_peaks: Vec<D>,
+
+    /// Peak digests of the state before the oldest retained ancestor batch, at
+    /// `ancestor_base_size`.
+    pub(crate) ancestor_base_peaks: Vec<D>,
+
     /// Arc refs to each ancestor's appended nodes, collected during merkleize while
     /// ancestors are alive. Root-to-tip order.
     pub(crate) ancestor_appended: Vec<Arc<Vec<D>>>,
@@ -551,6 +597,10 @@ pub struct MerkleizedBatch<F: Family, D: Digest, S: Strategy> {
     /// Arc refs to each ancestor's overwrites, collected during merkleize while
     /// ancestors are alive. Root-to-tip order.
     pub(crate) ancestor_overwrites: Vec<Arc<Overwrites<F, D>>>,
+
+    /// Each ancestor's peak digests at its tip, collected during merkleize while ancestors are
+    /// alive. Root-to-tip order, parallel to `ancestor_appended`.
+    pub(crate) ancestor_tip_peaks: Vec<Vec<D>>,
 
     pub(crate) strategy: S,
 }
@@ -567,6 +617,7 @@ impl<F: Family, D: Digest, S: Strategy> MerkleizedBatch<F, D, S> {
     /// Create a root batch representing the committed state of `mem`, using `strategy`
     /// for merkleization.
     pub fn from_mem_with_strategy(mem: &Mem<F, D>, strategy: S) -> Arc<Self> {
+        let peaks = mem.peaks();
         Arc::new(Self {
             parent: None,
             appended: Arc::new(Vec::new()),
@@ -575,8 +626,13 @@ impl<F: Family, D: Digest, S: Strategy> MerkleizedBatch<F, D, S> {
             base_size: mem.size(),
             ancestor_base_size: mem.size(),
             pruning_boundary: mem.pruning_boundary(),
+            base_peaks: Arc::new(peaks.clone()),
+            parent_peaks: peaks.clone(),
+            tip_peaks: peaks.clone(),
+            ancestor_base_peaks: peaks,
             ancestor_appended: Vec::new(),
             ancestor_overwrites: Vec::new(),
+            ancestor_tip_peaks: Vec::new(),
             strategy,
         })
     }

--- a/storage/src/merkle/mem.rs
+++ b/storage/src/merkle/mem.rs
@@ -195,6 +195,13 @@ impl<F: Family, D: Digest> Mem<F, D> {
         F::peaks(self.size())
     }
 
+    /// Return the digests of the peaks, oldest first.
+    pub fn peaks(&self) -> Vec<D> {
+        F::peaks(self.size())
+            .map(|(pos, _)| *self.get_node_unchecked(pos))
+            .collect()
+    }
+
     /// Return the requested node if it is either retained or present in the pinned_nodes map, and
     /// panic otherwise.
     ///
@@ -408,6 +415,80 @@ impl<F: Family, D: Digest> Mem<F, D> {
         }
     }
 
+    /// Check that `batch` can be applied to this structure, without mutating it.
+    ///
+    /// The structure must be at the state the batch chain was forked from or at the tip of one
+    /// of the batch's ancestors. States are compared by their peak digests, not by size alone, so
+    /// a sibling fork of the same size is rejected.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::StaleBatch`] if the structure is at none of the chain's states and
+    /// [`Error::AncestorDropped`] if an unapplied ancestor was dropped before the batch was
+    /// merkleized.
+    pub fn validate_batch<S: Strategy>(
+        &self,
+        batch: &batch::MerkleizedBatch<F, D, S>,
+    ) -> Result<(), Error<F>> {
+        self.skip_ancestors(batch).map(|_| ())
+    }
+
+    /// Validate `batch` (see [`Self::validate_batch`]) and return whether its ancestors are
+    /// already applied and must be skipped.
+    fn skip_ancestors<S: Strategy>(
+        &self,
+        batch: &batch::MerkleizedBatch<F, D, S>,
+    ) -> Result<bool, Error<F>> {
+        let size = self.size();
+        let stale = || Error::StaleBatch {
+            expected: batch.base_size,
+            actual: size,
+        };
+        let skip_ancestors = if size == batch.base_size {
+            false
+        } else if size > batch.base_size && size < batch.size() {
+            true
+        } else if size == batch.size() && batch.appended.is_empty() {
+            // All ancestors committed and this batch has overwrites only (no appends).
+            true
+        } else {
+            return Err(stale());
+        };
+
+        if size < batch.ancestor_base_size {
+            return Err(Error::AncestorDropped {
+                expected: batch.size(),
+                actual: size,
+            });
+        }
+
+        // Size alone cannot distinguish this chain's states from another fork of the same
+        // length, so the peaks must match one of the states the chain recorded at this size.
+        // Overwrite-only batches leave the size unchanged, so several states can share it.
+        let peaks = self.peaks();
+        let mut at_chain_state = (size == batch.base_size && peaks == *batch.base_peaks)
+            || (size == batch.ancestor_base_size && peaks == batch.ancestor_base_peaks);
+        let mut tip = *batch.ancestor_base_size;
+        for (appended, tip_peaks) in batch
+            .ancestor_appended
+            .iter()
+            .zip(&batch.ancestor_tip_peaks)
+        {
+            tip += appended.len() as u64;
+            if tip == *size && peaks == *tip_peaks {
+                at_chain_state = true;
+            }
+        }
+        // An overwrite-only batch may be re-applied at its own tip.
+        if size == batch.size() && peaks == batch.tip_peaks {
+            at_chain_state = true;
+        }
+        if !at_chain_state {
+            return Err(stale());
+        }
+        Ok(skip_ancestors)
+    }
+
     /// Apply a merkleized batch. Already-committed ancestors are skipped automatically.
     ///
     /// Pruning this structure after the batch was merkleized does not invalidate the batch: prune
@@ -415,33 +496,12 @@ impl<F: Family, D: Digest> Mem<F, D> {
     ///
     /// # Errors
     ///
-    /// Returns [`Error::StaleBatch`] if the structure has diverged from the batch's ancestor chain
-    /// and [`Error::AncestorDropped`] if an unapplied ancestor was dropped before the batch was
-    /// merkleized.
+    /// Returns the errors of [`Self::validate_batch`], without mutating the structure.
     pub fn apply_batch<S: Strategy>(
         &mut self,
         batch: &batch::MerkleizedBatch<F, D, S>,
     ) -> Result<(), Error<F>> {
-        let skip_ancestors = if self.size() == batch.base_size {
-            false
-        } else if self.size() > batch.base_size && self.size() < batch.size() {
-            true
-        } else if self.size() == batch.size() && batch.appended.is_empty() {
-            // All ancestors committed and this batch has overwrites only (no appends).
-            true
-        } else {
-            return Err(Error::StaleBatch {
-                expected: batch.base_size,
-                actual: self.size(),
-            });
-        };
-
-        if self.size() < batch.ancestor_base_size {
-            return Err(Error::AncestorDropped {
-                expected: batch.size(),
-                actual: self.size(),
-            });
-        }
+        let skip_ancestors = self.skip_ancestors(batch)?;
 
         // Apply ancestor batches in root-to-tip order. Already-committed
         // batches (whose appended nodes are already in the Mem) are skipped
@@ -1446,6 +1506,72 @@ mod tests {
         }
     }
 
+    /// A retained child of one fork must be rejected once a sibling fork of the same length has
+    /// been applied, whatever the geometry: size alone cannot tell the two histories apart.
+    fn apply_batch_rejects_sibling_fork_at_interior_size<F: Family>() {
+        let hasher: H = Standard::new(ForwardFold);
+        for n in 0..8u64 {
+            let mut mem = build_raw::<F>(&hasher, n);
+            let a = mem.new_batch().add(&hasher, b"a").merkleize(&mem, &hasher);
+            let b = a.new_batch().add(&hasher, b"b").merkleize(&mem, &hasher);
+            let sibling = mem
+                .new_batch()
+                .add(&hasher, b"a-prime")
+                .merkleize(&mem, &hasher);
+            mem.apply_batch(&sibling).unwrap();
+            let root = plain_root(&mem, &hasher);
+            let size = mem.size();
+
+            assert!(
+                matches!(mem.apply_batch(&b), Err(Error::StaleBatch { .. })),
+                "n={n}: child of the losing fork was accepted"
+            );
+            assert_eq!(
+                mem.size(),
+                size,
+                "n={n}: rejected batch mutated the structure"
+            );
+            assert_eq!(plain_root(&mem, &hasher), root, "n={n}");
+        }
+    }
+
+    /// An overwrite-only sibling leaves the size unchanged, so only the recorded peaks reveal
+    /// that the retained chain no longer describes the structure.
+    fn apply_batch_rejects_overwrite_sibling<F: Family>() {
+        let hasher: H = Standard::new(ForwardFold);
+        let mut mem = build_raw::<F>(&hasher, 8);
+        let a = mem
+            .new_batch()
+            .update_leaf(&hasher, Location::new(0), b"a")
+            .unwrap()
+            .merkleize(&mem, &hasher);
+        let b = a
+            .new_batch()
+            .update_leaf(&hasher, Location::new(1), b"b")
+            .unwrap()
+            .merkleize(&mem, &hasher);
+        let sibling = mem
+            .new_batch()
+            .update_leaf(&hasher, Location::new(0), b"a-prime")
+            .unwrap()
+            .merkleize(&mem, &hasher);
+        mem.apply_batch(&sibling).unwrap();
+        let root = plain_root(&mem, &hasher);
+
+        assert!(matches!(mem.apply_batch(&b), Err(Error::StaleBatch { .. })));
+        assert!(matches!(mem.apply_batch(&a), Err(Error::StaleBatch { .. })));
+        assert_eq!(plain_root(&mem, &hasher), root);
+
+        // The chain still applies to a structure at the state it was forked from.
+        let mut fresh = build_raw::<F>(&hasher, 8);
+        fresh.apply_batch(&a).unwrap();
+        fresh.apply_batch(&b).unwrap();
+        assert_eq!(
+            plain_root(&fresh, &hasher),
+            b.root(&fresh, &hasher, 0).unwrap()
+        );
+    }
+
     fn split_root_matches_recompute<F: Family>() {
         let hasher: H = Standard::new(ForwardFold);
         let plain = build::<F>(&hasher, 49);
@@ -1568,6 +1694,14 @@ mod tests {
         apply_batch_chain_after_prune_matches_prune_after_apply::<crate::mmr::Family>();
     }
     #[test]
+    fn mmr_apply_batch_rejects_sibling_fork_at_interior_size() {
+        apply_batch_rejects_sibling_fork_at_interior_size::<crate::mmr::Family>();
+    }
+    #[test]
+    fn mmr_apply_batch_rejects_overwrite_sibling() {
+        apply_batch_rejects_overwrite_sibling::<crate::mmr::Family>();
+    }
+    #[test]
     fn mmr_split_root_matches_recompute() {
         split_root_matches_recompute::<crate::mmr::Family>();
     }
@@ -1681,6 +1815,14 @@ mod tests {
     #[test]
     fn mmb_apply_batch_chain_after_prune_matches_prune_after_apply() {
         apply_batch_chain_after_prune_matches_prune_after_apply::<crate::mmb::Family>();
+    }
+    #[test]
+    fn mmb_apply_batch_rejects_sibling_fork_at_interior_size() {
+        apply_batch_rejects_sibling_fork_at_interior_size::<crate::mmb::Family>();
+    }
+    #[test]
+    fn mmb_apply_batch_rejects_overwrite_sibling() {
+        apply_batch_rejects_overwrite_sibling::<crate::mmb::Family>();
     }
     #[test]
     fn mmb_split_root_matches_recompute() {


### PR DESCRIPTION
## Summary

`Mem::apply_batch` and `Journal::apply_batch` decided whether a batch's ancestors were already applied purely from the structure's size: anything strictly between the chain's base and tip was taken to be an ancestor, and ancestor items and nodes were skipped by cumulative count. A same-length fork therefore passed as an ancestor. Retain a chain A then B, apply a sibling A' of the same length, then apply B: the journal appended B's items behind A' while installing B's precomputed nodes, which encode A. Depending on where the appended leaves merge, the stored items and the root then describe different histories, and the documented promise that a batch from a different fork is rejected did not hold.

QMDB was not affected, since its batch chain validates exact size-plus-root commitments before delegating. This closes the same gap for direct users of the Merkle and journal batch APIs.

## Fix

Give the Merkle batch chain the identity check QMDB already has:

- Each merkleized batch records the peak digests of the state it represents, root batches record the base structure's peaks, and children carry their retained ancestors' peaks alongside the ancestor data they already keep.
- `Mem::validate_batch` requires the structure's peaks to match one of the chain's recorded states at the current size: the fork base, an ancestor's tip, or the batch's own tip for an overwrite-only re-apply. `apply_batch` runs the same check first and returns `StaleBatch` otherwise.
- The authenticated journal validates against its Merkle store before appending any item, so a rejected batch leaves the journal untouched.

## Tests

- `apply_batch_rejects_sibling_fork_at_interior_size` in `merkle::mem` sweeps base sizes so every merge geometry is covered, and `apply_batch_rejects_overwrite_sibling` covers the same-size overwrite fork that no size check can see. Both run for MMR and MMB.
- `test_stale_batch_interior_fork` in the authenticated journal reproduces the reported sequence for both families and confirms a reopen recovers the sibling's state.
- All three fail without the peak comparison.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
