### PR TITLE
[consensus/marshal,storage] Reduce block copies and archive reads

### DIFF
--- a/codec/conformance.toml
+++ b/codec/conformance.toml
@@ -1,3 +1,11 @@
+["commonware_codec::codec::tests::conformance::CodecConformance<Arc<Vec<u8>>>"]
+n_cases = 65536
+hash = "edc22446bb2952609d0c8daccf2d22f8ad2b71eedfcf45296c3f4db49d78404a"
+
+["commonware_codec::codec::tests::conformance::CodecConformance<Arc<u64>>"]
+n_cases = 65536
+hash = "60235eab7c1e2b919b14bd3b8cfd3f6ca311f2de976a061ef99a5be848cbb61e"
+
 ["commonware_codec::mode::tests::conformance::CodecConformance<Modes<1>>"]
 n_cases = 65536
 hash = "39a93e796b1f7608760451ba8c4f9ced2a7d657ceeeab42eeacddef0d0fc9682"

--- a/codec/src/codec.rs
+++ b/codec/src/codec.rs
@@ -193,15 +193,6 @@ impl<T: Write + ?Sized> Write for Arc<T> {
     }
 }
 
-impl<T: Read> Read for Arc<T> {
-    type Cfg = T::Cfg;
-
-    #[inline]
-    fn read_cfg(buf: &mut impl Buf, cfg: &Self::Cfg) -> Result<Self, Error> {
-        T::read_cfg(buf, cfg).map(Self::new)
-    }
-}
-
 /// Trait for types that can be read (decoded) from a byte buffer.
 pub trait Read: Sized {
     /// The `Cfg` type parameter allows passing configuration during the read process. This is
@@ -260,6 +251,15 @@ pub trait Read: Sized {
         Ok(Self::read_vec(buf, N, cfg)?
             .try_into()
             .unwrap_or_else(|_| unreachable!("array length should match capacity")))
+    }
+}
+
+impl<T: Read> Read for Arc<T> {
+    type Cfg = T::Cfg;
+
+    #[inline]
+    fn read_cfg(buf: &mut impl Buf, cfg: &Self::Cfg) -> Result<Self, Error> {
+        T::read_cfg(buf, cfg).map(Self::new)
     }
 }
 
@@ -473,7 +473,10 @@ mod tests {
         );
 
         // Shared decoding enforces the inner type's bounds and rejects truncation
