### PR TITLE
[cryptography/curve25519] Reduce SIMD batch verification overhead

### DIFF
--- a/cryptography/curve25519/src/curve.rs
+++ b/cryptography/curve25519/src/curve.rs
@@ -900,7 +900,7 @@ pub trait WithBackend {
 // Scalar multiplication on the Montgomery form of the curve, for X25519.
 pub mod montgomery;
 
-/// Backend bucket kernels for MSM. Signing owns digit recoding and scheduling.
+// Backend bucket kernels for MSM. Signing owns digit recoding and scheduling.
 pub mod msm;
 
 // Now, a module for each backend.

--- a/cryptography/curve25519/src/curve.rs
+++ b/cryptography/curve25519/src/curve.rs
@@ -369,6 +369,14 @@ impl FVec {
 
 /// Abstracts over base field operations.
 pub trait FBackend: Copy {
+    /// Negates the selected lanes and preserves the other lanes' limb representations.
+    ///
+    /// Variable-time, so the mask must be public.
+    #[inline(always)]
+    fn conditional_neg(self, value: FVec, negative: &[bool; LANES]) -> FVec {
+        value.select_lanes(self.neg(value), negative)
+    }
+
     /// a + b.
     fn add(self, a: FVec, b: FVec) -> FVec;
 
@@ -834,9 +842,9 @@ impl GAffineVec {
         }
 
         Self {
-            x: packed.x.select_lanes(backend.neg(packed.x), negative),
+            x: backend.conditional_neg(packed.x, negative),
             y: packed.y,
-            t2d: packed.t2d.select_lanes(backend.neg(packed.t2d), negative),
+            t2d: backend.conditional_neg(packed.t2d, negative),
         }
     }
 }

--- a/cryptography/curve25519/src/curve.rs
+++ b/cryptography/curve25519/src/curve.rs
@@ -1,9 +1,14 @@
 use core::array;
 use subtle::{Choice, ConditionallySelectable};
 
-/// Number of independent field or group elements carried by a vector
+/// Number of independent field or group elements carried by a vector for SIMD operations.
 ///
-/// Backends may process these lanes in smaller native tiles
+/// This targets AVX-512's eight 64-bit lanes, the widest native vector used by these backends.
+/// Backends with narrower registers emulate this lane count by processing smaller native tiles,
+/// such as NEON's two-lane tiles.
+///
+/// A larger logical lane count can increase memory pressure, so operations that do not need
+/// all lanes can use smaller tiles directly.
 pub const LANES: usize = 8;
 
 /// The low 51 bits: what a limb holds once carries have been propagated out of it.

--- a/cryptography/curve25519/src/curve.rs
+++ b/cryptography/curve25519/src/curve.rs
@@ -1,3 +1,4 @@
+use self::msm::Backend as MBackend;
 use core::array;
 use subtle::{Choice, ConditionallySelectable};
 
@@ -879,7 +880,7 @@ pub trait GBackend: FBackend {
 }
 
 /// Abstracts over field and group operations.
-pub trait Backend: FBackend + GBackend + msm::MsmBackend + Send + Sync + 'static {}
+pub trait Backend: FBackend + GBackend + MBackend + Send + Sync + 'static {}
 
 /// A computation which can run over an arbitrary [`Backend`].
 ///

--- a/cryptography/curve25519/src/curve.rs
+++ b/cryptography/curve25519/src/curve.rs
@@ -1,15 +1,9 @@
 use core::array;
 use subtle::{Choice, ConditionallySelectable};
 
-/// How many parallel operations we try and do via SIMD.
+/// Number of independent field or group elements carried by a vector
 ///
-/// This is set to the highest realistic number, targeting AVX-512.
-/// On other backends, this is larger than necessary.
-///
-/// This should not be harmful to performance, because a larger lane count
-/// can be emulated with a smaller lane count.
-/// An exception to this would be if the memory pressure were particularly bad,
-/// but given how small this value is, this shouldn't be an issue.
+/// Backends may process these lanes in smaller native tiles
 pub const LANES: usize = 8;
 
 /// The low 51 bits: what a limb holds once carries have been propagated out of it.
@@ -382,6 +376,15 @@ pub trait FBackend: Copy {
     /// a * a.
     fn square(self, a: FVec) -> FVec {
         self.mul(a, a)
+    }
+
+    /// Squares every lane `k` times, returning `a` unchanged when `k` is zero.
+    #[inline(always)]
+    fn pow2k(self, mut a: FVec, k: u32) -> FVec {
+        for _ in 0..k {
+            a = self.square(a);
+        }
+        a
     }
 
     /// a - b.
@@ -833,14 +836,6 @@ impl GAffineVec {
     }
 }
 
-/// Squares `value` `k` times.
-fn pow2k<B: FBackend>(backend: B, mut value: FVec, k: u32) -> FVec {
-    for _ in 0..k {
-        value = backend.square(value);
-    }
-    value
-}
-
 /// Raises every lane to `2^250 - 1` using the standard addition chain.
 fn pow_2_250_minus_1<B: FBackend>(backend: B, value: FVec) -> FVec {
     let a = backend.square(value);
@@ -849,18 +844,18 @@ fn pow_2_250_minus_1<B: FBackend>(backend: B, value: FVec) -> FVec {
     let c = backend.mul(a, b);
     let d = backend.square(c);
     let e = backend.mul(b, d);
-    let f = backend.mul(pow2k(backend, e, 5), e);
-    let g = backend.mul(pow2k(backend, f, 10), f);
-    let h = backend.mul(pow2k(backend, g, 20), g);
-    let i = backend.mul(pow2k(backend, h, 10), f);
-    let j = backend.mul(pow2k(backend, i, 50), i);
-    let k = backend.mul(pow2k(backend, j, 100), j);
-    backend.mul(pow2k(backend, k, 50), i)
+    let f = backend.mul(backend.pow2k(e, 5), e);
+    let g = backend.mul(backend.pow2k(f, 10), f);
+    let h = backend.mul(backend.pow2k(g, 20), g);
+    let i = backend.mul(backend.pow2k(h, 10), f);
+    let j = backend.mul(backend.pow2k(i, 50), i);
+    let k = backend.mul(backend.pow2k(j, 100), j);
+    backend.mul(backend.pow2k(k, 50), i)
 }
 
 /// Raises every lane to `(p - 5) / 8 = 2^252 - 3` for point decompression.
 fn pow_p58<B: FBackend>(backend: B, value: FVec) -> FVec {
-    backend.mul(value, pow2k(backend, pow_2_250_minus_1(backend, value), 2))
+    backend.mul(value, backend.pow2k(pow_2_250_minus_1(backend, value), 2))
 }
 
 /// Abstracts over group operations.
@@ -876,6 +871,28 @@ pub trait GBackend: FBackend {
     ///
     /// This can be faster than [`Self::g_add`].
     fn g_add_mixed(self, a: GVec, b: GAffineVec) -> GVec;
+
+    /// Adds a signed affine point to each of two extended points
+    ///
+    /// Each result is `a[i] + b[i]` or `a[i] - b[i]` according to `negative[i]`.
+    /// Variable-time, so the signs must be public
+    #[cfg(target_arch = "aarch64")]
+    #[inline(always)]
+    fn g_add_mixed_pair(self, a: [G; 2], b: [GAffine; 2], negative: [bool; 2]) -> [G; 2] {
+        let mut current = [G::IDENTITY; LANES];
+        let mut incoming = [GAffine::IDENTITY; LANES];
+        let mut signs = [false; LANES];
+        current[..2].copy_from_slice(&a);
+        incoming[..2].copy_from_slice(&b);
+        signs[..2].copy_from_slice(&negative);
+        let updated = self
+            .g_add_mixed(
+                GVec::transpose(current),
+                GAffineVec::from_signed_lanes(self, &incoming, &signs),
+            )
+            .untranspose();
+        [updated[0], updated[1]]
+    }
 
     /// Add a point to itself.
     fn g_double(self, a: GVec) -> GVec {

--- a/cryptography/curve25519/src/curve.rs
+++ b/cryptography/curve25519/src/curve.rs
@@ -815,19 +815,6 @@ impl GAffineVec {
         }
     }
 
-    /// Untransposes backend lanes into scalar affine points.
-    #[cfg(any(test, feature = "fuzz", not(target_arch = "aarch64")))]
-    pub fn untranspose(self) -> [GAffine; LANES] {
-        let x = self.x.untranspose();
-        let y = self.y.untranspose();
-        let t2d = self.t2d.untranspose();
-        array::from_fn(|i| GAffine {
-            x: x[i],
-            y: y[i],
-            t2d: t2d[i],
-        })
-    }
-
     /// Packs affine points, negating the selected lanes.
     ///
     /// Variable-time, so the lane signs must be public.
@@ -885,28 +872,6 @@ pub trait GBackend: FBackend {
     /// This can be faster than [`Self::g_add`].
     fn g_add_mixed(self, a: GVec, b: GAffineVec) -> GVec;
 
-    /// Adds a signed affine point to each of two extended points.
-    ///
-    /// Each result is `a[i] + b[i]` or `a[i] - b[i]` according to `negative[i]`.
-    /// Variable-time, so the signs must be public.
-    #[cfg(target_arch = "aarch64")]
-    #[inline(always)]
-    fn g_add_mixed_pair(self, a: [G; 2], b: [GAffine; 2], negative: [bool; 2]) -> [G; 2] {
-        let mut current = [G::IDENTITY; LANES];
-        let mut incoming = [GAffine::IDENTITY; LANES];
-        let mut signs = [false; LANES];
-        current[..2].copy_from_slice(&a);
-        incoming[..2].copy_from_slice(&b);
-        signs[..2].copy_from_slice(&negative);
-        let updated = self
-            .g_add_mixed(
-                GVec::transpose(current),
-                GAffineVec::from_signed_lanes(self, &incoming, &signs),
-            )
-            .untranspose();
-        [updated[0], updated[1]]
-    }
-
     /// Add a point to itself.
     fn g_double(self, a: GVec) -> GVec {
         self.g_add(a, a)
@@ -914,7 +879,7 @@ pub trait GBackend: FBackend {
 }
 
 /// Abstracts over field and group operations.
-pub trait Backend: FBackend + GBackend + Send + Sync + 'static {}
+pub trait Backend: FBackend + GBackend + msm::MsmBackend + Send + Sync + 'static {}
 
 /// A computation which can run over an arbitrary [`Backend`].
 ///
@@ -933,6 +898,9 @@ pub trait WithBackend {
 
 // Scalar multiplication on the Montgomery form of the curve, for X25519.
 pub mod montgomery;
+
+/// Backend bucket kernels for MSM. Signing owns digit recoding and scheduling.
+pub mod msm;
 
 // Now, a module for each backend.
 #[cfg(all(target_arch = "x86_64", any(feature = "std", test)))]

--- a/cryptography/curve25519/src/curve.rs
+++ b/cryptography/curve25519/src/curve.rs
@@ -877,10 +877,10 @@ pub trait GBackend: FBackend {
     /// This can be faster than [`Self::g_add`].
     fn g_add_mixed(self, a: GVec, b: GAffineVec) -> GVec;
 
-    /// Adds a signed affine point to each of two extended points
+    /// Adds a signed affine point to each of two extended points.
     ///
     /// Each result is `a[i] + b[i]` or `a[i] - b[i]` according to `negative[i]`.
-    /// Variable-time, so the signs must be public
+    /// Variable-time, so the signs must be public.
     #[cfg(target_arch = "aarch64")]
     #[inline(always)]
     fn g_add_mixed_pair(self, a: [G; 2], b: [GAffine; 2], negative: [bool; 2]) -> [G; 2] {

--- a/cryptography/curve25519/src/curve/avx512.rs
+++ b/cryptography/curve25519/src/curve/avx512.rs
@@ -471,7 +471,7 @@ impl Backend {
 
 impl super::Backend for Backend {}
 
-impl super::msm::MsmBackend for Backend {}
+impl super::msm::Backend for Backend {}
 
 impl GBackend for Backend {
     #[inline(always)]

--- a/cryptography/curve25519/src/curve/avx512.rs
+++ b/cryptography/curve25519/src/curve/avx512.rs
@@ -255,37 +255,37 @@ impl Backend {
 impl FBackend for Backend {
     #[inline(always)]
     fn add(self, a: FVec, b: FVec) -> FVec {
-        // SAFETY: `Backend` construction checks AVX-512F and AVX-512 IFMA support
+        // SAFETY: `Backend` construction checks AVX-512F and AVX-512 IFMA support.
         unsafe { self.add_field(a, b) }
     }
 
     #[inline(always)]
     fn neg(self, a: FVec) -> FVec {
-        // SAFETY: `Backend` construction checks AVX-512F and AVX-512 IFMA support
+        // SAFETY: `Backend` construction checks AVX-512F and AVX-512 IFMA support.
         unsafe { self.neg_field(a) }
     }
 
     #[inline(always)]
     fn sub(self, a: FVec, b: FVec) -> FVec {
-        // SAFETY: `Backend` construction checks AVX-512F and AVX-512 IFMA support
+        // SAFETY: `Backend` construction checks AVX-512F and AVX-512 IFMA support.
         unsafe { self.sub_field(a, b) }
     }
 
     #[inline(always)]
     fn mul(self, a: FVec, b: FVec) -> FVec {
-        // SAFETY: `Backend` construction checks AVX-512F and AVX-512 IFMA support
+        // SAFETY: `Backend` construction checks AVX-512F and AVX-512 IFMA support.
         unsafe { self.mul_field(a, b) }
     }
 
     #[inline(always)]
     fn pow2k(self, a: FVec, k: u32) -> FVec {
-        // SAFETY: `Backend` construction checks AVX-512F and AVX-512 IFMA support
+        // SAFETY: `Backend` construction checks AVX-512F and AVX-512 IFMA support.
         unsafe { self.pow2k_field(a, k) }
     }
 
     #[inline(always)]
     fn square(self, a: FVec) -> FVec {
-        // SAFETY: `Backend` construction checks AVX-512F and AVX-512 IFMA support
+        // SAFETY: `Backend` construction checks AVX-512F and AVX-512 IFMA support.
         unsafe { self.square_field(a) }
     }
 }
@@ -432,19 +432,19 @@ impl super::Backend for Backend {}
 impl GBackend for Backend {
     #[inline(always)]
     fn g_add(self, p: GVec, q: GVec) -> GVec {
-        // SAFETY: `Backend` construction checks AVX-512F and AVX-512 IFMA support
+        // SAFETY: `Backend` construction checks AVX-512F and AVX-512 IFMA support.
         unsafe { self.add_points(p, q) }
     }
 
     #[inline(always)]
     fn g_add_mixed(self, p: GVec, q: GAffineVec) -> GVec {
-        // SAFETY: `Backend` construction checks AVX-512F and AVX-512 IFMA support
+        // SAFETY: `Backend` construction checks AVX-512F and AVX-512 IFMA support.
         unsafe { self.add_mixed_points(p, q) }
     }
 
     #[inline(always)]
     fn g_double(self, p: GVec) -> GVec {
-        // SAFETY: `Backend` construction checks AVX-512F and AVX-512 IFMA support
+        // SAFETY: `Backend` construction checks AVX-512F and AVX-512 IFMA support.
         unsafe { self.double_points(p) }
     }
 }

--- a/cryptography/curve25519/src/curve/avx512.rs
+++ b/cryptography/curve25519/src/curve/avx512.rs
@@ -471,7 +471,9 @@ impl Backend {
 
 impl super::Backend for Backend {}
 
-impl super::msm::Backend for Backend {}
+impl super::msm::Backend for Backend {
+    const STRIPES: usize = LANES;
+}
 
 impl GBackend for Backend {
     #[inline(always)]

--- a/cryptography/curve25519/src/curve/avx512.rs
+++ b/cryptography/curve25519/src/curve/avx512.rs
@@ -199,9 +199,6 @@ fn sub_raw(a: [__m512i; 5], b: [__m512i; 5]) -> [__m512i; 5] {
     })
 }
 
-// Complete operations carry their own target features so arithmetic stays fused even when
-// generic callers are outlined outside the feature-enabled dispatch function
-
 /// # Correctness
 ///
 /// Every input must satisfy [`FVec`]'s limb bound. That bound keeps raw field arithmetic within

--- a/cryptography/curve25519/src/curve/avx512.rs
+++ b/cryptography/curve25519/src/curve/avx512.rs
@@ -64,12 +64,29 @@ fn store(regs: [__m512i; 5]) -> [[u64; LANES]; 5] {
 /// # Correctness
 ///
 /// `z` must be less than `2^59` per lane so `19*z` fits in `u64`.
+///
+/// The explicit instruction sequence prevents LLVM from recognizing a packed `u64` multiplication
+/// and expanding it into two packed 32-bit multiplications, two shifts, and an addition. These
+/// four AVX-512F instructions preserve the shift-and-add calculation directly.
 #[target_feature(enable = "avx512f")]
 fn mul19(z: __m512i) -> __m512i {
-    _mm512_add_epi64(
-        _mm512_add_epi64(_mm512_slli_epi64(z, 4), _mm512_slli_epi64(z, 1)),
-        z,
-    )
+    let result;
+    // SAFETY: AVX-512F is enabled. The instructions only read their register input, write
+    // their register outputs, preserve flags, and stay within the documented limb bound.
+    unsafe {
+        core::arch::asm!(
+            "vpsllq {times16}, {z}, 4",
+            "vpsllq {doubled}, {z}, 1",
+            "vpaddq {doubled}, {doubled}, {times16}",
+            "vpaddq {result}, {doubled}, {z}",
+            z = in(zmm_reg) z,
+            times16 = out(zmm_reg) _,
+            doubled = out(zmm_reg) _,
+            result = lateout(zmm_reg) result,
+            options(pure, nomem, nostack, preserves_flags),
+        );
+    }
+    result
 }
 
 /// Reduces each radix-`2^51` lane with one parallel carry pass.
@@ -80,12 +97,13 @@ fn mul19(z: __m512i) -> __m512i {
 /// # Correctness
 ///
 /// Inputs must have limbs below `2^63`. Outputs then have limbs below `2^52`.
-#[target_feature(enable = "avx512f")]
+#[target_feature(enable = "avx512f,avx512ifma")]
 fn reduce_regs(l: [__m512i; 5]) -> [__m512i; 5] {
     let mask = _mm512_set1_epi64(MASK_51 as i64);
     let c: [__m512i; 5] = core::array::from_fn(|i| _mm512_srli_epi64(l[i], 51));
+    // Each carry is below 2^12, so IFMA computes the folded carry exactly.
     [
-        _mm512_add_epi64(_mm512_and_si512(l[0], mask), mul19(c[4])),
+        _mm512_madd52lo_epu64(_mm512_and_si512(l[0], mask), c[4], _mm512_set1_epi64(19)),
         _mm512_add_epi64(_mm512_and_si512(l[1], mask), c[0]),
         _mm512_add_epi64(_mm512_and_si512(l[2], mask), c[1]),
         _mm512_add_epi64(_mm512_and_si512(l[3], mask), c[2]),
@@ -204,6 +222,23 @@ fn sub_raw(a: [__m512i; 5], b: [__m512i; 5]) -> [__m512i; 5] {
 /// Every input must satisfy [`FVec`]'s limb bound. That bound keeps raw field arithmetic within
 /// its documented ranges and keeps every IFMA operand below its `2^52` ceiling.
 impl Backend {
+    /// Negates selected lanes with reduced output while preserving every unselected limb.
+    #[target_feature(enable = "avx512f,avx512ifma")]
+    fn conditional_neg_field(self, value: FVec, negative: &[bool; LANES]) -> FVec {
+        let mask = negative
+            .iter()
+            .enumerate()
+            .fold(0u8, |mask, (lane, &select)| mask | ((select as u8) << lane));
+        let value = load(&value.limbs);
+        let zero = [_mm512_setzero_si512(); 5];
+        let negated = reduce_regs(sub_raw(zero, value));
+        FVec {
+            limbs: store(core::array::from_fn(|limb| {
+                _mm512_mask_blend_epi64(mask, value[limb], negated[limb])
+            })),
+        }
+    }
+
     #[target_feature(enable = "avx512f,avx512ifma")]
     fn add_field(self, a: FVec, b: FVec) -> FVec {
         FVec {
@@ -253,6 +288,12 @@ impl Backend {
 }
 
 impl FBackend for Backend {
+    #[inline(always)]
+    fn conditional_neg(self, value: FVec, negative: &[bool; LANES]) -> FVec {
+        // SAFETY: `Backend` construction checks AVX-512F and AVX-512 IFMA support.
+        unsafe { self.conditional_neg_field(value, negative) }
+    }
+
     #[inline(always)]
     fn add(self, a: FVec, b: FVec) -> FVec {
         // SAFETY: `Backend` construction checks AVX-512F and AVX-512 IFMA support.

--- a/cryptography/curve25519/src/curve/avx512.rs
+++ b/cryptography/curve25519/src/curve/avx512.rs
@@ -199,161 +199,195 @@ fn sub_raw(a: [__m512i; 5], b: [__m512i; 5]) -> [__m512i; 5] {
     })
 }
 
+// Complete operations carry their own target features so arithmetic stays fused even when
+// generic callers are outlined outside the feature-enabled dispatch function
+
 /// # Correctness
 ///
 /// Every input must satisfy [`FVec`]'s limb bound. That bound keeps raw field arithmetic within
 /// its documented ranges and keeps every IFMA operand below its `2^52` ceiling.
-impl FBackend for Backend {
-    fn add(self, a: FVec, b: FVec) -> FVec {
-        // SAFETY: `Backend` can only be constructed when AVX-512F and AVX-512 IFMA are available.
-        unsafe {
-            FVec {
-                limbs: store(reduce_regs(add_raw(load(&a.limbs), load(&b.limbs)))),
-            }
+impl Backend {
+    #[target_feature(enable = "avx512f,avx512ifma")]
+    fn add_field(self, a: FVec, b: FVec) -> FVec {
+        FVec {
+            limbs: store(reduce_regs(add_raw(load(&a.limbs), load(&b.limbs)))),
         }
     }
 
-    fn neg(self, a: FVec) -> FVec {
-        // SAFETY: `Backend` can only be constructed when AVX-512F and AVX-512 IFMA are available.
-        unsafe {
-            let zero = [_mm512_setzero_si512(); 5];
-            FVec {
-                limbs: store(reduce_regs(sub_raw(zero, load(&a.limbs)))),
-            }
+    #[target_feature(enable = "avx512f,avx512ifma")]
+    fn neg_field(self, a: FVec) -> FVec {
+        let zero = [_mm512_setzero_si512(); 5];
+        FVec {
+            limbs: store(reduce_regs(sub_raw(zero, load(&a.limbs)))),
         }
     }
 
-    fn sub(self, a: FVec, b: FVec) -> FVec {
-        // SAFETY: `Backend` can only be constructed when AVX-512F and AVX-512 IFMA are available.
-        unsafe {
-            FVec {
-                limbs: store(reduce_regs(sub_raw(load(&a.limbs), load(&b.limbs)))),
-            }
+    #[target_feature(enable = "avx512f,avx512ifma")]
+    fn sub_field(self, a: FVec, b: FVec) -> FVec {
+        FVec {
+            limbs: store(reduce_regs(sub_raw(load(&a.limbs), load(&b.limbs)))),
         }
     }
 
-    fn mul(self, a: FVec, b: FVec) -> FVec {
-        // SAFETY: `Backend` can only be constructed when AVX-512F and AVX-512 IFMA are available.
-        unsafe {
-            FVec {
-                limbs: store(mul_regs(load(&a.limbs), load(&b.limbs))),
-            }
+    #[target_feature(enable = "avx512f,avx512ifma")]
+    fn mul_field(self, a: FVec, b: FVec) -> FVec {
+        FVec {
+            limbs: store(mul_regs(load(&a.limbs), load(&b.limbs))),
         }
     }
 
-    fn square(self, a: FVec) -> FVec {
-        // SAFETY: `Backend` can only be constructed when AVX-512F and AVX-512 IFMA are available.
-        unsafe {
-            FVec {
-                limbs: store(square_regs(load(&a.limbs))),
-            }
+    #[target_feature(enable = "avx512f,avx512ifma")]
+    fn pow2k_field(self, a: FVec, k: u32) -> FVec {
+        let mut value = load(&a.limbs);
+        for _ in 0..k {
+            value = square_regs(value);
+        }
+        FVec {
+            limbs: store(value),
+        }
+    }
+
+    #[target_feature(enable = "avx512f,avx512ifma")]
+    fn square_field(self, a: FVec) -> FVec {
+        FVec {
+            limbs: store(square_regs(load(&a.limbs))),
         }
     }
 }
 
-// These methods need forced inlining: without it, optimized `WithBackend` computations retain a
-// call to each group operation across the target-feature boundary.
-impl GBackend for Backend {
-    /// Fused point addition with every intermediate held in registers.
+impl FBackend for Backend {
+    #[inline(always)]
+    fn add(self, a: FVec, b: FVec) -> FVec {
+        // SAFETY: `Backend` construction checks AVX-512F and AVX-512 IFMA support
+        unsafe { self.add_field(a, b) }
+    }
+
+    #[inline(always)]
+    fn neg(self, a: FVec) -> FVec {
+        // SAFETY: `Backend` construction checks AVX-512F and AVX-512 IFMA support
+        unsafe { self.neg_field(a) }
+    }
+
+    #[inline(always)]
+    fn sub(self, a: FVec, b: FVec) -> FVec {
+        // SAFETY: `Backend` construction checks AVX-512F and AVX-512 IFMA support
+        unsafe { self.sub_field(a, b) }
+    }
+
+    #[inline(always)]
+    fn mul(self, a: FVec, b: FVec) -> FVec {
+        // SAFETY: `Backend` construction checks AVX-512F and AVX-512 IFMA support
+        unsafe { self.mul_field(a, b) }
+    }
+
+    #[inline(always)]
+    fn pow2k(self, a: FVec, k: u32) -> FVec {
+        // SAFETY: `Backend` construction checks AVX-512F and AVX-512 IFMA support
+        unsafe { self.pow2k_field(a, k) }
+    }
+
+    #[inline(always)]
+    fn square(self, a: FVec) -> FVec {
+        // SAFETY: `Backend` construction checks AVX-512F and AVX-512 IFMA support
+        unsafe { self.square_field(a) }
+    }
+}
+
+impl Backend {
+    /// Fused point addition.
     ///
     /// # Correctness
     ///
     /// All input limbs satisfy `FVec`'s bound; every loose intermediate stays below
     /// `reduce_regs`'s `2^63` bound, and every right operand of `sub_raw` is reduced below
     /// `2^52`.
-    #[inline(always)]
-    fn g_add(self, p: GVec, q: GVec) -> GVec {
-        // SAFETY: `Backend` can only be constructed when AVX-512F and AVX-512 IFMA are available.
-        unsafe {
-            let (x1, y1, z1, t1) = (
-                load(&p.x.limbs),
-                load(&p.y.limbs),
-                load(&p.z.limbs),
-                load(&p.t.limbs),
-            );
-            let (x2, y2, z2, t2) = (
-                load(&q.x.limbs),
-                load(&q.y.limbs),
-                load(&q.z.limbs),
-                load(&q.t.limbs),
-            );
-            let two_d = load(&EDWARDS_D2.limbs);
+    #[target_feature(enable = "avx512f,avx512ifma")]
+    fn add_points(self, p: GVec, q: GVec) -> GVec {
+        let (x1, y1, z1, t1) = (
+            load(&p.x.limbs),
+            load(&p.y.limbs),
+            load(&p.z.limbs),
+            load(&p.t.limbs),
+        );
+        let (x2, y2, z2, t2) = (
+            load(&q.x.limbs),
+            load(&q.y.limbs),
+            load(&q.z.limbs),
+            load(&q.t.limbs),
+        );
+        let two_d = load(&EDWARDS_D2.limbs);
 
-            // Unified extended-coordinates addition (Hisil-Wong-Carter-Dawson):
-            //
-            //   A = (Y1 - X1) * (Y2 - X2)        E = B - A        X3 = E*F
-            //   B = (Y1 + X1) * (Y2 + X2)        F = D - C        Y3 = G*H
-            //   C = 2d * T1 * T2                 G = D + C        Z3 = F*G
-            //   D = 2 * Z1 * Z2                  H = B + A        T3 = E*H
-            let a = mul_regs(reduce_regs(sub_raw(y1, x1)), reduce_regs(sub_raw(y2, x2)));
-            let b = mul_regs_loose(reduce_regs(add_raw(y1, x1)), reduce_regs(add_raw(y2, x2)));
-            let c = mul_regs(mul_regs(t1, t2), two_d);
-            let zz = mul_regs_loose(z1, z2);
-            let d = add_raw(zz, zz);
-            let e = reduce_regs(sub_raw(b, a));
-            let f = reduce_regs(sub_raw(d, c));
-            let g = reduce_regs(add_raw(d, c));
-            let h = reduce_regs(add_raw(b, a));
+        // Unified extended-coordinates addition (Hisil-Wong-Carter-Dawson):
+        //
+        //   A = (Y1 - X1) * (Y2 - X2)        E = B - A        X3 = E*F
+        //   B = (Y1 + X1) * (Y2 + X2)        F = D - C        Y3 = G*H
+        //   C = 2d * T1 * T2                 G = D + C        Z3 = F*G
+        //   D = 2 * Z1 * Z2                  H = B + A        T3 = E*H
+        let a = mul_regs(reduce_regs(sub_raw(y1, x1)), reduce_regs(sub_raw(y2, x2)));
+        let b = mul_regs_loose(reduce_regs(add_raw(y1, x1)), reduce_regs(add_raw(y2, x2)));
+        let c = mul_regs(mul_regs(t1, t2), two_d);
+        let zz = mul_regs_loose(z1, z2);
+        let d = add_raw(zz, zz);
+        let e = reduce_regs(sub_raw(b, a));
+        let f = reduce_regs(sub_raw(d, c));
+        let g = reduce_regs(add_raw(d, c));
+        let h = reduce_regs(add_raw(b, a));
 
-            GVec {
-                x: FVec {
-                    limbs: store(mul_regs(e, f)),
-                },
-                y: FVec {
-                    limbs: store(mul_regs(g, h)),
-                },
-                t: FVec {
-                    limbs: store(mul_regs(e, h)),
-                },
-                z: FVec {
-                    limbs: store(mul_regs(f, g)),
-                },
-            }
+        GVec {
+            x: FVec {
+                limbs: store(mul_regs(e, f)),
+            },
+            y: FVec {
+                limbs: store(mul_regs(g, h)),
+            },
+            t: FVec {
+                limbs: store(mul_regs(e, h)),
+            },
+            z: FVec {
+                limbs: store(mul_regs(f, g)),
+            },
         }
     }
 
-    /// Fused mixed point addition with every intermediate held in registers.
+    /// Fused mixed point addition.
     ///
     /// # Correctness
     ///
     /// All input limbs satisfy `FVec`'s bound; every loose intermediate stays below
     /// `reduce_regs`'s `2^63` bound, and every right operand of `sub_raw` is reduced below
     /// `2^52`.
-    #[inline(always)]
-    fn g_add_mixed(self, p: GVec, q: GAffineVec) -> GVec {
-        // SAFETY: `Backend` can only be constructed when AVX-512F and AVX-512 IFMA are available.
-        unsafe {
-            let (x1, y1, z1, t1) = (
-                load(&p.x.limbs),
-                load(&p.y.limbs),
-                load(&p.z.limbs),
-                load(&p.t.limbs),
-            );
-            let (x2, y2, t2d) = (load(&q.x.limbs), load(&q.y.limbs), load(&q.t2d.limbs));
+    #[target_feature(enable = "avx512f,avx512ifma")]
+    fn add_mixed_points(self, p: GVec, q: GAffineVec) -> GVec {
+        let (x1, y1, z1, t1) = (
+            load(&p.x.limbs),
+            load(&p.y.limbs),
+            load(&p.z.limbs),
+            load(&p.t.limbs),
+        );
+        let (x2, y2, t2d) = (load(&q.x.limbs), load(&q.y.limbs), load(&q.t2d.limbs));
 
-            let a = mul_regs(reduce_regs(sub_raw(y1, x1)), reduce_regs(sub_raw(y2, x2)));
-            let b = mul_regs_loose(reduce_regs(add_raw(y1, x1)), reduce_regs(add_raw(y2, x2)));
-            let c = mul_regs(t1, t2d);
-            let d = add_raw(z1, z1);
-            let e = reduce_regs(sub_raw(b, a));
-            let f = reduce_regs(sub_raw(d, c));
-            let g = reduce_regs(add_raw(d, c));
-            let h = reduce_regs(add_raw(b, a));
+        let a = mul_regs(reduce_regs(sub_raw(y1, x1)), reduce_regs(sub_raw(y2, x2)));
+        let b = mul_regs_loose(reduce_regs(add_raw(y1, x1)), reduce_regs(add_raw(y2, x2)));
+        let c = mul_regs(t1, t2d);
+        let d = add_raw(z1, z1);
+        let e = reduce_regs(sub_raw(b, a));
+        let f = reduce_regs(sub_raw(d, c));
+        let g = reduce_regs(add_raw(d, c));
+        let h = reduce_regs(add_raw(b, a));
 
-            GVec {
-                x: FVec {
-                    limbs: store(mul_regs(e, f)),
-                },
-                y: FVec {
-                    limbs: store(mul_regs(g, h)),
-                },
-                t: FVec {
-                    limbs: store(mul_regs(e, h)),
-                },
-                z: FVec {
-                    limbs: store(mul_regs(f, g)),
-                },
-            }
+        GVec {
+            x: FVec {
+                limbs: store(mul_regs(e, f)),
+            },
+            y: FVec {
+                limbs: store(mul_regs(g, h)),
+            },
+            t: FVec {
+                limbs: store(mul_regs(e, h)),
+            },
+            z: FVec {
+                limbs: store(mul_regs(f, g)),
+            },
         }
     }
 
@@ -364,39 +398,56 @@ impl GBackend for Backend {
     /// All input limbs satisfy `FVec`'s bound; every loose intermediate stays below
     /// `reduce_regs`'s `2^63` bound, and every right operand of `sub_raw` is reduced below
     /// `2^52`.
-    #[inline(always)]
-    fn g_double(self, p: GVec) -> GVec {
-        // SAFETY: `Backend` can only be constructed when AVX-512F and AVX-512 IFMA are available.
-        unsafe {
-            let (x, y, z) = (load(&p.x.limbs), load(&p.y.limbs), load(&p.z.limbs));
+    #[target_feature(enable = "avx512f,avx512ifma")]
+    fn double_points(self, p: GVec) -> GVec {
+        let (x, y, z) = (load(&p.x.limbs), load(&p.y.limbs), load(&p.z.limbs));
 
-            let a = square_regs(x);
-            let b = square_regs(y);
-            let c0 = square_regs_loose(z);
-            let c = reduce_regs(add_raw(c0, c0));
-            let xy2 = square_regs_loose(reduce_regs(add_raw(x, y)));
-            let e = reduce_regs(sub_raw(sub_raw(xy2, a), b));
-            let g = reduce_regs(sub_raw(b, a));
-            let f = reduce_regs(sub_raw(g, c));
-            let zero = [_mm512_setzero_si512(); 5];
-            let h = reduce_regs(sub_raw(sub_raw(zero, a), b));
+        let a = square_regs(x);
+        let b = square_regs(y);
+        let c0 = square_regs_loose(z);
+        let c = reduce_regs(add_raw(c0, c0));
+        let xy2 = square_regs_loose(reduce_regs(add_raw(x, y)));
+        let e = reduce_regs(sub_raw(sub_raw(xy2, a), b));
+        let g = reduce_regs(sub_raw(b, a));
+        let f = reduce_regs(sub_raw(g, c));
+        let zero = [_mm512_setzero_si512(); 5];
+        let h = reduce_regs(sub_raw(sub_raw(zero, a), b));
 
-            GVec {
-                x: FVec {
-                    limbs: store(mul_regs(e, f)),
-                },
-                y: FVec {
-                    limbs: store(mul_regs(g, h)),
-                },
-                t: FVec {
-                    limbs: store(mul_regs(e, h)),
-                },
-                z: FVec {
-                    limbs: store(mul_regs(f, g)),
-                },
-            }
+        GVec {
+            x: FVec {
+                limbs: store(mul_regs(e, f)),
+            },
+            y: FVec {
+                limbs: store(mul_regs(g, h)),
+            },
+            t: FVec {
+                limbs: store(mul_regs(e, h)),
+            },
+            z: FVec {
+                limbs: store(mul_regs(f, g)),
+            },
         }
     }
 }
 
 impl super::Backend for Backend {}
+
+impl GBackend for Backend {
+    #[inline(always)]
+    fn g_add(self, p: GVec, q: GVec) -> GVec {
+        // SAFETY: `Backend` construction checks AVX-512F and AVX-512 IFMA support
+        unsafe { self.add_points(p, q) }
+    }
+
+    #[inline(always)]
+    fn g_add_mixed(self, p: GVec, q: GAffineVec) -> GVec {
+        // SAFETY: `Backend` construction checks AVX-512F and AVX-512 IFMA support
+        unsafe { self.add_mixed_points(p, q) }
+    }
+
+    #[inline(always)]
+    fn g_double(self, p: GVec) -> GVec {
+        // SAFETY: `Backend` construction checks AVX-512F and AVX-512 IFMA support
+        unsafe { self.double_points(p) }
+    }
+}

--- a/cryptography/curve25519/src/curve/avx512.rs
+++ b/cryptography/curve25519/src/curve/avx512.rs
@@ -101,6 +101,7 @@ fn mul19(z: __m512i) -> __m512i {
 fn reduce_regs(l: [__m512i; 5]) -> [__m512i; 5] {
     let mask = _mm512_set1_epi64(MASK_51 as i64);
     let c: [__m512i; 5] = core::array::from_fn(|i| _mm512_srli_epi64(l[i], 51));
+
     // Each carry is below 2^12, so IFMA computes the folded carry exactly.
     [
         _mm512_madd52lo_epu64(_mm512_and_si512(l[0], mask), c[4], _mm512_set1_epi64(19)),
@@ -469,6 +470,8 @@ impl Backend {
 }
 
 impl super::Backend for Backend {}
+
+impl super::msm::MsmBackend for Backend {}
 
 impl GBackend for Backend {
     #[inline(always)]

--- a/cryptography/curve25519/src/curve/msm.rs
+++ b/cryptography/curve25519/src/curve/msm.rs
@@ -13,7 +13,7 @@ use alloc::vec::Vec;
 ///
 /// The defaults use one bucket stripe per logical lane and vector point arithmetic. Backends
 /// with narrower physical tiles can override these kernels without changing MSM scheduling.
-pub trait MsmBackend: GBackend {
+pub trait Backend: GBackend {
     /// Independent bucket stripes, indexed by `stripe * nb + abs(digit) - 1`.
     ///
     /// Override [`Self::fill_buckets`] when changing this from [`LANES`]. The default fold
@@ -128,7 +128,7 @@ pub fn fill_buckets<const STRIPES: usize, T>(
 ///
 /// Lanes without a stripe contribute the identity. Untouched top buckets can be skipped
 /// because their identity values leave both running sums unchanged.
-pub fn fold_buckets<B: MsmBackend>(
+pub fn fold_buckets<B: Backend>(
     backend: B,
     result: GVec,
     buckets: &[G],

--- a/cryptography/curve25519/src/curve/msm.rs
+++ b/cryptography/curve25519/src/curve/msm.rs
@@ -13,12 +13,12 @@ use alloc::vec::Vec;
 ///
 /// The defaults use one bucket stripe per logical lane and vector point arithmetic. Backends
 /// with narrower physical tiles can override these kernels without changing MSM scheduling.
-pub trait Backend: GBackend {
+pub trait Backend: GBackend + Send + Sync {
     /// Independent bucket stripes, indexed by `stripe * nb + abs(digit) - 1`.
     ///
-    /// Override [`Self::fill_buckets`] when changing this from [`LANES`]. The default fold
-    /// supports at most [`LANES`] stripes.
-    const STRIPES: usize = LANES;
+    /// Must be nonzero. The default fill requires [`super::LANES`] stripes, and the default fold
+    /// supports at most [`super::LANES`] stripes. Override those methods for other geometries.
+    const STRIPES: usize;
 
     /// Adds the projected points and signed digits to `Self::STRIPES * nb` buckets.
     ///
@@ -46,11 +46,12 @@ pub trait Backend: GBackend {
         );
     }
 
-    /// Returns lanes whose sum weights each bucket by its index plus one, across all stripes.
+    /// Returns the sum of all stripes, weighting each bucket by its index plus one.
     ///
     /// `used <= nb` is the largest nonzero digit magnitude. Buckets above it contribute nothing.
-    fn fold_buckets(self, buckets: &[G], nb: usize, used: usize) -> GVec {
-        fold_buckets(self, GVec::identity(), buckets, nb, used)
+    #[inline(always)]
+    fn fold_buckets(self, buckets: &[G], nb: usize, used: usize) -> G {
+        fold_buckets(self, GVec::identity(), buckets, nb, used).sum_lanes(self)
     }
 
     /// Sums `(window, point)` partials, then Horner-folds the windows with `width` doublings.
@@ -128,7 +129,7 @@ pub fn fill_buckets<const STRIPES: usize, T>(
 ///
 /// Lanes without a stripe contribute the identity. Untouched top buckets can be skipped
 /// because their identity values leave both running sums unchanged.
-pub fn fold_buckets<B: Backend>(
+fn fold_buckets<B: Backend>(
     backend: B,
     result: GVec,
     buckets: &[G],
@@ -184,7 +185,7 @@ fn fold_preserves_every_bucket_weight() {
                             .scalar_mul((0..usize::BITS).rev().map(|bit| used & (1 << bit) != 0));
                         expected = expected.add(weighted);
                     }
-                    let actual = backend.fold_buckets(&buckets, nb, used).sum_lanes(backend);
+                    let actual = backend.fold_buckets(&buckets, nb, used);
                     assert!(
                         actual.add(expected.negate()).is_identity(),
                         "width={width} used={used}"

--- a/cryptography/curve25519/src/curve/msm.rs
+++ b/cryptography/curve25519/src/curve/msm.rs
@@ -31,7 +31,6 @@ pub trait Backend: GBackend {
         terms: &[T],
         term: impl Fn(&T) -> (GAffine, i16),
     ) {
-        const { assert!(Self::STRIPES == LANES) };
         fill_buckets(
             |current, incoming, negative| {
                 self.g_add_mixed(
@@ -136,7 +135,6 @@ pub fn fold_buckets<B: Backend>(
     nb: usize,
     used: usize,
 ) -> GVec {
-    const { assert!(B::STRIPES <= LANES) };
     let mut sum = GVec::identity();
     let mut window_sum = GVec::identity();
     for d in (0..used).rev() {

--- a/cryptography/curve25519/src/curve/msm.rs
+++ b/cryptography/curve25519/src/curve/msm.rs
@@ -1,0 +1,199 @@
+//! Backend bucket arithmetic for variable-time multi-scalar multiplication.
+//!
+//! Backends own the bucket geometry and point arithmetic. Digit recoding, range partitioning,
+//! and scheduling remain independent of that choice.
+
+use super::{G, GAffine, GAffineVec, GBackend, GVec, LANES};
+#[cfg(not(feature = "std"))]
+use alloc::vec;
+#[cfg(all(test, not(feature = "std")))]
+use alloc::vec::Vec;
+
+/// Bucket filling, weighted folding, and window recombination for public scalar digits.
+///
+/// The defaults use one bucket stripe per logical lane and vector point arithmetic. Backends
+/// with narrower physical tiles can override these kernels without changing MSM scheduling.
+pub trait MsmBackend: GBackend {
+    /// Independent bucket stripes, indexed by `stripe * nb + abs(digit) - 1`.
+    ///
+    /// Override [`Self::fill_buckets`] when changing this from [`LANES`]. The default fold
+    /// supports at most [`LANES`] stripes.
+    const STRIPES: usize = LANES;
+
+    /// Adds the projected points and signed digits to `Self::STRIPES * nb` buckets.
+    ///
+    /// Digits must have magnitude at most `nb`. Each wave assigns one term to each stripe,
+    /// so updates within a wave cannot collide.
+    fn fill_buckets<T>(
+        self,
+        buckets: &mut [G],
+        nb: usize,
+        terms: &[T],
+        term: impl Fn(&T) -> (GAffine, i16),
+    ) {
+        fill_buckets(
+            |current, incoming, negative| {
+                self.g_add_mixed(
+                    GVec::transpose(current),
+                    GAffineVec::from_signed_lanes(self, &incoming, &negative),
+                )
+                .untranspose()
+            },
+            buckets,
+            nb,
+            terms,
+            term,
+        );
+    }
+
+    /// Returns lanes whose sum weights each bucket by its index plus one, across all stripes.
+    ///
+    /// `used <= nb` is the largest nonzero digit magnitude. Buckets above it contribute nothing.
+    fn fold_buckets(self, buckets: &[G], nb: usize, used: usize) -> GVec {
+        fold_buckets(self, GVec::identity(), buckets, nb, used)
+    }
+
+    /// Sums `(window, point)` partials, then Horner-folds the windows with `width` doublings.
+    ///
+    /// Window indices must be less than `windows`. Partials are added in their iteration order.
+    fn combine_windows(
+        self,
+        partials: impl IntoIterator<Item = (usize, G)>,
+        windows: usize,
+        width: u32,
+    ) -> G {
+        let mut window_sums = vec![GVec::identity(); windows];
+        for (window, partial) in partials {
+            window_sums[window] = self.g_add(window_sums[window], GVec::splat(partial));
+        }
+        let mut result = GVec::identity();
+        for window in window_sums.iter().rev() {
+            for _ in 0..width {
+                result = self.g_double(result);
+            }
+            result = self.g_add(result, *window);
+        }
+        result.untranspose()[0]
+    }
+}
+
+/// Adds each run in waves of one term per bucket stripe.
+///
+/// Missing or zero-digit lanes use identity inputs and never scatter a result. Entirely
+/// zero waves skip group arithmetic, including the high windows of short coefficients.
+/// Each piece may restart stripe assignment because the fold sums every stripe.
+#[allow(clippy::needless_range_loop)]
+pub fn fill_buckets<const STRIPES: usize, T>(
+    add: impl Fn([G; STRIPES], [GAffine; STRIPES], [bool; STRIPES]) -> [G; STRIPES],
+    buckets: &mut [G],
+    nb: usize,
+    terms: &[T],
+    term: impl Fn(&T) -> (GAffine, i16),
+) {
+    let identity_point = GAffine::IDENTITY;
+    for wave in terms.chunks(STRIPES) {
+        let mut incoming = [identity_point; STRIPES];
+        let mut negative = [false; STRIPES];
+        let mut current = [G::IDENTITY; STRIPES];
+        let mut bucket_index = [None::<usize>; STRIPES];
+        let mut any = false;
+        for (lane, item) in wave.iter().enumerate() {
+            let (point, digit) = term(item);
+            if digit > 0 {
+                bucket_index[lane] = Some(digit as usize - 1);
+                incoming[lane] = point;
+            } else if digit < 0 {
+                bucket_index[lane] = Some(digit.unsigned_abs() as usize - 1);
+                incoming[lane] = point;
+                negative[lane] = true;
+            }
+            if let Some(i) = bucket_index[lane] {
+                current[lane] = buckets[lane * nb + i];
+                any = true;
+            }
+        }
+        if !any {
+            continue;
+        }
+        let updated = add(current, incoming, negative);
+        for lane in 0..STRIPES {
+            if let Some(i) = bucket_index[lane] {
+                buckets[lane * nb + i] = updated[lane];
+            }
+        }
+    }
+}
+
+/// Folds each bucket stripe into its corresponding result lane with a running sum.
+///
+/// Lanes without a stripe contribute the identity. Untouched top buckets can be skipped
+/// because their identity values leave both running sums unchanged.
+pub fn fold_buckets<B: MsmBackend>(
+    backend: B,
+    result: GVec,
+    buckets: &[G],
+    nb: usize,
+    used: usize,
+) -> GVec {
+    let mut sum = GVec::identity();
+    let mut window_sum = GVec::identity();
+    for d in (0..used).rev() {
+        let bucket_group: [G; LANES] = core::array::from_fn(|lane| {
+            if lane < B::STRIPES {
+                buckets[lane * nb + d]
+            } else {
+                G::IDENTITY
+            }
+        });
+        sum = backend.g_add(sum, GVec::transpose(bucket_group));
+        window_sum = backend.g_add(window_sum, sum);
+    }
+    backend.g_add(result, window_sum)
+}
+
+#[cfg(test)]
+#[test]
+fn fold_preserves_every_bucket_weight() {
+    struct Check;
+    impl crate::curve::WithBackend for Check {
+        type Output = ();
+        fn call<B: crate::curve::Backend>(self, backend: B) {
+            let base = GAffine::BASEPOINT.to_extended();
+            let torsion = GAffine::decompress(&[0; 32]).unwrap().to_extended();
+            for width in [6, 7, 8, 9, 10] {
+                let nb = 1usize << (width - 1);
+                let mut point = base;
+                let buckets: Vec<G> = (0..B::STRIPES * nb)
+                    .map(|i| {
+                        point = point.add(base);
+                        match i % 7 {
+                            0 => torsion,
+                            1 => point.add(torsion),
+                            2 => point.negate(),
+                            3 => G::IDENTITY,
+                            _ => point,
+                        }
+                    })
+                    .collect();
+                let mut expected = G::IDENTITY;
+                for used in 0..=nb {
+                    if used != 0 {
+                        let bucket = (0..B::STRIPES).fold(G::IDENTITY, |sum, stripe| {
+                            sum.add(buckets[stripe * nb + used - 1])
+                        });
+                        let weighted = bucket
+                            .scalar_mul((0..usize::BITS).rev().map(|bit| used & (1 << bit) != 0));
+                        expected = expected.add(weighted);
+                    }
+                    let actual = backend.fold_buckets(&buckets, nb, used).sum_lanes(backend);
+                    assert!(
+                        actual.add(expected.negate()).is_identity(),
+                        "width={width} used={used}"
+                    );
+                }
+            }
+        }
+    }
+    crate::curve::WithBackend::call(Check, crate::curve::test_backend());
+    crate::curve::with_backend(Check);
+}

--- a/cryptography/curve25519/src/curve/msm.rs
+++ b/cryptography/curve25519/src/curve/msm.rs
@@ -31,6 +31,7 @@ pub trait Backend: GBackend {
         terms: &[T],
         term: impl Fn(&T) -> (GAffine, i16),
     ) {
+        const { assert!(Self::STRIPES == LANES) };
         fill_buckets(
             |current, incoming, negative| {
                 self.g_add_mixed(
@@ -135,6 +136,7 @@ pub fn fold_buckets<B: Backend>(
     nb: usize,
     used: usize,
 ) -> GVec {
+    const { assert!(B::STRIPES <= LANES) };
     let mut sum = GVec::identity();
     let mut window_sum = GVec::identity();
     for d in (0..used).rev() {
@@ -151,7 +153,6 @@ pub fn fold_buckets<B: Backend>(
     backend.g_add(result, window_sum)
 }
 
-#[cfg(test)]
 #[test]
 fn fold_preserves_every_bucket_weight() {
     struct Check;

--- a/cryptography/curve25519/src/curve/neon.rs
+++ b/cryptography/curve25519/src/curve/neon.rs
@@ -716,32 +716,18 @@ fn g_add_mixed_pair(p: [G; 2], q: [GAffine; 2], negative: [bool; 2]) -> [G; 2] {
     })
 }
 
-impl msm::Backend for Backend {
-    // One stripe per physical mixed-addition lane keeps wave updates independent. Folds retain
-    // LANES independent bucket indices.
-    const STRIPES: usize = WIDTH;
-
-    fn fill_buckets<T>(
-        self,
-        buckets: &mut [G],
-        nb: usize,
-        terms: &[T],
-        term: impl Fn(&T) -> (GAffine, i16),
-    ) {
-        msm::fill_buckets(g_add_mixed_pair, buckets, nb, terms, term);
-    }
-
+impl Backend {
     /// Returns lanes whose sum is the weighted sum of all bucket stripes.
     ///
     /// Let `B[k, lane]` sum the stripes at bucket index `k*LANES + lane`. The descending pass
     /// builds `sum[lane] = sum_k B[k, lane]` and `rows[lane] = sum_k k*B[k, lane]`.
     /// Final weighting gives `LANES*rows[lane] + (lane + 1)*sum[lane]`, assigning each bucket
     /// its index-plus-one weight. The lane count is a power of two.
-    fn fold_buckets(self, buckets: &[G], nb: usize, used: usize) -> GVec {
+    fn fold_buckets_lanes(self, buckets: &[G], nb: usize, used: usize) -> GVec {
         // A single used bucket has weight one, so return the stripes without weighting.
         if used == 1 {
             return GVec::transpose(core::array::from_fn(|lane| {
-                if lane < Self::STRIPES {
+                if lane < <Self as msm::Backend>::STRIPES {
                     buckets[lane * nb]
                 } else {
                     G::IDENTITY
@@ -762,7 +748,7 @@ impl msm::Backend for Backend {
                 }))
             };
             let mut combined = gather(0);
-            for stripe in 1..Self::STRIPES {
+            for stripe in 1..<Self as msm::Backend>::STRIPES {
                 combined = self.g_add(combined, gather(stripe));
             }
             rows = self.g_add(rows, sum);
@@ -793,6 +779,27 @@ impl msm::Backend for Backend {
             weighted = self.g_add(weighted, GVec::transpose(selected));
         }
         weighted
+    }
+}
+
+impl msm::Backend for Backend {
+    // One stripe per physical mixed-addition lane keeps wave updates independent. Folds retain
+    // LANES independent bucket indices.
+    const STRIPES: usize = WIDTH;
+
+    fn fill_buckets<T>(
+        self,
+        buckets: &mut [G],
+        nb: usize,
+        terms: &[T],
+        term: impl Fn(&T) -> (GAffine, i16),
+    ) {
+        msm::fill_buckets(g_add_mixed_pair, buckets, nb, terms, term);
+    }
+
+    #[inline(always)]
+    fn fold_buckets(self, buckets: &[G], nb: usize, used: usize) -> G {
+        self.fold_buckets_lanes(buckets, nb, used).sum_lanes(self)
     }
 
     /// Scalar recombination computes each point once, avoiding duplicate SIMD lanes.

--- a/cryptography/curve25519/src/curve/neon.rs
+++ b/cryptography/curve25519/src/curve/neon.rs
@@ -795,7 +795,7 @@ impl msm::Backend for Backend {
         weighted
     }
 
-    // Scalar recombination computes each point once, avoiding duplicate SIMD lanes.
+    /// Scalar recombination computes each point once, avoiding duplicate SIMD lanes.
     fn combine_windows(
         self,
         partials: impl IntoIterator<Item = (usize, G)>,

--- a/cryptography/curve25519/src/curve/neon.rs
+++ b/cryptography/curve25519/src/curve/neon.rs
@@ -8,8 +8,12 @@
 //! formulas keep their compact five-limb representation.
 
 use super::{
-    BIAS_16P as SUB_BIAS, F, FBackend, FVec, G, GAffine, GAffineVec, GBackend, GVec, LANES, MASK_51,
+    BIAS_16P as SUB_BIAS, F, FBackend, FVec, G, GAffine, GAffineVec, GBackend, GVec, LANES,
+    MASK_51,
+    msm::{self, MsmBackend},
 };
+#[cfg(not(feature = "std"))]
+use alloc::vec;
 use core::arch::aarch64::*;
 
 /// `2d` in every lane, for the `C = 2d*T1*T2` term of point addition.
@@ -559,7 +563,7 @@ fn unpack_pair(regs: Regs) -> [F; 2] {
 
 /// Applies the complete mixed-addition formula to two independent register lanes.
 ///
-/// Extended inputs and outputs use `[x, y, t, z]`; affine inputs use `[x, y, t2d]`.
+/// Extended inputs and outputs use `[x, y, t, z]`. Affine inputs use `[x, y, t2d]`.
 #[inline(always)]
 fn add_mixed_regs(p: [Regs; 4], q: [Regs; 3]) -> [Regs; 4] {
     let [x1, y1, t1, z1] = p;
@@ -641,43 +645,6 @@ impl GBackend for Backend {
         p
     }
 
-    #[inline(always)]
-    fn g_add_mixed_pair(self, p: [G; 2], q: [GAffine; 2], negative: [bool; 2]) -> [G; 2] {
-        let mut x2 = pack_pair(q.map(|point| point.x));
-        let mut t2d = pack_pair(q.map(|point| point.t2d));
-        if negative.iter().any(|&sign| sign) {
-            // SAFETY: AArch64 targets provide NEON, and the mask array has two complete lanes.
-            unsafe {
-                let masks = negative.map(|sign| 0u64.wrapping_sub(u64::from(sign)));
-                let mask = vld1q_u64(masks.as_ptr());
-                let zero = [vdupq_n_u64(0); 5];
-                let neg_x = reduce_regs(sub_raw(zero, x2));
-                let neg_t2d = reduce_regs(sub_raw(zero, t2d));
-                x2 = core::array::from_fn(|i| vbslq_u64(mask, neg_x[i], x2[i]));
-                t2d = core::array::from_fn(|i| vbslq_u64(mask, neg_t2d[i], t2d[i]));
-            }
-        }
-        let [x, y, t, z] = add_mixed_regs(
-            [
-                pack_pair(p.map(|point| point.x)),
-                pack_pair(p.map(|point| point.y)),
-                pack_pair(p.map(|point| point.t)),
-                pack_pair(p.map(|point| point.z)),
-            ],
-            [x2, pack_pair(q.map(|point| point.y)), t2d],
-        );
-        let x = unpack_pair(x);
-        let y = unpack_pair(y);
-        let t = unpack_pair(t);
-        let z = unpack_pair(z);
-        core::array::from_fn(|i| G {
-            x: x[i],
-            y: y[i],
-            t: t[i],
-            z: z[i],
-        })
-    }
-
     /// Fused point doubling using the dedicated `dbl-2008-hwcd` formula.
     #[inline(always)]
     fn g_double(self, mut p: GVec) -> GVec {
@@ -708,3 +675,225 @@ impl GBackend for Backend {
 }
 
 impl super::Backend for Backend {}
+
+/// Adds a signed affine point to each of two extended points.
+///
+/// Each result is `p[i] + q[i]` or `p[i] - q[i]` according to `negative[i]`.
+/// Variable-time, so the signs must be public.
+#[inline(always)]
+fn g_add_mixed_pair(p: [G; 2], q: [GAffine; 2], negative: [bool; 2]) -> [G; 2] {
+    let mut x2 = pack_pair(q.map(|point| point.x));
+    let mut t2d = pack_pair(q.map(|point| point.t2d));
+    if negative.iter().any(|&sign| sign) {
+        // SAFETY: AArch64 targets provide NEON, and the mask array has two complete lanes.
+        unsafe {
+            let masks = negative.map(|sign| 0u64.wrapping_sub(u64::from(sign)));
+            let mask = vld1q_u64(masks.as_ptr());
+            let zero = [vdupq_n_u64(0); 5];
+            let neg_x = reduce_regs(sub_raw(zero, x2));
+            let neg_t2d = reduce_regs(sub_raw(zero, t2d));
+            x2 = core::array::from_fn(|i| vbslq_u64(mask, neg_x[i], x2[i]));
+            t2d = core::array::from_fn(|i| vbslq_u64(mask, neg_t2d[i], t2d[i]));
+        }
+    }
+    let [x, y, t, z] = add_mixed_regs(
+        [
+            pack_pair(p.map(|point| point.x)),
+            pack_pair(p.map(|point| point.y)),
+            pack_pair(p.map(|point| point.t)),
+            pack_pair(p.map(|point| point.z)),
+        ],
+        [x2, pack_pair(q.map(|point| point.y)), t2d],
+    );
+    let x = unpack_pair(x);
+    let y = unpack_pair(y);
+    let t = unpack_pair(t);
+    let z = unpack_pair(z);
+    core::array::from_fn(|i| G {
+        x: x[i],
+        y: y[i],
+        t: t[i],
+        z: z[i],
+    })
+}
+
+impl MsmBackend for Backend {
+    // One stripe per physical mixed-addition lane keeps wave updates independent. Folds retain
+    // LANES independent bucket indices.
+    const STRIPES: usize = WIDTH;
+
+    fn fill_buckets<T>(
+        self,
+        buckets: &mut [G],
+        nb: usize,
+        terms: &[T],
+        term: impl Fn(&T) -> (GAffine, i16),
+    ) {
+        msm::fill_buckets(g_add_mixed_pair, buckets, nb, terms, term);
+    }
+
+    /// Returns lanes whose sum is the weighted sum of all bucket stripes.
+    ///
+    /// Let `B[k, lane]` sum the stripes at bucket index `k*LANES + lane`. The descending pass
+    /// builds `sum[lane] = sum_k B[k, lane]` and `rows[lane] = sum_k k*B[k, lane]`.
+    /// Final weighting gives `LANES*rows[lane] + (lane + 1)*sum[lane]`, assigning each bucket
+    /// its index-plus-one weight. The lane count is a power of two.
+    fn fold_buckets(self, buckets: &[G], nb: usize, used: usize) -> GVec {
+        // A single used bucket has weight one, so return the stripes without weighting.
+        if used == 1 {
+            return GVec::transpose(core::array::from_fn(|lane| {
+                if lane < Self::STRIPES {
+                    buckets[lane * nb]
+                } else {
+                    G::IDENTITY
+                }
+            }));
+        }
+        let mut sum = GVec::identity();
+        let mut rows = GVec::identity();
+        for block in (0..used.div_ceil(LANES)).rev() {
+            let gather = |stripe: usize| {
+                GVec::transpose(core::array::from_fn(|lane| {
+                    let digit = block * LANES + lane;
+                    if digit < used {
+                        buckets[stripe * nb + digit]
+                    } else {
+                        G::IDENTITY
+                    }
+                }))
+            };
+            let mut combined = gather(0);
+            for stripe in 1..Self::STRIPES {
+                combined = self.g_add(combined, gather(stripe));
+            }
+            rows = self.g_add(rows, sum);
+            sum = self.g_add(sum, combined);
+        }
+
+        // Seed the row weight and the high bit of lane + 1. Doubling shifts both together.
+        let lanes = sum.untranspose();
+        let mut weighted = self.g_add(
+            rows,
+            GVec::transpose(core::array::from_fn(|lane| {
+                if lane == LANES - 1 {
+                    lanes[lane]
+                } else {
+                    G::IDENTITY
+                }
+            })),
+        );
+        for bit in (0..LANES.ilog2()).rev() {
+            weighted = self.g_double(weighted);
+            let selected = core::array::from_fn(|lane| {
+                if (lane + 1) & (1 << bit) != 0 {
+                    lanes[lane]
+                } else {
+                    G::IDENTITY
+                }
+            });
+            weighted = self.g_add(weighted, GVec::transpose(selected));
+        }
+        weighted
+    }
+
+    // Scalar recombination computes each point once, avoiding duplicate SIMD lanes.
+    fn combine_windows(
+        self,
+        partials: impl IntoIterator<Item = (usize, G)>,
+        windows: usize,
+        width: u32,
+    ) -> G {
+        let mut window_sums = vec![G::IDENTITY; windows];
+        for (window, partial) in partials {
+            window_sums[window] = window_sums[window].add(partial);
+        }
+        let mut result = G::IDENTITY;
+        for window in window_sums.iter().rev() {
+            for _ in 0..width {
+                result = result.double();
+            }
+            result = result.add(*window);
+        }
+        result
+    }
+}
+
+#[cfg(test)]
+#[test]
+fn mixed_pair_matches_full_width() {
+    let reference = super::portable::Backend::new();
+    let torsion = GAffine::decompress(&[0; 32]).unwrap();
+    let mixed = GAffine::decompress(
+        &GAffine::BASEPOINT
+            .to_extended()
+            .add(torsion.to_extended())
+            .to_bytes(),
+    )
+    .unwrap();
+    let points = [GAffine::IDENTITY, GAffine::BASEPOINT, torsion, mixed];
+    let max = F([(1 << 52) - 1; 5]);
+    let loose = G {
+        x: max,
+        y: max,
+        t: max,
+        z: max,
+    };
+    let loose_affine = GAffine {
+        x: max,
+        y: max,
+        t2d: max,
+    };
+    for i in 0..points.len() {
+        for j in 0..points.len() {
+            let current = [points[i].to_extended(), points[j].to_extended()];
+            let current = core::array::from_fn(|lane| {
+                let factor = F([lane as u64 + 2, 0, 0, 0, 0]);
+                G {
+                    x: current[lane].x.mul(factor),
+                    y: current[lane].y.mul(factor),
+                    t: current[lane].t.mul(factor),
+                    z: current[lane].z.mul(factor),
+                }
+            });
+            let incoming = [points[j], points[(i + 1) % points.len()]];
+            for (current, incoming) in [
+                (current, incoming),
+                ([loose, current[1]], [loose_affine, incoming[1]]),
+            ] {
+                for negative in [[false, false], [false, true], [true, false], [true, true]] {
+                    let mut packed_current = [G::IDENTITY; LANES];
+                    let mut packed_incoming = [GAffine::IDENTITY; LANES];
+                    let mut packed_negative = [false; LANES];
+                    packed_current[..WIDTH].copy_from_slice(&current);
+                    packed_incoming[..WIDTH].copy_from_slice(&incoming);
+                    packed_negative[..WIDTH].copy_from_slice(&negative);
+                    let expected = reference
+                        .g_add_mixed(
+                            GVec::transpose(packed_current),
+                            GAffineVec::from_signed_lanes(
+                                reference,
+                                &packed_incoming,
+                                &packed_negative,
+                            ),
+                        )
+                        .untranspose();
+                    let actual = g_add_mixed_pair(current, incoming, negative);
+                    for lane in 0..2 {
+                        for (actual, expected) in [
+                            (actual[lane].x, expected[lane].x),
+                            (actual[lane].y, expected[lane].y),
+                            (actual[lane].t, expected[lane].t),
+                            (actual[lane].z, expected[lane].z),
+                        ] {
+                            super::test::assert_f_eq(
+                                FVec::splat(actual),
+                                FVec::splat(expected),
+                                "mixed pair coordinate",
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/cryptography/curve25519/src/curve/neon.rs
+++ b/cryptography/curve25519/src/curve/neon.rs
@@ -177,6 +177,7 @@ fn reduce_columns(c: [uint64x2_t; 10]) -> Regs {
                 vshlq_n_u64(vandq_u64(paired[i], mask25), 26),
             )
         });
+
         // Column 8 is at most 51*M^2 and column 9 at most 10*M^2, so the top carry fits
         // below 2^31 and can narrow losslessly. Its 19-fold and every other carry are
         // below 2^35, leaving each output below 2^51 + 2^35 < 2^52 without another pass

--- a/cryptography/curve25519/src/curve/neon.rs
+++ b/cryptography/curve25519/src/curve/neon.rs
@@ -7,7 +7,9 @@
 //! only while multiplying. Loose input digits can each occupy 26 bits. The surrounding group
 //! formulas keep their compact five-limb representation.
 
-use super::{BIAS_16P as SUB_BIAS, F, FBackend, FVec, GAffineVec, GBackend, GVec, LANES, MASK_51};
+use super::{
+    BIAS_16P as SUB_BIAS, F, FBackend, FVec, G, GAffine, GAffineVec, GBackend, GVec, LANES, MASK_51,
+};
 use core::arch::aarch64::*;
 
 /// `2d` in every lane, for the `C = 2d*T1*T2` term of point addition.
@@ -155,48 +157,35 @@ fn digit_product(a: uint32x2_t, b: uint32x2_t) -> uint64x2_t {
     unsafe { vmull_u32(a, b) }
 }
 
+/// Reduces ten alternating 26/25-bit product columns into five loose radix-`2^51` limbs
+///
+/// With `M = 2^26 - 1`, column bounds are `M^2` times
+/// `[267, 154, 213, 118, 159, 82, 105, 46, 51, 10]`.
+/// Each pair satisfies `c[2*i] + 2^26*c[2*i + 1] = low[i] + 2^51*carry[i]`, with
+/// `low[i] < 2^51`. Carries move to the next limb, wrapping the top carry by `2^255 = 19 (mod p)`
 #[inline(always)]
-fn reduce_columns(mut c: [uint64x2_t; 10]) -> Regs {
-    // SAFETY: AArch64 targets provide NEON. All accumulators and carry additions fit in `u64`.
+fn reduce_columns(c: [uint64x2_t; 10]) -> Regs {
+    // SAFETY: AArch64 targets provide NEON. Paired columns and carry additions fit in u64
     unsafe {
         let mask26 = vdupq_n_u64((1 << 26) - 1);
         let mask25 = vdupq_n_u64((1 << 25) - 1);
-        c[1] = vaddq_u64(c[1], vshrq_n_u64(c[0], 26));
-        c[0] = vandq_u64(c[0], mask26);
-        c[2] = vaddq_u64(c[2], vshrq_n_u64(c[1], 25));
-        c[1] = vandq_u64(c[1], mask25);
-        c[3] = vaddq_u64(c[3], vshrq_n_u64(c[2], 26));
-        c[2] = vandq_u64(c[2], mask26);
-        c[4] = vaddq_u64(c[4], vshrq_n_u64(c[3], 25));
-        c[3] = vandq_u64(c[3], mask25);
-        c[5] = vaddq_u64(c[5], vshrq_n_u64(c[4], 26));
-        c[4] = vandq_u64(c[4], mask26);
-        c[6] = vaddq_u64(c[6], vshrq_n_u64(c[5], 25));
-        c[5] = vandq_u64(c[5], mask25);
-        c[7] = vaddq_u64(c[7], vshrq_n_u64(c[6], 26));
-        c[6] = vandq_u64(c[6], mask26);
-        c[8] = vaddq_u64(c[8], vshrq_n_u64(c[7], 25));
-        c[7] = vandq_u64(c[7], mask25);
-        c[9] = vaddq_u64(c[9], vshrq_n_u64(c[8], 26));
-        c[8] = vandq_u64(c[8], mask26);
-        // Narrowing this carry is lossless, which needs a tighter bound than the worst-case
-        // column (`267 * (2^26 - 1)^2 < 2^61`): column 9 is where terms fold *from*, never
-        // *into*, so it accumulates at most ten unscaled products plus column 8's carry,
-        // `c[9] < 10 * (2^26 - 1)^2 + 2^32 < 2^56`, making the carry `c[9] >> 25` less than
-        // `2^31`. Narrowing enables one widening multiply instead of the longer packed-u64
-        // shift/add sequence.
-        let top = vmovn_u64(vshrq_n_u64(c[9], 25));
-        c[0] = vaddq_u64(c[0], vmull_n_u32(top, 19));
-        c[9] = vandq_u64(c[9], mask25);
-        c[1] = vaddq_u64(c[1], vshrq_n_u64(c[0], 26));
-        c[0] = vandq_u64(c[0], mask26);
-        [
-            vorrq_u64(c[0], vshlq_n_u64(c[1], 26)),
-            vorrq_u64(c[2], vshlq_n_u64(c[3], 26)),
-            vorrq_u64(c[4], vshlq_n_u64(c[5], 26)),
-            vorrq_u64(c[6], vshlq_n_u64(c[7], 26)),
-            vorrq_u64(c[8], vshlq_n_u64(c[9], 26)),
-        ]
+        let paired: Regs =
+            core::array::from_fn(|i| vaddq_u64(c[2 * i + 1], vshrq_n_u64(c[2 * i], 26)));
+        let mut out: Regs = core::array::from_fn(|i| {
+            vorrq_u64(
+                vandq_u64(c[2 * i], mask26),
+                vshlq_n_u64(vandq_u64(paired[i], mask25), 26),
+            )
+        });
+        // Column 8 is at most 51*M^2 and column 9 at most 10*M^2, so the top carry fits
+        // below 2^31 and can narrow losslessly. Its 19-fold and every other carry are
+        // below 2^35, leaving each output below 2^51 + 2^35 < 2^52 without another pass
+        let top = vmovn_u64(vshrq_n_u64(paired[4], 25));
+        out[0] = vaddq_u64(out[0], vmull_n_u32(top, 19));
+        for i in 1..5 {
+            out[i] = vaddq_u64(out[i], vshrq_n_u64(paired[i - 1], 25));
+        }
+        out
     }
 }
 
@@ -546,23 +535,54 @@ impl FBackend for Backend {
     }
 }
 
-/// Returns an all-zero point used as fully overwritten output storage.
+/// Packs two independent field elements into register lanes
 #[inline(always)]
-const fn empty_gvec() -> GVec {
-    let zero = FVec::splat(F::ZERO);
-    GVec {
-        x: zero,
-        y: zero,
-        t: zero,
-        z: zero,
+fn pack_pair(values: [F; 2]) -> Regs {
+    // SAFETY: AArch64 targets provide NEON, and the selected lane is within the two-lane register
+    unsafe {
+        core::array::from_fn(|i| vsetq_lane_u64(values[1].0[i], vdupq_n_u64(values[0].0[i]), 1))
     }
+}
+
+/// Unpacks both register lanes into independent field elements
+#[inline(always)]
+fn unpack_pair(regs: Regs) -> [F; 2] {
+    // SAFETY: AArch64 targets provide NEON, and both lane indices are within the register
+    unsafe {
+        [
+            F(regs.map(|reg| vgetq_lane_u64(reg, 0))),
+            F(regs.map(|reg| vgetq_lane_u64(reg, 1))),
+        ]
+    }
+}
+
+/// Applies the complete mixed-addition formula to two independent register lanes
+///
+/// Extended inputs and outputs use `[x, y, t, z]`; affine inputs use `[x, y, t2d]`
+#[inline(always)]
+fn add_mixed_regs(p: [Regs; 4], q: [Regs; 3]) -> [Regs; 4] {
+    let [x1, y1, t1, z1] = p;
+    let [x2, y2, t2d] = q;
+    let a = mul_regs(reduce_regs(sub_raw(y1, x1)), reduce_regs(sub_raw(y2, x2)));
+    let b = mul_regs(reduce_regs(add_raw(y1, x1)), reduce_regs(add_raw(y2, x2)));
+    let c = mul_regs(t1, t2d);
+    let d = add_raw(z1, z1);
+    let e = reduce_regs(sub_raw(b, a));
+    let f = reduce_regs(sub_raw(d, c));
+    let g = reduce_regs(add_raw(d, c));
+    let h = reduce_regs(add_raw(b, a));
+    [
+        mul_regs(e, f),
+        mul_regs(g, h),
+        mul_regs(e, h),
+        mul_regs(f, g),
+    ]
 }
 
 impl GBackend for Backend {
     /// Fused point addition, processed two lanes at a time to keep the working set in registers.
     #[inline(always)]
-    fn g_add(self, p: GVec, q: GVec) -> GVec {
-        let mut result = empty_gvec();
+    fn g_add(self, mut p: GVec, q: GVec) -> GVec {
         for tile in 0..TILES {
             // Unified extended-coordinates addition (Hisil-Wong-Carter-Dawson):
             //
@@ -581,51 +601,85 @@ impl GBackend for Backend {
                 load(&EDWARDS_D2.limbs, tile),
             );
             let zz = mul_regs(load(&p.z.limbs, tile), load(&q.z.limbs, tile));
-            let d = reduce_regs(add_raw(zz, zz));
+            let d = add_raw(zz, zz);
             let e = reduce_regs(sub_raw(b, a));
             let f = reduce_regs(sub_raw(d, c));
             let g = reduce_regs(add_raw(d, c));
             let h = reduce_regs(add_raw(b, a));
 
-            store(mul_regs(e, f), &mut result.x.limbs, tile);
-            store(mul_regs(g, h), &mut result.y.limbs, tile);
-            store(mul_regs(e, h), &mut result.t.limbs, tile);
-            store(mul_regs(f, g), &mut result.z.limbs, tile);
+            store(mul_regs(e, f), &mut p.x.limbs, tile);
+            store(mul_regs(g, h), &mut p.y.limbs, tile);
+            store(mul_regs(e, h), &mut p.t.limbs, tile);
+            store(mul_regs(f, g), &mut p.z.limbs, tile);
         }
-        result
+        p
     }
 
     /// Fused mixed point addition, processed two lanes at a time.
     #[inline(always)]
-    fn g_add_mixed(self, p: GVec, q: GAffineVec) -> GVec {
-        let mut result = empty_gvec();
+    fn g_add_mixed(self, mut p: GVec, q: GAffineVec) -> GVec {
         for tile in 0..TILES {
-            let x1 = load(&p.x.limbs, tile);
-            let y1 = load(&p.y.limbs, tile);
-            let x2 = load(&q.x.limbs, tile);
-            let y2 = load(&q.y.limbs, tile);
-            let a = mul_regs(reduce_regs(sub_raw(y1, x1)), reduce_regs(sub_raw(y2, x2)));
-            let b = mul_regs(reduce_regs(add_raw(y1, x1)), reduce_regs(add_raw(y2, x2)));
-            let c = mul_regs(load(&p.t.limbs, tile), load(&q.t2d.limbs, tile));
-            let z1 = load(&p.z.limbs, tile);
-            let d = reduce_regs(add_raw(z1, z1));
-            let e = reduce_regs(sub_raw(b, a));
-            let f = reduce_regs(sub_raw(d, c));
-            let g = reduce_regs(add_raw(d, c));
-            let h = reduce_regs(add_raw(b, a));
-
-            store(mul_regs(e, f), &mut result.x.limbs, tile);
-            store(mul_regs(g, h), &mut result.y.limbs, tile);
-            store(mul_regs(e, h), &mut result.t.limbs, tile);
-            store(mul_regs(f, g), &mut result.z.limbs, tile);
+            let [x, y, t, z] = add_mixed_regs(
+                [
+                    load(&p.x.limbs, tile),
+                    load(&p.y.limbs, tile),
+                    load(&p.t.limbs, tile),
+                    load(&p.z.limbs, tile),
+                ],
+                [
+                    load(&q.x.limbs, tile),
+                    load(&q.y.limbs, tile),
+                    load(&q.t2d.limbs, tile),
+                ],
+            );
+            store(x, &mut p.x.limbs, tile);
+            store(y, &mut p.y.limbs, tile);
+            store(t, &mut p.t.limbs, tile);
+            store(z, &mut p.z.limbs, tile);
         }
-        result
+        p
+    }
+
+    #[inline(always)]
+    fn g_add_mixed_pair(self, p: [G; 2], q: [GAffine; 2], negative: [bool; 2]) -> [G; 2] {
+        let mut x2 = pack_pair(q.map(|point| point.x));
+        let mut t2d = pack_pair(q.map(|point| point.t2d));
+        if negative.iter().any(|&sign| sign) {
+            // SAFETY: AArch64 targets provide NEON, and the mask array has two complete lanes
+            unsafe {
+                let masks = negative.map(|sign| 0u64.wrapping_sub(u64::from(sign)));
+                let mask = vld1q_u64(masks.as_ptr());
+                let zero = [vdupq_n_u64(0); 5];
+                let neg_x = reduce_regs(sub_raw(zero, x2));
+                let neg_t2d = reduce_regs(sub_raw(zero, t2d));
+                x2 = core::array::from_fn(|i| vbslq_u64(mask, neg_x[i], x2[i]));
+                t2d = core::array::from_fn(|i| vbslq_u64(mask, neg_t2d[i], t2d[i]));
+            }
+        }
+        let [x, y, t, z] = add_mixed_regs(
+            [
+                pack_pair(p.map(|point| point.x)),
+                pack_pair(p.map(|point| point.y)),
+                pack_pair(p.map(|point| point.t)),
+                pack_pair(p.map(|point| point.z)),
+            ],
+            [x2, pack_pair(q.map(|point| point.y)), t2d],
+        );
+        let x = unpack_pair(x);
+        let y = unpack_pair(y);
+        let t = unpack_pair(t);
+        let z = unpack_pair(z);
+        core::array::from_fn(|i| G {
+            x: x[i],
+            y: y[i],
+            t: t[i],
+            z: z[i],
+        })
     }
 
     /// Fused point doubling using the dedicated `dbl-2008-hwcd` formula.
     #[inline(always)]
-    fn g_double(self, p: GVec) -> GVec {
-        let mut result = empty_gvec();
+    fn g_double(self, mut p: GVec) -> GVec {
         for tile in 0..TILES {
             let x = load(&p.x.limbs, tile);
             let y = load(&p.y.limbs, tile);
@@ -643,12 +697,12 @@ impl GBackend for Backend {
             let zero = unsafe { [vdupq_n_u64(0); 5] };
             let h = reduce_regs(sub_raw(sub_raw(zero, a), b));
 
-            store(mul_regs(e, f), &mut result.x.limbs, tile);
-            store(mul_regs(g, h), &mut result.y.limbs, tile);
-            store(mul_regs(e, h), &mut result.t.limbs, tile);
-            store(mul_regs(f, g), &mut result.z.limbs, tile);
+            store(mul_regs(e, f), &mut p.x.limbs, tile);
+            store(mul_regs(g, h), &mut p.y.limbs, tile);
+            store(mul_regs(e, h), &mut p.t.limbs, tile);
+            store(mul_regs(f, g), &mut p.z.limbs, tile);
         }
-        result
+        p
     }
 }
 

--- a/cryptography/curve25519/src/curve/neon.rs
+++ b/cryptography/curve25519/src/curve/neon.rs
@@ -728,7 +728,7 @@ impl msm::Backend for Backend {
         terms: &[T],
         term: impl Fn(&T) -> (GAffine, i16),
     ) {
-        msm::fill_buckets(g_add_mixed_pair, buckets, nb, terms, term);
+        msm::fill_buckets::<{ Self::STRIPES }, T>(g_add_mixed_pair, buckets, nb, terms, term);
     }
 
     /// Returns lanes whose sum is the weighted sum of all bucket stripes.
@@ -817,7 +817,6 @@ impl msm::Backend for Backend {
     }
 }
 
-#[cfg(test)]
 #[test]
 fn mixed_pair_matches_full_width() {
     let reference = super::portable::Backend::new();
@@ -830,7 +829,7 @@ fn mixed_pair_matches_full_width() {
     )
     .unwrap();
     let points = [GAffine::IDENTITY, GAffine::BASEPOINT, torsion, mixed];
-    let max = F([(1 << 52) - 1; 5]);
+    let max = F([super::test::MASK_52; 5]);
     let loose = G {
         x: max,
         y: max,

--- a/cryptography/curve25519/src/curve/neon.rs
+++ b/cryptography/curve25519/src/curve/neon.rs
@@ -728,7 +728,7 @@ impl msm::Backend for Backend {
         terms: &[T],
         term: impl Fn(&T) -> (GAffine, i16),
     ) {
-        msm::fill_buckets::<{ Self::STRIPES }, T>(g_add_mixed_pair, buckets, nb, terms, term);
+        msm::fill_buckets(g_add_mixed_pair, buckets, nb, terms, term);
     }
 
     /// Returns lanes whose sum is the weighted sum of all bucket stripes.

--- a/cryptography/curve25519/src/curve/neon.rs
+++ b/cryptography/curve25519/src/curve/neon.rs
@@ -157,15 +157,15 @@ fn digit_product(a: uint32x2_t, b: uint32x2_t) -> uint64x2_t {
     unsafe { vmull_u32(a, b) }
 }
 
-/// Reduces ten alternating 26/25-bit product columns into five loose radix-`2^51` limbs
+/// Reduces ten alternating 26/25-bit product columns into five loose radix-`2^51` limbs.
 ///
 /// With `M = 2^26 - 1`, column bounds are `M^2` times
 /// `[267, 154, 213, 118, 159, 82, 105, 46, 51, 10]`.
 /// Each pair satisfies `c[2*i] + 2^26*c[2*i + 1] = low[i] + 2^51*carry[i]`, with
-/// `low[i] < 2^51`. Carries move to the next limb, wrapping the top carry by `2^255 = 19 (mod p)`
+/// `low[i] < 2^51`. Carries move to the next limb, wrapping the top carry by `2^255 = 19 (mod p)`.
 #[inline(always)]
 fn reduce_columns(c: [uint64x2_t; 10]) -> Regs {
-    // SAFETY: AArch64 targets provide NEON. Paired columns and carry additions fit in u64
+    // SAFETY: AArch64 targets provide NEON. Paired columns and carry additions fit in u64.
     unsafe {
         let mask26 = vdupq_n_u64((1 << 26) - 1);
         let mask25 = vdupq_n_u64((1 << 25) - 1);
@@ -180,7 +180,7 @@ fn reduce_columns(c: [uint64x2_t; 10]) -> Regs {
 
         // Column 8 is at most 51*M^2 and column 9 at most 10*M^2, so the top carry fits
         // below 2^31 and can narrow losslessly. Its 19-fold and every other carry are
-        // below 2^35, leaving each output below 2^51 + 2^35 < 2^52 without another pass
+        // below 2^35, leaving each output below 2^51 + 2^35 < 2^52 without another pass.
         let top = vmovn_u64(vshrq_n_u64(paired[4], 25));
         out[0] = vaddq_u64(out[0], vmull_n_u32(top, 19));
         for i in 1..5 {
@@ -536,19 +536,19 @@ impl FBackend for Backend {
     }
 }
 
-/// Packs two independent field elements into register lanes
+/// Packs two independent field elements into register lanes.
 #[inline(always)]
 fn pack_pair(values: [F; 2]) -> Regs {
-    // SAFETY: AArch64 targets provide NEON, and the selected lane is within the two-lane register
+    // SAFETY: AArch64 targets provide NEON, and the selected lane is within the two-lane register.
     unsafe {
         core::array::from_fn(|i| vsetq_lane_u64(values[1].0[i], vdupq_n_u64(values[0].0[i]), 1))
     }
 }
 
-/// Unpacks both register lanes into independent field elements
+/// Unpacks both register lanes into independent field elements.
 #[inline(always)]
 fn unpack_pair(regs: Regs) -> [F; 2] {
-    // SAFETY: AArch64 targets provide NEON, and both lane indices are within the register
+    // SAFETY: AArch64 targets provide NEON, and both lane indices are within the register.
     unsafe {
         [
             F(regs.map(|reg| vgetq_lane_u64(reg, 0))),
@@ -557,9 +557,9 @@ fn unpack_pair(regs: Regs) -> [F; 2] {
     }
 }
 
-/// Applies the complete mixed-addition formula to two independent register lanes
+/// Applies the complete mixed-addition formula to two independent register lanes.
 ///
-/// Extended inputs and outputs use `[x, y, t, z]`; affine inputs use `[x, y, t2d]`
+/// Extended inputs and outputs use `[x, y, t, z]`; affine inputs use `[x, y, t2d]`.
 #[inline(always)]
 fn add_mixed_regs(p: [Regs; 4], q: [Regs; 3]) -> [Regs; 4] {
     let [x1, y1, t1, z1] = p;
@@ -646,7 +646,7 @@ impl GBackend for Backend {
         let mut x2 = pack_pair(q.map(|point| point.x));
         let mut t2d = pack_pair(q.map(|point| point.t2d));
         if negative.iter().any(|&sign| sign) {
-            // SAFETY: AArch64 targets provide NEON, and the mask array has two complete lanes
+            // SAFETY: AArch64 targets provide NEON, and the mask array has two complete lanes.
             unsafe {
                 let masks = negative.map(|sign| 0u64.wrapping_sub(u64::from(sign)));
                 let mask = vld1q_u64(masks.as_ptr());

--- a/cryptography/curve25519/src/curve/neon.rs
+++ b/cryptography/curve25519/src/curve/neon.rs
@@ -9,8 +9,7 @@
 
 use super::{
     BIAS_16P as SUB_BIAS, F, FBackend, FVec, G, GAffine, GAffineVec, GBackend, GVec, LANES,
-    MASK_51,
-    msm::{self, MsmBackend},
+    MASK_51, msm,
 };
 #[cfg(not(feature = "std"))]
 use alloc::vec;
@@ -717,7 +716,7 @@ fn g_add_mixed_pair(p: [G; 2], q: [GAffine; 2], negative: [bool; 2]) -> [G; 2] {
     })
 }
 
-impl MsmBackend for Backend {
+impl msm::Backend for Backend {
     // One stripe per physical mixed-addition lane keeps wave updates independent. Folds retain
     // LANES independent bucket indices.
     const STRIPES: usize = WIDTH;

--- a/cryptography/curve25519/src/curve/portable.rs
+++ b/cryptography/curve25519/src/curve/portable.rs
@@ -98,4 +98,6 @@ impl GAffineVec {
     }
 }
 
-impl super::msm::Backend for Backend {}
+impl super::msm::Backend for Backend {
+    const STRIPES: usize = LANES;
+}

--- a/cryptography/curve25519/src/curve/portable.rs
+++ b/cryptography/curve25519/src/curve/portable.rs
@@ -98,4 +98,4 @@ impl GAffineVec {
     }
 }
 
-impl super::msm::MsmBackend for Backend {}
+impl super::msm::Backend for Backend {}

--- a/cryptography/curve25519/src/curve/portable.rs
+++ b/cryptography/curve25519/src/curve/portable.rs
@@ -1,6 +1,6 @@
 //! Plain-Rust lane adapter over scalar field and group arithmetic.
 
-use super::{F, FBackend, FVec, G, GAffineVec, GBackend, GVec};
+use super::{F, FBackend, FVec, G, GAffine, GAffineVec, GBackend, GVec, LANES};
 use core::array;
 
 /// The portable backend token.
@@ -83,3 +83,19 @@ impl GBackend for Backend {
 }
 
 impl super::Backend for Backend {}
+
+impl GAffineVec {
+    /// Untransposes backend lanes into scalar affine points.
+    fn untranspose(self) -> [GAffine; LANES] {
+        let x = self.x.untranspose();
+        let y = self.y.untranspose();
+        let t2d = self.t2d.untranspose();
+        array::from_fn(|i| GAffine {
+            x: x[i],
+            y: y[i],
+            t2d: t2d[i],
+        })
+    }
+}
+
+impl super::msm::MsmBackend for Backend {}

--- a/cryptography/curve25519/src/curve/test.rs
+++ b/cryptography/curve25519/src/curve/test.rs
@@ -318,6 +318,46 @@ fn fuzz_group<B: Backend>(u: &mut Unstructured<'_>, backend: B) -> arbitrary::Re
 
 #[cfg(test)]
 #[test]
+fn repeated_squaring_matches_scalar() {
+    #[derive(Clone, Copy)]
+    struct Check;
+
+    impl WithBackend for Check {
+        type Output = ();
+
+        fn call<B: Backend>(self, backend: B) -> Self::Output {
+            let max = FVec {
+                limbs: [[MASK_52; LANES]; 5],
+            };
+            let mixed = FVec::transpose([
+                F::ZERO,
+                F::ONE,
+                F([MASK_52; 5]),
+                F([MASK_51; 5]),
+                F([19, 0, 0, 0, 0]),
+                F([0, MASK_52, 0, MASK_52, 0]),
+                F([1 << 51; 5]),
+                F([0x123456789abcd, 7, MASK_52 - 1, 42, 1]),
+            ]);
+            for input in [max, mixed] {
+                for k in [0, 1, 2, 5, 10, 20, 50, 100] {
+                    let actual = backend.pow2k(input, k);
+                    if k == 0 {
+                        assert_eq!(actual.limbs, input.limbs);
+                    }
+                    let expected = FVec::transpose(input.untranspose().map(|v| v.pow2k(k)));
+                    assert_f_eq(actual, expected, "repeated squaring");
+                }
+            }
+        }
+    }
+
+    Check.call(super::portable::Backend::new());
+    super::with_backend(Check);
+}
+
+#[cfg(test)]
+#[test]
 fn backend_at_bounds() {
     struct CheckBackendAtBounds;
 
@@ -652,4 +692,81 @@ fn with_backend_matches_portable() {
         expected.1,
         "runtime-dispatched group computation",
     );
+}
+
+#[cfg(all(test, target_arch = "aarch64"))]
+#[test]
+fn mixed_pair_matches_full_width() {
+    struct Check;
+
+    impl WithBackend for Check {
+        type Output = ();
+
+        fn call<B: Backend>(self, backend: B) {
+            let reference = super::portable::Backend::new();
+            let torsion = GAffine::decompress(&[0; 32]).unwrap();
+            let mixed = GAffine::decompress(
+                &GAffine::BASEPOINT
+                    .to_extended()
+                    .add(torsion.to_extended())
+                    .to_bytes(),
+            )
+            .unwrap();
+            let points = [GAffine::IDENTITY, GAffine::BASEPOINT, torsion, mixed];
+            let max = F([MASK_52; 5]);
+            let loose = G {
+                x: max,
+                y: max,
+                t: max,
+                z: max,
+            };
+            let loose_affine = GAffine {
+                x: max,
+                y: max,
+                t2d: max,
+            };
+            for i in 0..points.len() {
+                for j in 0..points.len() {
+                    let current = [points[i].to_extended(), points[j].to_extended()];
+                    let current = array::from_fn(|lane| {
+                        let factor = F([lane as u64 + 2, 0, 0, 0, 0]);
+                        G {
+                            x: current[lane].x.mul(factor),
+                            y: current[lane].y.mul(factor),
+                            t: current[lane].t.mul(factor),
+                            z: current[lane].z.mul(factor),
+                        }
+                    });
+                    let incoming = [points[j], points[(i + 1) % points.len()]];
+                    for (current, incoming) in [
+                        (current, incoming),
+                        ([loose, current[1]], [loose_affine, incoming[1]]),
+                    ] {
+                        for negative in [[false, false], [false, true], [true, false], [true, true]]
+                        {
+                            let expected = reference.g_add_mixed_pair(current, incoming, negative);
+                            let actual = backend.g_add_mixed_pair(current, incoming, negative);
+                            for lane in 0..2 {
+                                for (actual, expected) in [
+                                    (actual[lane].x, expected[lane].x),
+                                    (actual[lane].y, expected[lane].y),
+                                    (actual[lane].t, expected[lane].t),
+                                    (actual[lane].z, expected[lane].z),
+                                ] {
+                                    assert_f_eq(
+                                        FVec::splat(actual),
+                                        FVec::splat(expected),
+                                        "mixed pair coordinate",
+                                    );
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Check.call(super::portable::Backend::new());
+    super::with_backend(Check);
 }

--- a/cryptography/curve25519/src/curve/test.rs
+++ b/cryptography/curve25519/src/curve/test.rs
@@ -8,7 +8,7 @@ use crate::test::ZIP215_POINTS;
 use arbitrary::{Arbitrary, Unstructured};
 use core::array;
 
-const MASK_52: u64 = (1 << 52) - 1;
+pub(super) const MASK_52: u64 = (1 << 52) - 1;
 
 /// A field or group arithmetic fuzzing operation.
 #[derive(Debug, Arbitrary)]

--- a/cryptography/curve25519/src/curve/test.rs
+++ b/cryptography/curve25519/src/curve/test.rs
@@ -739,3 +739,107 @@ fn backend_conditional_neg_matches_every_mask() {
     Check.call(super::portable::Backend::new());
     super::with_backend(Check);
 }
+
+#[test]
+fn bucket_fill_matches_scalar_sum_for_every_geometry() {
+    fn check<const STRIPES: usize>() {
+        const NB: usize = 7;
+        let torsion = GAffine::decompress(&[0; 32]).unwrap();
+        let mixed = GAffine::decompress(
+            &GAffine::BASEPOINT
+                .to_extended()
+                .add(torsion.to_extended())
+                .to_bytes(),
+        )
+        .unwrap();
+        let points = [GAffine::IDENTITY, GAffine::BASEPOINT, torsion, mixed];
+        let digits = [0, 1, -1, 7, -7, 3, 3, -3, 7];
+        let terms: [(GAffine, i16); 53] = array::from_fn(|i| {
+            let digit = if i < 16 {
+                0
+            } else {
+                digits[(i - 16) % digits.len()]
+            };
+            (points[i % points.len()], digit)
+        });
+        let expected = terms.iter().fold(G::IDENTITY, |sum, &(point, digit)| {
+            let point = point.to_extended();
+            let point = if digit < 0 { point.negate() } else { point };
+            (0..digit.unsigned_abs()).fold(sum, |sum, _| sum.add(point))
+        });
+
+        for split in [0, 1, 3, 17, 31, terms.len()] {
+            let mut buckets = [[G::IDENTITY; NB]; STRIPES];
+            for piece in [&terms[..split], &terms[split..]] {
+                super::msm::fill_buckets(
+                    |current: [G; STRIPES], incoming, negative| {
+                        array::from_fn(|lane| {
+                            let mut point = incoming[lane];
+                            if negative[lane] {
+                                point.x = point.x.neg();
+                                point.t2d = point.t2d.neg();
+                            }
+                            current[lane].add_mixed(point)
+                        })
+                    },
+                    buckets.as_flattened_mut(),
+                    NB,
+                    piece,
+                    |term| *term,
+                );
+            }
+            let actual = buckets
+                .iter()
+                .flatten()
+                .enumerate()
+                .fold(G::IDENTITY, |sum, (i, &point)| {
+                    (0..=i % NB).fold(sum, |sum, _| sum.add(point))
+                });
+            assert!(
+                actual.add(expected.negate()).is_identity(),
+                "stripes={STRIPES} split={split}"
+            );
+        }
+    }
+
+    check::<1>();
+    check::<2>();
+    check::<3>();
+    check::<8>();
+    check::<16>();
+}
+
+#[test]
+fn sum_lanes_matches_scalar_sum() {
+    struct Check;
+
+    impl WithBackend for Check {
+        type Output = ();
+
+        fn call<B: Backend>(self, backend: B) {
+            let base = GAffine::BASEPOINT.to_extended();
+            let torsion = GAffine::decompress(&[0; 32]).unwrap().to_extended();
+            let points = [G::IDENTITY, base, torsion, base.add(torsion), base.negate()];
+            for offset in 0..points.len() {
+                for mask in 0..1usize << LANES {
+                    let lanes = array::from_fn(|lane| {
+                        if mask & (1 << lane) != 0 {
+                            points[(lane + offset) % points.len()]
+                        } else {
+                            G::IDENTITY
+                        }
+                    });
+                    let expected = lanes.into_iter().fold(G::IDENTITY, G::add);
+                    let actual = GVec::transpose(lanes).sum_lanes(backend);
+                    assert!(
+                        actual.add(expected.negate()).is_identity(),
+                        "offset={offset} mask={mask:#x}"
+                    );
+                }
+            }
+        }
+    }
+
+    Check.call(super::portable::Backend::new());
+    super::with_backend(Check);
+}

--- a/cryptography/curve25519/src/curve/test.rs
+++ b/cryptography/curve25519/src/curve/test.rs
@@ -96,7 +96,7 @@ fn assert_bounded(value: FVec) {
     );
 }
 
-fn assert_f_eq(actual: FVec, expected: FVec, property: &str) {
+pub(super) fn assert_f_eq(actual: FVec, expected: FVec, property: &str) {
     assert_bounded(actual);
     assert_bounded(expected);
     for lane in 0..LANES {
@@ -444,24 +444,18 @@ fn minifuzz_field() {
 #[cfg(test)]
 #[test]
 fn minifuzz_group() {
-    // The fully inlined NEON group formulas need more than the test harness's default stack in
-    // unoptimized builds.
-    let run = || {
-        commonware_invariants::minifuzz::Builder::default()
-            .with_seed(0)
-            .with_search_limit(100)
-            .test(|u| Plan::Group.run(u));
-    };
-    if cfg!(target_arch = "aarch64") {
-        std::thread::Builder::new()
-            .stack_size(8 * 1024 * 1024)
-            .spawn(run)
-            .unwrap()
-            .join()
-            .unwrap();
-    } else {
-        run();
-    }
+    // Fully inlined group formulas can exceed the test harness's default stack in debug builds.
+    std::thread::Builder::new()
+        .stack_size(8 * 1024 * 1024)
+        .spawn(|| {
+            commonware_invariants::minifuzz::Builder::default()
+                .with_seed(0)
+                .with_search_limit(100)
+                .test(|u| Plan::Group.run(u));
+        })
+        .unwrap()
+        .join()
+        .unwrap();
 }
 
 /// Checks that a backend's field operations match the portable backend.
@@ -692,83 +686,6 @@ fn with_backend_matches_portable() {
         expected.1,
         "runtime-dispatched group computation",
     );
-}
-
-#[cfg(all(test, target_arch = "aarch64"))]
-#[test]
-fn mixed_pair_matches_full_width() {
-    struct Check;
-
-    impl WithBackend for Check {
-        type Output = ();
-
-        fn call<B: Backend>(self, backend: B) {
-            let reference = super::portable::Backend::new();
-            let torsion = GAffine::decompress(&[0; 32]).unwrap();
-            let mixed = GAffine::decompress(
-                &GAffine::BASEPOINT
-                    .to_extended()
-                    .add(torsion.to_extended())
-                    .to_bytes(),
-            )
-            .unwrap();
-            let points = [GAffine::IDENTITY, GAffine::BASEPOINT, torsion, mixed];
-            let max = F([MASK_52; 5]);
-            let loose = G {
-                x: max,
-                y: max,
-                t: max,
-                z: max,
-            };
-            let loose_affine = GAffine {
-                x: max,
-                y: max,
-                t2d: max,
-            };
-            for i in 0..points.len() {
-                for j in 0..points.len() {
-                    let current = [points[i].to_extended(), points[j].to_extended()];
-                    let current = array::from_fn(|lane| {
-                        let factor = F([lane as u64 + 2, 0, 0, 0, 0]);
-                        G {
-                            x: current[lane].x.mul(factor),
-                            y: current[lane].y.mul(factor),
-                            t: current[lane].t.mul(factor),
-                            z: current[lane].z.mul(factor),
-                        }
-                    });
-                    let incoming = [points[j], points[(i + 1) % points.len()]];
-                    for (current, incoming) in [
-                        (current, incoming),
-                        ([loose, current[1]], [loose_affine, incoming[1]]),
-                    ] {
-                        for negative in [[false, false], [false, true], [true, false], [true, true]]
-                        {
-                            let expected = reference.g_add_mixed_pair(current, incoming, negative);
-                            let actual = backend.g_add_mixed_pair(current, incoming, negative);
-                            for lane in 0..2 {
-                                for (actual, expected) in [
-                                    (actual[lane].x, expected[lane].x),
-                                    (actual[lane].y, expected[lane].y),
-                                    (actual[lane].t, expected[lane].t),
-                                    (actual[lane].z, expected[lane].z),
-                                ] {
-                                    assert_f_eq(
-                                        FVec::splat(actual),
-                                        FVec::splat(expected),
-                                        "mixed pair coordinate",
-                                    );
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    Check.call(super::portable::Backend::new());
-    super::with_backend(Check);
 }
 
 #[test]

--- a/cryptography/curve25519/src/curve/test.rs
+++ b/cryptography/curve25519/src/curve/test.rs
@@ -770,3 +770,55 @@ fn mixed_pair_matches_full_width() {
     Check.call(super::portable::Backend::new());
     super::with_backend(Check);
 }
+
+#[test]
+fn backend_conditional_neg_matches_every_mask() {
+    struct Check;
+
+    impl WithBackend for Check {
+        type Output = ();
+
+        fn call<B: Backend>(self, backend: B) {
+            let mixed = FVec {
+                limbs: array::from_fn(|limb| {
+                    array::from_fn(|lane| {
+                        let offset = (limb * LANES + lane) as u64;
+                        if (limb + lane) & 1 == 0 {
+                            offset
+                        } else {
+                            MASK_52 - offset
+                        }
+                    })
+                }),
+            };
+            for value in [FVec::splat(F::ZERO), FVec::splat(F([MASK_52; 5])), mixed] {
+                let lanes = value.untranspose();
+                for mask in 0..1u16 << LANES {
+                    let negative = array::from_fn(|lane| mask & (1 << lane) != 0);
+                    let actual = backend.conditional_neg(value, &negative);
+                    let expected = FVec::transpose(array::from_fn(|lane| {
+                        if negative[lane] {
+                            lanes[lane].neg()
+                        } else {
+                            lanes[lane]
+                        }
+                    }));
+                    assert_f_eq(actual, expected, "conditional negation");
+                    for (lane, negative) in negative.into_iter().enumerate() {
+                        if !negative {
+                            for limb in 0..5 {
+                                assert_eq!(
+                                    actual.limbs[limb][lane], value.limbs[limb][lane],
+                                    "unselected limb {limb}, lane {lane}, mask {mask:#04x}"
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Check.call(super::portable::Backend::new());
+    super::with_backend(Check);
+}

--- a/cryptography/curve25519/src/signing/core/msm.rs
+++ b/cryptography/curve25519/src/signing/core/msm.rs
@@ -1,7 +1,7 @@
 //! Variable-time Pippenger multi-scalar multiplication for batch signature verification.
 //!
 //! [`Term`]s arrive decompressed and recoded into signed digits. The bucket kernel processes
-//! [`LANES`] terms at once, with one private bucket stripe per SIMD lane so updates never collide.
+//! one term per private bucket stripe at once, so updates within each wave never collide.
 //!
 //! [`multiscalar_mul`] exposes one execution shape for every [`Strategy`]: `(window, term range)`
 //! tiles. A window can be split across several point ranges when there are fewer windows than
@@ -9,7 +9,9 @@
 //! added together, and one short Horner fold positions the window sums.
 
 use super::scalar::Scalar;
-use crate::curve::{Backend, G, GAffine, GAffineVec, GVec, LANES};
+#[cfg(not(target_arch = "aarch64"))]
+use crate::curve::GAffineVec;
+use crate::curve::{Backend, G, GAffine, GVec, LANES};
 #[cfg(not(feature = "std"))]
 use alloc::{vec, vec::Vec};
 use commonware_parallel::Strategy;
@@ -44,7 +46,7 @@ const fn num_buckets(width: u32) -> usize {
 /// Fit to a measured sweep (width 6-10 x batch 1k-64k signatures x 1/32 threads, AMD EPYC 9354P,
 /// AVX-512): the optimum grows at almost exactly half a bit of width per bit of batch size --
 /// shallower than the textbook `log2(terms) - 4` rule, because the wide-window penalty on real
-/// hardware includes the per-lane bucket array (`8 * 2^(width-1)` points, ~320KB at width 9)
+/// hardware includes the AVX-512 bucket array (`8 * 2^(width-1)` points, ~320KB at width 9)
 /// spilling L2, not just the fold-count arithmetic. Parallel runs want one step narrower than
 /// serial: folds replicate once per tile range, and every concurrent tile holds its own bucket
 /// array. Every prediction below matched the sweep's measured optimum (or a runner-up within
@@ -122,32 +124,32 @@ fn used_buckets(chunks: &[&[Term]], start: usize, end: usize, window: usize) -> 
 }
 
 mod transposed {
-    use super::{Backend, G, GAffine, GAffineVec, GVec, LANES, Term};
+    #[cfg(not(target_arch = "aarch64"))]
+    use super::GAffineVec;
+    use super::{Backend, G, GAffine, GVec, LANES, Term};
+
+    // NEON fills one stripe per physical mixed-addition lane, keeping wave updates independent
+    // Folds retain LANES independent bucket indices
+    #[cfg(target_arch = "aarch64")]
+    const STRIPES: usize = 2;
+    #[cfg(not(target_arch = "aarch64"))]
+    const STRIPES: usize = LANES;
     #[cfg(not(feature = "std"))]
     use alloc::{vec, vec::Vec};
 
-    /// Every lane's buckets for one window, flattened lane-major (`buckets[lane * nb + m]`, with
-    /// `nb = num_buckets(width)`): within each piece, lane `l` owns the terms whose index is
-    /// `l mod LANES`, plus this private bucket stripe, so the wave loop below can update `LANES`
-    /// buckets with one vectorized addition and no two lanes ever collide on a bucket.
-    /// Heap-allocated because the width (and so the array size) is a per-batch runtime value.
+    /// Independent bucket stripes, indexed by `stripe * nb + abs(digit) - 1`
+    ///
+    /// Each wave assigns one term to each stripe, so updates within a wave cannot collide.
+    /// Heap allocation accommodates the per-batch bucket count
     pub(super) fn identity_buckets(nb: usize) -> Vec<G> {
-        vec![G::IDENTITY; LANES * nb]
+        vec![G::IDENTITY; STRIPES * nb]
     }
 
-    /// Adds one contiguous run of terms into one window's bucket stripes via vectorized "wave"
-    /// passes, one wave of `LANES` consecutive terms (one per lane) at a time: gather each
-    /// lane's current bucket value (a scalar array read, cheap and branch-free since a digit of
-    /// 0 just gathers-and-discards the identity), add the wave's incoming (possibly negated, for
-    /// a negative digit) points via one vectorized backend mixed addition, then scatter the
-    /// results back (again cheap scalar writes, skipped only for zero-digit lanes since there is
-    /// no bucket to write into). A wave whose digits are *all* zero is skipped outright before
-    /// any point arithmetic -- common, not rare: batch verification's `R` terms carry 128-bit
-    /// coefficients, so every window above ~128 bits has zero digits for half the term sequence.
-    /// The `terms.len() % LANES` tail rides as a short wave, its missing lanes no-op identity
-    /// additions -- so a caller filling from several pieces pays at most one short wave per
-    /// piece. Accumulating (rather than returning fresh buckets) is what lets those pieces share
-    /// one bucket set and one fold.
+    /// Adds each run in waves of one term per bucket stripe
+    ///
+    /// Missing or zero-digit lanes use identity inputs and never scatter a result. Entirely
+    /// zero waves skip group arithmetic, including the high windows of short coefficients.
+    /// Each piece may restart stripe assignment because the fold sums every stripe
     #[allow(clippy::needless_range_loop)]
     fn fill_buckets<B: Backend>(
         backend: B,
@@ -157,11 +159,11 @@ mod transposed {
         window: usize,
     ) {
         let identity_point = GAffine::IDENTITY;
-        for wave in terms.chunks(LANES) {
-            let mut incoming = [identity_point; LANES];
-            let mut negative = [false; LANES];
-            let mut current = [G::IDENTITY; LANES];
-            let mut bucket_index = [None::<usize>; LANES];
+        for wave in terms.chunks(STRIPES) {
+            let mut incoming = [identity_point; STRIPES];
+            let mut negative = [false; STRIPES];
+            let mut current = [G::IDENTITY; STRIPES];
+            let mut bucket_index = [None::<usize>; STRIPES];
             let mut any = false;
             for (lane, term) in wave.iter().enumerate() {
                 let digit = term.digits[window];
@@ -181,13 +183,16 @@ mod transposed {
             if !any {
                 continue;
             }
+            #[cfg(target_arch = "aarch64")]
+            let updated = backend.g_add_mixed_pair(current, incoming, negative);
+            #[cfg(not(target_arch = "aarch64"))]
             let updated = backend
                 .g_add_mixed(
                     GVec::transpose(current),
                     GAffineVec::from_signed_lanes(backend, &incoming, &negative),
                 )
                 .untranspose();
-            for lane in 0..LANES {
+            for lane in 0..STRIPES {
                 if let Some(i) = bucket_index[lane] {
                     buckets[lane * nb + i] = updated[lane];
                 }
@@ -195,9 +200,11 @@ mod transposed {
         }
     }
 
-    /// Folds `LANES` lanes' worth of one window's bucket stripes into `result` with the standard
-    /// running-sum trick: starting below untouched top buckets is exact because identity buckets
-    /// leave both the running sum and window sum unchanged.
+    /// Folds each bucket stripe into its corresponding result lane with a running sum
+    ///
+    /// Lanes without a stripe contribute the identity. Untouched top buckets can be skipped
+    /// because their identity values leave both running sums unchanged
+    #[cfg(any(test, not(target_arch = "aarch64")))]
     fn fold_buckets<B: Backend>(
         backend: B,
         result: GVec,
@@ -208,11 +215,133 @@ mod transposed {
         let mut sum = GVec::identity();
         let mut window_sum = GVec::identity();
         for d in (0..used).rev() {
-            let bucket_group: [G; LANES] = core::array::from_fn(|lane| buckets[lane * nb + d]);
+            let bucket_group: [G; LANES] = core::array::from_fn(|lane| {
+                if lane < STRIPES {
+                    buckets[lane * nb + d]
+                } else {
+                    G::IDENTITY
+                }
+            });
             sum = backend.g_add(sum, GVec::transpose(bucket_group));
             window_sum = backend.g_add(window_sum, sum);
         }
         backend.g_add(result, window_sum)
+    }
+
+    /// Returns lanes whose sum is the weighted sum of all bucket stripes.
+    ///
+    /// Let `B[k, lane]` sum the stripes at bucket index `k*LANES + lane`. The descending pass
+    /// builds `sum[lane] = sum_k B[k, lane]` and `rows[lane] = sum_k k*B[k, lane]`.
+    /// Final weighting gives `LANES*rows[lane] + (lane + 1)*sum[lane]`, assigning each bucket
+    /// its index-plus-one weight. The lane count is a power of two
+    #[cfg(target_arch = "aarch64")]
+    fn fold_buckets_merged<B: Backend>(backend: B, buckets: &[G], nb: usize, used: usize) -> GVec {
+        // A single used bucket has weight one, so return the stripes without weighting
+        if used == 1 {
+            return GVec::transpose(core::array::from_fn(|lane| {
+                if lane < STRIPES {
+                    buckets[lane * nb]
+                } else {
+                    G::IDENTITY
+                }
+            }));
+        }
+        let mut sum = GVec::identity();
+        let mut rows = GVec::identity();
+        for block in (0..used.div_ceil(LANES)).rev() {
+            let gather = |stripe: usize| {
+                GVec::transpose(core::array::from_fn(|lane| {
+                    let digit = block * LANES + lane;
+                    if digit < used {
+                        buckets[stripe * nb + digit]
+                    } else {
+                        G::IDENTITY
+                    }
+                }))
+            };
+            let mut combined = gather(0);
+            for stripe in 1..STRIPES {
+                combined = backend.g_add(combined, gather(stripe));
+            }
+            rows = backend.g_add(rows, sum);
+            sum = backend.g_add(sum, combined);
+        }
+
+        // Seed the high bit of lane + 1, then fold its remaining bits
+        let lanes = sum.untranspose();
+        let mut weighted = GVec::transpose(core::array::from_fn(|lane| {
+            if lane == LANES - 1 {
+                lanes[lane]
+            } else {
+                G::IDENTITY
+            }
+        }));
+        for bit in (0..3).rev() {
+            rows = backend.g_double(rows);
+            weighted = backend.g_double(weighted);
+            let selected = core::array::from_fn(|lane| {
+                if (lane + 1) & (1 << bit) != 0 {
+                    lanes[lane]
+                } else {
+                    G::IDENTITY
+                }
+            });
+            weighted = backend.g_add(weighted, GVec::transpose(selected));
+        }
+        backend.g_add(rows, weighted)
+    }
+
+    #[cfg(all(test, target_arch = "aarch64"))]
+    mod merged_tests {
+        use super::*;
+
+        #[test]
+        fn merged_fold_preserves_every_bucket_weight() {
+            struct Check;
+            impl crate::curve::WithBackend for Check {
+                type Output = ();
+                fn call<B: Backend>(self, backend: B) {
+                    let base = GAffine::BASEPOINT.to_extended();
+                    let torsion = GAffine::decompress(&[0; 32]).unwrap().to_extended();
+                    for width in [6, 7, 8, 9, 10] {
+                        let nb = super::super::num_buckets(width);
+                        let mut point = base;
+                        let buckets: Vec<G> = (0..STRIPES * nb)
+                            .map(|i| {
+                                point = point.add(base);
+                                match i % 7 {
+                                    0 => torsion,
+                                    1 => point.add(torsion),
+                                    2 => point.negate(),
+                                    3 => G::IDENTITY,
+                                    _ => point,
+                                }
+                            })
+                            .collect();
+                        let mut expected = G::IDENTITY;
+                        for used in 0..=nb {
+                            if used != 0 {
+                                let bucket = (0..STRIPES).fold(G::IDENTITY, |sum, stripe| {
+                                    sum.add(buckets[stripe * nb + used - 1])
+                                });
+                                let weighted = bucket.scalar_mul(
+                                    (0..usize::BITS).rev().map(|bit| used & (1 << bit) != 0),
+                                );
+                                expected = expected.add(weighted);
+                            }
+                            let actual =
+                                fold_buckets_merged(backend, &buckets, nb, used).sum_lanes(backend);
+                            assert!(
+                                actual.add(expected.negate()).is_identity(),
+                                "width={width} used={used}"
+                            );
+                        }
+                    }
+                }
+            }
+            crate::curve::WithBackend::call(Check, crate::curve::test_backend());
+            crate::curve::with_backend(Check);
+        }
     }
 
     /// One window's contribution to the MSM over global term range `[start, end)`, *before* the
@@ -229,13 +358,21 @@ mod transposed {
         buckets: &mut [G],
     ) -> G {
         let nb = super::num_buckets(width);
-        debug_assert_eq!(buckets.len(), LANES * nb);
-        buckets.fill(G::IDENTITY);
+        debug_assert_eq!(buckets.len(), STRIPES * nb);
         let used = super::used_buckets(chunks, start, end, window);
+        // An all-zero window contributes the identity without resetting or folding scratch
+        if used == 0 {
+            return G::IDENTITY;
+        }
+        buckets.fill(G::IDENTITY);
         for piece in super::pieces(chunks, start, end) {
             fill_buckets(backend, buckets, nb, piece, window);
         }
-        fold_buckets(backend, GVec::identity(), buckets, nb, used).sum_lanes(backend)
+        #[cfg(target_arch = "aarch64")]
+        let partial = fold_buckets_merged(backend, buckets, nb, used);
+        #[cfg(not(target_arch = "aarch64"))]
+        let partial = fold_buckets(backend, GVec::identity(), buckets, nb, used);
+        partial.sum_lanes(backend)
     }
 
     /// Computes the full MSM over `chunks` via the lane-transposed Pippenger bucket method,
@@ -295,7 +432,20 @@ fn multiscalar_mul_points_serial<B: Backend>(
 
 /// Horner-folds per-window partial sums into the final MSM result: from the top window down,
 /// `width` doublings shift everything accumulated so far up one window, then the next window's
-/// partial joins.
+/// partial joins. Scalar recombination computes each point once, avoiding duplicate SIMD lanes.
+#[cfg(target_arch = "aarch64")]
+fn fold_windows<B: Backend>(_: B, windows: &[G], width: u32) -> G {
+    let mut result = G::IDENTITY;
+    for window in windows.iter().rev() {
+        for _ in 0..width {
+            result = result.double();
+        }
+        result = result.add(*window);
+    }
+    result
+}
+
+#[cfg(not(target_arch = "aarch64"))]
 fn fold_windows<B: Backend>(backend: B, windows: &[G], width: u32) -> G {
     let mut result = GVec::identity();
     for window in windows.iter().rev() {
@@ -389,14 +539,25 @@ pub(super) fn multiscalar_mul<B: Backend>(
             (tile.window, partial)
         },
     );
-    let mut window_sums = vec![GVec::identity(); windows];
-    for (window, partial) in partials {
-        window_sums[window] = backend.g_add(window_sums[window], GVec::splat(partial));
-    }
-    let window_sums: Vec<G> = window_sums
-        .into_iter()
-        .map(|window| window.untranspose()[0])
-        .collect();
+    #[cfg(target_arch = "aarch64")]
+    let window_sums = {
+        let mut window_sums = vec![G::IDENTITY; windows];
+        for (window, partial) in partials {
+            window_sums[window] = window_sums[window].add(partial);
+        }
+        window_sums
+    };
+    #[cfg(not(target_arch = "aarch64"))]
+    let window_sums = {
+        let mut window_sums = vec![GVec::identity(); windows];
+        for (window, partial) in partials {
+            window_sums[window] = backend.g_add(window_sums[window], GVec::splat(partial));
+        }
+        window_sums
+            .into_iter()
+            .map(|window| window.untranspose()[0])
+            .collect::<Vec<_>>()
+    };
     fold_windows(backend, &window_sums, width)
 }
 
@@ -626,6 +787,35 @@ mod tests {
                 }
                 Ok(())
             });
+    }
+
+    #[test]
+    fn window_partials_reuse_scratch_across_zero_windows() {
+        let backend = crate::curve::test_backend();
+        let point = GAffine::BASEPOINT;
+        for width in TEST_WIDTHS {
+            let scalar = Scalar::from_u128((1u128 << (2 * width)) | 1);
+            let terms = [Term::new(point, &scalar, width)];
+            let mut buckets = transposed::identity_buckets(num_buckets(width));
+            for (window, expected) in [point.to_extended(), G::IDENTITY, point.to_extended()]
+                .into_iter()
+                .enumerate()
+            {
+                let actual = transposed::window_partial(
+                    backend,
+                    &[&terms],
+                    0,
+                    terms.len(),
+                    window,
+                    width,
+                    &mut buckets,
+                );
+                assert!(
+                    points_equal(actual, expected),
+                    "window={window} width={width}"
+                );
+            }
+        }
     }
 
     /// Splitting a window's bucket fill at an arbitrary global index (deliberately not a slice

--- a/cryptography/curve25519/src/signing/core/msm.rs
+++ b/cryptography/curve25519/src/signing/core/msm.rs
@@ -128,8 +128,8 @@ mod transposed {
     use super::GAffineVec;
     use super::{Backend, G, GAffine, GVec, LANES, Term};
 
-    // NEON fills one stripe per physical mixed-addition lane, keeping wave updates independent
-    // Folds retain LANES independent bucket indices
+    // NEON fills one stripe per physical mixed-addition lane, keeping wave updates independent.
+    // Folds retain LANES independent bucket indices.
     #[cfg(target_arch = "aarch64")]
     const STRIPES: usize = 2;
     #[cfg(not(target_arch = "aarch64"))]
@@ -137,19 +137,19 @@ mod transposed {
     #[cfg(not(feature = "std"))]
     use alloc::{vec, vec::Vec};
 
-    /// Independent bucket stripes, indexed by `stripe * nb + abs(digit) - 1`
+    /// Independent bucket stripes, indexed by `stripe * nb + abs(digit) - 1`.
     ///
     /// Each wave assigns one term to each stripe, so updates within a wave cannot collide.
-    /// Heap allocation accommodates the per-batch bucket count
+    /// Heap allocation accommodates the per-batch bucket count.
     pub(super) fn identity_buckets(nb: usize) -> Vec<G> {
         vec![G::IDENTITY; STRIPES * nb]
     }
 
-    /// Adds each run in waves of one term per bucket stripe
+    /// Adds each run in waves of one term per bucket stripe.
     ///
     /// Missing or zero-digit lanes use identity inputs and never scatter a result. Entirely
     /// zero waves skip group arithmetic, including the high windows of short coefficients.
-    /// Each piece may restart stripe assignment because the fold sums every stripe
+    /// Each piece may restart stripe assignment because the fold sums every stripe.
     #[allow(clippy::needless_range_loop)]
     fn fill_buckets<B: Backend>(
         backend: B,
@@ -200,10 +200,10 @@ mod transposed {
         }
     }
 
-    /// Folds each bucket stripe into its corresponding result lane with a running sum
+    /// Folds each bucket stripe into its corresponding result lane with a running sum.
     ///
     /// Lanes without a stripe contribute the identity. Untouched top buckets can be skipped
-    /// because their identity values leave both running sums unchanged
+    /// because their identity values leave both running sums unchanged.
     #[cfg(any(test, not(target_arch = "aarch64")))]
     fn fold_buckets<B: Backend>(
         backend: B,
@@ -233,10 +233,10 @@ mod transposed {
     /// Let `B[k, lane]` sum the stripes at bucket index `k*LANES + lane`. The descending pass
     /// builds `sum[lane] = sum_k B[k, lane]` and `rows[lane] = sum_k k*B[k, lane]`.
     /// Final weighting gives `LANES*rows[lane] + (lane + 1)*sum[lane]`, assigning each bucket
-    /// its index-plus-one weight. The lane count is a power of two
+    /// its index-plus-one weight. The lane count is a power of two.
     #[cfg(target_arch = "aarch64")]
     fn fold_buckets_merged<B: Backend>(backend: B, buckets: &[G], nb: usize, used: usize) -> GVec {
-        // A single used bucket has weight one, so return the stripes without weighting
+        // A single used bucket has weight one, so return the stripes without weighting.
         if used == 1 {
             return GVec::transpose(core::array::from_fn(|lane| {
                 if lane < STRIPES {
@@ -267,7 +267,7 @@ mod transposed {
             sum = backend.g_add(sum, combined);
         }
 
-        // Seed the high bit of lane + 1, then fold its remaining bits
+        // Seed the high bit of lane + 1, then fold its remaining bits.
         let lanes = sum.untranspose();
         let mut weighted = GVec::transpose(core::array::from_fn(|lane| {
             if lane == LANES - 1 {
@@ -360,8 +360,8 @@ mod transposed {
         let nb = super::num_buckets(width);
         debug_assert_eq!(buckets.len(), STRIPES * nb);
         let used = super::used_buckets(chunks, start, end, window);
-        // An all-zero window contributes the identity without resetting or folding scratch
         if used == 0 {
+            // An all-zero window contributes the identity without resetting or folding scratch.
             return G::IDENTITY;
         }
         buckets.fill(G::IDENTITY);

--- a/cryptography/curve25519/src/signing/core/msm.rs
+++ b/cryptography/curve25519/src/signing/core/msm.rs
@@ -9,9 +9,7 @@
 //! added together, and one short Horner fold positions the window sums.
 
 use super::scalar::Scalar;
-#[cfg(test)]
-use crate::curve::GVec;
-use crate::curve::{Backend, G, GAffine};
+use crate::curve::{G, GAffine, msm::Backend};
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 use commonware_parallel::Strategy;
@@ -123,12 +121,8 @@ fn used_buckets(chunks: &[&[Term]], start: usize, end: usize, window: usize) -> 
         .unwrap_or(0)
 }
 
-mod transposed {
-    #[cfg(test)]
-    use super::GVec;
+mod bucketed {
     use super::{Backend, G, Term};
-    #[cfg(test)]
-    use crate::curve::msm::fold_buckets;
     #[cfg(not(feature = "std"))]
     use alloc::{vec, vec::Vec};
 
@@ -138,9 +132,7 @@ mod transposed {
     }
 
     /// One window's contribution to the MSM over global term range `[start, end)`, *before* the
-    /// doubling shift that positions it -- the vectorized counterpart of
-    /// the scalar bucket algorithm, with the `LANES` per-lane partials summed down to a
-    /// single point at the end (valid because MSM is linear in its terms).
+    /// doubling shift that positions it. The backend folds its bucket stripes into one point.
     pub(super) fn window_partial<B: Backend>(
         backend: B,
         chunks: &[&[Term]],
@@ -161,15 +153,11 @@ mod transposed {
         for piece in super::pieces(chunks, start, end) {
             backend.fill_buckets(buckets, nb, piece, |term| (term.point, term.digits[window]));
         }
-        let partial = backend.fold_buckets(buckets, nb, used);
-        partial.sum_lanes(backend)
+        backend.fold_buckets(buckets, nb, used)
     }
 
-    /// Computes the full MSM over `chunks` via the lane-transposed Pippenger bucket method,
-    /// window by window from the top down. Unlike [`window_partial`], the running `result` stays
-    /// a [`GVec`] across all windows -- the inter-window doublings run `LANES` wide, and the
-    /// lanes are only summed down to a single point once, at the very end. One bucket allocation
-    /// is reused (re-set to the identity) across every window.
+    /// Computes the full MSM with backend bucket filling and an independent scalar fold.
+    /// One bucket allocation is reused across every window.
     #[cfg(test)]
     pub(super) fn multiscalar_mul_serial<B: Backend>(
         backend: B,
@@ -178,11 +166,11 @@ mod transposed {
     ) -> G {
         let nb = super::num_buckets(width);
         let total = super::total_terms(chunks);
-        let mut result = GVec::identity();
+        let mut result = G::IDENTITY;
         let mut buckets = identity_buckets(backend, nb);
         for window in (0..super::num_windows(width)).rev() {
             for _ in 0..width {
-                result = backend.g_double(result);
+                result = result.double();
             }
             let used = super::used_buckets(chunks, 0, total, window);
             for piece in super::pieces(chunks, 0, total) {
@@ -190,18 +178,24 @@ mod transposed {
                     (term.point, term.digits[window])
                 });
             }
-            result = fold_buckets(backend, result, &buckets, nb, used);
+            let mut sum = G::IDENTITY;
+            for digit in (0..used).rev() {
+                for stripe in 0..B::STRIPES {
+                    sum = sum.add(buckets[stripe * nb + digit]);
+                }
+                result = result.add(sum);
+            }
             buckets.fill(G::IDENTITY);
         }
 
-        result.sum_lanes(backend)
+        result
     }
 }
 
-/// Computes the full MSM over `chunks` serially using the backend's transposed lanes.
+/// Computes the full MSM over `chunks` with an independent scalar fold.
 #[cfg(test)]
 fn multiscalar_mul_terms_serial<B: Backend>(backend: B, chunks: &[&[Term]], width: u32) -> G {
-    transposed::multiscalar_mul_serial(backend, chunks, width)
+    bucketed::multiscalar_mul_serial(backend, chunks, width)
 }
 
 /// Computes `sum(points[i] * scalars[i])` serially: the reference the differential tests below
@@ -290,9 +284,9 @@ pub(super) fn multiscalar_mul<B: Backend>(
     let buckets = num_buckets(width);
     let partials = strategy.map_init_collect_vec(
         tiles,
-        || transposed::identity_buckets(backend, buckets),
+        || bucketed::identity_buckets(backend, buckets),
         |scratch, tile| {
-            let partial = transposed::window_partial(
+            let partial = bucketed::window_partial(
                 backend,
                 chunks,
                 tile.start,
@@ -310,6 +304,7 @@ pub(super) fn multiscalar_mul<B: Backend>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::curve::Backend;
     #[cfg(not(feature = "std"))]
     use alloc::vec;
     use arbitrary::Unstructured;
@@ -358,7 +353,7 @@ mod tests {
         actual.add(expected.negate()).is_identity()
     }
 
-    /// Splits `terms` into owned chunks of the given (deliberately uneven, `LANES`-unaligned)
+    /// Splits `terms` into owned chunks of the given (deliberately uneven, stripe-unaligned)
     /// sizes, with any remainder in one final chunk.
     fn split_terms(mut terms: Vec<Term>, sizes: &[usize]) -> Vec<Vec<Term>> {
         let mut chunks = Vec::new();
@@ -457,7 +452,7 @@ mod tests {
             });
     }
 
-    /// Slice boundaries are pure layout: any split of the same terms (including `LANES`-unaligned
+    /// Slice boundaries are pure layout: any split of the same terms (including stripe-unaligned
     /// and empty slices, whose tail waves pad with identity lanes) must produce the same point as
     /// one contiguous slice.
     #[test]
@@ -576,13 +571,13 @@ mod tests {
                 for width in TEST_WIDTHS {
                     let scalar = Scalar::from_u128((1u128 << (2 * width)) | 1);
                     let terms = [Term::new(point, &scalar, width)];
-                    let mut buckets = transposed::identity_buckets(backend, num_buckets(width));
+                    let mut buckets = bucketed::identity_buckets(backend, num_buckets(width));
                     for (window, expected) in
                         [point.to_extended(), G::IDENTITY, point.to_extended()]
                             .into_iter()
                             .enumerate()
                     {
-                        let actual = transposed::window_partial(
+                        let actual = bucketed::window_partial(
                             backend,
                             &[&terms],
                             0,
@@ -629,11 +624,11 @@ mod tests {
                             let expected = multiscalar_mul_terms_serial(backend, &chunks, WIDTH);
 
                             let nw = num_windows(WIDTH);
-                            let mut transposed_windows = vec![G::IDENTITY; nw];
+                            let mut window_partials = vec![G::IDENTITY; nw];
                             let mut buckets =
-                                transposed::identity_buckets(backend, num_buckets(WIDTH));
-                            for (window, partial) in transposed_windows.iter_mut().enumerate() {
-                                let left = transposed::window_partial(
+                                bucketed::identity_buckets(backend, num_buckets(WIDTH));
+                            for (window, partial) in window_partials.iter_mut().enumerate() {
+                                let left = bucketed::window_partial(
                                     backend,
                                     &chunks,
                                     0,
@@ -642,7 +637,7 @@ mod tests {
                                     WIDTH,
                                     &mut buckets,
                                 );
-                                let right = transposed::window_partial(
+                                let right = bucketed::window_partial(
                                     backend,
                                     &chunks,
                                     mid,
@@ -656,7 +651,7 @@ mod tests {
 
                             assert!(points_equal(
                                 backend.combine_windows(
-                                    transposed_windows.into_iter().enumerate(),
+                                    window_partials.into_iter().enumerate(),
                                     nw,
                                     WIDTH
                                 ),

--- a/cryptography/curve25519/src/signing/core/msm.rs
+++ b/cryptography/curve25519/src/signing/core/msm.rs
@@ -9,9 +9,9 @@
 //! added together, and one short Horner fold positions the window sums.
 
 use super::scalar::Scalar;
-use crate::curve::{Backend, G, GAffine};
 #[cfg(test)]
-use crate::curve::{GVec, msm::Backend as _};
+use crate::curve::GVec;
+use crate::curve::{Backend, G, GAffine};
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 use commonware_parallel::Strategy;
@@ -462,24 +462,31 @@ mod tests {
     /// one contiguous slice.
     #[test]
     fn chunked_matches_single_chunk() {
-        let backend = crate::curve::test_backend();
-        Builder::default()
-            .with_seed(0)
-            .with_search_limit(8)
-            .test(|u| {
-                let terms = arbitrary_terms(u, 100, 7)?;
-                for n in [1, 2, 5, 8, 9, 32, 64, 100] {
-                    let terms = terms[..n].to_vec();
-                    let single = split_terms(terms.clone(), &[]);
-                    let mut chunks = split_terms(terms, &[1, 3, 7, 9, 24]);
-                    chunks.push(Vec::new());
+        struct Check;
+        impl crate::curve::WithBackend for Check {
+            type Output = ();
+            fn call<B: Backend>(self, backend: B) {
+                Builder::default()
+                    .with_seed(0)
+                    .with_search_limit(8)
+                    .test(|u| {
+                        let terms = arbitrary_terms(u, 100, 7)?;
+                        for n in [1, 2, 5, 8, 9, 32, 64, 100] {
+                            let terms = terms[..n].to_vec();
+                            let single = split_terms(terms.clone(), &[]);
+                            let mut chunks = split_terms(terms, &[1, 3, 7, 9, 24]);
+                            chunks.push(Vec::new());
 
-                    let expected = multiscalar_mul_terms_serial(backend, &refs(&single), 7);
-                    let actual = multiscalar_mul_terms_serial(backend, &refs(&chunks), 7);
-                    assert!(points_equal(actual, expected));
-                }
-                Ok(())
-            });
+                            let expected = multiscalar_mul_terms_serial(backend, &refs(&single), 7);
+                            let actual = multiscalar_mul_terms_serial(backend, &refs(&chunks), 7);
+                            assert!(points_equal(actual, expected));
+                        }
+                        Ok(())
+                    });
+            }
+        }
+        crate::curve::WithBackend::call(Check, crate::curve::test_backend());
+        crate::curve::with_backend(Check);
     }
 
     #[test]
@@ -603,57 +610,65 @@ mod tests {
     /// combine same-window tiles with a single addition.
     #[test]
     fn split_window_partials_match_whole_range() {
-        let backend = crate::curve::test_backend();
-        const WIDTH: u32 = 7;
-        Builder::default()
-            .with_seed(0)
-            .with_search_limit(8)
-            .test(|u| {
-                let terms = arbitrary_terms(u, 100, WIDTH)?;
-                for n in [1, 2, 5, 8, 9, 32, 64, 100] {
-                    let chunks = split_terms(terms[..n].to_vec(), &[n / 3, n / 3]);
-                    let chunks = refs(&chunks);
-                    let total = total_terms(&chunks);
-                    let mid = total / 2;
+        struct Check;
+        impl crate::curve::WithBackend for Check {
+            type Output = ();
+            fn call<B: Backend>(self, backend: B) {
+                const WIDTH: u32 = 7;
+                Builder::default()
+                    .with_seed(0)
+                    .with_search_limit(8)
+                    .test(|u| {
+                        let terms = arbitrary_terms(u, 100, WIDTH)?;
+                        for n in [1, 2, 5, 8, 9, 32, 64, 100] {
+                            let chunks = split_terms(terms[..n].to_vec(), &[n / 3, n / 3]);
+                            let chunks = refs(&chunks);
+                            let total = total_terms(&chunks);
+                            let mid = total / 2;
 
-                    let expected = multiscalar_mul_terms_serial(backend, &chunks, WIDTH);
+                            let expected = multiscalar_mul_terms_serial(backend, &chunks, WIDTH);
 
-                    let nw = num_windows(WIDTH);
-                    let mut transposed_windows = vec![G::IDENTITY; nw];
-                    let mut buckets = transposed::identity_buckets(backend, num_buckets(WIDTH));
-                    for (window, partial) in transposed_windows.iter_mut().enumerate() {
-                        let left = transposed::window_partial(
-                            backend,
-                            &chunks,
-                            0,
-                            mid,
-                            window,
-                            WIDTH,
-                            &mut buckets,
-                        );
-                        let right = transposed::window_partial(
-                            backend,
-                            &chunks,
-                            mid,
-                            total,
-                            window,
-                            WIDTH,
-                            &mut buckets,
-                        );
-                        *partial = left.add(right);
-                    }
+                            let nw = num_windows(WIDTH);
+                            let mut transposed_windows = vec![G::IDENTITY; nw];
+                            let mut buckets =
+                                transposed::identity_buckets(backend, num_buckets(WIDTH));
+                            for (window, partial) in transposed_windows.iter_mut().enumerate() {
+                                let left = transposed::window_partial(
+                                    backend,
+                                    &chunks,
+                                    0,
+                                    mid,
+                                    window,
+                                    WIDTH,
+                                    &mut buckets,
+                                );
+                                let right = transposed::window_partial(
+                                    backend,
+                                    &chunks,
+                                    mid,
+                                    total,
+                                    window,
+                                    WIDTH,
+                                    &mut buckets,
+                                );
+                                *partial = left.add(right);
+                            }
 
-                    assert!(points_equal(
-                        backend.combine_windows(
-                            transposed_windows.into_iter().enumerate(),
-                            nw,
-                            WIDTH
-                        ),
-                        expected,
-                    ));
-                }
-                Ok(())
-            });
+                            assert!(points_equal(
+                                backend.combine_windows(
+                                    transposed_windows.into_iter().enumerate(),
+                                    nw,
+                                    WIDTH
+                                ),
+                                expected,
+                            ));
+                        }
+                        Ok(())
+                    });
+            }
+        }
+        crate::curve::WithBackend::call(Check, crate::curve::test_backend());
+        crate::curve::with_backend(Check);
     }
 
     /// [`pieces`] must hand back exactly the requested global range, in order, for any cut --

--- a/cryptography/curve25519/src/signing/core/msm.rs
+++ b/cryptography/curve25519/src/signing/core/msm.rs
@@ -292,56 +292,52 @@ mod transposed {
     }
 
     #[cfg(all(test, target_arch = "aarch64"))]
-    mod merged_tests {
-        use super::*;
-
-        #[test]
-        fn merged_fold_preserves_every_bucket_weight() {
-            struct Check;
-            impl crate::curve::WithBackend for Check {
-                type Output = ();
-                fn call<B: Backend>(self, backend: B) {
-                    let base = GAffine::BASEPOINT.to_extended();
-                    let torsion = GAffine::decompress(&[0; 32]).unwrap().to_extended();
-                    for width in [6, 7, 8, 9, 10] {
-                        let nb = super::super::num_buckets(width);
-                        let mut point = base;
-                        let buckets: Vec<G> = (0..STRIPES * nb)
-                            .map(|i| {
-                                point = point.add(base);
-                                match i % 7 {
-                                    0 => torsion,
-                                    1 => point.add(torsion),
-                                    2 => point.negate(),
-                                    3 => G::IDENTITY,
-                                    _ => point,
-                                }
-                            })
-                            .collect();
-                        let mut expected = G::IDENTITY;
-                        for used in 0..=nb {
-                            if used != 0 {
-                                let bucket = (0..STRIPES).fold(G::IDENTITY, |sum, stripe| {
-                                    sum.add(buckets[stripe * nb + used - 1])
-                                });
-                                let weighted = bucket.scalar_mul(
-                                    (0..usize::BITS).rev().map(|bit| used & (1 << bit) != 0),
-                                );
-                                expected = expected.add(weighted);
+    #[test]
+    fn merged_fold_preserves_every_bucket_weight() {
+        struct Check;
+        impl crate::curve::WithBackend for Check {
+            type Output = ();
+            fn call<B: Backend>(self, backend: B) {
+                let base = GAffine::BASEPOINT.to_extended();
+                let torsion = GAffine::decompress(&[0; 32]).unwrap().to_extended();
+                for width in [6, 7, 8, 9, 10] {
+                    let nb = super::num_buckets(width);
+                    let mut point = base;
+                    let buckets: Vec<G> = (0..STRIPES * nb)
+                        .map(|i| {
+                            point = point.add(base);
+                            match i % 7 {
+                                0 => torsion,
+                                1 => point.add(torsion),
+                                2 => point.negate(),
+                                3 => G::IDENTITY,
+                                _ => point,
                             }
-                            let actual =
-                                fold_buckets_merged(backend, &buckets, nb, used).sum_lanes(backend);
-                            assert!(
-                                actual.add(expected.negate()).is_identity(),
-                                "width={width} used={used}"
+                        })
+                        .collect();
+                    let mut expected = G::IDENTITY;
+                    for used in 0..=nb {
+                        if used != 0 {
+                            let bucket = (0..STRIPES).fold(G::IDENTITY, |sum, stripe| {
+                                sum.add(buckets[stripe * nb + used - 1])
+                            });
+                            let weighted = bucket.scalar_mul(
+                                (0..usize::BITS).rev().map(|bit| used & (1 << bit) != 0),
                             );
+                            expected = expected.add(weighted);
                         }
+                        let actual =
+                            fold_buckets_merged(backend, &buckets, nb, used).sum_lanes(backend);
+                        assert!(
+                            actual.add(expected.negate()).is_identity(),
+                            "width={width} used={used}"
+                        );
                     }
                 }
             }
-            crate::curve::WithBackend::call(Check, crate::curve::test_backend());
-            crate::curve::with_backend(Check);
         }
+        crate::curve::WithBackend::call(Check, crate::curve::test_backend());
+        crate::curve::with_backend(Check);
     }
 
     /// One window's contribution to the MSM over global term range `[start, end)`, *before* the

--- a/cryptography/curve25519/src/signing/core/msm.rs
+++ b/cryptography/curve25519/src/signing/core/msm.rs
@@ -11,7 +11,7 @@
 use super::scalar::Scalar;
 use crate::curve::{Backend, G, GAffine};
 #[cfg(test)]
-use crate::curve::{GVec, msm::MsmBackend};
+use crate::curve::{GVec, msm::Backend as _};
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 use commonware_parallel::Strategy;

--- a/cryptography/curve25519/src/signing/core/msm.rs
+++ b/cryptography/curve25519/src/signing/core/msm.rs
@@ -9,11 +9,11 @@
 //! added together, and one short Horner fold positions the window sums.
 
 use super::scalar::Scalar;
-#[cfg(not(target_arch = "aarch64"))]
-use crate::curve::GAffineVec;
-use crate::curve::{Backend, G, GAffine, GVec, LANES};
+use crate::curve::{Backend, G, GAffine};
+#[cfg(test)]
+use crate::curve::{GVec, msm::MsmBackend};
 #[cfg(not(feature = "std"))]
-use alloc::{vec, vec::Vec};
+use alloc::vec::Vec;
 use commonware_parallel::Strategy;
 
 /// Bounds on the per-batch window width [`width_for`] may pick. The lower bound sizes every
@@ -124,220 +124,17 @@ fn used_buckets(chunks: &[&[Term]], start: usize, end: usize, window: usize) -> 
 }
 
 mod transposed {
-    #[cfg(not(target_arch = "aarch64"))]
-    use super::GAffineVec;
-    use super::{Backend, G, GAffine, GVec, LANES, Term};
-
-    // NEON fills one stripe per physical mixed-addition lane, keeping wave updates independent.
-    // Folds retain LANES independent bucket indices.
-    #[cfg(target_arch = "aarch64")]
-    const STRIPES: usize = 2;
-    #[cfg(not(target_arch = "aarch64"))]
-    const STRIPES: usize = LANES;
+    #[cfg(test)]
+    use super::GVec;
+    use super::{Backend, G, Term};
+    #[cfg(test)]
+    use crate::curve::msm::fold_buckets;
     #[cfg(not(feature = "std"))]
     use alloc::{vec, vec::Vec};
 
-    /// Independent bucket stripes, indexed by `stripe * nb + abs(digit) - 1`.
-    ///
-    /// Each wave assigns one term to each stripe, so updates within a wave cannot collide.
-    /// Heap allocation accommodates the per-batch bucket count.
-    pub(super) fn identity_buckets(nb: usize) -> Vec<G> {
-        vec![G::IDENTITY; STRIPES * nb]
-    }
-
-    /// Adds each run in waves of one term per bucket stripe.
-    ///
-    /// Missing or zero-digit lanes use identity inputs and never scatter a result. Entirely
-    /// zero waves skip group arithmetic, including the high windows of short coefficients.
-    /// Each piece may restart stripe assignment because the fold sums every stripe.
-    #[allow(clippy::needless_range_loop)]
-    fn fill_buckets<B: Backend>(
-        backend: B,
-        buckets: &mut [G],
-        nb: usize,
-        terms: &[Term],
-        window: usize,
-    ) {
-        let identity_point = GAffine::IDENTITY;
-        for wave in terms.chunks(STRIPES) {
-            let mut incoming = [identity_point; STRIPES];
-            let mut negative = [false; STRIPES];
-            let mut current = [G::IDENTITY; STRIPES];
-            let mut bucket_index = [None::<usize>; STRIPES];
-            let mut any = false;
-            for (lane, term) in wave.iter().enumerate() {
-                let digit = term.digits[window];
-                if digit > 0 {
-                    bucket_index[lane] = Some(digit as usize - 1);
-                    incoming[lane] = term.point;
-                } else if digit < 0 {
-                    bucket_index[lane] = Some(digit.unsigned_abs() as usize - 1);
-                    incoming[lane] = term.point;
-                    negative[lane] = true;
-                }
-                if let Some(i) = bucket_index[lane] {
-                    current[lane] = buckets[lane * nb + i];
-                    any = true;
-                }
-            }
-            if !any {
-                continue;
-            }
-            #[cfg(target_arch = "aarch64")]
-            let updated = backend.g_add_mixed_pair(current, incoming, negative);
-            #[cfg(not(target_arch = "aarch64"))]
-            let updated = backend
-                .g_add_mixed(
-                    GVec::transpose(current),
-                    GAffineVec::from_signed_lanes(backend, &incoming, &negative),
-                )
-                .untranspose();
-            for lane in 0..STRIPES {
-                if let Some(i) = bucket_index[lane] {
-                    buckets[lane * nb + i] = updated[lane];
-                }
-            }
-        }
-    }
-
-    /// Folds each bucket stripe into its corresponding result lane with a running sum.
-    ///
-    /// Lanes without a stripe contribute the identity. Untouched top buckets can be skipped
-    /// because their identity values leave both running sums unchanged.
-    #[cfg(any(test, not(target_arch = "aarch64")))]
-    fn fold_buckets<B: Backend>(
-        backend: B,
-        result: GVec,
-        buckets: &[G],
-        nb: usize,
-        used: usize,
-    ) -> GVec {
-        let mut sum = GVec::identity();
-        let mut window_sum = GVec::identity();
-        for d in (0..used).rev() {
-            let bucket_group: [G; LANES] = core::array::from_fn(|lane| {
-                if lane < STRIPES {
-                    buckets[lane * nb + d]
-                } else {
-                    G::IDENTITY
-                }
-            });
-            sum = backend.g_add(sum, GVec::transpose(bucket_group));
-            window_sum = backend.g_add(window_sum, sum);
-        }
-        backend.g_add(result, window_sum)
-    }
-
-    /// Returns lanes whose sum is the weighted sum of all bucket stripes.
-    ///
-    /// Let `B[k, lane]` sum the stripes at bucket index `k*LANES + lane`. The descending pass
-    /// builds `sum[lane] = sum_k B[k, lane]` and `rows[lane] = sum_k k*B[k, lane]`.
-    /// Final weighting gives `LANES*rows[lane] + (lane + 1)*sum[lane]`, assigning each bucket
-    /// its index-plus-one weight. The lane count is a power of two.
-    #[cfg(target_arch = "aarch64")]
-    fn fold_buckets_merged<B: Backend>(backend: B, buckets: &[G], nb: usize, used: usize) -> GVec {
-        // A single used bucket has weight one, so return the stripes without weighting.
-        if used == 1 {
-            return GVec::transpose(core::array::from_fn(|lane| {
-                if lane < STRIPES {
-                    buckets[lane * nb]
-                } else {
-                    G::IDENTITY
-                }
-            }));
-        }
-        let mut sum = GVec::identity();
-        let mut rows = GVec::identity();
-        for block in (0..used.div_ceil(LANES)).rev() {
-            let gather = |stripe: usize| {
-                GVec::transpose(core::array::from_fn(|lane| {
-                    let digit = block * LANES + lane;
-                    if digit < used {
-                        buckets[stripe * nb + digit]
-                    } else {
-                        G::IDENTITY
-                    }
-                }))
-            };
-            let mut combined = gather(0);
-            for stripe in 1..STRIPES {
-                combined = backend.g_add(combined, gather(stripe));
-            }
-            rows = backend.g_add(rows, sum);
-            sum = backend.g_add(sum, combined);
-        }
-
-        // Seed the high bit of lane + 1, then fold its remaining bits.
-        let lanes = sum.untranspose();
-        let mut weighted = GVec::transpose(core::array::from_fn(|lane| {
-            if lane == LANES - 1 {
-                lanes[lane]
-            } else {
-                G::IDENTITY
-            }
-        }));
-        for bit in (0..3).rev() {
-            rows = backend.g_double(rows);
-            weighted = backend.g_double(weighted);
-            let selected = core::array::from_fn(|lane| {
-                if (lane + 1) & (1 << bit) != 0 {
-                    lanes[lane]
-                } else {
-                    G::IDENTITY
-                }
-            });
-            weighted = backend.g_add(weighted, GVec::transpose(selected));
-        }
-        backend.g_add(rows, weighted)
-    }
-
-    #[cfg(all(test, target_arch = "aarch64"))]
-    #[test]
-    fn merged_fold_preserves_every_bucket_weight() {
-        struct Check;
-        impl crate::curve::WithBackend for Check {
-            type Output = ();
-            fn call<B: Backend>(self, backend: B) {
-                let base = GAffine::BASEPOINT.to_extended();
-                let torsion = GAffine::decompress(&[0; 32]).unwrap().to_extended();
-                for width in [6, 7, 8, 9, 10] {
-                    let nb = super::num_buckets(width);
-                    let mut point = base;
-                    let buckets: Vec<G> = (0..STRIPES * nb)
-                        .map(|i| {
-                            point = point.add(base);
-                            match i % 7 {
-                                0 => torsion,
-                                1 => point.add(torsion),
-                                2 => point.negate(),
-                                3 => G::IDENTITY,
-                                _ => point,
-                            }
-                        })
-                        .collect();
-                    let mut expected = G::IDENTITY;
-                    for used in 0..=nb {
-                        if used != 0 {
-                            let bucket = (0..STRIPES).fold(G::IDENTITY, |sum, stripe| {
-                                sum.add(buckets[stripe * nb + used - 1])
-                            });
-                            let weighted = bucket.scalar_mul(
-                                (0..usize::BITS).rev().map(|bit| used & (1 << bit) != 0),
-                            );
-                            expected = expected.add(weighted);
-                        }
-                        let actual =
-                            fold_buckets_merged(backend, &buckets, nb, used).sum_lanes(backend);
-                        assert!(
-                            actual.add(expected.negate()).is_identity(),
-                            "width={width} used={used}"
-                        );
-                    }
-                }
-            }
-        }
-        crate::curve::WithBackend::call(Check, crate::curve::test_backend());
-        crate::curve::with_backend(Check);
+    /// Independent bucket stripes, with per-batch bucket counts allocated on the heap.
+    pub(super) fn identity_buckets<B: Backend>(_: B, nb: usize) -> Vec<G> {
+        vec![G::IDENTITY; B::STRIPES * nb]
     }
 
     /// One window's contribution to the MSM over global term range `[start, end)`, *before* the
@@ -354,7 +151,7 @@ mod transposed {
         buckets: &mut [G],
     ) -> G {
         let nb = super::num_buckets(width);
-        debug_assert_eq!(buckets.len(), STRIPES * nb);
+        debug_assert_eq!(buckets.len(), B::STRIPES * nb);
         let used = super::used_buckets(chunks, start, end, window);
         if used == 0 {
             // An all-zero window contributes the identity without resetting or folding scratch.
@@ -362,12 +159,9 @@ mod transposed {
         }
         buckets.fill(G::IDENTITY);
         for piece in super::pieces(chunks, start, end) {
-            fill_buckets(backend, buckets, nb, piece, window);
+            backend.fill_buckets(buckets, nb, piece, |term| (term.point, term.digits[window]));
         }
-        #[cfg(target_arch = "aarch64")]
-        let partial = fold_buckets_merged(backend, buckets, nb, used);
-        #[cfg(not(target_arch = "aarch64"))]
-        let partial = fold_buckets(backend, GVec::identity(), buckets, nb, used);
+        let partial = backend.fold_buckets(buckets, nb, used);
         partial.sum_lanes(backend)
     }
 
@@ -385,14 +179,16 @@ mod transposed {
         let nb = super::num_buckets(width);
         let total = super::total_terms(chunks);
         let mut result = GVec::identity();
-        let mut buckets = identity_buckets(nb);
+        let mut buckets = identity_buckets(backend, nb);
         for window in (0..super::num_windows(width)).rev() {
             for _ in 0..width {
                 result = backend.g_double(result);
             }
             let used = super::used_buckets(chunks, 0, total, window);
             for piece in super::pieces(chunks, 0, total) {
-                fill_buckets(backend, &mut buckets, nb, piece, window);
+                backend.fill_buckets(&mut buckets, nb, piece, |term| {
+                    (term.point, term.digits[window])
+                });
             }
             result = fold_buckets(backend, result, &buckets, nb, used);
             buckets.fill(G::IDENTITY);
@@ -424,33 +220,6 @@ fn multiscalar_mul_points_serial<B: Backend>(
         .map(|(point, scalar)| Term::new(*point, scalar, width))
         .collect();
     multiscalar_mul_terms_serial(backend, &[&terms], width)
-}
-
-/// Horner-folds per-window partial sums into the final MSM result: from the top window down,
-/// `width` doublings shift everything accumulated so far up one window, then the next window's
-/// partial joins. Scalar recombination computes each point once, avoiding duplicate SIMD lanes.
-#[cfg(target_arch = "aarch64")]
-fn fold_windows<B: Backend>(_: B, windows: &[G], width: u32) -> G {
-    let mut result = G::IDENTITY;
-    for window in windows.iter().rev() {
-        for _ in 0..width {
-            result = result.double();
-        }
-        result = result.add(*window);
-    }
-    result
-}
-
-#[cfg(not(target_arch = "aarch64"))]
-fn fold_windows<B: Backend>(backend: B, windows: &[G], width: u32) -> G {
-    let mut result = GVec::identity();
-    for window in windows.iter().rev() {
-        for _ in 0..width {
-            result = backend.g_double(result);
-        }
-        result = backend.g_add(result, GVec::splat(*window));
-    }
-    result.untranspose()[0]
 }
 
 /// Floor on terms per tile range: a shorter range's fixed per-tile cost (folding the bucket
@@ -494,7 +263,7 @@ fn partition_ranges(total: usize, ranges: usize) -> Vec<(usize, usize)> {
 /// Computes the full MSM over `chunks` (whose terms were recoded at `width`; see [`width_for`]
 /// and [`Term::new`]) with the bucket phase spread across `strategy`'s threads as
 /// `(window, global term range)` tiles. Each tile reduces to one point, same-window points are
-/// added, and [`fold_windows`] positions the resulting window sums.
+/// added, and the backend positions the resulting window sums.
 pub(super) fn multiscalar_mul<B: Backend>(
     backend: B,
     chunks: &[&[Term]],
@@ -521,7 +290,7 @@ pub(super) fn multiscalar_mul<B: Backend>(
     let buckets = num_buckets(width);
     let partials = strategy.map_init_collect_vec(
         tiles,
-        || transposed::identity_buckets(buckets),
+        || transposed::identity_buckets(backend, buckets),
         |scratch, tile| {
             let partial = transposed::window_partial(
                 backend,
@@ -535,31 +304,14 @@ pub(super) fn multiscalar_mul<B: Backend>(
             (tile.window, partial)
         },
     );
-    #[cfg(target_arch = "aarch64")]
-    let window_sums = {
-        let mut window_sums = vec![G::IDENTITY; windows];
-        for (window, partial) in partials {
-            window_sums[window] = window_sums[window].add(partial);
-        }
-        window_sums
-    };
-    #[cfg(not(target_arch = "aarch64"))]
-    let window_sums = {
-        let mut window_sums = vec![GVec::identity(); windows];
-        for (window, partial) in partials {
-            window_sums[window] = backend.g_add(window_sums[window], GVec::splat(partial));
-        }
-        window_sums
-            .into_iter()
-            .map(|window| window.untranspose()[0])
-            .collect::<Vec<_>>()
-    };
-    fold_windows(backend, &window_sums, width)
+    backend.combine_windows(partials, windows, width)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(not(feature = "std"))]
+    use alloc::vec;
     use arbitrary::Unstructured;
     use commonware_invariants::minifuzz::Builder;
     use commonware_parallel::Sequential;
@@ -732,86 +484,116 @@ mod tests {
 
     #[test]
     fn strategy_path_matches_serial() {
-        let backend = crate::curve::test_backend();
-        Builder::default()
-            .with_seed(0)
-            .with_search_limit(2)
-            .test(|u| {
-                for width in TEST_WIDTHS {
-                    let terms = arbitrary_terms(u, 600, width)?;
-                    for n in [0, 1, 2, 5, 32, 600] {
-                        let chunks = split_terms(terms[..n].to_vec(), &[64, 64, 64, 64]);
-                        let chunks = refs(&chunks);
-                        let expected = multiscalar_mul_terms_serial(backend, &chunks, width);
-                        let actual = multiscalar_mul(backend, &chunks, width, &Sequential);
-                        assert!(points_equal(actual, expected), "n={n} width={width}");
-                    }
-                }
-                Ok(())
-            });
+        struct Check;
+        impl crate::curve::WithBackend for Check {
+            type Output = ();
+            fn call<B: Backend>(self, backend: B) {
+                Builder::default()
+                    .with_seed(0)
+                    .with_search_limit(2)
+                    .test(|u| {
+                        for width in TEST_WIDTHS {
+                            let terms = arbitrary_terms(u, 600, width)?;
+                            for n in [0, 1, 2, 5, 32, 600] {
+                                let chunks = split_terms(terms[..n].to_vec(), &[64, 64, 64, 64]);
+                                let chunks = refs(&chunks);
+                                let expected =
+                                    multiscalar_mul_terms_serial(backend, &chunks, width);
+                                let actual = multiscalar_mul(backend, &chunks, width, &Sequential);
+                                assert!(points_equal(actual, expected), "n={n} width={width}");
+                            }
+                        }
+                        Ok(())
+                    });
+            }
+        }
+        crate::curve::WithBackend::call(Check, crate::curve::test_backend());
+        crate::curve::with_backend(Check);
     }
 
     #[test]
     fn tile_parallel_matches_serial_under_real_parallelism() {
-        let backend = crate::curve::test_backend();
-        // `Manual` disables the adaptive serial/parallel policy, forcing every call through
-        // actual Rayon dispatch (rather than the policy falling back to serial for small inputs).
-        // Planning parallelism above the pool size splits every width below into several term
-        // ranges, which the assertion inside the loop pins.
-        let strategy = commonware_parallel::Rayon::new(commonware_utils::NZUsize!(4))
-            .unwrap()
-            .with_parallelism(commonware_utils::NZUsize!(32))
-            .manual();
+        struct Check;
+        impl crate::curve::WithBackend for Check {
+            type Output = ();
+            fn call<B: Backend>(self, backend: B) {
+                // `Manual` disables the adaptive serial/parallel policy, forcing every call through
+                // actual Rayon dispatch (rather than the policy falling back to serial for small inputs).
+                // Planning parallelism above the pool size splits every width below into several term
+                // ranges, which the assertion inside the loop pins.
+                let strategy = commonware_parallel::Rayon::new(commonware_utils::NZUsize!(4))
+                    .unwrap()
+                    .with_parallelism(commonware_utils::NZUsize!(32))
+                    .manual();
 
-        Builder::default()
-            .with_seed(0)
-            .with_search_limit(2)
-            .test(|u| {
-                for width in [6, 8, 10] {
-                    let terms = arbitrary_terms(u, 1000, width)?;
-                    assert!(
-                        range_count(terms.len(), num_windows(width), strategy.parallelism()) > 1
-                    );
-                    for n in [0, 1, 300, 600, 1000] {
-                        let chunks =
-                            split_terms(terms[..n].to_vec(), &[128, 128, 128, 128, 128, 128]);
-                        let chunks = refs(&chunks);
-                        let expected = multiscalar_mul_terms_serial(backend, &chunks, width);
-                        let actual = multiscalar_mul(backend, &chunks, width, &strategy);
-                        assert!(points_equal(actual, expected), "n={n} width={width}");
-                    }
-                }
-                Ok(())
-            });
+                Builder::default()
+                    .with_seed(0)
+                    .with_search_limit(2)
+                    .test(|u| {
+                        for width in [6, 8, 10] {
+                            let terms = arbitrary_terms(u, 1000, width)?;
+                            assert!(
+                                range_count(
+                                    terms.len(),
+                                    num_windows(width),
+                                    strategy.parallelism()
+                                ) > 1
+                            );
+                            for n in [0, 1, 300, 600, 1000] {
+                                let chunks = split_terms(
+                                    terms[..n].to_vec(),
+                                    &[128, 128, 128, 128, 128, 128],
+                                );
+                                let chunks = refs(&chunks);
+                                let expected =
+                                    multiscalar_mul_terms_serial(backend, &chunks, width);
+                                let actual = multiscalar_mul(backend, &chunks, width, &strategy);
+                                assert!(points_equal(actual, expected), "n={n} width={width}");
+                            }
+                        }
+                        Ok(())
+                    });
+            }
+        }
+        crate::curve::WithBackend::call(Check, crate::curve::test_backend());
+        crate::curve::with_backend(Check);
     }
 
     #[test]
     fn window_partials_reuse_scratch_across_zero_windows() {
-        let backend = crate::curve::test_backend();
-        let point = GAffine::BASEPOINT;
-        for width in TEST_WIDTHS {
-            let scalar = Scalar::from_u128((1u128 << (2 * width)) | 1);
-            let terms = [Term::new(point, &scalar, width)];
-            let mut buckets = transposed::identity_buckets(num_buckets(width));
-            for (window, expected) in [point.to_extended(), G::IDENTITY, point.to_extended()]
-                .into_iter()
-                .enumerate()
-            {
-                let actual = transposed::window_partial(
-                    backend,
-                    &[&terms],
-                    0,
-                    terms.len(),
-                    window,
-                    width,
-                    &mut buckets,
-                );
-                assert!(
-                    points_equal(actual, expected),
-                    "window={window} width={width}"
-                );
+        struct Check;
+        impl crate::curve::WithBackend for Check {
+            type Output = ();
+            fn call<B: Backend>(self, backend: B) {
+                let point = GAffine::BASEPOINT;
+                for width in TEST_WIDTHS {
+                    let scalar = Scalar::from_u128((1u128 << (2 * width)) | 1);
+                    let terms = [Term::new(point, &scalar, width)];
+                    let mut buckets = transposed::identity_buckets(backend, num_buckets(width));
+                    for (window, expected) in
+                        [point.to_extended(), G::IDENTITY, point.to_extended()]
+                            .into_iter()
+                            .enumerate()
+                    {
+                        let actual = transposed::window_partial(
+                            backend,
+                            &[&terms],
+                            0,
+                            terms.len(),
+                            window,
+                            width,
+                            &mut buckets,
+                        );
+                        assert!(
+                            points_equal(actual, expected),
+                            "window={window} width={width}"
+                        );
+                    }
+                }
             }
         }
+        crate::curve::WithBackend::call(Check, crate::curve::test_backend());
+        crate::curve::with_backend(Check);
     }
 
     /// Splitting a window's bucket fill at an arbitrary global index (deliberately not a slice
@@ -838,7 +620,7 @@ mod tests {
 
                     let nw = num_windows(WIDTH);
                     let mut transposed_windows = vec![G::IDENTITY; nw];
-                    let mut buckets = transposed::identity_buckets(num_buckets(WIDTH));
+                    let mut buckets = transposed::identity_buckets(backend, num_buckets(WIDTH));
                     for (window, partial) in transposed_windows.iter_mut().enumerate() {
                         let left = transposed::window_partial(
                             backend,
@@ -862,7 +644,11 @@ mod tests {
                     }
 
                     assert!(points_equal(
-                        fold_windows(backend, &transposed_windows, WIDTH),
+                        backend.combine_windows(
+                            transposed_windows.into_iter().enumerate(),
+                            nw,
+                            WIDTH
+                        ),
                         expected,
                     ));
                 }

--- a/cryptography/curve25519/src/signing/core/scalar.rs
+++ b/cryptography/curve25519/src/signing/core/scalar.rs
@@ -87,50 +87,22 @@ fn limbs_sub5(a: &[u64; 5], b: &[u64; 5]) -> [u64; 5] {
     limbs_sub_with_borrow(a, b).0
 }
 
-/// Returns the full 512-bit product `a * b` as eight little-endian 64-bit limbs, via the standard
+/// Returns the full product `a * b` as little-endian 64-bit limbs, via the standard
 /// schoolbook multiply-accumulate-with-carry ("Comba") method.
-fn limbs_mul_wide(a: &[u64; 4], b: &[u64; 4]) -> [u64; 8] {
-    let mut t = [0u64; 8];
-    for i in 0..4 {
+fn limbs_mul_wide<const A: usize, const B: usize, const OUT: usize>(
+    a: &[u64; A],
+    b: &[u64; B],
+) -> [u64; OUT] {
+    const { assert!(OUT == A + B) };
+    let mut t = [0u64; OUT];
+    for i in 0..A {
         let mut carry = 0u128;
-        for j in 0..4 {
+        for j in 0..B {
             let sum = t[i + j] as u128 + (a[i] as u128) * (b[j] as u128) + carry;
             t[i + j] = sum as u64;
             carry = sum >> 64;
         }
-        t[i + 4] = carry as u64;
-    }
-    t
-}
-
-/// Returns the full product `a * b` as ten little-endian 64-bit limbs, via the same
-/// schoolbook method as [`limbs_mul_wide`].
-fn mul5x5(a: &[u64; 5], b: &[u64; 5]) -> [u64; 10] {
-    let mut t = [0u64; 10];
-    for i in 0..5 {
-        let mut carry = 0u128;
-        for j in 0..5 {
-            let sum = t[i + j] as u128 + (a[i] as u128) * (b[j] as u128) + carry;
-            t[i + j] = sum as u64;
-            carry = sum >> 64;
-        }
-        t[i + 5] = carry as u64;
-    }
-    t
-}
-
-/// Returns the full product `a * b` as nine little-endian 64-bit limbs, via the same schoolbook
-/// method as [`limbs_mul_wide`].
-fn mul5x4(a: &[u64; 5], b: &[u64; 4]) -> [u64; 9] {
-    let mut t = [0u64; 9];
-    for i in 0..5 {
-        let mut carry = 0u128;
-        for j in 0..4 {
-            let sum = t[i + j] as u128 + (a[i] as u128) * (b[j] as u128) + carry;
-            t[i + j] = sum as u64;
-            carry = sum >> 64;
-        }
-        t[i + 4] = carry as u64;
+        t[i + B] = carry as u64;
     }
     t
 }
@@ -145,11 +117,11 @@ fn mul5x4(a: &[u64; 5], b: &[u64; 4]) -> [u64; 9] {
 /// at most two trial subtractions of `L` remain to reach the canonical residue.
 fn barrett_reduce(x: [u64; 8]) -> Scalar {
     let q1: [u64; 5] = x[3..8].try_into().expect("slice has 5 elements");
-    let q2 = mul5x5(&q1, &MU);
+    let q2 = limbs_mul_wide::<5, 5, 10>(&q1, &MU);
     let q3: [u64; 5] = q2[5..10].try_into().expect("slice has 5 elements");
 
     let r1: [u64; 5] = x[0..5].try_into().expect("slice has 5 elements");
-    let r2: [u64; 5] = mul5x4(&q3, &L)[0..5]
+    let r2: [u64; 5] = limbs_mul_wide::<5, 4, 9>(&q3, &L)[0..5]
         .try_into()
         .expect("slice has 5 elements");
     let mut r = limbs_sub5(&r1, &r2);
@@ -385,7 +357,7 @@ mod tests {
                 let a: Scalar = u.arbitrary()?;
                 let b: Scalar = u.arbitrary()?;
 
-                let wide = super::limbs_mul_wide(&a.0, &b.0);
+                let wide: [u64; 8] = super::limbs_mul_wide(&a.0, &b.0);
                 let mut bytes = [0u8; 64];
                 for (i, limb) in wide.iter().enumerate() {
                     bytes[i * 8..i * 8 + 8].copy_from_slice(&limb.to_le_bytes());


### PR DESCRIPTION
Stacked on #4675.

- Fuse AVX-512 field/group operations and repeated squaring inside feature-enabled helpers to reduce calls and intermediate memory traffic.
- Match NEON bucket filling to its two physical lanes, merge stripes before weighted folding, and finish accumulation with scalar points. Document carry bounds, bucket weights, and the weight-one shortcut.
- Keep MSM bucket geometry and arithmetic behind backend interfaces, with architecture checks confined to backend definition and selection.
- Skip all-zero MSM windows, consolidate fixed-limb multiplication helpers, and add equivalence tests.

Measured batch-verification latency reductions for each workload (positive means faster). Each cell compares the mean latency of two runs per build. Measurements ran serially with 20 samples per run, one second of warmup, and a three-second target measurement period, using Rust 1.98.1 / LLVM 22.1.8 and runtime backend dispatch. Fixtures use distinct 32-byte messages; fixture construction is outside timing.

AVX-512 on c8a.8xlarge (32 physical AMD EPYC 9R45 cores). Operation fusion is measured against the unfused control, which already includes the zero-window skip and scalar-helper cleanup. Repeated squaring is measured separately against the operation-fused control. These columns are separate measured stages; they are not a direct parent-to-final comparison.

| Signatures | Signing keys | Operation fusion: sequential | Operation fusion: 32 workers | Repeated squaring: sequential | Repeated squaring: 32 workers |
| ---: | --- | ---: | ---: | ---: | ---: |
| 1,024 | distinct | 21.72% | 10.93% | 6.57% | 2.39% |
| 1,024 | 64 | 21.31% | 9.73% | 5.84% | 2.42% |
| 1,024 | 1 | 21.90% | 10.26% | 6.02% | 2.58% |
| 16,384 | distinct | 18.11% | 11.71% | 5.65% | 5.84% |
| 16,384 | 64 | 17.13% | 7.12% | 7.43% | 1.16% |
| 16,384 | 1 | 17.11% | 7.89% | 7.61% | 1.37% |
| 65,536 | distinct | 16.50% | 10.43% | 5.02% | 3.10% |
| 65,536 | 64 | 16.00% | 7.26% | 8.09% | 3.33% |
| 65,536 | 1 | 16.24% | 7.48% | 8.39% | 3.24% |

NEON on Apple M5 Pro (6 performance and 12 efficiency cores), measured against the preserved original NEON control, which already includes the shared inline repeated-squaring default.

| Signatures | Signing keys | Sequential | 8 workers |
| ---: | --- | ---: | ---: |
| 1,024 | distinct | 29.09% | 28.18% |
| 1,024 | 64 | 38.93% | 22.63% |
| 1,024 | 1 | 38.06% | 24.38% |
| 16,384 | distinct | 15.79% | 14.89% |
| 16,384 | 64 | 19.69% | 14.54% |
| 16,384 | 1 | 18.25% | 14.28% |
| 65,536 | distinct | 12.42% | 10.91% |
| 65,536 | 64 | 13.07% | 11.96% |
| 65,536 | 1 | 13.19% | 11.15% |

Results apply to these hosts, compiler, worker counts, and valid-batch fixtures; individual small changes can fall within measurement variation.

<details>
<summary>AVX-512 arithmetic and conditional-negation results</summary>

These measurements isolate fused conditional negation and lane selection, plus a four-instruction shift/add implementation of multiplication by 19 with exact IFMA carry folding. The baseline is `1e53a42142289d426c3650c2e452c526d83cb5e3`.

Measured latency reductions on c8a.8xlarge, using the same compiler, fixtures, and sampling settings described above. Each cell compares two runs of that workload per build. Control and candidate runs were serialized in forward/reverse order.

| Signatures | Signing keys | Sequential | 32 workers |
| ---: | --- | ---: | ---: |
| 1,024 | distinct | 4.05% | 1.01% |
| 1,024 | 64 | 1.97% | 1.73% |
| 1,024 | 1 | 0.94% | 1.44% |
| 16,384 | distinct | 3.95% | 1.74% |
| 16,384 | 64 | 1.40% | 0.57% |
| 16,384 | 1 | 1.25% | 1.53% |
| 65,536 | distinct | 4.19% | 2.72% |
| 65,536 | 64 | 1.62% | 0.63% |
| 65,536 | 1 | 1.10% | 0.94% |

Both passes improved every workload against the baseline. These are modest gains; the smaller differences remain sensitive to measurement variation. Other candidates involving looser reductions, cached Niels points, and alternative lane-selection fusion did not show a consistent benefit across key distributions.

Native x86/ARM tests, conformance, Clippy, no-default-features, formatting, and WASM checks passed. The conditional-negation test covers all 256 masks. Miri stops at an unsupported AVX-512 IFMA intrinsic before reaching the multiplication-by-19 helper. Validation of this path relies on native execution and an independent assembly/bounds review.

</details>