-        assert!(Arc::<Vec<u8>>::decode_cfg(encoded.clone(), &((..=2).into(), ())).is_err());
+        assert!(matches!(
+            Arc::<Vec<u8>>::decode_cfg(encoded.clone(), &((..=2).into(), ())),
+            Err(Error::InvalidLength(3))
+        ));
         assert!(matches!(
             Arc::<Vec<u8>>::decode_cfg(&encoded[..encoded.len() - 1], &cfg),
             Err(Error::EndOfBuffer)

--- a/codec/src/codec.rs
+++ b/codec/src/codec.rs
@@ -193,6 +193,15 @@ impl<T: Write + ?Sized> Write for Arc<T> {
     }
 }
 
+impl<T: Read> Read for Arc<T> {
+    type Cfg = T::Cfg;
+
+    #[inline]
+    fn read_cfg(buf: &mut impl Buf, cfg: &Self::Cfg) -> Result<Self, Error> {
+        T::read_cfg(buf, cfg).map(Self::new)
+    }
+}
+
 /// Trait for types that can be read (decoded) from a byte buffer.
 pub trait Read: Sized {
     /// The `Cfg` type parameter allows passing configuration during the read process. This is
@@ -451,11 +460,24 @@ mod tests {
     }
 
     #[test]
-    fn test_arc_encode() {
+    fn test_arc_codec() {
         let value = Arc::new(vec![1u8, 2, 3]);
+        let encoded = value.encode();
+        let cfg = ((..=3).into(), ());
 
-        assert_eq!(value.encode(), value.as_ref().encode());
+        assert_eq!(encoded, value.as_ref().encode());
         assert_eq!(value.encode_size(), value.as_ref().encode_size());
+        assert_eq!(
+            Arc::<Vec<u8>>::decode_cfg(encoded.clone(), &cfg).unwrap(),
+            value
+        );
+
+        // Shared decoding enforces the inner type's bounds and rejects truncation
+        assert!(Arc::<Vec<u8>>::decode_cfg(encoded.clone(), &((..=2).into(), ())).is_err());
+        assert!(matches!(
+            Arc::<Vec<u8>>::decode_cfg(&encoded[..encoded.len() - 1], &cfg),
+            Err(Error::EndOfBuffer)
+        ));
     }
 
     #[test]
@@ -754,5 +776,16 @@ mod tests {
             LifetimeFixed::try_from([1u8, 2].as_slice()).unwrap().raw,
             [1, 2]
         );
+    }
+
+    #[cfg(feature = "arbitrary")]
+    mod conformance {
+        use super::Arc;
+        use crate::conformance::CodecConformance;
+
+        commonware_conformance::conformance_tests! {
+            CodecConformance<Arc<u64>>,
+            CodecConformance<Arc<Vec<u8>>>,
+        }
     }
 }

--- a/codec/src/lib.rs
+++ b/codec/src/lib.rs
@@ -60,7 +60,7 @@
 //!   [Encode], [Codec], [EncodeFixed], and [CodecFixed] when `T: FixedSize`.
 //! - Collections: [`Vec`], [`Option`], `BTreeMap`, `BTreeSet`
 //! - Tuples: `(T1, T2, ...)` (up to 12 elements)
-//! - Common External Types: [::bytes::Bytes], `Arc` (encoding only)
+//! - Common External Types: [::bytes::Bytes], `Arc<T>` (delegates to `T`)
 //!
 //! With the `std` feature (enabled by default):
 //! - Networking:

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -92,14 +92,6 @@ stability_scope!(BETA {
         /// Get the consensus context that was used when this block was proposed.
         fn context(&self) -> Self::Context;
     }
-
-    impl<B: CertifiableBlock> CertifiableBlock for Arc<B> {
-        type Context = B::Context;
-
-        fn context(&self) -> Self::Context {
-            self.as_ref().context()
-        }
-    }
 });
 stability_scope!(BETA, cfg(not(target_arch = "wasm32")) {
     use commonware_actor::Feedback;

--- a/consensus/src/lib.rs
+++ b/consensus/src/lib.rs
@@ -14,6 +14,7 @@ use commonware_macros::stability_scope;
 stability_scope!(BETA {
     use commonware_codec::{Codec, Encode};
     use commonware_cryptography::Digestible;
+    use std::sync::Arc;
 
     pub mod simplex;
 
@@ -32,6 +33,12 @@ stability_scope!(BETA {
     pub trait Heightable {
         /// Returns the height associated with this object.
         fn height(&self) -> Height;
+    }
+
+    impl<T: Heightable + ?Sized> Heightable for Arc<T> {
+        fn height(&self) -> Height {
+            self.as_ref().height()
+        }
     }
 
     /// Viewable is a trait that provides access to the view (round) number.
@@ -63,6 +70,12 @@ stability_scope!(BETA {
         fn parent(&self) -> Self::Digest;
     }
 
+    impl<B: Block> Block for Arc<B> {
+        fn parent(&self) -> Self::Digest {
+            self.as_ref().parent()
+        }
+    }
+
     /// CertifiableBlock extends [Block] with consensus context information.
     ///
     /// This trait is required for blocks used with deferred verification in [CertifiableAutomaton].
@@ -78,6 +91,14 @@ stability_scope!(BETA {
 
         /// Get the consensus context that was used when this block was proposed.
         fn context(&self) -> Self::Context;
+    }
+
+    impl<B: CertifiableBlock> CertifiableBlock for Arc<B> {
+        type Context = B::Context;
+
+        fn context(&self) -> Self::Context {
+            self.as_ref().context()
+        }
     }
 });
 stability_scope!(BETA, cfg(not(target_arch = "wasm32")) {

--- a/consensus/src/marshal/application/gates.rs
+++ b/consensus/src/marshal/application/gates.rs
@@ -106,7 +106,7 @@ impl<D: Digest, B> Gates<D, B> {
     pub(crate) fn flush_unrelayed<S, V>(&self, marshal: &Mailbox<S, V>, round: Round, id: D)
     where
         S: Scheme,
-        V: Variant<Block = B>,
+        V: Variant<Block = Arc<B>>,
     {
         if let Some((block, ack)) = self.take_staged(round, id) {
             marshal.verified_deferred(round, block, ack);

--- a/consensus/src/marshal/application/validation.rs
+++ b/consensus/src/marshal/application/validation.rs
@@ -8,7 +8,6 @@ use crate::{
     types::{Epoch, Epocher, Height, Round},
 };
 use commonware_cryptography::certificate::Scheme;
-use std::sync::Arc;
 
 /// Which marshal cache should hold a structurally valid candidate.
 ///
@@ -32,7 +31,7 @@ impl Stage {
         self,
         marshal: &Mailbox<S, V>,
         round: Round,
-        block: Arc<V::Block>,
+        block: V::Block,
     ) -> bool {
         match self {
             Self::Verified => marshal.verified(round, block).await,

--- a/consensus/src/marshal/coding/marshaled.rs
+++ b/consensus/src/marshal/coding/marshaled.rs
@@ -766,7 +766,7 @@ where
                         "reusing verified block from marshal on leader recovery"
                     );
                     gates
-                        .stage(round, commitment, Arc::new(block), tx, "recovered block")
+                        .stage(round, commitment, block, tx, "recovered block")
                         .await;
                     return;
                 }

--- a/consensus/src/marshal/coding/mod.rs
+++ b/consensus/src/marshal/coding/mod.rs
@@ -390,8 +390,8 @@ mod tests {
         StoredCodedBlock<CodingB, ReedSolomon<Sha256>, Sha256>,
     >;
 
-    /// Actor configuration for direct actor tests over [`direct_archives`].
-    fn direct_config(
+    /// Builds a marshal actor configuration for tests.
+    fn test_config(
         context: &deterministic::Context,
         partition_prefix: &str,
         provider: ConstantProvider<S, Epoch>,
@@ -426,8 +426,8 @@ mod tests {
         }
     }
 
-    /// Initialize immutable finalized stores for direct actor tests.
-    async fn direct_archives(
+    /// Initializes immutable finalized stores for tests.
+    async fn immutable_finalized_stores(
         context: &deterministic::Context,
         partition_prefix: &str,
         config: &Config<
@@ -511,9 +511,9 @@ mod tests {
         RecordingResolver,
         commonware_runtime::Handle<()>,
     ) {
-        let config = direct_config(&context, partition_prefix, provider);
+        let config = test_config(&context, partition_prefix, provider);
         let (finalizations_by_height, finalized_blocks) =
-            direct_archives(&context, partition_prefix, &config).await;
+            immutable_finalized_stores(&context, partition_prefix, &config).await;
         let (actor, mailbox, _) = core::Actor::init(
             context.child("actor"),
             finalizations_by_height,
@@ -1178,13 +1178,13 @@ mod tests {
         runner.start(|mut context| async move {
             let Fixture { schemes, .. } =
                 bls12381_threshold_vrf::fixture::<V, _>(&mut context, NAMESPACE, NUM_VALIDATORS);
-            let config = direct_config(
+            let config = test_config(
                 &context,
                 PARTITION_PREFIX,
                 ConstantProvider::new(schemes[0].clone()),
             );
             let (finalizations_by_height, finalized_blocks) =
-                direct_archives(&context, PARTITION_PREFIX, &config).await;
+                immutable_finalized_stores(&context, PARTITION_PREFIX, &config).await;
             let finalized_blocks = Recording::new(finalized_blocks);
             let ops = finalized_blocks.ops();
             let (actor, mut mailbox, _) = core::Actor::init(

--- a/consensus/src/marshal/coding/mod.rs
+++ b/consensus/src/marshal/coding/mod.rs
@@ -1235,7 +1235,7 @@ mod tests {
             let ops = ops.lock().clone();
             let written = ops
                 .iter()
-                .position(|op| *op == Op::Put(Height::new(1)))
+                .position(|op| matches!(op, Op::Put(height, _) if *height == Height::new(1)))
                 .expect("finalized block written");
             assert!(
                 !ops[written..].contains(&Op::Get(Some(Height::new(1)))),

--- a/consensus/src/marshal/coding/mod.rs
+++ b/consensus/src/marshal/coding/mod.rs
@@ -69,7 +69,9 @@ mod tests {
             ancestry::BlockProvider,
             coding::{
                 Coding, Marshaled, MarshaledConfig, shards,
-                types::{CodedBlock, coding_config_for_participants, hash_context},
+                types::{
+                    CodedBlock, StoredCodedBlock, coding_config_for_participants, hash_context,
+                },
             },
             config::{Config, Start},
             core,
@@ -81,12 +83,15 @@ mod tests {
                     UNRELIABLE_LINK, V, default_leader, genesis_commitment, make_coding_block,
                     setup_network_links, setup_network_with_participants,
                 },
+                store::{Op, Recording},
                 verifying::{GatedVerifyingApp, MockVerifyingApp},
             },
             resolver::handler,
         },
         simplex::{
-            Plan, scheme::bls12381_threshold::vrf as bls12381_threshold_vrf, types::Proposal,
+            Plan,
+            scheme::bls12381_threshold::vrf as bls12381_threshold_vrf,
+            types::{Finalization, Proposal},
         },
         types::{Epoch, Epocher, FixedEpocher, Height, Round, View, ViewDelta, coding::Commitment},
     };
@@ -317,17 +322,28 @@ mod tests {
         }
     }
 
-    async fn start_coding_actor_with_recording(
-        context: deterministic::Context,
+    type Finalizations =
+        immutable::Archive<deterministic::Context, D, Finalization<S, TestCommitment>>;
+    type FinalizedBlocks = immutable::Archive<
+        deterministic::Context,
+        D,
+        StoredCodedBlock<CodingB, ReedSolomon<Sha256>, Sha256>,
+    >;
+
+    /// Actor configuration for direct actor tests over [`direct_archives`].
+    fn direct_config(
+        context: &deterministic::Context,
         partition_prefix: &str,
         provider: ConstantProvider<S, Epoch>,
-        buffer: RecordingCodingBuffer,
-    ) -> (
-        core::Mailbox<S, TestCodingVariant>,
-        RecordingResolver,
-        commonware_runtime::Handle<()>,
-    ) {
-        let config = Config {
+    ) -> Config<
+        ConstantProvider<S, Epoch>,
+        FixedEpocher,
+        Sequential,
+        CodingB,
+        TestCodedBlock,
+        TestCommitment,
+    > {
+        Config {
             provider,
             epocher: FixedEpocher::new(BLOCKS_PER_EPOCH),
             start: Start::Genesis(CodingHarness::genesis_block(NUM_VALIDATORS as u16)),
@@ -342,13 +358,27 @@ mod tests {
             key_write_buffer: NZUsize!(1024),
             value_write_buffer: NZUsize!(1024),
             page_cache: CacheRef::from_pooler(
-                &context,
+                context,
                 harness::PAGE_SIZE,
                 harness::PAGE_CACHE_SIZE,
             ),
             strategy: Sequential,
-        };
+        }
+    }
 
+    /// Initialize immutable finalized stores for direct actor tests.
+    async fn direct_archives(
+        context: &deterministic::Context,
+        partition_prefix: &str,
+        config: &Config<
+            ConstantProvider<S, Epoch>,
+            FixedEpocher,
+            Sequential,
+            CodingB,
+            TestCodedBlock,
+            TestCommitment,
+        >,
+    ) -> (Finalizations, FinalizedBlocks) {
         let finalizations_by_height = immutable::Archive::init(
             context.child("finalizations_by_height"),
             immutable::Config {
@@ -408,7 +438,22 @@ mod tests {
         )
         .await
         .expect("failed to initialize finalized blocks archive");
+        (finalizations_by_height, finalized_blocks)
+    }
 
+    async fn start_coding_actor_with_recording(
+        context: deterministic::Context,
+        partition_prefix: &str,
+        provider: ConstantProvider<S, Epoch>,
+        buffer: RecordingCodingBuffer,
+    ) -> (
+        core::Mailbox<S, TestCodingVariant>,
+        RecordingResolver,
+        commonware_runtime::Handle<()>,
+    ) {
+        let config = direct_config(&context, partition_prefix, provider);
+        let (finalizations_by_height, finalized_blocks) =
+            direct_archives(&context, partition_prefix, &config).await;
         let (actor, mailbox, _) = core::Actor::init(
             context.child("actor"),
             finalizations_by_height,
@@ -1037,6 +1082,80 @@ mod tests {
     #[test_traced("WARN")]
     fn test_coding_ack_pipeline_backlog_persists_on_restart() {
         harness::ack_pipeline_backlog_persists_on_restart::<CodingHarness>();
+    }
+
+    /// Dispatch uses the finalized coded block without rereading the finalized archive.
+    #[test_traced("WARN")]
+    fn test_coding_dispatch_delivers_staged_block_without_archive_read() {
+        const PARTITION_PREFIX: &str = "coding-staged-dispatch";
+        let runner = deterministic::Runner::timed(Duration::from_secs(30));
+        runner.start(|mut context| async move {
+            let Fixture { schemes, .. } =
+                bls12381_threshold_vrf::fixture::<V, _>(&mut context, NAMESPACE, NUM_VALIDATORS);
+            let config = direct_config(
+                &context,
+                PARTITION_PREFIX,
+                ConstantProvider::new(schemes[0].clone()),
+            );
+            let (finalizations_by_height, finalized_blocks) =
+                direct_archives(&context, PARTITION_PREFIX, &config).await;
+            let finalized_blocks = Recording::new(finalized_blocks);
+            let ops = finalized_blocks.ops();
+            let (actor, mut mailbox, _) = core::Actor::init(
+                context.child("actor"),
+                finalizations_by_height,
+                finalized_blocks,
+                config,
+            )
+            .await;
+            let (resolver_rx, resolver) = RecordingResolver::holding(context.child("resolver"));
+            let application = Application::<CodingB>::manual_ack();
+            let _actor_handle = actor.start(
+                application.clone(),
+                RecordingCodingBuffer::default(),
+                (resolver_rx, resolver),
+            );
+            assert_eq!(application.acknowledged().await, Height::zero());
+
+            // Store a verified block, then finalize it through consensus.
+            let genesis = genesis_block();
+            let round = Round::new(Epoch::zero(), View::new(1));
+            let ctx = CodingCtx {
+                round,
+                leader: default_leader(),
+                parent: (View::zero(), genesis_coding_commitment(&genesis)),
+            };
+            let block = make_coding_block(ctx, genesis.digest(), Height::new(1), 100);
+            let coded: TestCodedBlock = CodedBlock::new(
+                block.clone(),
+                coding_config_for_participants(NUM_VALIDATORS as u16),
+                &Sequential,
+            );
+            assert!(mailbox.verified(round, coded.clone()).await);
+            let finalization = CodingHarness::make_finalization(
+                Proposal::new(round, View::zero(), coded.commitment()),
+                &schemes,
+                QUORUM,
+            );
+            CodingHarness::report_finalization(&mut mailbox, finalization).await;
+            assert_eq!(application.acknowledged().await, Height::new(1));
+
+            let delivered = application
+                .blocks()
+                .get(&Height::new(1))
+                .cloned()
+                .expect("finalized block dispatched");
+            assert_eq!(delivered.digest(), block.digest());
+            let ops = ops.lock().clone();
+            let written = ops
+                .iter()
+                .position(|op| *op == Op::Put(Height::new(1)))
+                .expect("finalized block written");
+            assert!(
+                !ops[written..].contains(&Op::Get(Some(Height::new(1)))),
+                "dispatch must not read the finalized block back from the archive: {ops:?}"
+            );
+        });
     }
 
     #[test_traced("WARN")]

--- a/consensus/src/marshal/coding/mod.rs
+++ b/consensus/src/marshal/coding/mod.rs
@@ -1234,7 +1234,7 @@ mod tests {
                 .cloned()
                 .expect("finalized block dispatched");
             assert_eq!(delivered.digest(), block.digest());
-            let ops = ops.lock().clone();
+            let ops = ops.lock();
             let written = ops
                 .iter()
                 .position(|op| matches!(op, Op::Put(height, _) if *height == Height::new(1)))

--- a/consensus/src/marshal/coding/mod.rs
+++ b/consensus/src/marshal/coding/mod.rs
@@ -400,13 +400,13 @@ mod tests {
         FixedEpocher,
         Sequential,
         CodingB,
-        TestCodedBlock,
+        Arc<TestCodedBlock>,
         TestCommitment,
     > {
         Config {
             provider,
             epocher: FixedEpocher::new(BLOCKS_PER_EPOCH),
-            start: Start::Genesis(CodingHarness::genesis_block(NUM_VALIDATORS as u16)),
+            start: Start::Genesis(CodingHarness::genesis_block(NUM_VALIDATORS as u16).into()),
             mailbox_size: NZUsize!(100),
             view_retention: ViewDelta::new(10),
             max_repair: NZUsize!(10),
@@ -435,7 +435,7 @@ mod tests {
             FixedEpocher,
             Sequential,
             CodingB,
-            TestCodedBlock,
+            Arc<TestCodedBlock>,
             TestCommitment,
         >,
     ) -> (Finalizations, FinalizedBlocks) {
@@ -1185,7 +1185,9 @@ mod tests {
             );
             let (finalizations_by_height, finalized_blocks) =
                 immutable_finalized_stores(&context, PARTITION_PREFIX, &config).await;
-            let finalized_blocks = Recording::new(finalized_blocks);
+            let finalized_blocks = Recording::new(finalized_blocks, |block| {
+                std::ptr::from_ref(block.inner()).addr()
+            });
             let ops = finalized_blocks.ops();
             let (actor, mut mailbox, _) = core::Actor::init(
                 context.child("actor"),
@@ -1237,6 +1239,11 @@ mod tests {
                 .iter()
                 .position(|op| matches!(op, Op::Put(height, _) if *height == Height::new(1)))
                 .expect("finalized block written");
+            assert_eq!(
+                ops[written],
+                Op::Put(Height::new(1), Arc::as_ptr(&delivered).addr()),
+                "storage must share the block payload dispatched to the application"
+            );
             assert!(
                 !ops[written..].contains(&Op::Get(Some(Height::new(1)))),
                 "dispatch must not read the finalized block back from the archive: {ops:?}"

--- a/consensus/src/marshal/coding/types.rs
+++ b/consensus/src/marshal/coding/types.rs
@@ -243,16 +243,6 @@ impl<B: Block, C: Scheme, H: Hasher> CodedBlock<B, C, H> {
     pub fn inner_shared(&self) -> Arc<B> {
         Arc::clone(&self.inner)
     }
-
-    /// Takes the shared inner [`Block`].
-    pub fn into_inner_shared(self) -> Arc<B> {
-        self.inner
-    }
-
-    /// Takes the inner [`Block`].
-    pub fn into_inner(self) -> B {
-        Arc::unwrap_or_clone(self.inner)
-    }
 }
 
 impl<B: CertifiableBlock, C: Scheme, H: Hasher> From<CodedBlock<B, C, H>>
@@ -263,6 +253,7 @@ impl<B: CertifiableBlock, C: Scheme, H: Hasher> From<CodedBlock<B, C, H>>
     }
 }
 
+/// Shares the inner block of a [`CodedBlock`] for archival.
 impl<B: CertifiableBlock, C: Scheme, H: Hasher> From<Arc<CodedBlock<B, C, H>>>
     for StoredCodedBlock<B, C, H>
 {
@@ -491,6 +482,7 @@ impl<B: Block, C: Scheme, H: Hasher> From<StoredCodedBlock<B, C, H>> for CodedBl
     }
 }
 
+/// Restores a shared [`CodedBlock`] from its stored form.
 impl<B: Block, C: Scheme, H: Hasher> From<StoredCodedBlock<B, C, H>> for Arc<CodedBlock<B, C, H>> {
     fn from(stored: StoredCodedBlock<B, C, H>) -> Self {
         Self::new(stored.into())

--- a/consensus/src/marshal/coding/types.rs
+++ b/consensus/src/marshal/coding/types.rs
@@ -263,6 +263,17 @@ impl<B: CertifiableBlock, C: Scheme, H: Hasher> From<CodedBlock<B, C, H>>
     }
 }
 
+impl<B: CertifiableBlock, C: Scheme, H: Hasher> From<Arc<CodedBlock<B, C, H>>>
+    for StoredCodedBlock<B, C, H>
+{
+    fn from(block: Arc<CodedBlock<B, C, H>>) -> Self {
+        Self {
+            commitment: block.commitment(),
+            inner: block.inner_shared(),
+        }
+    }
+}
+
 impl<B: Block, C: Scheme, H: Hasher> Clone for CodedBlock<B, C, H> {
     fn clone(&self) -> Self {
         Self {
@@ -477,6 +488,12 @@ impl<B: CertifiableBlock, C: Scheme, H: Hasher> StoredCodedBlock<B, C, H> {
 impl<B: Block, C: Scheme, H: Hasher> From<StoredCodedBlock<B, C, H>> for CodedBlock<B, C, H> {
     fn from(stored: StoredCodedBlock<B, C, H>) -> Self {
         Self::new_trusted_shared(stored.inner, stored.commitment)
+    }
+}
+
+impl<B: Block, C: Scheme, H: Hasher> From<StoredCodedBlock<B, C, H>> for Arc<CodedBlock<B, C, H>> {
+    fn from(stored: StoredCodedBlock<B, C, H>) -> Self {
+        Self::new(stored.into())
     }
 }
 

--- a/consensus/src/marshal/coding/variant.rs
+++ b/consensus/src/marshal/coding/variant.rs
@@ -101,7 +101,7 @@ where
         }
     }
 
-    fn into_inner(block: Self::Block) -> Arc<Self::ApplicationBlock> {
+    fn into_shared(block: Self::Block) -> Arc<Self::ApplicationBlock> {
         block.inner_shared()
     }
 
@@ -317,7 +317,7 @@ mod tests {
         let recovered = stored.into();
         assert_eq!(TestVariant::commitment(&recovered), expected);
         assert!(Arc::ptr_eq(
-            &TestVariant::into_inner(recovered),
+            &TestVariant::into_shared(recovered),
             &coded.inner_shared()
         ));
     }

--- a/consensus/src/marshal/coding/variant.rs
+++ b/consensus/src/marshal/coding/variant.rs
@@ -101,11 +101,7 @@ where
         }
     }
 
-    fn into_inner(block: Self::Block) -> Self::ApplicationBlock {
-        Arc::unwrap_or_clone(block).into_inner()
-    }
-
-    fn into_inner_shared(block: Self::Block) -> Arc<Self::ApplicationBlock> {
+    fn into_inner(block: Self::Block) -> Arc<Self::ApplicationBlock> {
         block.inner_shared()
     }
 
@@ -321,7 +317,7 @@ mod tests {
         let recovered = stored.into();
         assert_eq!(TestVariant::commitment(&recovered), expected);
         assert!(Arc::ptr_eq(
-            &TestVariant::into_inner_shared(recovered),
+            &TestVariant::into_inner(recovered),
             &coded.inner_shared()
         ));
     }

--- a/consensus/src/marshal/coding/variant.rs
+++ b/consensus/src/marshal/coding/variant.rs
@@ -59,7 +59,7 @@ where
     P: PublicKey,
 {
     type ApplicationBlock = B;
-    type Block = CodedBlock<B, C, H>;
+    type Block = Arc<CodedBlock<B, C, H>>;
     type StoredBlock = StoredCodedBlock<B, C, H>;
     type Commitment = Commitment<B, C, H>;
 
@@ -102,22 +102,18 @@ where
     }
 
     fn into_inner(block: Self::Block) -> Self::ApplicationBlock {
-        block.into_inner()
+        Arc::unwrap_or_clone(block).into_inner()
     }
 
-    fn into_inner_shared(block: Arc<Self::Block>) -> Arc<Self::ApplicationBlock> {
+    fn into_inner_shared(block: Self::Block) -> Arc<Self::ApplicationBlock> {
         block.inner_shared()
-    }
-
-    fn owned_into_inner_shared(block: Self::Block) -> Arc<Self::ApplicationBlock> {
-        block.into_inner_shared()
     }
 
     fn from_application_block(
         block: Self::ApplicationBlock,
         payload: Self::Commitment,
     ) -> Self::Block {
-        CodedBlock::new_trusted(block, payload)
+        Arc::new(CodedBlock::new_trusted(block, payload))
     }
 }
 
@@ -223,7 +219,7 @@ mod tests {
 
     impl Clone for NoCloneBlock {
         fn clone(&self) -> Self {
-            panic!("stored commitment lookup must not clone the inner block");
+            panic!("shared block operations must not clone the inner block");
         }
     }
 
@@ -301,7 +297,7 @@ mod tests {
     }
 
     #[test]
-    fn stored_commitment_does_not_clone_coding_block() {
+    fn storage_conversion_shares_coding_block() {
         const CONFIG: CodingConfig = CodingConfig {
             minimum_shards: NZU16!(1),
             extra_shards: NZU16!(2),
@@ -311,10 +307,22 @@ mod tests {
         type TestVariant = Coding<NoCloneBlock, TestScheme, Sha256, PublicKey>;
 
         let block = no_clone_block(CONFIG);
-        let coded = CodedBlock::<NoCloneBlock, TestScheme, Sha256>::new(block, CONFIG, &Sequential);
+        let coded = Arc::new(CodedBlock::<NoCloneBlock, TestScheme, Sha256>::new(
+            block,
+            CONFIG,
+            &Sequential,
+        ));
         let expected = coded.commitment();
-        let stored = StoredCodedBlock::new(coded);
+        let stored: StoredCodedBlock<_, _, _> = coded.clone().into();
 
         assert_eq!(TestVariant::stored_commitment(&stored), expected);
+        assert!(std::ptr::eq(stored.inner(), coded.inner()));
+
+        let recovered = stored.into();
+        assert_eq!(TestVariant::commitment(&recovered), expected);
+        assert!(Arc::ptr_eq(
+            &TestVariant::into_inner_shared(recovered),
+            &coded.inner_shared()
+        ));
     }
 }

--- a/consensus/src/marshal/config.rs
+++ b/consensus/src/marshal/config.rs
@@ -97,6 +97,9 @@ where
     /// Maximum number of blocks dispatched to the application that have not
     /// yet been acknowledged. Increasing this value allows the application
     /// to buffer work while marshal continues dispatching, hiding ack latency.
+    ///
+    /// Marshal also retains up to twice this many finalized blocks in memory
+    /// so dispatch can reuse them without an archive read.
     pub max_pending_acks: NonZeroUsize,
 
     /// Strategy for parallel operations.

--- a/consensus/src/marshal/config.rs
+++ b/consensus/src/marshal/config.rs
@@ -94,12 +94,9 @@ where
     /// Maximum number of blocks to repair at once.
     pub max_repair: NonZeroUsize,
 
-    /// Maximum number of blocks dispatched to the application that have not
-    /// yet been acknowledged. Increasing this value allows the application
-    /// to buffer work while marshal continues dispatching, hiding ack latency.
-    ///
-    /// Marshal also retains up to twice this many finalized blocks in memory
-    /// so dispatch can reuse them without an archive read.
+    /// Maximum number of dispatched blocks awaiting application acknowledgement,
+    /// with up to twice this many finalized blocks retained in memory for subsequent
+    /// dispatch without archive reads.
     pub max_pending_acks: NonZeroUsize,
 
     /// Strategy for parallel operations.

--- a/consensus/src/marshal/core/acks.rs
+++ b/consensus/src/marshal/core/acks.rs
@@ -59,11 +59,6 @@ impl<V: Variant, A: Acknowledgement> PendingAcks<V, A> {
         &mut self.current
     }
 
-    /// Returns the maximum number of in-flight acknowledgements.
-    pub(super) const fn capacity(&self) -> usize {
-        self.max
-    }
-
     /// Returns whether we can dispatch another block without exceeding capacity.
     pub(super) fn has_capacity(&self) -> bool {
         let reserved = usize::from(self.current.is_some());

--- a/consensus/src/marshal/core/acks.rs
+++ b/consensus/src/marshal/core/acks.rs
@@ -59,6 +59,11 @@ impl<V: Variant, A: Acknowledgement> PendingAcks<V, A> {
         &mut self.current
     }
 
+    /// Returns the maximum number of in-flight acknowledgements.
+    pub(super) const fn capacity(&self) -> usize {
+        self.max
+    }
+
     /// Returns whether we can dispatch another block without exceeding capacity.
     pub(super) fn has_capacity(&self) -> bool {
         let reserved = usize::from(self.current.is_some());

--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -1370,7 +1370,7 @@ where
             .take_pending_anchor()
             .expect("pending floor anchor missing");
         let round = finalization.round();
-        let stored: V::StoredBlock = block.clone().into();
+        let stored: V::StoredBlock = block.into();
         (self.finalized_blocks, self.finalizations_by_height) = try_join!(
             self.finalized_blocks.put(&stored).map_err(BoxedError::from),
             self.finalizations_by_height
@@ -1918,7 +1918,7 @@ where
             assert_eq!(height, next_height, "finalized block height mismatch");
 
             let (ack, ack_waiter) = A::handle();
-            application.report(Update::Block(V::into_inner_shared(block), ack));
+            application.report(Update::Block(V::into_inner(block), ack));
             self.pending_acks.enqueue(PendingAck {
                 height,
                 commitment,

--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -147,6 +147,7 @@ where
     // covering them completes
     dispatch_gate: DispatchGate,
     // Finalized blocks awaiting durable dispatch, capped at twice the pending-ack capacity
+    // to absorb bursts of finalizations while the application processes earlier blocks
     staged: BTreeMap<Height, Arc<V::Block>>,
 
     // ---------- Storage ----------

--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -7,6 +7,7 @@ use super::{
     durability::{DispatchGate, Durable as _},
     floor::{Floor, State as FloorState},
     mailbox::{CommitmentFallback, Mailbox, Message},
+    staged::Staged,
     stream::Stream,
     subscriptions::{Key as SubscriptionKey, KeyFor as SubscriptionKeyFor, Subscriptions},
     variant::NoBuffer,
@@ -55,7 +56,7 @@ use futures::{
     try_join,
 };
 use rand_core::CryptoRng;
-use std::{collections::BTreeMap, future::Future, num::NonZeroUsize, sync::Arc};
+use std::{collections::BTreeMap, future::Future, num::NonZeroUsize};
 use tracing::{Instrument as _, Span, debug, info_span, warn};
 
 // Resolver request keys are expressed in the variant commitment type, which
@@ -148,7 +149,7 @@ where
     dispatch_gate: DispatchGate,
     // Finalized blocks awaiting durable dispatch, capped at twice the pending-ack capacity
     // to absorb bursts of finalizations while the application processes earlier blocks
-    staged: BTreeMap<Height, Arc<V::Block>>,
+    staged: Staged<V::Block>,
 
     // ---------- Storage ----------
     // Prunable cache
@@ -271,7 +272,7 @@ where
                 block_subscriptions: Subscriptions::new(),
                 certified: Certified::new(),
                 dispatch_gate: DispatchGate::default(),
-                staged: BTreeMap::new(),
+                staged: Staged::new(config.max_pending_acks.get().saturating_mul(2)),
                 cache,
                 finalizations_by_height,
                 finalized_blocks,
@@ -386,7 +387,7 @@ where
         Buf: Buffer<V, PublicKey = <P::Scheme as Verifier>::PublicKey>,
     {
         // Create a local pool for waiter futures.
-        let mut waiters = AbortablePool::<Result<Arc<V::Block>, SubscriptionKeyFor<V>>>::default();
+        let mut waiters = AbortablePool::<Result<V::Block, SubscriptionKeyFor<V>>>::default();
 
         // Observe durable syncs that no consensus caller awaits (the
         // notarization and finalization paths). A flush failure inside
@@ -610,7 +611,7 @@ where
         mut self: Box<Self>,
         message: Message<P::Scheme, V>,
         resolver: &mut R,
-        waiters: &mut AbortablePool<'_, Result<Arc<V::Block>, SubscriptionKeyFor<V>>>,
+        waiters: &mut AbortablePool<'_, Result<V::Block, SubscriptionKeyFor<V>>>,
         syncs: &mut Pool<'_, PooledSync>,
         buffer: &mut Buf,
         application: &mut impl Reporter<Activity = Update<V::ApplicationBlock, A>>,
@@ -686,7 +687,7 @@ where
                 // storage tolerates multiple candidates per round (see
                 // [Mailbox::get_verified]), and the propose paths skip or
                 // reuse a recovered block on restart.
-                buffer.send(round, Arc::clone(&block), recipients);
+                buffer.send(round, block.clone(), recipients);
                 self = self
                     .persist_verified(round, block, ack, buffer, application, resolver)
                     .await;
@@ -702,7 +703,7 @@ where
                 round, block, ack, ..
             } => {
                 (self, _) = self
-                    .ingest(Arc::clone(&block), buffer, application, resolver)
+                    .ingest(block.clone(), buffer, application, resolver)
                     .await;
                 let digest = block.digest();
 
@@ -772,7 +773,7 @@ where
                 // certificate and wait for a later finalization/repair path.
                 if let Some(block) = self.find_block_by_commitment(buffer, commitment).await {
                     (self, _) = self
-                        .ingest(Arc::clone(&block), buffer, application, resolver)
+                        .ingest(block.clone(), buffer, application, resolver)
                         .await;
                     if self.cache.has_verified(round, &digest).await {
                         debug!(?round, "notarized block covered by verified write");
@@ -806,27 +807,21 @@ where
                     // advances floors, prunes below them, and resumes dispatch.
                     let anchored;
                     (self, anchored) = self
-                        .ingest(Arc::clone(&block), buffer, application, resolver)
+                        .ingest(block.clone(), buffer, application, resolver)
                         .await;
                     if anchored {
                         return self;
                     }
 
-                    // Retain only new archive entries that fit in staging
-                    // An existing height keeps its first block even if another finalization conflicts
                     let height = block.height();
-                    let stage = self.staged.len() < self.pending_acks.capacity().saturating_mul(2)
-                        && self.finalized_blocks.next_gap(height).0.is_none();
                     let stored;
                     (self, stored) = self
                         .update_processed_round_floor(height, round, buffer, application, resolver)
                         .await
                         .store_finalization(height, digest, &block, Some(finalization), application)
                         .await;
-                    if stage && stored {
-                        self.staged.insert(height, block);
-                    }
                     if stored {
+                        self.staged.insert(height, block);
                         // If a floor anchor is pending, repair and dispatch are
                         // no-ops until the anchor block is stored.
                         (self, _) = self.try_repair_gaps(buffer, resolver, application).await;
@@ -851,10 +846,7 @@ where
                 ..
             } => match identifier {
                 BlockID::Digest(digest) => {
-                    let result = self
-                        .find_block_by_digest(buffer, digest)
-                        .await
-                        .map(Arc::unwrap_or_clone);
+                    let result = self.find_block_by_digest(buffer, digest).await;
                     response.send_lossy(result);
                 }
                 BlockID::Height(height) => {
@@ -865,8 +857,7 @@ where
                     let block = match self.get_latest().await {
                         Some((_, digest, _)) => self.find_block_by_digest(buffer, digest).await,
                         None => None,
-                    }
-                    .map(Arc::unwrap_or_clone);
+                    };
                     response.send_lossy(block);
                 }
             },
@@ -1102,9 +1093,9 @@ where
         span: Span,
         fallback: CommitmentFallback,
         key: SubscriptionKeyFor<V>,
-        response: oneshot::Sender<Arc<V::Block>>,
+        response: oneshot::Sender<V::Block>,
         resolver: &mut impl Resolver<Key = ResolverRequestFor<V>, Subscriber = Annotation>,
-        waiters: &mut AbortablePool<'_, Result<Arc<V::Block>, SubscriptionKeyFor<V>>>,
+        waiters: &mut AbortablePool<'_, Result<V::Block, SubscriptionKeyFor<V>>>,
         buffer: &mut Buf,
     ) {
         let digest = match key {
@@ -1267,14 +1258,14 @@ where
     async fn persist_verified<Buf: Buffer<V>>(
         mut self: Box<Self>,
         round: Round,
-        block: Arc<V::Block>,
+        block: V::Block,
         ack: oneshot::Sender<Handle<()>>,
         buffer: &mut Buf,
         application: &mut impl Reporter<Activity = Update<V::ApplicationBlock, A>>,
         resolver: &mut impl Resolver<Key = ResolverRequestFor<V>, Subscriber = Annotation>,
     ) -> Box<Self> {
         (self, _) = self
-            .ingest(Arc::clone(&block), buffer, application, resolver)
+            .ingest(block.clone(), buffer, application, resolver)
             .await;
         let digest = block.digest();
         let handle;
@@ -1298,12 +1289,12 @@ where
     /// Returns true if the block was consumed as the floor anchor.
     async fn ingest<Buf: Buffer<V>>(
         mut self: Box<Self>,
-        block: Arc<V::Block>,
+        block: V::Block,
         buffer: &mut Buf,
         application: &mut impl Reporter<Activity = Update<V::ApplicationBlock, A>>,
         resolver: &mut impl Resolver<Key = ResolverRequestFor<V>, Subscriber = Annotation>,
     ) -> (Box<Self>, bool) {
-        self.block_subscriptions.notify(Arc::clone(&block));
+        self.block_subscriptions.notify(block.clone());
 
         if !self.floor.matches_pending_anchor(V::commitment(&block)) {
             return (self, false);
@@ -1322,7 +1313,7 @@ where
     /// Panics if no pending floor anchor is installed.
     async fn apply_pending_floor<Buf: Buffer<V>>(
         mut self: Box<Self>,
-        block: Arc<V::Block>,
+        block: V::Block,
         buffer: &mut Buf,
         application: &mut impl Reporter<Activity = Update<V::ApplicationBlock, A>>,
         resolver: &mut impl Resolver<Key = ResolverRequestFor<V>, Subscriber = Annotation>,
@@ -1379,11 +1370,9 @@ where
             .take_pending_anchor()
             .expect("pending floor anchor missing");
         let round = finalization.round();
-        let stored = V::stored(&block);
+        let stored: V::StoredBlock = block.clone().into();
         (self.finalized_blocks, self.finalizations_by_height) = try_join!(
-            self.finalized_blocks
-                .put(stored.as_ref())
-                .map_err(BoxedError::from),
+            self.finalized_blocks.put(&stored).map_err(BoxedError::from),
             self.finalizations_by_height
                 .put(height, digest, &finalization)
                 .map_err(BoxedError::from),
@@ -1406,7 +1395,7 @@ where
         self.update_processed_height(dispatch_floor, resolver);
 
         // Release staged blocks skipped by the floor transition
-        self.staged = self.staged.split_off(&height);
+        self.staged.retain(height);
 
         // Advance the round floor and persist the dispatch floor before pruning finalized data
         self = self
@@ -1505,10 +1494,9 @@ where
                 // This block may match the pending floor request. Whether it
                 // installs or is rejected as the floor anchor, do not also
                 // process it as an ordinary block delivery.
-                let block = Arc::new(block);
                 let anchored;
                 (self, anchored) = self
-                    .ingest(Arc::clone(&block), buffer, application, resolver)
+                    .ingest(block.clone(), buffer, application, resolver)
                     .await;
                 if anchored {
                     response.send_lossy(true);
@@ -1755,10 +1743,7 @@ where
                 } => {
                     // Valid finalization received.
                     response.send_lossy(true);
-                    let block = Arc::new(V::from_application_block(
-                        block,
-                        finalization.proposal.payload,
-                    ));
+                    let block = V::from_application_block(block, finalization.proposal.payload);
                     let round = finalization.round();
                     let height = block.height();
                     let digest = block.digest();
@@ -1768,7 +1753,7 @@ where
                     // and moves the lower bound past it.
                     let anchored;
                     (self, anchored) = self
-                        .ingest(Arc::clone(&block), buffer, application, resolver)
+                        .ingest(block.clone(), buffer, application, resolver)
                         .await;
                     if anchored {
                         continue;
@@ -1797,7 +1782,6 @@ where
                     // durable (or the runtime is shutting down) so the repair
                     // bookkeeping below never runs ahead of storage.
                     let height = block.height();
-                    let block = Arc::new(block);
                     let block_sync;
                     (self.cache, block_sync) =
                         self.cache.put_notarized(round, digest, &block).await;
@@ -1816,7 +1800,7 @@ where
                     // after the finalization is cached.
                     let anchored;
                     (self, anchored) = self
-                        .ingest(Arc::clone(&block), buffer, application, resolver)
+                        .ingest(block.clone(), buffer, application, resolver)
                         .await;
                     if anchored {
                         continue;
@@ -1922,30 +1906,25 @@ where
             }
 
             // Reuse the staged object or recover an unstaged block from the archive
-            let (height, commitment, block) = match self.staged.remove(&next_height) {
-                Some(block) => (
-                    block.height(),
-                    V::commitment(&block),
-                    V::into_inner_shared(block),
-                ),
+            let block = match self.staged.remove(next_height) {
+                Some(block) => block,
                 None => match self.get_finalized_block(next_height).await {
-                    Some(block) => (
-                        block.height(),
-                        V::commitment(&block),
-                        V::owned_into_inner_shared(block),
-                    ),
+                    Some(block) => block,
                     None => return self,
                 },
             };
+            let height = block.height();
+            let commitment = V::commitment(&block);
             assert_eq!(height, next_height, "finalized block height mismatch");
 
             let (ack, ack_waiter) = A::handle();
-            application.report(Update::Block(block, ack));
+            application.report(Update::Block(V::into_inner_shared(block), ack));
             self.pending_acks.enqueue(PendingAck {
                 height,
                 commitment,
                 receiver: ack_waiter,
             });
+            self.staged.retain(height.next());
         }
         self
     }
@@ -2127,31 +2106,29 @@ where
         }
 
         // Convert block to storage format
-        let stored = V::stored(block);
+        let stored: V::StoredBlock = block.clone().into();
         let round = finalization.as_ref().map(|f| f.round());
 
-        // In parallel, update the finalized blocks and finalizations archives
-        let finalizations_by_height = self.finalizations_by_height;
-        (self.finalized_blocks, self.finalizations_by_height) = try_join!(
-            // Update the finalized blocks archive
-            self.finalized_blocks
-                .put(stored.as_ref())
-                .map_err(BoxedError::from),
+        // Update the finalized blocks archive
+        let blocks = self.finalized_blocks.put(&stored).map_err(BoxedError::from);
 
-            // Update the finalizations archive (if provided)
-            async {
-                let store = if let Some(finalization) = finalization {
-                    finalizations_by_height
-                        .put(height, digest, &finalization)
-                        .await
-                        .map_err(BoxedError::from)?
-                } else {
-                    finalizations_by_height
-                };
-                Ok::<_, BoxedError>(store)
-            }
-        )
-        .unwrap_or_else(|e| panic!("failed to finalize: {e}"));
+        // Update the finalizations archive (if provided)
+        let finalizations_by_height = self.finalizations_by_height;
+        let finalizations = async {
+            let store = if let Some(finalization) = finalization {
+                finalizations_by_height
+                    .put(height, digest, &finalization)
+                    .await
+                    .map_err(BoxedError::from)?
+            } else {
+                finalizations_by_height
+            };
+            Ok::<_, BoxedError>(store)
+        };
+
+        // Update both archives in parallel
+        (self.finalized_blocks, self.finalizations_by_height) =
+            try_join!(blocks, finalizations).unwrap_or_else(|e| panic!("failed to finalize: {e}"));
 
         // The write above is buffered and readable before it is durable, so
         // hold dispatch at or above it until a sync covers it.
@@ -2242,11 +2219,11 @@ where
         &self,
         buffer: &Buf,
         digest: <V::Block as Digestible>::Digest,
-    ) -> Option<Arc<V::Block>> {
+    ) -> Option<V::Block> {
         if let Some(block) = buffer.find_by_digest(digest).await {
             return Some(block);
         }
-        self.find_block_in_storage(digest).await.map(Arc::new)
+        self.find_block_in_storage(digest).await
     }
 
     /// Looks for a block anywhere in local storage using the full commitment.
@@ -2257,13 +2234,11 @@ where
         &self,
         buffer: &Buf,
         commitment: V::Commitment,
-    ) -> Option<Arc<V::Block>> {
+    ) -> Option<V::Block> {
         if let Some(block) = buffer.find_by_commitment(commitment).await {
             return Some(block);
         }
-        self.find_block_in_storage_by_commitment(commitment)
-            .await
-            .map(Arc::new)
+        self.find_block_in_storage_by_commitment(commitment).await
     }
 
     /// Attempt to repair any identified gaps in the finalized blocks archive. The total

--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -816,6 +816,8 @@ where
                         return self;
                     }
 
+                    // Updating the round floor can release a superseded anchor and resume dispatch,
+                    // so check staging eligibility only after it completes
                     let height = block.height();
                     self = self
                         .update_processed_round_floor(height, round, buffer, application, resolver)

--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -2137,6 +2137,7 @@ where
             self.finalized_blocks
                 .put(stored.as_ref())
                 .map_err(BoxedError::from),
+
             // Update the finalizations archive (if provided)
             async {
                 let store = if let Some(finalization) = finalization {

--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -146,7 +146,7 @@ where
     // Defers application dispatch of finalized-archive writes until a sync
     // covering them completes
     dispatch_gate: DispatchGate,
-    // Finalized blocks awaiting durable dispatch, capped at the pending-ack capacity
+    // Finalized blocks awaiting durable dispatch, capped at twice the pending-ack capacity
     staged: BTreeMap<Height, Arc<V::Block>>,
 
     // ---------- Storage ----------
@@ -824,7 +824,9 @@ where
                     let next_height = self
                         .pending_acks
                         .next_dispatch_height(self.stream.next_height());
-                    if height >= next_height && self.staged.len() < self.pending_acks.capacity() {
+                    if height >= next_height
+                        && self.staged.len() < self.pending_acks.capacity().saturating_mul(2)
+                    {
                         self.staged.insert(height, Arc::clone(&block));
                     }
                     let stored;

--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -143,6 +143,8 @@ where
     // Defers application dispatch of finalized-archive writes until a sync
     // covering them completes
     dispatch_gate: DispatchGate,
+    // Finalized blocks awaiting durable dispatch, capped at the pending-ack capacity
+    staged: BTreeMap<Height, Arc<V::Block>>,
 
     // ---------- Storage ----------
     // Prunable cache
@@ -264,6 +266,7 @@ where
                 tip: Height::zero(),
                 block_subscriptions: Subscriptions::new(),
                 dispatch_gate: DispatchGate::default(),
+                staged: BTreeMap::new(),
                 cache,
                 finalizations_by_height,
                 finalized_blocks,
@@ -795,10 +798,19 @@ where
                     }
 
                     let height = block.height();
+                    self = self
+                        .update_processed_round_floor(height, round, buffer, application, resolver)
+                        .await;
+
+                    // Retain only blocks that can still be dispatched and fit in staging
+                    let next_height = self
+                        .pending_acks
+                        .next_dispatch_height(self.stream.next_height());
+                    let staged = (height >= next_height
+                        && self.staged.len() < self.pending_acks.capacity())
+                    .then(|| Arc::clone(&block));
                     let stored;
                     (self, stored) = self
-                        .update_processed_round_floor(height, round, buffer, application, resolver)
-                        .await
                         .store_finalization(
                             height,
                             digest,
@@ -808,6 +820,10 @@ where
                         )
                         .await;
                     if stored {
+                        if let Some(block) = staged {
+                            self.staged.insert(height, block);
+                        }
+
                         // If a floor anchor is pending, repair and dispatch are
                         // no-ops until the anchor block is stored.
                         (self, _) = self.try_repair_gaps(buffer, resolver, application).await;
@@ -1881,18 +1897,27 @@ where
             if barrier.is_some_and(|lowest| next_height >= lowest) {
                 return self;
             }
-            let Some(block) = self.get_finalized_block(next_height).await else {
-                return self;
-            };
-            assert_eq!(
-                block.height(),
-                next_height,
-                "finalized block height mismatch"
-            );
 
-            let (height, commitment) = (block.height(), V::commitment(&block));
+            // Reuse the staged object or recover an unstaged block from the archive
+            let (height, commitment, block) = match self.staged.remove(&next_height) {
+                Some(block) => (
+                    block.height(),
+                    V::commitment(&block),
+                    V::into_inner_shared(block),
+                ),
+                None => match self.get_finalized_block(next_height).await {
+                    Some(block) => (
+                        block.height(),
+                        V::commitment(&block),
+                        V::owned_into_inner_shared(block),
+                    ),
+                    None => return self,
+                },
+            };
+            assert_eq!(height, next_height, "finalized block height mismatch");
+
             let (ack, ack_waiter) = A::handle();
-            application.report(Update::Block(V::owned_into_inner_shared(block), ack));
+            application.report(Update::Block(block, ack));
             self.pending_acks.enqueue(PendingAck {
                 height,
                 commitment,
@@ -2375,6 +2400,9 @@ where
         let _ = self
             .processed_height
             .try_set(self.floor.processed_height().get());
+
+        // Release staged blocks skipped by a floor transition
+        self.staged = self.staged.split_off(&height.next());
 
         // Resolver request retention is independent of caller-owned block subscriptions.
         resolver.retain(handler::above_height_floor::<V::Commitment>(height));

--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -718,10 +718,8 @@ where
                     debug!(?round, "certified block covered by verified write");
                     (self.cache, block_sync) = self.cache.start_sync_verified(round).await;
                 } else {
-                    (self.cache, block_sync) = self
-                        .cache
-                        .put_notarized(round, digest, Arc::unwrap_or_clone(block).into())
-                        .await;
+                    (self.cache, block_sync) =
+                        self.cache.put_notarized(round, digest, &block).await;
                 }
 
                 // Hold the certify barrier until the round's notarization
@@ -762,7 +760,7 @@ where
                 let handle;
                 (self.cache, handle) = self
                     .cache
-                    .put_notarization(round, digest, notarization)
+                    .put_notarization(round, digest, &notarization)
                     .await;
                 syncs.push(async move {
                     handle.durable(round, "notarization").await;
@@ -780,10 +778,8 @@ where
                         debug!(?round, "notarized block covered by verified write");
                     } else {
                         let handle;
-                        (self.cache, handle) = self
-                            .cache
-                            .put_notarized(round, digest, Arc::unwrap_or_clone(block).into())
-                            .await;
+                        (self.cache, handle) =
+                            self.cache.put_notarized(round, digest, &block).await;
                         syncs.push(async move {
                             handle.durable(round, "notarized").await;
                             PooledSync::Observed
@@ -801,7 +797,7 @@ where
                 // Cache finalization by round.
                 self.cache = self
                     .cache
-                    .put_finalization(round, digest, finalization.clone())
+                    .put_finalization(round, digest, &finalization)
                     .await;
 
                 // Search for the finalized block locally, otherwise fetch it remotely.
@@ -1231,7 +1227,7 @@ where
         let digest = V::commitment_to_inner(commitment);
         self.cache = self
             .cache
-            .put_finalization(round, digest, finalization.clone())
+            .put_finalization(round, digest, &finalization)
             .await;
 
         // A pending anchor at the same or a newer floor already blocks
@@ -1282,10 +1278,7 @@ where
             .await;
         let digest = block.digest();
         let handle;
-        (self.cache, handle) = self
-            .cache
-            .put_verified(round, digest, Arc::unwrap_or_clone(block).into())
-            .await;
+        (self.cache, handle) = self.cache.put_verified(round, digest, &block).await;
         ack.send_lossy(handle);
         self
     }
@@ -1569,12 +1562,7 @@ where
                 {
                     self.cache = self
                         .cache
-                        .put_certified(
-                            bounds.epoch(),
-                            height,
-                            digest,
-                            Arc::unwrap_or_clone(block).into(),
-                        )
+                        .put_certified(bounds.epoch(), height, digest, &block)
                         .await;
                 }
                 debug!(?digest, %height, "received block");
@@ -1811,14 +1799,12 @@ where
                     let height = block.height();
                     let block = Arc::new(block);
                     let block_sync;
-                    (self.cache, block_sync) = self
-                        .cache
-                        .put_notarized(round, digest, block.as_ref().clone().into())
-                        .await;
+                    (self.cache, block_sync) =
+                        self.cache.put_notarized(round, digest, &block).await;
                     let notarization_sync;
                     (self.cache, notarization_sync) = self
                         .cache
-                        .put_notarization(round, digest, notarization)
+                        .put_notarization(round, digest, &notarization)
                         .await;
                     join(
                         block_sync.durable(round, "notarized"),

--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -147,8 +147,8 @@ where
     // Defers application dispatch of finalized-archive writes until a sync
     // covering them completes
     dispatch_gate: DispatchGate,
-    // Finalized blocks awaiting durable dispatch, capped at twice the pending-ack capacity
-    // to absorb bursts of finalizations while the application processes earlier blocks
+    // Finalized blocks awaiting dispatch, capped at twice the pending-ack
+    // capacity to absorb finalization bursts while earlier blocks are processed
     staged: Staged<V::Block>,
 
     // ---------- Storage ----------
@@ -822,6 +822,7 @@ where
                         .await;
                     if stored {
                         self.staged.insert(height, block);
+
                         // If a floor anchor is pending, repair and dispatch are
                         // no-ops until the anchor block is stored.
                         (self, _) = self.try_repair_gaps(buffer, resolver, application).await;
@@ -1069,7 +1070,7 @@ where
                     debug!(%height, "finalized block missing on request");
                     return;
                 };
-                response.send_lossy((finalization, V::into_inner(block)).encode());
+                response.send_lossy((finalization, V::into_shared(block)).encode());
             }
             Key::Notarized { round } => {
                 let Some(notarization) = self.cache.get_notarization(round).await else {
@@ -1397,7 +1398,8 @@ where
         // Release staged blocks skipped by the floor transition
         self.staged.retain(height);
 
-        // Advance the round floor and persist the dispatch floor before pruning finalized data
+        // Advance the round floor and persist the dispatch floor before
+        // pruning finalized data
         self = self
             .update_processed_round_floor(dispatch_floor, round, buffer, application, resolver)
             .await;
@@ -1905,7 +1907,7 @@ where
                 return self;
             }
 
-            // Reuse the staged object or recover an unstaged block from the archive
+            // Prefer the staged block and fall back to the archive
             let block = match self.staged.remove(next_height) {
                 Some(block) => block,
                 None => match self.get_finalized_block(next_height).await {
@@ -1918,7 +1920,7 @@ where
             assert_eq!(height, next_height, "finalized block height mismatch");
 
             let (ack, ack_waiter) = A::handle();
-            application.report(Update::Block(V::into_inner(block), ack));
+            application.report(Update::Block(V::into_shared(block), ack));
             self.pending_acks.enqueue(PendingAck {
                 height,
                 commitment,
@@ -2109,26 +2111,25 @@ where
         let stored: V::StoredBlock = block.clone().into();
         let round = finalization.as_ref().map(|f| f.round());
 
-        // Update the finalized blocks archive
-        let blocks = self.finalized_blocks.put(&stored).map_err(BoxedError::from);
-
-        // Update the finalizations archive (if provided)
+        // In parallel, update the finalized blocks and finalizations archives
         let finalizations_by_height = self.finalizations_by_height;
-        let finalizations = async {
-            let store = if let Some(finalization) = finalization {
-                finalizations_by_height
-                    .put(height, digest, &finalization)
-                    .await
-                    .map_err(BoxedError::from)?
-            } else {
-                finalizations_by_height
-            };
-            Ok::<_, BoxedError>(store)
-        };
-
-        // Update both archives in parallel
-        (self.finalized_blocks, self.finalizations_by_height) =
-            try_join!(blocks, finalizations).unwrap_or_else(|e| panic!("failed to finalize: {e}"));
+        (self.finalized_blocks, self.finalizations_by_height) = try_join!(
+            // Update the finalized blocks archive
+            self.finalized_blocks.put(&stored).map_err(BoxedError::from),
+            // Update the finalizations archive (if provided)
+            async {
+                let store = if let Some(finalization) = finalization {
+                    finalizations_by_height
+                        .put(height, digest, &finalization)
+                        .await
+                        .map_err(BoxedError::from)?
+                } else {
+                    finalizations_by_height
+                };
+                Ok::<_, BoxedError>(store)
+            }
+        )
+        .unwrap_or_else(|e| panic!("failed to finalize: {e}"));
 
         // The write above is buffered and readable before it is durable, so
         // hold dispatch at or above it until a sync covers it.

--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -816,23 +816,15 @@ where
                         return self;
                     }
 
-                    // Updating the round floor can release a superseded anchor and resume dispatch,
-                    // so check staging eligibility only after it completes
-                    let height = block.height();
-                    self = self
-                        .update_processed_round_floor(height, round, buffer, application, resolver)
-                        .await;
-
-                    // Retain only new archive entries that can still be dispatched and fit in staging
+                    // Retain only new archive entries that fit in staging
                     // An existing height keeps its first block even if another finalization conflicts
-                    let next_height = self
-                        .pending_acks
-                        .next_dispatch_height(self.stream.next_height());
-                    let stage = height >= next_height
-                        && self.staged.len() < self.pending_acks.capacity().saturating_mul(2)
+                    let height = block.height();
+                    let stage = self.staged.len() < self.pending_acks.capacity().saturating_mul(2)
                         && self.finalized_blocks.next_gap(height).0.is_none();
                     let stored;
                     (self, stored) = self
+                        .update_processed_round_floor(height, round, buffer, application, resolver)
+                        .await
                         .store_finalization(height, digest, &block, Some(finalization), application)
                         .await;
                     if stage && stored {

--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -319,7 +319,7 @@ where
                 }
 
                 finalized_blocks = finalized_blocks
-                    .put(anchor.into())
+                    .put(&anchor.into())
                     .await
                     .expect("failed to store startup anchor")
                     .sync()
@@ -823,25 +823,21 @@ where
                         .update_processed_round_floor(height, round, buffer, application, resolver)
                         .await;
 
-                    // Retain only blocks that can still be dispatched and fit in staging
+                    // Retain only new archive entries that can still be dispatched and fit in staging
+                    // An existing height keeps its first block even if another finalization conflicts
                     let next_height = self
                         .pending_acks
                         .next_dispatch_height(self.stream.next_height());
-                    if height >= next_height
+                    let stage = height >= next_height
                         && self.staged.len() < self.pending_acks.capacity().saturating_mul(2)
-                    {
-                        self.staged.insert(height, Arc::clone(&block));
-                    }
+                        && self.finalized_blocks.next_gap(height).0.is_none();
                     let stored;
                     (self, stored) = self
-                        .store_finalization(
-                            height,
-                            digest,
-                            Arc::unwrap_or_clone(block),
-                            Some(finalization),
-                            application,
-                        )
+                        .store_finalization(height, digest, &block, Some(finalization), application)
                         .await;
+                    if stage && stored {
+                        self.staged.insert(height, block);
+                    }
                     if stored {
                         // If a floor anchor is pending, repair and dispatch are
                         // no-ops until the anchor block is stored.
@@ -1398,12 +1394,13 @@ where
             .take_pending_anchor()
             .expect("pending floor anchor missing");
         let round = finalization.round();
+        let stored = V::stored(&block);
         (self.finalized_blocks, self.finalizations_by_height) = try_join!(
             self.finalized_blocks
-                .put(Arc::unwrap_or_clone(block).into())
+                .put(stored.as_ref())
                 .map_err(BoxedError::from),
             self.finalizations_by_height
-                .put(height, digest, finalization)
+                .put(height, digest, &finalization)
                 .map_err(BoxedError::from),
         )
         .expect("failed to store floor anchor");
@@ -1567,13 +1564,7 @@ where
                         .any(|annotation| matches!(annotation, Annotation::Finalized(_)))
                 {
                     (self, _) = self
-                        .store_finalization(
-                            height,
-                            digest,
-                            Arc::unwrap_or_clone(block),
-                            finalization,
-                            application,
-                        )
+                        .store_finalization(height, digest, &block, finalization, application)
                         .await;
                 } else if annotations.iter().any(|annotation| {
                     matches!(
@@ -1806,13 +1797,7 @@ where
                     (self, _) = self
                         .update_processed_round_floor(height, round, buffer, application, resolver)
                         .await
-                        .store_finalization(
-                            height,
-                            digest,
-                            Arc::unwrap_or_clone(block),
-                            Some(finalization),
-                            application,
-                        )
+                        .store_finalization(height, digest, &block, Some(finalization), application)
                         .await;
                 }
                 PendingVerification::Notarized {
@@ -1880,7 +1865,7 @@ where
                             .store_finalization(
                                 height,
                                 digest,
-                                Arc::unwrap_or_clone(block),
+                                &block,
                                 Some(finalization),
                                 application,
                             )
@@ -2146,7 +2131,7 @@ where
         mut self: Box<Self>,
         height: Height,
         digest: <V::Block as Digestible>::Digest,
-        block: V::Block,
+        block: &V::Block,
         finalization: Option<Finalization<P::Scheme, V::Commitment>>,
         application: &mut impl Reporter<Activity = Update<V::ApplicationBlock, A>>,
     ) -> (Box<Self>, bool) {
@@ -2164,19 +2149,21 @@ where
         }
 
         // Convert block to storage format
-        let stored: V::StoredBlock = block.into();
+        let stored = V::stored(block);
         let round = finalization.as_ref().map(|f| f.round());
 
         // In parallel, update the finalized blocks and finalizations archives
         let finalizations_by_height = self.finalizations_by_height;
         (self.finalized_blocks, self.finalizations_by_height) = try_join!(
             // Update the finalized blocks archive
-            self.finalized_blocks.put(stored).map_err(BoxedError::from),
+            self.finalized_blocks
+                .put(stored.as_ref())
+                .map_err(BoxedError::from),
             // Update the finalizations archive (if provided)
             async {
                 let store = if let Some(finalization) = finalization {
                     finalizations_by_height
-                        .put(height, digest, finalization)
+                        .put(height, digest, &finalization)
                         .await
                         .map_err(BoxedError::from)?
                 } else {
@@ -2349,7 +2336,7 @@ where
                         .store_finalization(
                             last_finalized,
                             digest,
-                            Arc::unwrap_or_clone(block),
+                            &block,
                             Some(finalization),
                             application,
                         )
@@ -2404,7 +2391,7 @@ where
                         .store_finalization(
                             next.0,
                             parent_digest,
-                            Arc::unwrap_or_clone(block),
+                            &block,
                             finalization,
                             application,
                         )

--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -1423,6 +1423,7 @@ where
         // Release staged blocks skipped by the floor transition
         self.staged = self.staged.split_off(&height);
 
+        // Advance the round floor and persist the dispatch floor before pruning finalized data
         self = self
             .update_processed_round_floor(dispatch_floor, round, buffer, application, resolver)
             .await;

--- a/consensus/src/marshal/core/actor.rs
+++ b/consensus/src/marshal/core/actor.rs
@@ -824,9 +824,9 @@ where
                     let next_height = self
                         .pending_acks
                         .next_dispatch_height(self.stream.next_height());
-                    let staged = (height >= next_height
-                        && self.staged.len() < self.pending_acks.capacity())
-                    .then(|| Arc::clone(&block));
+                    if height >= next_height && self.staged.len() < self.pending_acks.capacity() {
+                        self.staged.insert(height, Arc::clone(&block));
+                    }
                     let stored;
                     (self, stored) = self
                         .store_finalization(
@@ -838,10 +838,6 @@ where
                         )
                         .await;
                     if stored {
-                        if let Some(block) = staged {
-                            self.staged.insert(height, block);
-                        }
-
                         // If a floor anchor is pending, repair and dispatch are
                         // no-ops until the anchor block is stored.
                         (self, _) = self.try_repair_gaps(buffer, resolver, application).await;
@@ -1421,6 +1417,10 @@ where
             .previous()
             .expect("floor anchor above processed height must have predecessor");
         self.update_processed_height(dispatch_floor, resolver);
+
+        // Release staged blocks skipped by the floor transition
+        self.staged = self.staged.split_off(&height);
+
         self = self
             .update_processed_round_floor(dispatch_floor, round, buffer, application, resolver)
             .await;
@@ -2455,9 +2455,6 @@ where
         let _ = self
             .processed_height
             .try_set(self.floor.processed_height().get());
-
-        // Release staged blocks skipped by a floor transition
-        self.staged = self.staged.split_off(&height.next());
 
         // Resolver request retention is independent of caller-owned block subscriptions.
         resolver.retain(handler::above_height_floor::<V::Commitment>(height));

--- a/consensus/src/marshal/core/cache.rs
+++ b/consensus/src/marshal/core/cache.rs
@@ -333,7 +333,7 @@ where
         mut self,
         round: Round,
         digest: <V::Block as Digestible>::Digest,
-        block: V::StoredBlock,
+        block: &V::Block,
     ) -> (Self, Handle<()>) {
         let view = round.view().get();
         let handle;
@@ -354,9 +354,10 @@ where
                         "verified",
                     );
                 } else {
+                    let stored = V::stored(block);
                     let result = cache
                         .verified_blocks
-                        .put_multi_start_sync(view, digest, &block)
+                        .put_multi_start_sync(view, digest, stored.as_ref())
                         .await;
                     (cache.verified_blocks, handle) =
                         Self::handle_start_result(result, round, "verified");
@@ -373,7 +374,7 @@ where
         epoch: Epoch,
         height: Height,
         digest: <V::Block as Digestible>::Digest,
-        block: V::StoredBlock,
+        block: &V::Block,
     ) -> Self {
         (self, _) = self
             .with_epoch(epoch, |mut cache| async move {
@@ -384,9 +385,10 @@ where
                     Err(e) => panic!("failed to check certified block: {e}"),
                 };
                 if !exists {
+                    let stored = V::stored(block);
                     cache.certified_blocks = cache
                         .certified_blocks
-                        .put_multi_sync(height.get(), digest, &block)
+                        .put_multi_sync(height.get(), digest, stored.as_ref())
                         .await
                         .unwrap_or_else(|e| panic!("failed to insert certified block: {e}"));
                     debug!(%height, "cached certified block");
@@ -402,15 +404,16 @@ where
         mut self,
         round: Round,
         digest: <V::Block as Digestible>::Digest,
-        block: V::StoredBlock,
+        block: &V::Block,
     ) -> (Self, Handle<()>) {
         let view = round.view().get();
         let handle;
         (self, handle) = self
             .with_epoch(round.epoch(), |mut cache| async move {
+                let stored = V::stored(block);
                 let result = cache
                     .notarized_blocks
-                    .put_start_sync(view, digest, &block)
+                    .put_start_sync(view, digest, stored.as_ref())
                     .await;
                 let handle;
                 (cache.notarized_blocks, handle) =
@@ -463,7 +466,7 @@ where
         mut self,
         round: Round,
         digest: <V::Block as Digestible>::Digest,
-        notarization: Notarization<S, V::Commitment>,
+        notarization: &Notarization<S, V::Commitment>,
     ) -> (Self, Handle<()>) {
         let view = round.view().get();
         let handle;
@@ -471,7 +474,7 @@ where
             .with_epoch(round.epoch(), |mut cache| async move {
                 let result = cache
                     .notarizations
-                    .put_start_sync(view, digest, &notarization)
+                    .put_start_sync(view, digest, notarization)
                     .await;
                 let handle;
                 (cache.notarizations, handle) =
@@ -492,14 +495,14 @@ where
         mut self,
         round: Round,
         digest: <V::Block as Digestible>::Digest,
-        finalization: Finalization<S, V::Commitment>,
+        finalization: &Finalization<S, V::Commitment>,
     ) -> Self {
         let view = round.view().get();
         (self, _) = self
             .with_epoch(round.epoch(), |mut cache| async move {
                 cache.finalizations = cache
                     .finalizations
-                    .put_sync(view, digest, &finalization)
+                    .put_sync(view, digest, finalization)
                     .await
                     .unwrap_or_else(|e| panic!("failed to insert finalization: {e}"));
                 debug!(?round, "cached finalization");

--- a/consensus/src/marshal/core/cache.rs
+++ b/consensus/src/marshal/core/cache.rs
@@ -356,7 +356,7 @@ where
                 } else {
                     let result = cache
                         .verified_blocks
-                        .put_multi_start_sync(view, digest, block)
+                        .put_multi_start_sync(view, digest, &block)
                         .await;
                     (cache.verified_blocks, handle) =
                         Self::handle_start_result(result, round, "verified");
@@ -386,7 +386,7 @@ where
                 if !exists {
                     cache.certified_blocks = cache
                         .certified_blocks
-                        .put_multi_sync(height.get(), digest, block)
+                        .put_multi_sync(height.get(), digest, &block)
                         .await
                         .unwrap_or_else(|e| panic!("failed to insert certified block: {e}"));
                     debug!(%height, "cached certified block");
@@ -410,7 +410,7 @@ where
             .with_epoch(round.epoch(), |mut cache| async move {
                 let result = cache
                     .notarized_blocks
-                    .put_start_sync(view, digest, block)
+                    .put_start_sync(view, digest, &block)
                     .await;
                 let handle;
                 (cache.notarized_blocks, handle) =
@@ -471,7 +471,7 @@ where
             .with_epoch(round.epoch(), |mut cache| async move {
                 let result = cache
                     .notarizations
-                    .put_start_sync(view, digest, notarization)
+                    .put_start_sync(view, digest, &notarization)
                     .await;
                 let handle;
                 (cache.notarizations, handle) =
@@ -499,7 +499,7 @@ where
             .with_epoch(round.epoch(), |mut cache| async move {
                 cache.finalizations = cache
                     .finalizations
-                    .put_sync(view, digest, finalization)
+                    .put_sync(view, digest, &finalization)
                     .await
                     .unwrap_or_else(|e| panic!("failed to insert finalization: {e}"));
                 debug!(?round, "cached finalization");

--- a/consensus/src/marshal/core/cache.rs
+++ b/consensus/src/marshal/core/cache.rs
@@ -354,10 +354,10 @@ where
                         "verified",
                     );
                 } else {
-                    let stored = V::stored(block);
+                    let stored: V::StoredBlock = block.clone().into();
                     let result = cache
                         .verified_blocks
-                        .put_multi_start_sync(view, digest, stored.as_ref())
+                        .put_multi_start_sync(view, digest, &stored)
                         .await;
                     (cache.verified_blocks, handle) =
                         Self::handle_start_result(result, round, "verified");
@@ -385,10 +385,10 @@ where
                     Err(e) => panic!("failed to check certified block: {e}"),
                 };
                 if !exists {
-                    let stored = V::stored(block);
+                    let stored: V::StoredBlock = block.clone().into();
                     cache.certified_blocks = cache
                         .certified_blocks
-                        .put_multi_sync(height.get(), digest, stored.as_ref())
+                        .put_multi_sync(height.get(), digest, &stored)
                         .await
                         .unwrap_or_else(|e| panic!("failed to insert certified block: {e}"));
                     debug!(%height, "cached certified block");
@@ -410,10 +410,10 @@ where
         let handle;
         (self, handle) = self
             .with_epoch(round.epoch(), |mut cache| async move {
-                let stored = V::stored(block);
+                let stored: V::StoredBlock = block.clone().into();
                 let result = cache
                     .notarized_blocks
-                    .put_start_sync(view, digest, stored.as_ref())
+                    .put_start_sync(view, digest, &stored)
                     .await;
                 let handle;
                 (cache.notarized_blocks, handle) =

--- a/consensus/src/marshal/core/mailbox.rs
+++ b/consensus/src/marshal/core/mailbox.rs
@@ -857,7 +857,7 @@ impl<S: Scheme, V: Variant> Mailbox<S, V> {
     {
         let receiver = self.subscribe_by_digest(start_digest, fallback);
         receiver.await.ok().map(|block| {
-            let block = V::into_inner_shared(block);
+            let block = V::into_inner(block);
             self.ancestor_stream(clock, [block], fetch_duration)
         })
     }

--- a/consensus/src/marshal/core/mailbox.rs
+++ b/consensus/src/marshal/core/mailbox.rs
@@ -857,7 +857,7 @@ impl<S: Scheme, V: Variant> Mailbox<S, V> {
     {
         let receiver = self.subscribe_by_digest(start_digest, fallback);
         receiver.await.ok().map(|block| {
-            let block = V::into_inner(block);
+            let block = V::into_shared(block);
             self.ancestor_stream(clock, [block], fetch_duration)
         })
     }

--- a/consensus/src/marshal/core/mailbox.rs
+++ b/consensus/src/marshal/core/mailbox.rs
@@ -101,7 +101,7 @@ pub(crate) enum Message<S: Scheme, V: Variant> {
         /// How marshal should behave if the block is missing locally.
         fallback: DigestFallback,
         /// A channel to send the retrieved block.
-        response: oneshot::Sender<Arc<V::Block>>,
+        response: oneshot::Sender<V::Block>,
     },
     /// A request to subscribe to a block by its commitment.
     SubscribeByCommitment {
@@ -112,7 +112,7 @@ pub(crate) enum Message<S: Scheme, V: Variant> {
         /// How marshal should behave if the block is missing locally.
         fallback: CommitmentFallback,
         /// A channel to send the retrieved block.
-        response: oneshot::Sender<Arc<V::Block>>,
+        response: oneshot::Sender<V::Block>,
     },
     /// A hint to fetch a notarized block by round without adding another local subscriber.
     ///
@@ -153,7 +153,7 @@ pub(crate) enum Message<S: Scheme, V: Variant> {
         /// The round in which the block was proposed.
         round: Round,
         /// The proposed block.
-        block: Arc<V::Block>,
+        block: V::Block,
         /// The recipients to broadcast the block to.
         recipients: Recipients<S::PublicKey>,
         /// A channel sent once the block sync has started.
@@ -167,7 +167,7 @@ pub(crate) enum Message<S: Scheme, V: Variant> {
         /// The round of the verify request.
         round: Round,
         /// The block.
-        block: Arc<V::Block>,
+        block: V::Block,
         /// A channel sent once the block sync has started.
         ack: oneshot::Sender<Handle<()>>,
     },
@@ -179,7 +179,7 @@ pub(crate) enum Message<S: Scheme, V: Variant> {
         /// The round of the certify request.
         round: Round,
         /// The block.
-        block: Arc<V::Block>,
+        block: V::Block,
         /// A channel sent once the block and notarization syncs have started; the
         /// handle covers both.
         ack: oneshot::Sender<Handle<()>>,
@@ -773,7 +773,7 @@ impl<S: Scheme, V: Variant> Mailbox<S, V> {
         &self,
         digest: <V::Block as Digestible>::Digest,
         fallback: DigestFallback,
-    ) -> oneshot::Receiver<Arc<V::Block>> {
+    ) -> oneshot::Receiver<V::Block> {
         let (tx, rx) = oneshot::channel();
         let _ = self.sender.enqueue(Message::SubscribeByDigest {
             span: info_span!("marshal.mailbox.subscribe_by_digest", digest = %digest),
@@ -807,7 +807,7 @@ impl<S: Scheme, V: Variant> Mailbox<S, V> {
         &self,
         commitment: V::Commitment,
         fallback: CommitmentFallback,
-    ) -> oneshot::Receiver<Arc<V::Block>> {
+    ) -> oneshot::Receiver<V::Block> {
         let (tx, rx) = oneshot::channel();
         let _ = self.sender.enqueue(Message::SubscribeByCommitment {
             span: info_span!("marshal.mailbox.subscribe_by_commitment", commitment = %commitment),
@@ -892,7 +892,7 @@ impl<S: Scheme, V: Variant> Mailbox<S, V> {
     pub fn proposed(
         &self,
         round: Round,
-        block: impl Into<Arc<V::Block>>,
+        block: impl Into<V::Block>,
         recipients: Recipients<S::PublicKey>,
         ack: oneshot::Sender<Handle<()>>,
     ) -> Feedback {
@@ -914,7 +914,7 @@ impl<S: Scheme, V: Variant> Mailbox<S, V> {
     pub fn verified_deferred(
         &self,
         round: Round,
-        block: impl Into<Arc<V::Block>>,
+        block: impl Into<V::Block>,
         ack: oneshot::Sender<Handle<()>>,
     ) {
         let _ = self.sender.enqueue(Message::Verified {
@@ -931,7 +931,7 @@ impl<S: Scheme, V: Variant> Mailbox<S, V> {
     /// durable sync is awaited on the caller's task (off the actor), so the actor
     /// never blocks on fsync.
     #[must_use = "callers must consider block durability before proceeding"]
-    pub async fn verified(&self, round: Round, block: impl Into<Arc<V::Block>>) -> bool {
+    pub async fn verified(&self, round: Round, block: impl Into<V::Block>) -> bool {
         let (ack, receiver) = oneshot::channel();
         self.verified_deferred(round, block, ack);
         let Ok(handle) = receiver.await else {
@@ -944,7 +944,7 @@ impl<S: Scheme, V: Variant> Mailbox<S, V> {
     ///
     /// Returns after the block is durably persisted.
     #[must_use = "callers must consider block durability before proceeding"]
-    pub async fn certified(&self, round: Round, block: impl Into<Arc<V::Block>>) -> bool {
+    pub async fn certified(&self, round: Round, block: impl Into<V::Block>) -> bool {
         let (ack, receiver) = oneshot::channel();
         let _ = self.sender.enqueue(Message::Certified {
             span: info_span!("marshal.mailbox.certified", round = %round),
@@ -1055,7 +1055,7 @@ mod tests {
     }
 
     fn commitment(height: u64) -> harness::D {
-        <Standard<harness::B> as Variant>::commitment(&block(height))
+        block(height).digest()
     }
 
     fn finalization(height: u64) -> Finalization<harness::S, harness::D> {
@@ -1125,7 +1125,7 @@ mod tests {
         )
     }
 
-    fn get_block(height: u64) -> (TestMessage, oneshot::Receiver<Option<harness::B>>) {
+    fn get_block(height: u64) -> (TestMessage, oneshot::Receiver<Option<Arc<harness::B>>>) {
         let (response, receiver) = oneshot::channel();
         (
             TestMessage::GetBlock {

--- a/consensus/src/marshal/core/mod.rs
+++ b/consensus/src/marshal/core/mod.rs
@@ -52,6 +52,7 @@ mod delivery;
 pub(crate) mod durability;
 mod floor;
 pub use floor::Floor;
+mod staged;
 mod stream;
 
 mod mailbox;

--- a/consensus/src/marshal/core/staged.rs
+++ b/consensus/src/marshal/core/staged.rs
@@ -11,6 +11,7 @@ pub(super) struct Staged<B> {
 }
 
 impl<B> Staged<B> {
+    /// Creates empty staging that holds at most `max` blocks.
     pub(super) const fn new(max: usize) -> Self {
         Self {
             entries: BTreeMap::new(),
@@ -40,7 +41,11 @@ impl<B> Staged<B> {
             return;
         }
         self.min = min;
-        self.entries = self.entries.split_off(&min);
+        while let Some(entry) = self.entries.first_entry()
+            && *entry.key() < min
+        {
+            entry.remove();
+        }
     }
 }
 
@@ -48,6 +53,23 @@ impl<B> Staged<B> {
 mod tests {
     use super::*;
     use std::sync::Arc;
+
+    #[test]
+    fn insert_keeps_first_block_and_rejects_overflow() {
+        let mut staged = Staged::new(2);
+        let first = Arc::new(());
+        staged.insert(Height::new(5), Arc::clone(&first));
+        staged.insert(Height::new(5), Arc::new(()));
+        staged.insert(Height::new(6), Arc::new(()));
+        staged.insert(Height::new(7), Arc::new(()));
+        assert!(staged.remove(Height::new(7)).is_none());
+        assert!(
+            staged
+                .remove(Height::new(5))
+                .is_some_and(|block| Arc::ptr_eq(&block, &first))
+        );
+        assert!(staged.remove(Height::new(6)).is_some());
+    }
 
     #[test]
     fn retained_minimum_never_decreases() {

--- a/consensus/src/marshal/core/staged.rs
+++ b/consensus/src/marshal/core/staged.rs
@@ -1,0 +1,82 @@
+//! Finalized blocks awaiting application dispatch.
+
+use crate::types::Height;
+use std::collections::BTreeMap;
+
+/// Bounded staging that rejects heights below a monotonic retention minimum.
+pub(super) struct Staged<B> {
+    entries: BTreeMap<Height, B>,
+    min: Height,
+    max: usize,
+}
+
+impl<B> Staged<B> {
+    pub(super) const fn new(max: usize) -> Self {
+        Self {
+            entries: BTreeMap::new(),
+            min: Height::zero(),
+            max,
+        }
+    }
+
+    /// Stages a block if its height is retained and capacity is available.
+    /// Duplicate heights keep their existing block.
+    pub(super) fn insert(&mut self, height: Height, block: B) {
+        if height < self.min || self.entries.len() >= self.max {
+            return;
+        }
+        self.entries.entry(height).or_insert(block);
+    }
+
+    /// Removes the staged block at `height` for dispatch.
+    pub(super) fn remove(&mut self, height: Height) -> Option<B> {
+        self.entries.remove(&height)
+    }
+
+    /// Retains entries at or above `min` and rejects future inserts below it.
+    /// The retention minimum never decreases.
+    pub(super) fn retain(&mut self, min: Height) {
+        if min <= self.min {
+            return;
+        }
+        self.min = min;
+        self.entries = self.entries.split_off(&min);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    #[test]
+    fn retained_minimum_never_decreases() {
+        let mut staged = Staged::new(2);
+        let first = Arc::new(());
+        let second = Arc::new(());
+        staged.insert(Height::new(5), Arc::clone(&first));
+        staged.insert(Height::new(6), Arc::clone(&second));
+
+        staged.retain(Height::new(6));
+        assert!(staged.remove(Height::new(5)).is_none());
+        assert!(
+            staged
+                .remove(Height::new(6))
+                .is_some_and(|block| Arc::ptr_eq(&block, &second))
+        );
+
+        // A stale retain cannot restore eligibility after all entries are removed
+        staged.retain(Height::new(4));
+        staged.insert(Height::new(5), first);
+        staged.insert(Height::new(6), second);
+        assert!(staged.remove(Height::new(5)).is_none());
+        assert!(staged.remove(Height::new(6)).is_some());
+
+        // Advancing an empty staging map still rejects late inserts
+        staged.retain(Height::new(8));
+        staged.insert(Height::new(7), Arc::new(()));
+        staged.insert(Height::new(8), Arc::new(()));
+        assert!(staged.remove(Height::new(7)).is_none());
+        assert!(staged.remove(Height::new(8)).is_some());
+    }
+}

--- a/consensus/src/marshal/core/subscriptions.rs
+++ b/consensus/src/marshal/core/subscriptions.rs
@@ -4,10 +4,7 @@ use commonware_utils::{
     channel::{fallible::OneshotExt, oneshot},
     futures::{AbortablePool, Aborter},
 };
-use std::{
-    collections::{BTreeMap, btree_map::Entry},
-    sync::Arc,
-};
+use std::collections::{BTreeMap, btree_map::Entry};
 use tracing::{Span, info_span};
 
 /// A set of local subscribers waiting for one block.
@@ -25,14 +22,14 @@ struct BlockSubscription<V: Variant> {
 /// A waiter for a block, carrying the span of its mailbox request.
 struct Subscriber<V: Variant> {
     span: Span,
-    sender: oneshot::Sender<Arc<V::Block>>,
+    sender: oneshot::Sender<V::Block>,
 }
 
 /// Delivers a block to a subscriber inside the dequeue-side child of its
 /// carried span, marking fulfillment in the trace.
-fn deliver<V: Variant>(subscriber: Subscriber<V>, block: &Arc<V::Block>) {
+fn deliver<V: Variant>(subscriber: Subscriber<V>, block: &V::Block) {
     let _guard = info_span!(parent: &subscriber.span, "marshal.actor.notify").entered();
-    subscriber.sender.send_lossy(Arc::clone(block));
+    subscriber.sender.send_lossy(block.clone());
 }
 
 /// The key used to track block subscriptions.
@@ -73,7 +70,7 @@ impl<V: Variant> Subscriptions<V> {
     }
 
     /// Notify subscribers waiting for the provided block.
-    pub(super) fn notify(&mut self, block: Arc<V::Block>) {
+    pub(super) fn notify(&mut self, block: V::Block) {
         let digest_key = Key::Digest(block.digest());
         let commitment_key = Key::Commitment(V::commitment(&block));
 
@@ -93,8 +90,8 @@ impl<V: Variant> Subscriptions<V> {
         &mut self,
         span: Span,
         key: KeyFor<V>,
-        response: oneshot::Sender<Arc<V::Block>>,
-        waiters: &mut AbortablePool<'_, Result<Arc<V::Block>, KeyFor<V>>>,
+        response: oneshot::Sender<V::Block>,
+        waiters: &mut AbortablePool<'_, Result<V::Block, KeyFor<V>>>,
         buffer: &Buf,
     ) {
         let subscriber = Subscriber {

--- a/consensus/src/marshal/core/variant.rs
+++ b/consensus/src/marshal/core/variant.rs
@@ -17,7 +17,7 @@ use commonware_codec::{Codec, Read};
 use commonware_cryptography::{Digest, Digestible, PublicKey};
 use commonware_p2p::Recipients;
 use commonware_utils::channel::oneshot;
-use std::{borrow::Cow, future::Future, marker::PhantomData, sync::Arc};
+use std::{future::Future, marker::PhantomData, sync::Arc};
 
 /// An atomic retirement from a buffer's retained state.
 ///
@@ -46,7 +46,8 @@ pub enum ExpectedCommitment<C> {
 pub trait Variant: Clone + Send + Sync + 'static {
     /// The working block type of marshal, supporting the consensus commitment.
     ///
-    /// Must be convertible to `StoredBlock` via `Into` for archival.
+    /// Clones must share the block payload. Must be convertible to `StoredBlock`
+    /// via `Into` for archival without copying the payload.
     type Block: Block<Digest = <Self::ApplicationBlock as Digestible>::Digest>
         + Into<Self::StoredBlock>;
 
@@ -62,14 +63,6 @@ pub trait Variant: Clone + Send + Sync + 'static {
 
     /// The [`Digest`] type used by consensus.
     type Commitment: Digest;
-
-    /// Obtain the storage representation of a borrowed working block.
-    ///
-    /// Must preserve the same encoded value and commitment as converting
-    /// `block.clone()` into [Self::StoredBlock].
-    fn stored(block: &Self::Block) -> Cow<'_, Self::StoredBlock> {
-        Cow::Owned(block.clone().into())
-    }
 
     /// Computes the consensus commitment for a block.
     ///
@@ -110,17 +103,13 @@ pub trait Variant: Clone + Send + Sync + 'static {
         expected: ExpectedCommitment<Self::Commitment>,
     ) -> <Self::Block as Read>::Cfg;
 
-    /// Converts a working block to an application block.
+    /// Converts a working block to an owned application block.
     ///
-    /// This conversion cannot use `Into` due to orphan rules when `Block` wraps
-    /// `ApplicationBlock` (e.g., `CodedBlock<B, C, H> -> B`).
+    /// This may clone the payload if other owners still hold it.
     fn into_inner(block: Self::Block) -> Self::ApplicationBlock;
 
-    /// Converts a shared working block to a shared application block.
-    fn into_inner_shared(block: Arc<Self::Block>) -> Arc<Self::ApplicationBlock>;
-
-    /// Converts an owned working block to a shared application block.
-    fn owned_into_inner_shared(block: Self::Block) -> Arc<Self::ApplicationBlock>;
+    /// Converts a working block to a shared application block without copying the payload.
+    fn into_inner_shared(block: Self::Block) -> Arc<Self::ApplicationBlock>;
 
     /// Reconstructs a working block from an application block and trusted payload.
     fn from_application_block(
@@ -152,7 +141,7 @@ pub trait Buffer<V: Variant>: Clone + Send + Sync + 'static {
     fn find_by_digest(
         &self,
         digest: <V::Block as Digestible>::Digest,
-    ) -> impl Future<Output = Option<Arc<V::Block>>> + Send;
+    ) -> impl Future<Output = Option<V::Block>> + Send;
 
     /// Attempt to find a block by its commitment.
     ///
@@ -165,7 +154,7 @@ pub trait Buffer<V: Variant>: Clone + Send + Sync + 'static {
     fn find_by_commitment(
         &self,
         commitment: V::Commitment,
-    ) -> impl Future<Output = Option<Arc<V::Block>>> + Send;
+    ) -> impl Future<Output = Option<V::Block>> + Send;
 
     /// Subscribe to a block's availability by its digest.
     ///
@@ -180,7 +169,7 @@ pub trait Buffer<V: Variant>: Clone + Send + Sync + 'static {
     fn subscribe_by_digest(
         &self,
         digest: <V::Block as Digestible>::Digest,
-    ) -> Option<oneshot::Receiver<Arc<V::Block>>>;
+    ) -> Option<oneshot::Receiver<V::Block>>;
 
     /// Subscribe to a block's availability by its commitment.
     ///
@@ -198,7 +187,7 @@ pub trait Buffer<V: Variant>: Clone + Send + Sync + 'static {
     fn subscribe_by_commitment(
         &self,
         commitment: V::Commitment,
-    ) -> Option<oneshot::Receiver<Arc<V::Block>>>;
+    ) -> Option<oneshot::Receiver<V::Block>>;
 
     /// Retire entries made eligible by durable application progress.
     ///
@@ -209,7 +198,7 @@ pub trait Buffer<V: Variant>: Clone + Send + Sync + 'static {
     fn retire(&self, update: Retirement<V::Commitment>);
 
     /// Send a block to peers.
-    fn send(&self, round: Round, block: Arc<V::Block>, recipients: Recipients<Self::PublicKey>);
+    fn send(&self, round: Round, block: V::Block, recipients: Recipients<Self::PublicKey>);
 }
 
 /// A buffer implementation that never stores, subscribes, finalizes, or sends blocks.
@@ -240,29 +229,26 @@ where
 {
     type PublicKey = P;
 
-    async fn find_by_digest(&self, _: <V::Block as Digestible>::Digest) -> Option<Arc<V::Block>> {
+    async fn find_by_digest(&self, _: <V::Block as Digestible>::Digest) -> Option<V::Block> {
         None
     }
 
-    async fn find_by_commitment(&self, _: V::Commitment) -> Option<Arc<V::Block>> {
+    async fn find_by_commitment(&self, _: V::Commitment) -> Option<V::Block> {
         None
     }
 
     fn subscribe_by_digest(
         &self,
         _: <V::Block as Digestible>::Digest,
-    ) -> Option<oneshot::Receiver<Arc<V::Block>>> {
+    ) -> Option<oneshot::Receiver<V::Block>> {
         None
     }
 
-    fn subscribe_by_commitment(
-        &self,
-        _: V::Commitment,
-    ) -> Option<oneshot::Receiver<Arc<V::Block>>> {
+    fn subscribe_by_commitment(&self, _: V::Commitment) -> Option<oneshot::Receiver<V::Block>> {
         None
     }
 
     fn retire(&self, _: Retirement<V::Commitment>) {}
 
-    fn send(&self, _: Round, _: Arc<V::Block>, _: Recipients<Self::PublicKey>) {}
+    fn send(&self, _: Round, _: V::Block, _: Recipients<Self::PublicKey>) {}
 }

--- a/consensus/src/marshal/core/variant.rs
+++ b/consensus/src/marshal/core/variant.rs
@@ -17,7 +17,7 @@ use commonware_codec::{Codec, Read};
 use commonware_cryptography::{Digest, Digestible, PublicKey};
 use commonware_p2p::Recipients;
 use commonware_utils::channel::oneshot;
-use std::{future::Future, marker::PhantomData, sync::Arc};
+use std::{borrow::Cow, future::Future, marker::PhantomData, sync::Arc};
 
 /// An atomic retirement from a buffer's retained state.
 ///
@@ -62,6 +62,14 @@ pub trait Variant: Clone + Send + Sync + 'static {
 
     /// The [`Digest`] type used by consensus.
     type Commitment: Digest;
+
+    /// Obtain the storage representation of a borrowed working block.
+    ///
+    /// Must preserve the same encoded value and commitment as converting
+    /// `block.clone()` into [Self::StoredBlock].
+    fn stored(block: &Self::Block) -> Cow<'_, Self::StoredBlock> {
+        Cow::Owned(block.clone().into())
+    }
 
     /// Computes the consensus commitment for a block.
     ///

--- a/consensus/src/marshal/core/variant.rs
+++ b/consensus/src/marshal/core/variant.rs
@@ -104,7 +104,7 @@ pub trait Variant: Clone + Send + Sync + 'static {
     ) -> <Self::Block as Read>::Cfg;
 
     /// Converts a working block to a shared application block without copying the payload.
-    fn into_inner(block: Self::Block) -> Arc<Self::ApplicationBlock>;
+    fn into_shared(block: Self::Block) -> Arc<Self::ApplicationBlock>;
 
     /// Reconstructs a working block from an application block and trusted payload.
     fn from_application_block(

--- a/consensus/src/marshal/core/variant.rs
+++ b/consensus/src/marshal/core/variant.rs
@@ -103,13 +103,8 @@ pub trait Variant: Clone + Send + Sync + 'static {
         expected: ExpectedCommitment<Self::Commitment>,
     ) -> <Self::Block as Read>::Cfg;
 
-    /// Converts a working block to an owned application block.
-    ///
-    /// This may clone the payload if other owners still hold it.
-    fn into_inner(block: Self::Block) -> Self::ApplicationBlock;
-
     /// Converts a working block to a shared application block without copying the payload.
-    fn into_inner_shared(block: Self::Block) -> Arc<Self::ApplicationBlock>;
+    fn into_inner(block: Self::Block) -> Arc<Self::ApplicationBlock>;
 
     /// Reconstructs a working block from an application block and trusted payload.
     fn from_application_block(

--- a/consensus/src/marshal/core/variant.rs
+++ b/consensus/src/marshal/core/variant.rs
@@ -46,8 +46,8 @@ pub enum ExpectedCommitment<C> {
 pub trait Variant: Clone + Send + Sync + 'static {
     /// The working block type of marshal, supporting the consensus commitment.
     ///
-    /// Clones must share the block payload. Must be convertible to `StoredBlock`
-    /// via `Into` for archival without copying the payload.
+    /// Cloning must share the block payload, and conversion to [`Self::StoredBlock`]
+    /// must not copy it.
     type Block: Block<Digest = <Self::ApplicationBlock as Digestible>::Digest>
         + Into<Self::StoredBlock>;
 

--- a/consensus/src/marshal/mocks/harness.rs
+++ b/consensus/src/marshal/mocks/harness.rs
@@ -1878,7 +1878,7 @@ impl TestHarness for StandardHarness {
         let config = Config {
             provider,
             epocher: FixedEpocher::new(BLOCKS_PER_EPOCH),
-            start: Start::Genesis(Self::genesis_block(NUM_VALIDATORS as u16)),
+            start: Start::Genesis(Self::genesis_block(NUM_VALIDATORS as u16).into()),
             mailbox_size: NZUsize!(100),
             view_retention: ViewDelta::new(10),
             max_repair: NZUsize!(10),
@@ -2110,7 +2110,7 @@ impl TestHarness for StandardHarness {
         let config = Config {
             provider,
             epocher: FixedEpocher::new(BLOCKS_PER_EPOCH),
-            start: Start::Genesis(Self::genesis_block(NUM_VALIDATORS as u16)),
+            start: Start::Genesis(Self::genesis_block(NUM_VALIDATORS as u16).into()),
             mailbox_size: NZUsize!(100),
             view_retention: ViewDelta::new(10),
             max_repair: NZUsize!(10),
@@ -2670,7 +2670,7 @@ impl TestHarness for CodingHarness {
         let config = Config {
             provider: provider.clone(),
             epocher: FixedEpocher::new(BLOCKS_PER_EPOCH),
-            start: Start::Genesis(Self::genesis_block(NUM_VALIDATORS as u16)),
+            start: Start::Genesis(Self::genesis_block(NUM_VALIDATORS as u16).into()),
             mailbox_size: NZUsize!(100),
             view_retention: ViewDelta::new(10),
             max_repair: NZUsize!(10),
@@ -2942,7 +2942,7 @@ impl TestHarness for CodingHarness {
         let config = Config {
             provider: provider.clone(),
             epocher: FixedEpocher::new(BLOCKS_PER_EPOCH),
-            start: Start::Genesis(Self::genesis_block(NUM_VALIDATORS as u16)),
+            start: Start::Genesis(Self::genesis_block(NUM_VALIDATORS as u16).into()),
             mailbox_size: NZUsize!(100),
             view_retention: ViewDelta::new(10),
             max_repair: NZUsize!(10),

--- a/consensus/src/marshal/mocks/mod.rs
+++ b/consensus/src/marshal/mocks/mod.rs
@@ -2,4 +2,5 @@ pub mod application;
 pub mod block;
 pub mod harness;
 pub mod resolver;
+pub mod store;
 pub mod verifying;

--- a/consensus/src/marshal/mocks/store.rs
+++ b/consensus/src/marshal/mocks/store.rs
@@ -8,8 +8,8 @@ use std::sync::Arc;
 /// A finalized-block store operation observed by [`Recording`].
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Op {
-    /// A `put` of the block at this height.
-    Put(Height),
+    /// A `put` of the block at this height and the address passed to storage.
+    Put(Height, usize),
     /// A `get` by height, or by digest when `None`.
     Get(Option<Height>),
 }
@@ -39,8 +39,10 @@ impl<T: Blocks> Blocks for Recording<T> {
     type Block = T::Block;
     type Error = T::Error;
 
-    async fn put(mut self, block: Self::Block) -> Result<Self, Self::Error> {
-        self.ops.lock().push(Op::Put(block.height()));
+    async fn put(mut self, block: &Self::Block) -> Result<Self, Self::Error> {
+        self.ops
+            .lock()
+            .push(Op::Put(block.height(), std::ptr::from_ref(block).addr()));
         self.inner = self.inner.put(block).await?;
         Ok(self)
     }

--- a/consensus/src/marshal/mocks/store.rs
+++ b/consensus/src/marshal/mocks/store.rs
@@ -1,0 +1,87 @@
+use crate::{Heightable, marshal::store::Blocks, types::Height};
+use commonware_cryptography::Digestible;
+use commonware_runtime::Handle;
+use commonware_storage::archive::Identifier;
+use commonware_utils::sync::Mutex;
+use std::sync::Arc;
+
+/// A finalized-block store operation observed by [`Recording`].
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Op {
+    /// A `put` of the block at this height.
+    Put(Height),
+    /// A `get` by height, or by digest when `None`.
+    Get(Option<Height>),
+}
+
+/// A finalized-block store that records `put` and `get` calls in order.
+pub struct Recording<T> {
+    inner: T,
+    ops: Arc<Mutex<Vec<Op>>>,
+}
+
+impl<T> Recording<T> {
+    /// Wraps `inner` with an empty operation log.
+    pub fn new(inner: T) -> Self {
+        Self {
+            inner,
+            ops: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    /// Returns the shared operation log.
+    pub fn ops(&self) -> Arc<Mutex<Vec<Op>>> {
+        Arc::clone(&self.ops)
+    }
+}
+
+impl<T: Blocks> Blocks for Recording<T> {
+    type Block = T::Block;
+    type Error = T::Error;
+
+    async fn put(mut self, block: Self::Block) -> Result<Self, Self::Error> {
+        self.ops.lock().push(Op::Put(block.height()));
+        self.inner = self.inner.put(block).await?;
+        Ok(self)
+    }
+
+    async fn sync(mut self) -> Result<Self, Self::Error> {
+        self.inner = self.inner.sync().await?;
+        Ok(self)
+    }
+
+    async fn start_sync(mut self) -> Result<(Self, Handle<()>), Self::Error> {
+        let handle;
+        (self.inner, handle) = self.inner.start_sync().await?;
+        Ok((self, handle))
+    }
+
+    async fn get(
+        &self,
+        id: Identifier<'_, <Self::Block as Digestible>::Digest>,
+    ) -> Result<Option<Self::Block>, Self::Error> {
+        let height = match &id {
+            Identifier::Index(index) => Some(Height::new(*index)),
+            Identifier::Key(_) => None,
+        };
+        self.ops.lock().push(Op::Get(height));
+        self.inner.get(id).await
+    }
+
+    async fn prune(mut self, min: Height) -> Result<Self, Self::Error> {
+        self.inner = self.inner.prune(min).await?;
+        Ok(self)
+    }
+
+    fn missing_items(&self, start: Height, max: usize) -> Vec<Height> {
+        self.inner.missing_items(start, max)
+    }
+
+    fn next_gap(&self, value: Height) -> (Option<Height>, Option<Height>) {
+        self.inner.next_gap(value)
+    }
+
+    fn last_index(&self) -> Option<Height> {
+        self.inner.last_index()
+    }
+}

--- a/consensus/src/marshal/mocks/store.rs
+++ b/consensus/src/marshal/mocks/store.rs
@@ -6,7 +6,7 @@ use commonware_utils::sync::Mutex;
 use std::sync::Arc;
 
 /// A finalized-block store operation observed by [`Recording`].
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum Op {
     /// A `put` of the block at this height and the payload address passed to storage.
     Put(Height, usize),

--- a/consensus/src/marshal/mocks/store.rs
+++ b/consensus/src/marshal/mocks/store.rs
@@ -8,24 +8,26 @@ use std::sync::Arc;
 /// A finalized-block store operation observed by [`Recording`].
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Op {
-    /// A `put` of the block at this height and the address passed to storage.
+    /// A `put` of the block at this height and the payload address passed to storage.
     Put(Height, usize),
     /// A `get` by height, or by digest when `None`.
     Get(Option<Height>),
 }
 
 /// A finalized-block store that records `put` and `get` calls in order.
-pub struct Recording<T> {
+pub struct Recording<T: Blocks> {
     inner: T,
     ops: Arc<Mutex<Vec<Op>>>,
+    payload_address: fn(&T::Block) -> usize,
 }
 
-impl<T> Recording<T> {
-    /// Wraps `inner` with an empty operation log.
-    pub fn new(inner: T) -> Self {
+impl<T: Blocks> Recording<T> {
+    /// Wraps `inner`, recording payload addresses with `payload_address`.
+    pub fn new(inner: T, payload_address: fn(&T::Block) -> usize) -> Self {
         Self {
             inner,
             ops: Arc::new(Mutex::new(Vec::new())),
+            payload_address,
         }
     }
 
@@ -42,7 +44,7 @@ impl<T: Blocks> Blocks for Recording<T> {
     async fn put(mut self, block: &Self::Block) -> Result<Self, Self::Error> {
         self.ops
             .lock()
-            .push(Op::Put(block.height(), std::ptr::from_ref(block).addr()));
+            .push(Op::Put(block.height(), (self.payload_address)(block)));
         self.inner = self.inner.put(block).await?;
         Ok(self)
     }

--- a/consensus/src/marshal/standard/deferred.rs
+++ b/consensus/src/marshal/standard/deferred.rs
@@ -576,7 +576,7 @@ where
                         .stage(
                             consensus_context.round,
                             digest,
-                            Arc::new(block),
+                            block,
                             tx,
                             "recovered block",
                         )

--- a/consensus/src/marshal/standard/mod.rs
+++ b/consensus/src/marshal/standard/mod.rs
@@ -200,7 +200,7 @@ mod tests {
                 ConstantProvider::new(schemes[0].clone()),
                 Application::<B>::manual_ack(),
                 Some(buffer),
-                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16)),
+                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16).into()),
             )
             .await;
             let buffer = buffer.expect("buffer was provided");
@@ -875,7 +875,7 @@ mod tests {
             );
             assert_eq!(
                 recovering.mailbox.get_block(Height::new(2)).await,
-                Some(block_two.clone()),
+                Some(block_two.clone().into()),
                 "block without a finalization row should still be queryable by height"
             );
             assert_eq!(
@@ -1299,7 +1299,7 @@ mod tests {
                 key_page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
             };
 
-            let block = make_raw_block(Sha256::hash(&[b""]), Height::new(1), 100);
+            let block = Arc::new(make_raw_block(Sha256::hash(&[b""]), Height::new(1), 100));
             let digest = block.digest();
             let round = Round::new(Epoch::zero(), View::new(1));
 
@@ -2476,7 +2476,7 @@ mod tests {
                     ConstantProvider::new(schemes[0].clone()),
                     Application::<B>::manual_ack(),
                     Some(RecordingBuffer::default()),
-                    Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16)),
+                    Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16).into()),
                 )
                 .await;
                 let buffer = buffer.expect("buffer was provided");
@@ -2552,7 +2552,7 @@ mod tests {
                     ConstantProvider::new(schemes[0].clone()),
                     Application::<B>::manual_ack(),
                     Some(RecordingBuffer::default()),
-                    Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16)),
+                    Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16).into()),
                 )
                 .await;
                 let buffer = buffer.expect("buffer was provided");
@@ -2634,7 +2634,7 @@ mod tests {
             ConstantProvider::new(schemes[0].clone()),
             Application::<B>::manual_ack(),
             Some(RecordingBuffer::default()),
-            Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16)),
+            Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16).into()),
         )
         .await;
         let buffer = buffer.expect("buffer was provided");
@@ -2827,7 +2827,7 @@ mod tests {
                 ConstantProvider::new(schemes[0].clone()),
                 Application::<B>::manual_ack(),
                 Some(RecordingBuffer::default()),
-                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16)),
+                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16).into()),
             )
             .await;
             let mock_app: MockVerifyingApp<B, S> = MockVerifyingApp::new();
@@ -2908,7 +2908,7 @@ mod tests {
                     ConstantProvider::new(schemes[0].clone()),
                     Application::<B>::manual_ack(),
                     Some(RecordingBuffer::default()),
-                    Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16)),
+                    Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16).into()),
                 )
                 .await;
                 let mock_app: MockVerifyingApp<B, S> = MockVerifyingApp::new();
@@ -4285,7 +4285,7 @@ mod tests {
         provider: P,
         application: R,
         buffer: Option<Buf>,
-        start: Start<S, D, B>,
+        start: Start<S, D, Arc<B>>,
     ) -> (
         Mailbox<S, Standard<B>>,
         Option<Buf>,
@@ -4433,7 +4433,7 @@ mod tests {
                 provider.clone(),
                 ApplicationReporter { updates },
                 Some(RecordingBuffer::default()),
-                Start::Genesis(genesis.clone()),
+                Start::Genesis(genesis.clone().into()),
             )
             .await;
 
@@ -4476,7 +4476,7 @@ mod tests {
                 provider,
                 restart_application.clone(),
                 Some(RecordingBuffer::default()),
-                Start::Genesis(genesis),
+                Start::Genesis(genesis.into()),
             )
             .await;
             select! {
@@ -4514,7 +4514,7 @@ mod tests {
                 ConstantProvider::new(schemes[0].clone()),
                 Application::<B>::manual_ack(),
                 None::<RecordingBuffer>,
-                Start::Genesis(genesis.clone()),
+                Start::Genesis(genesis.clone().into()),
             )
             .await;
 
@@ -4607,7 +4607,7 @@ mod tests {
                 ConstantProvider::new(wrong_schemes[0].clone()),
                 Application::<B>::manual_ack(),
                 Some(RecordingBuffer::default()),
-                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16)),
+                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16).into()),
             )
             .await;
             mailbox.set_floor(floor_finalization);
@@ -4836,7 +4836,7 @@ mod tests {
                 ConstantProvider::new(schemes[0].clone()),
                 application,
                 Some(RecordingBuffer::default()),
-                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16)),
+                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16).into()),
             )
             .await;
             let mut mailbox = mailbox;
@@ -4920,7 +4920,7 @@ mod tests {
                 ConstantProvider::new(schemes[0].clone()),
                 application.clone(),
                 Some(RecordingBuffer::default()),
-                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16)),
+                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16).into()),
             )
             .await;
             let mut mailbox = mailbox;
@@ -5024,7 +5024,7 @@ mod tests {
                 ConstantProvider::new(schemes[0].clone()),
                 application.clone(),
                 Some(buffer.clone()),
-                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16)),
+                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16).into()),
             )
             .await;
             let mut mailbox = mailbox;
@@ -5127,7 +5127,7 @@ mod tests {
                 ConstantProvider::new(schemes[0].clone()),
                 application.clone(),
                 Some(RecordingBuffer::default()),
-                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16)),
+                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16).into()),
             )
             .await;
             let mut mailbox = mailbox;
@@ -5300,7 +5300,7 @@ mod tests {
                 ConstantProvider::new(schemes[0].clone()),
                 application,
                 Some(RecordingBuffer::default()),
-                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16)),
+                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16).into()),
             )
             .await;
             let mut mailbox = mailbox;
@@ -5490,7 +5490,7 @@ mod tests {
                 ConstantProvider::new(schemes[0].clone()),
                 application,
                 Some(buffer.clone()),
-                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16)),
+                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16).into()),
             )
             .await;
             let mut mailbox = mailbox;
@@ -5546,7 +5546,7 @@ mod tests {
                 ConstantProvider::new(schemes[0].clone()),
                 application.clone(),
                 Some(RecordingBuffer::default()),
-                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16)),
+                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16).into()),
             )
             .await;
             let mut mailbox = mailbox;
@@ -5662,7 +5662,7 @@ mod tests {
                 ConstantProvider::new(schemes[0].clone()),
                 application.clone(),
                 Some(RecordingBuffer::default()),
-                Start::Genesis(genesis.clone()),
+                Start::Genesis(genesis.clone().into()),
             )
             .await;
             let mut mailbox = mailbox;
@@ -5739,7 +5739,7 @@ mod tests {
                 ConstantProvider::new(schemes[0].clone()),
                 application.clone(),
                 Some(RecordingBuffer::default()),
-                Start::Genesis(genesis.clone()),
+                Start::Genesis(genesis.clone().into()),
             )
             .await;
             let mut mailbox = mailbox;
@@ -5873,7 +5873,7 @@ mod tests {
                 ConstantProvider::new(schemes[0].clone()),
                 application.clone(),
                 Some(RecordingBuffer::default()),
-                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16)),
+                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16).into()),
             )
             .await;
             let mut mailbox = mailbox;
@@ -5966,7 +5966,7 @@ mod tests {
                 ConstantProvider::new(schemes[0].clone()),
                 application.clone(),
                 Some(RecordingBuffer::default()),
-                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16)),
+                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16).into()),
             )
             .await;
             let mut mailbox = mailbox;
@@ -6066,7 +6066,7 @@ mod tests {
                 ConstantProvider::new(schemes[0].clone()),
                 Application::<B>::manual_ack(),
                 Some(RecordingBuffer::default()),
-                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16)),
+                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16).into()),
             )
             .await;
 
@@ -6150,7 +6150,7 @@ mod tests {
                 ConstantProvider::new(schemes[0].clone()),
                 Application::<B>::manual_ack(),
                 Some(RecordingBuffer::default()),
-                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16)),
+                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16).into()),
             )
             .await;
 
@@ -6233,7 +6233,7 @@ mod tests {
                 ConstantProvider::new(schemes[0].clone()),
                 Application::<B>::manual_ack(),
                 Some(RecordingBuffer::default()),
-                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16)),
+                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16).into()),
             )
             .await;
 
@@ -6282,7 +6282,7 @@ mod tests {
                 VerifierProvider::new(schemes[0].clone()),
                 Application::<B>::manual_ack(),
                 Some(RecordingBuffer::default()),
-                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16)),
+                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16).into()),
             )
             .await;
 
@@ -6332,7 +6332,7 @@ mod tests {
                 VerifierProvider::new(verifier.clone()),
                 application.clone(),
                 Some(RecordingBuffer::default()),
-                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16)),
+                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16).into()),
             )
             .await;
 
@@ -6378,7 +6378,7 @@ mod tests {
                 VerifierProvider::new(verifier),
                 Application::<B>::default(),
                 Some(RecordingBuffer::default()),
-                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16)),
+                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16).into()),
             )
             .await;
 
@@ -6417,7 +6417,7 @@ mod tests {
                 VerifierProvider::new(schemes[0].clone()),
                 Application::<B>::manual_ack(),
                 Some(RecordingBuffer::default()),
-                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16)),
+                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16).into()),
             )
             .await;
 
@@ -6469,7 +6469,7 @@ mod tests {
                 provider.clone(),
                 application.clone(),
                 Some(RecordingBuffer::default()),
-                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16)),
+                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16).into()),
             )
             .await;
             assert!(
@@ -6533,7 +6533,7 @@ mod tests {
                 provider.clone(),
                 Application::<B>::manual_ack(),
                 Some(RecordingBuffer::default()),
-                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16)),
+                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16).into()),
             )
             .await;
             assert!(
@@ -6603,7 +6603,7 @@ mod tests {
                 provider.clone(),
                 Application::<B>::manual_ack(),
                 Some(RecordingBuffer::default()),
-                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16)),
+                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16).into()),
             )
             .await;
             assert!(
@@ -6688,7 +6688,7 @@ mod tests {
                 provider.clone(),
                 application.clone(),
                 Some(RecordingBuffer::default()),
-                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16)),
+                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16).into()),
             )
             .await;
             assert!(
@@ -6762,7 +6762,7 @@ mod tests {
                 ConstantProvider::new(schemes[0].clone()),
                 application.clone(),
                 Some(RecordingBuffer::default()),
-                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16)),
+                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16).into()),
             )
             .await;
             let buffer = buffer.expect("buffer was provided");
@@ -6844,7 +6844,7 @@ mod tests {
                 ConstantProvider::new(schemes[0].clone()),
                 application.clone(),
                 Some(RecordingBuffer::default()),
-                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16)),
+                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16).into()),
             )
             .await;
             let mut mailbox = mailbox;
@@ -6911,7 +6911,7 @@ mod tests {
                 ConstantProvider::new(schemes[0].clone()),
                 Application::<B>::manual_ack(),
                 Some(RecordingBuffer::default()),
-                Start::Genesis(original_genesis.clone()),
+                Start::Genesis(original_genesis.clone().into()),
             )
             .await;
             assert_eq!(
@@ -6931,7 +6931,7 @@ mod tests {
                 ConstantProvider::new(schemes[0].clone()),
                 Application::<B>::manual_ack(),
                 Some(RecordingBuffer::default()),
-                Start::Genesis(replacement_genesis.clone()),
+                Start::Genesis(replacement_genesis.clone().into()),
             )
             .await;
         });
@@ -6963,7 +6963,7 @@ mod tests {
                 ConstantProvider::new(schemes[0].clone()),
                 application.clone(),
                 Some(RecordingBuffer::default()),
-                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16)),
+                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16).into()),
             )
             .await;
             let mut mailbox = mailbox;
@@ -6998,7 +6998,7 @@ mod tests {
                 ConstantProvider::new(schemes[0].clone()),
                 Application::<B>::manual_ack(),
                 Some(RecordingBuffer::default()),
-                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16)),
+                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16).into()),
             )
             .await;
             let buffer = buffer.expect("buffer was provided");
@@ -7069,7 +7069,7 @@ mod tests {
                 ConstantProvider::new(schemes[0].clone()),
                 Application::<B>::manual_ack(),
                 Some(RecordingBuffer::default()),
-                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16)),
+                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16).into()),
             )
             .await;
 
@@ -7159,7 +7159,7 @@ mod tests {
                 ConstantProvider::new(schemes[0].clone()),
                 application,
                 Some(RecordingBuffer::default()),
-                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16)),
+                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16).into()),
             )
             .await;
 
@@ -7192,7 +7192,7 @@ mod tests {
                 ConstantProvider::new(schemes[0].clone()),
                 Application::<B>::manual_ack(),
                 Some(RecordingBuffer::default()),
-                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16)),
+                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16).into()),
             )
             .await;
 
@@ -7241,7 +7241,7 @@ mod tests {
                 ConstantProvider::new(schemes[0].clone()),
                 Application::<B>::manual_ack(),
                 Some(RecordingBuffer::default()),
-                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16)),
+                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16).into()),
             )
             .await;
             let missing = Sha256::hash(&[b"missing-before-set-floor"]);
@@ -7458,7 +7458,7 @@ mod tests {
             let config = Config {
                 provider: EmptyProvider,
                 epocher: FixedEpocher::new(BLOCKS_PER_EPOCH),
-                start: Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16)),
+                start: Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16).into()),
                 mailbox_size: NZUsize!(100),
                 view_retention: ViewDelta::new(10),
                 max_repair: NZUsize!(10),
@@ -7619,7 +7619,7 @@ mod tests {
                 ConstantProvider::new(schemes[0].clone()),
                 application,
                 Some(RecordingBuffer::default()),
-                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16)),
+                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16).into()),
             )
             .await;
 
@@ -7653,7 +7653,7 @@ mod tests {
                 ConstantProvider::new(schemes[0].clone()),
                 Application::<B>::manual_ack(),
                 Some(RecordingBuffer::default()),
-                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16)),
+                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16).into()),
             )
             .await;
 
@@ -7807,7 +7807,7 @@ mod tests {
     }
 
     type Finalizations = prunable::Archive<EightCap, deterministic::Context, D, Finalization<S, D>>;
-    type FinalizedBlocks<T = B> = prunable::Archive<EightCap, deterministic::Context, D, T>;
+    type FinalizedBlocks<T = Arc<B>> = prunable::Archive<EightCap, deterministic::Context, D, T>;
 
     /// Initialize prunable finalized stores for direct actor tests.
     async fn prunable_finalized_stores<T: crate::Block<Digest = D> + Read<Cfg = ()>>(
@@ -7882,11 +7882,11 @@ mod tests {
         partition_prefix: &str,
         provider: harness::P,
         max_pending_acks: NonZeroUsize,
-    ) -> Config<harness::P, FixedEpocher, Sequential, B, B, D> {
+    ) -> Config<harness::P, FixedEpocher, Sequential, B, Arc<B>, D> {
         Config {
             provider,
             epocher: FixedEpocher::new(BLOCKS_PER_EPOCH),
-            start: Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16)),
+            start: Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16).into()),
             mailbox_size: NZUsize!(100),
             view_retention: ViewDelta::new(10),
             max_repair: NZUsize!(10),
@@ -7930,9 +7930,9 @@ mod tests {
     }
 
     #[test_traced("WARN")]
-    fn test_standard_cache_writes_borrow_shared_blocks() {
+    fn test_standard_cache_writes_do_not_clone_block_payloads() {
         type CountedBlock = crate::marshal::mocks::block::Block<D, CloneCounter>;
-        const PREFIX: &str = "borrowed-cache";
+        const PREFIX: &str = "shared-cache";
         let runner = deterministic::Runner::timed(Duration::from_secs(30));
         runner.start(|mut context| async move {
             let Fixture { schemes, .. } =
@@ -7952,7 +7952,7 @@ mod tests {
                 Config {
                     provider: ConstantProvider::new(schemes[0].clone()),
                     epocher: FixedEpocher::new(BLOCKS_PER_EPOCH),
-                    start: Start::Genesis(genesis),
+                    start: Start::Genesis(genesis.into()),
                     mailbox_size: NZUsize!(100),
                     view_retention: ViewDelta::new(10),
                     max_repair: NZUsize!(10),
@@ -7994,7 +7994,7 @@ mod tests {
                     assert_eq!(
                         block.context.0.load(Ordering::Relaxed),
                         0,
-                        "cache persistence must borrow the shared block (certified={certified})"
+                        "cache persistence must not clone the block payload (certified={certified})"
                     );
                     assert_eq!(
                         mailbox.get_block(&block.digest()).await.unwrap().digest(),
@@ -8472,7 +8472,8 @@ mod tests {
                 bls12381_threshold_vrf::fixture::<V, _>(&mut context, NAMESPACE, NUM_VALIDATORS);
             let (finalizations_by_height, finalized_blocks) =
                 prunable_finalized_stores(&context, PARTITION_PREFIX).await;
-            let finalized_blocks = Recording::new(finalized_blocks);
+            let finalized_blocks =
+                Recording::new(finalized_blocks, |block: &Arc<B>| Arc::as_ptr(block).addr());
             let ops = finalized_blocks.ops();
             let (actor, mut mailbox, _) = Actor::init(
                 context.child("actor"),
@@ -8534,7 +8535,7 @@ mod tests {
             assert_eq!(
                 ops[written],
                 Op::Put(Height::new(1), Arc::as_ptr(&delivered).addr()),
-                "storage must borrow the block object dispatched to the application"
+                "storage must share the block payload dispatched to the application"
             );
             assert!(
                 !ops[written..].contains(&Op::Get(Some(Height::new(1)))),
@@ -8543,21 +8544,23 @@ mod tests {
         });
     }
 
-    fn staged_dispatch_preserves_first_write(preexisting: bool) {
-        const PARTITION_PREFIX: &str = "staged-first-write";
+    fn staged_dispatch_deduplicates_finalizations(preexisting: bool) {
+        const PARTITION_PREFIX: &str = "staged-dedup";
         let runner = deterministic::Runner::timed(Duration::from_secs(30));
         runner.start(|mut context| async move {
             let Fixture { schemes, .. } =
                 bls12381_threshold_vrf::fixture::<V, _>(&mut context, NAMESPACE, NUM_VALIDATORS);
             let genesis = StandardHarness::genesis_block(NUM_VALIDATORS as u16);
-            let first = make_raw_block(genesis.digest(), Height::new(1), 100);
-            let conflicting = make_raw_block(genesis.digest(), Height::new(1), 200);
-            assert_ne!(first.digest(), conflicting.digest());
+            let block = make_raw_block(genesis.digest(), Height::new(1), 100);
             let (finalizations_by_height, mut finalized_blocks) =
                 prunable_finalized_stores(&context, PARTITION_PREFIX).await;
             if preexisting {
                 finalized_blocks = finalized_blocks
-                    .put_sync(first.height().get(), first.digest(), &first)
+                    .put_sync(
+                        block.height().get(),
+                        block.digest(),
+                        &Arc::new(block.clone()),
+                    )
                     .await
                     .unwrap();
             }
@@ -8584,34 +8587,50 @@ mod tests {
                 reschedule().await;
             }
 
-            // A Byzantine quorum can certify conflicting blocks at the same height
-            // Local durable delivery must still match the archive's first write
-            for (view, block) in [(1, &first), (2, &conflicting)] {
-                if preexisting && view == 1 {
-                    continue;
-                }
-                buffer.insert(block.clone());
-                let finalization = StandardHarness::make_finalization(
-                    Proposal::new(
-                        Round::new(Epoch::zero(), View::new(view)),
-                        View::zero(),
-                        block.digest(),
-                    ),
-                    &schemes,
-                    QUORUM,
-                );
-                StandardHarness::report_finalization(&mut mailbox, finalization).await;
+            // Repeated finalizations retain the first staged object
+            buffer.insert(block.clone());
+            let finalization = StandardHarness::make_finalization(
+                Proposal::new(
+                    Round::new(Epoch::zero(), View::new(1)),
+                    View::zero(),
+                    block.digest(),
+                ),
+                &schemes,
+                QUORUM,
+            );
+            let mut handed = Vec::new();
+            for _ in 0..2 {
+                StandardHarness::report_finalization(&mut mailbox, finalization.clone()).await;
 
                 // A served read proves the preceding finalization arm has run
                 let archived = mailbox.get_block(Height::new(1)).await.unwrap();
-                assert_eq!(archived.digest(), first.digest());
+                assert_eq!(archived.digest(), block.digest());
+                handed.push(
+                    buffer
+                        .last_handed()
+                        .expect("buffer must have served the finalized block"),
+                );
             }
+            assert!(
+                handed[0].upgrade().is_some(),
+                "the first buffered object must remain staged even if already archived"
+            );
+            assert!(
+                handed[1].upgrade().is_none(),
+                "a duplicate finalization must not replace the staged object"
+            );
 
             assert_eq!(application.acknowledged().await, Height::zero());
             while !application.blocks().contains_key(&Height::new(1)) {
                 reschedule().await;
             }
             let delivered = application.blocks()[&Height::new(1)].clone();
+            assert!(
+                handed[0]
+                    .upgrade()
+                    .is_some_and(|block| Arc::ptr_eq(&block, &delivered)),
+                "dispatch must reuse the first staged object"
+            );
             let archived = mailbox.get_block(Height::new(1)).await.unwrap();
             assert_eq!(
                 delivered.digest(),
@@ -8622,13 +8641,13 @@ mod tests {
     }
 
     #[test_traced("WARN")]
-    fn test_standard_staged_dispatch_preserves_first_write() {
-        staged_dispatch_preserves_first_write(false);
+    fn test_standard_staged_dispatch_deduplicates_finalizations() {
+        staged_dispatch_deduplicates_finalizations(false);
     }
 
     #[test_traced("WARN")]
-    fn test_standard_staged_dispatch_preserves_preexisting_write() {
-        staged_dispatch_preserves_first_write(true);
+    fn test_standard_staged_dispatch_deduplicates_preexisting_block() {
+        staged_dispatch_deduplicates_finalizations(true);
     }
 
     /// Staging retains twice the ack capacity until dispatch or a floor skips the blocks.
@@ -8646,7 +8665,8 @@ mod tests {
                 );
                 let (finalizations_by_height, finalized_blocks) =
                     prunable_finalized_stores(&context, PARTITION_PREFIX).await;
-                let finalized_blocks = Recording::new(finalized_blocks);
+                let finalized_blocks =
+                    Recording::new(finalized_blocks, |block: &Arc<B>| Arc::as_ptr(block).addr());
                 let ops = finalized_blocks.ops();
                 let (actor, mut mailbox, _) = Actor::init(
                     context.child("actor"),
@@ -8987,7 +9007,7 @@ mod tests {
                 ConstantProvider::new(schemes[0].clone()),
                 Application::<B>::manual_ack(),
                 Some(RecordingBuffer::default()),
-                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16)),
+                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16).into()),
             )
             .await;
             let buffer = buffer.expect("buffer was provided");
@@ -9030,7 +9050,7 @@ mod tests {
                 ConstantProvider::new(schemes[0].clone()),
                 Application::<B>::manual_ack(),
                 Some(RecordingBuffer::default()),
-                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16)),
+                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16).into()),
             )
             .await;
             let buffer = buffer.expect("buffer was provided");
@@ -9092,7 +9112,7 @@ mod tests {
                 ConstantProvider::new(schemes[0].clone()),
                 Application::<B>::manual_ack(),
                 Some(RecordingBuffer::default()),
-                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16)),
+                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16).into()),
             )
             .await;
             let buffer = buffer.expect("buffer was provided");
@@ -9160,7 +9180,7 @@ mod tests {
                 ConstantProvider::new(schemes[0].clone()),
                 Application::<B>::manual_ack(),
                 Some(RecordingBuffer::default()),
-                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16)),
+                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16).into()),
             )
             .await;
             let buffer = buffer.expect("buffer was provided");
@@ -9235,7 +9255,7 @@ mod tests {
                 ConstantProvider::new(schemes[0].clone()),
                 Application::<B>::manual_ack(),
                 Some(RecordingBuffer::default()),
-                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16)),
+                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16).into()),
             )
             .await;
             let buffer = buffer.expect("buffer was provided");
@@ -9281,7 +9301,7 @@ mod tests {
                 ConstantProvider::new(schemes[0].clone()),
                 Application::<B>::manual_ack(),
                 Some(RecordingBuffer::default()),
-                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16)),
+                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16).into()),
             )
             .await;
             let buffer = buffer.expect("buffer was provided");
@@ -9326,7 +9346,7 @@ mod tests {
                 ConstantProvider::new(schemes[0].clone()),
                 Application::<B>::manual_ack(),
                 Some(RecordingBuffer::default()),
-                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16)),
+                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16).into()),
             )
             .await;
 
@@ -9389,7 +9409,7 @@ mod tests {
                 ConstantProvider::new(schemes[0].clone()),
                 Application::<B>::manual_ack(),
                 Some(RecordingBuffer::default()),
-                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16)),
+                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16).into()),
             )
             .await;
 
@@ -9430,7 +9450,7 @@ mod tests {
                 ConstantProvider::new(schemes[0].clone()),
                 Application::<B>::manual_ack(),
                 Some(RecordingBuffer::default()),
-                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16)),
+                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16).into()),
             )
             .await;
 
@@ -9480,7 +9500,7 @@ mod tests {
                 ConstantProvider::new(schemes[0].clone()),
                 Application::<B>::manual_ack(),
                 Some(RecordingBuffer::default()),
-                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16)),
+                Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16).into()),
             )
             .await;
 

--- a/consensus/src/marshal/standard/mod.rs
+++ b/consensus/src/marshal/standard/mod.rs
@@ -78,10 +78,10 @@ mod tests {
         },
         types::{Epoch, Epocher, FixedEpocher, Height, Round, View, ViewDelta},
     };
-    use bytes::Bytes;
+    use bytes::{Buf, BufMut, Bytes};
     use commonware_actor::{Feedback, mailbox};
     use commonware_broadcast::{Broadcaster as _, buffered};
-    use commonware_codec::{DecodeExt as _, Encode};
+    use commonware_codec::{DecodeExt as _, Encode, FixedSize, Read, Write};
     use commonware_cryptography::{
         Digestible, Hasher as _,
         certificate::{ConstantProvider, Provider, Scoped, Verifier as _, mocks::Fixture},
@@ -1311,7 +1311,7 @@ mod tests {
                     (),
                 )
                 .await;
-                let (_mgr, handle) = mgr.put_notarized(round, digest, block.clone()).await;
+                let (_mgr, handle) = mgr.put_notarized(round, digest, &block).await;
                 handle.await.expect("failed to sync block");
             }
 
@@ -1371,7 +1371,7 @@ mod tests {
                     (),
                 )
                 .await;
-                let (mgr, handle) = mgr.put_notarization(round, digest, notarization).await;
+                let (mgr, handle) = mgr.put_notarization(round, digest, &notarization).await;
                 drop(handle);
                 let (_mgr, sync) = mgr.start_sync_notarizations(round).await;
                 sync.await.expect("failed to sync notarizations");
@@ -7807,13 +7807,13 @@ mod tests {
     }
 
     type Finalizations = prunable::Archive<EightCap, deterministic::Context, D, Finalization<S, D>>;
-    type FinalizedBlocks = prunable::Archive<EightCap, deterministic::Context, D, B>;
+    type FinalizedBlocks<T = B> = prunable::Archive<EightCap, deterministic::Context, D, T>;
 
     /// Initialize prunable finalized stores for direct actor tests.
-    async fn prunable_finalized_stores(
+    async fn prunable_finalized_stores<T: crate::Block<Digest = D> + Read<Cfg = ()>>(
         context: &deterministic::Context,
         partition_prefix: &str,
-    ) -> (Finalizations, FinalizedBlocks) {
+    ) -> (Finalizations, FinalizedBlocks<T>) {
         let page_cache = CacheRef::from_pooler(context, PAGE_SIZE, PAGE_CACHE_SIZE);
         let finalizations_by_height = prunable::Archive::init(
             context.child("finalizations_by_height"),
@@ -7900,6 +7900,109 @@ mod tests {
             page_cache: CacheRef::from_pooler(context, PAGE_SIZE, PAGE_CACHE_SIZE),
             strategy: Sequential,
         }
+    }
+
+    /// Counts full block clones through a zero-byte mock context.
+    #[derive(Debug, Default)]
+    struct CloneCounter(Arc<AtomicUsize>);
+
+    impl Clone for CloneCounter {
+        fn clone(&self) -> Self {
+            self.0.fetch_add(1, Ordering::Relaxed);
+            Self(Arc::clone(&self.0))
+        }
+    }
+
+    impl FixedSize for CloneCounter {
+        const SIZE: usize = 0;
+    }
+
+    impl Write for CloneCounter {
+        fn write(&self, _: &mut impl BufMut) {}
+    }
+
+    impl Read for CloneCounter {
+        type Cfg = ();
+
+        fn read_cfg(_: &mut impl Buf, _: &()) -> Result<Self, commonware_codec::Error> {
+            Ok(Self::default())
+        }
+    }
+
+    #[test_traced("WARN")]
+    fn test_standard_cache_writes_borrow_shared_blocks() {
+        type CountedBlock = crate::marshal::mocks::block::Block<D, CloneCounter>;
+        const PREFIX: &str = "borrowed-cache";
+        let runner = deterministic::Runner::timed(Duration::from_secs(30));
+        runner.start(|mut context| async move {
+            let Fixture { schemes, .. } =
+                bls12381_threshold_vrf::fixture::<V, _>(&mut context, NAMESPACE, NUM_VALIDATORS);
+            let genesis = CountedBlock::new::<Sha256>(
+                CloneCounter::default(),
+                Sha256::hash(&[b""]),
+                Height::zero(),
+                0,
+            );
+            let parent = genesis.digest();
+            let (finalizations, blocks) = prunable_finalized_stores(&context, PREFIX).await;
+            let (actor, mailbox, _) = Actor::<_, Standard<CountedBlock>, _, _, _, _, _>::init(
+                context.child("actor"),
+                finalizations,
+                blocks,
+                Config {
+                    provider: ConstantProvider::new(schemes[0].clone()),
+                    epocher: FixedEpocher::new(BLOCKS_PER_EPOCH),
+                    start: Start::Genesis(genesis),
+                    mailbox_size: NZUsize!(100),
+                    view_retention: ViewDelta::new(10),
+                    max_repair: NZUsize!(10),
+                    max_pending_acks: NZUsize!(1),
+                    block_codec_config: (),
+                    partition_prefix: PREFIX.to_string(),
+                    prunable_items_per_section: NZU64!(10),
+                    replay_buffer: NZUsize!(1024),
+                    key_write_buffer: NZUsize!(1024),
+                    value_write_buffer: NZUsize!(1024),
+                    page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
+                    strategy: Sequential,
+                },
+            )
+            .await;
+            let (resolver_rx, resolver) = RecordingResolver::holding(context.child("resolver"));
+            let _actor_handle = actor.start_unbuffered(
+                Application::<CountedBlock>::default(),
+                (resolver_rx, resolver),
+            );
+
+            for (view, certified) in [(1, false), (2, true)] {
+                let round = Round::new(Epoch::zero(), View::new(view));
+                let block = Arc::new(CountedBlock::new::<Sha256>(
+                    CloneCounter::default(),
+                    parent,
+                    Height::new(1),
+                    view,
+                ));
+
+                // Keep an external owner through both insertion and duplicate delivery
+                for _ in 0..2 {
+                    let durable = if certified {
+                        mailbox.certified(round, Arc::clone(&block)).await
+                    } else {
+                        mailbox.verified(round, Arc::clone(&block)).await
+                    };
+                    assert!(durable);
+                    assert_eq!(
+                        block.context.0.load(Ordering::Relaxed),
+                        0,
+                        "cache persistence must borrow the shared block (certified={certified})"
+                    );
+                    assert_eq!(
+                        mailbox.get_block(&block.digest()).await.unwrap().digest(),
+                        block.digest()
+                    );
+                }
+            }
+        });
     }
 
     /// A slow finalized-archive sync must not block the marshal mailbox.

--- a/consensus/src/marshal/standard/mod.rs
+++ b/consensus/src/marshal/standard/mod.rs
@@ -7880,8 +7880,8 @@ mod tests {
         )
     }
 
-    /// Actor configuration for direct actor tests over [`prunable_finalized_stores`].
-    fn direct_config(
+    /// Builds a marshal actor configuration for tests.
+    fn test_config(
         context: &deterministic::Context,
         partition_prefix: &str,
         provider: harness::P,
@@ -7926,7 +7926,7 @@ mod tests {
         runner.start(|mut context| async move {
             let Fixture { schemes, .. } =
                 bls12381_threshold_vrf::fixture::<V, _>(&mut context, NAMESPACE, NUM_VALIDATORS);
-            let config = direct_config(
+            let config = test_config(
                 &context,
                 "paced-finalized-sync",
                 ConstantProvider::new(schemes[0].clone()),
@@ -8050,7 +8050,7 @@ mod tests {
         runner.start(|mut context| async move {
             let Fixture { schemes, .. } =
                 bls12381_threshold_vrf::fixture::<V, _>(&mut context, NAMESPACE, NUM_VALIDATORS);
-            let config = direct_config(
+            let config = test_config(
                 &context,
                 "stale-floor-anchor",
                 ConstantProvider::new(schemes[0].clone()),
@@ -8251,7 +8251,7 @@ mod tests {
         runner.start(|mut context| async move {
             let Fixture { schemes, .. } =
                 bls12381_threshold_vrf::fixture::<V, _>(&mut context, NAMESPACE, NUM_VALIDATORS);
-            let config = direct_config(
+            let config = test_config(
                 &context,
                 "overlapping-finalized-syncs",
                 ConstantProvider::new(schemes[0].clone()),
@@ -8379,7 +8379,7 @@ mod tests {
                 context.child("actor"),
                 finalizations_by_height,
                 finalized_blocks,
-                direct_config(
+                test_config(
                     &context,
                     PARTITION_PREFIX,
                     ConstantProvider::new(schemes[0].clone()),
@@ -8439,123 +8439,127 @@ mod tests {
         });
     }
 
-    /// Staging stops at the pending-ack capacity and releases blocks skipped by a floor anchor.
+    /// Staging retains twice the ack capacity until dispatch or a floor skips the blocks.
     #[test_traced("WARN")]
     fn test_standard_staged_blocks_bounded() {
         const PARTITION_PREFIX: &str = "staged-bounded";
         const ANCHOR_HEIGHT: u64 = 5;
-        let runner = deterministic::Runner::timed(Duration::from_secs(30));
-        runner.start(|mut context| async move {
-            let Fixture { schemes, .. } =
-                bls12381_threshold_vrf::fixture::<V, _>(&mut context, NAMESPACE, NUM_VALIDATORS);
-            let (finalizations_by_height, finalized_blocks) =
-                prunable_finalized_stores(&context, PARTITION_PREFIX).await;
-            let (actor, mut mailbox, _) = Actor::init(
-                context.child("actor"),
-                finalizations_by_height,
-                finalized_blocks,
-                direct_config(
-                    &context,
-                    PARTITION_PREFIX,
-                    ConstantProvider::new(schemes[0].clone()),
-                    NZUsize!(1),
-                ),
-            )
-            .await;
-            let (resolver_rx, resolver) = RecordingResolver::holding(context.child("resolver"));
-            let application = Application::<B>::manual_ack();
-            let buffer = RecordingBuffer::default();
-            let _actor_handle =
-                actor.start(application.clone(), buffer.clone(), (resolver_rx, resolver));
+        for skip_to_floor in [false, true] {
+            let runner = deterministic::Runner::timed(Duration::from_secs(30));
+            runner.start(|mut context| async move {
+                let Fixture { schemes, .. } = bls12381_threshold_vrf::fixture::<V, _>(
+                    &mut context,
+                    NAMESPACE,
+                    NUM_VALIDATORS,
+                );
+                let (finalizations_by_height, finalized_blocks) =
+                    prunable_finalized_stores(&context, PARTITION_PREFIX).await;
+                let finalized_blocks = Recording::new(finalized_blocks);
+                let ops = finalized_blocks.ops();
+                let (actor, mut mailbox, _) = Actor::init(
+                    context.child("actor"),
+                    finalizations_by_height,
+                    finalized_blocks,
+                    test_config(
+                        &context,
+                        PARTITION_PREFIX,
+                        ConstantProvider::new(schemes[0].clone()),
+                        NZUsize!(1),
+                    ),
+                )
+                .await;
+                let (resolver_rx, resolver) = RecordingResolver::holding(context.child("resolver"));
+                let application = Application::<B>::manual_ack();
+                let buffer = RecordingBuffer::default();
+                let _actor_handle =
+                    actor.start(application.clone(), buffer.clone(), (resolver_rx, resolver));
 
-            // Hold the genesis acknowledgement so nothing else can dispatch.
-            while application.pending_ack_heights() != vec![Height::zero()] {
-                reschedule().await;
-            }
+                // Hold the genesis acknowledgement so nothing else can dispatch
+                while application.pending_ack_heights() != vec![Height::zero()] {
+                    reschedule().await;
+                }
 
-            // Build a chain whose tip is the floor anchor.
-            let mut parent = StandardHarness::genesis_block(NUM_VALIDATORS as u16).digest();
-            let mut chain = Vec::new();
-            for i in 1..=ANCHOR_HEIGHT {
-                let block = make_raw_block(parent, Height::new(i), i);
-                parent = block.digest();
-                chain.push(block);
-            }
-            let first = &chain[0];
-            let second = &chain[1];
-            let anchor = &chain[chain.len() - 1];
+                // Build a chain whose tip is the floor anchor
+                let mut parent = StandardHarness::genesis_block(NUM_VALIDATORS as u16).digest();
+                let mut chain = Vec::new();
+                for i in 1..=ANCHOR_HEIGHT {
+                    let block = make_raw_block(parent, Height::new(i), i);
+                    parent = block.digest();
+                    chain.push(block);
+                }
 
-            // Finalize block 1: it is stored and staged but cannot dispatch.
-            let round = Round::new(Epoch::zero(), View::new(1));
-            buffer.insert(first.clone());
-            let finalization = StandardHarness::make_finalization(
-                Proposal::new(round, View::zero(), first.digest()),
-                &schemes,
-                QUORUM,
-            );
-            StandardHarness::report_finalization(&mut mailbox, finalization).await;
+                // Two blocks fit in staging; a third must not displace either
+                let mut handed = Vec::new();
+                for block in &chain[..3] {
+                    let height = block.height();
+                    let round = Round::new(Epoch::zero(), View::new(height.get()));
+                    buffer.insert(block.clone());
+                    let finalization = StandardHarness::make_finalization(
+                        Proposal::new(round, View::new(height.get() - 1), block.digest()),
+                        &schemes,
+                        QUORUM,
+                    );
+                    StandardHarness::report_finalization(&mut mailbox, finalization).await;
 
-            // Mailbox messages are FIFO, so a served read proves the
-            // finalization arm has run.
-            assert!(
-                mailbox.get_block(Height::new(1)).await.is_some(),
-                "finalized block must be stored"
-            );
-            let staged = buffer
-                .last_handed()
-                .expect("buffer must have served the finalized block");
-            assert!(
-                staged.upgrade().is_some(),
-                "marshal must hold the staged block while dispatch waits"
-            );
-            assert!(!application.blocks().contains_key(&Height::new(1)));
+                    // A served read proves the preceding finalization arm has run
+                    assert!(mailbox.get_block(height).await.is_some());
+                    handed.push(
+                        buffer
+                            .last_handed()
+                            .expect("buffer must have served the finalized block"),
+                    );
+                }
+                assert!(
+                    handed[..2].iter().all(|block| block.upgrade().is_some()),
+                    "staging must retain two blocks without evicting either on overflow"
+                );
+                assert!(
+                    handed[2].upgrade().is_none(),
+                    "staging must stop at twice the pending-ack capacity"
+                );
+                assert_eq!(application.pending_ack_heights(), vec![Height::zero()]);
 
-            // Finalize block 2: staging is at capacity, so the block is
-            // written but not held in memory.
-            let round = Round::new(Epoch::zero(), View::new(2));
-            buffer.insert(second.clone());
-            let finalization = StandardHarness::make_finalization(
-                Proposal::new(round, View::new(1), second.digest()),
-                &schemes,
-                QUORUM,
-            );
-            StandardHarness::report_finalization(&mut mailbox, finalization).await;
-            assert!(
-                mailbox.get_block(Height::new(2)).await.is_some(),
-                "finalized block must be stored"
-            );
-            let unstaged = buffer
-                .last_handed()
-                .expect("buffer must have served the finalized block");
-            assert!(
-                unstaged.upgrade().is_none(),
-                "staging must stop at the pending-ack capacity"
-            );
-
-            // Install a floor anchor above both blocks.
-            let anchor_round = Round::new(Epoch::zero(), View::new(ANCHOR_HEIGHT));
-            buffer.insert(anchor.clone());
-            let finalization = StandardHarness::make_finalization(
-                Proposal::new(anchor_round, View::new(ANCHOR_HEIGHT - 1), anchor.digest()),
-                &schemes,
-                QUORUM,
-            );
-            mailbox.set_floor(finalization);
-            while !application
-                .blocks()
-                .contains_key(&Height::new(ANCHOR_HEIGHT))
-            {
-                reschedule().await;
-            }
-
-            // The floor skipped block 1, so its staged block is released.
-            assert!(
-                staged.upgrade().is_none(),
-                "floor transition must evict staged blocks at or below the processed floor"
-            );
-            assert!(!application.blocks().contains_key(&Height::new(1)));
-            assert!(!application.blocks().contains_key(&Height::new(2)));
-        });
+                if skip_to_floor {
+                    // A floor anchor releases the blocks it skips
+                    let anchor = chain.last().unwrap();
+                    let anchor_round = Round::new(Epoch::zero(), View::new(ANCHOR_HEIGHT));
+                    buffer.insert(anchor.clone());
+                    let finalization = StandardHarness::make_finalization(
+                        Proposal::new(anchor_round, View::new(ANCHOR_HEIGHT - 1), anchor.digest()),
+                        &schemes,
+                        QUORUM,
+                    );
+                    mailbox.set_floor(finalization);
+                    while !application
+                        .blocks()
+                        .contains_key(&Height::new(ANCHOR_HEIGHT))
+                    {
+                        reschedule().await;
+                    }
+                    assert!(
+                        handed.iter().all(|block| block.upgrade().is_none()),
+                        "floor transition must release skipped staged blocks"
+                    );
+                    for block in &chain[..3] {
+                        assert!(!application.blocks().contains_key(&block.height()));
+                    }
+                } else {
+                    // Drain the backlog: only the overflow block needs an archive read
+                    ops.lock().clear();
+                    for height in 0..=3 {
+                        assert_eq!(application.acknowledged().await, Height::new(height));
+                    }
+                    let ops = ops.lock();
+                    for height in 1..=3 {
+                        let reads = ops
+                            .iter()
+                            .filter(|op| **op == Op::Get(Some(Height::new(height))))
+                            .count();
+                        assert_eq!(reads, usize::from(height == 3), "archive reads at {height}");
+                    }
+                }
+            });
+        }
     }
 
     /// Repeated finalization of an in-flight block must not consume staging capacity.
@@ -8572,7 +8576,7 @@ mod tests {
                 context.child("actor"),
                 finalizations_by_height,
                 finalized_blocks,
-                direct_config(
+                test_config(
                     &context,
                     PARTITION_PREFIX,
                     ConstantProvider::new(schemes[0].clone()),

--- a/consensus/src/marshal/standard/mod.rs
+++ b/consensus/src/marshal/standard/mod.rs
@@ -8462,7 +8462,7 @@ mod tests {
         });
     }
 
-    /// Dispatch preserves the buffered block object and performs no archive read after its write.
+    /// Dispatch preserves the buffered block object without rereading it from the archive.
     #[test_traced("WARN")]
     fn test_standard_dispatch_delivers_staged_block_without_archive_read() {
         const PARTITION_PREFIX: &str = "staged-dispatch";
@@ -8650,7 +8650,7 @@ mod tests {
         staged_dispatch_deduplicates_finalizations(true);
     }
 
-    /// Staging retains twice the ack capacity until dispatch or a floor skips the blocks.
+    /// Staging retains at most twice the ack capacity until dispatch or a floor skips the blocks.
     #[test_traced("WARN")]
     fn test_standard_staged_blocks_bounded() {
         const PARTITION_PREFIX: &str = "staged-bounded";

--- a/consensus/src/marshal/standard/mod.rs
+++ b/consensus/src/marshal/standard/mod.rs
@@ -61,6 +61,7 @@ mod tests {
                     ValidatorHandle, default_leader, make_raw_block, setup_network_links,
                     setup_network_with_participants,
                 },
+                store::{Op, Recording},
                 verifying::MockVerifyingApp,
             },
             resolver::handler,
@@ -93,7 +94,7 @@ mod tests {
     use commonware_resolver::{Consumer, Delivery, Fetch, Resolver, TargetedResolver};
     use commonware_runtime::{
         Clock, Metrics, Quota, Runner, Spawner, Supervisor as _, buffer::paged::CacheRef,
-        deterministic,
+        deterministic, utils::reschedule,
     };
     use commonware_storage::{
         archive::{Archive as _, immutable, prunable},
@@ -115,7 +116,7 @@ mod tests {
         collections::BTreeMap,
         num::{NonZeroU32, NonZeroU64, NonZeroUsize},
         sync::{
-            Arc,
+            Arc, Weak,
             atomic::{AtomicUsize, Ordering},
         },
         time::Duration,
@@ -3902,6 +3903,7 @@ mod tests {
     #[derive(Clone, Default)]
     struct RecordingBuffer {
         blocks: Arc<Mutex<Vec<B>>>,
+        handed: Arc<Mutex<Vec<Weak<B>>>>,
         evict_on_next_hit: Arc<Mutex<bool>>,
         digest_subscriptions: Arc<Mutex<Vec<oneshot::Sender<Arc<B>>>>>,
         commitment_subscriptions: Arc<Mutex<Vec<oneshot::Sender<Arc<B>>>>>,
@@ -3933,7 +3935,14 @@ mod tests {
             } else {
                 blocks[index].clone()
             };
-            Some(Arc::new(block))
+            let block = Arc::new(block);
+            self.handed.lock().push(Arc::downgrade(&block));
+            Some(block)
+        }
+
+        /// Weak references to every block `find` handed to marshal, in order.
+        fn handed(&self) -> Vec<Weak<B>> {
+            self.handed.lock().clone()
         }
 
         fn sends(&self) -> Vec<BufferSend> {
@@ -7800,16 +7809,14 @@ mod tests {
         }
     }
 
-    /// Initialize paced prunable finalized stores for direct actor tests.
-    #[allow(clippy::type_complexity)]
-    async fn paced_finalized_stores(
+    type Finalizations = prunable::Archive<EightCap, deterministic::Context, D, Finalization<S, D>>;
+    type FinalizedBlocks = prunable::Archive<EightCap, deterministic::Context, D, B>;
+
+    /// Initialize prunable finalized stores for direct actor tests.
+    async fn prunable_finalized_stores(
         context: &deterministic::Context,
         partition_prefix: &str,
-        pace: Duration,
-    ) -> (
-        PacedStore<prunable::Archive<EightCap, deterministic::Context, D, Finalization<S, D>>>,
-        PacedStore<prunable::Archive<EightCap, deterministic::Context, D, B>>,
-    ) {
+    ) -> (Finalizations, FinalizedBlocks) {
         let page_cache = CacheRef::from_pooler(context, PAGE_SIZE, PAGE_CACHE_SIZE);
         let finalizations_by_height = prunable::Archive::init(
             context.child("finalizations_by_height"),
@@ -7847,6 +7854,17 @@ mod tests {
         )
         .await
         .expect("failed to initialize finalized blocks archive");
+        (finalizations_by_height, finalized_blocks)
+    }
+
+    /// Initialize paced prunable finalized stores for direct actor tests.
+    async fn paced_finalized_stores(
+        context: &deterministic::Context,
+        partition_prefix: &str,
+        pace: Duration,
+    ) -> (PacedStore<Finalizations>, PacedStore<FinalizedBlocks>) {
+        let (finalizations_by_height, finalized_blocks) =
+            prunable_finalized_stores(context, partition_prefix).await;
         (
             PacedStore {
                 inner: finalizations_by_height,
@@ -7859,6 +7877,32 @@ mod tests {
                 pace,
             },
         )
+    }
+
+    /// Actor configuration for direct actor tests over [`prunable_finalized_stores`].
+    fn direct_config(
+        context: &deterministic::Context,
+        partition_prefix: &str,
+        provider: harness::P,
+        max_pending_acks: NonZeroUsize,
+    ) -> Config<harness::P, FixedEpocher, Sequential, B, B, D> {
+        Config {
+            provider,
+            epocher: FixedEpocher::new(BLOCKS_PER_EPOCH),
+            start: Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16)),
+            mailbox_size: NZUsize!(100),
+            view_retention: ViewDelta::new(10),
+            max_repair: NZUsize!(10),
+            max_pending_acks,
+            block_codec_config: (),
+            partition_prefix: partition_prefix.to_string(),
+            prunable_items_per_section: NZU64!(10),
+            replay_buffer: NZUsize!(1024),
+            key_write_buffer: NZUsize!(1024),
+            value_write_buffer: NZUsize!(1024),
+            page_cache: CacheRef::from_pooler(context, PAGE_SIZE, PAGE_CACHE_SIZE),
+            strategy: Sequential,
+        }
     }
 
     /// A slow finalized-archive sync must not block the marshal mailbox.
@@ -7881,23 +7925,12 @@ mod tests {
         runner.start(|mut context| async move {
             let Fixture { schemes, .. } =
                 bls12381_threshold_vrf::fixture::<V, _>(&mut context, NAMESPACE, NUM_VALIDATORS);
-            let config = Config {
-                provider: ConstantProvider::new(schemes[0].clone()),
-                epocher: FixedEpocher::new(BLOCKS_PER_EPOCH),
-                start: Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16)),
-                mailbox_size: NZUsize!(100),
-                view_retention: ViewDelta::new(10),
-                max_repair: NZUsize!(10),
-                max_pending_acks: NZUsize!(1),
-                block_codec_config: (),
-                partition_prefix: "paced-finalized-sync".to_string(),
-                prunable_items_per_section: NZU64!(10),
-                replay_buffer: NZUsize!(1024),
-                key_write_buffer: NZUsize!(1024),
-                value_write_buffer: NZUsize!(1024),
-                page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
-                strategy: Sequential,
-            };
+            let config = direct_config(
+                &context,
+                "paced-finalized-sync",
+                ConstantProvider::new(schemes[0].clone()),
+                NZUsize!(1),
+            );
             let (finalizations_by_height, finalized_blocks) =
                 paced_finalized_stores(&context, "paced-finalized-sync", PACE).await;
             let (actor, mut mailbox, _) = Actor::init(
@@ -8016,23 +8049,12 @@ mod tests {
         runner.start(|mut context| async move {
             let Fixture { schemes, .. } =
                 bls12381_threshold_vrf::fixture::<V, _>(&mut context, NAMESPACE, NUM_VALIDATORS);
-            let config = Config {
-                provider: ConstantProvider::new(schemes[0].clone()),
-                epocher: FixedEpocher::new(BLOCKS_PER_EPOCH),
-                start: Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16)),
-                mailbox_size: NZUsize!(100),
-                view_retention: ViewDelta::new(10),
-                max_repair: NZUsize!(10),
-                max_pending_acks: NZUsize!(4),
-                block_codec_config: (),
-                partition_prefix: "stale-floor-anchor".to_string(),
-                prunable_items_per_section: NZU64!(10),
-                replay_buffer: NZUsize!(1024),
-                key_write_buffer: NZUsize!(1024),
-                value_write_buffer: NZUsize!(1024),
-                page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
-                strategy: Sequential,
-            };
+            let config = direct_config(
+                &context,
+                "stale-floor-anchor",
+                ConstantProvider::new(schemes[0].clone()),
+                NZUsize!(4),
+            );
             let (finalizations_by_height, finalized_blocks) =
                 paced_finalized_stores(&context, "stale-floor-anchor", PACE).await;
             let (actor, mut mailbox, _) = Actor::init(
@@ -8228,23 +8250,12 @@ mod tests {
         runner.start(|mut context| async move {
             let Fixture { schemes, .. } =
                 bls12381_threshold_vrf::fixture::<V, _>(&mut context, NAMESPACE, NUM_VALIDATORS);
-            let config = Config {
-                provider: ConstantProvider::new(schemes[0].clone()),
-                epocher: FixedEpocher::new(BLOCKS_PER_EPOCH),
-                start: Start::Genesis(StandardHarness::genesis_block(NUM_VALIDATORS as u16)),
-                mailbox_size: NZUsize!(100),
-                view_retention: ViewDelta::new(10),
-                max_repair: NZUsize!(10),
-                max_pending_acks: NZUsize!(4),
-                block_codec_config: (),
-                partition_prefix: "overlapping-finalized-syncs".to_string(),
-                prunable_items_per_section: NZU64!(10),
-                replay_buffer: NZUsize!(1024),
-                key_write_buffer: NZUsize!(1024),
-                value_write_buffer: NZUsize!(1024),
-                page_cache: CacheRef::from_pooler(&context, PAGE_SIZE, PAGE_CACHE_SIZE),
-                strategy: Sequential,
-            };
+            let config = direct_config(
+                &context,
+                "overlapping-finalized-syncs",
+                ConstantProvider::new(schemes[0].clone()),
+                NZUsize!(4),
+            );
             let (finalizations_by_height, finalized_blocks) =
                 paced_finalized_stores(&context, "overlapping-finalized-syncs", PACE).await;
             let (actor, mut mailbox, _) = Actor::init(
@@ -8262,7 +8273,7 @@ mod tests {
                 &context,
                 Duration::from_secs(5),
                 "genesis processed",
-                || parse_processed_height(&context.encode()) == Some(0),
+                || application.blocks().contains_key(&Height::zero()),
             )
             .await;
 
@@ -8347,6 +8358,358 @@ mod tests {
             assert!(
                 second_dispatched >= STAGGER + PACE,
                 "block dispatched before its sync completed: {second_dispatched:?}"
+            );
+        });
+    }
+
+    /// Dispatch preserves the buffered block object and performs no archive read after its write.
+    #[test_traced("WARN")]
+    fn test_standard_dispatch_delivers_staged_block_without_archive_read() {
+        const PARTITION_PREFIX: &str = "staged-dispatch";
+        let runner = deterministic::Runner::timed(Duration::from_secs(30));
+        runner.start(|mut context| async move {
+            let Fixture { schemes, .. } =
+                bls12381_threshold_vrf::fixture::<V, _>(&mut context, NAMESPACE, NUM_VALIDATORS);
+            let (finalizations_by_height, finalized_blocks) =
+                prunable_finalized_stores(&context, PARTITION_PREFIX).await;
+            let finalized_blocks = Recording::new(finalized_blocks);
+            let ops = finalized_blocks.ops();
+            let (actor, mut mailbox, _) = Actor::init(
+                context.child("actor"),
+                finalizations_by_height,
+                finalized_blocks,
+                direct_config(
+                    &context,
+                    PARTITION_PREFIX,
+                    ConstantProvider::new(schemes[0].clone()),
+                    NZUsize!(1),
+                ),
+            )
+            .await;
+            let (resolver_rx, resolver) = RecordingResolver::holding(context.child("resolver"));
+            let application = Application::<B>::default();
+            let buffer = RecordingBuffer::default();
+            let _actor_handle =
+                actor.start(application.clone(), buffer.clone(), (resolver_rx, resolver));
+
+            // Genesis is dispatched from the archive and acknowledged on
+            // delivery, so the pipeline is idle before the finalization arrives.
+            while !application.blocks().contains_key(&Height::zero()) {
+                reschedule().await;
+            }
+
+            // Finalize a block the buffer serves.
+            let genesis = StandardHarness::genesis_block(NUM_VALIDATORS as u16);
+            let round = Round::new(Epoch::zero(), View::new(1));
+            let block = make_raw_block(genesis.digest(), Height::new(1), 100);
+            buffer.insert(block.clone());
+            let finalization = StandardHarness::make_finalization(
+                Proposal::new(round, View::zero(), StandardHarness::commitment(&block)),
+                &schemes,
+                QUORUM,
+            );
+            StandardHarness::report_finalization(&mut mailbox, finalization).await;
+            while !application.blocks().contains_key(&Height::new(1)) {
+                reschedule().await;
+            }
+
+            let delivered = application
+                .blocks()
+                .get(&Height::new(1))
+                .cloned()
+                .expect("finalized block dispatched");
+            assert_eq!(delivered.digest(), block.digest());
+            assert!(
+                buffer.handed().iter().any(|handed| {
+                    handed
+                        .upgrade()
+                        .is_some_and(|handed| Arc::ptr_eq(&handed, &delivered))
+                }),
+                "dispatch must deliver the block object the buffer handed to marshal"
+            );
+            let ops = ops.lock().clone();
+            let written = ops
+                .iter()
+                .position(|op| *op == Op::Put(Height::new(1)))
+                .expect("finalized block written");
+            assert!(
+                !ops[written..].contains(&Op::Get(Some(Height::new(1)))),
+                "dispatch must not read the finalized block back from the archive: {ops:?}"
+            );
+        });
+    }
+
+    /// A restart redelivers an unacknowledged finalized block from the archive.
+    #[test_traced("WARN")]
+    fn test_standard_restart_dispatches_from_archive() {
+        const PARTITION_PREFIX: &str = "restart-dispatch";
+        let runner = deterministic::Runner::timed(Duration::from_secs(30));
+        runner.start(|mut context| async move {
+            let Fixture { schemes, .. } =
+                bls12381_threshold_vrf::fixture::<V, _>(&mut context, NAMESPACE, NUM_VALIDATORS);
+            let genesis = StandardHarness::genesis_block(NUM_VALIDATORS as u16);
+            let round = Round::new(Epoch::zero(), View::new(1));
+            let block = make_raw_block(genesis.digest(), Height::new(1), 100);
+
+            let (finalizations_by_height, finalized_blocks) =
+                prunable_finalized_stores(&context, PARTITION_PREFIX).await;
+            let (actor, mut mailbox, _) = Actor::init(
+                context.child("actor"),
+                finalizations_by_height,
+                finalized_blocks,
+                direct_config(
+                    &context,
+                    PARTITION_PREFIX,
+                    ConstantProvider::new(schemes[0].clone()),
+                    NZUsize!(1),
+                ),
+            )
+            .await;
+            let (resolver_rx, resolver) = RecordingResolver::holding(context.child("resolver"));
+            let application = Application::<B>::manual_ack();
+            let actor_handle = actor.start_unbuffered(application.clone(), (resolver_rx, resolver));
+            assert_eq!(application.acknowledged().await, Height::zero());
+
+            // Finalize block 1 and leave its acknowledgement pending.
+            assert!(mailbox.verified(round, block.clone()).await);
+            let finalization = StandardHarness::make_finalization(
+                Proposal::new(round, View::zero(), StandardHarness::commitment(&block)),
+                &schemes,
+                QUORUM,
+            );
+            StandardHarness::report_finalization(&mut mailbox, finalization).await;
+            while application.pending_ack_heights() != vec![Height::new(1)] {
+                reschedule().await;
+            }
+
+            actor_handle.abort();
+            drop(mailbox);
+
+            // Wait for the actor to release its storage handles before reopening
+            assert!(actor_handle.await.is_err());
+
+            let restart = context.child("restart");
+            let (finalizations_by_height, finalized_blocks) =
+                prunable_finalized_stores(&restart, PARTITION_PREFIX).await;
+            let finalized_blocks = Recording::new(finalized_blocks);
+            let ops = finalized_blocks.ops();
+            let (actor, _mailbox, _): (_, Mailbox<S, Standard<B>>, _) = Actor::init(
+                restart.child("actor"),
+                finalizations_by_height,
+                finalized_blocks,
+                direct_config(
+                    &restart,
+                    PARTITION_PREFIX,
+                    ConstantProvider::new(schemes[0].clone()),
+                    NZUsize!(1),
+                ),
+            )
+            .await;
+            let (resolver_rx, resolver) = RecordingResolver::holding(restart.child("resolver"));
+            let application = Application::<B>::manual_ack();
+            let before = ops.lock().len();
+            let _actor_handle =
+                actor.start_unbuffered(application.clone(), (resolver_rx, resolver));
+            while application.pending_ack_heights() != vec![Height::new(1)] {
+                reschedule().await;
+            }
+
+            let delivered = application
+                .blocks()
+                .get(&Height::new(1))
+                .cloned()
+                .expect("finalized block redelivered");
+            assert_eq!(delivered.digest(), block.digest());
+            assert_eq!(
+                ops.lock()[before..].to_vec(),
+                vec![Op::Get(Some(Height::new(1)))],
+                "restart dispatch must read the finalized block from the archive"
+            );
+        });
+    }
+
+    /// Staging stops at the pending-ack capacity and releases blocks skipped by a floor anchor.
+    #[test_traced("WARN")]
+    fn test_standard_staged_blocks_bounded() {
+        const PARTITION_PREFIX: &str = "staged-bounded";
+        const ANCHOR_HEIGHT: u64 = 5;
+        let runner = deterministic::Runner::timed(Duration::from_secs(30));
+        runner.start(|mut context| async move {
+            let Fixture { schemes, .. } =
+                bls12381_threshold_vrf::fixture::<V, _>(&mut context, NAMESPACE, NUM_VALIDATORS);
+            let (finalizations_by_height, finalized_blocks) =
+                prunable_finalized_stores(&context, PARTITION_PREFIX).await;
+            let (actor, mut mailbox, _) = Actor::init(
+                context.child("actor"),
+                finalizations_by_height,
+                finalized_blocks,
+                direct_config(
+                    &context,
+                    PARTITION_PREFIX,
+                    ConstantProvider::new(schemes[0].clone()),
+                    NZUsize!(1),
+                ),
+            )
+            .await;
+            let (resolver_rx, resolver) = RecordingResolver::holding(context.child("resolver"));
+            let application = Application::<B>::manual_ack();
+            let buffer = RecordingBuffer::default();
+            let _actor_handle =
+                actor.start(application.clone(), buffer.clone(), (resolver_rx, resolver));
+
+            // Hold the genesis acknowledgement so nothing else can dispatch.
+            while application.pending_ack_heights() != vec![Height::zero()] {
+                reschedule().await;
+            }
+
+            // Build a chain whose tip is the floor anchor.
+            let mut parent = StandardHarness::genesis_block(NUM_VALIDATORS as u16).digest();
+            let mut chain = Vec::new();
+            for i in 1..=ANCHOR_HEIGHT {
+                let block = make_raw_block(parent, Height::new(i), i);
+                parent = block.digest();
+                chain.push(block);
+            }
+            let first = &chain[0];
+            let second = &chain[1];
+            let anchor = &chain[chain.len() - 1];
+
+            // Finalize block 1: it is stored and staged but cannot dispatch.
+            let round = Round::new(Epoch::zero(), View::new(1));
+            buffer.insert(first.clone());
+            let finalization = StandardHarness::make_finalization(
+                Proposal::new(round, View::zero(), first.digest()),
+                &schemes,
+                QUORUM,
+            );
+            StandardHarness::report_finalization(&mut mailbox, finalization).await;
+
+            // Mailbox messages are FIFO, so a served read proves the
+            // finalization arm has run.
+            assert!(
+                mailbox.get_block(Height::new(1)).await.is_some(),
+                "finalized block must be stored"
+            );
+            let staged = buffer
+                .handed()
+                .pop()
+                .expect("buffer must have served the finalized block");
+            assert!(
+                staged.upgrade().is_some(),
+                "marshal must hold the staged block while dispatch waits"
+            );
+            assert!(!application.blocks().contains_key(&Height::new(1)));
+
+            // Finalize block 2: staging is at capacity, so the block is
+            // written but not held in memory.
+            let round = Round::new(Epoch::zero(), View::new(2));
+            buffer.insert(second.clone());
+            let finalization = StandardHarness::make_finalization(
+                Proposal::new(round, View::new(1), second.digest()),
+                &schemes,
+                QUORUM,
+            );
+            StandardHarness::report_finalization(&mut mailbox, finalization).await;
+            assert!(
+                mailbox.get_block(Height::new(2)).await.is_some(),
+                "finalized block must be stored"
+            );
+            let unstaged = buffer
+                .handed()
+                .pop()
+                .expect("buffer must have served the finalized block");
+            assert!(
+                unstaged.upgrade().is_none(),
+                "staging must stop at the pending-ack capacity"
+            );
+
+            // Install a floor anchor above both blocks.
+            let anchor_round = Round::new(Epoch::zero(), View::new(ANCHOR_HEIGHT));
+            buffer.insert(anchor.clone());
+            let finalization = StandardHarness::make_finalization(
+                Proposal::new(anchor_round, View::new(ANCHOR_HEIGHT - 1), anchor.digest()),
+                &schemes,
+                QUORUM,
+            );
+            mailbox.set_floor(finalization);
+            while !application
+                .blocks()
+                .contains_key(&Height::new(ANCHOR_HEIGHT))
+            {
+                reschedule().await;
+            }
+
+            // The floor skipped block 1, so its staged block is released.
+            assert!(
+                staged.upgrade().is_none(),
+                "floor transition must evict staged blocks at or below the processed floor"
+            );
+            assert!(!application.blocks().contains_key(&Height::new(1)));
+            assert!(!application.blocks().contains_key(&Height::new(2)));
+        });
+    }
+
+    /// Repeated finalization of an in-flight block must not consume staging capacity.
+    #[test_traced("WARN")]
+    fn test_standard_does_not_restage_dispatched_block() {
+        const PARTITION_PREFIX: &str = "restaged-ack";
+        let runner = deterministic::Runner::timed(Duration::from_secs(30));
+        runner.start(|mut context| async move {
+            let Fixture { schemes, .. } =
+                bls12381_threshold_vrf::fixture::<V, _>(&mut context, NAMESPACE, NUM_VALIDATORS);
+            let (finalizations_by_height, finalized_blocks) =
+                prunable_finalized_stores(&context, PARTITION_PREFIX).await;
+            let (actor, mut mailbox, _) = Actor::init(
+                context.child("actor"),
+                finalizations_by_height,
+                finalized_blocks,
+                direct_config(
+                    &context,
+                    PARTITION_PREFIX,
+                    ConstantProvider::new(schemes[0].clone()),
+                    NZUsize!(1),
+                ),
+            )
+            .await;
+            let (resolver_rx, resolver) = RecordingResolver::holding(context.child("resolver"));
+            let application = Application::<B>::manual_ack();
+            let buffer = RecordingBuffer::default();
+            let _actor_handle =
+                actor.start(application.clone(), buffer.clone(), (resolver_rx, resolver));
+            assert_eq!(application.acknowledged().await, Height::zero());
+
+            // Finalize block 1 and hold its acknowledgement once dispatched.
+            let genesis = StandardHarness::genesis_block(NUM_VALIDATORS as u16);
+            let round = Round::new(Epoch::zero(), View::new(1));
+            let block = make_raw_block(genesis.digest(), Height::new(1), 100);
+            buffer.insert(block.clone());
+            let finalization = StandardHarness::make_finalization(
+                Proposal::new(round, View::zero(), StandardHarness::commitment(&block)),
+                &schemes,
+                QUORUM,
+            );
+            StandardHarness::report_finalization(&mut mailbox, finalization.clone()).await;
+            while application.pending_ack_heights() != vec![Height::new(1)] {
+                reschedule().await;
+            }
+
+            // The block is already in flight, so another finalization needs no retained copy
+            StandardHarness::report_finalization(&mut mailbox, finalization).await;
+
+            // Mailbox messages are FIFO, so a served read proves the
+            // finalization arm has run.
+            assert!(
+                mailbox.get_block(Height::new(1)).await.is_some(),
+                "finalized block must be stored"
+            );
+            let repeated = buffer
+                .handed()
+                .pop()
+                .expect("buffer must have served the finalized block again");
+            assert_eq!(application.pending_ack_heights(), vec![Height::new(1)]);
+            assert!(
+                repeated.upgrade().is_none(),
+                "an already-dispatched block must not consume staging capacity"
             );
         });
     }

--- a/consensus/src/marshal/standard/mod.rs
+++ b/consensus/src/marshal/standard/mod.rs
@@ -3904,7 +3904,7 @@ mod tests {
     #[derive(Clone, Default)]
     struct RecordingBuffer {
         blocks: Arc<Mutex<Vec<B>>>,
-        handed: Arc<Mutex<Vec<Weak<B>>>>,
+        last_handed: Arc<Mutex<Option<Weak<B>>>>,
         evict_on_next_hit: Arc<Mutex<bool>>,
         digest_subscriptions: Arc<Mutex<Vec<oneshot::Sender<Arc<B>>>>>,
         commitment_subscriptions: Arc<Mutex<Vec<oneshot::Sender<Arc<B>>>>>,
@@ -3937,13 +3937,13 @@ mod tests {
                 blocks[index].clone()
             };
             let block = Arc::new(block);
-            self.handed.lock().push(Arc::downgrade(&block));
+            *self.last_handed.lock() = Some(Arc::downgrade(&block));
             Some(block)
         }
 
-        /// Weak references to every block `find` handed to marshal, in order.
-        fn handed(&self) -> Vec<Weak<B>> {
-            self.handed.lock().clone()
+        /// Weak reference to the last block `find` handed to marshal.
+        fn last_handed(&self) -> Option<Weak<B>> {
+            self.last_handed.lock().clone()
         }
 
         fn sends(&self) -> Vec<BufferSend> {
@@ -8421,11 +8421,10 @@ mod tests {
                 .expect("finalized block dispatched");
             assert_eq!(delivered.digest(), block.digest());
             assert!(
-                buffer.handed().iter().any(|handed| {
-                    handed
-                        .upgrade()
-                        .is_some_and(|handed| Arc::ptr_eq(&handed, &delivered))
-                }),
+                buffer
+                    .last_handed()
+                    .and_then(|handed| handed.upgrade())
+                    .is_some_and(|handed| Arc::ptr_eq(&handed, &delivered)),
                 "dispatch must deliver the block object the buffer handed to marshal"
             );
             let ops = ops.lock().clone();
@@ -8436,95 +8435,6 @@ mod tests {
             assert!(
                 !ops[written..].contains(&Op::Get(Some(Height::new(1)))),
                 "dispatch must not read the finalized block back from the archive: {ops:?}"
-            );
-        });
-    }
-
-    /// A restart redelivers an unacknowledged finalized block from the archive.
-    #[test_traced("WARN")]
-    fn test_standard_restart_dispatches_from_archive() {
-        const PARTITION_PREFIX: &str = "restart-dispatch";
-        let runner = deterministic::Runner::timed(Duration::from_secs(30));
-        runner.start(|mut context| async move {
-            let Fixture { schemes, .. } =
-                bls12381_threshold_vrf::fixture::<V, _>(&mut context, NAMESPACE, NUM_VALIDATORS);
-            let genesis = StandardHarness::genesis_block(NUM_VALIDATORS as u16);
-            let round = Round::new(Epoch::zero(), View::new(1));
-            let block = make_raw_block(genesis.digest(), Height::new(1), 100);
-
-            let (finalizations_by_height, finalized_blocks) =
-                prunable_finalized_stores(&context, PARTITION_PREFIX).await;
-            let (actor, mut mailbox, _) = Actor::init(
-                context.child("actor"),
-                finalizations_by_height,
-                finalized_blocks,
-                direct_config(
-                    &context,
-                    PARTITION_PREFIX,
-                    ConstantProvider::new(schemes[0].clone()),
-                    NZUsize!(1),
-                ),
-            )
-            .await;
-            let (resolver_rx, resolver) = RecordingResolver::holding(context.child("resolver"));
-            let application = Application::<B>::manual_ack();
-            let actor_handle = actor.start_unbuffered(application.clone(), (resolver_rx, resolver));
-            assert_eq!(application.acknowledged().await, Height::zero());
-
-            // Finalize block 1 and leave its acknowledgement pending.
-            assert!(mailbox.verified(round, block.clone()).await);
-            let finalization = StandardHarness::make_finalization(
-                Proposal::new(round, View::zero(), StandardHarness::commitment(&block)),
-                &schemes,
-                QUORUM,
-            );
-            StandardHarness::report_finalization(&mut mailbox, finalization).await;
-            while application.pending_ack_heights() != vec![Height::new(1)] {
-                reschedule().await;
-            }
-
-            actor_handle.abort();
-            drop(mailbox);
-
-            // Wait for the actor to release its storage handles before reopening
-            assert!(actor_handle.await.is_err());
-
-            let restart = context.child("restart");
-            let (finalizations_by_height, finalized_blocks) =
-                prunable_finalized_stores(&restart, PARTITION_PREFIX).await;
-            let finalized_blocks = Recording::new(finalized_blocks);
-            let ops = finalized_blocks.ops();
-            let (actor, _mailbox, _): (_, Mailbox<S, Standard<B>>, _) = Actor::init(
-                restart.child("actor"),
-                finalizations_by_height,
-                finalized_blocks,
-                direct_config(
-                    &restart,
-                    PARTITION_PREFIX,
-                    ConstantProvider::new(schemes[0].clone()),
-                    NZUsize!(1),
-                ),
-            )
-            .await;
-            let (resolver_rx, resolver) = RecordingResolver::holding(restart.child("resolver"));
-            let application = Application::<B>::manual_ack();
-            let before = ops.lock().len();
-            let _actor_handle =
-                actor.start_unbuffered(application.clone(), (resolver_rx, resolver));
-            while application.pending_ack_heights() != vec![Height::new(1)] {
-                reschedule().await;
-            }
-
-            let delivered = application
-                .blocks()
-                .get(&Height::new(1))
-                .cloned()
-                .expect("finalized block redelivered");
-            assert_eq!(delivered.digest(), block.digest());
-            assert_eq!(
-                ops.lock()[before..].to_vec(),
-                vec![Op::Get(Some(Height::new(1)))],
-                "restart dispatch must read the finalized block from the archive"
             );
         });
     }
@@ -8592,8 +8502,7 @@ mod tests {
                 "finalized block must be stored"
             );
             let staged = buffer
-                .handed()
-                .pop()
+                .last_handed()
                 .expect("buffer must have served the finalized block");
             assert!(
                 staged.upgrade().is_some(),
@@ -8616,8 +8525,7 @@ mod tests {
                 "finalized block must be stored"
             );
             let unstaged = buffer
-                .handed()
-                .pop()
+                .last_handed()
                 .expect("buffer must have served the finalized block");
             assert!(
                 unstaged.upgrade().is_none(),
@@ -8704,8 +8612,7 @@ mod tests {
                 "finalized block must be stored"
             );
             let repeated = buffer
-                .handed()
-                .pop()
+                .last_handed()
                 .expect("buffer must have served the finalized block again");
             assert_eq!(application.pending_ack_heights(), vec![Height::new(1)]);
             assert!(

--- a/consensus/src/marshal/standard/mod.rs
+++ b/consensus/src/marshal/standard/mod.rs
@@ -8651,127 +8651,131 @@ mod tests {
     }
 
     /// Staging retains at most twice the ack capacity until dispatch or a floor skips the blocks.
-    #[test_traced("WARN")]
-    fn test_standard_staged_blocks_bounded() {
+    fn staged_blocks_bounded(skip_to_floor: bool) {
         const PARTITION_PREFIX: &str = "staged-bounded";
         const ANCHOR_HEIGHT: u64 = 5;
-        for skip_to_floor in [false, true] {
-            let runner = deterministic::Runner::timed(Duration::from_secs(30));
-            runner.start(|mut context| async move {
-                let Fixture { schemes, .. } = bls12381_threshold_vrf::fixture::<V, _>(
-                    &mut context,
-                    NAMESPACE,
-                    NUM_VALIDATORS,
-                );
-                let (finalizations_by_height, finalized_blocks) =
-                    prunable_finalized_stores(&context, PARTITION_PREFIX).await;
-                let finalized_blocks =
-                    Recording::new(finalized_blocks, |block: &Arc<B>| Arc::as_ptr(block).addr());
-                let ops = finalized_blocks.ops();
-                let (actor, mut mailbox, _) = Actor::init(
-                    context.child("actor"),
-                    finalizations_by_height,
-                    finalized_blocks,
-                    test_config(
-                        &context,
-                        PARTITION_PREFIX,
-                        ConstantProvider::new(schemes[0].clone()),
-                        NZUsize!(1),
-                    ),
-                )
-                .await;
-                let (resolver_rx, resolver) = RecordingResolver::holding(context.child("resolver"));
-                let application = Application::<B>::manual_ack();
-                let buffer = RecordingBuffer::default();
-                let _actor_handle =
-                    actor.start(application.clone(), buffer.clone(), (resolver_rx, resolver));
+        let runner = deterministic::Runner::timed(Duration::from_secs(30));
+        runner.start(|mut context| async move {
+            let Fixture { schemes, .. } =
+                bls12381_threshold_vrf::fixture::<V, _>(&mut context, NAMESPACE, NUM_VALIDATORS);
+            let (finalizations_by_height, finalized_blocks) =
+                prunable_finalized_stores(&context, PARTITION_PREFIX).await;
+            let finalized_blocks =
+                Recording::new(finalized_blocks, |block: &Arc<B>| Arc::as_ptr(block).addr());
+            let ops = finalized_blocks.ops();
+            let (actor, mut mailbox, _) = Actor::init(
+                context.child("actor"),
+                finalizations_by_height,
+                finalized_blocks,
+                test_config(
+                    &context,
+                    PARTITION_PREFIX,
+                    ConstantProvider::new(schemes[0].clone()),
+                    NZUsize!(1),
+                ),
+            )
+            .await;
+            let (resolver_rx, resolver) = RecordingResolver::holding(context.child("resolver"));
+            let application = Application::<B>::manual_ack();
+            let buffer = RecordingBuffer::default();
+            let _actor_handle =
+                actor.start(application.clone(), buffer.clone(), (resolver_rx, resolver));
 
-                // Hold the genesis acknowledgement so nothing else can dispatch
-                while application.pending_ack_heights() != vec![Height::zero()] {
+            // Hold the genesis acknowledgement so nothing else can dispatch
+            while application.pending_ack_heights() != vec![Height::zero()] {
+                reschedule().await;
+            }
+
+            // Build a chain whose tip is the floor anchor
+            let mut parent = StandardHarness::genesis_block(NUM_VALIDATORS as u16).digest();
+            let mut chain = Vec::new();
+            for i in 1..=ANCHOR_HEIGHT {
+                let block = make_raw_block(parent, Height::new(i), i);
+                parent = block.digest();
+                chain.push(block);
+            }
+
+            // Two blocks fit in staging. A third must not displace either.
+            let mut handed = Vec::new();
+            for block in &chain[..3] {
+                let height = block.height();
+                let round = Round::new(Epoch::zero(), View::new(height.get()));
+                buffer.insert(block.clone());
+                let finalization = StandardHarness::make_finalization(
+                    Proposal::new(round, View::new(height.get() - 1), block.digest()),
+                    &schemes,
+                    QUORUM,
+                );
+                StandardHarness::report_finalization(&mut mailbox, finalization).await;
+
+                // A served read proves the preceding finalization arm has run
+                assert!(mailbox.get_block(height).await.is_some());
+                handed.push(
+                    buffer
+                        .last_handed()
+                        .expect("buffer must have served the finalized block"),
+                );
+            }
+            assert!(
+                handed[..2].iter().all(|block| block.upgrade().is_some()),
+                "staging must retain two blocks without evicting either on overflow"
+            );
+            assert!(
+                handed[2].upgrade().is_none(),
+                "staging must stop at twice the pending-ack capacity"
+            );
+            assert_eq!(application.pending_ack_heights(), vec![Height::zero()]);
+
+            if skip_to_floor {
+                // A floor anchor releases the blocks it skips
+                let anchor = chain.last().unwrap();
+                let anchor_round = Round::new(Epoch::zero(), View::new(ANCHOR_HEIGHT));
+                buffer.insert(anchor.clone());
+                let finalization = StandardHarness::make_finalization(
+                    Proposal::new(anchor_round, View::new(ANCHOR_HEIGHT - 1), anchor.digest()),
+                    &schemes,
+                    QUORUM,
+                );
+                mailbox.set_floor(finalization);
+                while !application
+                    .blocks()
+                    .contains_key(&Height::new(ANCHOR_HEIGHT))
+                {
                     reschedule().await;
                 }
-
-                // Build a chain whose tip is the floor anchor
-                let mut parent = StandardHarness::genesis_block(NUM_VALIDATORS as u16).digest();
-                let mut chain = Vec::new();
-                for i in 1..=ANCHOR_HEIGHT {
-                    let block = make_raw_block(parent, Height::new(i), i);
-                    parent = block.digest();
-                    chain.push(block);
-                }
-
-                // Two blocks fit in staging; a third must not displace either
-                let mut handed = Vec::new();
+                assert!(
+                    handed.iter().all(|block| block.upgrade().is_none()),
+                    "floor transition must release skipped staged blocks"
+                );
                 for block in &chain[..3] {
-                    let height = block.height();
-                    let round = Round::new(Epoch::zero(), View::new(height.get()));
-                    buffer.insert(block.clone());
-                    let finalization = StandardHarness::make_finalization(
-                        Proposal::new(round, View::new(height.get() - 1), block.digest()),
-                        &schemes,
-                        QUORUM,
-                    );
-                    StandardHarness::report_finalization(&mut mailbox, finalization).await;
-
-                    // A served read proves the preceding finalization arm has run
-                    assert!(mailbox.get_block(height).await.is_some());
-                    handed.push(
-                        buffer
-                            .last_handed()
-                            .expect("buffer must have served the finalized block"),
-                    );
+                    assert!(!application.blocks().contains_key(&block.height()));
                 }
-                assert!(
-                    handed[..2].iter().all(|block| block.upgrade().is_some()),
-                    "staging must retain two blocks without evicting either on overflow"
-                );
-                assert!(
-                    handed[2].upgrade().is_none(),
-                    "staging must stop at twice the pending-ack capacity"
-                );
-                assert_eq!(application.pending_ack_heights(), vec![Height::zero()]);
-
-                if skip_to_floor {
-                    // A floor anchor releases the blocks it skips
-                    let anchor = chain.last().unwrap();
-                    let anchor_round = Round::new(Epoch::zero(), View::new(ANCHOR_HEIGHT));
-                    buffer.insert(anchor.clone());
-                    let finalization = StandardHarness::make_finalization(
-                        Proposal::new(anchor_round, View::new(ANCHOR_HEIGHT - 1), anchor.digest()),
-                        &schemes,
-                        QUORUM,
-                    );
-                    mailbox.set_floor(finalization);
-                    while !application
-                        .blocks()
-                        .contains_key(&Height::new(ANCHOR_HEIGHT))
-                    {
-                        reschedule().await;
-                    }
-                    assert!(
-                        handed.iter().all(|block| block.upgrade().is_none()),
-                        "floor transition must release skipped staged blocks"
-                    );
-                    for block in &chain[..3] {
-                        assert!(!application.blocks().contains_key(&block.height()));
-                    }
-                } else {
-                    // Drain the backlog: only the overflow block needs an archive read
-                    ops.lock().clear();
-                    for height in 0..=3 {
-                        assert_eq!(application.acknowledged().await, Height::new(height));
-                    }
-                    let ops = ops.lock();
-                    for height in 1..=3 {
-                        let reads = ops
-                            .iter()
-                            .filter(|op| **op == Op::Get(Some(Height::new(height))))
-                            .count();
-                        assert_eq!(reads, usize::from(height == 3), "archive reads at {height}");
-                    }
+            } else {
+                // Drain the backlog: only the overflow block needs an archive read
+                ops.lock().clear();
+                for height in 0..=3 {
+                    assert_eq!(application.acknowledged().await, Height::new(height));
                 }
-            });
-        }
+                let ops = ops.lock();
+                for height in 1..=3 {
+                    let reads = ops
+                        .iter()
+                        .filter(|op| **op == Op::Get(Some(Height::new(height))))
+                        .count();
+                    assert_eq!(reads, usize::from(height == 3), "archive reads at {height}");
+                }
+            }
+        });
+    }
+
+    #[test_traced("WARN")]
+    fn test_standard_staged_blocks_bounded_drain() {
+        staged_blocks_bounded(false);
+    }
+
+    #[test_traced("WARN")]
+    fn test_standard_staged_blocks_bounded_floor() {
+        staged_blocks_bounded(true);
     }
 
     /// Repeated finalization of an in-flight block must not consume staging capacity.

--- a/consensus/src/marshal/standard/mod.rs
+++ b/consensus/src/marshal/standard/mod.rs
@@ -8527,7 +8527,7 @@ mod tests {
                     .is_some_and(|handed| Arc::ptr_eq(&handed, &delivered)),
                 "dispatch must deliver the block object the buffer handed to marshal"
             );
-            let ops = ops.lock().clone();
+            let ops = ops.lock();
             let written = ops
                 .iter()
                 .position(|op| matches!(op, Op::Put(height, _) if *height == Height::new(1)))

--- a/consensus/src/marshal/standard/mod.rs
+++ b/consensus/src/marshal/standard/mod.rs
@@ -505,7 +505,7 @@ mod tests {
 
         for block in blocks {
             finalized_blocks = finalized_blocks
-                .put(block.height().get(), block.digest(), block.clone())
+                .put(block.height().get(), block.digest(), block)
                 .await
                 .expect("failed to seed finalized block");
         }
@@ -516,11 +516,7 @@ mod tests {
 
         for (height, finalization) in finalizations {
             finalizations_by_height = finalizations_by_height
-                .put(
-                    height.get(),
-                    finalization.proposal.payload,
-                    finalization.clone(),
-                )
+                .put(height.get(), finalization.proposal.payload, finalization)
                 .await
                 .expect("failed to seed finalization");
         }
@@ -600,7 +596,7 @@ mod tests {
             .await
             .expect("failed to initialize notarized blocks archive");
         notarized
-            .put_sync(view.get(), block.digest(), block.clone())
+            .put_sync(view.get(), block.digest(), block)
             .await
             .expect("failed to seed notarized block");
     }
@@ -7697,7 +7693,7 @@ mod tests {
         type Block = T::Block;
         type Error = T::Error;
 
-        async fn put(mut self, block: Self::Block) -> Result<Self, Self::Error> {
+        async fn put(mut self, block: &Self::Block) -> Result<Self, Self::Error> {
             self.inner = self.inner.put(block).await?;
             Ok(self)
         }
@@ -7758,7 +7754,7 @@ mod tests {
             mut self,
             height: Height,
             digest: Self::BlockDigest,
-            finalization: Finalization<Self::Scheme, Self::Commitment>,
+            finalization: &Finalization<Self::Scheme, Self::Commitment>,
         ) -> Result<Self, Self::Error> {
             self.inner = self.inner.put(height, digest, finalization).await?;
             Ok(self)
@@ -8430,13 +8426,106 @@ mod tests {
             let ops = ops.lock().clone();
             let written = ops
                 .iter()
-                .position(|op| *op == Op::Put(Height::new(1)))
+                .position(|op| matches!(op, Op::Put(height, _) if *height == Height::new(1)))
                 .expect("finalized block written");
+            assert_eq!(
+                ops[written],
+                Op::Put(Height::new(1), Arc::as_ptr(&delivered).addr()),
+                "storage must borrow the block object dispatched to the application"
+            );
             assert!(
                 !ops[written..].contains(&Op::Get(Some(Height::new(1)))),
                 "dispatch must not read the finalized block back from the archive: {ops:?}"
             );
         });
+    }
+
+    fn staged_dispatch_preserves_first_write(preexisting: bool) {
+        const PARTITION_PREFIX: &str = "staged-first-write";
+        let runner = deterministic::Runner::timed(Duration::from_secs(30));
+        runner.start(|mut context| async move {
+            let Fixture { schemes, .. } =
+                bls12381_threshold_vrf::fixture::<V, _>(&mut context, NAMESPACE, NUM_VALIDATORS);
+            let genesis = StandardHarness::genesis_block(NUM_VALIDATORS as u16);
+            let first = make_raw_block(genesis.digest(), Height::new(1), 100);
+            let conflicting = make_raw_block(genesis.digest(), Height::new(1), 200);
+            assert_ne!(first.digest(), conflicting.digest());
+            let (finalizations_by_height, mut finalized_blocks) =
+                prunable_finalized_stores(&context, PARTITION_PREFIX).await;
+            if preexisting {
+                finalized_blocks = finalized_blocks
+                    .put_sync(first.height().get(), first.digest(), &first)
+                    .await
+                    .unwrap();
+            }
+            let (actor, mut mailbox, _) = Actor::init(
+                context.child("actor"),
+                finalizations_by_height,
+                finalized_blocks,
+                test_config(
+                    &context,
+                    PARTITION_PREFIX,
+                    ConstantProvider::new(schemes[0].clone()),
+                    NZUsize!(1),
+                ),
+            )
+            .await;
+            let (resolver_rx, resolver) = RecordingResolver::holding(context.child("resolver"));
+            let application = Application::<B>::manual_ack();
+            let buffer = RecordingBuffer::default();
+            let _actor_handle =
+                actor.start(application.clone(), buffer.clone(), (resolver_rx, resolver));
+
+            // Hold genesis so both finalizations precede dispatch at height one
+            while application.pending_ack_heights() != vec![Height::zero()] {
+                reschedule().await;
+            }
+
+            // A Byzantine quorum can certify conflicting blocks at the same height
+            // Local durable delivery must still match the archive's first write
+            for (view, block) in [(1, &first), (2, &conflicting)] {
+                if preexisting && view == 1 {
+                    continue;
+                }
+                buffer.insert(block.clone());
+                let finalization = StandardHarness::make_finalization(
+                    Proposal::new(
+                        Round::new(Epoch::zero(), View::new(view)),
+                        View::zero(),
+                        block.digest(),
+                    ),
+                    &schemes,
+                    QUORUM,
+                );
+                StandardHarness::report_finalization(&mut mailbox, finalization).await;
+
+                // A served read proves the preceding finalization arm has run
+                let archived = mailbox.get_block(Height::new(1)).await.unwrap();
+                assert_eq!(archived.digest(), first.digest());
+            }
+
+            assert_eq!(application.acknowledged().await, Height::zero());
+            while !application.blocks().contains_key(&Height::new(1)) {
+                reschedule().await;
+            }
+            let delivered = application.blocks()[&Height::new(1)].clone();
+            let archived = mailbox.get_block(Height::new(1)).await.unwrap();
+            assert_eq!(
+                delivered.digest(),
+                archived.digest(),
+                "dispatch must deliver the block retained by the archive"
+            );
+        });
+    }
+
+    #[test_traced("WARN")]
+    fn test_standard_staged_dispatch_preserves_first_write() {
+        staged_dispatch_preserves_first_write(false);
+    }
+
+    #[test_traced("WARN")]
+    fn test_standard_staged_dispatch_preserves_preexisting_write() {
+        staged_dispatch_preserves_first_write(true);
     }
 
     /// Staging retains twice the ack capacity until dispatch or a floor skips the blocks.

--- a/consensus/src/marshal/standard/variant.rs
+++ b/consensus/src/marshal/standard/variant.rs
@@ -22,7 +22,6 @@ use std::{future::Future, sync::Arc};
 /// The standard variant of Marshal, which broadcasts complete blocks.
 ///
 /// This variant sends the entire block to all peers.
-/// Both the working and stored block types are `Arc<B>`.
 #[derive(Default, Clone, Copy)]
 pub struct Standard<B: Block>(std::marker::PhantomData<B>);
 

--- a/consensus/src/marshal/standard/variant.rs
+++ b/consensus/src/marshal/standard/variant.rs
@@ -68,11 +68,7 @@ where
         block_cfg.clone()
     }
 
-    fn into_inner(block: Self::Block) -> Self::ApplicationBlock {
-        Arc::unwrap_or_clone(block)
-    }
-
-    fn into_inner_shared(block: Self::Block) -> Arc<Self::ApplicationBlock> {
+    fn into_inner(block: Self::Block) -> Arc<Self::ApplicationBlock> {
         block
     }
 

--- a/consensus/src/marshal/standard/variant.rs
+++ b/consensus/src/marshal/standard/variant.rs
@@ -17,11 +17,12 @@ use commonware_codec::Read;
 use commonware_cryptography::{Digestible, PublicKey, certificate::Scheme};
 use commonware_p2p::Recipients;
 use commonware_utils::channel::oneshot;
-use std::{borrow::Cow, future::Future, sync::Arc};
+use std::{future::Future, sync::Arc};
 
 /// The standard variant of Marshal, which broadcasts complete blocks.
 ///
 /// This variant sends the entire block to all peers.
+/// Both the working and stored block types are `Arc<B>`.
 #[derive(Default, Clone, Copy)]
 pub struct Standard<B: Block>(std::marker::PhantomData<B>);
 
@@ -30,13 +31,9 @@ where
     B: Block,
 {
     type ApplicationBlock = B;
-    type Block = B;
-    type StoredBlock = B;
+    type Block = Arc<B>;
+    type StoredBlock = Arc<B>;
     type Commitment = <B as Digestible>::Digest;
-
-    fn stored(block: &Self::Block) -> Cow<'_, Self::StoredBlock> {
-        Cow::Borrowed(block)
-    }
 
     fn commitment(block: &Self::Block) -> Self::Commitment {
         // Standard variant commitment is exactly the block digest.
@@ -72,22 +69,18 @@ where
     }
 
     fn into_inner(block: Self::Block) -> Self::ApplicationBlock {
-        block
+        Arc::unwrap_or_clone(block)
     }
 
-    fn into_inner_shared(block: Arc<Self::Block>) -> Arc<Self::ApplicationBlock> {
+    fn into_inner_shared(block: Self::Block) -> Arc<Self::ApplicationBlock> {
         block
-    }
-
-    fn owned_into_inner_shared(block: Self::Block) -> Arc<Self::ApplicationBlock> {
-        Arc::new(block)
     }
 
     fn from_application_block(
         block: Self::ApplicationBlock,
         _payload: Self::Commitment,
     ) -> Self::Block {
-        block
+        Arc::new(block)
     }
 }
 

--- a/consensus/src/marshal/standard/variant.rs
+++ b/consensus/src/marshal/standard/variant.rs
@@ -17,7 +17,7 @@ use commonware_codec::Read;
 use commonware_cryptography::{Digestible, PublicKey, certificate::Scheme};
 use commonware_p2p::Recipients;
 use commonware_utils::channel::oneshot;
-use std::{future::Future, sync::Arc};
+use std::{borrow::Cow, future::Future, sync::Arc};
 
 /// The standard variant of Marshal, which broadcasts complete blocks.
 ///
@@ -33,6 +33,10 @@ where
     type Block = B;
     type StoredBlock = B;
     type Commitment = <B as Digestible>::Digest;
+
+    fn stored(block: &Self::Block) -> Cow<'_, Self::StoredBlock> {
+        Cow::Borrowed(block)
+    }
 
     fn commitment(block: &Self::Block) -> Self::Commitment {
         // Standard variant commitment is exactly the block digest.

--- a/consensus/src/marshal/standard/variant.rs
+++ b/consensus/src/marshal/standard/variant.rs
@@ -68,7 +68,7 @@ where
         block_cfg.clone()
     }
 
-    fn into_inner(block: Self::Block) -> Arc<Self::ApplicationBlock> {
+    fn into_shared(block: Self::Block) -> Arc<Self::ApplicationBlock> {
         block
     }
 

--- a/consensus/src/marshal/store.rs
+++ b/consensus/src/marshal/store.rs
@@ -46,7 +46,7 @@ pub trait Certificates: Send + Sync + Sized + 'static {
         self,
         height: Height,
         digest: Self::BlockDigest,
-        finalization: Finalization<Self::Scheme, Self::Commitment>,
+        finalization: &Finalization<Self::Scheme, Self::Commitment>,
     ) -> impl Future<Output = Result<Self, Self::Error>> + Send;
 
     /// Flush all buffered writes to durable storage.
@@ -132,7 +132,7 @@ pub trait Blocks: Send + Sync + Sized + 'static {
     /// # Arguments
     ///
     /// * `block`: The finalized block, which provides its `height()` and `digest()`.
-    fn put(self, block: Self::Block) -> impl Future<Output = Result<Self, Self::Error>> + Send;
+    fn put(self, block: &Self::Block) -> impl Future<Output = Result<Self, Self::Error>> + Send;
 
     /// Flush all buffered writes to durable storage.
     fn sync(self) -> impl Future<Output = Result<Self, Self::Error>> + Send;
@@ -243,7 +243,7 @@ where
         self,
         height: Height,
         digest: Self::BlockDigest,
-        finalization: Finalization<S, Self::Commitment>,
+        finalization: &Finalization<S, Self::Commitment>,
     ) -> Result<Self, Self::Error> {
         Archive::put(self, height.get(), digest, finalization).await
     }
@@ -290,7 +290,7 @@ where
     type Block = B;
     type Error = archive::Error;
 
-    async fn put(self, block: Self::Block) -> Result<Self, Self::Error> {
+    async fn put(self, block: &Self::Block) -> Result<Self, Self::Error> {
         Archive::put(self, block.height().get(), block.digest(), block).await
     }
 
@@ -348,7 +348,7 @@ where
         self,
         height: Height,
         digest: Self::BlockDigest,
-        finalization: Finalization<S, Self::Commitment>,
+        finalization: &Finalization<S, Self::Commitment>,
     ) -> Result<Self, Self::Error> {
         Archive::put(self, height.get(), digest, finalization).await
     }
@@ -395,7 +395,7 @@ where
     type Block = B;
     type Error = archive::Error;
 
-    async fn put(self, block: Self::Block) -> Result<Self, Self::Error> {
+    async fn put(self, block: &Self::Block) -> Result<Self, Self::Error> {
         Archive::put(self, block.height().get(), block.digest(), block).await
     }
 

--- a/cryptography/src/lib.rs
+++ b/cryptography/src/lib.rs
@@ -64,12 +64,16 @@ commonware_macros::stability_scope!(ALPHA {
     pub mod zk;
 });
 commonware_macros::stability_scope!(BETA {
+    #[cfg(not(feature = "std"))]
+    use alloc::sync::Arc;
     use commonware_codec::{Encode, ReadExt};
     use commonware_math::algebra::Random;
     use commonware_parallel::Strategy;
     use commonware_utils::Array;
     use rand_chacha::ChaCha20Rng;
     use rand_core::{CryptoRng, SeedableRng as _};
+    #[cfg(feature = "std")]
+    use std::sync::Arc;
 
     pub mod secret;
     pub use crate::secret::Secret;
@@ -227,6 +231,14 @@ commonware_macros::stability_scope!(BETA {
         /// If many objects with [Digest]s are related (map to some higher-level
         /// group [Digest]), you should also implement [Committable].
         fn digest(&self) -> Self::Digest;
+    }
+
+    impl<T: Digestible> Digestible for Arc<T> {
+        type Digest = T::Digest;
+
+        fn digest(&self) -> Self::Digest {
+            self.as_ref().digest()
+        }
     }
 
     /// An object that can produce a commitment of itself.

--- a/examples/reshare/src/validator.rs
+++ b/examples/reshare/src/validator.rs
@@ -216,7 +216,7 @@ pub async fn run(context: tokio::Context, args: Validator) {
         marshal::Config {
             provider: provider.clone(),
             epocher: FixedEpocher::new(BLOCKS_PER_EPOCH),
-            start: plan.marshal_start(genesis.clone()),
+            start: plan.marshal_start(genesis.clone().into()),
             partition_prefix: partition_prefix.to_string(),
             mailbox_size: MAILBOX_SIZE,
             view_retention: ViewDelta::new(10),

--- a/glue/src/dkg/bootstrap/mod.rs
+++ b/glue/src/dkg/bootstrap/mod.rs
@@ -443,7 +443,7 @@ where
             marshal::Config {
                 provider: provider.clone(),
                 epocher: FixedEpocher::new(self.config.blocks_per_epoch),
-                start: Start::Genesis(genesis.clone()),
+                start: Start::Genesis(genesis.clone().into()),
                 partition_prefix: format!("{}-marshal", self.config.partition_prefix),
                 mailbox_size: MAILBOX_SIZE,
                 view_retention: ViewDelta::new(10),

--- a/glue/src/dkg/orchestrator/actor.rs
+++ b/glue/src/dkg/orchestrator/actor.rs
@@ -518,7 +518,7 @@ where
             return None;
         };
         let commitment = MV::commitment(&boundary);
-        let block = MV::into_inner(boundary);
+        let block = MV::into_shared(boundary);
         let Some(Payload::EpochInfo(info)) = block.payload() else {
             panic!("boundary block {height} missing epoch info");
         };

--- a/glue/src/dkg/orchestrator/mod.rs
+++ b/glue/src/dkg/orchestrator/mod.rs
@@ -365,7 +365,7 @@ mod tests {
                 marshal::Config {
                     provider: mocks::TestProvider::new(fixture.schemes[index].clone()),
                     epocher: FixedEpocher::new(NZU64!(2)),
-                    start: MarshalStart::Genesis(genesis),
+                    start: MarshalStart::Genesis(genesis.into()),
                     partition_prefix: partition_prefix.clone(),
                     mailbox_size: NZUsize!(16),
                     view_retention: ViewDelta::new(8),
@@ -499,7 +499,7 @@ mod tests {
     ) -> mocks::TestBlock {
         for _ in 0..50 {
             if let Some(block) = marshal.get_block(height).await {
-                return block;
+                return Arc::unwrap_or_clone(block);
             }
             context.sleep(Duration::from_millis(10)).await;
         }
@@ -731,7 +731,7 @@ mod tests {
                     marshal::Config {
                         provider: mocks::TestProvider::new(fixture.schemes[0].clone()),
                         epocher: FixedEpocher::new(NZU64!(2)),
-                        start: MarshalStart::Genesis(genesis),
+                        start: MarshalStart::Genesis(genesis.into()),
                         partition_prefix: partition_prefix.clone(),
                         mailbox_size: NZUsize!(16),
                         view_retention: ViewDelta::new(8),
@@ -986,7 +986,7 @@ mod tests {
                 marshal::Config {
                     provider: mocks::TestProvider::new(fixture.schemes[0].clone()),
                     epocher: FixedEpocher::new(NZU64!(2)),
-                    start: MarshalStart::Genesis(genesis),
+                    start: MarshalStart::Genesis(genesis.into()),
                     partition_prefix: partition_prefix.clone(),
                     mailbox_size: NZUsize!(16),
                     view_retention: ViewDelta::new(8),

--- a/glue/src/dkg/orchestrator/mod.rs
+++ b/glue/src/dkg/orchestrator/mod.rs
@@ -496,10 +496,10 @@ mod tests {
         context: &deterministic::Context,
         marshal: &mocks::TestMarshalMailbox,
         height: Height,
-    ) -> mocks::TestBlock {
+    ) -> Arc<mocks::TestBlock> {
         for _ in 0..50 {
             if let Some(block) = marshal.get_block(height).await {
-                return Arc::unwrap_or_clone(block);
+                return block;
             }
             context.sleep(Duration::from_millis(10)).await;
         }

--- a/glue/src/dkg/probe/actor/discovery.rs
+++ b/glue/src/dkg/probe/actor/discovery.rs
@@ -625,7 +625,7 @@ mod tests {
     use commonware_parallel::Sequential;
     use commonware_runtime::{Runner as _, deterministic};
     use commonware_utils::non_empty;
-    use std::time::Duration;
+    use std::{sync::Arc, time::Duration};
 
     const THRESHOLD_NAMESPACE: &[u8] = b"_COMMONWARE_GLUE_DKG_PROBE_DISCOVERY_TEST";
 
@@ -761,7 +761,7 @@ mod tests {
     fn coding_block(
         leader: mocks::TestPublicKey,
         participants: u16,
-    ) -> CodedBlock<CodingBlock, ReedSolomon<Sha256>, Sha256> {
+    ) -> Arc<CodedBlock<CodingBlock, ReedSolomon<Sha256>, Sha256>> {
         let parent = Sha256::hash(&[b"parent"]);
         let context = CodingContext {
             round: Round::new(Epoch::zero(), View::new(1)),
@@ -777,11 +777,11 @@ mod tests {
             ),
         };
         let block = CodingBlock::new::<Sha256>(context, parent, Height::new(1), 0);
-        CodedBlock::new(
+        Arc::new(CodedBlock::new(
             block,
             coding_config_for_participants(participants),
             &Sequential,
-        )
+        ))
     }
 
     #[test]
@@ -867,7 +867,7 @@ mod tests {
             let block_message =
                 wire::Message::<mocks::TestScheme, mocks::TestMarshalVariant>::BlockResponse {
                     epoch: Epoch::zero(),
-                    block: block.clone(),
+                    block: block.clone().into(),
                 }
                 .encode()
                 .to_vec();
@@ -880,7 +880,7 @@ mod tests {
                 authenticate_boundary_block::<mocks::TestMarshalVariant>(&(), commitment, body)
                     .expect("standard block authenticated");
 
-            assert_eq!(decoded, block);
+            assert_eq!(decoded.as_ref(), &block);
         });
     }
 

--- a/glue/src/dkg/probe/actor/discovery.rs
+++ b/glue/src/dkg/probe/actor/discovery.rs
@@ -559,7 +559,7 @@ where
             return None;
         }
 
-        let block = V::into_inner(block);
+        let block = V::into_shared(block);
         let Some(Payload::EpochInfo(info)) = block.payload() else {
             return None;
         };

--- a/glue/src/dkg/probe/mod.rs
+++ b/glue/src/dkg/probe/mod.rs
@@ -616,7 +616,7 @@ mod tests {
             marshal::Config {
                 provider: mocks::TestProvider::new(schemes[index].clone()),
                 epocher: FixedEpocher::new(BLOCKS_PER_EPOCH),
-                start: Start::Genesis(mocks::genesis_block(public_key)),
+                start: Start::Genesis(mocks::genesis_block(public_key).into()),
                 partition_prefix,
                 mailbox_size: NZUsize!(16),
                 view_retention: ViewDelta::new(8),
@@ -1032,7 +1032,7 @@ mod tests {
                 Recipients::One(harness.participants[1].clone()),
                 wire::Message::<mocks::TestScheme, mocks::TestMarshalVariant>::BlockResponse {
                     epoch: Epoch::new(1),
-                    block: harness.boundary.clone(),
+                    block: harness.boundary.clone().into(),
                 }
                 .encode()
                 .to_vec(),
@@ -1099,7 +1099,7 @@ mod tests {
                 Recipients::One(harness.participants[1].clone()),
                 wire::Message::<mocks::TestScheme, mocks::TestMarshalVariant>::BlockResponse {
                     epoch: Epoch::new(1),
-                    block: harness.boundary.clone(),
+                    block: harness.boundary.clone().into(),
                 }
                 .encode()
                 .to_vec(),
@@ -1170,7 +1170,7 @@ mod tests {
                 Recipients::One(harness.participants[1].clone()),
                 wire::Message::<mocks::TestScheme, mocks::TestMarshalVariant>::BlockResponse {
                     epoch: Epoch::new(1),
-                    block: wrong_block,
+                    block: wrong_block.into(),
                 }
                 .encode()
                 .to_vec(),
@@ -1190,7 +1190,7 @@ mod tests {
                 Recipients::One(harness.participants[1].clone()),
                 wire::Message::<mocks::TestScheme, mocks::TestMarshalVariant>::BlockResponse {
                     epoch: Epoch::new(1),
-                    block: harness.boundary.clone(),
+                    block: harness.boundary.clone().into(),
                 }
                 .encode()
                 .to_vec(),

--- a/glue/src/dkg/reshare/actor/setup.rs
+++ b/glue/src/dkg/reshare/actor/setup.rs
@@ -270,7 +270,7 @@ where
             .marshal
             .get_block(Identifier::Height(height))
             .await
-            .map(MV::into_inner)?;
+            .map(MV::into_shared)?;
         let Some(Payload::EpochInfo(info)) = block.payload() else {
             panic!("boundary block {height} missing epoch info");
         };

--- a/glue/src/dkg/tests/mocks.rs
+++ b/glue/src/dkg/tests/mocks.rs
@@ -671,7 +671,7 @@ pub(crate) async fn closed_marshal_mailbox(
         marshal::Config {
             provider: TestProvider::new(scheme),
             epocher: FixedEpocher::new(blocks_per_epoch),
-            start: MarshalStart::Genesis(genesis_block(signer.public_key())),
+            start: MarshalStart::Genesis(genesis_block(signer.public_key()).into()),
             partition_prefix: format!("{partition_prefix}-marshal"),
             mailbox_size: NZUsize!(16),
             view_retention: ViewDelta::new(8),

--- a/glue/src/dkg/tests/reshare/harness.rs
+++ b/glue/src/dkg/tests/reshare/harness.rs
@@ -987,7 +987,7 @@ impl EngineDefinition for ReshareEngine {
                     *self.initial.info.output.public().public(),
                 )),
                 epocher: FixedEpocher::new(EPOCH_LENGTH),
-                start: plan.marshal_start(genesis.clone()),
+                start: plan.marshal_start(genesis.clone().into()),
                 partition_prefix: partition_prefix.clone(),
                 mailbox_size: NZUsize!(100),
                 view_retention: ViewDelta::new(10),

--- a/glue/src/stateful/actor/syncer/mod.rs
+++ b/glue/src/stateful/actor/syncer/mod.rs
@@ -323,7 +323,7 @@ where
     let block = if let Some(height) = floor.height()
         && floor.round() >= finalization.round()
     {
-        V::owned_into_inner_shared(processed_anchor(marshal, height).await)
+        V::into_inner_shared(processed_anchor(marshal, height).await)
     } else {
         // Marshal's configured startup floor fetches its anchor when needed. This local-only
         // subscription observes that result without starting a separate fetch.
@@ -340,7 +340,7 @@ where
         // dispatched once.
         match marshal.get_processed_height().await {
             Some(height) if height > selected.height() => {
-                V::owned_into_inner_shared(processed_anchor(marshal, height).await)
+                V::into_inner_shared(processed_anchor(marshal, height).await)
             }
             _ => selected,
         }

--- a/glue/src/stateful/actor/syncer/mod.rs
+++ b/glue/src/stateful/actor/syncer/mod.rs
@@ -323,7 +323,7 @@ where
     let block = if let Some(height) = floor.height()
         && floor.round() >= finalization.round()
     {
-        V::into_inner(processed_anchor(marshal, height).await)
+        V::into_shared(processed_anchor(marshal, height).await)
     } else {
         // Marshal's configured startup floor fetches its anchor when needed. This local-only
         // subscription observes that result without starting a separate fetch.
@@ -332,7 +332,7 @@ where
                 .subscribe_by_commitment(finalization.proposal.payload, CommitmentFallback::Wait)
                 .await
                 .expect("marshal must yield floor block");
-            V::into_inner(block)
+            V::into_shared(block)
         };
 
         // Marshal does not redeliver acknowledged blocks. A newly installed floor is the
@@ -340,7 +340,7 @@ where
         // dispatched once.
         match marshal.get_processed_height().await {
             Some(height) if height > selected.height() => {
-                V::into_inner(processed_anchor(marshal, height).await)
+                V::into_shared(processed_anchor(marshal, height).await)
             }
             _ => selected,
         }
@@ -404,9 +404,9 @@ where
         .max()
         .unwrap_or_else(Height::zero);
     let floor_block = if processed_height == Some(marshal_floor) {
-        V::into_inner(processed_anchor(marshal, marshal_floor).await)
+        V::into_shared(processed_anchor(marshal, marshal_floor).await)
     } else {
-        V::into_inner(
+        V::into_shared(
             marshal
                 .get_block(Identifier::Height(marshal_floor))
                 .await

--- a/glue/src/stateful/actor/syncer/mod.rs
+++ b/glue/src/stateful/actor/syncer/mod.rs
@@ -323,7 +323,7 @@ where
     let block = if let Some(height) = floor.height()
         && floor.round() >= finalization.round()
     {
-        V::into_inner_shared(processed_anchor(marshal, height).await)
+        V::into_inner(processed_anchor(marshal, height).await)
     } else {
         // Marshal's configured startup floor fetches its anchor when needed. This local-only
         // subscription observes that result without starting a separate fetch.
@@ -332,7 +332,7 @@ where
                 .subscribe_by_commitment(finalization.proposal.payload, CommitmentFallback::Wait)
                 .await
                 .expect("marshal must yield floor block");
-            V::into_inner_shared(block)
+            V::into_inner(block)
         };
 
         // Marshal does not redeliver acknowledged blocks. A newly installed floor is the
@@ -340,7 +340,7 @@ where
         // dispatched once.
         match marshal.get_processed_height().await {
             Some(height) if height > selected.height() => {
-                V::into_inner_shared(processed_anchor(marshal, height).await)
+                V::into_inner(processed_anchor(marshal, height).await)
             }
             _ => selected,
         }

--- a/glue/src/stateful/probe/mod.rs
+++ b/glue/src/stateful/probe/mod.rs
@@ -630,7 +630,7 @@ mod test {
                 let marshal_config = marshal::Config {
                     provider: ConstantProvider::new(scheme.clone()),
                     epocher: FixedEpocher::new(EPOCH_LENGTH),
-                    start: Start::Genesis(genesis.clone()),
+                    start: Start::Genesis(genesis.clone().into()),
                     partition_prefix: partition_prefix.clone(),
                     mailbox_size: NZUsize!(100),
                     view_retention: ViewDelta::new(10),

--- a/glue/src/stateful/tests/fixtures.rs
+++ b/glue/src/stateful/tests/fixtures.rs
@@ -330,7 +330,11 @@ pub(crate) async fn prunable_marshal_fixture(
     .expect("failed to initialize blocks archive");
     if let Some(block) = options.block {
         finalized_blocks = finalized_blocks
-            .put(block.height().get(), block.digest(), block)
+            .put(
+                block.height().get(),
+                block.digest(),
+                &Arc::new(block.clone()),
+            )
             .await
             .expect("failed to seed finalized block")
             .sync()
@@ -371,7 +375,11 @@ async fn marshal_fixture_inner(
     .expect("failed to initialize blocks archive");
     if let Some(block) = options.block {
         finalized_blocks = finalized_blocks
-            .put(block.height().get(), block.digest(), block)
+            .put(
+                block.height().get(),
+                block.digest(),
+                &Arc::new(block.clone()),
+            )
             .await
             .expect("failed to seed finalized block")
             .sync()
@@ -415,7 +423,7 @@ where
             Commitment = Sha256Digest,
             Scheme = TestScheme,
         >,
-    FB: marshal::store::Blocks<Block = TestBlock>,
+    FB: marshal::store::Blocks<Block = Arc<TestBlock>>,
 {
     let provider = ConstantProvider::new(scheme);
     let (actor, mailbox, floor) = MarshalActor::<_, TestVariant, _, _, _, _, _>::init(
@@ -426,7 +434,7 @@ where
             provider,
             epocher: FixedEpocher::new(NZU64!(u64::MAX)),
             start: options.floor.map_or_else(
-                || marshal::Start::Genesis(TestBlock::new(0, 0)),
+                || marshal::Start::Genesis(TestBlock::new(0, 0).into()),
                 marshal::Start::Floor,
             ),
             partition_prefix: format!("{prefix}-marshal"),

--- a/glue/src/stateful/tests/fixtures.rs
+++ b/glue/src/stateful/tests/fixtures.rs
@@ -330,7 +330,7 @@ pub(crate) async fn prunable_marshal_fixture(
     .expect("failed to initialize blocks archive");
     if let Some(block) = options.block {
         finalized_blocks = finalized_blocks
-            .put(block.height().get(), block.digest(), block.clone())
+            .put(block.height().get(), block.digest(), block)
             .await
             .expect("failed to seed finalized block")
             .sync()
@@ -371,7 +371,7 @@ async fn marshal_fixture_inner(
     .expect("failed to initialize blocks archive");
     if let Some(block) = options.block {
         finalized_blocks = finalized_blocks
-            .put(block.height().get(), block.digest(), block.clone())
+            .put(block.height().get(), block.digest(), block)
             .await
             .expect("failed to seed finalized block")
             .sync()
@@ -380,7 +380,7 @@ async fn marshal_fixture_inner(
     }
     if let Some((block, finalization)) = options.seed.take() {
         finalizations_by_height = finalizations_by_height
-            .put(block.height().get(), block.digest(), finalization)
+            .put(block.height().get(), block.digest(), &finalization)
             .await
             .expect("failed to seed finalization")
             .sync()

--- a/glue/src/stateful/tests/mod.rs
+++ b/glue/src/stateful/tests/mod.rs
@@ -1201,7 +1201,7 @@ fn out_of_order_certifications_complete_on_qmdb() {
                 marshal::Config {
                     provider,
                     epocher: FixedEpocher::new(EPOCH_LENGTH),
-                    start: marshal::Start::Genesis(genesis.clone()),
+                    start: marshal::Start::Genesis(genesis.clone().into()),
                     partition_prefix: "certify-qmdb-marshal".to_string(),
                     mailbox_size: NZUsize!(8),
                     view_retention: ViewDelta::new(10),
@@ -1333,7 +1333,7 @@ fn stable_leader_finalizations_outpace_slow_qmdb_sync() {
                 marshal::Config {
                     provider,
                     epocher: FixedEpocher::new(EPOCH_LENGTH),
-                    start: marshal::Start::Genesis(genesis.clone()),
+                    start: marshal::Start::Genesis(genesis.clone().into()),
                     partition_prefix: "stable-leader-qmdb-marshal".to_string(),
                     mailbox_size: NZUsize!(64),
                     view_retention: ViewDelta::new(BLOCKS),
@@ -1524,7 +1524,7 @@ fn overlapping_finalizations_complete_on_multi_qmdb() {
                 marshal::Config {
                     provider,
                     epocher: FixedEpocher::new(EPOCH_LENGTH),
-                    start: marshal::Start::Genesis(genesis.clone()),
+                    start: marshal::Start::Genesis(genesis.clone().into()),
                     partition_prefix: "certify-multi-qmdb-marshal".to_string(),
                     mailbox_size: NZUsize!(8),
                     view_retention: ViewDelta::new(10),
@@ -1778,7 +1778,7 @@ fn pruning_quiesces_and_retries_verification_on_real_qmdbs() {
                 marshal::Config {
                     provider,
                     epocher: FixedEpocher::new(EPOCH_LENGTH),
-                    start: marshal::Start::Genesis(genesis.clone()),
+                    start: marshal::Start::Genesis(genesis.clone().into()),
                     partition_prefix: "prune-overlap-multi-qmdb-marshal".to_string(),
                     mailbox_size: NZUsize!(8),
                     view_retention: ViewDelta::new(10),

--- a/glue/src/stateful/tests/multi_db_app.rs
+++ b/glue/src/stateful/tests/multi_db_app.rs
@@ -582,7 +582,7 @@ impl EngineDefinition for MultiDbEngine {
         let marshal_config = marshal::Config {
             provider: provider.clone(),
             epocher: FixedEpocher::new(EPOCH_LENGTH),
-            start: plan.marshal_start(genesis_block.clone()),
+            start: plan.marshal_start(genesis_block.clone().into()),
             partition_prefix: partition_prefix.clone(),
             mailbox_size: NZUsize!(100),
             view_retention: ViewDelta::new(10),

--- a/glue/src/stateful/tests/single_db_app.rs
+++ b/glue/src/stateful/tests/single_db_app.rs
@@ -482,7 +482,7 @@ impl EngineDefinition for SingleDbEngine {
         let marshal_config = marshal::Config {
             provider: provider.clone(),
             epocher: FixedEpocher::new(EPOCH_LENGTH),
-            start: plan.marshal_start(genesis_block.clone()),
+            start: plan.marshal_start(genesis_block.clone().into()),
             partition_prefix: partition_prefix.clone(),
             mailbox_size: NZUsize!(100),
             view_retention: ViewDelta::new(10),

--- a/storage/fuzz/fuzz_targets/archive_immutable_recovery.rs
+++ b/storage/fuzz/fuzz_targets/archive_immutable_recovery.rs
@@ -276,7 +276,7 @@ fn run(input: &FuzzInput, mode: PartialWriteMode) {
                     .expect("initial immutable archive init failed");
             for entry in &phase_floor {
                 archive = archive
-                    .put(entry.index, entry.key.clone(), entry.value.clone())
+                    .put(entry.index, entry.key.clone(), &entry.value)
                     .await
                     .expect("baseline put failed");
             }
@@ -290,7 +290,7 @@ fn run(input: &FuzzInput, mode: PartialWriteMode) {
             .filter(|entry| !phase_floor.iter().any(|floor| floor.index == entry.index))
         {
             archive = match archive
-                .put(entry.index, entry.key.clone(), entry.value.clone())
+                .put(entry.index, entry.key.clone(), &entry.value)
                 .await
             {
                 Ok(archive) => archive,
@@ -339,7 +339,7 @@ fn run(input: &FuzzInput, mode: PartialWriteMode) {
         // consumers.
         let sentinel = entry(&recovery_input, 4, 0xEF);
         archive = archive
-            .put(sentinel.index, sentinel.key.clone(), sentinel.value.clone())
+            .put(sentinel.index, sentinel.key.clone(), &sentinel.value)
             .await
             .expect("post-recovery put failed");
         archive = archive.sync().await.expect("post-recovery sync failed");

--- a/storage/fuzz/fuzz_targets/archive_prunable_operations.rs
+++ b/storage/fuzz/fuzz_targets/archive_prunable_operations.rs
@@ -182,7 +182,7 @@ fn fuzz(data: FuzzInput) {
                     // Put the item into the archive. A put below the prune floor is
                     // satisfied without storing, so the model only records puts at or
                     // above the floor.
-                    archive = archive.put(*index, key, value).await.expect("put failed");
+                    archive = archive.put(*index, key, &value).await.expect("put failed");
                     let below_floor = oldest_allowed.is_some_and(|min| *index < min);
 
                     // Only add if not already written (Archive doesn't allow overwrites)
@@ -208,7 +208,7 @@ fn fuzz(data: FuzzInput) {
                     let value = Value::new(value_data);
 
                     archive = archive
-                        .put_multi(index, key, value)
+                        .put_multi(index, key, &value)
                         .await
                         .expect("put_multi failed");
                     let below_floor = oldest_allowed.is_some_and(|min| index < min);

--- a/storage/fuzz/fuzz_targets/archive_prunable_recovery.rs
+++ b/storage/fuzz/fuzz_targets/archive_prunable_recovery.rs
@@ -493,12 +493,12 @@ fn fuzz(input: FuzzInput) {
                 }
                 archive = if first_phase_input.multi {
                     archive
-                        .put_multi(entry.index, entry.key, entry.value)
+                        .put_multi(entry.index, entry.key, &entry.value)
                         .await
                         .expect("put_multi failed")
                 } else {
                     archive
-                        .put(entry.index, entry.key, entry.value)
+                        .put(entry.index, entry.key, &entry.value)
                         .await
                         .expect("put failed")
                 };
@@ -729,12 +729,12 @@ fn fuzz(input: FuzzInput) {
             }
             archive = if input.multi {
                 archive
-                    .put_multi(entry.index, entry.key.clone(), entry.value.clone())
+                    .put_multi(entry.index, entry.key.clone(), &entry.value)
                     .await
                     .expect("put_multi repair failed")
             } else {
                 archive
-                    .put(entry.index, entry.key.clone(), entry.value.clone())
+                    .put(entry.index, entry.key.clone(), &entry.value)
                     .await
                     .expect("put repair failed")
             };

--- a/storage/fuzz/fuzz_targets/freezer_operations.rs
+++ b/storage/fuzz/fuzz_targets/freezer_operations.rs
@@ -76,7 +76,7 @@ fn fuzz(input: FuzzInput) {
             match op {
                 Op::Put { key, value } => {
                     let k = vec_to_key(&key);
-                    (freezer, _) = freezer.put(k.clone(), value).await.unwrap();
+                    (freezer, _) = freezer.put(k.clone(), &value).await.unwrap();
                     expected_state.insert(k, value);
                 }
                 Op::Get { key } => {

--- a/storage/fuzz/fuzz_targets/freezer_recovery.rs
+++ b/storage/fuzz/fuzz_targets/freezer_recovery.rs
@@ -158,7 +158,7 @@ fn run(input: &FuzzInput, mode: PartialWriteMode) {
                     let key = key_for_slot(round % TABLE_SIZE, 0x30 + round as u8);
                     let value = 300 + round as i32;
                     (freezer, _) = freezer
-                        .put(key.clone(), value)
+                        .put(key.clone(), &value)
                         .await
                         .expect("filler put failed");
                     baseline.push((key, value));
@@ -180,7 +180,7 @@ fn run(input: &FuzzInput, mode: PartialWriteMode) {
                 let key = baseline_key(slot);
                 let value = 100 + slot as i32;
                 (freezer, _) = freezer
-                    .put(key.clone(), value)
+                    .put(key.clone(), &value)
                     .await
                     .expect("baseline put failed");
                 baseline.push((key, value));
@@ -219,7 +219,7 @@ fn run(input: &FuzzInput, mode: PartialWriteMode) {
 
             let candidate_cursors = match phase_input.path {
                 WritePath::Put => {
-                    let updated = freezer.put(baseline_key(0), 900).await;
+                    let updated = freezer.put(baseline_key(0), &900).await;
                     let (freezer, updated_cursor) = match updated {
                         Ok(result) => result,
                         Err(_) => {
@@ -239,7 +239,7 @@ fn run(input: &FuzzInput, mode: PartialWriteMode) {
                             .expect("write faults configured")
                             .failure_rate = Probability::new(1, 1).unwrap();
                     }
-                    let inserted = freezer.put(candidate_key(), 901).await;
+                    let inserted = freezer.put(candidate_key(), &901).await;
                     let (freezer, inserted_cursor) = match inserted {
                         Ok(result) => result,
                         Err(_) => {
@@ -303,7 +303,7 @@ fn run(input: &FuzzInput, mode: PartialWriteMode) {
         let sentinel = sentinel_key();
         let mut expected = baseline;
         (freezer, _) = freezer
-            .put(sentinel.clone(), 999)
+            .put(sentinel.clone(), &999)
             .await
             .expect("post-recovery put failed");
         expected.push((sentinel, 999));

--- a/storage/src/archive/benches/utils.rs
+++ b/storage/src/archive/benches/utils.rs
@@ -110,7 +110,7 @@ impl ArchiveTrait for Archive {
         self,
         index: u64,
         key: Key,
-        value: Val,
+        value: &Val,
     ) -> Result<Self, commonware_storage::archive::Error> {
         match self {
             Self::Immutable(a) => a.put(index, key, value).await.map(Self::Immutable),
@@ -208,7 +208,7 @@ pub async fn append_random(mut archive: Archive, count: u64) -> (Archive, Vec<Ke
 
         let mut val_buf = vec![0u8; VALUE_SIZE];
         rng.fill_bytes(&mut val_buf);
-        archive = archive.put(i, key, val_buf).await.unwrap();
+        archive = archive.put(i, key, &val_buf).await.unwrap();
     }
     archive = archive.sync().await.unwrap();
     (archive, keys)

--- a/storage/src/archive/conformance.rs
+++ b/storage/src/archive/conformance.rs
@@ -53,7 +53,7 @@ impl StorageWorkload for ArchivePrunableWorkload {
             context.fill(&mut key_bytes);
             let key = FixedBytes::<64>::decode(key_bytes.as_ref()).expect("key should decode");
             let value: i32 = context.random();
-            archive = archive.put(i as u64, key, value).await?;
+            archive = archive.put(i as u64, key, &value).await?;
         }
         archive.sync().await?;
         Ok(())
@@ -98,7 +98,7 @@ impl StorageWorkload for ArchiveImmutableWorkload {
             context.fill(&mut key_bytes);
             let key = FixedBytes::<64>::decode(key_bytes.as_ref()).expect("key should decode");
             let value: i32 = context.random();
-            archive = archive.put(i as u64, key, value).await?;
+            archive = archive.put(i as u64, key, &value).await?;
         }
         archive.sync().await?;
         Ok(())

--- a/storage/src/archive/immutable/mod.rs
+++ b/storage/src/archive/immutable/mod.rs
@@ -68,7 +68,7 @@
 //!     let mut archive = Archive::init(context, cfg).await.unwrap();
 //!
 //!     // Put a key
-//!     archive = archive.put(1, Sha256::hash(&[b"data"]), 10).await.unwrap();
+//!     archive = archive.put(1, Sha256::hash(&[b"data"]), &10).await.unwrap();
 //!
 //!     // Sync the archive
 //!     archive.sync().await.unwrap();
@@ -189,8 +189,8 @@ mod tests {
             // Add some data
             let key1 = Sha256::hash(&[b"key1"]);
             let key2 = Sha256::hash(&[b"key2"]);
-            archive = archive.put(1, key1, 2000).await.unwrap();
-            archive = archive.put(2, key2, 2001).await.unwrap();
+            archive = archive.put(1, key1, &2000).await.unwrap();
+            archive = archive.put(2, key2, &2001).await.unwrap();
 
             // Sync archive to save the checkpoint
             let archive = archive.sync().await.unwrap();
@@ -257,7 +257,7 @@ mod tests {
 
             // Write data after restart to confirm archive is functional
             let key = Sha256::hash(&[b"after-restart"]);
-            let archive = archive.put_sync(0, key, 42).await.unwrap();
+            let archive = archive.put_sync(0, key, &42).await.unwrap();
             drop(archive);
 
             // Third init to verify persistence

--- a/storage/src/archive/immutable/storage.rs
+++ b/storage/src/archive/immutable/storage.rs
@@ -234,7 +234,7 @@ impl<E: Context, K: Array, V: CodecShared> Inner<E, K, V> {
 
 impl<E: Context, K: Array, V: CodecShared> Inner<E, K, V> {
     /// See [crate::archive::Archive::put].
-    async fn put(mut self: Box<Self>, index: u64, key: K, data: V) -> Result<Box<Self>, Error> {
+    async fn put(mut self: Box<Self>, index: u64, key: K, data: &V) -> Result<Box<Self>, Error> {
         // Ignore duplicates
         if self.ordinal.has(index) {
             return Ok(self);
@@ -383,7 +383,7 @@ impl<E: Context, K: Array, V: CodecShared> crate::archive::Archive for Archive<E
     type Key = K;
     type Value = V;
 
-    async fn put(mut self, index: u64, key: K, data: V) -> Result<Self, Error> {
+    async fn put(mut self, index: u64, key: K, data: &V) -> Result<Self, Error> {
         self.0 = self.0.put(index, key, data).await?;
         Ok(self)
     }

--- a/storage/src/archive/mod.rs
+++ b/storage/src/archive/mod.rs
@@ -60,7 +60,7 @@ pub trait Archive: Send + Sized {
     type Key: Array;
 
     /// The type of the value.
-    type Value: Codec + Send;
+    type Value: Codec + Send + Sync;
 
     /// Store an item in [Archive].
     ///
@@ -74,7 +74,7 @@ pub trait Archive: Send + Sized {
         self,
         index: u64,
         key: Self::Key,
-        value: Self::Value,
+        value: &Self::Value,
     ) -> impl Future<Output = Result<Self, Error>> + Send;
 
     /// Perform a [Archive::put] and [Archive::sync] in a single operation.
@@ -82,7 +82,7 @@ pub trait Archive: Send + Sized {
         self,
         index: u64,
         key: Self::Key,
-        value: Self::Value,
+        value: &Self::Value,
     ) -> impl Future<Output = Result<Self, Error>> + Send {
         async move { self.put(index, key, value).await?.sync().await }
     }
@@ -96,7 +96,7 @@ pub trait Archive: Send + Sized {
         self,
         index: u64,
         key: Self::Key,
-        value: Self::Value,
+        value: &Self::Value,
     ) -> impl Future<Output = Result<(Self, Handle<()>), Error>> + Send {
         async move { self.put(index, key, value).await?.start_sync().await }
     }
@@ -198,7 +198,7 @@ pub trait MultiArchive: Archive {
         self,
         index: u64,
         key: Self::Key,
-        value: Self::Value,
+        value: &Self::Value,
     ) -> impl Future<Output = Result<Self, Error>> + Send;
 
     /// Perform a [MultiArchive::put_multi] and [Archive::sync] in a single operation.
@@ -206,7 +206,7 @@ pub trait MultiArchive: Archive {
         self,
         index: u64,
         key: Self::Key,
-        value: Self::Value,
+        value: &Self::Value,
     ) -> impl Future<Output = Result<Self, Error>> + Send {
         async move { self.put_multi(index, key, value).await?.sync().await }
     }
@@ -216,7 +216,7 @@ pub trait MultiArchive: Archive {
         self,
         index: u64,
         key: Self::Key,
-        value: Self::Value,
+        value: &Self::Value,
     ) -> impl Future<Output = Result<(Self, Handle<()>), Error>> + Send {
         async move { self.put_multi(index, key, value).await?.start_sync().await }
     }
@@ -317,7 +317,7 @@ mod tests {
 
         // Put the key-data pair
         archive = archive
-            .put(index, key.clone(), data)
+            .put(index, key.clone(), &data)
             .await
             .expect("Failed to put data");
 
@@ -395,13 +395,13 @@ mod tests {
 
         // Put the key-data pair
         archive = archive
-            .put(index, key.clone(), data1)
+            .put(index, key.clone(), &data1)
             .await
             .expect("Failed to put data");
 
         // Put the key-data pair again (should be idempotent)
         archive = archive
-            .put(index, key.clone(), data2)
+            .put(index, key.clone(), &data2)
             .await
             .expect("Duplicate put should not fail");
 
@@ -454,8 +454,8 @@ mod tests {
         // Store the same key at two different indices; distinct values only so
         // the test can observe which entry wins a key lookup.
         let key = test_key("dupe-xindex");
-        archive = archive.put(2, key.clone(), 20).await.expect("put(2)");
-        archive = archive.put(5, key.clone(), 50).await.expect("put(5)");
+        archive = archive.put(2, key.clone(), &20).await.expect("put(2)");
+        archive = archive.put(5, key.clone(), &50).await.expect("put(5)");
 
         // Both indices must resolve individually.
         assert_eq!(
@@ -598,7 +598,7 @@ mod tests {
 
             for (index, key, data) in &keys {
                 archive = archive
-                    .put(*index, key.clone(), *data)
+                    .put(*index, key.clone(), data)
                     .await
                     .expect("Failed to put data");
             }
@@ -696,7 +696,7 @@ mod tests {
                 keys.insert(index, (key.clone(), data));
 
                 archive = archive
-                    .put(index, key, data)
+                    .put(index, key, &data)
                     .await
                     .expect("Failed to put data");
             }
@@ -809,7 +809,7 @@ mod tests {
                 let data: i32 = context.random();
 
                 archive = archive
-                    .put(index, key.clone(), data)
+                    .put(index, key.clone(), &data)
                     .await
                     .expect("Failed to put data");
                 keys.insert(key, (index, data));
@@ -922,15 +922,15 @@ mod tests {
         let key_c = test_key("ccc");
 
         archive = archive
-            .put_multi(index, key_a.clone(), 10)
+            .put_multi(index, key_a.clone(), &10)
             .await
             .expect("put_multi a");
         archive = archive
-            .put_multi(index, key_b.clone(), 20)
+            .put_multi(index, key_b.clone(), &20)
             .await
             .expect("put_multi b");
         archive = archive
-            .put_multi(index, key_c.clone(), 30)
+            .put_multi(index, key_c.clone(), &30)
             .await
             .expect("put_multi c");
 
@@ -971,8 +971,8 @@ mod tests {
         mut archive: impl MultiArchive<Key = FixedBytes<64>, Value = i32>,
     ) {
         let key = test_key("dup");
-        archive = archive.put_multi(5, key.clone(), 10).await.unwrap();
-        archive = archive.put_multi(7, key.clone(), 20).await.unwrap();
+        archive = archive.put_multi(5, key.clone(), &10).await.unwrap();
+        archive = archive.put_multi(7, key.clone(), &20).await.unwrap();
 
         // Duplicate key is allowed across indices.
         assert_eq!(archive.get(Identifier::Index(5)).await.unwrap(), Some(10));
@@ -1001,12 +1001,12 @@ mod tests {
 
     async fn test_get_all_impl(mut archive: impl MultiArchive<Key = FixedBytes<64>, Value = i32>) {
         // Three items at the same index
-        archive = archive.put_multi(5, test_key("aaa"), 10).await.unwrap();
-        archive = archive.put_multi(5, test_key("bbb"), 20).await.unwrap();
-        archive = archive.put_multi(5, test_key("ccc"), 30).await.unwrap();
+        archive = archive.put_multi(5, test_key("aaa"), &10).await.unwrap();
+        archive = archive.put_multi(5, test_key("bbb"), &20).await.unwrap();
+        archive = archive.put_multi(5, test_key("ccc"), &30).await.unwrap();
 
         // One item at a different index
-        archive = archive.put_multi(7, test_key("ddd"), 40).await.unwrap();
+        archive = archive.put_multi(7, test_key("ddd"), &40).await.unwrap();
 
         // get_all returns all values at the index in insertion order
         let all = archive.get_all(5).await.unwrap();
@@ -1038,17 +1038,17 @@ mod tests {
     ) {
         // put_multi two items at the same index
         archive = archive
-            .put_multi(1, test_key("aaa"), 10)
+            .put_multi(1, test_key("aaa"), &10)
             .await
             .expect("put_multi");
         archive = archive
-            .put_multi(1, test_key("bbb"), 20)
+            .put_multi(1, test_key("bbb"), &20)
             .await
             .expect("put_multi");
 
         // Archive::put is a no-op when index already exists
         archive = archive
-            .put(1, test_key("ccc"), 30)
+            .put(1, test_key("ccc"), &30)
             .await
             .expect("Archive::put should no-op");
 
@@ -1109,9 +1109,9 @@ mod tests {
                 compression,
             )
             .await;
-            archive = archive.put_multi(5, test_key("aaa"), 10).await.unwrap();
-            archive = archive.put_multi(5, test_key("bbb"), 20).await.unwrap();
-            archive = archive.put_multi(7, test_key("ccc"), 30).await.unwrap();
+            archive = archive.put_multi(5, test_key("aaa"), &10).await.unwrap();
+            archive = archive.put_multi(5, test_key("bbb"), &20).await.unwrap();
+            archive = archive.put_multi(7, test_key("ccc"), &30).await.unwrap();
             archive.sync().await.unwrap();
         }
 
@@ -1162,17 +1162,17 @@ mod tests {
         mut archive: impl MultiArchive<Key = FixedBytes<64>, Value = i32>,
     ) {
         // Mix Archive::put (single-item) and MultiArchive::put_multi
-        archive = archive.put(1, test_key("single"), 100).await.unwrap();
+        archive = archive.put(1, test_key("single"), &100).await.unwrap();
         archive = archive
-            .put_multi(2, test_key("multi-a"), 200)
+            .put_multi(2, test_key("multi-a"), &200)
             .await
             .unwrap();
         archive = archive
-            .put_multi(2, test_key("multi-b"), 201)
+            .put_multi(2, test_key("multi-b"), &201)
             .await
             .unwrap();
         archive = archive
-            .put_multi(3, test_key("multi-c"), 300)
+            .put_multi(3, test_key("multi-c"), &300)
             .await
             .unwrap();
 
@@ -1245,9 +1245,9 @@ mod tests {
         assert_send(archive.has(Identifier::Key(&key)));
         #[allow(clippy::redundant_clone)]
         match 0u8 {
-            0 => assert_send(archive.put(1, key.clone(), value.clone())),
-            1 => assert_send(archive.put_sync(2, key.clone(), value.clone())),
-            2 => assert_send(archive.put_start_sync(3, key, value)),
+            0 => assert_send(archive.put(1, key.clone(), &value)),
+            1 => assert_send(archive.put_sync(2, key.clone(), &value)),
+            2 => assert_send(archive.put_start_sync(3, key, &value)),
             3 => assert_send(archive.sync()),
             4 => assert_send(archive.start_sync()),
             _ => assert_send(archive.destroy()),
@@ -1266,9 +1266,9 @@ mod tests {
         assert_send(archive.get_all(1));
         #[allow(clippy::redundant_clone)]
         match 0u8 {
-            0 => assert_send(archive.put_multi(1, key.clone(), value.clone())),
-            1 => assert_send(archive.put_multi_sync(2, key.clone(), value.clone())),
-            2 => assert_send(archive.put_multi_start_sync(3, key.clone(), value.clone())),
+            0 => assert_send(archive.put_multi(1, key.clone(), &value)),
+            1 => assert_send(archive.put_multi_sync(2, key.clone(), &value)),
+            2 => assert_send(archive.put_multi_start_sync(3, key.clone(), &value)),
             _ => assert_archive_futures_are_send(archive, key, value),
         }
     }

--- a/storage/src/archive/mod.rs
+++ b/storage/src/archive/mod.rs
@@ -1231,13 +1231,12 @@ mod tests {
 
     // Mutators consume the archive, so each consuming future is constructed in
     // its own match arm (only one arm ever runs, but all are type-checked). Every arm
-    // but the last needs its own key/value, so clippy's per-path analysis flags
+    // but the last needs its own key, so clippy's per-path analysis flags
     // the clones as redundant.
     #[allow(dead_code)]
     fn assert_archive_futures_are_send<T: super::Archive>(archive: T, key: T::Key, value: T::Value)
     where
         T::Key: Clone,
-        T::Value: Clone,
     {
         assert_send(archive.get(Identifier::Index(1)));
         assert_send(archive.get(Identifier::Key(&key)));
@@ -1261,7 +1260,6 @@ mod tests {
         value: T::Value,
     ) where
         T::Key: Clone,
-        T::Value: Clone,
     {
         assert_send(archive.get_all(1));
         #[allow(clippy::redundant_clone)]

--- a/storage/src/archive/mod.rs
+++ b/storage/src/archive/mod.rs
@@ -6,7 +6,7 @@
 //! to be retrieved). The same key may be stored at multiple indices in either case, and a key lookup may
 //! return any of the associated values.
 
-use commonware_codec::Codec;
+use commonware_codec::CodecShared;
 use commonware_runtime::Handle;
 use commonware_utils::Array;
 use std::future::Future;
@@ -60,7 +60,7 @@ pub trait Archive: Send + Sized {
     type Key: Array;
 
     /// The type of the value.
-    type Value: Codec + Send + Sync;
+    type Value: CodecShared;
 
     /// Store an item in [Archive].
     ///

--- a/storage/src/archive/prunable/mod.rs
+++ b/storage/src/archive/prunable/mod.rs
@@ -160,7 +160,7 @@
 //!     let mut archive = Archive::init(context, cfg).await.unwrap();
 //!
 //!     // Put a key
-//!     archive = archive.put(1, Sha256::hash(&[b"data"]), 10).await.unwrap();
+//!     archive = archive.put(1, Sha256::hash(&[b"data"]), &10).await.unwrap();
 //!
 //!     // Sync the archive
 //!     archive.sync().await.unwrap();
@@ -302,7 +302,7 @@ mod tests {
                 .expect("Failed to initialize archive");
 
             let (mut archive, handle) = archive
-                .put_start_sync(1, test_key("aaa"), 10)
+                .put_start_sync(1, test_key("aaa"), &10)
                 .await
                 .expect("Failed to start sync");
             let pending_after_start = pending.lock().len();
@@ -312,7 +312,7 @@ mod tests {
             );
 
             archive = archive
-                .put(2, test_key("bbb"), 20)
+                .put(2, test_key("bbb"), &20)
                 .await
                 .expect("archive should remain usable before sync completion");
             assert_eq!(
@@ -363,13 +363,13 @@ mod tests {
                 .expect("Failed to initialize archive");
 
             let (archive, first) = archive
-                .put_start_sync(1, test_key("aaa"), 10)
+                .put_start_sync(1, test_key("aaa"), &10)
                 .await
                 .expect("Failed to start sync");
             assert_eq!(pending.lock().len(), 2);
 
             let (archive, second) = archive
-                .put_start_sync(1, test_key("duplicate"), 99)
+                .put_start_sync(1, test_key("duplicate"), &99)
                 .await
                 .expect("Failed to start duplicate sync");
             assert_eq!(
@@ -427,7 +427,7 @@ mod tests {
             // section 2.
             let archive = archive.prune(1).await.expect("Failed to set prune floor");
             let archive = archive
-                .put(2, test_key("pending"), 20)
+                .put(2, test_key("pending"), &20)
                 .await
                 .expect("Failed to buffer retained write");
 
@@ -436,7 +436,7 @@ mod tests {
             // value syncs.
             assert!(pending.lock().is_empty());
             let (archive, handle) = archive
-                .put_start_sync(0, test_key("pruned"), 0)
+                .put_start_sync(0, test_key("pruned"), &0)
                 .await
                 .expect("Failed to request sync through below-floor put");
             assert_eq!(
@@ -472,7 +472,7 @@ mod tests {
             // section 2.
             let archive = archive.prune(1).await.expect("Failed to set prune floor");
             let archive = archive
-                .put_multi(2, test_key("pending"), 20)
+                .put_multi(2, test_key("pending"), &20)
                 .await
                 .expect("Failed to buffer retained write");
 
@@ -482,7 +482,7 @@ mod tests {
             let completed = Arc::new(AtomicUsize::new(0));
             let completed_clone = completed.clone();
             let task = context.inner.child("put_multi_sync").spawn(|_| async move {
-                let result = archive.put_multi_sync(0, test_key("pruned"), 0).await;
+                let result = archive.put_multi_sync(0, test_key("pruned"), &0).await;
                 completed_clone.store(1, Ordering::Relaxed);
                 result
             });
@@ -525,7 +525,7 @@ mod tests {
                 .expect("Failed to initialize archive");
 
             let (archive, first) = archive
-                .put_start_sync(1, test_key("aaa"), 10)
+                .put_start_sync(1, test_key("aaa"), &10)
                 .await
                 .expect("Failed to start sync");
             let pending_after_first = pending.lock().len();
@@ -538,7 +538,7 @@ mod tests {
             let waiter = context.inner.child("second").spawn(|_| async move {
                 started_clone.fetch_add(1, Ordering::Relaxed);
                 let (archive, second) = archive
-                    .put_start_sync(2, test_key("bbb"), 20)
+                    .put_start_sync(2, test_key("bbb"), &20)
                     .await
                     .expect("Failed to start second sync");
                 completed_clone.fetch_add(1, Ordering::Relaxed);
@@ -586,7 +586,7 @@ mod tests {
                 .expect("Failed to initialize archive");
 
             let (archive, first) = archive
-                .put_start_sync(1, test_key("aaa"), 10)
+                .put_start_sync(1, test_key("aaa"), &10)
                 .await
                 .expect("Failed to start sync");
             assert!(!pending.lock().is_empty());
@@ -637,7 +637,7 @@ mod tests {
                 .expect("Failed to initialize archive");
 
             let (archive, first) = archive
-                .put_start_sync(1, test_key("aaa"), 10)
+                .put_start_sync(1, test_key("aaa"), &10)
                 .await
                 .expect("Failed to start sync");
             assert!(!pending.lock().is_empty());
@@ -686,7 +686,7 @@ mod tests {
                 .expect("Failed to initialize archive");
 
             let (archive, first) = archive
-                .put_start_sync(1, test_key("aaa"), 10)
+                .put_start_sync(1, test_key("aaa"), &10)
                 .await
                 .expect("Failed to start sync");
             assert!(!pending.lock().is_empty());
@@ -739,7 +739,7 @@ mod tests {
                 .expect("Failed to initialize archive");
 
             let (archive, first) = archive
-                .put_start_sync(1, test_key("aaa"), 10)
+                .put_start_sync(1, test_key("aaa"), &10)
                 .await
                 .expect("Failed to start sync");
             fail_pending_syncs(&pending);
@@ -773,7 +773,7 @@ mod tests {
                 .expect("Failed to initialize archive");
 
             let (archive, first) = archive
-                .put_start_sync(1, test_key("aaa"), 10)
+                .put_start_sync(1, test_key("aaa"), &10)
                 .await
                 .expect("Failed to start sync");
             release_pending_syncs(&pending);
@@ -784,7 +784,7 @@ mod tests {
             // If pruning left section 1 in the retained sync-request set, these calls would trip
             // the journal's prune guard.
             let (archive, second) = archive
-                .put_start_sync(2, test_key("bbb"), 20)
+                .put_start_sync(2, test_key("bbb"), &20)
                 .await
                 .expect("put_start_sync after prune should succeed");
             release_pending_syncs(&pending);
@@ -813,13 +813,13 @@ mod tests {
                 .expect("Failed to initialize archive");
 
             let (archive, first) = archive
-                .put_start_sync(1, test_key("aaa"), 10)
+                .put_start_sync(1, test_key("aaa"), &10)
                 .await
                 .expect("Failed to start first sync");
             assert_eq!(pending.lock().len(), 2);
 
             let (_archive, second) = archive
-                .put_start_sync(2, test_key("bbb"), 20)
+                .put_start_sync(2, test_key("bbb"), &20)
                 .await
                 .expect("Failed to start second sync");
             assert_eq!(
@@ -859,11 +859,11 @@ mod tests {
                 .expect("Failed to initialize archive");
 
             let (archive, first) = archive
-                .put_start_sync(1, test_key("aaa"), 10)
+                .put_start_sync(1, test_key("aaa"), &10)
                 .await
                 .expect("Failed to start first sync");
             let (archive, second) = archive
-                .put_start_sync(2, test_key("bbb"), 20)
+                .put_start_sync(2, test_key("bbb"), &20)
                 .await
                 .expect("Failed to start second sync");
             assert_eq!(pending.lock().len(), 4);
@@ -901,14 +901,14 @@ mod tests {
                 .expect("Failed to initialize archive");
 
             let (archive, first) = archive
-                .put_start_sync(1, test_key("aaa"), 10)
+                .put_start_sync(1, test_key("aaa"), &10)
                 .await
                 .expect("Failed to start sync");
             assert_eq!(pending.lock().len(), 2);
             fail_pending_syncs(&pending);
 
             let archive = archive
-                .put(2, test_key("bbb"), 20)
+                .put(2, test_key("bbb"), &20)
                 .await
                 .expect("write should be accepted before observing the failed sync");
 
@@ -940,7 +940,7 @@ mod tests {
                     .unwrap();
                 for (index, value) in [10, 20, 30].into_iter().enumerate() {
                     archive = archive
-                        .put(index as u64, test_key(&format!("key-{index}")), value)
+                        .put(index as u64, test_key(&format!("key-{index}")), &value)
                         .await
                         .unwrap();
                 }
@@ -1003,7 +1003,7 @@ mod tests {
             let archive = Archive::init(context.child("seed"), cfg.clone())
                 .await
                 .unwrap();
-            let archive = archive.put(0, test_key("zero"), 10).await.unwrap();
+            let archive = archive.put(0, test_key("zero"), &10).await.unwrap();
             let archive = archive.sync().await.unwrap();
             drop(archive);
             context.remove(&cfg.metadata_partition, None).await.unwrap();
@@ -1074,7 +1074,7 @@ mod tests {
 
             // The repaired empty section accepts a fresh write at the reclaimed offsets, and
             // the write survives reopen.
-            let archive = archive.put(0, test_key("new"), 20).await.unwrap();
+            let archive = archive.put(0, test_key("new"), &20).await.unwrap();
             let archive = archive.sync().await.unwrap();
             drop(archive);
             let (_, value_size) = context
@@ -1101,8 +1101,8 @@ mod tests {
             let mut archive = Archive::init(context.child("seed"), cfg.clone())
                 .await
                 .unwrap();
-            archive = archive.put(0, test_key("zero"), 10).await.unwrap();
-            archive = archive.put(1, test_key("one"), 20).await.unwrap();
+            archive = archive.put(0, test_key("zero"), &10).await.unwrap();
+            archive = archive.put(1, test_key("one"), &20).await.unwrap();
             archive = archive.sync().await.unwrap();
             drop(archive);
 
@@ -1132,7 +1132,7 @@ mod tests {
 
             // Append a third value above the marker. Its boundary stays debt, so the third open
             // must validate the suffix and adopt the covered pair into one contiguous range.
-            let archive = archive.put(2, test_key("two"), 30).await.unwrap();
+            let archive = archive.put(2, test_key("two"), &30).await.unwrap();
             let archive = archive.sync().await.unwrap();
             drop(archive);
 
@@ -1157,8 +1157,8 @@ mod tests {
             let archive = Archive::init(context.child("seed"), cfg.clone())
                 .await
                 .unwrap();
-            let archive = archive.put(0, test_key("zero"), 10).await.unwrap();
-            let archive = archive.put(1, test_key("one"), 20).await.unwrap();
+            let archive = archive.put(0, test_key("zero"), &10).await.unwrap();
+            let archive = archive.put(1, test_key("one"), &20).await.unwrap();
 
             // The first sync proves the data durable. The second publishes the resulting marker.
             let archive = archive.sync().await.unwrap();
@@ -1215,7 +1215,7 @@ mod tests {
                 let archive = Archive::init(case.child("seed"), cfg.clone())
                     .await
                     .unwrap();
-                let archive = archive.put_sync(0, test_key("zero"), 10).await.unwrap();
+                let archive = archive.put_sync(0, test_key("zero"), &10).await.unwrap();
                 let archive = archive.sync().await.unwrap();
                 drop(archive);
 
@@ -1351,7 +1351,7 @@ mod tests {
                 Archive::<_, _, FixedBytes<64>, i32>::init(context.child("seed"), cfg.clone())
                     .await
                     .unwrap();
-            let archive = archive.put_sync(0, test_key("zero"), 10).await.unwrap();
+            let archive = archive.put_sync(0, test_key("zero"), &10).await.unwrap();
             let archive = archive.sync().await.unwrap();
             drop(archive);
 
@@ -1421,7 +1421,7 @@ mod tests {
                 .unwrap();
 
             // Publish a marker for one record while its index occupies only part of the first page.
-            let archive = archive.put_sync(0, test_key("zero"), 10).await.unwrap();
+            let archive = archive.put_sync(0, test_key("zero"), &10).await.unwrap();
             let archive = archive.sync().await.unwrap();
 
             // A physical page is the logical page plus a two-slot trailer, where each slot is a
@@ -1457,7 +1457,7 @@ mod tests {
             // Capture Archive's same-page extension, then persist only the prefix through the new
             // slot's length. This is the exact Prefix fault cut: the old slot remains valid while
             // the new slot's checksum retains its prior zero bytes.
-            let archive = archive.put_sync(1, test_key("one"), 20).await.unwrap();
+            let archive = archive.put_sync(1, test_key("one"), &20).await.unwrap();
             drop(archive);
             let (index, size) = context
                 .open(&cfg.key_partition, &0u64.to_be_bytes())
@@ -1568,7 +1568,7 @@ mod tests {
             let archive = Archive::init(context.child("seed"), cfg.clone())
                 .await
                 .unwrap();
-            let archive = archive.put(0, test_key("zero"), 10).await.unwrap();
+            let archive = archive.put(0, test_key("zero"), &10).await.unwrap();
             let archive = archive.sync().await.unwrap();
             drop(archive);
 
@@ -1633,7 +1633,7 @@ mod tests {
             let archive = Archive::init(context.child("seed"), cfg.clone())
                 .await
                 .unwrap();
-            let archive = archive.put(0, test_key("zero"), 10).await.unwrap();
+            let archive = archive.put(0, test_key("zero"), &10).await.unwrap();
             let archive = archive.sync().await.unwrap();
             drop(archive);
 
@@ -1679,14 +1679,14 @@ mod tests {
             // call 1: section 0 data durable, marker absent
             // call 2: section 4 data pending, section 0 marker pending
             let (archive, first) = archive
-                .put_start_sync(0, test_key("zero"), 10)
+                .put_start_sync(0, test_key("zero"), &10)
                 .await
                 .unwrap();
             assert_eq!(pending.lock().len(), 2);
             release_pending_syncs(&pending);
             first.await.unwrap();
 
-            let archive = archive.put(4, test_key("four"), 40).await.unwrap();
+            let archive = archive.put(4, test_key("four"), &40).await.unwrap();
             let (archive, second) = archive.start_sync().await.unwrap();
             assert_eq!(pending.lock().len(), 3);
             release_pending_syncs(&pending);
@@ -1730,7 +1730,7 @@ mod tests {
 
             // Prove section 0's single item durable so its boundary becomes publishable debt.
             let (archive, first) = archive
-                .put_start_sync(0, test_key("zero"), 10)
+                .put_start_sync(0, test_key("zero"), &10)
                 .await
                 .unwrap();
             assert_eq!(pending.lock().len(), 2);
@@ -1738,7 +1738,7 @@ mod tests {
             first.await.unwrap();
 
             // Buffer section 4 and park its blocking sync behind the armed gate.
-            let archive = archive.put(4, test_key("four"), 40).await.unwrap();
+            let archive = archive.put(4, test_key("four"), &40).await.unwrap();
             pending.arm();
             let completed = Arc::new(AtomicUsize::new(0));
             let completed_clone = completed.clone();
@@ -1825,7 +1825,7 @@ mod tests {
                 .await
                 .unwrap();
             let initial_starts = pending.starts();
-            let archive = archive.put_sync(0, test_key("zero"), 10).await.unwrap();
+            let archive = archive.put_sync(0, test_key("zero"), &10).await.unwrap();
 
             // The unblocked wrapper returns immediately-ready data-sync handles while retaining
             // the number of durability operations. The current boundary must still become
@@ -1861,14 +1861,14 @@ mod tests {
 
             // Repeated writes in one active section start only the index and value durability
             // operations. Its marker remains debt until writes move to another section.
-            let archive = archive.put_sync(0, test_key("zero"), 10).await.unwrap();
-            let archive = archive.put_sync(1, test_key("one"), 20).await.unwrap();
+            let archive = archive.put_sync(0, test_key("zero"), &10).await.unwrap();
+            let archive = archive.put_sync(1, test_key("one"), &20).await.unwrap();
             assert_eq!(pending.starts() - initial_starts, 4);
 
             // Moving to section 4 publishes section 0's completed boundary alongside the two data
             // operations for section 4. An explicit empty sync then flushes the final partial
             // section once. Another empty sync has no durability work.
-            let archive = archive.put_sync(4, test_key("four"), 40).await.unwrap();
+            let archive = archive.put_sync(4, test_key("four"), &40).await.unwrap();
             assert_eq!(pending.starts() - initial_starts, 7);
             let archive = archive.sync().await.unwrap();
             assert_eq!(pending.starts() - initial_starts, 8);
@@ -1895,14 +1895,14 @@ mod tests {
 
             // Prove section 0's single item so it owns publishable marker debt.
             let (archive, first) = archive
-                .put_start_sync(0, test_key("zero"), 10)
+                .put_start_sync(0, test_key("zero"), &10)
                 .await
                 .unwrap();
             release_pending_syncs(&pending);
             first.await.unwrap();
 
             // Moving to section 4 starts its data syncs and publishes section 0's boundary.
-            let archive = archive.put(4, test_key("four"), 40).await.unwrap();
+            let archive = archive.put(4, test_key("four"), &40).await.unwrap();
             let (archive, second) = archive.start_sync().await.unwrap();
             assert_eq!(pending.lock().len(), 3);
 
@@ -1920,7 +1920,7 @@ mod tests {
             // its unproven length as a marker would let a crash that keeps the marker but
             // loses the in-flight items make every reopen fail. The two operations started
             // here are section 8's index and value syncs.
-            let archive = archive.put(8, test_key("eight"), 80).await.unwrap();
+            let archive = archive.put(8, test_key("eight"), &80).await.unwrap();
             let before = pending.starts();
             let (archive, third) = archive.start_sync().await.unwrap();
             assert_eq!(pending.starts() - before, 2);
@@ -1961,13 +1961,13 @@ mod tests {
 
             // Three items land in three single-item sections, each through its own blocking
             // sync.
-            let archive = drive_pending_syncs(&pending, archive.put_sync(0, test_key("zero"), 10))
+            let archive = drive_pending_syncs(&pending, archive.put_sync(0, test_key("zero"), &10))
                 .await
                 .unwrap();
-            let archive = drive_pending_syncs(&pending, archive.put_sync(1, test_key("one"), 20))
+            let archive = drive_pending_syncs(&pending, archive.put_sync(1, test_key("one"), &20))
                 .await
                 .unwrap();
-            let archive = drive_pending_syncs(&pending, archive.put_sync(2, test_key("two"), 30))
+            let archive = drive_pending_syncs(&pending, archive.put_sync(2, test_key("two"), &30))
                 .await
                 .unwrap();
             drop(archive);
@@ -2017,7 +2017,7 @@ mod tests {
                 .unwrap();
 
             // Seed one durable item. The two starts are section 0's index and value syncs.
-            let archive = drive_pending_syncs(&pending, archive.put_sync(0, test_key("zero"), 10))
+            let archive = drive_pending_syncs(&pending, archive.put_sync(0, test_key("zero"), &10))
                 .await
                 .unwrap();
             assert_eq!(pending.starts(), 2);
@@ -2060,15 +2060,15 @@ mod tests {
             // Each successful call publishes the preceding section and retains the current one as
             // marker debt. Returning to section 0 must start its new barrier at the retained
             // one-item prefix rather than at zero.
-            let archive = drive_pending_syncs(&pending, archive.put_sync(0, test_key("zero"), 10))
+            let archive = drive_pending_syncs(&pending, archive.put_sync(0, test_key("zero"), &10))
                 .await
                 .unwrap();
             assert_eq!(pending.starts(), 2);
-            let archive = drive_pending_syncs(&pending, archive.put_sync(2, test_key("two"), 30))
+            let archive = drive_pending_syncs(&pending, archive.put_sync(2, test_key("two"), &30))
                 .await
                 .unwrap();
             assert_eq!(pending.starts(), 5);
-            let archive = drive_pending_syncs(&pending, archive.put_sync(1, test_key("one"), 20))
+            let archive = drive_pending_syncs(&pending, archive.put_sync(1, test_key("one"), &20))
                 .await
                 .unwrap();
             assert_eq!(pending.starts(), 8);
@@ -2104,7 +2104,7 @@ mod tests {
             let archive = Archive::init(context.child("seed"), cfg.clone())
                 .await
                 .unwrap();
-            let archive = archive.put_sync(0, test_key("old"), 10).await.unwrap();
+            let archive = archive.put_sync(0, test_key("old"), &10).await.unwrap();
             let archive = archive.sync().await.unwrap();
             let archive = archive.prune(2).await.unwrap();
             drop(archive);
@@ -2125,7 +2125,7 @@ mod tests {
             let archive = Archive::init(delayed.child("reuse"), cfg.clone())
                 .await
                 .unwrap();
-            let archive = archive.put(0, test_key("new"), 20).await.unwrap();
+            let archive = archive.put(0, test_key("new"), &20).await.unwrap();
             let (archive, handle) = archive.start_sync().await.unwrap();
             assert_eq!(pending.lock().len(), 2);
             release_pending_syncs(&pending);
@@ -2167,7 +2167,7 @@ mod tests {
             let key = test_key("testkey");
             let data = 1;
             archive = archive
-                .put(index, key.clone(), data)
+                .put(index, key.clone(), &data)
                 .await
                 .expect("Failed to put data");
 
@@ -2240,13 +2240,13 @@ mod tests {
 
             // Put the key-data pair
             archive = archive
-                .put(index1, key1.clone(), data1)
+                .put(index1, key1.clone(), &data1)
                 .await
                 .expect("Failed to put data");
 
             // Put the key-data pair
             archive = archive
-                .put(index2, key2.clone(), data2)
+                .put(index2, key2.clone(), &data2)
                 .await
                 .expect("Failed to put data");
 
@@ -2306,13 +2306,13 @@ mod tests {
 
             // Put the key-data pair
             archive = archive
-                .put(index1, key1.clone(), data1)
+                .put(index1, key1.clone(), &data1)
                 .await
                 .expect("Failed to put data");
 
             // Put the key-data pair
             archive = archive
-                .put(index2, key2.clone(), data2)
+                .put(index2, key2.clone(), &data2)
                 .await
                 .expect("Failed to put data");
 
@@ -2368,7 +2368,7 @@ mod tests {
 
             for (index, key, data) in &keys {
                 archive = archive
-                    .put(*index, key.clone(), *data)
+                    .put(*index, key.clone(), data)
                     .await
                     .expect("Failed to put data");
             }
@@ -2407,7 +2407,7 @@ mod tests {
 
             // Trigger lazy removal of keys
             archive = archive
-                .put(6, test_key("key2-blfh"), 5)
+                .put(6, test_key("key2-blfh"), &5)
                 .await
                 .expect("Failed to put data");
 
@@ -2419,7 +2419,7 @@ mod tests {
 
             // A put below the prune floor is satisfied without storing
             let archive = archive
-                .put(1, test_key("key1-blah"), 1)
+                .put(1, test_key("key1-blah"), &1)
                 .await
                 .expect("Failed to put below floor");
             assert_eq!(
@@ -2433,12 +2433,12 @@ mod tests {
             // With no earlier pending writes, the below-floor sync combinators complete without
             // storing the pruned item.
             let (archive, handle) = archive
-                .put_start_sync(1, test_key("key1-blah"), 1)
+                .put_start_sync(1, test_key("key1-blah"), &1)
                 .await
                 .expect("Failed to put_start_sync below floor");
             handle.await.expect("handle must resolve");
             let archive = archive
-                .put_sync(2, test_key("key2-blfh"), 2)
+                .put_sync(2, test_key("key2-blfh"), &2)
                 .await
                 .expect("Failed to put_sync below floor");
             assert_eq!(archive.get(Identifier::Index(1)).await.unwrap(), None);
@@ -2484,7 +2484,7 @@ mod tests {
                 let data = FixedBytes::<1024>::decode(data.as_ref()).unwrap();
 
                 archive = archive
-                    .put(index, key.clone(), data.clone())
+                    .put(index, key.clone(), &data)
                     .await
                     .expect("Failed to put data");
                 keys.insert(key, (index, data));
@@ -2646,8 +2646,8 @@ mod tests {
             // to make it observable which entry wins; a real caller would
             // store the same value (e.g. the same block) at both indices.
             let key = test_key("dupe-key");
-            archive = archive.put(2, key.clone(), 20).await.unwrap();
-            archive = archive.put(5, key.clone(), 50).await.unwrap();
+            archive = archive.put(2, key.clone(), &20).await.unwrap();
+            archive = archive.put(5, key.clone(), &50).await.unwrap();
 
             // Before pruning, either entry is a permitted answer per the
             // trait contract. The implementation happens to return the
@@ -2694,9 +2694,9 @@ mod tests {
                 .await
                 .expect("Failed to initialize archive");
 
-            archive = archive.put_multi(1, test_key("aaa"), 10).await.unwrap();
-            archive = archive.put_multi(1, test_key("bbb"), 20).await.unwrap();
-            archive = archive.put_multi(3, test_key("ccc"), 30).await.unwrap();
+            archive = archive.put_multi(1, test_key("aaa"), &10).await.unwrap();
+            archive = archive.put_multi(1, test_key("bbb"), &20).await.unwrap();
+            archive = archive.put_multi(3, test_key("ccc"), &30).await.unwrap();
 
             // Prune below index 3
             let archive = archive.prune(3).await.unwrap();
@@ -2724,7 +2724,7 @@ mod tests {
             assert!(!archive.has_at(1, &test_key("aaaa1")).await.unwrap());
 
             // Exact key at the index
-            archive = archive.put_multi(1, test_key("aaaa1"), 10).await.unwrap();
+            archive = archive.put_multi(1, test_key("aaaa1"), &10).await.unwrap();
             assert!(archive.has_at(1, &test_key("aaaa1")).await.unwrap());
 
             // Same key is not reported at other indices
@@ -2735,14 +2735,14 @@ mod tests {
             assert!(!archive.has_at(1, &test_key("aaaa2")).await.unwrap());
 
             // A second entry at the same index is visible alongside the first
-            archive = archive.put_multi(1, test_key("aaaa2"), 20).await.unwrap();
+            archive = archive.put_multi(1, test_key("aaaa2"), &20).await.unwrap();
             assert!(archive.has_at(1, &test_key("aaaa1")).await.unwrap());
             assert!(archive.has_at(1, &test_key("aaaa2")).await.unwrap());
 
             // A different key at an occupied index is absent
             assert!(!archive.has_at(1, &test_key("bbbb")).await.unwrap());
 
-            archive = archive.put_multi(3, test_key("cccc"), 30).await.unwrap();
+            archive = archive.put_multi(3, test_key("cccc"), &30).await.unwrap();
             archive.sync().await.unwrap();
         });
 
@@ -2781,20 +2781,20 @@ mod tests {
             assert!(!archive.has(Identifier::Key(&key)).await.unwrap());
 
             // Exact key
-            archive = archive.put(1, key.clone(), 10).await.unwrap();
+            archive = archive.put(1, key.clone(), &10).await.unwrap();
             assert!(archive.has(Identifier::Key(&key)).await.unwrap());
 
             // A translated-key collision (FourCap shares the "aaaa" prefix)
             // must not produce a false positive
             let collision = test_key("aaaa2");
             assert!(!archive.has(Identifier::Key(&collision)).await.unwrap());
-            archive = archive.put(2, collision.clone(), 20).await.unwrap();
+            archive = archive.put(2, collision.clone(), &20).await.unwrap();
             assert!(archive.has(Identifier::Key(&collision)).await.unwrap());
 
             // Pruned keys report absent. Pruning is section-granular
             // (items_per_section = 2), so prune at a section boundary that
             // drops indices 1 and 2 while retaining index 4.
-            archive = archive.put(4, test_key("cccc"), 30).await.unwrap();
+            archive = archive.put(4, test_key("cccc"), &30).await.unwrap();
             let archive = archive.prune(4).await.unwrap();
             assert!(!archive.has(Identifier::Key(&key)).await.unwrap());
             assert!(!archive.has(Identifier::Key(&collision)).await.unwrap());
@@ -2831,9 +2831,9 @@ mod tests {
                 .expect("Failed to initialize archive");
 
             // Two items at index 1, one at index 3
-            archive = archive.put_multi(1, test_key("aaa"), 10).await.unwrap();
-            archive = archive.put_multi(1, test_key("bbb"), 20).await.unwrap();
-            archive = archive.put_multi(3, test_key("ccc"), 30).await.unwrap();
+            archive = archive.put_multi(1, test_key("aaa"), &10).await.unwrap();
+            archive = archive.put_multi(1, test_key("bbb"), &20).await.unwrap();
+            archive = archive.put_multi(3, test_key("ccc"), &30).await.unwrap();
 
             let buffer = context.encode();
             assert!(has_metric_value(&buffer, "items_tracked", 2));
@@ -2872,7 +2872,7 @@ mod tests {
 
             // put_multi below the prune floor is satisfied without storing
             let archive = archive
-                .put_multi(2, test_key("ddd"), 40)
+                .put_multi(2, test_key("ddd"), &40)
                 .await
                 .expect("Failed to put below floor");
             assert_eq!(
@@ -2886,7 +2886,7 @@ mod tests {
             // With no earlier pending writes, put_multi_start_sync below the prune floor returns
             // a ready handle without storing the pruned item.
             let (archive, handle) = archive
-                .put_multi_start_sync(2, test_key("ddd"), 41)
+                .put_multi_start_sync(2, test_key("ddd"), &41)
                 .await
                 .expect("Failed to put_multi_start_sync below floor");
             handle.await.expect("handle must resolve");
@@ -2894,7 +2894,7 @@ mod tests {
 
             // put_multi_sync below the prune floor stores nothing.
             let archive = archive
-                .put_multi_sync(2, test_key("ddd"), 42)
+                .put_multi_sync(2, test_key("ddd"), &42)
                 .await
                 .expect("Failed to put_multi_sync below floor");
             assert_eq!(archive.get_all(2).await.expect("Failed to get data"), None);

--- a/storage/src/archive/prunable/storage.rs
+++ b/storage/src/archive/prunable/storage.rs
@@ -351,7 +351,7 @@ impl<T: Translator, E: Context, K: Array, V: CodecShared> Inner<T, E, K, V> {
         mut self: Box<Self>,
         index: u64,
         key: K,
-        data: V,
+        data: &V,
         skip_if_index_exists: bool,
     ) -> Result<Box<Self>, Error> {
         // A put below the prune floor is satisfied without storing
@@ -370,7 +370,7 @@ impl<T: Translator, E: Context, K: Array, V: CodecShared> Inner<T, E, K, V> {
         let section = self.section(index);
         let entry = Record::new(index, key.clone(), 0, 0);
         let position;
-        (self.oversized, position, _, _) = self.oversized.append(section, entry, &data).await?;
+        (self.oversized, position, _, _) = self.oversized.append(section, entry, data).await?;
 
         // Store index location
         match self.indices.entry(index) {
@@ -625,7 +625,7 @@ impl<T: Translator, E: Context, K: Array, V: CodecShared> crate::archive::Archiv
     type Key = K;
     type Value = V;
 
-    async fn put(mut self, index: u64, key: K, data: V) -> Result<Self, Error> {
+    async fn put(mut self, index: u64, key: K, data: &V) -> Result<Self, Error> {
         self.0 = self.0.put_internal(index, key, data, true).await?;
         Ok(self)
     }
@@ -685,7 +685,7 @@ impl<T: Translator, E: Context, K: Array, V: CodecShared> crate::archive::MultiA
         self.0.get_all(index).await
     }
 
-    async fn put_multi(mut self, index: u64, key: K, data: V) -> Result<Self, Error> {
+    async fn put_multi(mut self, index: u64, key: K, data: &V) -> Result<Self, Error> {
         self.0 = self.0.put_internal(index, key, data, false).await?;
         Ok(self)
     }

--- a/storage/src/freezer/benches/utils.rs
+++ b/storage/src/freezer/benches/utils.rs
@@ -78,7 +78,7 @@ pub async fn append_random(mut freezer: FreezerType, count: u64) -> (FreezerType
         let key = Key::new(key_buf);
         keys.push(key.clone());
         rng.fill_bytes(&mut val_buf);
-        (freezer, _) = freezer.put(key, Val::new(val_buf)).await.unwrap();
+        (freezer, _) = freezer.put(key, &Val::new(val_buf)).await.unwrap();
     }
     let (freezer, _) = freezer.sync().await.unwrap();
     (freezer, keys)

--- a/storage/src/freezer/conformance.rs
+++ b/storage/src/freezer/conformance.rs
@@ -48,7 +48,7 @@ impl StorageWorkload for FreezerWorkload {
         for i in 0..64 {
             let mut key = [0u8; 64];
             context.fill(&mut key);
-            (freezer, _) = freezer.put(FixedBytes::new(key), i).await?;
+            (freezer, _) = freezer.put(FixedBytes::new(key), &i).await?;
 
             // Sync periodically to trigger resize chunks
             if i % 8 == 0 {

--- a/storage/src/freezer/mod.rs
+++ b/storage/src/freezer/mod.rs
@@ -197,7 +197,7 @@
 //!
 //!     // Put a key-value pair
 //!     let key = FixedBytes::new([1u8; 32]);
-//!     let (freezer, _cursor) = freezer.put(key.clone(), 42).await.unwrap();
+//!     let (freezer, _cursor) = freezer.put(key.clone(), &42).await.unwrap();
 //!
 //!     // Sync to disk
 //!     let (freezer, _checkpoint) = freezer.sync().await.unwrap();
@@ -354,7 +354,7 @@ mod tests {
 
             // Put the key-data pair
             let (freezer, _) = freezer
-                .put(key.clone(), data)
+                .put(key.clone(), &data)
                 .await
                 .expect("Failed to put data");
 
@@ -419,7 +419,7 @@ mod tests {
 
             // Present key
             let (freezer, _) = freezer
-                .put(key.clone(), 42)
+                .put(key.clone(), &42)
                 .await
                 .expect("Failed to put data");
             assert!(freezer.has(&key).await.expect("Failed to check key"));
@@ -479,7 +479,7 @@ mod tests {
 
             for (key, data) in &keys {
                 (freezer, _) = freezer
-                    .put(key.clone(), *data)
+                    .put(key.clone(), data)
                     .await
                     .expect("Failed to put data");
             }
@@ -539,7 +539,7 @@ mod tests {
 
             for (key, data) in &keys {
                 (freezer, _) = freezer
-                    .put(key.clone(), *data)
+                    .put(key.clone(), data)
                     .await
                     .expect("Failed to put data");
             }
@@ -603,7 +603,7 @@ mod tests {
 
                 for (key, data) in &keys {
                     (freezer, _) = freezer
-                        .put(key.clone(), *data)
+                        .put(key.clone(), data)
                         .await
                         .expect("Failed to put data");
                 }
@@ -671,11 +671,11 @@ mod tests {
                 .expect("Failed to initialize freezer");
 
                 let (freezer, _) = freezer
-                    .put(test_key("committed1"), 1)
+                    .put(test_key("committed1"), &1)
                     .await
                     .expect("Failed to put data");
                 let (freezer, _) = freezer
-                    .put(test_key("committed2"), 2)
+                    .put(test_key("committed2"), &2)
                     .await
                     .expect("Failed to put data");
 
@@ -684,11 +684,11 @@ mod tests {
 
                 // Add more data but don't sync (simulating crash)
                 let (freezer, _) = freezer
-                    .put(test_key("uncommitted1"), 3)
+                    .put(test_key("uncommitted1"), &3)
                     .await
                     .expect("Failed to put data");
                 let (freezer, _) = freezer
-                    .put(test_key("uncommitted2"), 4)
+                    .put(test_key("uncommitted2"), &4)
                     .await
                     .expect("Failed to put data");
 
@@ -773,11 +773,11 @@ mod tests {
                 .expect("Failed to initialize freezer");
 
                 let (freezer, _) = freezer
-                    .put(test_key("destroy1"), 1)
+                    .put(test_key("destroy1"), &1)
                     .await
                     .expect("Failed to put data");
                 let (freezer, _) = freezer
-                    .put(test_key("destroy2"), 2)
+                    .put(test_key("destroy2"), &2)
                     .await
                     .expect("Failed to put data");
 
@@ -844,7 +844,7 @@ mod tests {
                 .await
                 .expect("Failed to initialize freezer");
 
-                let (freezer, _) = freezer.put(test_key("key1"), 42).await.unwrap();
+                let (freezer, _) = freezer.put(test_key("key1"), &42).await.unwrap();
                 let (freezer, _) = freezer.sync().await.unwrap();
                 freezer.close().await.unwrap()
             };
@@ -910,7 +910,7 @@ mod tests {
                 .await
                 .expect("Failed to initialize freezer");
 
-                let (freezer, _) = freezer.put(test_key("key1"), 42).await.unwrap();
+                let (freezer, _) = freezer.put(test_key("key1"), &42).await.unwrap();
                 let (freezer, _) = freezer.sync().await.unwrap();
                 freezer.close().await.unwrap()
             };
@@ -980,7 +980,7 @@ mod tests {
                 .await
                 .expect("Failed to initialize freezer");
 
-                let (freezer, _) = freezer.put(test_key("key1"), 42).await.unwrap();
+                let (freezer, _) = freezer.put(test_key("key1"), &42).await.unwrap();
                 let (freezer, _) = freezer.sync().await.unwrap();
                 freezer.close().await.unwrap()
             };
@@ -1014,7 +1014,7 @@ mod tests {
                 );
 
                 // And write new data
-                let (freezer, _) = freezer.put(test_key("key2"), 43).await.unwrap();
+                let (freezer, _) = freezer.put(test_key("key2"), &43).await.unwrap();
                 assert_eq!(
                     freezer
                         .get(Identifier::Key(&test_key("key2")))
@@ -1060,7 +1060,7 @@ mod tests {
                 keys.push((key.clone(), i));
 
                 // Force sync to ensure resize occurs ASAP
-                (freezer, _) = freezer.put(key, i).await.expect("Failed to put data");
+                (freezer, _) = freezer.put(key, &i).await.expect("Failed to put data");
                 (freezer, _) = freezer.sync().await.expect("Failed to sync");
             }
 
@@ -1131,8 +1131,8 @@ mod tests {
 
             // Insert keys to trigger resize
             // key0 -> entry 0, key2 -> entry 1
-            (freezer, _) = freezer.put(test_key("key0"), 0).await.unwrap();
-            (freezer, _) = freezer.put(test_key("key2"), 1).await.unwrap();
+            (freezer, _) = freezer.put(test_key("key0"), &0).await.unwrap();
+            (freezer, _) = freezer.put(test_key("key2"), &1).await.unwrap();
             (freezer, _) = freezer.sync().await.unwrap(); // should start resize
 
             // Verify resize started
@@ -1140,13 +1140,13 @@ mod tests {
 
             // Insert during resize (to first entry)
             // key6 -> entry 0
-            (freezer, _) = freezer.put(test_key("key6"), 2).await.unwrap();
+            (freezer, _) = freezer.put(test_key("key6"), &2).await.unwrap();
             assert!(context.encode().contains("unnecessary_writes_total 1"));
             assert_eq!(freezer.resizable(), 3);
 
             // Insert another key (to unmodified entry)
             // key3 -> entry 1
-            (freezer, _) = freezer.put(test_key("key3"), 3).await.unwrap();
+            (freezer, _) = freezer.put(test_key("key3"), &3).await.unwrap();
             assert!(context.encode().contains("unnecessary_writes_total 1"));
             assert_eq!(freezer.resizable(), 3);
 
@@ -1157,8 +1157,8 @@ mod tests {
 
             // More inserts
             // key4 -> entry 1, key7 -> entry 0
-            (freezer, _) = freezer.put(test_key("key4"), 4).await.unwrap();
-            (freezer, _) = freezer.put(test_key("key7"), 5).await.unwrap();
+            (freezer, _) = freezer.put(test_key("key4"), &4).await.unwrap();
+            (freezer, _) = freezer.put(test_key("key7"), &5).await.unwrap();
             (freezer, _) = freezer.sync().await.unwrap();
 
             // Another resize should've started
@@ -1215,8 +1215,8 @@ mod tests {
 
                 // Insert keys to trigger resize
                 // key0 -> entry 0, key2 -> entry 1
-                let (freezer, _) = freezer.put(test_key("key0"), 0).await.unwrap();
-                let (freezer, _) = freezer.put(test_key("key2"), 1).await.unwrap();
+                let (freezer, _) = freezer.put(test_key("key0"), &0).await.unwrap();
+                let (freezer, _) = freezer.put(test_key("key2"), &1).await.unwrap();
                 let (freezer, checkpoint) = freezer.sync().await.unwrap();
 
                 // Verify resize started
@@ -1292,7 +1292,7 @@ mod tests {
 
                 // Store the key-value pair
                 (freezer, _) = freezer
-                    .put(key.clone(), value.clone())
+                    .put(key.clone(), &value)
                     .await
                     .expect("Failed to put data");
                 pairs.push((key, value));
@@ -1373,7 +1373,7 @@ mod tests {
                 context.fill_bytes(&mut value);
                 let value = FixedBytes::<256>::new(value);
 
-                (freezer, _) = freezer.put(key, value).await.expect("Failed to put data");
+                (freezer, _) = freezer.put(key, &value).await.expect("Failed to put data");
             }
 
             // Multiple syncs to test epoch progression
@@ -1390,7 +1390,7 @@ mod tests {
                     context.fill_bytes(&mut value);
                     let value = FixedBytes::<256>::new(value);
 
-                    (freezer, _) = freezer.put(key, value).await.expect("Failed to put data");
+                    (freezer, _) = freezer.put(key, &value).await.expect("Failed to put data");
                 }
             }
 
@@ -1442,11 +1442,11 @@ mod tests {
             let key = test_key("key1");
 
             let (freezer, _) = freezer
-                .put(key.clone(), 1)
+                .put(key.clone(), &1)
                 .await
                 .expect("Failed to put data");
             let (freezer, _) = freezer
-                .put(key.clone(), 2)
+                .put(key.clone(), &2)
                 .await
                 .expect("Failed to put data");
             let (freezer, _) = freezer.sync().await.expect("Failed to sync");

--- a/storage/src/freezer/storage.rs
+++ b/storage/src/freezer/storage.rs
@@ -826,7 +826,7 @@ impl<E: Context, K: Array, V: CodecShared> Inner<E, K, V> {
     }
 
     /// See [Freezer::put].
-    async fn put(mut self: Box<Self>, key: K, value: V) -> Result<(Box<Self>, Cursor), Error> {
+    async fn put(mut self: Box<Self>, key: K, value: &V) -> Result<(Box<Self>, Cursor), Error> {
         self.puts.inc();
 
         // Update the section if needed
@@ -849,7 +849,7 @@ impl<E: Context, K: Array, V: CodecShared> Inner<E, K, V> {
         let (position, value_offset, value_size);
         (self.oversized, position, value_offset, value_size) = self
             .oversized
-            .append(self.current_section, key_entry, &value)
+            .append(self.current_section, key_entry, value)
             .await?;
 
         // Update the number of items added to the entry.
@@ -1178,7 +1178,7 @@ impl<E: Context, K: Array, V: CodecShared> Freezer<E, K, V> {
 
     /// Put a key-value pair into the [Freezer].
     /// If the key already exists, the value is updated.
-    pub async fn put(mut self, key: K, value: V) -> Result<(Self, Cursor), Error> {
+    pub async fn put(mut self, key: K, value: &V) -> Result<(Self, Cursor), Error> {
         let cursor;
         (self.0, cursor) = self.0.put(key, value).await?;
         Ok((self, cursor))
@@ -1304,7 +1304,7 @@ mod tests {
     #[allow(dead_code)]
     fn assert_freezer_futures_are_send(freezer: TestFreezer, key: U64) {
         is_send(freezer.get(Identifier::Key(&key)));
-        is_send(freezer.put(key, 0u64));
+        is_send(freezer.put(key, &0u64));
     }
 
     #[allow(dead_code)]
@@ -1339,8 +1339,8 @@ mod tests {
 
             // Insert only 2 keys to different entries. With table_size=4, entries 2 and 3
             // should remain empty.
-            let (freezer, _) = freezer.put(test_key("key0"), 0).await.unwrap();
-            let (freezer, _) = freezer.put(test_key("key2"), 1).await.unwrap();
+            let (freezer, _) = freezer.put(test_key("key0"), &0).await.unwrap();
+            let (freezer, _) = freezer.put(test_key("key2"), &1).await.unwrap();
             freezer.close().await.unwrap();
 
             let (blob, size) = context.open(&cfg.table_partition, b"table").await.unwrap();
@@ -1400,7 +1400,7 @@ mod tests {
                 )
                 .await
                 .unwrap();
-                let (freezer, _) = freezer.put(test_key("key0"), 42).await.unwrap();
+                let (freezer, _) = freezer.put(test_key("key0"), &42).await.unwrap();
                 let (freezer, _) = freezer.sync().await.unwrap();
                 freezer.close().await.unwrap()
             };
@@ -1466,7 +1466,7 @@ mod tests {
                 )
                 .await
                 .unwrap();
-                let (freezer, _) = freezer.put(key.clone(), 42).await.unwrap();
+                let (freezer, _) = freezer.put(key.clone(), &42).await.unwrap();
                 let (freezer, _) = freezer.sync().await.unwrap();
 
                 assert_eq!(freezer.resizing(), Some(1));
@@ -1512,7 +1512,7 @@ mod tests {
                 )
                 .await
                 .unwrap();
-                let (freezer, _) = freezer.put(key.clone(), 42).await.unwrap();
+                let (freezer, _) = freezer.put(key.clone(), &42).await.unwrap();
                 let (freezer, _) = freezer.sync().await.unwrap();
                 assert_eq!(freezer.get(Identifier::Key(&key)).await.unwrap(), Some(42));
             }
@@ -1564,7 +1564,7 @@ mod tests {
                 )
                 .await
                 .unwrap();
-                let (freezer, _) = freezer.put(key.clone(), 42).await.unwrap();
+                let (freezer, _) = freezer.put(key.clone(), &42).await.unwrap();
                 let checkpoint = freezer.close().await.unwrap();
                 assert_eq!(checkpoint.table_size, 2);
             }
@@ -1608,7 +1608,7 @@ mod tests {
                 )
                 .await
                 .unwrap();
-                let (freezer, _) = freezer.put(key.clone(), 42).await.unwrap();
+                let (freezer, _) = freezer.put(key.clone(), &42).await.unwrap();
                 let (freezer, checkpoint) = freezer.sync().await.unwrap();
 
                 assert_eq!(checkpoint.table_size, 4);
@@ -1657,7 +1657,7 @@ mod tests {
                 let (freezer, stale_checkpoint) = freezer.sync().await.unwrap();
                 assert_eq!(stale_checkpoint.table_size, 2);
 
-                let (freezer, _) = freezer.put(key.clone(), 42).await.unwrap();
+                let (freezer, _) = freezer.put(key.clone(), &42).await.unwrap();
                 let (freezer, checkpoint) = freezer.sync().await.unwrap();
                 assert_eq!(checkpoint.table_size, 4);
                 assert_eq!(freezer.resizing(), None);
@@ -1800,8 +1800,8 @@ mod tests {
                 )
                 .await
                 .unwrap();
-                let (freezer, _) = freezer.put(test_key("key0"), 42).await.unwrap();
-                let (freezer, _) = freezer.put(test_key("key1"), 43).await.unwrap();
+                let (freezer, _) = freezer.put(test_key("key0"), &42).await.unwrap();
+                let (freezer, _) = freezer.put(test_key("key1"), &43).await.unwrap();
                 let (freezer, _) = freezer.sync().await.unwrap();
                 freezer.close().await.unwrap()
             };
@@ -1850,7 +1850,7 @@ mod tests {
             );
 
             // The freezer remains usable
-            let (freezer, _) = freezer.put(test_key("key2"), 44).await.unwrap();
+            let (freezer, _) = freezer.put(test_key("key2"), &44).await.unwrap();
             let (freezer, _) = freezer.sync().await.unwrap();
             assert_eq!(
                 freezer
@@ -1892,8 +1892,8 @@ mod tests {
                 )
                 .await
                 .unwrap();
-                let (freezer, _) = freezer.put(test_key("key0"), 42).await.unwrap();
-                let (freezer, _) = freezer.put(test_key("key1"), 43).await.unwrap();
+                let (freezer, _) = freezer.put(test_key("key0"), &42).await.unwrap();
+                let (freezer, _) = freezer.put(test_key("key1"), &43).await.unwrap();
                 let (freezer, _) = freezer.sync().await.unwrap();
                 freezer.close().await.unwrap()
             };


### PR DESCRIPTION
Reduce block and certificate copies during persistence by accepting borrowed values in marshal stores and archive/freezer insertion APIs.

Reuse finalized blocks for application dispatch after their covering archive sync completes, avoiding archive reads and decoding in both marshal variants. Staging is capped at twice `max_pending_acks`, preserves the first stored block at each height, and falls back to the archive on a miss or restart.

Validation: CI passes, including tests for borrowed writes, staged dispatch, duplicate finalizations, capacity, durability, restart recovery, and floor transitions.
