### PR TITLE
[cryptography/secret] add opt-in hardened secret storage on Linux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1505,6 +1505,7 @@ dependencies = [
  "getrandom 0.2.17",
  "getrandom 0.4.3",
  "hashbrown 0.17.1",
+ "libc",
  "num-rational",
  "num-traits",
  "once_cell",

--- a/cryptography/Cargo.toml
+++ b/cryptography/Cargo.toml
@@ -125,7 +125,6 @@ std = [
 	"p256/std",
 	"rand/std",
 	"rand/std_rng",
-	"rand/sys_rng",
 	"rand_chacha/std",
 	"thiserror/std",
 	"zeroize/std",

--- a/cryptography/Cargo.toml
+++ b/cryptography/Cargo.toml
@@ -45,6 +45,9 @@ thiserror.workspace = true
 x25519-dalek = { workspace = true, features = ["static_secrets", "zeroize"] }
 zeroize = { workspace = true, features = ["zeroize_derive"] }
 
+[target.'cfg(target_os = "linux")'.dependencies]
+libc.workspace = true
+
 [target.'cfg(any(target_arch = "x86_64", target_arch = "aarch64"))'.dependencies]
 # aws-lc-rs provides optimized P-256 verification and handshake cipher on x86_64 and aarch64.
 aws-lc-rs.workspace = true
@@ -122,6 +125,7 @@ std = [
 	"p256/std",
 	"rand/std",
 	"rand/std_rng",
+	"rand/sys_rng",
 	"rand_chacha/std",
 	"thiserror/std",
 	"zeroize/std",

--- a/cryptography/src/banderwagon.rs
+++ b/cryptography/src/banderwagon.rs
@@ -16,6 +16,7 @@ use core::{
     array,
     ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign},
 };
+use zeroize::{Zeroize, ZeroizeOnDrop};
 
 /// A scalar exponent for the Banderwagon group [`G`]: an element of the scalar
 /// field `Z/r`, where `r` is the prime group order.
@@ -32,6 +33,20 @@ use core::{
 pub struct F {
     limbs: [u64; 4],
 }
+
+impl Zeroize for F {
+    fn zeroize(&mut self) {
+        self.limbs.zeroize();
+    }
+}
+
+impl Drop for F {
+    fn drop(&mut self) {
+        self.zeroize();
+    }
+}
+
+impl ZeroizeOnDrop for F {}
 
 impl F {
     /// The bit-width of the modulus `r`; enough bits to represent any element of

--- a/cryptography/src/bls12381/dkg/feldman_desmedt.rs
+++ b/cryptography/src/bls12381/dkg/feldman_desmedt.rs
@@ -355,7 +355,7 @@ use crate::{
     transcript::{Summary, Transcript, Version},
 };
 use commonware_codec::{
-    Encode, EncodeSize, Mode as CodecMode, RangeCfg, Read, ReadExt, Write, mode, modes,
+    Encode, EncodeSize, FixedSize, Mode as CodecMode, RangeCfg, Read, ReadExt, Write, mode, modes,
 };
 use commonware_math::{
     algebra::{Additive, CryptoGroup, Random, Ring as _},
@@ -1057,7 +1057,7 @@ impl DealerPrivMsg {
 
 impl EncodeSize for DealerPrivMsg {
     fn encode_size(&self) -> usize {
-        self.share.access(|share| share.encode_size())
+        Scalar::SIZE
     }
 }
 

--- a/cryptography/src/bls12381/dkg/feldman_desmedt.rs
+++ b/cryptography/src/bls12381/dkg/feldman_desmedt.rs
@@ -841,7 +841,7 @@ impl<V: Variant, P: PublicKey> Info<V, P> {
         let expected = pub_msg.commitment.eval_msm(&scalar, &Sequential);
         priv_msg
             .share
-            .expose(|share| expected == V::Public::generator() * share)
+            .access(|share| expected == V::Public::generator() * share)
     }
 
     fn check_dealer_log<M: Faults, B: BatchVerifier<PublicKey = P>>(
@@ -892,7 +892,7 @@ impl<V: Variant, P: PublicKey> Info<V, P> {
                     reveal_eval_points.push((coeff.clone(), player_scalar));
                     priv_msg
                         .share
-                        .expose(|share| reveal_sum += &(coeff * share));
+                        .access(|share| reveal_sum += &(coeff * share));
                 }
             }
         }
@@ -1057,13 +1057,13 @@ impl DealerPrivMsg {
 
 impl EncodeSize for DealerPrivMsg {
     fn encode_size(&self) -> usize {
-        self.share.expose(|share| share.encode_size())
+        self.share.access(|share| share.encode_size())
     }
 }
 
 impl Write for DealerPrivMsg {
     fn write(&self, buf: &mut impl bytes::BufMut) {
-        self.share.expose(|share| share.write(buf));
+        self.share.access(|share| share.write(buf));
     }
 }
 
@@ -1783,7 +1783,7 @@ impl<V: Variant, S: Signer> Dealer<V, S> {
             // `Poly::new_with_constant` requires an owned value. The extracted scalar is
             // scoped to this function and will be zeroized on drop (i.e. the secret is
             // only exposed for the duration of this function).
-            share.map(|x| x.private.expose_unwrap()),
+            share.map(|x| x.private.extract_or_clone()),
         )?;
         let my_poly = Poly::new_with_constant(&mut rng, info.degree::<M>(), share);
         let priv_msgs = info
@@ -2154,10 +2154,10 @@ impl<V: Variant, S: Signer> Player<V, S> {
                 let persisted = self.view.get(dealer);
                 let share = match persisted {
                     Some((pub_msg, priv_msg)) if pub_msg == &log.pub_msg => {
-                        priv_msg.share.clone().expose_unwrap()
+                        priv_msg.share.clone().extract_or_clone()
                     }
                     _ => match log.get_reveal(&self.me_pub) {
-                        Some(priv_msg) => priv_msg.share.clone().expose_unwrap(),
+                        Some(priv_msg) => priv_msg.share.clone().extract_or_clone(),
                         None if persisted.is_some() => {
                             return Err(Error::InvalidPersistedDealing {
                                 dealer: format!("{dealer:?}"),
@@ -2728,7 +2728,7 @@ mod test_plan {
                             let share = info
                                 .unwrap_or_random_share(
                                     &mut rng,
-                                    share.map(|s| s.private.expose_unwrap()),
+                                    share.map(|s| s.private.extract_or_clone()),
                                 )
                                 .expect("Failed to generate dealer share");
 

--- a/cryptography/src/bls12381/dkg/golden/evrf/banderwagon.rs
+++ b/cryptography/src/bls12381/dkg/golden/evrf/banderwagon.rs
@@ -177,6 +177,11 @@ fn build_circuit<'ctx>(
 ///
 /// The committed values, in order, are the VRF outputs for `receivers`; recover
 /// them with [`Witness::values`].
+///
+/// The returned witness includes the private exponent's bits in ordinary memory.
+/// Its [Scalar] elements erase themselves on drop, but temporary exponent copies
+/// and bit buffers require a separate scratch-erasure review. Protecting `x` does
+/// not protect these allocations or the complete proving computation.
 pub fn vrf_batch_checked(msg: &[u8], x: &F, receivers: &[G]) -> (Circuit<Scalar>, Witness<Scalar>) {
     let sender = G::generator() * x;
     let outputs: Vec<Scalar> = receivers

--- a/cryptography/src/bls12381/dkg/golden/evrf/mod.rs
+++ b/cryptography/src/bls12381/dkg/golden/evrf/mod.rs
@@ -1,7 +1,7 @@
 mod banderwagon;
 
 use crate::{
-    Secret,
+    HardenError, Secret,
     bls12381::primitives::group::{G1, Scalar, ScalarReadCfg},
     transcript::{Summary, Transcript, Version},
     zk::{
@@ -172,7 +172,7 @@ impl crate::Signer for PrivateKey {
 
     fn public_key(&self) -> Self::PublicKey {
         self.inner
-            .expose(|x| PublicKey::from_point(G::generator() * x))
+            .access(|x| PublicKey::from_point(G::generator() * x))
     }
 
     fn sign(&self, namespace: &[u8], msg: &[u8]) -> Signature {
@@ -181,7 +181,7 @@ impl crate::Signer for PrivateKey {
         t.commit(namespace).commit(msg).commit(pk.raw.as_slice());
 
         // Derive deterministic nonce from secret key + public transcript state
-        let k = self.inner.expose(|x| {
+        let k = self.inner.access(|x| {
             let mut nonce_t = t.fork(b"nonce");
             let x_bytes = Zeroizing::new(x.encode_fixed::<{ F::SIZE }>());
             nonce_t.commit(x_bytes.as_slice());
@@ -194,7 +194,7 @@ impl crate::Signer for PrivateKey {
         let e = F::random(t.noise(b"challenge"));
 
         // s = k + e * x
-        let s = self.inner.expose(|x| e * x + &k);
+        let s = self.inner.access(|x| e * x + &k);
 
         let mut raw = [0u8; Signature::SIZE];
         raw[..G::SIZE].copy_from_slice(&k_big_bytes);
@@ -204,6 +204,18 @@ impl crate::Signer for PrivateKey {
 }
 
 impl PrivateKey {
+    /// Moves the private scalar into hardened storage.
+    ///
+    /// Clones share storage, erased when its last owner drops. Already hardened
+    /// keys are unchanged. Earlier copies and exported material remain unprotected.
+    ///
+    /// Returns an error if hardening is unsupported or its protections cannot be established.
+    pub fn try_harden(self) -> Result<Self, HardenError> {
+        Ok(Self {
+            inner: self.inner.try_harden()?,
+        })
+    }
+
     /// Get the [`PublicKey`] associated with this private key.
     pub fn public(&self) -> PublicKey {
         crate::Signer::public_key(self)
@@ -219,7 +231,7 @@ impl PrivateKey {
     /// a random value.
     pub(super) fn vrf_recv(&self, msg: &Summary, sender: &PublicKey) -> Scalar {
         self.inner
-            .expose(|inner| vrf_recv(msg, &sender.point, inner))
+            .access(|inner| vrf_recv(msg, &sender.point, inner))
     }
 
     /// Compute the VRF output for each receiver, along with [`VrfCommitments`]
@@ -243,7 +255,7 @@ impl PrivateKey {
         }));
         let (circuit, witness) = self
             .inner
-            .expose(|x| vrf_batch_checked(msg, x, receivers.values()));
+            .access(|x| vrf_batch_checked(msg, x, receivers.values()));
         let claim = witness.claim(setup.inner());
         let circuit_proof = prove(
             &mut *rng,
@@ -302,7 +314,7 @@ impl PrivateKey {
 impl Write for PrivateKey {
     fn write(&self, buf: &mut impl BufMut) {
         self.inner
-            .expose(|x| buf.put_slice(&x.encode_fixed::<{ F::SIZE }>()));
+            .access(|x| buf.put_slice(&x.encode_fixed::<{ F::SIZE }>()));
     }
 }
 

--- a/cryptography/src/bls12381/dkg/golden/evrf/mod.rs
+++ b/cryptography/src/bls12381/dkg/golden/evrf/mod.rs
@@ -222,12 +222,9 @@ impl PrivateKey {
     ///
     /// # Errors
     ///
-    /// Consumes `self` on failure, including when hardening is unsupported.
-    pub fn try_harden(self) -> Result<Self, HardenError> {
-        Ok(Self {
-            inner: self.inner.try_harden()?,
-            public: self.public,
-        })
+    /// Leaves `self` unchanged on failure, including when hardening is unsupported.
+    pub fn try_harden(&mut self) -> Result<(), HardenError> {
+        self.inner.try_harden()
     }
 
     /// Get the [`PublicKey`] associated with this private key.

--- a/cryptography/src/bls12381/dkg/golden/evrf/mod.rs
+++ b/cryptography/src/bls12381/dkg/golden/evrf/mod.rs
@@ -153,16 +153,20 @@ impl Read for Setup {
     }
 }
 
+/// A private exponent for Golden DKG VRF evaluation and Schnorr signing.
+///
+/// The public key is cached separately, so retrieving it does not access the
+/// private scalar. [Self::try_harden] protects the retained scalar, subject to
+/// the [secret storage contract](crate::secret).
 #[derive(Clone, Debug)]
 pub struct PrivateKey {
     inner: Secret<F>,
+    public: PublicKey,
 }
 
 impl Random for PrivateKey {
     fn random(rng: impl CryptoRng) -> Self {
-        Self {
-            inner: Secret::new(F::random(rng)),
-        }
+        Self::from_scalar(F::random(rng))
     }
 }
 
@@ -171,16 +175,16 @@ impl crate::Signer for PrivateKey {
     type PublicKey = PublicKey;
 
     fn public_key(&self) -> Self::PublicKey {
-        self.inner
-            .access(|x| PublicKey::from_point(G::generator() * x))
+        self.public.clone()
     }
 
     fn sign(&self, namespace: &[u8], msg: &[u8]) -> Signature {
-        let pk = self.public();
         let mut t = Transcript::new(SCHNORR_NS, Version::V1);
-        t.commit(namespace).commit(msg).commit(pk.raw.as_slice());
+        t.commit(namespace)
+            .commit(msg)
+            .commit(self.public.raw.as_slice());
 
-        // Derive deterministic nonce from secret key + public transcript state
+        // Derive the deterministic nonce from the key and public transcript state.
         let k = self.inner.access(|x| {
             let mut nonce_t = t.fork(b"nonce");
             let x_bytes = Zeroizing::new(x.encode_fixed::<{ F::SIZE }>());
@@ -188,6 +192,8 @@ impl crate::Signer for PrivateKey {
             F::random(nonce_t.noise(b"k"))
         });
 
+        // Keep the private pages inaccessible during the group multiplication.
+        // Only nonce derivation and the final response need the retained scalar.
         let k_big = G::generator() * &k;
         let k_big_bytes: [u8; G::SIZE] = k_big.encode_fixed();
         t.commit(k_big_bytes.as_slice());
@@ -204,19 +210,27 @@ impl crate::Signer for PrivateKey {
 }
 
 impl PrivateKey {
+    /// Derives the public key before placing the scalar in secret storage.
+    fn from_scalar(scalar: F) -> Self {
+        let public = PublicKey::from_point(G::generator() * &scalar);
+        Self {
+            inner: Secret::new(scalar),
+            public,
+        }
+    }
+
     /// Moves the private scalar into hardened storage.
     ///
-    /// Clones share storage, erased when its last owner drops. Already hardened
-    /// keys are unchanged. Earlier copies and exported material remain unprotected.
-    ///
-    /// Returns an error if hardening is unsupported or its protections cannot be established.
+    /// See [Secret::try_harden] for platform requirements, shared ownership, and
+    /// consumption on failure, and [crate::secret] for the protection boundary.
     pub fn try_harden(self) -> Result<Self, HardenError> {
         Ok(Self {
             inner: self.inner.try_harden()?,
+            public: self.public,
         })
     }
 
-    /// Get the [`PublicKey`] associated with this private key.
+    /// Returns the cached [PublicKey] without accessing private storage.
     pub fn public(&self) -> PublicKey {
         crate::Signer::public_key(self)
     }
@@ -237,6 +251,11 @@ impl PrivateKey {
     /// Compute the VRF output for each receiver, along with [`VrfCommitments`]
     /// that bind those outputs and prove they were evaluated correctly.
     ///
+    /// The witness contains the private exponent's bits in ordinary allocations.
+    /// Hardening the retained scalar does not protect that witness or the proof's
+    /// scratch storage. Temporary exponent copies and bit buffers need a separate
+    /// scratch-erasure review, even though witness scalars erase on drop.
+    ///
     /// # Panics
     ///
     /// Panics if `receivers` contains duplicate public keys.
@@ -253,6 +272,8 @@ impl PrivateKey {
             let point = x.point.clone();
             (x, point)
         }));
+        // The witness outlives this access and includes the secret exponent's bits.
+        // Keeping the scalar readable during proving would not protect those copies.
         let (circuit, witness) = self
             .inner
             .access(|x| vrf_batch_checked(msg, x, receivers.values()));
@@ -313,8 +334,10 @@ impl PrivateKey {
 
 impl Write for PrivateKey {
     fn write(&self, buf: &mut impl BufMut) {
-        self.inner
-            .access(|x| buf.put_slice(&x.encode_fixed::<{ F::SIZE }>()));
+        self.inner.access(|x| {
+            let raw = Zeroizing::new(x.encode_fixed::<{ F::SIZE }>());
+            buf.put_slice(raw.as_slice());
+        });
     }
 }
 
@@ -324,9 +347,7 @@ impl Read for PrivateKey {
     fn read_cfg(buf: &mut impl Buf, _: &()) -> Result<Self, CodecError> {
         let raw = Zeroizing::new(<[u8; Self::SIZE]>::read(buf)?);
         let x: F = ReadExt::read(&mut raw.as_slice())?;
-        Ok(Self {
-            inner: Secret::new(x),
-        })
+        Ok(Self::from_scalar(x))
     }
 }
 

--- a/cryptography/src/bls12381/dkg/golden/evrf/mod.rs
+++ b/cryptography/src/bls12381/dkg/golden/evrf/mod.rs
@@ -156,8 +156,7 @@ impl Read for Setup {
 /// A private exponent for Golden DKG VRF evaluation and Schnorr signing.
 ///
 /// The public key is cached separately, so retrieving it does not access the
-/// private scalar. [Self::try_harden] protects the retained scalar, subject to
-/// the [secret storage contract](crate::secret).
+/// private scalar.
 #[derive(Clone, Debug)]
 pub struct PrivateKey {
     inner: Secret<F>,
@@ -184,7 +183,7 @@ impl crate::Signer for PrivateKey {
             .commit(msg)
             .commit(self.public.raw.as_slice());
 
-        // Derive the deterministic nonce from the key and public transcript state.
+        // Derive deterministic nonce from secret key + public transcript state
         let k = self.inner.access(|x| {
             let mut nonce_t = t.fork(b"nonce");
             let x_bytes = Zeroizing::new(x.encode_fixed::<{ F::SIZE }>());
@@ -192,8 +191,6 @@ impl crate::Signer for PrivateKey {
             F::random(nonce_t.noise(b"k"))
         });
 
-        // Keep the private pages inaccessible during the group multiplication.
-        // Only nonce derivation and the final response need the retained scalar.
         let k_big = G::generator() * &k;
         let k_big_bytes: [u8; G::SIZE] = k_big.encode_fixed();
         t.commit(k_big_bytes.as_slice());
@@ -210,7 +207,7 @@ impl crate::Signer for PrivateKey {
 }
 
 impl PrivateKey {
-    /// Derives the public key before placing the scalar in secret storage.
+    /// Creates a private key from a scalar.
     fn from_scalar(scalar: F) -> Self {
         let public = PublicKey::from_point(G::generator() * &scalar);
         Self {
@@ -219,10 +216,13 @@ impl PrivateKey {
         }
     }
 
-    /// Moves the private scalar into hardened storage.
+    /// Moves the secret material into hardened storage.
     ///
-    /// See [Secret::try_harden] for platform requirements, shared ownership, and
-    /// consumption on failure, and [crate::secret] for the protection boundary.
+    /// See [crate::Secret::try_harden] for requirements and guarantees.
+    ///
+    /// # Errors
+    ///
+    /// Consumes `self` on failure, including when hardening is unsupported.
     pub fn try_harden(self) -> Result<Self, HardenError> {
         Ok(Self {
             inner: self.inner.try_harden()?,
@@ -230,7 +230,7 @@ impl PrivateKey {
         })
     }
 
-    /// Returns the cached [PublicKey] without accessing private storage.
+    /// Get the [`PublicKey`] associated with this private key.
     pub fn public(&self) -> PublicKey {
         crate::Signer::public_key(self)
     }

--- a/cryptography/src/bls12381/dkg/golden/mod.rs
+++ b/cryptography/src/bls12381/dkg/golden/mod.rs
@@ -496,7 +496,7 @@ pub fn deal(
         // `Poly::new_with_constant` requires an owned value. The extracted scalar is
         // scoped to this function and will be zeroized on drop (i.e. the secret is
         // only exposed for the duration of this function).
-        share.map(|x| x.private.expose_unwrap()),
+        share.map(|x| x.private.extract_or_clone()),
     )?;
     let poly = Poly::new_with_constant(&mut *rng, info.degree(), share);
 
@@ -1332,7 +1332,7 @@ mod test_plan {
                         let constant = info
                             .unwrap_or_random_share(
                                 &mut rng,
-                                share.as_ref().map(|s| s.private.clone().expose_unwrap()),
+                                share.as_ref().map(|s| s.private.clone().extract_or_clone()),
                             )
                             .expect("share should be available");
                         let poly = Poly::new_with_constant(&mut rng, new_degree, constant);

--- a/cryptography/src/bls12381/primitives/group.rs
+++ b/cryptography/src/bls12381/primitives/group.rs
@@ -515,19 +515,18 @@ impl Private {
         }
     }
 
-    /// Reports the storage mode for conversions that preserve hardening.
+    /// Returns whether the private scalar is stored in hardened memory.
     pub(crate) const fn is_hardened(&self) -> bool {
         self.scalar.is_hardened()
     }
 
-    /// Moves the scalar into hardened storage.
+    /// Moves the secret material into hardened storage.
     ///
-    /// Clones then share the protected allocation. Already hardened keys are
-    /// unchanged. Failure consumes the key. Earlier clones and exported material
-    /// are unaffected.
+    /// See [crate::Secret::try_harden] for requirements and guarantees.
     ///
-    /// See [Secret::try_harden] for platform requirements, protection guarantees,
-    /// and limits.
+    /// # Errors
+    ///
+    /// Consumes `self` on failure, including when hardening is unsupported.
     pub fn try_harden(self) -> Result<Self, HardenError> {
         Ok(Self {
             scalar: self.scalar.try_harden()?,
@@ -660,7 +659,7 @@ impl Scalar {
         Self::from_limbs([i, 0, 0, 0])
     }
 
-    /// Returns the canonical big-endian encoding, erased on drop.
+    /// Encodes the scalar into a byte array.
     pub(crate) fn as_slice(&self) -> Zeroizing<[u8; Self::SIZE]> {
         let mut slice = Zeroizing::new([0u8; Self::SIZE]);
         // SAFETY: All pointers valid; blst_bendian_from_scalar writes exactly 32 bytes.
@@ -1012,14 +1011,13 @@ impl Share {
         Self { index, private }
     }
 
-    /// Moves the private scalar into hardened storage.
+    /// Moves the secret material into hardened storage.
     ///
-    /// Clones then share the protected allocation. Already hardened shares are
-    /// unchanged. Failure consumes the share. Earlier clones and exported material
-    /// are unaffected.
+    /// See [crate::Secret::try_harden] for requirements and guarantees.
     ///
-    /// See [Secret::try_harden] for platform requirements, protection guarantees,
-    /// and limits.
+    /// # Errors
+    ///
+    /// Consumes `self` on failure, including when hardening is unsupported.
     pub fn try_harden(self) -> Result<Self, HardenError> {
         Ok(Self {
             index: self.index,

--- a/cryptography/src/bls12381/primitives/group.rs
+++ b/cryptography/src/bls12381/primitives/group.rs
@@ -14,7 +14,7 @@
 //! at its own boundary.
 
 use super::variant::Variant;
-use crate::Secret;
+use crate::{HardenError, Secret};
 #[cfg(not(feature = "std"))]
 use alloc::{vec, vec::Vec};
 use blst::{
@@ -515,24 +515,37 @@ impl Private {
         }
     }
 
-    /// Temporarily exposes the inner scalar to a closure.
+    /// Moves the scalar into hardened storage.
     ///
-    /// See [`Secret::expose`](crate::Secret::expose) for more details.
-    pub fn expose<R>(&self, f: impl for<'a> FnOnce(&'a Scalar) -> R) -> R {
-        self.scalar.expose(f)
+    /// Clones share storage, erased when its last owner drops. Already hardened
+    /// keys are unchanged. Earlier copies and exported material remain unprotected.
+    ///
+    /// Returns an error if hardening is unsupported or its protections cannot be established.
+    pub fn try_harden(self) -> Result<Self, HardenError> {
+        Ok(Self {
+            scalar: self.scalar.try_harden()?,
+        })
     }
 
-    /// Consumes the private key and returns the inner scalar.
+    /// Grants temporary access to the inner scalar through a closure.
     ///
-    /// See [`Secret::expose_unwrap`](crate::Secret::expose_unwrap) for more details.
-    pub fn expose_unwrap(self) -> Scalar {
-        self.scalar.expose_unwrap()
+    /// See [`Secret::access`](crate::Secret::access) for more details.
+    pub fn access<R>(&self, f: impl for<'a> FnOnce(&'a Scalar) -> R) -> R {
+        self.scalar.access(f)
+    }
+
+    /// Consumes the private key, moving out its scalar or cloning it if shared.
+    ///
+    /// The returned scalar is unprotected and zeroized on drop. Other handles to
+    /// shared hardened storage retain their protection. See [Secret::extract_or_clone].
+    pub fn extract_or_clone(self) -> Scalar {
+        self.scalar.extract_or_clone()
     }
 }
 
 impl Write for Private {
     fn write(&self, buf: &mut impl BufMut) {
-        self.expose(|scalar| scalar.write(buf));
+        self.access(|scalar| scalar.write(buf));
     }
 }
 
@@ -992,19 +1005,32 @@ impl Share {
         Self { index, private }
     }
 
+    /// Moves the private scalar into hardened storage.
+    ///
+    /// Clones share storage, erased when its last owner drops. Already hardened
+    /// shares are unchanged. Earlier copies and exported material remain unprotected.
+    ///
+    /// Returns an error if hardening is unsupported or its protections cannot be established.
+    pub fn try_harden(self) -> Result<Self, HardenError> {
+        Ok(Self {
+            index: self.index,
+            private: self.private.try_harden()?,
+        })
+    }
+
     /// Returns the public key corresponding to the share.
     ///
     /// This can be verified against the public polynomial.
     pub fn public<V: Variant>(&self) -> V::Public {
         self.private
-            .expose(|private| V::Public::generator() * private)
+            .access(|private| V::Public::generator() * private)
     }
 }
 
 impl Write for Share {
     fn write(&self, buf: &mut impl BufMut) {
         self.index.write(buf);
-        self.private.expose(|private| private.write(buf));
+        self.private.access(|private| private.write(buf));
     }
 }
 
@@ -1020,7 +1046,7 @@ impl Read for Share {
 
 impl EncodeSize for Share {
     fn encode_size(&self) -> usize {
-        self.index.encode_size() + self.private.expose(|private| private.encode_size())
+        self.index.encode_size() + self.private.access(|private| private.encode_size())
     }
 }
 

--- a/cryptography/src/bls12381/primitives/group.rs
+++ b/cryptography/src/bls12381/primitives/group.rs
@@ -594,6 +594,7 @@ impl Scalar {
             blst_keygen(&mut sc, ikm.as_ptr(), ikm.len(), ptr::null(), 0);
             blst_fr_from_scalar(&mut ret, &sc);
         }
+        sc.b.zeroize();
         Self(ret)
     }
 
@@ -628,12 +629,13 @@ impl Scalar {
 
         // Transform expanded bytes with modular reduction
         let mut fr = blst_fr::default();
+        let mut scalar = blst_scalar::default();
         // SAFETY: uniform_bytes is a valid 48-byte buffer.
         unsafe {
-            let mut scalar = blst_scalar::default();
             blst_scalar_from_be_bytes(&mut scalar, uniform_bytes.as_ptr(), L);
             blst_fr_from_scalar(&mut fr, &scalar);
         }
+        scalar.b.zeroize();
 
         Self(fr)
     }
@@ -660,12 +662,13 @@ impl Scalar {
     /// Encodes the scalar into a byte array.
     pub(crate) fn as_slice(&self) -> Zeroizing<[u8; Self::SIZE]> {
         let mut slice = Zeroizing::new([0u8; Self::SIZE]);
+        let mut scalar = blst_scalar::default();
         // SAFETY: All pointers valid; blst_bendian_from_scalar writes exactly 32 bytes.
         unsafe {
-            let mut scalar = blst_scalar::default();
             blst_scalar_from_fr(&mut scalar, &self.0);
             blst_bendian_from_scalar(slice.as_mut_ptr(), &scalar);
         }
+        scalar.b.zeroize();
         slice
     }
 
@@ -775,19 +778,24 @@ impl Read for Scalar {
     fn read_cfg(buf: &mut impl Buf, cfg: &ScalarReadCfg) -> Result<Self, Error> {
         let bytes = Zeroizing::new(<[u8; Self::SIZE]>::read(buf)?);
         let mut ret = blst_fr::default();
+        let mut scalar = blst_scalar::default();
         // SAFETY: bytes is a valid 32-byte array. blst_scalar_fr_check validates in-range.
         //
         // For private key material, callers pass `RejectZero` to preserve the
         // IETF BLS non-zero secret-key requirement:
         // * https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature-03#section-2.3
         // * https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature-04#section-2.3
-        unsafe {
-            let mut scalar = blst_scalar::default();
+        let valid = unsafe {
             blst_scalar_from_bendian(&mut scalar, bytes.as_ptr());
-            if !blst_scalar_fr_check(&scalar) {
-                return Err(Invalid("Scalar", "Invalid"));
+            let valid = blst_scalar_fr_check(&scalar);
+            if valid {
+                blst_fr_from_scalar(&mut ret, &scalar);
             }
-            blst_fr_from_scalar(&mut ret, &scalar);
+            valid
+        };
+        scalar.b.zeroize();
+        if !valid {
+            return Err(Invalid("Scalar", "Invalid"));
         }
         let out = Self(ret);
         if *cfg == ScalarReadCfg::RejectZero && out == Self::zero() {
@@ -1422,6 +1430,7 @@ impl<'a> MulAssign<&'a Scalar> for G1 {
             blst_scalar_from_fr(&mut scalar, &rhs.0);
             blst_p1_mult(ptr, ptr, scalar.b.as_ptr(), SCALAR_BITS);
         }
+        scalar.b.zeroize();
     }
 }
 
@@ -1457,14 +1466,16 @@ impl<'a> Mul<&'a SmallScalar> for G1 {
 impl Space<Scalar> for G1 {
     fn msm(points: &[Self], scalars: &[Scalar], strategy: &impl Strategy) -> Self {
         assert_eq!(points.len(), scalars.len(), "mismatched lengths");
-        let scalar_bytes: Vec<_> = scalars.iter().map(|s| s.as_blst_scalar()).collect();
-        Self::msm_inner(
+        let mut scalar_bytes: Vec<_> = scalars.iter().map(|s| s.as_blst_scalar()).collect();
+        let result = Self::msm_inner(
             points
                 .iter()
                 .zip(scalar_bytes.iter().map(|s| s.b.as_slice())),
             SCALAR_BITS,
             strategy,
-        )
+        );
+        scalar_bytes.iter_mut().for_each(|s| s.b.zeroize());
+        result
     }
 }
 
@@ -1845,6 +1856,7 @@ impl<'a> MulAssign<&'a Scalar> for G2 {
             blst_scalar_from_fr(&mut scalar, &rhs.0);
             blst_p2_mult(ptr, ptr, scalar.b.as_ptr(), SCALAR_BITS);
         }
+        scalar.b.zeroize();
     }
 }
 
@@ -1880,14 +1892,16 @@ impl<'a> Mul<&'a SmallScalar> for G2 {
 impl Space<Scalar> for G2 {
     fn msm(points: &[Self], scalars: &[Scalar], strategy: &impl Strategy) -> Self {
         assert_eq!(points.len(), scalars.len(), "mismatched lengths");
-        let scalar_bytes: Vec<_> = scalars.iter().map(|s| s.as_blst_scalar()).collect();
-        Self::msm_inner(
+        let mut scalar_bytes: Vec<_> = scalars.iter().map(|s| s.as_blst_scalar()).collect();
+        let result = Self::msm_inner(
             points
                 .iter()
                 .zip(scalar_bytes.iter().map(|s| s.b.as_slice())),
             SCALAR_BITS,
             strategy,
-        )
+        );
+        scalar_bytes.iter_mut().for_each(|s| s.b.zeroize());
+        result
     }
 }
 

--- a/cryptography/src/bls12381/primitives/group.rs
+++ b/cryptography/src/bls12381/primitives/group.rs
@@ -515,12 +515,19 @@ impl Private {
         }
     }
 
+    /// Reports the storage mode for conversions that preserve hardening.
+    pub(crate) const fn is_hardened(&self) -> bool {
+        self.scalar.is_hardened()
+    }
+
     /// Moves the scalar into hardened storage.
     ///
-    /// Clones share storage, erased when its last owner drops. Already hardened
-    /// keys are unchanged. Earlier copies and exported material remain unprotected.
+    /// Clones then share the protected allocation. Already hardened keys are
+    /// unchanged. Failure consumes the key. Earlier clones and exported material
+    /// are unaffected.
     ///
-    /// Returns an error if hardening is unsupported or its protections cannot be established.
+    /// See [Secret::try_harden] for platform requirements, protection guarantees,
+    /// and limits.
     pub fn try_harden(self) -> Result<Self, HardenError> {
         Ok(Self {
             scalar: self.scalar.try_harden()?,
@@ -653,8 +660,8 @@ impl Scalar {
         Self::from_limbs([i, 0, 0, 0])
     }
 
-    /// Encodes the scalar into a byte array.
-    fn as_slice(&self) -> Zeroizing<[u8; Self::SIZE]> {
+    /// Returns the canonical big-endian encoding, erased on drop.
+    pub(crate) fn as_slice(&self) -> Zeroizing<[u8; Self::SIZE]> {
         let mut slice = Zeroizing::new([0u8; Self::SIZE]);
         // SAFETY: All pointers valid; blst_bendian_from_scalar writes exactly 32 bytes.
         unsafe {
@@ -1007,10 +1014,12 @@ impl Share {
 
     /// Moves the private scalar into hardened storage.
     ///
-    /// Clones share storage, erased when its last owner drops. Already hardened
-    /// shares are unchanged. Earlier copies and exported material remain unprotected.
+    /// Clones then share the protected allocation. Already hardened shares are
+    /// unchanged. Failure consumes the share. Earlier clones and exported material
+    /// are unaffected.
     ///
-    /// Returns an error if hardening is unsupported or its protections cannot be established.
+    /// See [Secret::try_harden] for platform requirements, protection guarantees,
+    /// and limits.
     pub fn try_harden(self) -> Result<Self, HardenError> {
         Ok(Self {
             index: self.index,
@@ -1030,7 +1039,7 @@ impl Share {
 impl Write for Share {
     fn write(&self, buf: &mut impl BufMut) {
         self.index.write(buf);
-        self.private.access(|private| private.write(buf));
+        self.private.write(buf);
     }
 }
 
@@ -1046,7 +1055,7 @@ impl Read for Share {
 
 impl EncodeSize for Share {
     fn encode_size(&self) -> usize {
-        self.index.encode_size() + self.private.access(|private| private.encode_size())
+        self.index.encode_size() + Scalar::SIZE
     }
 }
 
@@ -1936,6 +1945,8 @@ impl HashToGroup for G2 {
 mod tests {
     use super::*;
     use crate::bls12381::primitives::group::Scalar;
+    #[cfg(all(feature = "std", target_os = "linux", not(miri)))]
+    use crate::bls12381::primitives::variant::MinPk;
     use commonware_codec::{Decode, DecodeExt, Encode, EncodeFixed};
     use commonware_invariants::minifuzz;
     use commonware_macros::test_group;
@@ -2427,6 +2438,88 @@ mod tests {
         assert_eq!(s1, s2);
         // Different scalars should (very likely) be different
         assert_ne!(s1, s3);
+    }
+
+    #[test]
+    fn test_private_encoding() {
+        // Keep construction usable in const contexts without an encoding cache.
+        const fn private_from_scalar(scalar: Scalar) -> Private {
+            Private::new(scalar)
+        }
+
+        let original = Private::random(test_rng());
+        let encoded = original.access(|scalar| scalar.encode());
+        let index = Participant::new(1);
+        let mut share_bytes = Vec::new();
+        index.write(&mut share_bytes);
+        share_bytes.extend_from_slice(&encoded);
+
+        for private in [
+            original.clone(),
+            private_from_scalar(original.access(Clone::clone)),
+            Private::decode(encoded.as_ref()).unwrap(),
+        ] {
+            assert!(!private.is_hardened());
+            assert_eq!(private, original);
+            assert_eq!(private.encode(), encoded);
+            let share = Share::new(index, private.clone());
+            assert_eq!(share.encode().as_ref(), share_bytes);
+            assert_eq!(Share::decode(share_bytes.as_slice()).unwrap(), share);
+            assert_eq!(private.extract_or_clone(), original.access(Clone::clone));
+        }
+
+        // Construction still accepts zero even though private-key decoding rejects it.
+        let zero = Private::new(Scalar::zero());
+        assert_eq!(zero.encode().as_ref(), &[0; PRIVATE_KEY_LENGTH]);
+        assert_eq!(zero.extract_or_clone(), Scalar::zero());
+    }
+
+    #[cfg(all(feature = "std", target_os = "linux", not(miri)))]
+    #[test]
+    fn test_hardened_private_extraction() {
+        let original = Private::random(test_rng());
+        let encoded = original.encode();
+        let hardened = original.clone().try_harden().unwrap();
+        let cloned = hardened.clone();
+        assert!(hardened.is_hardened());
+        hardened.access(|value| cloned.access(|other| assert!(core::ptr::eq(value, other))));
+
+        let shared_scalar = hardened.extract_or_clone();
+        cloned.access(|scalar| assert_eq!(scalar, &shared_scalar));
+        assert_eq!(cloned.encode(), encoded);
+        assert_eq!(cloned, original);
+
+        // The remaining owner can move out its scalar.
+        let unique_scalar = cloned.extract_or_clone();
+        assert_eq!(unique_scalar, shared_scalar);
+        assert_eq!(unique_scalar, original.extract_or_clone());
+    }
+
+    #[cfg(all(feature = "std", target_os = "linux", not(miri)))]
+    #[test]
+    fn test_hardened_share() {
+        let original = Share::new(Participant::new(1), Private::random(test_rng()));
+        let encoded = original.encode();
+        let public = original.public::<MinPk>();
+        let hardened = original.clone().try_harden().unwrap();
+        assert_eq!(hardened, original);
+        assert_eq!(hardened.encode(), encoded);
+        assert_eq!(hardened.public::<MinPk>(), public);
+
+        let cloned = hardened.clone();
+        hardened
+            .private
+            .access(|a| cloned.private.access(|b| assert!(core::ptr::eq(a, b))));
+        let hardened = hardened.try_harden().unwrap();
+        hardened
+            .private
+            .access(|a| cloned.private.access(|b| assert!(core::ptr::eq(a, b))));
+        let exported = hardened.private.extract_or_clone();
+        cloned
+            .private
+            .access(|scalar| assert_eq!(scalar, &exported));
+        assert_eq!(cloned.public::<MinPk>(), public);
+        assert_eq!(Share::decode(encoded).unwrap(), cloned);
     }
 
     #[test]

--- a/cryptography/src/bls12381/primitives/group.rs
+++ b/cryptography/src/bls12381/primitives/group.rs
@@ -526,11 +526,9 @@ impl Private {
     ///
     /// # Errors
     ///
-    /// Consumes `self` on failure, including when hardening is unsupported.
-    pub fn try_harden(self) -> Result<Self, HardenError> {
-        Ok(Self {
-            scalar: self.scalar.try_harden()?,
-        })
+    /// Leaves `self` unchanged on failure, including when hardening is unsupported.
+    pub fn try_harden(&mut self) -> Result<(), HardenError> {
+        self.scalar.try_harden()
     }
 
     /// Grants temporary access to the inner scalar through a closure.
@@ -1017,12 +1015,9 @@ impl Share {
     ///
     /// # Errors
     ///
-    /// Consumes `self` on failure, including when hardening is unsupported.
-    pub fn try_harden(self) -> Result<Self, HardenError> {
-        Ok(Self {
-            index: self.index,
-            private: self.private.try_harden()?,
-        })
+    /// Leaves `self` unchanged on failure, including when hardening is unsupported.
+    pub fn try_harden(&mut self) -> Result<(), HardenError> {
+        self.private.try_harden()
     }
 
     /// Returns the public key corresponding to the share.
@@ -2475,9 +2470,9 @@ mod tests {
     #[cfg(all(feature = "std", target_os = "linux", not(miri)))]
     #[test]
     fn test_hardened_private_extraction() {
-        let original = Private::random(test_rng());
-        let encoded = original.encode();
-        let hardened = original.clone().try_harden().unwrap();
+        let mut hardened = Private::random(test_rng());
+        let encoded = hardened.encode();
+        hardened.try_harden().unwrap();
         let cloned = hardened.clone();
         assert!(hardened.is_hardened());
         hardened.access(|value| cloned.access(|other| assert!(core::ptr::eq(value, other))));
@@ -2485,22 +2480,19 @@ mod tests {
         let shared_scalar = hardened.extract_or_clone();
         cloned.access(|scalar| assert_eq!(scalar, &shared_scalar));
         assert_eq!(cloned.encode(), encoded);
-        assert_eq!(cloned, original);
 
         // The remaining owner can move out its scalar.
         let unique_scalar = cloned.extract_or_clone();
         assert_eq!(unique_scalar, shared_scalar);
-        assert_eq!(unique_scalar, original.extract_or_clone());
     }
 
     #[cfg(all(feature = "std", target_os = "linux", not(miri)))]
     #[test]
     fn test_hardened_share() {
-        let original = Share::new(Participant::new(1), Private::random(test_rng()));
-        let encoded = original.encode();
-        let public = original.public::<MinPk>();
-        let hardened = original.clone().try_harden().unwrap();
-        assert_eq!(hardened, original);
+        let mut hardened = Share::new(Participant::new(1), Private::random(test_rng()));
+        let encoded = hardened.encode();
+        let public = hardened.public::<MinPk>();
+        hardened.try_harden().unwrap();
         assert_eq!(hardened.encode(), encoded);
         assert_eq!(hardened.public::<MinPk>(), public);
 
@@ -2508,7 +2500,7 @@ mod tests {
         hardened
             .private
             .access(|a| cloned.private.access(|b| assert!(core::ptr::eq(a, b))));
-        let hardened = hardened.try_harden().unwrap();
+        hardened.try_harden().unwrap();
         hardened
             .private
             .access(|a| cloned.private.access(|b| assert!(core::ptr::eq(a, b))));

--- a/cryptography/src/bls12381/primitives/ops/mod.rs
+++ b/cryptography/src/bls12381/primitives/ops/mod.rs
@@ -57,7 +57,8 @@ pub fn hash_with_namespace<V: Variant>(dst: DST, namespace: &[u8], message: &[u8
 
 /// Signs the provided message with the private key.
 pub fn sign<V: Variant>(private: &Private, dst: DST, message: &[u8]) -> V::Signature {
-    private.access(|scalar| hash::<V>(dst, message) * scalar)
+    let hashed = hash::<V>(dst, message);
+    private.access(|scalar| hashed * scalar)
 }
 
 /// Verifies the signature with the provided public key.

--- a/cryptography/src/bls12381/primitives/ops/mod.rs
+++ b/cryptography/src/bls12381/primitives/ops/mod.rs
@@ -33,7 +33,7 @@ use commonware_utils::union_unique;
 
 /// Computes the public key from the private key.
 pub fn compute_public<V: Variant>(private: &Private) -> V::Public {
-    private.expose(|scalar| V::Public::generator() * scalar)
+    private.access(|scalar| V::Public::generator() * scalar)
 }
 
 /// Returns a new keypair derived from the provided randomness.
@@ -57,7 +57,7 @@ pub fn hash_with_namespace<V: Variant>(dst: DST, namespace: &[u8], message: &[u8
 
 /// Signs the provided message with the private key.
 pub fn sign<V: Variant>(private: &Private, dst: DST, message: &[u8]) -> V::Signature {
-    private.expose(|scalar| hash::<V>(dst, message) * scalar)
+    private.access(|scalar| hash::<V>(dst, message) * scalar)
 }
 
 /// Verifies the signature with the provided public key.
@@ -111,7 +111,7 @@ pub fn sign_proof_of_possession<V: Variant>(private: &Private, namespace: &[u8])
     let public = compute_public::<V>(private);
     let hm = hash_with_namespace::<V>(V::PROOF_OF_POSSESSION, namespace, &public.encode());
 
-    private.expose(|scalar| hm * scalar)
+    private.access(|scalar| hm * scalar)
 }
 
 /// Verifies a proof of possession for the provided public key.

--- a/cryptography/src/bls12381/scheme.rs
+++ b/cryptography/src/bls12381/scheme.rs
@@ -28,7 +28,7 @@
 //! ```
 
 use super::primitives::{
-    group::{self, Private},
+    group::{self, Private, Scalar, ScalarReadCfg},
     ops,
     variant::{MinPk, Variant},
 };
@@ -37,10 +37,11 @@ use crate::{BatchVerifier, HardenError, Secret, Signer as _};
 use alloc::vec::Vec;
 use bytes::{Buf, BufMut};
 use commonware_codec::{
-    DecodeExt, EncodeFixed, Error as CodecError, FixedArray, FixedSize, Read, ReadExt, Write,
+    Decode, DecodeExt, EncodeFixed, Error as CodecError, FixedArray, FixedSize, Read, ReadExt,
+    Write,
 };
 use commonware_formatting::Hex;
-use commonware_math::algebra::Random;
+use commonware_math::algebra::{CryptoGroup, Random};
 use commonware_parallel::Strategy;
 use commonware_utils::{Array, Span};
 use core::{
@@ -48,28 +49,55 @@ use core::{
     hash::{Hash, Hasher},
     ops::Deref,
 };
+use ctutils::{Choice, CtEq};
 use rand_core::CryptoRng;
 use zeroize::Zeroizing;
 
 const CURVE_NAME: &str = "bls12381";
 
+/// A scalar and its cached canonical encoding.
+///
+/// Both fields remain immutable and occupy the same protected value after hardening.
+#[derive(Clone)]
+struct PrivateValue {
+    raw: Zeroizing<[u8; group::PRIVATE_KEY_LENGTH]>,
+    scalar: Scalar,
+}
+
+impl CtEq for PrivateValue {
+    fn ct_eq(&self, other: &Self) -> Choice {
+        // The immutable cache is determined by the scalar, whose comparison is constant-time.
+        self.scalar.ct_eq(&other.scalar)
+    }
+}
+
 /// BLS12-381 private key.
 #[derive(Clone, Debug)]
 pub struct PrivateKey {
-    raw: Secret<[u8; group::PRIVATE_KEY_LENGTH]>,
-    key: Private,
+    key: Secret<PrivateValue>,
 }
 
 impl PrivateKey {
-    /// Moves the serialized private key and its scalar into hardened storage.
+    /// Creates an inline key and caches its canonical encoding.
+    fn new(scalar: Scalar) -> Self {
+        Self {
+            key: Secret::new(PrivateValue {
+                raw: scalar.as_slice(),
+                scalar,
+            }),
+        }
+    }
+
+    /// Moves the private scalar and its cached encoding into hardened storage.
     ///
-    /// Clones share storage, erased when its last owner drops. Already hardened
-    /// keys are unchanged. Earlier copies and exported material remain unprotected.
+    /// Clones then share the protected allocation. Already hardened keys are
+    /// unchanged. Failure consumes the key. Earlier clones and exported material
+    /// are unaffected.
     ///
-    /// Returns an error if hardening is unsupported or its protections cannot be established.
+    /// See [Secret::try_harden](crate::Secret::try_harden) for platform requirements,
+    /// protection guarantees, and limits.
     pub fn try_harden(self) -> Result<Self, HardenError> {
         Ok(Self {
-            raw: self.raw.try_harden()?,
             key: self.key.try_harden()?,
         })
     }
@@ -77,7 +105,8 @@ impl PrivateKey {
 
 impl PartialEq for PrivateKey {
     fn eq(&self, other: &Self) -> bool {
-        self.raw == other.raw
+        // PrivateValue compares its scalar through Secret's constant-time equality.
+        self.key == other.key
     }
 }
 
@@ -85,7 +114,7 @@ impl Eq for PrivateKey {}
 
 impl Write for PrivateKey {
     fn write(&self, buf: &mut impl BufMut) {
-        self.raw.access(|raw| raw.write(buf));
+        self.key.access(|value| value.raw.write(buf));
     }
 }
 
@@ -94,11 +123,10 @@ impl Read for PrivateKey {
 
     fn read_cfg(buf: &mut impl Buf, _: &()) -> Result<Self, CodecError> {
         let raw = Zeroizing::new(<[u8; Self::SIZE]>::read(buf)?);
-        let key =
-            Private::decode(raw.as_ref()).map_err(|e| CodecError::Wrapped(CURVE_NAME, e.into()))?;
+        let scalar = Scalar::decode_cfg(raw.as_ref(), &ScalarReadCfg::RejectZero)
+            .map_err(|e| CodecError::Wrapped(CURVE_NAME, e.into()))?;
         Ok(Self {
-            raw: Secret::new(*raw),
-            key,
+            key: Secret::new(PrivateValue { raw, scalar }),
         })
     }
 }
@@ -107,13 +135,24 @@ impl FixedSize for PrivateKey {
     const SIZE: usize = group::PRIVATE_KEY_LENGTH;
 }
 
-impl From<Private> for PrivateKey {
-    fn from(key: Private) -> Self {
-        let raw = Zeroizing::new(key.access(|s| s.encode_fixed()));
-        Self {
-            raw: Secret::new(*raw),
-            key,
-        }
+impl TryFrom<Private> for PrivateKey {
+    type Error = HardenError;
+
+    /// Converts a primitive private key, preserving whether its storage is hardened.
+    ///
+    /// Inline input produces an inline key without allocating. Hardened input
+    /// requires a new protected allocation containing the scalar and its encoding.
+    /// Existing clones retain their original storage and do not share the new allocation.
+    /// The scalar passes through ordinary temporary storage during conversion.
+    ///
+    /// # Errors
+    ///
+    /// Returns [HardenError] if hardening the new allocation fails. The input is
+    /// consumed on success or failure. See [Secret::try_harden] for protection limits.
+    fn try_from(key: Private) -> Result<Self, Self::Error> {
+        let hardened = key.is_hardened();
+        let key = Self::new(key.extract_or_clone());
+        if hardened { key.try_harden() } else { Ok(key) }
     }
 }
 
@@ -130,18 +169,22 @@ impl crate::Signer for PrivateKey {
     type PublicKey = PublicKey;
 
     fn public_key(&self) -> Self::PublicKey {
-        PublicKey::from(ops::compute_public::<MinPk>(&self.key))
+        let public = self
+            .key
+            .access(|value| <MinPk as Variant>::Public::generator() * &value.scalar);
+        public.into()
     }
 
     fn sign(&self, namespace: &[u8], msg: &[u8]) -> Self::Signature {
-        ops::sign_message::<MinPk>(&self.key, namespace, msg).into()
+        // Hash public input before opening the private allocation.
+        let hashed = ops::hash_with_namespace::<MinPk>(MinPk::MESSAGE, namespace, msg);
+        self.key.access(|value| hashed * &value.scalar).into()
     }
 }
 
 impl Random for PrivateKey {
-    fn random(mut rng: impl CryptoRng) -> Self {
-        let (private, _) = ops::keypair::<_, MinPk>(&mut rng);
-        private.into()
+    fn random(rng: impl CryptoRng) -> Self {
+        Self::new(Scalar::random(rng))
     }
 }
 
@@ -482,8 +525,7 @@ mod tests {
     fn test_from_private() {
         let mut rng = test_rng();
         let private = Private::random(&mut rng);
-        let private_key = PrivateKey::from(private);
-        // Verify the key works by signing and verifying
+        let private_key = PrivateKey::try_from(private).unwrap();
         let msg = b"test message";
         let sig = private_key.sign(b"ns", msg);
         assert!(private_key.public_key().verify(b"ns", msg, &sig));

--- a/cryptography/src/bls12381/scheme.rs
+++ b/cryptography/src/bls12381/scheme.rs
@@ -60,7 +60,7 @@ const CURVE_NAME: &str = "bls12381";
 /// Both fields remain immutable and occupy the same protected value after hardening.
 #[derive(Clone)]
 struct PrivateValue {
-    raw: Zeroizing<[u8; group::PRIVATE_KEY_LENGTH]>,
+    raw: [u8; group::PRIVATE_KEY_LENGTH],
     scalar: Scalar,
 }
 
@@ -82,7 +82,7 @@ impl PrivateKey {
     fn new(scalar: Scalar) -> Self {
         Self {
             key: Secret::new(PrivateValue {
-                raw: scalar.as_slice(),
+                raw: *scalar.as_slice(),
                 scalar,
             }),
         }
@@ -123,7 +123,7 @@ impl Read for PrivateKey {
         let scalar = Scalar::decode_cfg(raw.as_ref(), &ScalarReadCfg::RejectZero)
             .map_err(|e| CodecError::Wrapped(CURVE_NAME, e.into()))?;
         Ok(Self {
-            key: Secret::new(PrivateValue { raw, scalar }),
+            key: Secret::new(PrivateValue { raw: *raw, scalar }),
         })
     }
 }

--- a/cryptography/src/bls12381/scheme.rs
+++ b/cryptography/src/bls12381/scheme.rs
@@ -94,11 +94,9 @@ impl PrivateKey {
     ///
     /// # Errors
     ///
-    /// Consumes `self` on failure, including when hardening is unsupported.
-    pub fn try_harden(self) -> Result<Self, HardenError> {
-        Ok(Self {
-            key: self.key.try_harden()?,
-        })
+    /// Leaves `self` unchanged on failure, including when hardening is unsupported.
+    pub fn try_harden(&mut self) -> Result<(), HardenError> {
+        self.key.try_harden()
     }
 }
 
@@ -150,8 +148,11 @@ impl TryFrom<Private> for PrivateKey {
     /// consumed on success or failure. See [Secret::try_harden] for protection limits.
     fn try_from(key: Private) -> Result<Self, Self::Error> {
         let hardened = key.is_hardened();
-        let key = Self::new(key.extract_or_clone());
-        if hardened { key.try_harden() } else { Ok(key) }
+        let mut key = Self::new(key.extract_or_clone());
+        if hardened {
+            key.try_harden()?;
+        }
+        Ok(key)
     }
 }
 

--- a/cryptography/src/bls12381/scheme.rs
+++ b/cryptography/src/bls12381/scheme.rs
@@ -88,14 +88,13 @@ impl PrivateKey {
         }
     }
 
-    /// Moves the private scalar and its cached encoding into hardened storage.
+    /// Moves the secret material into hardened storage.
     ///
-    /// Clones then share the protected allocation. Already hardened keys are
-    /// unchanged. Failure consumes the key. Earlier clones and exported material
-    /// are unaffected.
+    /// See [crate::Secret::try_harden] for requirements and guarantees.
     ///
-    /// See [Secret::try_harden](crate::Secret::try_harden) for platform requirements,
-    /// protection guarantees, and limits.
+    /// # Errors
+    ///
+    /// Consumes `self` on failure, including when hardening is unsupported.
     pub fn try_harden(self) -> Result<Self, HardenError> {
         Ok(Self {
             key: self.key.try_harden()?,
@@ -176,7 +175,6 @@ impl crate::Signer for PrivateKey {
     }
 
     fn sign(&self, namespace: &[u8], msg: &[u8]) -> Self::Signature {
-        // Hash public input before opening the private allocation.
         let hashed = ops::hash_with_namespace::<MinPk>(MinPk::MESSAGE, namespace, msg);
         self.key.access(|value| hashed * &value.scalar).into()
     }
@@ -526,6 +524,7 @@ mod tests {
         let mut rng = test_rng();
         let private = Private::random(&mut rng);
         let private_key = PrivateKey::try_from(private).unwrap();
+        // Verify the key works by signing and verifying
         let msg = b"test message";
         let sig = private_key.sign(b"ns", msg);
         assert!(private_key.public_key().verify(b"ns", msg, &sig));

--- a/cryptography/src/bls12381/scheme.rs
+++ b/cryptography/src/bls12381/scheme.rs
@@ -32,7 +32,7 @@ use super::primitives::{
     ops,
     variant::{MinPk, Variant},
 };
-use crate::{BatchVerifier, Secret, Signer as _};
+use crate::{BatchVerifier, HardenError, Secret, Signer as _};
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 use bytes::{Buf, BufMut};
@@ -60,6 +60,21 @@ pub struct PrivateKey {
     key: Private,
 }
 
+impl PrivateKey {
+    /// Moves the serialized private key and its scalar into hardened storage.
+    ///
+    /// Clones share storage, erased when its last owner drops. Already hardened
+    /// keys are unchanged. Earlier copies and exported material remain unprotected.
+    ///
+    /// Returns an error if hardening is unsupported or its protections cannot be established.
+    pub fn try_harden(self) -> Result<Self, HardenError> {
+        Ok(Self {
+            raw: self.raw.try_harden()?,
+            key: self.key.try_harden()?,
+        })
+    }
+}
+
 impl PartialEq for PrivateKey {
     fn eq(&self, other: &Self) -> bool {
         self.raw == other.raw
@@ -70,7 +85,7 @@ impl Eq for PrivateKey {}
 
 impl Write for PrivateKey {
     fn write(&self, buf: &mut impl BufMut) {
-        self.raw.expose(|raw| raw.write(buf));
+        self.raw.access(|raw| raw.write(buf));
     }
 }
 
@@ -94,7 +109,7 @@ impl FixedSize for PrivateKey {
 
 impl From<Private> for PrivateKey {
     fn from(key: Private) -> Self {
-        let raw = Zeroizing::new(key.expose(|s| s.encode_fixed()));
+        let raw = Zeroizing::new(key.access(|s| s.encode_fixed()));
         Self {
             raw: Secret::new(*raw),
             key,

--- a/cryptography/src/ed25519/core/mod.rs
+++ b/cryptography/src/ed25519/core/mod.rs
@@ -6,6 +6,8 @@
 //! - Reduces the clamped Ed25519 scalar with [`Scalar::from_bytes_mod_order`] before public-key
 //!   derivation and scalar-scalar arithmetic (equivalent to [`ed25519_zebra`]).
 //! - Zeroizes the signing key's prefix, along with the seed and scalar.
+//! - Separates private signing material from its cached verification key so the
+//!   outer signer can protect private storage without opening it for public data.
 //! - Removed `serde` dependency.
 //! - Swapped `hex` dependency to [`commonware_formatting::Hex`].
 //! - Adapted code to `commonware`'s clippy rules.
@@ -25,5 +27,5 @@ mod verification_key;
 
 pub use error::Error;
 pub use signature::Signature;
-pub use signing_key::SigningKey;
+pub use signing_key::{SigningKey, SigningSecret};
 pub use verification_key::{VerificationKey, VerificationKeyBytes};

--- a/cryptography/src/ed25519/core/signing_key.rs
+++ b/cryptography/src/ed25519/core/signing_key.rs
@@ -5,14 +5,20 @@ use curve25519_dalek::{constants, scalar::Scalar};
 use rand_core::{CryptoRng, Rng};
 use sha2::{Digest, Sha512, digest::Update};
 
+/// The private seed, scalar, and nonce prefix of an Ed25519 signing key.
+#[derive(Clone)]
+pub struct SigningSecret {
+    seed: [u8; 32],
+    s: Scalar,
+    prefix: [u8; 32],
+}
+
 /// An Ed25519 signing key.
 ///
 /// This is also called a secret key by other implementations.
 #[derive(Clone)]
 pub struct SigningKey {
-    seed: [u8; 32],
-    s: Scalar,
-    prefix: [u8; 32],
+    secret: SigningSecret,
     vk: VerificationKey,
 }
 
@@ -21,26 +27,31 @@ impl SigningKey {
     ///
     /// This is the same as `.into()`, but does not require type inference.
     pub const fn to_bytes(&self) -> [u8; 32] {
-        self.seed
+        self.secret.seed
     }
 
     /// View the byte encoding of the signing key.
     pub const fn as_bytes(&self) -> &[u8; 32] {
-        &self.seed
+        &self.secret.seed
     }
 
     /// Obtain the verification key associated with this signing key.
     pub const fn verification_key(&self) -> VerificationKey {
         self.vk
     }
+
+    /// Separates the private material from its matching cached public key.
+    pub const fn into_parts(self) -> (SigningSecret, VerificationKey) {
+        (self.secret, self.vk)
+    }
 }
 
 impl core::fmt::Debug for SigningKey {
     fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         fmt.debug_struct("SigningKey")
-            .field("seed", &Hex(&self.seed))
-            .field("s", &self.s)
-            .field("prefix", &Hex(&self.prefix))
+            .field("seed", &Hex(&self.secret.seed))
+            .field("s", &self.secret.s)
+            .field("prefix", &Hex(&self.secret.prefix))
             .field("vk", &self.vk)
             .finish()
     }
@@ -60,13 +71,13 @@ impl<'a> From<&'a SigningKey> for VerificationKeyBytes {
 
 impl AsRef<[u8]> for SigningKey {
     fn as_ref(&self) -> &[u8] {
-        &self.seed[..]
+        &self.secret.seed[..]
     }
 }
 
 impl From<SigningKey> for [u8; 32] {
     fn from(sk: SigningKey) -> [u8; 32] {
-        sk.seed
+        sk.secret.seed
     }
 }
 
@@ -110,9 +121,7 @@ impl From<[u8; 32]> for SigningKey {
         let A = &s * constants::ED25519_BASEPOINT_TABLE;
 
         Self {
-            seed,
-            s,
-            prefix,
+            secret: SigningSecret { seed, s, prefix },
             vk: VerificationKey {
                 minus_A: -A,
                 A_bytes: VerificationKeyBytes(A.compress().to_bytes()),
@@ -123,9 +132,9 @@ impl From<[u8; 32]> for SigningKey {
 
 impl zeroize::Zeroize for SigningKey {
     fn zeroize(&mut self) {
-        self.seed.zeroize();
-        self.s.zeroize();
-        self.prefix.zeroize()
+        self.secret.seed.zeroize();
+        self.secret.s.zeroize();
+        self.secret.prefix.zeroize()
     }
 }
 
@@ -138,8 +147,23 @@ impl SigningKey {
     }
 
     /// Create a signature on `msg` using this key.
-    #[allow(non_snake_case)]
     pub fn sign(&self, msg: &[u8]) -> Signature {
+        self.secret.sign(&self.vk, msg)
+    }
+}
+
+impl SigningSecret {
+    /// Returns the seed encoding.
+    pub const fn as_bytes(&self) -> &[u8; 32] {
+        &self.seed
+    }
+
+    /// Signs with the public key returned alongside this secret by `into_parts`.
+    ///
+    /// Supplying a different public key can reuse a nonce under different
+    /// challenges and reveal the signing scalar. Keep these parts paired.
+    #[allow(non_snake_case)]
+    pub fn sign(&self, vk: &VerificationKey, msg: &[u8]) -> Signature {
         let r = Scalar::from_hash(Sha512::default().chain(&self.prefix[..]).chain(msg));
 
         let R_bytes = (&r * constants::ED25519_BASEPOINT_TABLE)
@@ -149,7 +173,7 @@ impl SigningKey {
         let k = Scalar::from_hash(
             Sha512::default()
                 .chain(&R_bytes[..])
-                .chain(&self.vk.A_bytes.0[..])
+                .chain(&vk.A_bytes.0[..])
                 .chain(msg),
         );
 

--- a/cryptography/src/ed25519/core/signing_key.rs
+++ b/cryptography/src/ed25519/core/signing_key.rs
@@ -4,6 +4,7 @@ use core::convert::TryFrom;
 use curve25519_dalek::{constants, scalar::Scalar};
 use rand_core::{CryptoRng, Rng};
 use sha2::{Digest, Sha512, digest::Update};
+use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
 
 /// The private seed, scalar, and nonce prefix of an Ed25519 signing key.
 #[derive(Clone)]
@@ -41,7 +42,7 @@ impl SigningKey {
     }
 
     /// Separates the private material from its matching cached public key.
-    pub const fn into_parts(self) -> (SigningSecret, VerificationKey) {
+    pub fn into_parts(self) -> (SigningSecret, VerificationKey) {
         (self.secret, self.vk)
     }
 }
@@ -97,17 +98,18 @@ impl TryFrom<&[u8]> for SigningKey {
 impl From<[u8; 32]> for SigningKey {
     #[allow(non_snake_case)]
     fn from(seed: [u8; 32]) -> Self {
-        // Expand the seed to a 64-byte array with SHA512.
-        let h = Sha512::digest(&seed[..]);
+        // Expand the seed to a 64-byte array with SHA512. The digest and the
+        // clamped scalar bytes are secret, so they are erased when dropped.
+        let h = Zeroizing::new(Sha512::digest(&seed[..]));
 
         // Scalar-scalar arithmetic in `sign` requires the reduced representation.
         let s = {
-            let mut scalar_bytes = [0u8; 32];
+            let mut scalar_bytes = Zeroizing::new([0u8; 32]);
             scalar_bytes[..].copy_from_slice(&h.as_slice()[0..32]);
             scalar_bytes[0] &= 248;
             scalar_bytes[31] &= 127;
             scalar_bytes[31] |= 64;
-            Scalar::from_bytes_mod_order(scalar_bytes)
+            Scalar::from_bytes_mod_order(*scalar_bytes)
         };
 
         // Extract and cache the high half.
@@ -130,20 +132,34 @@ impl From<[u8; 32]> for SigningKey {
     }
 }
 
-impl zeroize::Zeroize for SigningKey {
+impl Zeroize for SigningSecret {
     fn zeroize(&mut self) {
-        self.secret.seed.zeroize();
-        self.secret.s.zeroize();
-        self.secret.prefix.zeroize()
+        self.seed.zeroize();
+        self.s.zeroize();
+        self.prefix.zeroize();
+    }
+}
+
+impl Drop for SigningSecret {
+    fn drop(&mut self) {
+        self.zeroize();
+    }
+}
+
+impl ZeroizeOnDrop for SigningSecret {}
+
+impl Zeroize for SigningKey {
+    fn zeroize(&mut self) {
+        self.secret.zeroize();
     }
 }
 
 impl SigningKey {
     /// Generate a new signing key.
     pub fn new<R: Rng + CryptoRng>(mut rng: R) -> Self {
-        let mut bytes = [0u8; 32];
+        let mut bytes = Zeroizing::new([0u8; 32]);
         rng.fill_bytes(&mut bytes[..]);
-        bytes.into()
+        Self::from(*bytes)
     }
 
     /// Create a signature on `msg` using this key.
@@ -161,9 +177,12 @@ impl SigningSecret {
     /// Create a signature on `msg` using this key.
     #[allow(non_snake_case)]
     pub fn sign(&self, vk: &VerificationKey, msg: &[u8]) -> Signature {
-        let r = Scalar::from_hash(Sha512::default().chain(&self.prefix[..]).chain(msg));
+        // A leaked nonce recovers the private scalar, so erase it on drop.
+        let r = Zeroizing::new(Scalar::from_hash(
+            Sha512::default().chain(&self.prefix[..]).chain(msg),
+        ));
 
-        let R_bytes = (&r * constants::ED25519_BASEPOINT_TABLE)
+        let R_bytes = (&*r * constants::ED25519_BASEPOINT_TABLE)
             .compress()
             .to_bytes();
 
@@ -174,7 +193,7 @@ impl SigningSecret {
                 .chain(msg),
         );
 
-        let s_bytes = (r + k * self.s).to_bytes();
+        let s_bytes = (*r + k * self.s).to_bytes();
 
         Signature { R_bytes, s_bytes }
     }

--- a/cryptography/src/ed25519/core/signing_key.rs
+++ b/cryptography/src/ed25519/core/signing_key.rs
@@ -158,10 +158,7 @@ impl SigningSecret {
         &self.seed
     }
 
-    /// Signs with the public key returned alongside this secret by `into_parts`.
-    ///
-    /// Supplying a different public key can reuse a nonce under different
-    /// challenges and reveal the signing scalar. Keep these parts paired.
+    /// Create a signature on `msg` using this key.
     #[allow(non_snake_case)]
     pub fn sign(&self, vk: &VerificationKey, msg: &[u8]) -> Signature {
         let r = Scalar::from_hash(Sha512::default().chain(&self.prefix[..]).chain(msg));

--- a/cryptography/src/ed25519/scheme.rs
+++ b/cryptography/src/ed25519/scheme.rs
@@ -3,7 +3,7 @@ use crate::{
     ed25519::core::{self as ed_core, VerificationKey},
 };
 #[cfg(not(feature = "std"))]
-use alloc::borrow::{Cow, ToOwned};
+use alloc::borrow::Cow;
 use bytes::{Buf, BufMut};
 use commonware_codec::{Error as CodecError, FixedArray, FixedSize, Read, ReadExt, Write};
 use commonware_formatting::Hex;
@@ -17,7 +17,7 @@ use core::{
 };
 use rand_core::CryptoRng;
 #[cfg(feature = "std")]
-use std::borrow::{Cow, ToOwned};
+use std::borrow::Cow;
 use zeroize::Zeroizing;
 
 const CURVE_NAME: &str = "ed25519";
@@ -28,7 +28,9 @@ const SIGNATURE_LENGTH: usize = 64;
 /// Ed25519 Private Key.
 #[derive(Clone, Debug)]
 pub struct PrivateKey {
-    key: Secret<ed_core::SigningKey>,
+    key: Secret<ed_core::SigningSecret>,
+    // Public operations must not make the private pages readable.
+    public: VerificationKey,
 }
 
 impl crate::PrivateKey for PrivateKey {}
@@ -42,25 +44,23 @@ impl crate::Signer for PrivateKey {
     }
 
     fn public_key(&self) -> Self::PublicKey {
-        self.key.access(|key| Self::PublicKey {
-            key: key.verification_key().to_owned(),
-        })
+        Self::PublicKey { key: self.public }
     }
 }
 
 impl PrivateKey {
-    /// Moves the private material into locked, non-dumpable memory that is
-    /// inaccessible between operations.
+    /// Moves the private material into hardened storage.
     ///
-    /// Clones of a hardened key share its protected allocation. Existing copies
-    /// are unaffected. Repeated calls preserve the existing allocation.
+    /// Clones share the protected allocation. Public-key access leaves it sealed.
+    /// See [Secret::try_harden] for the protections, costs, and ownership contract.
     ///
     /// # Errors
     ///
-    /// Returns an error if hardening is unsupported or protection cannot be established.
+    /// Consumes the key on failure, including when hardening is unsupported.
     pub fn try_harden(self) -> Result<Self, HardenError> {
         Ok(Self {
             key: self.key.try_harden()?,
+            public: self.public,
         })
     }
 
@@ -69,16 +69,15 @@ impl PrivateKey {
         let payload = namespace
             .map(|namespace| Cow::Owned(union_unique(namespace, msg)))
             .unwrap_or_else(|| Cow::Borrowed(msg));
-        self.key.access(|key| Signature::from(key.sign(&payload)))
+        self.key
+            .access(|key| Signature::from(key.sign(&self.public, &payload)))
     }
 }
 
 impl Random for PrivateKey {
     fn random(rng: impl CryptoRng) -> Self {
         let key = ed_core::SigningKey::new(rng);
-        Self {
-            key: Secret::new(key),
-        }
+        key.into()
     }
 }
 
@@ -94,9 +93,7 @@ impl Read for PrivateKey {
     fn read_cfg(buf: &mut impl Buf, _: &()) -> Result<Self, CodecError> {
         let raw = Zeroizing::new(<[u8; Self::SIZE]>::read(buf)?);
         let key = ed_core::SigningKey::from(*raw);
-        Ok(Self {
-            key: Secret::new(key),
-        })
+        Ok(key.into())
     }
 }
 
@@ -106,8 +103,10 @@ impl FixedSize for PrivateKey {
 
 impl From<ed_core::SigningKey> for PrivateKey {
     fn from(key: ed_core::SigningKey) -> Self {
+        let (key, public) = key.into_parts();
         Self {
             key: Secret::new(key),
+            public,
         }
     }
 }
@@ -144,9 +143,7 @@ pub struct PublicKey {
 
 impl From<PrivateKey> for PublicKey {
     fn from(value: PrivateKey) -> Self {
-        value.key.access(|key| Self {
-            key: key.verification_key(),
-        })
+        Self { key: value.public }
     }
 }
 

--- a/cryptography/src/ed25519/scheme.rs
+++ b/cryptography/src/ed25519/scheme.rs
@@ -29,7 +29,6 @@ const SIGNATURE_LENGTH: usize = 64;
 #[derive(Clone, Debug)]
 pub struct PrivateKey {
     key: Secret<ed_core::SigningSecret>,
-    // Public operations must not make the private pages readable.
     public: VerificationKey,
 }
 
@@ -49,14 +48,13 @@ impl crate::Signer for PrivateKey {
 }
 
 impl PrivateKey {
-    /// Moves the private material into hardened storage.
+    /// Moves the secret material into hardened storage.
     ///
-    /// Clones share the protected allocation. Public-key access leaves it sealed.
-    /// See [Secret::try_harden] for the protections, costs, and ownership contract.
+    /// See [crate::Secret::try_harden] for requirements and guarantees.
     ///
     /// # Errors
     ///
-    /// Consumes the key on failure, including when hardening is unsupported.
+    /// Consumes `self` on failure, including when hardening is unsupported.
     pub fn try_harden(self) -> Result<Self, HardenError> {
         Ok(Self {
             key: self.key.try_harden()?,

--- a/cryptography/src/ed25519/scheme.rs
+++ b/cryptography/src/ed25519/scheme.rs
@@ -54,12 +54,9 @@ impl PrivateKey {
     ///
     /// # Errors
     ///
-    /// Consumes `self` on failure, including when hardening is unsupported.
-    pub fn try_harden(self) -> Result<Self, HardenError> {
-        Ok(Self {
-            key: self.key.try_harden()?,
-            public: self.public,
-        })
+    /// Leaves `self` unchanged on failure, including when hardening is unsupported.
+    pub fn try_harden(&mut self) -> Result<(), HardenError> {
+        self.key.try_harden()
     }
 
     #[inline(always)]

--- a/cryptography/src/ed25519/scheme.rs
+++ b/cryptography/src/ed25519/scheme.rs
@@ -1,5 +1,5 @@
 use crate::{
-    BatchVerifier, Secret,
+    BatchVerifier, HardenError, Secret,
     ed25519::core::{self as ed_core, VerificationKey},
 };
 #[cfg(not(feature = "std"))]
@@ -42,19 +42,34 @@ impl crate::Signer for PrivateKey {
     }
 
     fn public_key(&self) -> Self::PublicKey {
-        self.key.expose(|key| Self::PublicKey {
+        self.key.access(|key| Self::PublicKey {
             key: key.verification_key().to_owned(),
         })
     }
 }
 
 impl PrivateKey {
+    /// Moves the private material into locked, non-dumpable memory that is
+    /// inaccessible between operations.
+    ///
+    /// Clones of a hardened key share its protected allocation. Existing copies
+    /// are unaffected. Repeated calls preserve the existing allocation.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if hardening is unsupported or protection cannot be established.
+    pub fn try_harden(self) -> Result<Self, HardenError> {
+        Ok(Self {
+            key: self.key.try_harden()?,
+        })
+    }
+
     #[inline(always)]
     fn sign_inner(&self, namespace: Option<&[u8]>, msg: &[u8]) -> Signature {
         let payload = namespace
             .map(|namespace| Cow::Owned(union_unique(namespace, msg)))
             .unwrap_or_else(|| Cow::Borrowed(msg));
-        self.key.expose(|key| Signature::from(key.sign(&payload)))
+        self.key.access(|key| Signature::from(key.sign(&payload)))
     }
 }
 
@@ -69,7 +84,7 @@ impl Random for PrivateKey {
 
 impl Write for PrivateKey {
     fn write(&self, buf: &mut impl BufMut) {
-        self.key.expose(|key| key.as_bytes().write(buf));
+        self.key.access(|key| key.as_bytes().write(buf));
     }
 }
 
@@ -117,7 +132,7 @@ impl arbitrary::Arbitrary<'_> for PrivateKey {
 impl PartialEq for PrivateKey {
     fn eq(&self, other: &Self) -> bool {
         self.key
-            .expose(|key1| other.key.expose(|key2| key1.as_bytes() == key2.as_bytes()))
+            .access(|key1| other.key.access(|key2| key1.as_bytes() == key2.as_bytes()))
     }
 }
 
@@ -129,7 +144,7 @@ pub struct PublicKey {
 
 impl From<PrivateKey> for PublicKey {
     fn from(value: PrivateKey) -> Self {
-        value.key.expose(|key| Self {
+        value.key.access(|key| Self {
             key: key.verification_key(),
         })
     }

--- a/cryptography/src/handshake.rs
+++ b/cryptography/src/handshake.rs
@@ -309,7 +309,7 @@ pub fn dial_end<P: PublicKey>(
     };
     shared
         .secret
-        .expose(|secret| transcript.commit(secret.as_ref()));
+        .access(|secret| transcript.commit(secret.as_ref()));
     let recv = RecvCipher::new(transcript.noise(LABEL_CIPHER_L2D));
     let send = SendCipher::new(transcript.noise(LABEL_CIPHER_D2L));
     let confirmation_l2d = transcript.fork(LABEL_CONFIRMATION_L2D).summarize();
@@ -364,7 +364,7 @@ pub fn listen_start<S: Signer, P: PublicKey>(
     };
     shared
         .secret
-        .expose(|secret| transcript.commit(secret.as_ref()));
+        .access(|secret| transcript.commit(secret.as_ref()));
     let send = SendCipher::new(transcript.noise(LABEL_CIPHER_L2D));
     let recv = RecvCipher::new(transcript.noise(LABEL_CIPHER_D2L));
     let confirmation_l2d = transcript.fork(LABEL_CONFIRMATION_L2D).summarize();

--- a/cryptography/src/handshake/cipher.rs
+++ b/cryptography/src/handshake/cipher.rs
@@ -151,7 +151,7 @@ impl SendCipher {
     pub fn send_in_place(&mut self, data: &mut [u8]) -> Result<[u8; TAG_SIZE], Error> {
         let nonce = self.nonce.inc()?;
         self.inner
-            .expose(|cipher| cipher.encrypt_in_place(&nonce, data))
+            .access(|cipher| cipher.encrypt_in_place(&nonce, data))
     }
 
     /// Encrypts data and returns the ciphertext.
@@ -205,7 +205,7 @@ impl RecvCipher {
             return Err(Error::DecryptionFailed);
         }
         self.inner
-            .expose(|cipher| cipher.decrypt_in_place(&nonce, encrypted_data))
+            .access(|cipher| cipher.decrypt_in_place(&nonce, encrypted_data))
     }
 
     /// Decrypts ciphertext and returns the original data.

--- a/cryptography/src/handshake/key_exchange.rs
+++ b/cryptography/src/handshake/key_exchange.rs
@@ -72,7 +72,7 @@ impl SecretKey {
 
     /// Derives the corresponding public key.
     pub fn public(&self) -> EphemeralPublicKey {
-        self.inner.expose(|secret| EphemeralPublicKey {
+        self.inner.access(|secret| EphemeralPublicKey {
             inner: x25519_dalek::PublicKey::from(secret),
         })
     }
@@ -80,7 +80,10 @@ impl SecretKey {
     /// Performs X25519 key exchange with another public key.
     /// Returns None if the exchange is non-contributory.
     pub fn exchange(self, other: &EphemeralPublicKey) -> Option<SharedSecret> {
-        let secret = self.inner.expose_unwrap();
+        let secret = self
+            .inner
+            .try_extract()
+            .expect("ephemeral secret is uniquely owned");
         let out = secret.diffie_hellman(&other.inner);
         if !out.was_contributory() {
             return None;

--- a/cryptography/src/hardened_secret.rs
+++ b/cryptography/src/hardened_secret.rs
@@ -455,7 +455,7 @@ impl<T> Drop for ReadGuard<'_, T> {
 
 #[cfg(all(test, not(miri)))]
 mod tests {
-    use crate::{HardenError, Secret};
+    use crate::Secret;
     use std::{
         panic::{AssertUnwindSafe, catch_unwind},
         ptr,
@@ -627,52 +627,6 @@ mod tests {
             .is_err()
         );
         assert_eq!(mapping_info(data).0, "---");
-    }
-
-    #[test]
-    fn test_sizes_and_alignment() {
-        // A zero-sized value hardens like any other.
-        round_trip::<0>();
-
-        // Const array lengths and repr(align) require compile-time page sizes.
-        // Dispatch on the actual page size rather than assuming 4 KiB pages.
-        macro_rules! page_cases {
-            ($page:literal, $over:literal) => {{
-                // Values of exactly one page and of one byte more both round-trip.
-                round_trip::<$page>();
-                round_trip::<{ $page + 1 }>();
-
-                // Page alignment is the most the mapping can honor.
-                #[repr(align($page))]
-                struct Aligned([u8; 1]);
-                let mut value = Secret::new(Aligned([73]));
-                value.try_harden().unwrap();
-                value.access(|value| assert_eq!(value.0, [73]));
-
-                // Stricter alignment is rejected, and the inline value stays usable.
-                #[repr(align($over))]
-                struct OverAligned([u8; 1]);
-                let mut value = Secret::new(OverAligned([73]));
-                assert!(matches!(value.try_harden(), Err(HardenError::Layout)));
-                assert!(!value.is_hardened());
-                value.access(|value| assert_eq!(value.0, [73]));
-            }};
-        }
-        match page_size() {
-            4096 => page_cases!(4096, 8192),
-            8192 => page_cases!(8192, 16384),
-            16384 => page_cases!(16384, 32768),
-            65536 => page_cases!(65536, 131072),
-            page => panic!("add fixtures for {page}-byte pages"),
-        }
-    }
-
-    /// Hardens a byte array, reads it back, and moves it out again.
-    fn round_trip<const N: usize>() {
-        let mut secret = Secret::new([37u8; N]);
-        secret.try_harden().unwrap();
-        secret.access(|value| assert_eq!(value, &[37; N]));
-        assert_eq!(secret.try_extract().unwrap(), [37; N]);
     }
 
     /// Returns the kernel's page size.

--- a/cryptography/src/hardened_secret.rs
+++ b/cryptography/src/hardened_secret.rs
@@ -360,6 +360,7 @@ impl Drop for Mapping {
 /// Construction, extraction, and destruction hold exclusive write access. After
 /// publication, the first reader grants read access and the last revokes it.
 struct ProtectedAllocation<T> {
+    /// Guarded pages holding the value. Erased and unmapped after `T` is gone.
     mapping: Mapping,
     /// Aligned location of the initialized value within mapping's data region.
     ///
@@ -377,6 +378,7 @@ struct ProtectedAllocation<T> {
 // SAFETY: T can be moved to another thread. The mapping has one owner, shared
 // access is coordinated by readers, and destruction requires exclusive ownership.
 unsafe impl<T: Send> Send for ProtectedAllocation<T> {}
+
 // SAFETY: T can be shared between threads. Permission transitions and reader
 // counts are serialized, and no reference outlives its read guard.
 unsafe impl<T: Sync> Sync for ProtectedAllocation<T> {}
@@ -438,9 +440,13 @@ struct ReadGuard<'a, T>(&'a ProtectedAllocation<T>);
 
 impl<T> Drop for ReadGuard<'_, T> {
     fn drop(&mut self) {
+        // Runs on return and on unwind, so a panicking callback still gives up
+        // its slot.
         let mut readers = self.0.readers.lock();
         *readers -= 1;
 
+        // The last reader revokes access. Holding the mutex across the revoke
+        // keeps a concurrent first reader from granting access underneath it.
         if *readers == 0 && self.0.mapping.protect(libc::PROT_NONE).is_err() {
             process::abort();
         }
@@ -467,6 +473,7 @@ mod tests {
     /// Creates an allocation whose mappings can be inspected by backend tests.
     fn harden<T>(value: InlineSecret<T>) -> Result<HardenedSecret<T>, HardenError> {
         let mut value = ManuallyDrop::new(value);
+
         // SAFETY: Success immediately retires the source without dropping T.
         // Failure leaves it initialized, so only that path runs its destructor.
         unsafe {
@@ -487,7 +494,10 @@ mod tests {
         }
     }
 
-    /// Runs deliberate memory faults in a subprocess so the test runner survives.
+    /// Runs one `subprocess_child` case in a fresh process and checks how it ended.
+    ///
+    /// Faults and aborts must kill the child with `signal`. Every other case must
+    /// exit successfully.
     fn child(case: &str, signal: Option<i32>) -> Output {
         let output = Command::new(std::env::current_exe().unwrap())
             .args([

--- a/cryptography/src/hardened_secret.rs
+++ b/cryptography/src/hardened_secret.rs
@@ -455,12 +455,10 @@ impl<T> Drop for ReadGuard<'_, T> {
 
 #[cfg(all(test, not(miri)))]
 mod tests {
-    use super::*;
-    use crate::secret::Secret;
+    use crate::{HardenError, Secret};
     use std::{
-        os::unix::process::ExitStatusExt,
         panic::{AssertUnwindSafe, catch_unwind},
-        process::{Command, Output},
+        ptr,
         sync::{
             Arc, Barrier,
             atomic::{AtomicUsize, Ordering},
@@ -468,102 +466,101 @@ mod tests {
         thread,
     };
 
-    const CHILD_ENV: &str = "COMMONWARE_HARDENED_SECRET_TEST";
+    /// A value with a borrowed, nonsecret destruction counter.
+    #[derive(Clone)]
+    struct Tracked<'a> {
+        bytes: [u8; 32],
+        drops: &'a AtomicUsize,
+    }
 
-    /// Creates an allocation whose mappings can be inspected by backend tests.
-    fn harden<T>(value: InlineSecret<T>) -> Result<HardenedSecret<T>, HardenError> {
-        let mut value = ManuallyDrop::new(value);
-
-        // SAFETY: Success immediately retires the source without dropping T.
-        // Failure leaves it initialized, so only that path runs its destructor.
-        unsafe {
-            match HardenedSecret::try_from_inline(&mut value) {
-                Ok(hardened) => {
-                    slice::from_raw_parts_mut(
-                        (&raw mut *value).cast::<MaybeUninit<u8>>(),
-                        size_of::<InlineSecret<T>>(),
-                    )
-                    .zeroize();
-                    Ok(hardened)
-                }
-                Err(error) => {
-                    ManuallyDrop::drop(&mut value);
-                    Err(error)
-                }
-            }
+    impl Drop for Tracked<'_> {
+        fn drop(&mut self) {
+            self.drops.fetch_add(1, Ordering::Relaxed);
         }
     }
 
-    /// Runs one `subprocess_child` case in a fresh process and checks how it ended.
-    ///
-    /// Faults and aborts must kill the child with `signal`. Every other case must
-    /// exit successfully.
-    fn child(case: &str, signal: Option<i32>) -> Output {
-        let output = Command::new(std::env::current_exe().unwrap())
-            .args([
-                "--exact",
-                "hardened_secret::tests::subprocess_child",
-                "--nocapture",
-            ])
-            .env(CHILD_ENV, case)
-            .output()
-            .unwrap();
-        assert_eq!(output.status.signal(), signal, "{output:?}");
-        if signal.is_none() {
-            assert!(output.status.success(), "{output:?}");
-        }
-        output
-    }
-
-    #[test]
-    fn protected_access_and_guards() {
-        child("inaccessible", Some(libc::SIGSEGV));
-        child("readonly", Some(libc::SIGSEGV));
-        child("leading_guard", Some(libc::SIGSEGV));
-        child("trailing_guard", Some(libc::SIGSEGV));
-        child("enter_failure", Some(libc::SIGABRT));
-        child("exit_failure", Some(libc::SIGABRT));
-        child("cleanup_failure", Some(libc::SIGABRT));
-        child("harden_seal_failure", None);
-    }
-
-    #[test]
-    fn locked_memory_limit() {
-        child("locked_memory_limit", None);
-    }
-
-    #[test]
-    fn public_access_unwind() {
-        for case in ["borrowed_panic_protection", "owned_panic_protection"] {
-            let output = child(case, Some(libc::SIGSEGV));
-            // A fault during recovery must not pass as the deliberate sealed-page probe.
-            assert!(String::from_utf8_lossy(&output.stderr).contains("access recovered"));
+    const fn tracked(drops: &AtomicUsize) -> Tracked<'_> {
+        Tracked {
+            bytes: [42; 32],
+            drops,
         }
     }
 
     #[test]
-    fn fork_wipes_inherited_data() {
-        child("fork_wipe", None);
-    }
+    fn test_harden_and_extract() {
+        let drops = AtomicUsize::new(0);
 
-    #[test]
-    fn nested_and_concurrent_access() {
-        let secret = harden(InlineSecret::new([42u8; 32])).unwrap();
-        let cloned = secret.clone();
-        assert!(Arc::ptr_eq(&secret.inner, &cloned.inner));
+        // Hardening moves the value without destroying it, and hardening again
+        // keeps the same allocation.
+        let mut secret = Secret::new(tracked(&drops));
+        secret.try_harden().unwrap();
+        assert!(secret.is_hardened());
+        let address = secret.access(ptr::from_ref);
+        secret.try_harden().unwrap();
         secret.access(|value| {
+            assert_eq!(ptr::from_ref(value), address);
+            assert_eq!(value.bytes, [42; 32]);
+        });
+        assert_eq!(drops.load(Ordering::Relaxed), 0);
+
+        // Unique extraction moves the value out instead of destroying it.
+        let value = secret.try_extract().ok().unwrap();
+        assert_eq!(value.bytes, [42; 32]);
+        assert_eq!(drops.load(Ordering::Relaxed), 0);
+        drop(value);
+        assert_eq!(drops.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn test_clones_share_one_allocation() {
+        let drops = AtomicUsize::new(0);
+        let mut secret = Secret::new(tracked(&drops));
+        secret.try_harden().unwrap();
+        let clone = secret.clone();
+
+        // Both handles see the same value at the same address.
+        let address = secret.access(ptr::from_ref);
+        assert!(clone.is_hardened());
+        clone.access(|value| assert_eq!(ptr::from_ref(value), address));
+
+        // A shared value cannot be moved out, and the handle comes back unchanged.
+        let Err(secret) = secret.try_extract() else {
+            panic!("shared value moved out");
+        };
+        secret.access(|value| assert_eq!(ptr::from_ref(value), address));
+
+        // Dropping one handle destroys nothing. The last one destroys the value
+        // exactly once.
+        drop(secret);
+        assert_eq!(drops.load(Ordering::Relaxed), 0);
+        clone.access(|value| assert_eq!(value.bytes, [42; 32]));
+        drop(clone);
+        assert_eq!(drops.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn test_nested_and_concurrent_access() {
+        let mut secret = Secret::new([42u8; 32]);
+        secret.try_harden().unwrap();
+        let cloned = secret.clone();
+
+        // Nested calls through the same handle or another one see the value, and
+        // a panic in an inner call leaves the outer one usable.
+        secret.access(|value| {
+            secret.access(|inner| assert!(ptr::eq(value, inner)));
             assert!(
                 catch_unwind(AssertUnwindSafe(|| {
                     cloned.access(|other| {
-                        assert_eq!(value, other);
+                        assert!(ptr::eq(value, other));
                         panic!("nested access panic");
                     });
                 }))
                 .is_err()
             );
-            assert_eq!(*secret.inner.readers.lock(), 1);
             assert_eq!(value, &[42; 32]);
         });
+
+        // Readers on other threads see the value while the main thread reads too.
         let barrier = Arc::new(Barrier::new(5));
         thread::scope(|scope| {
             for _ in 0..4 {
@@ -578,30 +575,81 @@ mod tests {
                 });
             }
             barrier.wait();
-            assert_eq!(*secret.inner.readers.lock(), 4);
             secret.access(|value| assert_eq!(value, &[42; 32]));
             barrier.wait();
         });
-        assert_eq!(*secret.inner.readers.lock(), 0);
-        child("panic_protection", Some(libc::SIGSEGV));
+        secret.access(|value| assert_eq!(value, &[42; 32]));
     }
 
     #[test]
-    fn initialize_and_layout() {
-        check_layout::<0>(1);
+    fn test_protections() {
+        let mut secret = Secret::new([42u8; 32]);
+        secret.try_harden().unwrap();
+
+        // The value is smaller than a page, so its data region is the one page
+        // containing it, with a guard page on each side.
+        let page = page_size();
+        let data = secret
+            .access(ptr::from_ref)
+            .cast::<u8>()
+            .map_addr(|address| address & !(page - 1));
+        let leading = data.map_addr(|address| address - page);
+        let trailing = data.map_addr(|address| address + page);
+
+        // Idle data pages are inaccessible, locked, excluded from core dumps, and
+        // wiped on fork. Both guards are inaccessible and never locked.
+        let (permissions, flags) = mapping_info(data);
+        assert_eq!(permissions, "---");
+        for flag in ["lo", "dd", "wf"] {
+            assert!(
+                flags.iter().any(|f| f == flag),
+                "missing {flag} in {flags:?}"
+            );
+        }
+        for guard in [leading, trailing] {
+            let (permissions, flags) = mapping_info(guard);
+            assert_eq!(permissions, "---");
+            assert!(!flags.iter().any(|f| f == "lo"), "guard locked: {flags:?}");
+        }
+
+        // A callback makes the data pages readable but not writable and leaves
+        // the guards alone. Access is revoked on return and on unwind.
+        secret.access(|_| {
+            assert_eq!(mapping_info(data).0, "r--");
+            assert_eq!(mapping_info(leading).0, "---");
+            assert_eq!(mapping_info(trailing).0, "---");
+        });
+        assert_eq!(mapping_info(data).0, "---");
+        assert!(
+            catch_unwind(AssertUnwindSafe(|| {
+                secret.access(|_| panic!("access panic"));
+            }))
+            .is_err()
+        );
+        assert_eq!(mapping_info(data).0, "---");
+    }
+
+    #[test]
+    fn test_sizes_and_alignment() {
+        // A zero-sized value hardens like any other.
+        round_trip::<0>();
+
         // Const array lengths and repr(align) require compile-time page sizes.
         // Dispatch on the actual page size rather than assuming 4 KiB pages.
         macro_rules! page_cases {
             ($page:literal, $over:literal) => {{
-                check_layout::<$page>(1);
-                check_layout::<{ $page + 1 }>(2);
+                // Values of exactly one page and of one byte more both round-trip.
+                round_trip::<$page>();
+                round_trip::<{ $page + 1 }>();
+
+                // Page alignment is the most the mapping can honor.
                 #[repr(align($page))]
                 struct Aligned([u8; 1]);
-                let value = harden(InlineSecret::new(Aligned([73]))).unwrap();
-                assert_eq!(value.inner.value.as_ptr().addr() % $page, 0);
-                assert_eq!(value.inner.mapping.data_len, $page);
+                let mut value = Secret::new(Aligned([73]));
+                value.try_harden().unwrap();
                 value.access(|value| assert_eq!(value.0, [73]));
-                drop(value);
+
+                // Stricter alignment is rejected, and the inline value stays usable.
                 #[repr(align($over))]
                 struct OverAligned([u8; 1]);
                 let mut value = Secret::new(OverAligned([73]));
@@ -615,520 +663,56 @@ mod tests {
             8192 => page_cases!(8192, 16384),
             16384 => page_cases!(16384, 32768),
             65536 => page_cases!(65536, 131072),
-            page => panic!("add layout test fixtures for {page}-byte pages"),
+            page => panic!("add fixtures for {page}-byte pages"),
         }
     }
 
-    /// Checks both ends of the allocation around a fully initialized value.
-    fn check_layout<const N: usize>(pages: usize) {
-        let secret = harden(InlineSecret::new([37u8; N])).unwrap();
-        let mapping = &secret.inner.mapping;
-        let page = page_size();
-        assert_eq!(mapping.data_len, pages * page);
-        assert_eq!(mapping.total_len, (pages + 2) * page);
-        assert_eq!(
-            mapping.data.as_ptr().addr(),
-            mapping.base.as_ptr().addr() + page
-        );
-        assert_eq!(
-            secret.inner.value.as_ptr().addr() + N,
-            mapping.data.as_ptr().addr() + mapping.data_len
-        );
+    /// Hardens a byte array, reads it back, and moves it out again.
+    fn round_trip<const N: usize>() {
+        let mut secret = Secret::new([37u8; N]);
+        secret.try_harden().unwrap();
         secret.access(|value| assert_eq!(value, &[37; N]));
-        let data = mapping.data.as_ptr();
-        assert_eq!(secret.try_extract().ok().unwrap(), [37; N]);
-        assert_unmapped(data);
+        assert_eq!(secret.try_extract().unwrap(), [37; N]);
     }
 
-    #[test]
-    fn unwind_releases_mapping() {
-        struct PanicOnDrop([u8; 32]);
-        impl Drop for PanicOnDrop {
-            fn drop(&mut self) {
-                assert_eq!(self.0, [99; 32]);
-                panic!("destructor panic");
-            }
-        }
-        let secret = harden(InlineSecret::new(PanicOnDrop([99; 32]))).unwrap();
-        let data = secret.inner.mapping.data.as_ptr();
-        assert!(catch_unwind(AssertUnwindSafe(|| drop(secret))).is_err());
-        assert_unmapped(data);
-    }
-
-    #[test]
-    fn redaction_and_storage_conversion() {
-        let mut secret = Secret::new([42u8; 32]);
-        assert!(!secret.is_hardened());
-        secret.try_harden().unwrap();
-        assert!(secret.is_hardened());
-        let address = secret.access(|value| value as *const _);
-        secret.try_harden().unwrap();
-        secret.access(|value| assert_eq!(value as *const _, address));
-        assert_eq!(format!("{secret:?}"), "Secret([REDACTED])");
-        let cloned = secret.clone();
-        assert!(cloned.is_hardened());
-        assert_eq!(secret, cloned);
-        assert_eq!(cloned.extract_or_clone(), [42u8; 32]);
-        assert!(secret.is_hardened());
-        assert_eq!(format!("{secret}"), "[REDACTED]");
-        child("no_permission_changes", None);
-    }
-
-    /// A non-Clone inline value with a borrowed, nonsecret destruction counter.
-    struct Tracked<'a> {
-        bytes: [u8; 32],
-        drops: &'a AtomicUsize,
-    }
-
-    impl Drop for Tracked<'_> {
-        fn drop(&mut self) {
-            self.drops.fetch_add(1, Ordering::Relaxed);
-        }
-    }
-
-    #[test]
-    fn harden_nonclone_value_in_place() {
-        let drops = AtomicUsize::new(0);
-        let mut secret = Secret::new(Tracked {
-            bytes: [42; 32],
-            drops: &drops,
-        });
-        let result: Result<(), HardenError> = secret.try_harden();
-        result.unwrap();
-        assert!(secret.is_hardened());
-        secret.access(|value| assert_eq!(value.bytes, [42; 32]));
-        assert_eq!(drops.load(Ordering::Relaxed), 0);
-        drop(secret);
-        assert_eq!(drops.load(Ordering::Relaxed), 1);
-    }
-
-    /// A failed attempt must not destroy or replace the original owning value.
-    fn assert_harden_failure(operation: &str) {
-        struct Value<'a> {
-            bytes: Box<[u8; 32]>,
-            drops: &'a AtomicUsize,
-        }
-        impl Drop for Value<'_> {
-            fn drop(&mut self) {
-                self.drops.fetch_add(1, Ordering::Relaxed);
-            }
-        }
-
-        let drops = AtomicUsize::new(0);
-        let mut secret = Secret::new(Value {
-            bytes: Box::new([42; 32]),
-            drops: &drops,
-        });
-        let address = secret.access(ptr::from_ref);
-        let locked = locked_kib();
-        // A second attempt must also preserve ownership and release its mapping.
-        for _ in 0..2 {
-            let error = secret.try_harden().unwrap_err();
-            assert!(
-                matches!(error, HardenError::System { operation: failed, .. } if failed == operation)
-            );
-            assert!(!secret.is_hardened());
-            secret.access(|value| {
-                assert_eq!(ptr::from_ref(value), address);
-                assert_eq!(*value.bytes, [42; 32]);
-            });
-            assert_eq!(drops.load(Ordering::Relaxed), 0);
-            assert_eq!(locked_kib(), locked);
-        }
-        drop(secret);
-        assert_eq!(drops.load(Ordering::Relaxed), 1);
-    }
-
-    /// Reads the locked data size reported by Linux, in KiB.
-    fn locked_kib() -> usize {
-        std::fs::read_to_string("/proc/self/status")
-            .unwrap()
-            .lines()
-            .find_map(|line| line.strip_prefix("VmLck:"))
-            .unwrap()
-            .split_whitespace()
-            .next()
-            .unwrap()
-            .parse()
-            .unwrap()
-    }
-
-    #[test]
-    fn last_owner_destroys_value() {
-        let drops = AtomicUsize::new(0);
-        let secret = harden(InlineSecret::new(Tracked {
-            bytes: [42; 32],
-            drops: &drops,
-        }))
-        .unwrap();
-        let data = secret.inner.mapping.data.as_ptr();
-        let clone = secret.clone();
-        secret.access(|value| assert_eq!(value.bytes, [42; 32]));
-        drop(secret);
-        assert_eq!(drops.load(Ordering::Relaxed), 0);
-        drop(clone);
-        assert_eq!(drops.load(Ordering::Relaxed), 1);
-        assert_unmapped(data);
-    }
-
-    #[test]
-    fn unique_extraction_moves_nonclone_value() {
-        let drops = AtomicUsize::new(0);
-        let secret = harden(InlineSecret::new(Tracked {
-            bytes: [42; 32],
-            drops: &drops,
-        }))
-        .unwrap();
-        let data = secret.inner.mapping.data.as_ptr();
-        let value = secret.try_extract().ok().unwrap();
-        assert_unmapped(data);
-        assert_eq!(value.bytes, [42; 32]);
-        assert_eq!(drops.load(Ordering::Relaxed), 0);
-        drop(value);
-        assert_eq!(drops.load(Ordering::Relaxed), 1);
-    }
-
-    #[test]
-    fn subprocess_child() {
-        let Ok(case) = std::env::var(CHILD_ENV) else {
-            return;
-        };
-        // SAFETY: This subprocess owns its resource limits. Disabling core files
-        // prevents deliberate fault tests from creating artifacts.
-        unsafe {
-            let limit = libc::rlimit {
-                rlim_cur: 0,
-                rlim_max: 0,
-            };
-            assert_eq!(libc::setrlimit(libc::RLIMIT_CORE, &limit), 0);
-        }
-        if case == "locked_memory_limit" {
-            drop_ipc_lock_capability();
-            // SAFETY: This subprocess lowers only its own locked-memory allowance.
-            unsafe {
-                let limit = libc::rlimit {
-                    rlim_cur: 0,
-                    rlim_max: 0,
-                };
-                assert_eq!(libc::setrlimit(libc::RLIMIT_MEMLOCK, &limit), 0);
-            }
-            assert_harden_failure("mlock");
-            return;
-        }
-        match case.as_str() {
-            "exit_failure" => {
-                exit_failure();
-                panic!("revocation did not abort");
-            }
-            "harden_seal_failure" => {
-                deny_mprotect(&[libc::PROT_NONE]);
-                assert_harden_failure("mprotect");
-                return;
-            }
-            "no_permission_changes" => {
-                let mut public = Secret::new([42u8; 32]);
-                public.try_harden().unwrap();
-                let shared = harden(InlineSecret::new([73u8; 32])).unwrap();
-                let clone = shared.clone();
-                deny_mprotect(&[
-                    libc::PROT_NONE,
-                    libc::PROT_READ,
-                    libc::PROT_READ | libc::PROT_WRITE,
-                ]);
-                public.try_harden().unwrap();
-                assert!(public.is_hardened());
-                let returned = shared.try_extract().unwrap_err();
-                assert!(Arc::ptr_eq(&returned.inner, &clone.inner));
-                assert_eq!(*returned.inner.readers.lock(), 0);
-                drop(returned);
-                // SAFETY: Leave the disposable subprocess without destructors.
-                // Final release would require the deliberately forbidden write transition.
-                unsafe { libc::_exit(0) };
-            }
-            "borrowed_panic_protection" | "owned_panic_protection" => {
-                let mut secret = Secret::new([42u8; 32]);
-                secret.try_harden().unwrap();
-                let address = secret.access(|value| value as *const [u8; 32]);
-                if case == "borrowed_panic_protection" {
-                    assert!(catch_unwind(|| secret.access(|_| panic!("borrowed panic"))).is_err());
-                } else {
-                    let cloned = secret.clone();
-                    assert!(
-                        catch_unwind(move || cloned.access(|_| panic!("owned panic"))).is_err()
-                    );
-                }
-                // The surviving owner remains usable after either kind of unwind.
-                secret.access(|value| assert_eq!(value, &[42; 32]));
-                eprintln!("access recovered");
-                // SAFETY: Deliberately probe the still-owned mapping after the last
-                // reader exits. This subprocess must fault on its sealed data page.
-                unsafe { std::hint::black_box(address.read_volatile()) };
-                return;
-            }
-            _ => {}
-        }
-        let secret = harden(InlineSecret::new([42u8; 32])).unwrap();
-        match case.as_str() {
-            "inaccessible" | "panic_protection" => {
-                if case == "panic_protection" {
-                    assert!(
-                        catch_unwind(AssertUnwindSafe(|| {
-                            secret.access(|_| panic!("access panic"));
-                        }))
-                        .is_err()
-                    );
-                }
-                // SAFETY: Intentionally probe our allocated, inaccessible page in
-                // an isolated subprocess, expecting an operating-system fault.
-                unsafe {
-                    std::hint::black_box(secret.inner.value.as_ptr().read_volatile());
-                }
-            }
-            "readonly" => secret.access(|_| {
-                // SAFETY: Deliberately test the read-only mapping in a subprocess.
-                unsafe {
-                    secret.inner.value.as_ptr().write_volatile([0; 32]);
-                }
-            }),
-            "leading_guard" => secret.access(|_| {
-                // SAFETY: Deliberately read the mapped but inaccessible guard page.
-                unsafe {
-                    std::hint::black_box(secret.inner.mapping.base.as_ptr().read_volatile());
-                }
-            }),
-            "trailing_guard" => secret.access(|_| {
-                // SAFETY: The pointer is within the trailing mapped guard page.
-                unsafe {
-                    std::hint::black_box(
-                        secret
-                            .inner
-                            .mapping
-                            .data
-                            .as_ptr()
-                            .add(secret.inner.mapping.data_len)
-                            .read_volatile(),
-                    );
-                }
-            }),
-            "enter_failure" => {
-                // SAFETY: Remove our mapping to force mprotect failure. The next
-                // operation must abort without dereferencing the stale pointer.
-                unsafe {
-                    assert_eq!(
-                        libc::munmap(
-                            secret.inner.mapping.base.as_ptr().cast(),
-                            secret.inner.mapping.total_len
-                        ),
-                        0
-                    );
-                }
-                secret.access(|_| ());
-            }
-            "cleanup_failure" => {
-                // SAFETY: Remove the data region so the final owner cannot restore
-                // write access. Nothing dereferences the stale pointer afterward.
-                unsafe {
-                    assert_eq!(
-                        libc::munmap(
-                            secret.inner.mapping.data.as_ptr().cast(),
-                            secret.inner.mapping.data_len
-                        ),
-                        0
-                    );
-                }
-                drop(secret);
-                panic!("cleanup did not abort");
-            }
-            "fork_wipe" => {
-                // SAFETY: The child inspects raw bytes, drops its inherited handle,
-                // and exits without returning to the test harness.
-                let pid = unsafe { libc::fork() };
-                assert!(pid >= 0);
-                if pid == 0 {
-                    let data = secret.inner.mapping.data.as_ptr();
-                    let len = secret.inner.mapping.data_len;
-                    // SAFETY: WIPEONFORK supplies zero pages, and the child owns
-                    // this private mapping.
-                    unsafe {
-                        if libc::mprotect(data.cast(), len, libc::PROT_READ) != 0 {
-                            libc::_exit(1);
-                        }
-                        for i in 0..len {
-                            if data.add(i).read_volatile() != 0 {
-                                libc::_exit(2);
-                            }
-                        }
-                    }
-                    // Dropping here is sound only because all-zero bytes are a
-                    // valid [u8; 32]. The public contract forbids it in general.
-                    drop(secret);
-                    // SAFETY: Terminate the child without invoking the test harness.
-                    unsafe { libc::_exit(0) };
-                }
-                wait_for_child(pid, None);
-                secret.access(|value| assert_eq!(value, &[42; 32]));
-                return;
-            }
-            _ => panic!("unknown subprocess case: {case}"),
-        }
-        panic!("expected subprocess fault: {case}");
-    }
-
-    /// Forces revocation failure without assuming a particular page size.
-    fn exit_failure() {
-        // A ZST still owns one data page. Its reference occupies no bytes, so
-        // removing that page leaves no live reference into unmapped data.
-        let secret = harden(InlineSecret::new(())).unwrap();
-        secret.access(|_| {
-            // SAFETY: Remove the test's data page to force last-reader mprotect
-            // failure. The ZST's trailing-guard address stays mapped.
-            unsafe {
-                assert_eq!(
-                    libc::munmap(
-                        secret.inner.mapping.data.as_ptr().cast(),
-                        secret.inner.mapping.data_len,
-                    ),
-                    0
-                );
-            }
-        });
-    }
-
-    /// Rejects selected permission transitions at the syscall boundary.
-    /// The filter is installed only in a disposable subprocess, without test hooks
-    /// in the allocator. Other syscall numbers and permissions remain allowed.
-    fn deny_mprotect(protections: &[libc::c_int]) {
-        let stmt = |code, k| libc::sock_filter {
-            code,
-            jt: 0,
-            jf: 0,
-            k,
-        };
-        let jump = |k, jt, jf| libc::sock_filter {
-            code: (libc::BPF_JMP | libc::BPF_JEQ | libc::BPF_K) as u16,
-            jt,
-            jf,
-            k,
-        };
-        // seccomp_data.nr is at offset 0 and args[2] at offset 32. Reading the
-        // low word of the protection argument works on little-endian hosts.
-        #[cfg(target_endian = "little")]
-        let protection_offset = 32;
-        #[cfg(target_endian = "big")]
-        let protection_offset = 36;
-        let count = u8::try_from(protections.len()).unwrap();
-        let mut filter = vec![
-            stmt((libc::BPF_LD | libc::BPF_W | libc::BPF_ABS) as u16, 0),
-            jump(libc::SYS_mprotect as u32, 0, count + 1),
-            stmt(
-                (libc::BPF_LD | libc::BPF_W | libc::BPF_ABS) as u16,
-                protection_offset,
-            ),
-        ];
-        for (index, protection) in protections.iter().enumerate() {
-            // A match skips the remaining comparisons and the ALLOW instruction.
-            filter.push(jump(*protection as u32, count - index as u8, 0));
-        }
-        filter.push(stmt(
-            (libc::BPF_RET | libc::BPF_K) as u16,
-            libc::SECCOMP_RET_ALLOW,
-        ));
-        filter.push(stmt(
-            (libc::BPF_RET | libc::BPF_K) as u16,
-            libc::SECCOMP_RET_ERRNO | libc::EPERM as u32,
-        ));
-        let program = libc::sock_fprog {
-            len: filter.len() as u16,
-            filter: filter.as_mut_ptr(),
-        };
-        // SAFETY: This thread permanently narrows its own syscall permissions.
-        // The kernel copies the valid filter while prctl runs.
-        unsafe {
-            assert_eq!(libc::prctl(libc::PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0), 0);
-            assert_eq!(
-                libc::prctl(libc::PR_SET_SECCOMP, libc::SECCOMP_MODE_FILTER, &program),
-                0
-            );
-        }
-    }
-
-    /// Removes effective CAP_IPC_LOCK from the child thread before lowering its limit.
-    fn drop_ipc_lock_capability() {
-        // Linux's version 3 capability syscall ABI uses a header and two words.
-        #[repr(C)]
-        struct Header {
-            version: u32,
-            pid: libc::pid_t,
-        }
-        #[repr(C)]
-        #[derive(Clone, Copy, Default)]
-        struct Capabilities {
-            effective: u32,
-            permitted: u32,
-            inheritable: u32,
-        }
-        let mut header = Header {
-            version: 0x20080522,
-            pid: 0,
-        };
-        let mut data = [Capabilities::default(); 2];
-        // SAFETY: Version 3 writes two capability words. pid 0 selects this thread.
-        unsafe {
-            assert_eq!(
-                libc::syscall(libc::SYS_capget, &raw mut header, data.as_mut_ptr()),
-                0
-            );
-            // CAP_IPC_LOCK is bit 14. UID alone does not determine this privilege.
-            if data[0].effective & (1 << 14) != 0 {
-                data[0].effective &= !(1 << 14);
-                assert_eq!(
-                    libc::syscall(libc::SYS_capset, &raw mut header, data.as_ptr()),
-                    0
-                );
-                assert_eq!(
-                    libc::syscall(libc::SYS_capget, &raw mut header, data.as_mut_ptr()),
-                    0
-                );
-            }
-        }
-        assert_eq!(data[0].effective & (1 << 14), 0);
-    }
-
-    /// Returns the kernel's base page size used by the allocation under test.
+    /// Returns the kernel's page size.
     fn page_size() -> usize {
         // SAFETY: sysconf has no memory preconditions.
-        let page = usize::try_from(unsafe { libc::sysconf(libc::_SC_PAGESIZE) }).unwrap();
-        assert!(page.is_power_of_two());
-        page
+        usize::try_from(unsafe { libc::sysconf(libc::_SC_PAGESIZE) }).unwrap()
     }
 
-    /// Checks release without reading through a pointer whose allocation is gone.
-    fn assert_unmapped(address: *mut u8) {
-        let page = page_size();
-        // SAFETY: mincore checks virtual mappings
-        // without dereferencing the queried address in userspace.
-        unsafe {
-            let base = address.map_addr(|address| address & !(page - 1));
-            let mut resident = 0;
-            assert_eq!(libc::mincore(base.cast(), page, &mut resident), -1);
-            assert_eq!(
-                io::Error::last_os_error().raw_os_error(),
-                Some(libc::ENOMEM)
-            );
+    /// Returns the permissions and `VmFlags` of the mapping containing `address`
+    /// from `/proc/self/smaps`.
+    fn mapping_info(address: *const u8) -> (String, Vec<String>) {
+        let address = address.addr();
+        let smaps = std::fs::read_to_string("/proc/self/smaps").unwrap();
+        let mut lines = smaps.lines();
+        while let Some(line) = lines.next() {
+            // Each entry starts with "start-end perms ..." followed by attribute
+            // lines, of which VmFlags is the last.
+            let Some((range, rest)) = line.split_once(' ') else {
+                continue;
+            };
+            let Some((start, end)) = range.split_once('-') else {
+                continue;
+            };
+            let (Ok(start), Ok(end)) = (
+                usize::from_str_radix(start, 16),
+                usize::from_str_radix(end, 16),
+            ) else {
+                continue;
+            };
+            if !(start..end).contains(&address) {
+                continue;
+            }
+            let flags = lines
+                .find_map(|line| line.strip_prefix("VmFlags:"))
+                .unwrap()
+                .split_whitespace()
+                .map(str::to_string)
+                .collect();
+            return (rest[..3].to_string(), flags);
         }
-    }
-
-    /// Waits for the isolated fork branch and checks its exact termination mode.
-    fn wait_for_child(pid: libc::pid_t, signal: Option<i32>) {
-        let mut status = 0;
-        // SAFETY: pid is our child and status is a writable output location.
-        assert_eq!(unsafe { libc::waitpid(pid, &mut status, 0) }, pid);
-        if let Some(signal) = signal {
-            assert!(libc::WIFSIGNALED(status), "child status: {status}");
-            assert_eq!(libc::WTERMSIG(status), signal);
-        } else {
-            assert!(libc::WIFEXITED(status), "child status: {status}");
-            assert_eq!(libc::WEXITSTATUS(status), 0);
-        }
+        panic!("address {address:#x} is not mapped");
     }
 }

--- a/cryptography/src/hardened_secret.rs
+++ b/cryptography/src/hardened_secret.rs
@@ -1,10 +1,19 @@
-//! Linux storage ownership, permissions, and fork invariants.
+//! Linux backend for [crate::secret]: guarded mappings and permission transitions.
 //!
-//! The public contract is in [crate::secret]. This module owns the OS mappings
-//! behind that contract. [HardenedSecret] shares a [ProtectedAllocation] through
-//! `Arc`. Its metadata, including the reader mutex, lives in ordinary memory.
-//! [Mapping] independently owns raw data cleanup, so erasure does not depend on
-//! `T` being initialized or its destructor returning normally.
+//! Three owners split the work:
+//!
+//! - [Mapping] owns the pages and their cleanup. It never interprets the bytes
+//!   as `T`, so it can erase and unmap after partial construction, extraction,
+//!   or a panicking destructor.
+//! - [ProtectedAllocation] owns the initialized `T` and the reader count. Its
+//!   metadata, including the reader mutex, lives in ordinary memory.
+//! - [HardenedSecret] is an `Arc` handle. Clones share one allocation.
+//!
+//! Terminology here and in the item docs: the wrapper is the public `Secret<T>`,
+//! a handle is one `HardenedSecret<T>`, the allocation is its
+//! `ProtectedAllocation<T>`, the mapping is the whole mmap region including
+//! guards, and the data region is the page-rounded part between the guards.
+//! Only the data region is locked or changes permissions.
 //!
 //! # Layout
 //!
@@ -17,104 +26,70 @@
 //! +----------------+-----------------------+-------------+----------------+
 //! |<-- one page -->|<---------- whole data pages -------->|<-- one page -->|
 //!
-//! Guards: NONE throughout the mapping's lifetime
+//! Guards: NONE for the mapping's lifetime, never locked
 //! Data:   locked, excluded from kernel cores, wiped in fork children
-//! T:      ends at the trailing guard, with its alignment validated
-//!
-//! Separate identity mapping: one readable, unlocked page, also wiped on fork
+//! T:      ends at the trailing guard
 //! ```
 //!
-//! `data_len = round_up(max(size_of::<T>(), 1), page_size)`. Checked arithmetic
-//! includes both guards within Rust's `isize::MAX` allocation bound. Page size
-//! must be a power of two, and `T`'s alignment must divide it. Since Rust sizes
-//! are multiples of alignment, placing `T` against the trailing guard aligns it.
-//! A zero-sized value still owns a data page. Its non-null aligned pointer can
-//! coincide with the start of the trailing guard because it occupies no bytes.
-//! Unused data immediately before `T` shares the data permissions, so an underrun
-//! need not reach the leading guard.
+//! - `data_len = round_up(max(size_of::<T>(), 1), page_size)`, so a zero-sized
+//!   value still owns a data page. Checked arithmetic keeps both guards within
+//!   Rust's `isize::MAX` allocation bound.
+//! - The page size must be a power of two and `T`'s alignment must divide it.
+//!   Rust sizes are multiples of alignment, so ending `T` at the trailing guard
+//!   aligns it. A zero-sized `T` may sit exactly at the guard boundary.
+//! - Unused data bytes before `T` share the data permissions, so an underrun
+//!   need not reach the leading guard.
 //!
-//! # Permission and ownership states
+//! # Permissions
 //!
 //! ```text
-//! SETUP RW
-//!   establish required protections before sensitive writes
-//!   mark data dirty before copying T or invoking an initializer
-//!   inline source owns T until the copied bytes are sealed
-//!   zeroed byte arrays have a typed owner before the initializer callback
-//!        |
-//!        | protect(NONE), commit ownership, then publish
-//!        v
-//! IDLE NONE, readers = 0
-//!        |
-//!        | first reader: protect(READ), increment count
-//!        v
-//! READABLE READ, readers > 0
-//!        | nested/concurrent readers share the readable interval
-//!        | last reader: decrement to zero, protect(NONE)
-//!        v
-//! IDLE NONE
-//!        |
-//!        | unique extraction or final release
-//!        v
-//! RELEASE RW -> move out or destroy T -> erase data -> UNMAPPED
+//! SETUP     RW     allocate, then copy T
+//!   |
+//!   | protect(NONE), publish
+//!   v
+//! IDLE      NONE   readers = 0
+//!   |    ^
+//!   |    | first reader: protect(READ), readers = 1
+//!   |    | last reader:  readers = 0, protect(NONE)
+//!   v    |
+//! READABLE  READ   readers > 0, further readers only change the count
+//!
+//! IDLE -> RELEASE  RW   unique extraction or final release: move out or drop T,
+//!                       erase the data region, unmap
 //! ```
 //!
-//! `UNMAPPED` is terminal. Non-final handle drops may occur while another handle
-//! is reading. Final release and successful unique extraction require exclusive
-//! ownership, so no reader remains. Shared extraction failure returns its handle
-//! without entering this state machine or reading protected memory.
+//! - Hold the reader mutex across a permission change and its count update.
+//!   Release it before user code so nested and overlapping access cannot
+//!   deadlock. [ReadGuard] closes the interval on return or unwind. A plain
+//!   atomic counter would not serialize revocation against the next grant.
+//! - A `&T` exists only inside a [ReadGuard]'s lifetime or during the exclusive
+//!   RW phases of construction, extraction, and destruction. Otherwise `value`
+//!   is a raw pointer into inaccessible memory and must not be dereferenced.
+//! - Cleanup restores write access, erases every data byte including unused
+//!   bytes and padding, then unmaps while still locked. The data region is
+//!   already writable when [Mapping] takes over cleanup during construction.
+//! - Non-final handle drops may happen while another handle is reading. Final
+//!   release and unique extraction require exclusive ownership, so no reader
+//!   remains. A failed shared extraction returns the handle without entering
+//!   this state machine.
+//! - Before publication, any failure including final sealing returns an error
+//!   if cleanup succeeds. Hardening stages a raw copy while the inline source
+//!   still owns `T`, so an error leaves the source intact and success hands
+//!   ownership to the sealed allocation. After publication, permission
+//!   failures, count overflow, and cleanup failures abort rather than panic:
+//!   a failed mprotect leaves the region's permissions unknown, and continuing
+//!   could expose or corrupt the secret.
 //!
-//! Hold the reader mutex across permission changes and count updates. Release it
-//! before calling user code, allowing nested and overlapping access. [ReadGuard]
-//! closes the interval on return or unwind. A plain atomic counter would not
-//! serialize revocation against the next reader's permission grant.
+//! # Fork
 //!
-//! Permission state records the last fully successful transition, or an unknown
-//! state before a syscall whose failure may leave partial changes. Cleanup must
-//! restore write access after an unknown transition. Already writable data needs
-//! no redundant syscall. `dirty` is independent of initialization validity and
-//! is set before the first sensitive write. Raw cleanup erases all data bytes,
-//! including unused bytes and uninitialized padding, then unmaps while still
-//! locked. It never interprets bytes as `T`.
-//!
-//! Setup, including final sealing, can return an error if cleanup succeeds.
-//! Hardening stages a raw copy while the inline source still owns `T`. On error,
-//! raw cleanup erases the copy without destroying `T`, leaving the source intact.
-//! On success, ownership transfers to the sealed allocation and the caller erases
-//! the source without destroying it. Byte-array initialization instead installs a
-//! typed owner before invoking user code. Published access or extraction permission
-//! failures, count overflow, and cleanup failures abort. Abort does not run
-//! destructors or guarantee erasure.
-//!
-//! # Fork identity
-//!
-//! ```text
-//! Parent allocation                  Inherited child allocation
-//! +----------------------+           +----------------------+
-//! | initialized T        | --fork--> | wiped data bytes     |
-//! | identity byte = 1    |           | identity byte = 0    |
-//! +----------------------+           +----------------------+
-//! parent remains usable              reject typed access before mutex/ref
-//!                                    reject inherited read-guard return
-//!                                    final release unmaps without T::drop
-//! ```
-//!
-//! Each allocation retains its creator PID and its own [ForkIdentity] mapping.
-//! The readable marker is initialized once and never reset. It rejects inherited
-//! storage even when PID reuse or namespaces produce the same numeric PID. New
-//! allocations created in a child get independent markers. No process-global
-//! sentinel or inherited lock is needed to establish identity.
-//!
-//! Check identity before the reader mutex, typed access, unique extraction, and
-//! typed destruction. Check again when an access guard or initializer returns,
-//! because its callback may have forked. Child final release skips `T::drop` and
-//! erasure of already wiped data, then releases both mappings. Keep the identity
-//! mapping alive until data cleanup has finished. PID collisions in tests are
-//! simulated against real fork-wiped pages, without waiting for kernel PID reuse.
-//!
-//! These checks supplement the caller's fork safety obligations. References
-//! already inside a callback must never be used in the child. Wiped bytes may
-//! not be a valid `T`, and permission changes cannot enforce reference lifetimes.
+//! `MADV_WIPEONFORK` gives a child zeroed data pages, so the secret never
+//! crosses `fork`. Nothing detects the child. An inherited handle used there
+//! reads zeros, and dropping it runs `T`'s destructor on those zeros before
+//! erasing and unmapping the child's copy. The child also inherits the `Arc`
+//! count, the reader mutex, and the reader count exactly as they were at fork,
+//! so a mutex held by another parent thread at that moment stays locked forever
+//! in the child. The public contract makes leaving inherited hardened values
+//! alone in a child the caller's obligation.
 
 use crate::secret::{HardenError, InlineSecret};
 use commonware_utils::sync::Mutex;
@@ -123,20 +98,13 @@ use core::{
     mem::{ManuallyDrop, MaybeUninit, align_of, size_of},
     ptr::{self, NonNull},
 };
-use std::{
-    io, process,
-    sync::{
-        Arc,
-        atomic::{AtomicI32, Ordering},
-    },
-};
+use std::{io, process, sync::Arc};
 use zeroize::Zeroize;
 
-/// Shares one protected value without reallocating or cloning it.
+/// Handle to one shared protected allocation.
 ///
-/// OS-specific ownership and permission transitions stay behind this wrapper.
-/// See the module documentation for invariants and [crate::secret] for the public
-/// guarantees, type requirements, costs, and operational limits.
+/// [crate::secret] states the public contract. The module documentation covers
+/// the invariants behind it.
 pub(crate) struct HardenedSecret<T> {
     inner: Arc<ProtectedAllocation<T>>,
 }
@@ -151,12 +119,11 @@ impl<T> HardenedSecret<T> {
     /// without an intervening operation that can panic. On error, the source
     /// remains its sole owner and is unchanged.
     pub(crate) unsafe fn try_from_inline(value: &mut InlineSecret<T>) -> Result<Self, HardenError> {
-        let (mut mapping, destination) = Mapping::allocate::<T>()?;
+        let (mapping, destination) = Mapping::allocate::<T>()?;
         // Allocate metadata and prepare the reader mutex before transferring ownership.
         let mut inner = Arc::<ProtectedAllocation<T>>::new_uninit();
         let slot = Arc::get_mut(&mut inner).unwrap();
         let readers = Mutex::new(0);
-        mapping.dirty = true;
         value.access(|source| {
             // SAFETY: The destination is writable, aligned, and disjoint from the
             // initialized source. This is only a raw copy. Until sealing succeeds,
@@ -177,36 +144,22 @@ impl<T> HardenedSecret<T> {
         })
     }
 
-    /// Keeps the data readable for `f`, sharing the interval with other readers.
+    /// Runs `f` inside a shared readable interval.
     ///
-    /// The callback runs without the reader mutex held. Unwinding releases its
-    /// reader slot. Published permission failures and inherited use abort.
+    /// The reader mutex is not held during `f`, and unwinding releases the
+    /// reader slot.
     pub(crate) fn access<R>(&self, f: impl for<'a> FnOnce(&'a T) -> R) -> R {
         self.inner.access(f)
     }
 
     /// Moves out `T` and erases its allocation, or returns this handle if shared.
     ///
-    /// The returned value is unprotected. A failed ownership check leaves the
-    /// allocation and its permissions unchanged. Extraction failures abort as
-    /// described in the type's documentation.
+    /// A shared allocation is left untouched.
     pub(crate) fn try_extract(self) -> Result<T, Self> {
         match Arc::try_unwrap(self.inner) {
             Ok(allocation) => Ok(allocation.extract()),
             Err(inner) => Err(Self { inner }),
         }
-    }
-}
-
-impl<const N: usize> HardenedSecret<[u8; N]> {
-    /// Initializes zeroed bytes after protection setup, before publication.
-    ///
-    /// The typed owner exists before user code can unwind or final sealing can
-    /// fail. Both paths erase the data and release the mappings if cleanup succeeds.
-    pub(crate) fn try_init(f: impl FnOnce(&mut [u8; N])) -> Result<Self, HardenError> {
-        ProtectedAllocation::try_init(f).map(|inner| Self {
-            inner: Arc::new(inner),
-        })
     }
 }
 
@@ -239,75 +192,11 @@ fn abort_on_error(result: libc::c_int) {
     }
 }
 
-/// Owns a readable marker that distinguishes this allocation from fork copies.
+/// Owns the raw pages independently of `T`'s initialization and destruction.
 ///
-/// The creator writes one once. WIPEONFORK supplies zero in every descendant,
-/// including when its numeric PID matches the creator's. An inherited marker is
-/// never reset. A child can create new allocations with independent markers.
-/// This page contains no secret and is not locked against swapping.
-struct ForkIdentity {
-    address: NonNull<u8>,
-    page: usize,
-}
-
-impl ForkIdentity {
-    /// Creates a read-only marker before the secret allocation is initialized.
-    fn new(page: usize) -> Result<Self, HardenError> {
-        // SAFETY: A null hint requests a fresh private mapping of one valid page.
-        let address = unsafe {
-            libc::mmap(
-                ptr::null_mut(),
-                page,
-                libc::PROT_READ | libc::PROT_WRITE,
-                libc::MAP_PRIVATE | libc::MAP_ANONYMOUS,
-                -1,
-                0,
-            )
-        };
-        if address == libc::MAP_FAILED {
-            return Err(system("mmap"));
-        }
-        let Some(address) = NonNull::new(address.cast::<u8>()) else {
-            // SAFETY: Release the mapping that cannot form a non-null Rust pointer.
-            unsafe { abort_on_error(libc::munmap(address, page)) };
-            return Err(HardenError::Layout);
-        };
-        let identity = Self { address, page };
-        // SAFETY: The marker is a page-aligned private anonymous mapping we own.
-        if unsafe { libc::madvise(address.as_ptr().cast(), page, libc::MADV_WIPEONFORK) } != 0 {
-            return Err(system("madvise(MADV_WIPEONFORK)"));
-        }
-        // SAFETY: Construction exclusively owns this writable marker page.
-        unsafe { address.as_ptr().write(1) };
-        // SAFETY: No writable references remain. Identity checks only read the marker.
-        if unsafe { libc::mprotect(address.as_ptr().cast(), page, libc::PROT_READ) } != 0 {
-            return Err(system("mprotect"));
-        }
-        Ok(identity)
-    }
-
-    /// Checks the marker before any inherited mutex or typed value can be used.
-    fn is_original(&self) -> bool {
-        // SAFETY: The mapping remains readable for this owner's lifetime. A fork
-        // child gets initialized zero bytes. Volatile prevents reusing a read
-        // made before a fork that occurs in a caller's access callback.
-        unsafe { self.address.as_ptr().read_volatile() == 1 }
-    }
-}
-
-impl Drop for ForkIdentity {
-    fn drop(&mut self) {
-        // SAFETY: This owner releases only its own private mapping, including in
-        // a child. The marker remains live until the secret mapping is released.
-        unsafe { abort_on_error(libc::munmap(self.address.as_ptr().cast(), self.page)) };
-    }
-}
-
-/// Owns raw pages independently of the initialization and destruction of `T`.
-///
-/// Only the data region is locked or changes permissions. This owner never
-/// interprets its bytes as `T`, allowing cleanup after partial construction,
-/// extraction, or a panicking destructor. See the module layout and state diagram.
+/// Only the data region is locked or changes permissions. The bytes are never
+/// interpreted as `T`. See the module documentation for the layout and the
+/// permission states.
 struct Mapping {
     /// Start of the entire mapping, including the leading guard.
     base: NonNull<u8>,
@@ -317,17 +206,6 @@ struct Mapping {
     data: NonNull<u8>,
     /// Page-rounded length of the data region, including unused bytes.
     data_len: usize,
-    /// Process that created the mapping, used to reject inherited handles.
-    pid: libc::pid_t,
-    /// Allocation-specific identity, independent of numeric PID reuse or namespaces.
-    identity: ForkIdentity,
-    // Last permissions successfully applied to the whole data region, or -1 if
-    // uncertain. The reader mutex or exclusive ownership serializes changes, so
-    // relaxed atomic access suffices for updates through shared references.
-    protection: AtomicI32,
-    // Set before the first write. Earlier construction failures can just unmap
-    // the untouched pages without restoring write access for erasure.
-    dirty: bool,
 }
 
 impl Mapping {
@@ -357,7 +235,6 @@ impl Mapping {
             .and_then(|guards| data_len.checked_add(guards))
             .filter(|size| *size <= isize::MAX as usize)
             .ok_or(HardenError::Layout)?;
-        let identity = ForkIdentity::new(page)?;
         // SAFETY: A null hint requests a new mapping. Length is checked above.
         let base = unsafe {
             libc::mmap(
@@ -380,26 +257,35 @@ impl Mapping {
         };
         // SAFETY: The data region follows the first guard within the mapping.
         let data = unsafe { NonNull::new_unchecked(base.as_ptr().add(page)) };
+        // Cleanup erases through write access, so the data region becomes
+        // writable before Drop takes over.
+        // SAFETY: The page-aligned data region lies entirely inside our mapping.
+        if unsafe {
+            libc::mprotect(
+                data.as_ptr().cast(),
+                data_len,
+                libc::PROT_READ | libc::PROT_WRITE,
+            )
+        } != 0
+        {
+            let error = system("mprotect");
+            // SAFETY: Nothing was written. Release the mapping we own exclusively.
+            unsafe { abort_on_error(libc::munmap(base.as_ptr().cast(), total_len)) };
+            return Err(error);
+        }
         let mapping = Self {
             base,
             total_len,
             data,
             data_len,
-            // SAFETY: getpid has no preconditions.
-            pid: unsafe { libc::getpid() },
-            identity,
-            protection: AtomicI32::new(libc::PROT_NONE),
-            dirty: false,
         };
         // Establish all protections before writing secret bytes into the mapping.
-        mapping.protect(libc::PROT_READ | libc::PROT_WRITE)?;
         // SAFETY: The page-aligned data region lies entirely inside our mapping.
         if unsafe { libc::madvise(data.as_ptr().cast(), data_len, libc::MADV_DONTDUMP) } != 0 {
             return Err(system("madvise(MADV_DONTDUMP)"));
         }
         // SAFETY: The page-aligned region is private anonymous memory, as required
-        // by WIPEONFORK. Child-side access rejects the resulting invalid T bytes
-        // before constructing references or touching the inherited reader mutex.
+        // by WIPEONFORK.
         if unsafe { libc::madvise(data.as_ptr().cast(), data_len, libc::MADV_WIPEONFORK) } != 0 {
             return Err(system("madvise(MADV_WIPEONFORK)"));
         }
@@ -416,19 +302,15 @@ impl Mapping {
         Ok((mapping, value))
     }
 
-    /// Changes data permissions and records whether the entire operation succeeded.
+    /// Changes the data region's permissions.
     ///
     /// Callers serialize transitions with exclusive ownership or the reader mutex.
     /// They must not revoke permissions required by an outstanding reference.
     fn protect(&self, protection: libc::c_int) -> Result<(), HardenError> {
-        // A failed mprotect can have changed part of a region. Cleanup must
-        // reestablish writable permissions unless the full operation succeeded.
-        self.protection.store(-1, Ordering::Relaxed);
         // SAFETY: The data pointer and length describe our page-aligned mapping.
         if unsafe { libc::mprotect(self.data.as_ptr().cast(), self.data_len, protection) } != 0 {
             return Err(system("mprotect"));
         }
-        self.protection.store(protection, Ordering::Relaxed);
         Ok(())
     }
 
@@ -436,22 +318,7 @@ impl Mapping {
     ///
     /// Called only with exclusive ownership, when no reader remains active.
     fn make_writable(&self) {
-        if self.protection.load(Ordering::Relaxed) != (libc::PROT_READ | libc::PROT_WRITE)
-            && self.protect(libc::PROT_READ | libc::PROT_WRITE).is_err()
-        {
-            process::abort();
-        }
-    }
-
-    /// Checks whether this is the original mapping or a wiped fork-child copy.
-    fn in_creator(&self) -> bool {
-        // SAFETY: getpid has no preconditions.
-        self.pid == unsafe { libc::getpid() } && self.identity.is_original()
-    }
-
-    /// Rejects child-side access before touching inherited state or wiped bytes.
-    fn require_creator(&self) {
-        if !self.in_creator() {
+        if self.protect(libc::PROT_READ | libc::PROT_WRITE).is_err() {
             process::abort();
         }
     }
@@ -459,32 +326,29 @@ impl Mapping {
 
 impl Drop for Mapping {
     fn drop(&mut self) {
-        if self.in_creator() && self.dirty {
-            self.make_writable();
-            // SAFETY: We exclusively own the writable data region. Any T has
-            // already been destroyed, moved out, or was never initialized.
-            // MaybeUninit permits erasing padding without reading uninitialized bytes.
-            unsafe {
-                core::slice::from_raw_parts_mut(
-                    self.data.as_ptr().cast::<MaybeUninit<u8>>(),
-                    self.data_len,
-                )
-                .zeroize();
-            }
+        self.make_writable();
+        // SAFETY: We exclusively own the writable data region. Any T has
+        // already been destroyed, moved out, or was never initialized.
+        // MaybeUninit permits erasing padding without reading uninitialized bytes.
+        unsafe {
+            core::slice::from_raw_parts_mut(
+                self.data.as_ptr().cast::<MaybeUninit<u8>>(),
+                self.data_len,
+            )
+            .zeroize();
         }
         // Unmapping also releases the memory lock. Keep the pages locked until
         // after erasure instead of unlocking them in a separate step.
-        // SAFETY: This mapping belongs to this process. In a fork child, unmapping
-        // its private inherited copy does not touch the parent's backing pages.
+        // SAFETY: This mapping belongs to this process, including a fork child's
+        // private inherited copy.
         unsafe { abort_on_error(libc::munmap(self.base.as_ptr().cast(), self.total_len)) };
     }
 }
 
-/// Owns an initialized `T` and coordinates its readable lifetime.
+/// Owns an initialized `T` and its reader count.
 ///
-/// Construction, extraction, and destruction have exclusive write access. After publication,
-/// the first reader grants read access and the last reader revokes it. The mutex
-/// serializes those transitions, but is released while callbacks run.
+/// Construction, extraction, and destruction hold exclusive write access. After
+/// publication, the first reader grants read access and the last revokes it.
 struct ProtectedAllocation<T> {
     mapping: Mapping,
     /// Aligned location of the initialized value within mapping's data region.
@@ -503,9 +367,6 @@ unsafe impl<T: Sync> Sync for ProtectedAllocation<T> {}
 impl<T> ProtectedAllocation<T> {
     /// Holds one reader slot across the callback, including panic unwinding.
     fn access<R>(&self, f: impl for<'a> FnOnce(&'a T) -> R) -> R {
-        // A fork child can inherit a held mutex. Reject it before locking or
-        // constructing a reference to the wiped value.
-        self.mapping.require_creator();
         // Release the mutex before user code so nested calls cannot deadlock.
         {
             let mut readers = self.readers.lock();
@@ -523,14 +384,13 @@ impl<T> ProtectedAllocation<T> {
 
     /// Moves out the value and erases the allocation before returning it.
     fn extract(self) -> T {
-        self.mapping.require_creator();
         self.mapping.make_writable();
         let mut owner = ManuallyDrop::new(self);
         let allocation = &mut *owner;
         // SAFETY: Exclusive ownership rules out active readers. The value is
         // initialized and readable. ManuallyDrop prevents destroying the moved-out T.
         // Explicitly drop both owning fields to erase and release the source and
-        // destroy the reader mutex. The remaining fields own no resources.
+        // destroy the reader mutex. The remaining field owns no resources.
         unsafe {
             let value = allocation.value.as_ptr().read();
             ptr::drop_in_place(&raw mut allocation.mapping);
@@ -540,35 +400,8 @@ impl<T> ProtectedAllocation<T> {
     }
 }
 
-impl<const N: usize> ProtectedAllocation<[u8; N]> {
-    /// Creates an owner for the zeroed array before running the initializer.
-    fn try_init(f: impl FnOnce(&mut [u8; N])) -> Result<Self, HardenError> {
-        let (mut mapping, value) = Mapping::allocate::<[u8; N]>()?;
-        mapping.dirty = true;
-        // Anonymous mappings are zeroed, so the array is already a valid value.
-        // Its owner must exist before the initializer can unwind.
-        let mut allocation = Self {
-            mapping,
-            value,
-            readers: Mutex::new(0),
-        };
-        // SAFETY: Construction exclusively owns the writable, zeroed byte array.
-        f(unsafe { allocation.value.as_mut() });
-        // The initializer may have forked. Reject its return in the child before
-        // publishing a handle whose array has been wiped.
-        allocation.mapping.require_creator();
-        allocation.mapping.protect(libc::PROT_NONE)?;
-        Ok(allocation)
-    }
-}
-
 impl<T> Drop for ProtectedAllocation<T> {
     fn drop(&mut self) {
-        // The child's wiped bytes may not represent a valid T. Mapping::drop
-        // still runs after this return and releases the inherited mapping.
-        if !self.mapping.in_creator() {
-            return;
-        }
         self.mapping.make_writable();
         // SAFETY: The last owner has exclusive access, permissions allow
         // destruction, and this owner is only constructed after initializing T.
@@ -582,8 +415,6 @@ struct ReadGuard<'a, T>(&'a ProtectedAllocation<T>);
 
 impl<T> Drop for ReadGuard<'_, T> {
     fn drop(&mut self) {
-        // An unsafe fork inside the callback can also inherit this guard.
-        self.0.mapping.require_creator();
         let mut readers = self.0.readers.lock();
         *readers -= 1;
         if *readers == 0 && self.0.mapping.protect(libc::PROT_NONE).is_err() {
@@ -659,7 +490,6 @@ mod tests {
         child("enter_failure", Some(libc::SIGABRT));
         child("exit_failure", Some(libc::SIGABRT));
         child("cleanup_failure", Some(libc::SIGABRT));
-        child("final_seal_failure", None);
         child("harden_seal_failure", None);
     }
 
@@ -678,22 +508,8 @@ mod tests {
     }
 
     #[test]
-    fn fork_wipes_and_rejects_inherited_handles() {
-        child("fork_drop", None);
-        child("fork_access", None);
-        child("fork_extract", None);
-        child("fork_init", None);
-        child("fork_guard", None);
-        child("fork_collision_access", None);
-        child("fork_collision_locked", None);
-        child("fork_collision_extract", None);
-        child("fork_collision_drop", None);
-        child("fork_new_allocation", None);
-    }
-
-    #[test]
-    fn fork_identity_survives_pid_collision() {
-        child("fork_pid_collision", None);
+    fn fork_wipes_inherited_data() {
+        child("fork_wipe", None);
     }
 
     #[test]
@@ -712,10 +528,6 @@ mod tests {
                 .is_err()
             );
             assert_eq!(*secret.inner.readers.lock(), 1);
-            assert_eq!(
-                secret.inner.mapping.protection.load(Ordering::Relaxed),
-                libc::PROT_READ
-            );
             assert_eq!(value, &[42; 32]);
         });
         let barrier = Arc::new(Barrier::new(5));
@@ -737,10 +549,6 @@ mod tests {
             barrier.wait();
         });
         assert_eq!(*secret.inner.readers.lock(), 0);
-        assert_eq!(
-            secret.inner.mapping.protection.load(Ordering::Relaxed),
-            libc::PROT_NONE
-        );
         child("panic_protection", Some(libc::SIGSEGV));
     }
 
@@ -777,13 +585,9 @@ mod tests {
         }
     }
 
-    /// Checks both ends of the allocation and initializes every value byte.
+    /// Checks both ends of the allocation around a fully initialized value.
     fn check_layout<const N: usize>(pages: usize) {
-        let secret = HardenedSecret::<[u8; N]>::try_init(|value| {
-            assert_eq!(value, &[0; N]);
-            value.fill(37);
-        })
-        .unwrap();
+        let secret = harden(InlineSecret::new([37u8; N])).unwrap();
         let mapping = &secret.inner.mapping;
         let page = page_size();
         assert_eq!(mapping.data_len, pages * page);
@@ -798,28 +602,12 @@ mod tests {
         );
         secret.access(|value| assert_eq!(value, &[37; N]));
         let data = mapping.data.as_ptr();
-        let marker = mapping.identity.address.as_ptr();
         assert_eq!(secret.try_extract().unwrap(), [37; N]);
         assert_unmapped(data);
-        assert_unmapped(marker);
     }
 
     #[test]
     fn unwind_releases_mapping() {
-        let mut address = ptr::null_mut();
-        assert!(
-            catch_unwind(AssertUnwindSafe(|| {
-                let _ = Secret::<[u8; 32]>::try_init(|value| {
-                    value.fill(99);
-                    address = value.as_mut_ptr();
-                    panic!("initializer panic");
-                });
-            }))
-            .is_err()
-        );
-        assert!(!address.is_null());
-        assert_unmapped(address);
-
         struct PanicOnDrop([u8; 32]);
         impl Drop for PanicOnDrop {
             fn drop(&mut self) {
@@ -829,10 +617,8 @@ mod tests {
         }
         let secret = harden(InlineSecret::new(PanicOnDrop([99; 32]))).unwrap();
         let data = secret.inner.mapping.data.as_ptr();
-        let marker = secret.inner.mapping.identity.address.as_ptr();
         assert!(catch_unwind(AssertUnwindSafe(|| drop(secret))).is_err());
         assert_unmapped(data);
-        assert_unmapped(marker);
     }
 
     #[test]
@@ -942,7 +728,6 @@ mod tests {
         }))
         .unwrap();
         let data = secret.inner.mapping.data.as_ptr();
-        let marker = secret.inner.mapping.identity.address.as_ptr();
         let clone = secret.clone();
         secret.access(|value| assert_eq!(value.bytes, [42; 32]));
         drop(secret);
@@ -950,7 +735,6 @@ mod tests {
         drop(clone);
         assert_eq!(drops.load(Ordering::Relaxed), 1);
         assert_unmapped(data);
-        assert_unmapped(marker);
     }
 
     #[test]
@@ -962,10 +746,8 @@ mod tests {
         }))
         .unwrap();
         let data = secret.inner.mapping.data.as_ptr();
-        let marker = secret.inner.mapping.identity.address.as_ptr();
         let value = secret.try_extract().unwrap();
         assert_unmapped(data);
-        assert_unmapped(marker);
         assert_eq!(value.bytes, [42; 32]);
         assert_eq!(drops.load(Ordering::Relaxed), 0);
         drop(value);
@@ -999,61 +781,10 @@ mod tests {
             assert_harden_failure("mlock");
             return;
         }
-        if case == "fork_pid_collision" {
-            let mut allocation =
-                Arc::try_unwrap(harden(InlineSecret::new([42u8; 32])).unwrap().inner)
-                    .ok()
-                    .unwrap();
-            // SAFETY: The child only checks mapping identity and exits. It never
-            // interprets the wiped allocation as T or enters inherited locks.
-            let pid = unsafe { libc::fork() };
-            assert!(pid >= 0);
-            if pid == 0 {
-                // Simulate a reused or namespace-relative PID with real fork-wiped
-                // pages. Waiting for actual numeric PID reuse would be unreliable.
-                // SAFETY: getpid and _exit have no memory preconditions.
-                unsafe {
-                    allocation.mapping.pid = libc::getpid();
-                    libc::_exit(if allocation.mapping.in_creator() {
-                        1
-                    } else {
-                        0
-                    });
-                }
-            }
-            let mut status = 0;
-            // SAFETY: pid names our child and status is writable.
-            assert_eq!(unsafe { libc::waitpid(pid, &mut status, 0) }, pid);
-            assert!(libc::WIFEXITED(status));
-            assert_eq!(libc::WEXITSTATUS(status), 0);
-            allocation.access(|value| assert_eq!(value, &[42; 32]));
-            return;
-        }
         match case.as_str() {
             "exit_failure" => {
                 exit_failure();
                 panic!("revocation did not abort");
-            }
-            "final_seal_failure" | "cleanup_failure" => {
-                let mut address = ptr::null_mut();
-                let result = Secret::<[u8; 32]>::try_init(|bytes| {
-                    bytes.fill(71);
-                    address = bytes.as_mut_ptr();
-                    if case == "cleanup_failure" {
-                        deny_mprotect(&[libc::PROT_NONE, libc::PROT_READ | libc::PROT_WRITE]);
-                    } else {
-                        deny_mprotect(&[libc::PROT_NONE]);
-                    }
-                });
-                assert!(matches!(
-                    result,
-                    Err(HardenError::System {
-                        operation: "mprotect",
-                        ..
-                    })
-                ));
-                assert_unmapped(address);
-                return;
             }
             "harden_seal_failure" => {
                 deny_mprotect(&[libc::PROT_NONE]);
@@ -1075,10 +806,6 @@ mod tests {
                 let returned = shared.try_extract().unwrap_err();
                 assert!(Arc::ptr_eq(&returned.inner, &clone.inner));
                 assert_eq!(*returned.inner.readers.lock(), 0);
-                assert_eq!(
-                    returned.inner.mapping.protection.load(Ordering::Relaxed),
-                    libc::PROT_NONE
-                );
                 drop(returned);
                 // SAFETY: Leave the disposable subprocess without destructors.
                 // Final release would require the deliberately forbidden write transition.
@@ -1102,41 +829,6 @@ mod tests {
                 // SAFETY: Deliberately probe the still-owned mapping after the last
                 // reader exits. This subprocess must fault on its sealed data page.
                 unsafe { std::hint::black_box(address.read_volatile()) };
-                return;
-            }
-            "fork_init" => {
-                let mut pid = -1;
-                let secret = Secret::<[u8; 32]>::try_init(|bytes| {
-                    bytes.fill(42);
-                    // SAFETY: Neither branch uses the array after fork. The child
-                    // returns only to the constructor's explicit rejection check.
-                    pid = unsafe { libc::fork() };
-                    assert!(pid >= 0);
-                })
-                .unwrap();
-                wait_for_child(pid, Some(libc::SIGABRT));
-                secret.access(|value| assert_eq!(value, &[42; 32]));
-                return;
-            }
-            "fork_guard" => {
-                let secret = harden(InlineSecret::new([42u8; 32])).unwrap();
-                let mut pid = -1;
-                secret.access(|_| {
-                    // SAFETY: The child returns directly to inherited-guard rejection
-                    // without using a reference to the fork-wiped value.
-                    pid = unsafe { libc::fork() };
-                    assert!(pid >= 0);
-                });
-                wait_for_child(pid, Some(libc::SIGABRT));
-                secret.access(|value| assert_eq!(value, &[42; 32]));
-                return;
-            }
-            "fork_collision_access"
-            | "fork_collision_locked"
-            | "fork_collision_extract"
-            | "fork_collision_drop"
-            | "fork_new_allocation" => {
-                fork_collision(&case);
                 return;
             }
             _ => {}
@@ -1198,24 +890,31 @@ mod tests {
                 }
                 secret.access(|_| ());
             }
-            "fork_drop" | "fork_access" | "fork_extract" => {
-                // SAFETY: The child only invokes the hardened handle's explicit
-                // child rejection/drop path, raw mapping syscalls, and _exit.
+            "cleanup_failure" => {
+                // SAFETY: Remove the data region so the final owner cannot restore
+                // write access. Nothing dereferences the stale pointer afterward.
+                unsafe {
+                    assert_eq!(
+                        libc::munmap(
+                            secret.inner.mapping.data.as_ptr().cast(),
+                            secret.inner.mapping.data_len
+                        ),
+                        0
+                    );
+                }
+                drop(secret);
+                panic!("cleanup did not abort");
+            }
+            "fork_wipe" => {
+                // SAFETY: The child inspects raw bytes, drops its inherited handle,
+                // and exits without returning to the test harness.
                 let pid = unsafe { libc::fork() };
                 assert!(pid >= 0);
                 if pid == 0 {
-                    if case == "fork_access" {
-                        secret.access(|_| ());
-                    }
-                    if case == "fork_extract" {
-                        let _ = secret.try_extract();
-                        // SAFETY: Reaching this point means child rejection failed.
-                        unsafe { libc::_exit(3) };
-                    }
                     let data = secret.inner.mapping.data.as_ptr();
                     let len = secret.inner.mapping.data_len;
-                    // SAFETY: Inspect raw bytes, never an inherited T. WIPEONFORK
-                    // supplies zero pages, and the child owns this private mapping.
+                    // SAFETY: WIPEONFORK supplies zero pages, and the child owns
+                    // this private mapping.
                     unsafe {
                         if libc::mprotect(data.cast(), len, libc::PROT_READ) != 0 {
                             libc::_exit(1);
@@ -1226,22 +925,13 @@ mod tests {
                             }
                         }
                     }
+                    // Dropping here is sound only because all-zero bytes are a
+                    // valid [u8; 32]. The public contract forbids it in general.
                     drop(secret);
                     // SAFETY: Terminate the child without invoking the test harness.
-                    unsafe {
-                        libc::_exit(0);
-                    }
+                    unsafe { libc::_exit(0) };
                 }
-                let mut status = 0;
-                // SAFETY: pid identifies our child and status is writable.
-                assert_eq!(unsafe { libc::waitpid(pid, &mut status, 0) }, pid);
-                if case != "fork_drop" {
-                    assert!(libc::WIFSIGNALED(status));
-                    assert_eq!(libc::WTERMSIG(status), libc::SIGABRT);
-                } else {
-                    assert!(libc::WIFEXITED(status));
-                    assert_eq!(libc::WEXITSTATUS(status), 0);
-                }
+                wait_for_child(pid, None);
                 secret.access(|value| assert_eq!(value, &[42; 32]));
                 return;
             }
@@ -1257,7 +947,7 @@ mod tests {
         let secret = harden(InlineSecret::new(())).unwrap();
         secret.access(|_| {
             // SAFETY: Remove the test's data page to force last-reader mprotect
-            // failure. The marker and the ZST's trailing-guard address stay mapped.
+            // failure. The ZST's trailing-guard address stays mapped.
             unsafe {
                 assert_eq!(
                     libc::munmap(
@@ -1406,65 +1096,5 @@ mod tests {
             assert!(libc::WIFEXITED(status), "child status: {status}");
             assert_eq!(libc::WEXITSTATUS(status), 0);
         }
-    }
-
-    /// Exercises inherited state with a simulated PID match and real wiped pages.
-    fn fork_collision(case: &str) {
-        struct Value([u8; 32]);
-        impl Drop for Value {
-            fn drop(&mut self) {
-                // Wiped bytes must never reach typed destruction in the child.
-                assert_eq!(self.0, [42; 32]);
-            }
-        }
-        let mut allocation =
-            Arc::try_unwrap(harden(InlineSecret::new(Value([42; 32]))).unwrap().inner)
-                .ok()
-                .unwrap();
-        // SAFETY: The child only executes explicit rejection/drop paths or creates
-        // independent storage. It never uses a borrowed inherited value.
-        let pid = unsafe { libc::fork() };
-        assert!(pid >= 0);
-        if pid == 0 {
-            // SAFETY: Alter only child-local metadata to model a numeric collision.
-            allocation.mapping.pid = unsafe { libc::getpid() };
-            match case {
-                "fork_collision_access" => {
-                    // Model forking during an overlapping read. Identity must be
-                    // rejected even when first-reader permission setup is skipped.
-                    *allocation.readers.lock() = 1;
-                    allocation.access(|_| ());
-                }
-                "fork_collision_locked" => {
-                    // A held inherited mutex must not be touched. An alarm turns
-                    // accidental blocking into a distinct, bounded test failure.
-                    let _held = allocation.readers.lock();
-                    // SAFETY: Set a child-local timeout for a potential deadlock.
-                    unsafe { libc::alarm(5) };
-                    allocation.access(|_| ());
-                }
-                "fork_collision_extract" => {
-                    let _ = allocation.extract();
-                }
-                "fork_collision_drop" => drop(allocation),
-                "fork_new_allocation" => {
-                    let fresh = harden(InlineSecret::new([73u8; 32])).unwrap();
-                    fresh.access(|bytes| assert_eq!(bytes, &[73; 32]));
-                    drop(fresh);
-                    assert!(!allocation.mapping.in_creator());
-                    drop(allocation);
-                }
-                _ => unreachable!(),
-            }
-            // SAFETY: Leave without running the inherited test harness.
-            unsafe { libc::_exit(0) };
-        }
-        let signal = if matches!(case, "fork_collision_drop" | "fork_new_allocation") {
-            None
-        } else {
-            Some(libc::SIGABRT)
-        };
-        wait_for_child(pid, signal);
-        allocation.access(|value| assert_eq!(value.0, [42; 32]));
     }
 }

--- a/cryptography/src/hardened_secret.rs
+++ b/cryptography/src/hardened_secret.rs
@@ -1,0 +1,936 @@
+//! Shared secret storage backed by Linux memory protections.
+//!
+//! [HardenedSecret] keeps a value in a dedicated mapping that is locked against
+//! swapping, excluded from core dumps, and inaccessible between operations.
+//! Clones share the mapping. See the type's documentation for its costs, type
+//! requirements, and behavior across `fork`.
+//!
+//! This module is available only on Linux with the `std` feature. Construction
+//! requires `MADV_WIPEONFORK`, available since Linux 4.14, and permission to use
+//! all required memory operations. Successful construction establishes every
+//! protection. See [HardenedSecret::try_from_inline] for construction and cleanup failures.
+
+use crate::secret::{HardenError, InlineSecret};
+use commonware_utils::sync::Mutex;
+use core::{
+    fmt::{Debug, Display, Formatter},
+    marker::PhantomData,
+    mem::{ManuallyDrop, MaybeUninit, align_of, size_of},
+    ptr::{self, NonNull},
+};
+use ctutils::CtEq;
+#[cfg(test)]
+use rand::RngExt as _;
+#[cfg(not(test))]
+use rand::{TryRng as _, rngs::SysRng};
+use std::{
+    io, process,
+    sync::{
+        Arc,
+        atomic::{AtomicI32, Ordering},
+    },
+};
+use zeroize::Zeroize;
+
+/// A shared secret whose backing pages are inaccessible between access calls.
+///
+/// The value is stored in a dedicated allocation with these protections:
+///
+/// - [mlock](https://man7.org/linux/man-pages/man2/mlock.2.html) keeps the data
+///   pages resident, preventing them from being swapped out.
+/// - [MADV_DONTDUMP](https://man7.org/linux/man-pages/man2/madvise.2.html)
+///   excludes the data pages from kernel-generated core dumps.
+/// - `mprotect` makes the data pages read-only during [Self::access] and
+///   inaccessible between calls. Construction, extraction, and destruction
+///   have write access.
+/// - Inaccessible guard pages surround the data region. A random canary immediately
+///   before `T` detects writes that change it when the canary is next checked.
+///
+/// `Debug` prints `HardenedSecret([REDACTED])` and `Display` prints `[REDACTED]`.
+/// When `T: CtEq`, equality accesses both values and calls `T`'s constant-time comparison.
+///
+/// # Ownership and cost
+///
+/// Cloning shares the existing allocation without cloning `T`, allocating memory,
+/// or changing permissions. Dropping the last owner calls `T`'s destructor, zeroizes the
+/// entire data region, and releases the mapping. Erasure also runs if that
+/// destructor unwinds. Leaking the last handle prevents this cleanup.
+///
+/// Each allocation locks at least one whole data page, even for a zero-sized
+/// value, and reserves two additional guard pages in the virtual address space.
+/// The value and canary can require multiple data pages. Access calls synchronize
+/// a reader count, with a permission syscall on entry to the first call and exit
+/// from the last. Keep access scopes short, while avoiding repeated calls within
+/// a single operation.
+///
+/// # Requirements and limits
+///
+/// Store sensitive bytes directly in `T`. Memory reached through pointers, such
+/// as a `Vec` or `Box` allocation, receives no protection or erasure from this
+/// wrapper. Operations on `&T` must not write to `T`'s storage, including through
+/// interior mutability, because its pages are read-only. Such writes can terminate
+/// the process. `T`'s destructor must not panic, so failures before transferring
+/// ownership from inline storage can finish erasing the input.
+///
+/// Protection applies to this allocation. Earlier copies, exported values, and
+/// temporary values created by computations remain outside it. During access,
+/// the pages are readable throughout the process, including by other threads.
+/// These protections do not defend against arbitrary code execution, privileged
+/// memory inspection, or hibernation images.
+///
+/// Construction reports errors through [HardenError]. After construction, a
+/// failed permission change or detected canary corruption aborts the process.
+/// Cleanup also aborts if it cannot restore write access or release the mapping.
+/// Aborting does not run destructors or guarantee erasure.
+///
+/// # Forking
+///
+/// `MADV_WIPEONFORK` replaces the child's data pages with zeroes. Inherited
+/// handles cannot access or move out the value: access aborts before touching
+/// the reader mutex or reading `T`. The final release in the child only
+/// unmaps its copy, without calling `T`'s destructor on the wiped bytes. The
+/// parent's allocation is unaffected.
+///
+/// A caller using an unsafe fork API during access must ensure that the child
+/// never uses references into the inherited allocation. Their bytes have been
+/// wiped and may no longer represent a valid `T`. Returning through an inherited
+/// read guard in the child also aborts. These restrictions do not replace
+/// the fork API's own safety requirements.
+///
+pub(crate) struct HardenedSecret<T> {
+    inner: Arc<ProtectedAllocation<T>>,
+}
+
+impl<T> HardenedSecret<T> {
+    /// Consumes `value` and moves it into a new protected allocation.
+    ///
+    /// On success, the consumed inline storage is erased after the move. On
+    /// error, the input is dropped and its inline storage erased, subject to the
+    /// type's nonpanicking-destructor requirement. The input is not returned.
+    /// Earlier locations left behind by moving the argument cannot be erased here.
+    /// For byte arrays, [Self::try_init] can initialize the value directly in
+    /// protected memory.
+    ///
+    /// # Errors
+    ///
+    /// Returns [HardenError::Layout] if a suitable mapping cannot be represented,
+    /// including when `T`'s alignment exceeds the system page size. Returns
+    /// [HardenError::System] if mapping, canary generation, or a required memory
+    /// operation fails. Locking is subject to the process's `RLIMIT_MEMLOCK`
+    /// allowance, even when ordinary memory is available.
+    ///
+    /// Allocating the shared ownership metadata uses the ordinary Rust allocator
+    /// and follows its allocation-failure behavior. Cleanup failures abort as
+    /// described in the type's documentation.
+    pub(crate) fn try_from_inline(value: InlineSecret<T>) -> Result<Self, HardenError> {
+        ProtectedAllocation::try_new(value).map(|inner| Self {
+            inner: Arc::new(inner),
+        })
+    }
+
+    /// Passes a shared reference to the stored value to `f` and returns its result.
+    ///
+    /// The first active call makes the data pages read-only. Nested and concurrent
+    /// calls, including through other clones, keep them readable until the last
+    /// call ends. Returning from this call does not revoke access while another
+    /// call remains active. The reader mutex is not held while `f` runs.
+    ///
+    /// Borrows into the stored value cannot escape the closure. Copied values,
+    /// raw pointers, and references already stored inside `T` can escape and
+    /// receive no additional protection. Operations on `&T` must not modify its
+    /// storage, even through interior mutability.
+    ///
+    /// # Panics
+    ///
+    /// A panic from `f` propagates. During unwinding, access is revoked if no
+    /// other call remains active. Failed permission changes or detected canary
+    /// corruption abort the process.
+    pub(crate) fn access<R>(&self, f: impl for<'a> FnOnce(&'a T) -> R) -> R {
+        self.inner.access(f)
+    }
+
+    /// Moves out `T` and erases its allocation, or returns this handle if shared.
+    ///
+    /// The returned value is unprotected. A failed ownership check leaves the
+    /// allocation and its permissions unchanged. Extraction failures abort as
+    /// described in the type's documentation.
+    pub(crate) fn try_extract(self) -> Result<T, Self> {
+        match Arc::try_unwrap(self.inner) {
+            Ok(allocation) => Ok(allocation.extract()),
+            Err(inner) => Err(Self { inner }),
+        }
+    }
+}
+
+impl<const N: usize> HardenedSecret<[u8; N]> {
+    /// Initializes a byte array directly in a new protected allocation.
+    ///
+    /// Calls `f` with a zeroed array after locking the data pages and excluding
+    /// them from core dumps. The array is writable during initialization and
+    /// inaccessible when construction completes. Any bytes left untouched by `f`
+    /// remain zero. The closure's own temporaries are outside the allocation.
+    ///
+    /// # Errors
+    ///
+    /// Returns the same construction errors as [Self::try_from_inline]. The initializer
+    /// is not called if allocation or initial protection setup fails. If a later
+    /// step fails, the initialized array is erased before returning the error.
+    ///
+    /// # Panics
+    ///
+    /// A panic from `f` propagates. During unwinding, the allocation is erased
+    /// and released. Cleanup failures abort as described in the type's documentation.
+    ///
+    pub(crate) fn try_init(f: impl FnOnce(&mut [u8; N])) -> Result<Self, HardenError> {
+        ProtectedAllocation::try_init(f).map(|inner| Self {
+            inner: Arc::new(inner),
+        })
+    }
+}
+
+impl<T> Clone for HardenedSecret<T> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+impl<T> Debug for HardenedSecret<T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        f.write_str("HardenedSecret([REDACTED])")
+    }
+}
+
+impl<T> Display for HardenedSecret<T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        f.write_str("[REDACTED]")
+    }
+}
+
+impl<T: CtEq> PartialEq for HardenedSecret<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.access(|a| other.access(|b| a.ct_eq(b).into()))
+    }
+}
+
+impl<T: CtEq> Eq for HardenedSecret<T> {}
+
+const CANARY_SIZE: usize = 16;
+
+/// Captures errno immediately after a failed memory operation.
+fn system(operation: &'static str) -> HardenError {
+    HardenError::System {
+        operation,
+        source: io::Error::last_os_error(),
+    }
+}
+
+/// Handles cleanup syscalls whose failure cannot be returned to the caller.
+fn abort_on_error(result: libc::c_int) {
+    if result != 0 {
+        process::abort();
+    }
+}
+
+/// Generates the pattern placed immediately before the value to detect corruption.
+fn random_canary() -> Result<[u8; CANARY_SIZE], HardenError> {
+    let mut canary = [0; CANARY_SIZE];
+    #[cfg(test)]
+    {
+        commonware_utils::test_rng().fill(&mut canary);
+    }
+    #[cfg(not(test))]
+    SysRng
+        .try_fill_bytes(&mut canary)
+        .map_err(|error| HardenError::System {
+            operation: "getrandom",
+            source: error.into(),
+        })?;
+    Ok(canary)
+}
+
+/// Owns the raw mapping and erases it independently of `T`'s initialization or drop.
+///
+/// The data region is rounded up to whole pages. Its layout places `T` against
+/// the trailing guard, with the canary immediately before it:
+///
+/// ```text
+/// | guard page | unused bytes | canary | T | guard page |
+///              <------- data_len -------->
+/// <-------------------- total_len -------------------->
+/// ```
+///
+/// Guards always remain inaccessible. Only the data region is locked or has its
+/// permissions changed. This owner never interprets those bytes as `T`, so it
+/// can clean up both partially constructed allocations and destroyed values.
+struct Mapping {
+    /// Start of the entire mapping, including the leading guard.
+    base: NonNull<u8>,
+    /// Length passed to munmap, including both guards.
+    total_len: usize,
+    /// First byte after the leading guard.
+    data: NonNull<u8>,
+    /// Page-rounded length of the data region, including unused bytes and canary.
+    data_len: usize,
+    /// Process that created the mapping, used to reject inherited handles.
+    pid: libc::pid_t,
+    // Last permissions successfully applied to the whole data region, or -1 if
+    // uncertain. The reader mutex or exclusive ownership serializes changes, so
+    // relaxed atomic access suffices for updates through shared references.
+    protection: AtomicI32,
+    // Set before the first write. Earlier construction failures can just unmap
+    // the untouched pages without restoring write access for erasure.
+    dirty: bool,
+}
+
+impl Mapping {
+    /// Reserves the guarded layout and returns a pointer to storage for `T`.
+    ///
+    /// On success, the data region is zeroed, writable, locked, excluded from
+    /// dumps, and wiped in fork children. The caller has not yet written `T` or
+    /// the expected canary into it.
+    fn allocate<T>() -> Result<(Self, NonNull<T>), HardenError> {
+        // SAFETY: sysconf has no pointer arguments or memory preconditions.
+        let page = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
+        let page = usize::try_from(page)
+            .ok()
+            .filter(|page| page.is_power_of_two())
+            .ok_or(HardenError::Layout)?;
+        if align_of::<T>() > page {
+            return Err(HardenError::Layout);
+        }
+        // Reserve the canary even for zero-sized values, then round to pages.
+        let data_len = size_of::<T>()
+            .checked_add(CANARY_SIZE)
+            .and_then(|size| size.checked_add(page - 1))
+            .map(|size| size & !(page - 1))
+            .ok_or(HardenError::Layout)?;
+        // Include both guards in Rust's maximum pointer-offset bound.
+        let total_len = page
+            .checked_mul(2)
+            .and_then(|guards| data_len.checked_add(guards))
+            .filter(|size| *size <= isize::MAX as usize)
+            .ok_or(HardenError::Layout)?;
+        // SAFETY: A null hint requests a new mapping. Length is checked above.
+        let base = unsafe {
+            libc::mmap(
+                ptr::null_mut(),
+                total_len,
+                libc::PROT_NONE,
+                libc::MAP_PRIVATE | libc::MAP_ANONYMOUS,
+                -1,
+                0,
+            )
+        };
+        if base == libc::MAP_FAILED {
+            return Err(system("mmap"));
+        }
+        // A mapping at address zero cannot be represented as a Rust allocation.
+        let Some(base) = NonNull::new(base.cast::<u8>()) else {
+            // SAFETY: mmap returned this mapping and length, which we own exclusively.
+            unsafe { abort_on_error(libc::munmap(base, total_len)) };
+            return Err(HardenError::Layout);
+        };
+        // SAFETY: The data region follows the first guard within the mapping.
+        let data = unsafe { NonNull::new_unchecked(base.as_ptr().add(page)) };
+        let mapping = Self {
+            base,
+            total_len,
+            data,
+            data_len,
+            // SAFETY: getpid has no preconditions.
+            pid: unsafe { libc::getpid() },
+            protection: AtomicI32::new(libc::PROT_NONE),
+            dirty: false,
+        };
+        // Establish all protections before writing secret bytes into the mapping.
+        mapping.protect(libc::PROT_READ | libc::PROT_WRITE)?;
+        // SAFETY: The page-aligned data region lies entirely inside our mapping.
+        if unsafe { libc::madvise(data.as_ptr().cast(), data_len, libc::MADV_DONTDUMP) } != 0 {
+            return Err(system("madvise(MADV_DONTDUMP)"));
+        }
+        // SAFETY: The page-aligned region is private anonymous memory, as required
+        // by WIPEONFORK. Child-side access rejects the resulting invalid T bytes
+        // before constructing references or touching the inherited reader mutex.
+        if unsafe { libc::madvise(data.as_ptr().cast(), data_len, libc::MADV_WIPEONFORK) } != 0 {
+            return Err(system("madvise(MADV_WIPEONFORK)"));
+        }
+        // SAFETY: The data region is a valid, writable mapping of data_len bytes.
+        if unsafe { libc::mlock(data.as_ptr().cast(), data_len) } != 0 {
+            return Err(system("mlock"));
+        }
+        // The size of T is a multiple of its alignment, which divides the page
+        // size. Placing its end at the trailing guard therefore aligns its start
+        // and leaves no gap between T and the guard.
+        // SAFETY: data_len includes the value and canary, and alignment was checked.
+        let value =
+            unsafe { NonNull::new_unchecked(data.as_ptr().add(data_len - size_of::<T>()).cast()) };
+        Ok((mapping, value))
+    }
+
+    /// Changes data permissions and records whether the entire operation succeeded.
+    ///
+    /// Callers serialize transitions with exclusive ownership or the reader mutex.
+    /// They must not revoke permissions required by an outstanding reference.
+    fn protect(&self, protection: libc::c_int) -> Result<(), HardenError> {
+        // A failed mprotect can have changed part of a region. Cleanup must
+        // reestablish writable permissions unless the full operation succeeded.
+        self.protection.store(-1, Ordering::Relaxed);
+        // SAFETY: The data pointer and length describe our page-aligned mapping.
+        if unsafe { libc::mprotect(self.data.as_ptr().cast(), self.data_len, protection) } != 0 {
+            return Err(system("mprotect"));
+        }
+        self.protection.store(protection, Ordering::Relaxed);
+        Ok(())
+    }
+
+    /// Restores write access for extraction, destruction, or erasure, aborting on failure.
+    ///
+    /// Called only with exclusive ownership, when no reader remains active.
+    fn make_writable(&self) {
+        if self.protection.load(Ordering::Relaxed) != (libc::PROT_READ | libc::PROT_WRITE)
+            && self.protect(libc::PROT_READ | libc::PROT_WRITE).is_err()
+        {
+            process::abort();
+        }
+    }
+
+    /// Checks whether this is the original mapping or a wiped fork-child copy.
+    fn in_creator(&self) -> bool {
+        // SAFETY: getpid has no preconditions.
+        self.pid == unsafe { libc::getpid() }
+    }
+
+    /// Rejects child-side access before touching inherited state or wiped bytes.
+    fn require_creator(&self) {
+        if !self.in_creator() {
+            process::abort();
+        }
+    }
+}
+
+impl Drop for Mapping {
+    fn drop(&mut self) {
+        if self.in_creator() && self.dirty {
+            self.make_writable();
+            // SAFETY: We exclusively own the writable data region. Any T has
+            // already been destroyed, moved out, or was never initialized.
+            // MaybeUninit permits erasing padding without reading uninitialized bytes.
+            unsafe {
+                core::slice::from_raw_parts_mut(
+                    self.data.as_ptr().cast::<MaybeUninit<u8>>(),
+                    self.data_len,
+                )
+                .zeroize();
+            }
+        }
+        // Unmapping also releases the memory lock. Keep the pages locked until
+        // after erasure instead of unlocking them in a separate step.
+        // SAFETY: This mapping belongs to this process. In a fork child, unmapping
+        // its private inherited copy does not touch the parent's backing pages.
+        unsafe { abort_on_error(libc::munmap(self.base.as_ptr().cast(), self.total_len)) };
+    }
+}
+
+/// Owns an initialized `T` and coordinates its readable lifetime.
+///
+/// Construction, extraction, and destruction have exclusive write access. After publication,
+/// the first reader grants read access and the last reader revokes it. The mutex
+/// serializes those transitions, but is released while callbacks run.
+struct ProtectedAllocation<T> {
+    mapping: Mapping,
+    /// Aligned location of the initialized value within mapping's data region.
+    value: NonNull<T>,
+    /// Expected canary, kept outside the protected data region for comparison.
+    canary: [u8; CANARY_SIZE],
+    /// Active readers across all handles to this allocation.
+    readers: Mutex<usize>,
+    /// Records ownership of T for drop checking, including any borrowed lifetimes.
+    marker: PhantomData<T>,
+}
+
+// SAFETY: T can be moved to another thread. The mapping has one owner, shared
+// access is coordinated by readers, and destruction requires exclusive ownership.
+unsafe impl<T: Send> Send for ProtectedAllocation<T> {}
+// SAFETY: T can be shared between threads. Permission transitions and reader
+// counts are serialized, and no reference outlives its read guard.
+unsafe impl<T: Sync> Sync for ProtectedAllocation<T> {}
+
+impl<T> ProtectedAllocation<T> {
+    /// Allocates writable storage and initializes its canary, leaving `T` uninitialized.
+    ///
+    /// Mapping alone owns cleanup until the caller initializes `T` and constructs
+    /// a ProtectedAllocation. Any early return therefore erases raw bytes only.
+    fn allocate() -> Result<(Mapping, NonNull<T>, [u8; CANARY_SIZE]), HardenError> {
+        let canary = random_canary()?;
+        let (mut mapping, value) = Mapping::allocate::<T>()?;
+        mapping.dirty = true;
+        // SAFETY: Construction owns the writable mapping, and the checked layout
+        // reserves CANARY_SIZE bytes immediately before the aligned value.
+        unsafe {
+            let canary_ptr = value.as_ptr().cast::<u8>().sub(CANARY_SIZE);
+            ptr::copy_nonoverlapping(canary.as_ptr(), canary_ptr, CANARY_SIZE);
+        }
+        Ok((mapping, value, canary))
+    }
+
+    /// Transfers the inline value after setup succeeds, then revokes access.
+    fn try_new(value: InlineSecret<T>) -> Result<Self, HardenError> {
+        let (mapping, destination, canary) = Self::allocate()?;
+        // SAFETY: The mapping is writable, aligned for T, and disjoint from the
+        // source. Ownership transfers into its previously uninitialized storage.
+        unsafe {
+            value.move_into(destination.as_ptr());
+        }
+        // Transfer cleanup to the typed owner before protection can fail.
+        let allocation = Self {
+            mapping,
+            value: destination,
+            canary,
+            readers: Mutex::new(0),
+            marker: PhantomData,
+        };
+        allocation.mapping.protect(libc::PROT_NONE)?;
+        Ok(allocation)
+    }
+
+    /// Locates the canary without accessing the potentially inaccessible mapping.
+    const fn canary_ptr(&self) -> *mut u8 {
+        // SAFETY: Layout reserves CANARY_SIZE bytes before the value.
+        unsafe { self.value.as_ptr().cast::<u8>().sub(CANARY_SIZE) }
+    }
+
+    /// Aborts on corruption. Callers must first make the data region readable.
+    fn check_canary(&self) {
+        // SAFETY: Called only while the data region is readable. The canary is
+        // initialized before publication and has exactly CANARY_SIZE bytes.
+        let actual = unsafe { core::slice::from_raw_parts(self.canary_ptr(), CANARY_SIZE) };
+        if actual != self.canary {
+            process::abort();
+        }
+    }
+
+    /// Holds one reader slot across the callback, including panic unwinding.
+    fn access<R>(&self, f: impl for<'a> FnOnce(&'a T) -> R) -> R {
+        // A fork child can inherit a held mutex. Reject it before locking or
+        // constructing a reference to the wiped value.
+        self.mapping.require_creator();
+        // Release the mutex before user code so nested calls cannot deadlock.
+        {
+            let mut readers = self.readers.lock();
+            if *readers == 0 {
+                if self.mapping.protect(libc::PROT_READ).is_err() {
+                    process::abort();
+                }
+                self.check_canary();
+            }
+            // Wrapping to zero would allow revoking access while readers exist.
+            *readers = readers.checked_add(1).unwrap_or_else(|| process::abort());
+        }
+        let _guard = ReadGuard(self);
+        // SAFETY: The read guard keeps the initialized T readable
+        // through this closure, including overlapping and nested calls.
+        f(unsafe { self.value.as_ref() })
+    }
+
+    /// Moves out the value and erases the allocation before returning it.
+    fn extract(self) -> T {
+        self.mapping.require_creator();
+        self.mapping.make_writable();
+        self.check_canary();
+        let mut allocation = ManuallyDrop::new(self);
+        // SAFETY: Exclusive ownership rules out active readers. The value is
+        // initialized and readable. ManuallyDrop prevents destroying the moved-out T.
+        // Explicitly drop both owning fields to erase and release the source and
+        // destroy the reader mutex. The remaining fields own no resources.
+        unsafe {
+            let value = allocation.value.as_ptr().read();
+            ptr::drop_in_place(&raw mut allocation.mapping);
+            ptr::drop_in_place(&raw mut allocation.readers);
+            value
+        }
+    }
+}
+
+impl<const N: usize> ProtectedAllocation<[u8; N]> {
+    /// Creates an owner for the zeroed array before running the initializer.
+    fn try_init(f: impl FnOnce(&mut [u8; N])) -> Result<Self, HardenError> {
+        let (mapping, value, canary) = Self::allocate()?;
+        // Anonymous mappings are zeroed, so the array is already a valid value.
+        // Its owner must exist before the initializer can unwind.
+        let mut allocation = Self {
+            mapping,
+            value,
+            canary,
+            readers: Mutex::new(0),
+            marker: PhantomData,
+        };
+        // SAFETY: Construction exclusively owns the writable, zeroed byte array.
+        f(unsafe { allocation.value.as_mut() });
+        allocation.check_canary();
+        allocation.mapping.protect(libc::PROT_NONE)?;
+        Ok(allocation)
+    }
+}
+
+impl<T> Drop for ProtectedAllocation<T> {
+    fn drop(&mut self) {
+        // The child's wiped bytes may not represent a valid T. Mapping::drop
+        // still runs after this return and releases the inherited mapping.
+        if !self.mapping.in_creator() {
+            return;
+        }
+        self.mapping.make_writable();
+        self.check_canary();
+        // SAFETY: The last owner has exclusive access, permissions allow
+        // destruction, and this owner is only constructed after initializing T.
+        unsafe { ptr::drop_in_place(self.value.as_ptr()) };
+        // Mapping::drop wipes the data region even if a destructor unwinds.
+    }
+}
+
+/// Keeps the mapping readable until the last overlapping access call finishes.
+struct ReadGuard<'a, T>(&'a ProtectedAllocation<T>);
+
+impl<T> Drop for ReadGuard<'_, T> {
+    fn drop(&mut self) {
+        // An unsafe fork inside the callback can also inherit this guard.
+        self.0.mapping.require_creator();
+        let mut readers = self.0.readers.lock();
+        *readers -= 1;
+        if *readers == 0 {
+            self.0.check_canary();
+            if self.0.mapping.protect(libc::PROT_NONE).is_err() {
+                process::abort();
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::secret::Secret;
+    use std::{
+        os::unix::process::ExitStatusExt,
+        panic::{AssertUnwindSafe, catch_unwind},
+        process::Command,
+        sync::{
+            Arc, Barrier,
+            atomic::{AtomicUsize, Ordering},
+        },
+        thread,
+    };
+
+    const CHILD_ENV: &str = "COMMONWARE_HARDENED_SECRET_TEST";
+
+    /// Runs deliberate memory faults in a subprocess so the test runner survives.
+    fn child(case: &str, signal: Option<i32>) {
+        let output = Command::new(std::env::current_exe().unwrap())
+            .args([
+                "--exact",
+                "hardened_secret::tests::subprocess_child",
+                "--nocapture",
+            ])
+            .env(CHILD_ENV, case)
+            .output()
+            .unwrap();
+        assert_eq!(output.status.signal(), signal, "{output:?}");
+        if signal.is_none() {
+            assert!(output.status.success(), "{output:?}");
+        }
+    }
+
+    #[test]
+    fn protected_access_and_guards() {
+        child("inaccessible", Some(libc::SIGSEGV));
+        child("readonly", Some(libc::SIGSEGV));
+        child("leading_guard", Some(libc::SIGSEGV));
+        child("trailing_guard", Some(libc::SIGSEGV));
+        child("canary", Some(libc::SIGABRT));
+        child("extract_canary", Some(libc::SIGABRT));
+        child("enter_failure", Some(libc::SIGABRT));
+        child("exit_failure", Some(libc::SIGABRT));
+    }
+
+    #[test]
+    fn locked_memory_limit() {
+        child("locked_memory_limit", None);
+    }
+
+    #[test]
+    fn fork_wipes_and_rejects_inherited_handles() {
+        child("fork_drop", None);
+        child("fork_access", None);
+        child("fork_extract", None);
+    }
+
+    #[test]
+    fn nested_and_concurrent_access() {
+        let secret = HardenedSecret::try_from_inline(InlineSecret::new([42u8; 32])).unwrap();
+        let cloned = secret.clone();
+        assert!(Arc::ptr_eq(&secret.inner, &cloned.inner));
+        secret.access(|value| cloned.access(|other| assert_eq!(value, other)));
+        let barrier = Arc::new(Barrier::new(5));
+        thread::scope(|scope| {
+            for _ in 0..4 {
+                let cloned = secret.clone();
+                let barrier = barrier.clone();
+                scope.spawn(move || {
+                    cloned.access(|value| {
+                        barrier.wait();
+                        assert_eq!(value, &[42; 32]);
+                        barrier.wait();
+                    });
+                });
+            }
+            barrier.wait();
+            assert_eq!(*secret.inner.readers.lock(), 4);
+            secret.access(|value| assert_eq!(value, &[42; 32]));
+            barrier.wait();
+        });
+        assert_eq!(*secret.inner.readers.lock(), 0);
+        child("panic_protection", Some(libc::SIGSEGV));
+    }
+
+    #[test]
+    fn initialize_and_layout() {
+        let secret = Secret::<[u8; 8193]>::try_init(|value| value.fill(37)).unwrap();
+        assert!(secret.is_hardened());
+        secret.access(|value| assert_eq!(value, &[37; 8193]));
+        let empty = HardenedSecret::try_from_inline(InlineSecret::new([0u8; 0])).unwrap();
+        empty.access(|value| assert!(value.is_empty()));
+        assert_eq!(empty.try_extract().unwrap(), []);
+        let panic = catch_unwind(|| {
+            let _ = Secret::<[u8; 32]>::try_init(|value| {
+                value.fill(99);
+                panic!("initializer panic");
+            });
+        });
+        assert!(panic.is_err());
+        let usable = HardenedSecret::try_from_inline(InlineSecret::new([1; 32])).unwrap();
+        usable.access(|value| assert_eq!(value[0], 1));
+    }
+
+    #[test]
+    fn redaction_and_storage_conversion() {
+        let secret = Secret::new([42u8; 32]);
+        assert!(!secret.is_hardened());
+        let secret = secret.try_harden().unwrap();
+        assert!(secret.is_hardened());
+        let secret = secret.try_harden().unwrap();
+        assert_eq!(format!("{secret:?}"), "Secret([REDACTED])");
+        let cloned = secret.clone();
+        assert!(cloned.is_hardened());
+        assert_eq!(secret, cloned);
+        assert_eq!(cloned.extract_or_clone(), [42u8; 32]);
+        assert!(secret.is_hardened());
+        assert_eq!(format!("{secret}"), "[REDACTED]");
+    }
+
+    static DROPS: AtomicUsize = AtomicUsize::new(0);
+    struct Tracked([u8; 32]);
+    impl Drop for Tracked {
+        fn drop(&mut self) {
+            DROPS.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    #[test]
+    fn last_owner_destroys_value() {
+        let secret = HardenedSecret::try_from_inline(InlineSecret::new(Tracked([42; 32]))).unwrap();
+        let clone = secret.clone();
+        secret.access(|value| assert_eq!(value.0, [42; 32]));
+        drop(secret);
+        assert_eq!(DROPS.load(Ordering::SeqCst), 0);
+        drop(clone);
+        assert_eq!(DROPS.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn subprocess_child() {
+        let Ok(case) = std::env::var(CHILD_ENV) else {
+            return;
+        };
+        // SAFETY: This subprocess owns its resource limits. Disabling core files
+        // prevents deliberate fault tests from creating artifacts.
+        unsafe {
+            let limit = libc::rlimit {
+                rlim_cur: 0,
+                rlim_max: 0,
+            };
+            assert_eq!(libc::setrlimit(libc::RLIMIT_CORE, &limit), 0);
+        }
+        if case == "locked_memory_limit" {
+            // SAFETY: This subprocess lowers only its own locked-memory allowance.
+            unsafe {
+                let limit = libc::rlimit {
+                    rlim_cur: 0,
+                    rlim_max: 0,
+                };
+                assert_eq!(libc::setrlimit(libc::RLIMIT_MEMLOCK, &limit), 0);
+            }
+            assert!(matches!(
+                HardenedSecret::try_from_inline(InlineSecret::new([42u8; 32])),
+                Err(HardenError::System {
+                    operation: "mlock",
+                    ..
+                })
+            ));
+            return;
+        }
+        let secret = HardenedSecret::try_from_inline(InlineSecret::new([42u8; 32])).unwrap();
+        match case.as_str() {
+            "inaccessible" | "panic_protection" => {
+                if case == "panic_protection" {
+                    assert!(
+                        catch_unwind(AssertUnwindSafe(|| {
+                            secret.access(|_| panic!("access panic"));
+                        }))
+                        .is_err()
+                    );
+                }
+                // SAFETY: Intentionally probe our allocated, inaccessible page in
+                // an isolated subprocess, expecting an operating-system fault.
+                unsafe {
+                    std::hint::black_box(secret.inner.value.as_ptr().read_volatile());
+                }
+            }
+            "readonly" => secret.access(|_| {
+                // SAFETY: Deliberately test the read-only mapping in a subprocess.
+                unsafe {
+                    secret.inner.value.as_ptr().write_volatile([0; 32]);
+                }
+            }),
+            "leading_guard" => secret.access(|_| {
+                // SAFETY: Deliberately read the mapped but inaccessible guard page.
+                unsafe {
+                    std::hint::black_box(secret.inner.mapping.base.as_ptr().read_volatile());
+                }
+            }),
+            "trailing_guard" => secret.access(|_| {
+                // SAFETY: The pointer is within the trailing mapped guard page.
+                unsafe {
+                    std::hint::black_box(
+                        secret
+                            .inner
+                            .mapping
+                            .data
+                            .as_ptr()
+                            .add(secret.inner.mapping.data_len)
+                            .read_volatile(),
+                    );
+                }
+            }),
+            "canary" | "extract_canary" => {
+                secret
+                    .inner
+                    .mapping
+                    .protect(libc::PROT_READ | libc::PROT_WRITE)
+                    .unwrap();
+                // SAFETY: The test owns the writable canary and deliberately corrupts it.
+                unsafe {
+                    let canary = secret.inner.canary_ptr();
+                    canary.write(canary.read() ^ 1);
+                }
+                secret.inner.mapping.protect(libc::PROT_NONE).unwrap();
+                if case == "extract_canary" {
+                    let _ = secret.try_extract();
+                } else {
+                    secret.access(|_| ());
+                }
+            }
+            "enter_failure" => {
+                // SAFETY: Remove our mapping to force mprotect failure. The next
+                // operation must abort without dereferencing the stale pointer.
+                unsafe {
+                    assert_eq!(
+                        libc::munmap(
+                            secret.inner.mapping.base.as_ptr().cast(),
+                            secret.inner.mapping.total_len
+                        ),
+                        0
+                    );
+                }
+                secret.access(|_| ());
+            }
+            "exit_failure" => exit_failure(),
+            "fork_drop" | "fork_access" | "fork_extract" => {
+                // SAFETY: The child only invokes the hardened handle's explicit
+                // child rejection/drop path, raw mapping syscalls, and _exit.
+                let pid = unsafe { libc::fork() };
+                assert!(pid >= 0);
+                if pid == 0 {
+                    if case == "fork_access" {
+                        secret.access(|_| ());
+                    }
+                    if case == "fork_extract" {
+                        let _ = secret.try_extract();
+                        // SAFETY: Reaching this point means child rejection failed.
+                        unsafe { libc::_exit(3) };
+                    }
+                    let data = secret.inner.mapping.data.as_ptr();
+                    let len = secret.inner.mapping.data_len;
+                    // SAFETY: Inspect raw bytes, never an inherited T. WIPEONFORK
+                    // supplies zero pages, and the child owns this private mapping.
+                    unsafe {
+                        if libc::mprotect(data.cast(), len, libc::PROT_READ) != 0 {
+                            libc::_exit(1);
+                        }
+                        for i in 0..len {
+                            if data.add(i).read_volatile() != 0 {
+                                libc::_exit(2);
+                            }
+                        }
+                    }
+                    drop(secret);
+                    // SAFETY: Terminate the child without invoking the test harness.
+                    unsafe {
+                        libc::_exit(0);
+                    }
+                }
+                let mut status = 0;
+                // SAFETY: pid identifies our child and status is writable.
+                assert_eq!(unsafe { libc::waitpid(pid, &mut status, 0) }, pid);
+                if case != "fork_drop" {
+                    assert!(libc::WIFSIGNALED(status));
+                    assert_eq!(libc::WTERMSIG(status), libc::SIGABRT);
+                } else {
+                    assert!(libc::WIFEXITED(status));
+                    assert_eq!(libc::WEXITSTATUS(status), 0);
+                }
+                secret.access(|value| assert_eq!(value, &[42; 32]));
+                return;
+            }
+            _ => panic!("unknown subprocess case: {case}"),
+        }
+        panic!("expected subprocess fault: {case}");
+    }
+
+    /// Forces revocation to fail after a readable access scope has already started.
+    fn exit_failure() {
+        let secret = HardenedSecret::try_from_inline(InlineSecret::new([42u8; 131073])).unwrap();
+        secret.access(|_| {
+            // SAFETY: Deliberately unmap the last data page in this subprocess,
+            // leaving the canary readable. Revoking access must abort when
+            // mprotect encounters the gap, without accessing the missing page.
+            unsafe {
+                let page = libc::sysconf(libc::_SC_PAGESIZE) as usize;
+                assert_eq!(
+                    libc::munmap(
+                        secret
+                            .inner
+                            .mapping
+                            .data
+                            .as_ptr()
+                            .add(secret.inner.mapping.data_len - page)
+                            .cast(),
+                        page
+                    ),
+                    0
+                );
+            }
+        });
+    }
+}

--- a/cryptography/src/hardened_secret.rs
+++ b/cryptography/src/hardened_secret.rs
@@ -38,11 +38,11 @@
 //! ```text
 //! SETUP RW
 //!   establish required protections before sensitive writes
-//!   mark data dirty before moving T or invoking an initializer
-//!   install typed owner as soon as T is valid
-//!   for zeroed byte arrays, install owner before initializer callback
+//!   mark data dirty before copying T or invoking an initializer
+//!   inline source owns T until the copied bytes are sealed
+//!   zeroed byte arrays have a typed owner before the initializer callback
 //!        |
-//!        | protect(NONE), then publish
+//!        | protect(NONE), commit ownership, then publish
 //!        v
 //! IDLE NONE, readers = 0
 //!        |
@@ -77,11 +77,14 @@
 //! including unused bytes and uninitialized padding, then unmaps while still
 //! locked. It never interprets bytes as `T`.
 //!
-//! Setup, including final sealing, can return an error if cleanup succeeds. The
-//! typed owner is installed before final sealing, so its failure destroys `T`
-//! before raw erasure. A failed seal does not inherently imply abort. Published
-//! access or extraction permission failures, count overflow, and cleanup failures
-//! abort. Abort does not run destructors or guarantee erasure.
+//! Setup, including final sealing, can return an error if cleanup succeeds.
+//! Hardening stages a raw copy while the inline source still owns `T`. On error,
+//! raw cleanup erases the copy without destroying `T`, leaving the source intact.
+//! On success, ownership transfers to the sealed allocation and the caller erases
+//! the source without destroying it. Byte-array initialization instead installs a
+//! typed owner before invoking user code. Published access or extraction permission
+//! failures, count overflow, and cleanup failures abort. Abort does not run
+//! destructors or guarantee erasure.
 //!
 //! # Fork identity
 //!
@@ -139,14 +142,38 @@ pub(crate) struct HardenedSecret<T> {
 }
 
 impl<T> HardenedSecret<T> {
-    /// Moves the inline value into protected storage, erasing its consumed source.
+    /// Copies the inline value into protected storage, preserving it on error.
     ///
-    /// Layout and OS failures consume the input. Setup can fail before transfer,
-    /// or final sealing can fail after the typed owner has taken responsibility
-    /// for destruction. Ordinary `Arc` allocation follows Rust allocator policy.
-    pub(crate) fn try_from_inline(value: InlineSecret<T>) -> Result<Self, HardenError> {
-        ProtectedAllocation::try_new(value).map(|inner| Self {
-            inner: Arc::new(inner),
+    /// # Safety
+    ///
+    /// On success, the returned allocation owns `T`. The caller must immediately
+    /// erase and retire the source without accessing or dropping its value, and
+    /// without an intervening operation that can panic. On error, the source
+    /// remains its sole owner and is unchanged.
+    pub(crate) unsafe fn try_from_inline(value: &mut InlineSecret<T>) -> Result<Self, HardenError> {
+        let (mut mapping, destination) = Mapping::allocate::<T>()?;
+        // Allocate metadata and prepare the reader mutex before transferring ownership.
+        let mut inner = Arc::<ProtectedAllocation<T>>::new_uninit();
+        let slot = Arc::get_mut(&mut inner).unwrap();
+        let readers = Mutex::new(0);
+        mapping.dirty = true;
+        value.access(|source| {
+            // SAFETY: The destination is writable, aligned, and disjoint from the
+            // initialized source. This is only a raw copy. Until sealing succeeds,
+            // Mapping owns cleanup and never accesses or destroys it as T.
+            unsafe { ptr::copy_nonoverlapping(source, destination.as_ptr(), 1) };
+        });
+        mapping.protect(libc::PROT_NONE)?;
+        // No fallible or panicking operations may follow the ownership transfer.
+        slot.write(ProtectedAllocation {
+            mapping,
+            value: destination,
+            readers,
+        });
+        Ok(Self {
+            // SAFETY: The Arc's unique slot was initialized above. The caller
+            // retires the inline source as required by this function's contract.
+            inner: unsafe { inner.assume_init() },
         })
     }
 
@@ -474,26 +501,6 @@ unsafe impl<T: Send> Send for ProtectedAllocation<T> {}
 unsafe impl<T: Sync> Sync for ProtectedAllocation<T> {}
 
 impl<T> ProtectedAllocation<T> {
-    /// Transfers the inline value after setup succeeds, then revokes access.
-    fn try_new(value: InlineSecret<T>) -> Result<Self, HardenError> {
-        let (mut mapping, destination) = Mapping::allocate::<T>()?;
-        // Cleanup must erase even if a later permission change fails.
-        mapping.dirty = true;
-        // SAFETY: The mapping is writable, aligned for T, and disjoint from the
-        // source. Ownership transfers into its previously uninitialized storage.
-        unsafe {
-            value.move_into(destination.as_ptr());
-        }
-        // Transfer cleanup to the typed owner before protection can fail.
-        let allocation = Self {
-            mapping,
-            value: destination,
-            readers: Mutex::new(0),
-        };
-        allocation.mapping.protect(libc::PROT_NONE)?;
-        Ok(allocation)
-    }
-
     /// Holds one reader slot across the callback, including panic unwinding.
     fn access<R>(&self, f: impl for<'a> FnOnce(&'a T) -> R) -> R {
         // A fork child can inherit a held mutex. Reject it before locking or
@@ -602,6 +609,29 @@ mod tests {
 
     const CHILD_ENV: &str = "COMMONWARE_HARDENED_SECRET_TEST";
 
+    /// Creates an allocation whose mappings can be inspected by backend tests.
+    fn harden<T>(value: InlineSecret<T>) -> Result<HardenedSecret<T>, HardenError> {
+        let mut value = ManuallyDrop::new(value);
+        // SAFETY: Success immediately retires the source without dropping T.
+        // Failure leaves it initialized, so only that path runs its destructor.
+        unsafe {
+            match HardenedSecret::try_from_inline(&mut value) {
+                Ok(hardened) => {
+                    core::slice::from_raw_parts_mut(
+                        (&raw mut *value).cast::<MaybeUninit<u8>>(),
+                        size_of::<InlineSecret<T>>(),
+                    )
+                    .zeroize();
+                    Ok(hardened)
+                }
+                Err(error) => {
+                    ManuallyDrop::drop(&mut value);
+                    Err(error)
+                }
+            }
+        }
+    }
+
     /// Runs deliberate memory faults in a subprocess so the test runner survives.
     fn child(case: &str, signal: Option<i32>) -> Output {
         let output = Command::new(std::env::current_exe().unwrap())
@@ -630,7 +660,7 @@ mod tests {
         child("exit_failure", Some(libc::SIGABRT));
         child("cleanup_failure", Some(libc::SIGABRT));
         child("final_seal_failure", None);
-        child("post_move_failure", None);
+        child("harden_seal_failure", None);
     }
 
     #[test]
@@ -668,7 +698,7 @@ mod tests {
 
     #[test]
     fn nested_and_concurrent_access() {
-        let secret = HardenedSecret::try_from_inline(InlineSecret::new([42u8; 32])).unwrap();
+        let secret = harden(InlineSecret::new([42u8; 32])).unwrap();
         let cloned = secret.clone();
         assert!(Arc::ptr_eq(&secret.inner, &cloned.inner));
         secret.access(|value| {
@@ -725,18 +755,17 @@ mod tests {
                 check_layout::<{ $page + 1 }>(2);
                 #[repr(align($page))]
                 struct Aligned([u8; 1]);
-                let value =
-                    HardenedSecret::try_from_inline(InlineSecret::new(Aligned([73]))).unwrap();
+                let value = harden(InlineSecret::new(Aligned([73]))).unwrap();
                 assert_eq!(value.inner.value.as_ptr().addr() % $page, 0);
                 assert_eq!(value.inner.mapping.data_len, $page);
                 value.access(|value| assert_eq!(value.0, [73]));
                 drop(value);
                 #[repr(align($over))]
-                struct OverAligned;
-                assert!(matches!(
-                    HardenedSecret::try_from_inline(InlineSecret::new(OverAligned)),
-                    Err(HardenError::Layout)
-                ));
+                struct OverAligned([u8; 1]);
+                let mut value = Secret::new(OverAligned([73]));
+                assert!(matches!(value.try_harden(), Err(HardenError::Layout)));
+                assert!(!value.is_hardened());
+                value.access(|value| assert_eq!(value.0, [73]));
             }};
         }
         match page_size() {
@@ -798,8 +827,7 @@ mod tests {
                 panic!("destructor panic");
             }
         }
-        let secret =
-            HardenedSecret::try_from_inline(InlineSecret::new(PanicOnDrop([99; 32]))).unwrap();
+        let secret = harden(InlineSecret::new(PanicOnDrop([99; 32]))).unwrap();
         let data = secret.inner.mapping.data.as_ptr();
         let marker = secret.inner.mapping.identity.address.as_ptr();
         assert!(catch_unwind(AssertUnwindSafe(|| drop(secret))).is_err());
@@ -809,12 +837,12 @@ mod tests {
 
     #[test]
     fn redaction_and_storage_conversion() {
-        let secret = Secret::new([42u8; 32]);
+        let mut secret = Secret::new([42u8; 32]);
         assert!(!secret.is_hardened());
-        let secret = secret.try_harden().unwrap();
+        secret.try_harden().unwrap();
         assert!(secret.is_hardened());
         let address = secret.access(|value| value as *const _);
-        let secret = secret.try_harden().unwrap();
+        secret.try_harden().unwrap();
         secret.access(|value| assert_eq!(value as *const _, address));
         assert_eq!(format!("{secret:?}"), "Secret([REDACTED])");
         let cloned = secret.clone();
@@ -839,9 +867,76 @@ mod tests {
     }
 
     #[test]
+    fn harden_nonclone_value_in_place() {
+        let drops = AtomicUsize::new(0);
+        let mut secret = Secret::new(Tracked {
+            bytes: [42; 32],
+            drops: &drops,
+        });
+        let result: Result<(), HardenError> = secret.try_harden();
+        result.unwrap();
+        assert!(secret.is_hardened());
+        secret.access(|value| assert_eq!(value.bytes, [42; 32]));
+        assert_eq!(drops.load(Ordering::Relaxed), 0);
+        drop(secret);
+        assert_eq!(drops.load(Ordering::Relaxed), 1);
+    }
+
+    /// A failed attempt must not destroy or replace the original owning value.
+    fn assert_harden_failure(operation: &str) {
+        struct Value<'a> {
+            bytes: Box<[u8; 32]>,
+            drops: &'a AtomicUsize,
+        }
+        impl Drop for Value<'_> {
+            fn drop(&mut self) {
+                self.drops.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+
+        let drops = AtomicUsize::new(0);
+        let mut secret = Secret::new(Value {
+            bytes: Box::new([42; 32]),
+            drops: &drops,
+        });
+        let address = secret.access(ptr::from_ref);
+        let locked = locked_kib();
+        // A second attempt must also preserve ownership and release its mapping.
+        for _ in 0..2 {
+            let error = secret.try_harden().unwrap_err();
+            assert!(
+                matches!(error, HardenError::System { operation: failed, .. } if failed == operation)
+            );
+            assert!(!secret.is_hardened());
+            secret.access(|value| {
+                assert_eq!(ptr::from_ref(value), address);
+                assert_eq!(*value.bytes, [42; 32]);
+            });
+            assert_eq!(drops.load(Ordering::Relaxed), 0);
+            assert_eq!(locked_kib(), locked);
+        }
+        drop(secret);
+        assert_eq!(drops.load(Ordering::Relaxed), 1);
+    }
+
+    /// Reads the locked data size reported by Linux, in KiB.
+    fn locked_kib() -> usize {
+        std::fs::read_to_string("/proc/self/status")
+            .unwrap()
+            .lines()
+            .find_map(|line| line.strip_prefix("VmLck:"))
+            .unwrap()
+            .split_whitespace()
+            .next()
+            .unwrap()
+            .parse()
+            .unwrap()
+    }
+
+    #[test]
     fn last_owner_destroys_value() {
         let drops = AtomicUsize::new(0);
-        let secret = HardenedSecret::try_from_inline(InlineSecret::new(Tracked {
+        let secret = harden(InlineSecret::new(Tracked {
             bytes: [42; 32],
             drops: &drops,
         }))
@@ -861,7 +956,7 @@ mod tests {
     #[test]
     fn unique_extraction_moves_nonclone_value() {
         let drops = AtomicUsize::new(0);
-        let secret = HardenedSecret::try_from_inline(InlineSecret::new(Tracked {
+        let secret = harden(InlineSecret::new(Tracked {
             bytes: [42; 32],
             drops: &drops,
         }))
@@ -901,18 +996,14 @@ mod tests {
                 };
                 assert_eq!(libc::setrlimit(libc::RLIMIT_MEMLOCK, &limit), 0);
             }
-            assert!(matches!(
-                HardenedSecret::try_from_inline(InlineSecret::new([42u8; 32])),
-                Err(HardenError::System {
-                    operation: "mlock",
-                    ..
-                })
-            ));
+            assert_harden_failure("mlock");
             return;
         }
         if case == "fork_pid_collision" {
             let mut allocation =
-                ProtectedAllocation::try_new(InlineSecret::new([42u8; 32])).unwrap();
+                Arc::try_unwrap(harden(InlineSecret::new([42u8; 32])).unwrap().inner)
+                    .ok()
+                    .unwrap();
             // SAFETY: The child only checks mapping identity and exits. It never
             // interprets the wiped allocation as T or enters inherited locks.
             let pid = unsafe { libc::fork() };
@@ -964,47 +1055,22 @@ mod tests {
                 assert_unmapped(address);
                 return;
             }
-            "post_move_failure" => {
-                let drops = AtomicUsize::new(0);
-                let address = AtomicUsize::new(0);
-                struct Value<'a> {
-                    drops: &'a AtomicUsize,
-                    address: &'a AtomicUsize,
-                }
-                impl Drop for Value<'_> {
-                    fn drop(&mut self) {
-                        self.address
-                            .store(self as *const Self as usize, Ordering::Relaxed);
-                        self.drops.fetch_add(1, Ordering::Relaxed);
-                    }
-                }
+            "harden_seal_failure" => {
                 deny_mprotect(&[libc::PROT_NONE]);
-                let result = HardenedSecret::try_from_inline(InlineSecret::new(Value {
-                    drops: &drops,
-                    address: &address,
-                }));
-                assert!(matches!(
-                    result,
-                    Err(HardenError::System {
-                        operation: "mprotect",
-                        ..
-                    })
-                ));
-                assert_eq!(drops.load(Ordering::Relaxed), 1);
-                assert_unmapped(address.load(Ordering::Relaxed) as *mut u8);
+                assert_harden_failure("mprotect");
                 return;
             }
             "no_permission_changes" => {
-                let public = Secret::new([42u8; 32]).try_harden().unwrap();
-                let shared =
-                    HardenedSecret::try_from_inline(InlineSecret::new([73u8; 32])).unwrap();
+                let mut public = Secret::new([42u8; 32]);
+                public.try_harden().unwrap();
+                let shared = harden(InlineSecret::new([73u8; 32])).unwrap();
                 let clone = shared.clone();
                 deny_mprotect(&[
                     libc::PROT_NONE,
                     libc::PROT_READ,
                     libc::PROT_READ | libc::PROT_WRITE,
                 ]);
-                let public = public.try_harden().unwrap();
+                public.try_harden().unwrap();
                 assert!(public.is_hardened());
                 let returned = shared.try_extract().unwrap_err();
                 assert!(Arc::ptr_eq(&returned.inner, &clone.inner));
@@ -1019,7 +1085,8 @@ mod tests {
                 unsafe { libc::_exit(0) };
             }
             "borrowed_panic_protection" | "owned_panic_protection" => {
-                let secret = Secret::new([42u8; 32]).try_harden().unwrap();
+                let mut secret = Secret::new([42u8; 32]);
+                secret.try_harden().unwrap();
                 let address = secret.access(|value| value as *const [u8; 32]);
                 if case == "borrowed_panic_protection" {
                     assert!(catch_unwind(|| secret.access(|_| panic!("borrowed panic"))).is_err());
@@ -1052,8 +1119,7 @@ mod tests {
                 return;
             }
             "fork_guard" => {
-                let secret =
-                    HardenedSecret::try_from_inline(InlineSecret::new([42u8; 32])).unwrap();
+                let secret = harden(InlineSecret::new([42u8; 32])).unwrap();
                 let mut pid = -1;
                 secret.access(|_| {
                     // SAFETY: The child returns directly to inherited-guard rejection
@@ -1075,7 +1141,7 @@ mod tests {
             }
             _ => {}
         }
-        let secret = HardenedSecret::try_from_inline(InlineSecret::new([42u8; 32])).unwrap();
+        let secret = harden(InlineSecret::new([42u8; 32])).unwrap();
         match case.as_str() {
             "inaccessible" | "panic_protection" => {
                 if case == "panic_protection" {
@@ -1188,7 +1254,7 @@ mod tests {
     fn exit_failure() {
         // A ZST still owns one data page. Its reference occupies no bytes, so
         // removing that page leaves no live reference into unmapped data.
-        let secret = HardenedSecret::try_from_inline(InlineSecret::new(())).unwrap();
+        let secret = harden(InlineSecret::new(())).unwrap();
         secret.access(|_| {
             // SAFETY: Remove the test's data page to force last-reader mprotect
             // failure. The marker and the ZST's trailing-guard address stay mapped.
@@ -1352,7 +1418,9 @@ mod tests {
             }
         }
         let mut allocation =
-            ProtectedAllocation::try_new(InlineSecret::new(Value([42; 32]))).unwrap();
+            Arc::try_unwrap(harden(InlineSecret::new(Value([42; 32]))).unwrap().inner)
+                .ok()
+                .unwrap();
         // SAFETY: The child only executes explicit rejection/drop paths or creates
         // independent storage. It never uses a borrowed inherited value.
         let pid = unsafe { libc::fork() };
@@ -1380,8 +1448,7 @@ mod tests {
                 }
                 "fork_collision_drop" => drop(allocation),
                 "fork_new_allocation" => {
-                    let fresh =
-                        HardenedSecret::try_from_inline(InlineSecret::new([73u8; 32])).unwrap();
+                    let fresh = harden(InlineSecret::new([73u8; 32])).unwrap();
                     fresh.access(|bytes| assert_eq!(bytes, &[73; 32]));
                     drop(fresh);
                     assert!(!allocation.mapping.in_creator());

--- a/cryptography/src/hardened_secret.rs
+++ b/cryptography/src/hardened_secret.rs
@@ -80,12 +80,14 @@
 
 use crate::secret::{HardenError, InlineSecret};
 use commonware_utils::sync::Mutex;
-use core::{
-    fmt::{Debug, Formatter},
+use std::{
+    io,
     mem::{ManuallyDrop, MaybeUninit, align_of, size_of},
+    process,
     ptr::{self, NonNull},
+    slice,
+    sync::Arc,
 };
-use std::{io, process, sync::Arc};
 use zeroize::Zeroize;
 
 /// Handle to one shared protected allocation.
@@ -104,23 +106,28 @@ impl<T> HardenedSecret<T> {
     /// remains its sole owner and is unchanged.
     pub(crate) unsafe fn try_from_inline(value: &mut InlineSecret<T>) -> Result<Self, HardenError> {
         let (mapping, destination) = Mapping::allocate::<T>()?;
+
         // Allocate metadata and prepare the reader mutex before transferring ownership.
         let mut inner = Arc::<ProtectedAllocation<T>>::new_uninit();
         let slot = Arc::get_mut(&mut inner).unwrap();
         let readers = Mutex::new(0);
+
         value.access(|source| {
             // SAFETY: The destination is writable, aligned, and disjoint from the
             // initialized source. This is only a raw copy. Until sealing succeeds,
             // Mapping owns cleanup and never accesses or destroys it as T.
             unsafe { ptr::copy_nonoverlapping(source, destination.as_ptr(), 1) };
         });
+
         mapping.protect(libc::PROT_NONE)?;
+
         // No fallible or panicking operations may follow the ownership transfer.
         slot.write(ProtectedAllocation {
             mapping,
             value: destination,
             readers,
         });
+
         Ok(Self {
             // SAFETY: The Arc's unique slot was initialized above. The caller
             // retires the inline source as required by this function's contract.
@@ -155,27 +162,6 @@ impl<T> Clone for HardenedSecret<T> {
     }
 }
 
-impl<T> Debug for HardenedSecret<T> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
-        f.write_str("HardenedSecret([REDACTED])")
-    }
-}
-
-/// Captures errno immediately after a failed memory operation.
-fn system(operation: &'static str) -> HardenError {
-    HardenError::System {
-        operation,
-        source: io::Error::last_os_error(),
-    }
-}
-
-/// Handles cleanup syscalls whose failure cannot be returned to the caller.
-fn abort_on_error(result: libc::c_int) {
-    if result != 0 {
-        process::abort();
-    }
-}
-
 /// Owns the raw pages independently of `T`'s initialization and destruction.
 ///
 /// Only the data region is locked or changes permissions. The bytes are never
@@ -204,21 +190,25 @@ impl Mapping {
             .ok()
             .filter(|page| page.is_power_of_two())
             .ok_or(HardenError::Layout)?;
+
         if align_of::<T>() > page {
             return Err(HardenError::Layout);
         }
+
         // Keep a data page even for zero-sized values, then round up to pages.
         let data_len = size_of::<T>()
             .max(1)
             .checked_add(page - 1)
             .map(|size| size & !(page - 1))
             .ok_or(HardenError::Layout)?;
+
         // Include both guards in Rust's maximum pointer-offset bound.
         let total_len = page
             .checked_mul(2)
             .and_then(|guards| data_len.checked_add(guards))
             .filter(|size| *size <= isize::MAX as usize)
             .ok_or(HardenError::Layout)?;
+
         // SAFETY: A null hint requests a new mapping. Length is checked above.
         let base = unsafe {
             libc::mmap(
@@ -230,17 +220,26 @@ impl Mapping {
                 0,
             )
         };
+
         if base == libc::MAP_FAILED {
-            return Err(system("mmap"));
+            return Err(HardenError::System {
+                operation: "mmap",
+                source: io::Error::last_os_error(),
+            });
         }
+
         // A mapping at address zero cannot be represented as a Rust allocation.
         let Some(base) = NonNull::new(base.cast::<u8>()) else {
             // SAFETY: mmap returned this mapping and length, which we own exclusively.
-            unsafe { abort_on_error(libc::munmap(base, total_len)) };
+            if unsafe { libc::munmap(base, total_len) } != 0 {
+                process::abort();
+            }
             return Err(HardenError::Layout);
         };
+
         // SAFETY: The data region follows the first guard within the mapping.
         let data = unsafe { NonNull::new_unchecked(base.as_ptr().add(page)) };
+
         // Cleanup erases through write access, so the data region becomes
         // writable before Drop takes over.
         // SAFETY: The page-aligned data region lies entirely inside our mapping.
@@ -252,37 +251,57 @@ impl Mapping {
             )
         } != 0
         {
-            let error = system("mprotect");
+            let error = HardenError::System {
+                operation: "mprotect",
+                source: io::Error::last_os_error(),
+            };
             // SAFETY: Nothing was written. Release the mapping we own exclusively.
-            unsafe { abort_on_error(libc::munmap(base.as_ptr().cast(), total_len)) };
+            if unsafe { libc::munmap(base.as_ptr().cast(), total_len) } != 0 {
+                process::abort();
+            }
             return Err(error);
         }
+
         let mapping = Self {
             base,
             total_len,
             data,
             data_len,
         };
+
         // Establish all protections before writing secret bytes into the mapping.
         // SAFETY: The page-aligned data region lies entirely inside our mapping.
         if unsafe { libc::madvise(data.as_ptr().cast(), data_len, libc::MADV_DONTDUMP) } != 0 {
-            return Err(system("madvise(MADV_DONTDUMP)"));
+            return Err(HardenError::System {
+                operation: "madvise(MADV_DONTDUMP)",
+                source: io::Error::last_os_error(),
+            });
         }
+
         // SAFETY: The page-aligned region is private anonymous memory, as required
         // by WIPEONFORK.
         if unsafe { libc::madvise(data.as_ptr().cast(), data_len, libc::MADV_WIPEONFORK) } != 0 {
-            return Err(system("madvise(MADV_WIPEONFORK)"));
+            return Err(HardenError::System {
+                operation: "madvise(MADV_WIPEONFORK)",
+                source: io::Error::last_os_error(),
+            });
         }
+
         // SAFETY: The data region is a valid, writable mapping of data_len bytes.
         if unsafe { libc::mlock(data.as_ptr().cast(), data_len) } != 0 {
-            return Err(system("mlock"));
+            return Err(HardenError::System {
+                operation: "mlock",
+                source: io::Error::last_os_error(),
+            });
         }
+
         // The size of T is a multiple of its alignment, which divides the page
         // size. Placing its end at the trailing guard therefore aligns its start
         // and leaves no gap between T and the guard.
         // SAFETY: data_len covers T, and alignment was checked, including for a ZST.
         let value =
             unsafe { NonNull::new_unchecked(data.as_ptr().add(data_len - size_of::<T>()).cast()) };
+
         Ok((mapping, value))
     }
 
@@ -295,8 +314,12 @@ impl Mapping {
     fn protect(&self, protection: libc::c_int) -> Result<(), HardenError> {
         // SAFETY: The data pointer and length describe our page-aligned mapping.
         if unsafe { libc::mprotect(self.data.as_ptr().cast(), self.data_len, protection) } != 0 {
-            return Err(system("mprotect"));
+            return Err(HardenError::System {
+                operation: "mprotect",
+                source: io::Error::last_os_error(),
+            });
         }
+
         Ok(())
     }
 
@@ -313,21 +336,22 @@ impl Mapping {
 impl Drop for Mapping {
     fn drop(&mut self) {
         self.make_writable();
+
         // SAFETY: We exclusively own the writable data region. Any T has
         // already been destroyed, moved out, or was never initialized.
         // MaybeUninit permits erasing padding without reading uninitialized bytes.
         unsafe {
-            core::slice::from_raw_parts_mut(
-                self.data.as_ptr().cast::<MaybeUninit<u8>>(),
-                self.data_len,
-            )
-            .zeroize();
+            slice::from_raw_parts_mut(self.data.as_ptr().cast::<MaybeUninit<u8>>(), self.data_len)
+                .zeroize();
         }
+
         // Unmapping also releases the memory lock. Keep the pages locked until
         // after erasure instead of unlocking them in a separate step.
         // SAFETY: This mapping belongs to this process, including a fork child's
         // private inherited copy.
-        unsafe { abort_on_error(libc::munmap(self.base.as_ptr().cast(), self.total_len)) };
+        if unsafe { libc::munmap(self.base.as_ptr().cast(), self.total_len) } != 0 {
+            process::abort();
+        }
     }
 }
 
@@ -366,10 +390,13 @@ impl<T> ProtectedAllocation<T> {
             if *readers == 0 && self.mapping.protect(libc::PROT_READ).is_err() {
                 process::abort();
             }
+
             // Wrapping to zero would allow revoking access while readers exist.
             *readers = readers.checked_add(1).unwrap_or_else(|| process::abort());
         }
+
         let _guard = ReadGuard(self);
+
         // SAFETY: The read guard keeps the initialized T readable
         // through this closure, including overlapping and nested calls.
         f(unsafe { self.value.as_ref() })
@@ -380,6 +407,7 @@ impl<T> ProtectedAllocation<T> {
         self.mapping.make_writable();
         let mut owner = ManuallyDrop::new(self);
         let allocation = &mut *owner;
+
         // SAFETY: Exclusive ownership rules out active readers. The value is
         // initialized and readable. ManuallyDrop prevents destroying the moved-out T.
         // Explicitly drop both owning fields to erase and release the source and
@@ -396,9 +424,11 @@ impl<T> ProtectedAllocation<T> {
 impl<T> Drop for ProtectedAllocation<T> {
     fn drop(&mut self) {
         self.mapping.make_writable();
+
         // SAFETY: The last owner has exclusive access, permissions allow
         // destruction, and this owner is only constructed after initializing T.
         unsafe { ptr::drop_in_place(self.value.as_ptr()) };
+
         // Mapping::drop wipes the data region even if a destructor unwinds.
     }
 }
@@ -410,6 +440,7 @@ impl<T> Drop for ReadGuard<'_, T> {
     fn drop(&mut self) {
         let mut readers = self.0.readers.lock();
         *readers -= 1;
+
         if *readers == 0 && self.0.mapping.protect(libc::PROT_NONE).is_err() {
             process::abort();
         }
@@ -441,7 +472,7 @@ mod tests {
         unsafe {
             match HardenedSecret::try_from_inline(&mut value) {
                 Ok(hardened) => {
-                    core::slice::from_raw_parts_mut(
+                    slice::from_raw_parts_mut(
                         (&raw mut *value).cast::<MaybeUninit<u8>>(),
                         size_of::<InlineSecret<T>>(),
                     )
@@ -595,7 +626,7 @@ mod tests {
         );
         secret.access(|value| assert_eq!(value, &[37; N]));
         let data = mapping.data.as_ptr();
-        assert_eq!(secret.try_extract().unwrap(), [37; N]);
+        assert_eq!(secret.try_extract().ok().unwrap(), [37; N]);
         assert_unmapped(data);
     }
 
@@ -739,7 +770,7 @@ mod tests {
         }))
         .unwrap();
         let data = secret.inner.mapping.data.as_ptr();
-        let value = secret.try_extract().unwrap();
+        let value = secret.try_extract().ok().unwrap();
         assert_unmapped(data);
         assert_eq!(value.bytes, [42; 32]);
         assert_eq!(drops.load(Ordering::Relaxed), 0);

--- a/cryptography/src/hardened_secret.rs
+++ b/cryptography/src/hardened_secret.rs
@@ -1,4 +1,4 @@
-//! Linux backend for [crate::secret]: guarded mappings and permission transitions.
+//! Hardened storage for [crate::Secret] on Linux.
 //!
 //! Three owners split the work:
 //!
@@ -24,7 +24,7 @@
 //! +----------------+-----------------------+-------------+----------------+
 //! | leading guard  | unused data bytes     | T           | trailing guard |
 //! +----------------+-----------------------+-------------+----------------+
-//! |<-- one page -->|<---------- whole data pages -------->|<-- one page -->|
+//! |<-- one page -->|<---------- whole data pages ------->|<-- one page -->|
 //!
 //! Guards: NONE for the mapping's lifetime, never locked
 //! Data:   locked, excluded from kernel cores, wiped in fork children
@@ -40,45 +40,32 @@
 //! - Unused data bytes before `T` share the data permissions, so an underrun
 //!   need not reach the leading guard.
 //!
-//! # Permissions
+//! # Lifecycle
 //!
 //! ```text
-//! SETUP     RW     allocate, then copy T
-//!   |
-//!   | protect(NONE), publish
-//!   v
-//! IDLE      NONE   readers = 0
-//!   |    ^
-//!   |    | first reader: protect(READ), readers = 1
-//!   |    | last reader:  readers = 0, protect(NONE)
-//!   v    |
-//! READABLE  READ   readers > 0, further readers only change the count
+//!      allocate: mmap, protect(RW), madvise, mlock
+//!               |
+//!               v
+//!      +-----------------+  copy T into the data region
+//!      | SETUP       RW  |  any failure: erase, unmap, return the error
+//!      +-----------------+
+//!               | protect(NONE), publish
+//!               v
+//!      +-----------------+  lock, protect(READ) if readers == 0,   +-----------------+
+//!      | IDLE      NONE  |  readers += 1, unlock                   | READABLE  READ  |
+//!      | readers = 0     | --------------------------------------> | readers > 0     |
+//!      |                 | <-------------------------------------- | f(&T), unlocked |
+//!      +-----------------+  lock, readers -= 1,                    +-----------------+
+//!               |            protect(NONE) if readers == 0, unlock
+//!               |
+//!               | unique extraction or final release: exclusive, so readers = 0
+//!               v
+//!      +-----------------+
+//!      | RELEASE     RW  |  move out or drop T, erase the data region, unmap
+//!      +-----------------+
 //!
-//! IDLE -> RELEASE  RW   unique extraction or final release: move out or drop T,
-//!                       erase the data region, unmap
+//!      After publication, a failed protect or a reader count overflow aborts.
 //! ```
-//!
-//! - Hold the reader mutex across a permission change and its count update.
-//!   Release it before user code so nested and overlapping access cannot
-//!   deadlock. [ReadGuard] closes the interval on return or unwind. A plain
-//!   atomic counter would not serialize revocation against the next grant.
-//! - A `&T` exists only inside a [ReadGuard]'s lifetime or during the exclusive
-//!   RW phases of construction, extraction, and destruction. Otherwise `value`
-//!   is a raw pointer into inaccessible memory and must not be dereferenced.
-//! - Cleanup restores write access, erases every data byte including unused
-//!   bytes and padding, then unmaps while still locked. The data region is
-//!   already writable when [Mapping] takes over cleanup during construction.
-//! - Non-final handle drops may happen while another handle is reading. Final
-//!   release and unique extraction require exclusive ownership, so no reader
-//!   remains. A failed shared extraction returns the handle without entering
-//!   this state machine.
-//! - Before publication, any failure including final sealing returns an error
-//!   if cleanup succeeds. Hardening stages a raw copy while the inline source
-//!   still owns `T`, so an error leaves the source intact and success hands
-//!   ownership to the sealed allocation. After publication, permission
-//!   failures, count overflow, and cleanup failures abort rather than panic:
-//!   a failed mprotect leaves the region's permissions unknown, and continuing
-//!   could expose or corrupt the secret.
 //!
 //! # Fork
 //!
@@ -102,9 +89,6 @@ use std::{io, process, sync::Arc};
 use zeroize::Zeroize;
 
 /// Handle to one shared protected allocation.
-///
-/// [crate::secret] states the public contract. The module documentation covers
-/// the invariants behind it.
 pub(crate) struct HardenedSecret<T> {
     inner: Arc<ProtectedAllocation<T>>,
 }
@@ -196,7 +180,7 @@ fn abort_on_error(result: libc::c_int) {
 ///
 /// Only the data region is locked or changes permissions. The bytes are never
 /// interpreted as `T`. See the module documentation for the layout and the
-/// permission states.
+/// lifecycle.
 struct Mapping {
     /// Start of the entire mapping, including the leading guard.
     base: NonNull<u8>,
@@ -305,7 +289,9 @@ impl Mapping {
     /// Changes the data region's permissions.
     ///
     /// Callers serialize transitions with exclusive ownership or the reader mutex.
-    /// They must not revoke permissions required by an outstanding reference.
+    /// They must not revoke permissions required by an outstanding reference. A
+    /// failed call may have changed part of the region, so callers after
+    /// publication abort rather than continue with unknown permissions.
     fn protect(&self, protection: libc::c_int) -> Result<(), HardenError> {
         // SAFETY: The data pointer and length describe our page-aligned mapping.
         if unsafe { libc::mprotect(self.data.as_ptr().cast(), self.data_len, protection) } != 0 {
@@ -352,8 +338,15 @@ impl Drop for Mapping {
 struct ProtectedAllocation<T> {
     mapping: Mapping,
     /// Aligned location of the initialized value within mapping's data region.
+    ///
+    /// Dereferenced only while a [ReadGuard] is alive or during the exclusive
+    /// RW phases of construction, extraction, and destruction.
     value: NonNull<T>,
     /// Active readers across all handles to this allocation.
+    ///
+    /// The mutex is held across each count update and the permission change it
+    /// triggers, and released before user code runs. A plain atomic would let a
+    /// revoke land after the next reader's grant.
     readers: Mutex<usize>,
 }
 

--- a/cryptography/src/hardened_secret.rs
+++ b/cryptography/src/hardened_secret.rs
@@ -1,28 +1,125 @@
-//! Shared secret storage backed by Linux memory protections.
+//! Linux storage ownership, permissions, and fork invariants.
 //!
-//! [HardenedSecret] keeps a value in a dedicated mapping that is locked against
-//! swapping, excluded from core dumps, and inaccessible between operations.
-//! Clones share the mapping. See the type's documentation for its costs, type
-//! requirements, and behavior across `fork`.
+//! The public contract is in [crate::secret]. This module owns the OS mappings
+//! behind that contract. [HardenedSecret] shares a [ProtectedAllocation] through
+//! `Arc`. Its metadata, including the reader mutex, lives in ordinary memory.
+//! [Mapping] independently owns raw data cleanup, so erasure does not depend on
+//! `T` being initialized or its destructor returning normally.
 //!
-//! This module is available only on Linux with the `std` feature. Construction
-//! requires `MADV_WIPEONFORK`, available since Linux 4.14, and permission to use
-//! all required memory operations. Successful construction establishes every
-//! protection. See [HardenedSecret::try_from_inline] for construction and cleanup failures.
+//! # Layout
+//!
+//! ```text
+//! base             data                                  data + data_len
+//! |                |                                     |
+//! v                v                                     v
+//! +----------------+-----------------------+-------------+----------------+
+//! | leading guard  | unused data bytes     | T           | trailing guard |
+//! +----------------+-----------------------+-------------+----------------+
+//! |<-- one page -->|<---------- whole data pages -------->|<-- one page -->|
+//!
+//! Guards: NONE throughout the mapping's lifetime
+//! Data:   locked, excluded from kernel cores, wiped in fork children
+//! T:      ends at the trailing guard, with its alignment validated
+//!
+//! Separate identity mapping: one readable, unlocked page, also wiped on fork
+//! ```
+//!
+//! `data_len = round_up(max(size_of::<T>(), 1), page_size)`. Checked arithmetic
+//! includes both guards within Rust's `isize::MAX` allocation bound. Page size
+//! must be a power of two, and `T`'s alignment must divide it. Since Rust sizes
+//! are multiples of alignment, placing `T` against the trailing guard aligns it.
+//! A zero-sized value still owns a data page. Its non-null aligned pointer can
+//! coincide with the start of the trailing guard because it occupies no bytes.
+//! Unused data immediately before `T` shares the data permissions, so an underrun
+//! need not reach the leading guard.
+//!
+//! # Permission and ownership states
+//!
+//! ```text
+//! SETUP RW
+//!   establish required protections before sensitive writes
+//!   mark data dirty before moving T or invoking an initializer
+//!   install typed owner as soon as T is valid
+//!   for zeroed byte arrays, install owner before initializer callback
+//!        |
+//!        | protect(NONE), then publish
+//!        v
+//! IDLE NONE, readers = 0
+//!        |
+//!        | first reader: protect(READ), increment count
+//!        v
+//! READABLE READ, readers > 0
+//!        | nested/concurrent readers share the readable interval
+//!        | last reader: decrement to zero, protect(NONE)
+//!        v
+//! IDLE NONE
+//!        |
+//!        | unique extraction or final release
+//!        v
+//! RELEASE RW -> move out or destroy T -> erase data -> UNMAPPED
+//! ```
+//!
+//! `UNMAPPED` is terminal. Non-final handle drops may occur while another handle
+//! is reading. Final release and successful unique extraction require exclusive
+//! ownership, so no reader remains. Shared extraction failure returns its handle
+//! without entering this state machine or reading protected memory.
+//!
+//! Hold the reader mutex across permission changes and count updates. Release it
+//! before calling user code, allowing nested and overlapping access. [ReadGuard]
+//! closes the interval on return or unwind. A plain atomic counter would not
+//! serialize revocation against the next reader's permission grant.
+//!
+//! Permission state records the last fully successful transition, or an unknown
+//! state before a syscall whose failure may leave partial changes. Cleanup must
+//! restore write access after an unknown transition. Already writable data needs
+//! no redundant syscall. `dirty` is independent of initialization validity and
+//! is set before the first sensitive write. Raw cleanup erases all data bytes,
+//! including unused bytes and uninitialized padding, then unmaps while still
+//! locked. It never interprets bytes as `T`.
+//!
+//! Setup, including final sealing, can return an error if cleanup succeeds. The
+//! typed owner is installed before final sealing, so its failure destroys `T`
+//! before raw erasure. A failed seal does not inherently imply abort. Published
+//! access or extraction permission failures, count overflow, and cleanup failures
+//! abort. Abort does not run destructors or guarantee erasure.
+//!
+//! # Fork identity
+//!
+//! ```text
+//! Parent allocation                  Inherited child allocation
+//! +----------------------+           +----------------------+
+//! | initialized T        | --fork--> | wiped data bytes     |
+//! | identity byte = 1    |           | identity byte = 0    |
+//! +----------------------+           +----------------------+
+//! parent remains usable              reject typed access before mutex/ref
+//!                                    reject inherited read-guard return
+//!                                    final release unmaps without T::drop
+//! ```
+//!
+//! Each allocation retains its creator PID and its own [ForkIdentity] mapping.
+//! The readable marker is initialized once and never reset. It rejects inherited
+//! storage even when PID reuse or namespaces produce the same numeric PID. New
+//! allocations created in a child get independent markers. No process-global
+//! sentinel or inherited lock is needed to establish identity.
+//!
+//! Check identity before the reader mutex, typed access, unique extraction, and
+//! typed destruction. Check again when an access guard or initializer returns,
+//! because its callback may have forked. Child final release skips `T::drop` and
+//! erasure of already wiped data, then releases both mappings. Keep the identity
+//! mapping alive until data cleanup has finished. PID collisions in tests are
+//! simulated against real fork-wiped pages, without waiting for kernel PID reuse.
+//!
+//! These checks supplement the caller's fork safety obligations. References
+//! already inside a callback must never be used in the child. Wiped bytes may
+//! not be a valid `T`, and permission changes cannot enforce reference lifetimes.
 
 use crate::secret::{HardenError, InlineSecret};
 use commonware_utils::sync::Mutex;
 use core::{
-    fmt::{Debug, Display, Formatter},
-    marker::PhantomData,
+    fmt::{Debug, Formatter},
     mem::{ManuallyDrop, MaybeUninit, align_of, size_of},
     ptr::{self, NonNull},
 };
-use ctutils::CtEq;
-#[cfg(test)]
-use rand::RngExt as _;
-#[cfg(not(test))]
-use rand::{TryRng as _, rngs::SysRng};
 use std::{
     io, process,
     sync::{
@@ -32,119 +129,31 @@ use std::{
 };
 use zeroize::Zeroize;
 
-/// A shared secret whose backing pages are inaccessible between access calls.
+/// Shares one protected value without reallocating or cloning it.
 ///
-/// The value is stored in a dedicated allocation with these protections:
-///
-/// - [mlock](https://man7.org/linux/man-pages/man2/mlock.2.html) keeps the data
-///   pages resident, preventing them from being swapped out.
-/// - [MADV_DONTDUMP](https://man7.org/linux/man-pages/man2/madvise.2.html)
-///   excludes the data pages from kernel-generated core dumps.
-/// - `mprotect` makes the data pages read-only during [Self::access] and
-///   inaccessible between calls. Construction, extraction, and destruction
-///   have write access.
-/// - Inaccessible guard pages surround the data region. A random canary immediately
-///   before `T` detects writes that change it when the canary is next checked.
-///
-/// `Debug` prints `HardenedSecret([REDACTED])` and `Display` prints `[REDACTED]`.
-/// When `T: CtEq`, equality accesses both values and calls `T`'s constant-time comparison.
-///
-/// # Ownership and cost
-///
-/// Cloning shares the existing allocation without cloning `T`, allocating memory,
-/// or changing permissions. Dropping the last owner calls `T`'s destructor, zeroizes the
-/// entire data region, and releases the mapping. Erasure also runs if that
-/// destructor unwinds. Leaking the last handle prevents this cleanup.
-///
-/// Each allocation locks at least one whole data page, even for a zero-sized
-/// value, and reserves two additional guard pages in the virtual address space.
-/// The value and canary can require multiple data pages. Access calls synchronize
-/// a reader count, with a permission syscall on entry to the first call and exit
-/// from the last. Keep access scopes short, while avoiding repeated calls within
-/// a single operation.
-///
-/// # Requirements and limits
-///
-/// Store sensitive bytes directly in `T`. Memory reached through pointers, such
-/// as a `Vec` or `Box` allocation, receives no protection or erasure from this
-/// wrapper. Operations on `&T` must not write to `T`'s storage, including through
-/// interior mutability, because its pages are read-only. Such writes can terminate
-/// the process. `T`'s destructor must not panic, so failures before transferring
-/// ownership from inline storage can finish erasing the input.
-///
-/// Protection applies to this allocation. Earlier copies, exported values, and
-/// temporary values created by computations remain outside it. During access,
-/// the pages are readable throughout the process, including by other threads.
-/// These protections do not defend against arbitrary code execution, privileged
-/// memory inspection, or hibernation images.
-///
-/// Construction reports errors through [HardenError]. After construction, a
-/// failed permission change or detected canary corruption aborts the process.
-/// Cleanup also aborts if it cannot restore write access or release the mapping.
-/// Aborting does not run destructors or guarantee erasure.
-///
-/// # Forking
-///
-/// `MADV_WIPEONFORK` replaces the child's data pages with zeroes. Inherited
-/// handles cannot access or move out the value: access aborts before touching
-/// the reader mutex or reading `T`. The final release in the child only
-/// unmaps its copy, without calling `T`'s destructor on the wiped bytes. The
-/// parent's allocation is unaffected.
-///
-/// A caller using an unsafe fork API during access must ensure that the child
-/// never uses references into the inherited allocation. Their bytes have been
-/// wiped and may no longer represent a valid `T`. Returning through an inherited
-/// read guard in the child also aborts. These restrictions do not replace
-/// the fork API's own safety requirements.
-///
+/// OS-specific ownership and permission transitions stay behind this wrapper.
+/// See the module documentation for invariants and [crate::secret] for the public
+/// guarantees, type requirements, costs, and operational limits.
 pub(crate) struct HardenedSecret<T> {
     inner: Arc<ProtectedAllocation<T>>,
 }
 
 impl<T> HardenedSecret<T> {
-    /// Consumes `value` and moves it into a new protected allocation.
+    /// Moves the inline value into protected storage, erasing its consumed source.
     ///
-    /// On success, the consumed inline storage is erased after the move. On
-    /// error, the input is dropped and its inline storage erased, subject to the
-    /// type's nonpanicking-destructor requirement. The input is not returned.
-    /// Earlier locations left behind by moving the argument cannot be erased here.
-    /// For byte arrays, [Self::try_init] can initialize the value directly in
-    /// protected memory.
-    ///
-    /// # Errors
-    ///
-    /// Returns [HardenError::Layout] if a suitable mapping cannot be represented,
-    /// including when `T`'s alignment exceeds the system page size. Returns
-    /// [HardenError::System] if mapping, canary generation, or a required memory
-    /// operation fails. Locking is subject to the process's `RLIMIT_MEMLOCK`
-    /// allowance, even when ordinary memory is available.
-    ///
-    /// Allocating the shared ownership metadata uses the ordinary Rust allocator
-    /// and follows its allocation-failure behavior. Cleanup failures abort as
-    /// described in the type's documentation.
+    /// Layout and OS failures consume the input. Setup can fail before transfer,
+    /// or final sealing can fail after the typed owner has taken responsibility
+    /// for destruction. Ordinary `Arc` allocation follows Rust allocator policy.
     pub(crate) fn try_from_inline(value: InlineSecret<T>) -> Result<Self, HardenError> {
         ProtectedAllocation::try_new(value).map(|inner| Self {
             inner: Arc::new(inner),
         })
     }
 
-    /// Passes a shared reference to the stored value to `f` and returns its result.
+    /// Keeps the data readable for `f`, sharing the interval with other readers.
     ///
-    /// The first active call makes the data pages read-only. Nested and concurrent
-    /// calls, including through other clones, keep them readable until the last
-    /// call ends. Returning from this call does not revoke access while another
-    /// call remains active. The reader mutex is not held while `f` runs.
-    ///
-    /// Borrows into the stored value cannot escape the closure. Copied values,
-    /// raw pointers, and references already stored inside `T` can escape and
-    /// receive no additional protection. Operations on `&T` must not modify its
-    /// storage, even through interior mutability.
-    ///
-    /// # Panics
-    ///
-    /// A panic from `f` propagates. During unwinding, access is revoked if no
-    /// other call remains active. Failed permission changes or detected canary
-    /// corruption abort the process.
+    /// The callback runs without the reader mutex held. Unwinding releases its
+    /// reader slot. Published permission failures and inherited use abort.
     pub(crate) fn access<R>(&self, f: impl for<'a> FnOnce(&'a T) -> R) -> R {
         self.inner.access(f)
     }
@@ -163,24 +172,10 @@ impl<T> HardenedSecret<T> {
 }
 
 impl<const N: usize> HardenedSecret<[u8; N]> {
-    /// Initializes a byte array directly in a new protected allocation.
+    /// Initializes zeroed bytes after protection setup, before publication.
     ///
-    /// Calls `f` with a zeroed array after locking the data pages and excluding
-    /// them from core dumps. The array is writable during initialization and
-    /// inaccessible when construction completes. Any bytes left untouched by `f`
-    /// remain zero. The closure's own temporaries are outside the allocation.
-    ///
-    /// # Errors
-    ///
-    /// Returns the same construction errors as [Self::try_from_inline]. The initializer
-    /// is not called if allocation or initial protection setup fails. If a later
-    /// step fails, the initialized array is erased before returning the error.
-    ///
-    /// # Panics
-    ///
-    /// A panic from `f` propagates. During unwinding, the allocation is erased
-    /// and released. Cleanup failures abort as described in the type's documentation.
-    ///
+    /// The typed owner exists before user code can unwind or final sealing can
+    /// fail. Both paths erase the data and release the mappings if cleanup succeeds.
     pub(crate) fn try_init(f: impl FnOnce(&mut [u8; N])) -> Result<Self, HardenError> {
         ProtectedAllocation::try_init(f).map(|inner| Self {
             inner: Arc::new(inner),
@@ -202,22 +197,6 @@ impl<T> Debug for HardenedSecret<T> {
     }
 }
 
-impl<T> Display for HardenedSecret<T> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
-        f.write_str("[REDACTED]")
-    }
-}
-
-impl<T: CtEq> PartialEq for HardenedSecret<T> {
-    fn eq(&self, other: &Self) -> bool {
-        self.access(|a| other.access(|b| a.ct_eq(b).into()))
-    }
-}
-
-impl<T: CtEq> Eq for HardenedSecret<T> {}
-
-const CANARY_SIZE: usize = 16;
-
 /// Captures errno immediately after a failed memory operation.
 fn system(operation: &'static str) -> HardenError {
     HardenError::System {
@@ -233,37 +212,75 @@ fn abort_on_error(result: libc::c_int) {
     }
 }
 
-/// Generates the pattern placed immediately before the value to detect corruption.
-fn random_canary() -> Result<[u8; CANARY_SIZE], HardenError> {
-    let mut canary = [0; CANARY_SIZE];
-    #[cfg(test)]
-    {
-        commonware_utils::test_rng().fill(&mut canary);
-    }
-    #[cfg(not(test))]
-    SysRng
-        .try_fill_bytes(&mut canary)
-        .map_err(|error| HardenError::System {
-            operation: "getrandom",
-            source: error.into(),
-        })?;
-    Ok(canary)
+/// Owns a readable marker that distinguishes this allocation from fork copies.
+///
+/// The creator writes one once. WIPEONFORK supplies zero in every descendant,
+/// including when its numeric PID matches the creator's. An inherited marker is
+/// never reset. A child can create new allocations with independent markers.
+/// This page contains no secret and is not locked against swapping.
+struct ForkIdentity {
+    address: NonNull<u8>,
+    page: usize,
 }
 
-/// Owns the raw mapping and erases it independently of `T`'s initialization or drop.
+impl ForkIdentity {
+    /// Creates a read-only marker before the secret allocation is initialized.
+    fn new(page: usize) -> Result<Self, HardenError> {
+        // SAFETY: A null hint requests a fresh private mapping of one valid page.
+        let address = unsafe {
+            libc::mmap(
+                ptr::null_mut(),
+                page,
+                libc::PROT_READ | libc::PROT_WRITE,
+                libc::MAP_PRIVATE | libc::MAP_ANONYMOUS,
+                -1,
+                0,
+            )
+        };
+        if address == libc::MAP_FAILED {
+            return Err(system("mmap"));
+        }
+        let Some(address) = NonNull::new(address.cast::<u8>()) else {
+            // SAFETY: Release the mapping that cannot form a non-null Rust pointer.
+            unsafe { abort_on_error(libc::munmap(address, page)) };
+            return Err(HardenError::Layout);
+        };
+        let identity = Self { address, page };
+        // SAFETY: The marker is a page-aligned private anonymous mapping we own.
+        if unsafe { libc::madvise(address.as_ptr().cast(), page, libc::MADV_WIPEONFORK) } != 0 {
+            return Err(system("madvise(MADV_WIPEONFORK)"));
+        }
+        // SAFETY: Construction exclusively owns this writable marker page.
+        unsafe { address.as_ptr().write(1) };
+        // SAFETY: No writable references remain. Identity checks only read the marker.
+        if unsafe { libc::mprotect(address.as_ptr().cast(), page, libc::PROT_READ) } != 0 {
+            return Err(system("mprotect"));
+        }
+        Ok(identity)
+    }
+
+    /// Checks the marker before any inherited mutex or typed value can be used.
+    fn is_original(&self) -> bool {
+        // SAFETY: The mapping remains readable for this owner's lifetime. A fork
+        // child gets initialized zero bytes. Volatile prevents reusing a read
+        // made before a fork that occurs in a caller's access callback.
+        unsafe { self.address.as_ptr().read_volatile() == 1 }
+    }
+}
+
+impl Drop for ForkIdentity {
+    fn drop(&mut self) {
+        // SAFETY: This owner releases only its own private mapping, including in
+        // a child. The marker remains live until the secret mapping is released.
+        unsafe { abort_on_error(libc::munmap(self.address.as_ptr().cast(), self.page)) };
+    }
+}
+
+/// Owns raw pages independently of the initialization and destruction of `T`.
 ///
-/// The data region is rounded up to whole pages. Its layout places `T` against
-/// the trailing guard, with the canary immediately before it:
-///
-/// ```text
-/// | guard page | unused bytes | canary | T | guard page |
-///              <------- data_len -------->
-/// <-------------------- total_len -------------------->
-/// ```
-///
-/// Guards always remain inaccessible. Only the data region is locked or has its
-/// permissions changed. This owner never interprets those bytes as `T`, so it
-/// can clean up both partially constructed allocations and destroyed values.
+/// Only the data region is locked or changes permissions. This owner never
+/// interprets its bytes as `T`, allowing cleanup after partial construction,
+/// extraction, or a panicking destructor. See the module layout and state diagram.
 struct Mapping {
     /// Start of the entire mapping, including the leading guard.
     base: NonNull<u8>,
@@ -271,10 +288,12 @@ struct Mapping {
     total_len: usize,
     /// First byte after the leading guard.
     data: NonNull<u8>,
-    /// Page-rounded length of the data region, including unused bytes and canary.
+    /// Page-rounded length of the data region, including unused bytes.
     data_len: usize,
     /// Process that created the mapping, used to reject inherited handles.
     pid: libc::pid_t,
+    /// Allocation-specific identity, independent of numeric PID reuse or namespaces.
+    identity: ForkIdentity,
     // Last permissions successfully applied to the whole data region, or -1 if
     // uncertain. The reader mutex or exclusive ownership serializes changes, so
     // relaxed atomic access suffices for updates through shared references.
@@ -288,8 +307,7 @@ impl Mapping {
     /// Reserves the guarded layout and returns a pointer to storage for `T`.
     ///
     /// On success, the data region is zeroed, writable, locked, excluded from
-    /// dumps, and wiped in fork children. The caller has not yet written `T` or
-    /// the expected canary into it.
+    /// dumps, and wiped in fork children. The caller has not yet written `T`.
     fn allocate<T>() -> Result<(Self, NonNull<T>), HardenError> {
         // SAFETY: sysconf has no pointer arguments or memory preconditions.
         let page = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
@@ -300,10 +318,10 @@ impl Mapping {
         if align_of::<T>() > page {
             return Err(HardenError::Layout);
         }
-        // Reserve the canary even for zero-sized values, then round to pages.
+        // Keep a data page even for zero-sized values, then round up to pages.
         let data_len = size_of::<T>()
-            .checked_add(CANARY_SIZE)
-            .and_then(|size| size.checked_add(page - 1))
+            .max(1)
+            .checked_add(page - 1)
             .map(|size| size & !(page - 1))
             .ok_or(HardenError::Layout)?;
         // Include both guards in Rust's maximum pointer-offset bound.
@@ -312,6 +330,7 @@ impl Mapping {
             .and_then(|guards| data_len.checked_add(guards))
             .filter(|size| *size <= isize::MAX as usize)
             .ok_or(HardenError::Layout)?;
+        let identity = ForkIdentity::new(page)?;
         // SAFETY: A null hint requests a new mapping. Length is checked above.
         let base = unsafe {
             libc::mmap(
@@ -341,6 +360,7 @@ impl Mapping {
             data_len,
             // SAFETY: getpid has no preconditions.
             pid: unsafe { libc::getpid() },
+            identity,
             protection: AtomicI32::new(libc::PROT_NONE),
             dirty: false,
         };
@@ -363,7 +383,7 @@ impl Mapping {
         // The size of T is a multiple of its alignment, which divides the page
         // size. Placing its end at the trailing guard therefore aligns its start
         // and leaves no gap between T and the guard.
-        // SAFETY: data_len includes the value and canary, and alignment was checked.
+        // SAFETY: data_len covers T, and alignment was checked, including for a ZST.
         let value =
             unsafe { NonNull::new_unchecked(data.as_ptr().add(data_len - size_of::<T>()).cast()) };
         Ok((mapping, value))
@@ -399,7 +419,7 @@ impl Mapping {
     /// Checks whether this is the original mapping or a wiped fork-child copy.
     fn in_creator(&self) -> bool {
         // SAFETY: getpid has no preconditions.
-        self.pid == unsafe { libc::getpid() }
+        self.pid == unsafe { libc::getpid() } && self.identity.is_original()
     }
 
     /// Rejects child-side access before touching inherited state or wiped bytes.
@@ -442,12 +462,8 @@ struct ProtectedAllocation<T> {
     mapping: Mapping,
     /// Aligned location of the initialized value within mapping's data region.
     value: NonNull<T>,
-    /// Expected canary, kept outside the protected data region for comparison.
-    canary: [u8; CANARY_SIZE],
     /// Active readers across all handles to this allocation.
     readers: Mutex<usize>,
-    /// Records ownership of T for drop checking, including any borrowed lifetimes.
-    marker: PhantomData<T>,
 }
 
 // SAFETY: T can be moved to another thread. The mapping has one owner, shared
@@ -458,26 +474,11 @@ unsafe impl<T: Send> Send for ProtectedAllocation<T> {}
 unsafe impl<T: Sync> Sync for ProtectedAllocation<T> {}
 
 impl<T> ProtectedAllocation<T> {
-    /// Allocates writable storage and initializes its canary, leaving `T` uninitialized.
-    ///
-    /// Mapping alone owns cleanup until the caller initializes `T` and constructs
-    /// a ProtectedAllocation. Any early return therefore erases raw bytes only.
-    fn allocate() -> Result<(Mapping, NonNull<T>, [u8; CANARY_SIZE]), HardenError> {
-        let canary = random_canary()?;
-        let (mut mapping, value) = Mapping::allocate::<T>()?;
-        mapping.dirty = true;
-        // SAFETY: Construction owns the writable mapping, and the checked layout
-        // reserves CANARY_SIZE bytes immediately before the aligned value.
-        unsafe {
-            let canary_ptr = value.as_ptr().cast::<u8>().sub(CANARY_SIZE);
-            ptr::copy_nonoverlapping(canary.as_ptr(), canary_ptr, CANARY_SIZE);
-        }
-        Ok((mapping, value, canary))
-    }
-
     /// Transfers the inline value after setup succeeds, then revokes access.
     fn try_new(value: InlineSecret<T>) -> Result<Self, HardenError> {
-        let (mapping, destination, canary) = Self::allocate()?;
+        let (mut mapping, destination) = Mapping::allocate::<T>()?;
+        // Cleanup must erase even if a later permission change fails.
+        mapping.dirty = true;
         // SAFETY: The mapping is writable, aligned for T, and disjoint from the
         // source. Ownership transfers into its previously uninitialized storage.
         unsafe {
@@ -487,28 +488,10 @@ impl<T> ProtectedAllocation<T> {
         let allocation = Self {
             mapping,
             value: destination,
-            canary,
             readers: Mutex::new(0),
-            marker: PhantomData,
         };
         allocation.mapping.protect(libc::PROT_NONE)?;
         Ok(allocation)
-    }
-
-    /// Locates the canary without accessing the potentially inaccessible mapping.
-    const fn canary_ptr(&self) -> *mut u8 {
-        // SAFETY: Layout reserves CANARY_SIZE bytes before the value.
-        unsafe { self.value.as_ptr().cast::<u8>().sub(CANARY_SIZE) }
-    }
-
-    /// Aborts on corruption. Callers must first make the data region readable.
-    fn check_canary(&self) {
-        // SAFETY: Called only while the data region is readable. The canary is
-        // initialized before publication and has exactly CANARY_SIZE bytes.
-        let actual = unsafe { core::slice::from_raw_parts(self.canary_ptr(), CANARY_SIZE) };
-        if actual != self.canary {
-            process::abort();
-        }
     }
 
     /// Holds one reader slot across the callback, including panic unwinding.
@@ -519,11 +502,8 @@ impl<T> ProtectedAllocation<T> {
         // Release the mutex before user code so nested calls cannot deadlock.
         {
             let mut readers = self.readers.lock();
-            if *readers == 0 {
-                if self.mapping.protect(libc::PROT_READ).is_err() {
-                    process::abort();
-                }
-                self.check_canary();
+            if *readers == 0 && self.mapping.protect(libc::PROT_READ).is_err() {
+                process::abort();
             }
             // Wrapping to zero would allow revoking access while readers exist.
             *readers = readers.checked_add(1).unwrap_or_else(|| process::abort());
@@ -538,8 +518,8 @@ impl<T> ProtectedAllocation<T> {
     fn extract(self) -> T {
         self.mapping.require_creator();
         self.mapping.make_writable();
-        self.check_canary();
-        let mut allocation = ManuallyDrop::new(self);
+        let mut owner = ManuallyDrop::new(self);
+        let allocation = &mut *owner;
         // SAFETY: Exclusive ownership rules out active readers. The value is
         // initialized and readable. ManuallyDrop prevents destroying the moved-out T.
         // Explicitly drop both owning fields to erase and release the source and
@@ -556,19 +536,20 @@ impl<T> ProtectedAllocation<T> {
 impl<const N: usize> ProtectedAllocation<[u8; N]> {
     /// Creates an owner for the zeroed array before running the initializer.
     fn try_init(f: impl FnOnce(&mut [u8; N])) -> Result<Self, HardenError> {
-        let (mapping, value, canary) = Self::allocate()?;
+        let (mut mapping, value) = Mapping::allocate::<[u8; N]>()?;
+        mapping.dirty = true;
         // Anonymous mappings are zeroed, so the array is already a valid value.
         // Its owner must exist before the initializer can unwind.
         let mut allocation = Self {
             mapping,
             value,
-            canary,
             readers: Mutex::new(0),
-            marker: PhantomData,
         };
         // SAFETY: Construction exclusively owns the writable, zeroed byte array.
         f(unsafe { allocation.value.as_mut() });
-        allocation.check_canary();
+        // The initializer may have forked. Reject its return in the child before
+        // publishing a handle whose array has been wiped.
+        allocation.mapping.require_creator();
         allocation.mapping.protect(libc::PROT_NONE)?;
         Ok(allocation)
     }
@@ -582,7 +563,6 @@ impl<T> Drop for ProtectedAllocation<T> {
             return;
         }
         self.mapping.make_writable();
-        self.check_canary();
         // SAFETY: The last owner has exclusive access, permissions allow
         // destruction, and this owner is only constructed after initializing T.
         unsafe { ptr::drop_in_place(self.value.as_ptr()) };
@@ -599,23 +579,20 @@ impl<T> Drop for ReadGuard<'_, T> {
         self.0.mapping.require_creator();
         let mut readers = self.0.readers.lock();
         *readers -= 1;
-        if *readers == 0 {
-            self.0.check_canary();
-            if self.0.mapping.protect(libc::PROT_NONE).is_err() {
-                process::abort();
-            }
+        if *readers == 0 && self.0.mapping.protect(libc::PROT_NONE).is_err() {
+            process::abort();
         }
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(miri)))]
 mod tests {
     use super::*;
     use crate::secret::Secret;
     use std::{
         os::unix::process::ExitStatusExt,
         panic::{AssertUnwindSafe, catch_unwind},
-        process::Command,
+        process::{Command, Output},
         sync::{
             Arc, Barrier,
             atomic::{AtomicUsize, Ordering},
@@ -626,7 +603,7 @@ mod tests {
     const CHILD_ENV: &str = "COMMONWARE_HARDENED_SECRET_TEST";
 
     /// Runs deliberate memory faults in a subprocess so the test runner survives.
-    fn child(case: &str, signal: Option<i32>) {
+    fn child(case: &str, signal: Option<i32>) -> Output {
         let output = Command::new(std::env::current_exe().unwrap())
             .args([
                 "--exact",
@@ -640,6 +617,7 @@ mod tests {
         if signal.is_none() {
             assert!(output.status.success(), "{output:?}");
         }
+        output
     }
 
     #[test]
@@ -648,10 +626,11 @@ mod tests {
         child("readonly", Some(libc::SIGSEGV));
         child("leading_guard", Some(libc::SIGSEGV));
         child("trailing_guard", Some(libc::SIGSEGV));
-        child("canary", Some(libc::SIGABRT));
-        child("extract_canary", Some(libc::SIGABRT));
         child("enter_failure", Some(libc::SIGABRT));
         child("exit_failure", Some(libc::SIGABRT));
+        child("cleanup_failure", Some(libc::SIGABRT));
+        child("final_seal_failure", None);
+        child("post_move_failure", None);
     }
 
     #[test]
@@ -660,10 +639,31 @@ mod tests {
     }
 
     #[test]
+    fn public_access_unwind() {
+        for case in ["borrowed_panic_protection", "owned_panic_protection"] {
+            let output = child(case, Some(libc::SIGSEGV));
+            // A fault during recovery must not pass as the deliberate sealed-page probe.
+            assert!(String::from_utf8_lossy(&output.stderr).contains("access recovered"));
+        }
+    }
+
+    #[test]
     fn fork_wipes_and_rejects_inherited_handles() {
         child("fork_drop", None);
         child("fork_access", None);
         child("fork_extract", None);
+        child("fork_init", None);
+        child("fork_guard", None);
+        child("fork_collision_access", None);
+        child("fork_collision_locked", None);
+        child("fork_collision_extract", None);
+        child("fork_collision_drop", None);
+        child("fork_new_allocation", None);
+    }
+
+    #[test]
+    fn fork_identity_survives_pid_collision() {
+        child("fork_pid_collision", None);
     }
 
     #[test]
@@ -671,7 +671,23 @@ mod tests {
         let secret = HardenedSecret::try_from_inline(InlineSecret::new([42u8; 32])).unwrap();
         let cloned = secret.clone();
         assert!(Arc::ptr_eq(&secret.inner, &cloned.inner));
-        secret.access(|value| cloned.access(|other| assert_eq!(value, other)));
+        secret.access(|value| {
+            assert!(
+                catch_unwind(AssertUnwindSafe(|| {
+                    cloned.access(|other| {
+                        assert_eq!(value, other);
+                        panic!("nested access panic");
+                    });
+                }))
+                .is_err()
+            );
+            assert_eq!(*secret.inner.readers.lock(), 1);
+            assert_eq!(
+                secret.inner.mapping.protection.load(Ordering::Relaxed),
+                libc::PROT_READ
+            );
+            assert_eq!(value, &[42; 32]);
+        });
         let barrier = Arc::new(Barrier::new(5));
         thread::scope(|scope| {
             for _ in 0..4 {
@@ -691,26 +707,104 @@ mod tests {
             barrier.wait();
         });
         assert_eq!(*secret.inner.readers.lock(), 0);
+        assert_eq!(
+            secret.inner.mapping.protection.load(Ordering::Relaxed),
+            libc::PROT_NONE
+        );
         child("panic_protection", Some(libc::SIGSEGV));
     }
 
     #[test]
     fn initialize_and_layout() {
-        let secret = Secret::<[u8; 8193]>::try_init(|value| value.fill(37)).unwrap();
-        assert!(secret.is_hardened());
-        secret.access(|value| assert_eq!(value, &[37; 8193]));
-        let empty = HardenedSecret::try_from_inline(InlineSecret::new([0u8; 0])).unwrap();
-        empty.access(|value| assert!(value.is_empty()));
-        assert_eq!(empty.try_extract().unwrap(), []);
-        let panic = catch_unwind(|| {
-            let _ = Secret::<[u8; 32]>::try_init(|value| {
-                value.fill(99);
-                panic!("initializer panic");
-            });
-        });
-        assert!(panic.is_err());
-        let usable = HardenedSecret::try_from_inline(InlineSecret::new([1; 32])).unwrap();
-        usable.access(|value| assert_eq!(value[0], 1));
+        check_layout::<0>(1);
+        // Const array lengths and repr(align) require compile-time page sizes.
+        // Dispatch on the actual page size rather than assuming 4 KiB pages.
+        macro_rules! page_cases {
+            ($page:literal, $over:literal) => {{
+                check_layout::<$page>(1);
+                check_layout::<{ $page + 1 }>(2);
+                #[repr(align($page))]
+                struct Aligned([u8; 1]);
+                let value =
+                    HardenedSecret::try_from_inline(InlineSecret::new(Aligned([73]))).unwrap();
+                assert_eq!(value.inner.value.as_ptr().addr() % $page, 0);
+                assert_eq!(value.inner.mapping.data_len, $page);
+                value.access(|value| assert_eq!(value.0, [73]));
+                drop(value);
+                #[repr(align($over))]
+                struct OverAligned;
+                assert!(matches!(
+                    HardenedSecret::try_from_inline(InlineSecret::new(OverAligned)),
+                    Err(HardenError::Layout)
+                ));
+            }};
+        }
+        match page_size() {
+            4096 => page_cases!(4096, 8192),
+            8192 => page_cases!(8192, 16384),
+            16384 => page_cases!(16384, 32768),
+            65536 => page_cases!(65536, 131072),
+            page => panic!("add layout test fixtures for {page}-byte pages"),
+        }
+    }
+
+    /// Checks both ends of the allocation and initializes every value byte.
+    fn check_layout<const N: usize>(pages: usize) {
+        let secret = HardenedSecret::<[u8; N]>::try_init(|value| {
+            assert_eq!(value, &[0; N]);
+            value.fill(37);
+        })
+        .unwrap();
+        let mapping = &secret.inner.mapping;
+        let page = page_size();
+        assert_eq!(mapping.data_len, pages * page);
+        assert_eq!(mapping.total_len, (pages + 2) * page);
+        assert_eq!(
+            mapping.data.as_ptr().addr(),
+            mapping.base.as_ptr().addr() + page
+        );
+        assert_eq!(
+            secret.inner.value.as_ptr().addr() + N,
+            mapping.data.as_ptr().addr() + mapping.data_len
+        );
+        secret.access(|value| assert_eq!(value, &[37; N]));
+        let data = mapping.data.as_ptr();
+        let marker = mapping.identity.address.as_ptr();
+        assert_eq!(secret.try_extract().unwrap(), [37; N]);
+        assert_unmapped(data);
+        assert_unmapped(marker);
+    }
+
+    #[test]
+    fn unwind_releases_mapping() {
+        let mut address = ptr::null_mut();
+        assert!(
+            catch_unwind(AssertUnwindSafe(|| {
+                let _ = Secret::<[u8; 32]>::try_init(|value| {
+                    value.fill(99);
+                    address = value.as_mut_ptr();
+                    panic!("initializer panic");
+                });
+            }))
+            .is_err()
+        );
+        assert!(!address.is_null());
+        assert_unmapped(address);
+
+        struct PanicOnDrop([u8; 32]);
+        impl Drop for PanicOnDrop {
+            fn drop(&mut self) {
+                assert_eq!(self.0, [99; 32]);
+                panic!("destructor panic");
+            }
+        }
+        let secret =
+            HardenedSecret::try_from_inline(InlineSecret::new(PanicOnDrop([99; 32]))).unwrap();
+        let data = secret.inner.mapping.data.as_ptr();
+        let marker = secret.inner.mapping.identity.address.as_ptr();
+        assert!(catch_unwind(AssertUnwindSafe(|| drop(secret))).is_err());
+        assert_unmapped(data);
+        assert_unmapped(marker);
     }
 
     #[test]
@@ -719,7 +813,9 @@ mod tests {
         assert!(!secret.is_hardened());
         let secret = secret.try_harden().unwrap();
         assert!(secret.is_hardened());
+        let address = secret.access(|value| value as *const _);
         let secret = secret.try_harden().unwrap();
+        secret.access(|value| assert_eq!(value as *const _, address));
         assert_eq!(format!("{secret:?}"), "Secret([REDACTED])");
         let cloned = secret.clone();
         assert!(cloned.is_hardened());
@@ -727,25 +823,58 @@ mod tests {
         assert_eq!(cloned.extract_or_clone(), [42u8; 32]);
         assert!(secret.is_hardened());
         assert_eq!(format!("{secret}"), "[REDACTED]");
+        child("no_permission_changes", None);
     }
 
-    static DROPS: AtomicUsize = AtomicUsize::new(0);
-    struct Tracked([u8; 32]);
-    impl Drop for Tracked {
+    /// A non-Clone inline value with a borrowed, nonsecret destruction counter.
+    struct Tracked<'a> {
+        bytes: [u8; 32],
+        drops: &'a AtomicUsize,
+    }
+
+    impl Drop for Tracked<'_> {
         fn drop(&mut self) {
-            DROPS.fetch_add(1, Ordering::SeqCst);
+            self.drops.fetch_add(1, Ordering::Relaxed);
         }
     }
 
     #[test]
     fn last_owner_destroys_value() {
-        let secret = HardenedSecret::try_from_inline(InlineSecret::new(Tracked([42; 32]))).unwrap();
+        let drops = AtomicUsize::new(0);
+        let secret = HardenedSecret::try_from_inline(InlineSecret::new(Tracked {
+            bytes: [42; 32],
+            drops: &drops,
+        }))
+        .unwrap();
+        let data = secret.inner.mapping.data.as_ptr();
+        let marker = secret.inner.mapping.identity.address.as_ptr();
         let clone = secret.clone();
-        secret.access(|value| assert_eq!(value.0, [42; 32]));
+        secret.access(|value| assert_eq!(value.bytes, [42; 32]));
         drop(secret);
-        assert_eq!(DROPS.load(Ordering::SeqCst), 0);
+        assert_eq!(drops.load(Ordering::Relaxed), 0);
         drop(clone);
-        assert_eq!(DROPS.load(Ordering::SeqCst), 1);
+        assert_eq!(drops.load(Ordering::Relaxed), 1);
+        assert_unmapped(data);
+        assert_unmapped(marker);
+    }
+
+    #[test]
+    fn unique_extraction_moves_nonclone_value() {
+        let drops = AtomicUsize::new(0);
+        let secret = HardenedSecret::try_from_inline(InlineSecret::new(Tracked {
+            bytes: [42; 32],
+            drops: &drops,
+        }))
+        .unwrap();
+        let data = secret.inner.mapping.data.as_ptr();
+        let marker = secret.inner.mapping.identity.address.as_ptr();
+        let value = secret.try_extract().unwrap();
+        assert_unmapped(data);
+        assert_unmapped(marker);
+        assert_eq!(value.bytes, [42; 32]);
+        assert_eq!(drops.load(Ordering::Relaxed), 0);
+        drop(value);
+        assert_eq!(drops.load(Ordering::Relaxed), 1);
     }
 
     #[test]
@@ -763,6 +892,7 @@ mod tests {
             assert_eq!(libc::setrlimit(libc::RLIMIT_CORE, &limit), 0);
         }
         if case == "locked_memory_limit" {
+            drop_ipc_lock_capability();
             // SAFETY: This subprocess lowers only its own locked-memory allowance.
             unsafe {
                 let limit = libc::rlimit {
@@ -779,6 +909,171 @@ mod tests {
                 })
             ));
             return;
+        }
+        if case == "fork_pid_collision" {
+            let mut allocation =
+                ProtectedAllocation::try_new(InlineSecret::new([42u8; 32])).unwrap();
+            // SAFETY: The child only checks mapping identity and exits. It never
+            // interprets the wiped allocation as T or enters inherited locks.
+            let pid = unsafe { libc::fork() };
+            assert!(pid >= 0);
+            if pid == 0 {
+                // Simulate a reused or namespace-relative PID with real fork-wiped
+                // pages. Waiting for actual numeric PID reuse would be unreliable.
+                // SAFETY: getpid and _exit have no memory preconditions.
+                unsafe {
+                    allocation.mapping.pid = libc::getpid();
+                    libc::_exit(if allocation.mapping.in_creator() {
+                        1
+                    } else {
+                        0
+                    });
+                }
+            }
+            let mut status = 0;
+            // SAFETY: pid names our child and status is writable.
+            assert_eq!(unsafe { libc::waitpid(pid, &mut status, 0) }, pid);
+            assert!(libc::WIFEXITED(status));
+            assert_eq!(libc::WEXITSTATUS(status), 0);
+            allocation.access(|value| assert_eq!(value, &[42; 32]));
+            return;
+        }
+        match case.as_str() {
+            "exit_failure" => {
+                exit_failure();
+                panic!("revocation did not abort");
+            }
+            "final_seal_failure" | "cleanup_failure" => {
+                let mut address = ptr::null_mut();
+                let result = Secret::<[u8; 32]>::try_init(|bytes| {
+                    bytes.fill(71);
+                    address = bytes.as_mut_ptr();
+                    if case == "cleanup_failure" {
+                        deny_mprotect(&[libc::PROT_NONE, libc::PROT_READ | libc::PROT_WRITE]);
+                    } else {
+                        deny_mprotect(&[libc::PROT_NONE]);
+                    }
+                });
+                assert!(matches!(
+                    result,
+                    Err(HardenError::System {
+                        operation: "mprotect",
+                        ..
+                    })
+                ));
+                assert_unmapped(address);
+                return;
+            }
+            "post_move_failure" => {
+                let drops = AtomicUsize::new(0);
+                let address = AtomicUsize::new(0);
+                struct Value<'a> {
+                    drops: &'a AtomicUsize,
+                    address: &'a AtomicUsize,
+                }
+                impl Drop for Value<'_> {
+                    fn drop(&mut self) {
+                        self.address
+                            .store(self as *const Self as usize, Ordering::Relaxed);
+                        self.drops.fetch_add(1, Ordering::Relaxed);
+                    }
+                }
+                deny_mprotect(&[libc::PROT_NONE]);
+                let result = HardenedSecret::try_from_inline(InlineSecret::new(Value {
+                    drops: &drops,
+                    address: &address,
+                }));
+                assert!(matches!(
+                    result,
+                    Err(HardenError::System {
+                        operation: "mprotect",
+                        ..
+                    })
+                ));
+                assert_eq!(drops.load(Ordering::Relaxed), 1);
+                assert_unmapped(address.load(Ordering::Relaxed) as *mut u8);
+                return;
+            }
+            "no_permission_changes" => {
+                let public = Secret::new([42u8; 32]).try_harden().unwrap();
+                let shared =
+                    HardenedSecret::try_from_inline(InlineSecret::new([73u8; 32])).unwrap();
+                let clone = shared.clone();
+                deny_mprotect(&[
+                    libc::PROT_NONE,
+                    libc::PROT_READ,
+                    libc::PROT_READ | libc::PROT_WRITE,
+                ]);
+                let public = public.try_harden().unwrap();
+                assert!(public.is_hardened());
+                let returned = shared.try_extract().unwrap_err();
+                assert!(Arc::ptr_eq(&returned.inner, &clone.inner));
+                assert_eq!(*returned.inner.readers.lock(), 0);
+                assert_eq!(
+                    returned.inner.mapping.protection.load(Ordering::Relaxed),
+                    libc::PROT_NONE
+                );
+                drop(returned);
+                // SAFETY: Leave the disposable subprocess without destructors.
+                // Final release would require the deliberately forbidden write transition.
+                unsafe { libc::_exit(0) };
+            }
+            "borrowed_panic_protection" | "owned_panic_protection" => {
+                let secret = Secret::new([42u8; 32]).try_harden().unwrap();
+                let address = secret.access(|value| value as *const [u8; 32]);
+                if case == "borrowed_panic_protection" {
+                    assert!(catch_unwind(|| secret.access(|_| panic!("borrowed panic"))).is_err());
+                } else {
+                    let cloned = secret.clone();
+                    assert!(
+                        catch_unwind(move || cloned.access(|_| panic!("owned panic"))).is_err()
+                    );
+                }
+                // The surviving owner remains usable after either kind of unwind.
+                secret.access(|value| assert_eq!(value, &[42; 32]));
+                eprintln!("access recovered");
+                // SAFETY: Deliberately probe the still-owned mapping after the last
+                // reader exits. This subprocess must fault on its sealed data page.
+                unsafe { std::hint::black_box(address.read_volatile()) };
+                return;
+            }
+            "fork_init" => {
+                let mut pid = -1;
+                let secret = Secret::<[u8; 32]>::try_init(|bytes| {
+                    bytes.fill(42);
+                    // SAFETY: Neither branch uses the array after fork. The child
+                    // returns only to the constructor's explicit rejection check.
+                    pid = unsafe { libc::fork() };
+                    assert!(pid >= 0);
+                })
+                .unwrap();
+                wait_for_child(pid, Some(libc::SIGABRT));
+                secret.access(|value| assert_eq!(value, &[42; 32]));
+                return;
+            }
+            "fork_guard" => {
+                let secret =
+                    HardenedSecret::try_from_inline(InlineSecret::new([42u8; 32])).unwrap();
+                let mut pid = -1;
+                secret.access(|_| {
+                    // SAFETY: The child returns directly to inherited-guard rejection
+                    // without using a reference to the fork-wiped value.
+                    pid = unsafe { libc::fork() };
+                    assert!(pid >= 0);
+                });
+                wait_for_child(pid, Some(libc::SIGABRT));
+                secret.access(|value| assert_eq!(value, &[42; 32]));
+                return;
+            }
+            "fork_collision_access"
+            | "fork_collision_locked"
+            | "fork_collision_extract"
+            | "fork_collision_drop"
+            | "fork_new_allocation" => {
+                fork_collision(&case);
+                return;
+            }
+            _ => {}
         }
         let secret = HardenedSecret::try_from_inline(InlineSecret::new([42u8; 32])).unwrap();
         match case.as_str() {
@@ -823,24 +1118,6 @@ mod tests {
                     );
                 }
             }),
-            "canary" | "extract_canary" => {
-                secret
-                    .inner
-                    .mapping
-                    .protect(libc::PROT_READ | libc::PROT_WRITE)
-                    .unwrap();
-                // SAFETY: The test owns the writable canary and deliberately corrupts it.
-                unsafe {
-                    let canary = secret.inner.canary_ptr();
-                    canary.write(canary.read() ^ 1);
-                }
-                secret.inner.mapping.protect(libc::PROT_NONE).unwrap();
-                if case == "extract_canary" {
-                    let _ = secret.try_extract();
-                } else {
-                    secret.access(|_| ());
-                }
-            }
             "enter_failure" => {
                 // SAFETY: Remove our mapping to force mprotect failure. The next
                 // operation must abort without dereferencing the stale pointer.
@@ -855,7 +1132,6 @@ mod tests {
                 }
                 secret.access(|_| ());
             }
-            "exit_failure" => exit_failure(),
             "fork_drop" | "fork_access" | "fork_extract" => {
                 // SAFETY: The child only invokes the hardened handle's explicit
                 // child rejection/drop path, raw mapping syscalls, and _exit.
@@ -908,29 +1184,220 @@ mod tests {
         panic!("expected subprocess fault: {case}");
     }
 
-    /// Forces revocation to fail after a readable access scope has already started.
+    /// Forces revocation failure without assuming a particular page size.
     fn exit_failure() {
-        let secret = HardenedSecret::try_from_inline(InlineSecret::new([42u8; 131073])).unwrap();
+        // A ZST still owns one data page. Its reference occupies no bytes, so
+        // removing that page leaves no live reference into unmapped data.
+        let secret = HardenedSecret::try_from_inline(InlineSecret::new(())).unwrap();
         secret.access(|_| {
-            // SAFETY: Deliberately unmap the last data page in this subprocess,
-            // leaving the canary readable. Revoking access must abort when
-            // mprotect encounters the gap, without accessing the missing page.
+            // SAFETY: Remove the test's data page to force last-reader mprotect
+            // failure. The marker and the ZST's trailing-guard address stay mapped.
             unsafe {
-                let page = libc::sysconf(libc::_SC_PAGESIZE) as usize;
                 assert_eq!(
                     libc::munmap(
-                        secret
-                            .inner
-                            .mapping
-                            .data
-                            .as_ptr()
-                            .add(secret.inner.mapping.data_len - page)
-                            .cast(),
-                        page
+                        secret.inner.mapping.data.as_ptr().cast(),
+                        secret.inner.mapping.data_len,
                     ),
                     0
                 );
             }
         });
+    }
+
+    /// Rejects selected permission transitions at the syscall boundary.
+    /// The filter is installed only in a disposable subprocess, without test hooks
+    /// in the allocator. Other syscall numbers and permissions remain allowed.
+    fn deny_mprotect(protections: &[libc::c_int]) {
+        let stmt = |code, k| libc::sock_filter {
+            code,
+            jt: 0,
+            jf: 0,
+            k,
+        };
+        let jump = |k, jt, jf| libc::sock_filter {
+            code: (libc::BPF_JMP | libc::BPF_JEQ | libc::BPF_K) as u16,
+            jt,
+            jf,
+            k,
+        };
+        // seccomp_data.nr is at offset 0 and args[2] at offset 32. Reading the
+        // low word of the protection argument works on little-endian hosts.
+        #[cfg(target_endian = "little")]
+        let protection_offset = 32;
+        #[cfg(target_endian = "big")]
+        let protection_offset = 36;
+        let count = u8::try_from(protections.len()).unwrap();
+        let mut filter = vec![
+            stmt((libc::BPF_LD | libc::BPF_W | libc::BPF_ABS) as u16, 0),
+            jump(libc::SYS_mprotect as u32, 0, count + 1),
+            stmt(
+                (libc::BPF_LD | libc::BPF_W | libc::BPF_ABS) as u16,
+                protection_offset,
+            ),
+        ];
+        for (index, protection) in protections.iter().enumerate() {
+            // A match skips the remaining comparisons and the ALLOW instruction.
+            filter.push(jump(*protection as u32, count - index as u8, 0));
+        }
+        filter.push(stmt(
+            (libc::BPF_RET | libc::BPF_K) as u16,
+            libc::SECCOMP_RET_ALLOW,
+        ));
+        filter.push(stmt(
+            (libc::BPF_RET | libc::BPF_K) as u16,
+            libc::SECCOMP_RET_ERRNO | libc::EPERM as u32,
+        ));
+        let program = libc::sock_fprog {
+            len: filter.len() as u16,
+            filter: filter.as_mut_ptr(),
+        };
+        // SAFETY: This thread permanently narrows its own syscall permissions.
+        // The kernel copies the valid filter while prctl runs.
+        unsafe {
+            assert_eq!(libc::prctl(libc::PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0), 0);
+            assert_eq!(
+                libc::prctl(libc::PR_SET_SECCOMP, libc::SECCOMP_MODE_FILTER, &program),
+                0
+            );
+        }
+    }
+
+    /// Removes effective CAP_IPC_LOCK from the child thread before lowering its limit.
+    fn drop_ipc_lock_capability() {
+        // Linux's version 3 capability syscall ABI uses a header and two words.
+        #[repr(C)]
+        struct Header {
+            version: u32,
+            pid: libc::pid_t,
+        }
+        #[repr(C)]
+        #[derive(Clone, Copy, Default)]
+        struct Capabilities {
+            effective: u32,
+            permitted: u32,
+            inheritable: u32,
+        }
+        let mut header = Header {
+            version: 0x20080522,
+            pid: 0,
+        };
+        let mut data = [Capabilities::default(); 2];
+        // SAFETY: Version 3 writes two capability words. pid 0 selects this thread.
+        unsafe {
+            assert_eq!(
+                libc::syscall(libc::SYS_capget, &raw mut header, data.as_mut_ptr()),
+                0
+            );
+            // CAP_IPC_LOCK is bit 14. UID alone does not determine this privilege.
+            if data[0].effective & (1 << 14) != 0 {
+                data[0].effective &= !(1 << 14);
+                assert_eq!(
+                    libc::syscall(libc::SYS_capset, &raw mut header, data.as_ptr()),
+                    0
+                );
+                assert_eq!(
+                    libc::syscall(libc::SYS_capget, &raw mut header, data.as_mut_ptr()),
+                    0
+                );
+            }
+        }
+        assert_eq!(data[0].effective & (1 << 14), 0);
+    }
+
+    /// Returns the kernel's base page size used by the allocation under test.
+    fn page_size() -> usize {
+        // SAFETY: sysconf has no memory preconditions.
+        let page = usize::try_from(unsafe { libc::sysconf(libc::_SC_PAGESIZE) }).unwrap();
+        assert!(page.is_power_of_two());
+        page
+    }
+
+    /// Checks release without reading through a pointer whose allocation is gone.
+    fn assert_unmapped(address: *mut u8) {
+        let page = page_size();
+        // SAFETY: mincore checks virtual mappings
+        // without dereferencing the queried address in userspace.
+        unsafe {
+            let base = address.map_addr(|address| address & !(page - 1));
+            let mut resident = 0;
+            assert_eq!(libc::mincore(base.cast(), page, &mut resident), -1);
+            assert_eq!(
+                io::Error::last_os_error().raw_os_error(),
+                Some(libc::ENOMEM)
+            );
+        }
+    }
+
+    /// Waits for the isolated fork branch and checks its exact termination mode.
+    fn wait_for_child(pid: libc::pid_t, signal: Option<i32>) {
+        let mut status = 0;
+        // SAFETY: pid is our child and status is a writable output location.
+        assert_eq!(unsafe { libc::waitpid(pid, &mut status, 0) }, pid);
+        if let Some(signal) = signal {
+            assert!(libc::WIFSIGNALED(status), "child status: {status}");
+            assert_eq!(libc::WTERMSIG(status), signal);
+        } else {
+            assert!(libc::WIFEXITED(status), "child status: {status}");
+            assert_eq!(libc::WEXITSTATUS(status), 0);
+        }
+    }
+
+    /// Exercises inherited state with a simulated PID match and real wiped pages.
+    fn fork_collision(case: &str) {
+        struct Value([u8; 32]);
+        impl Drop for Value {
+            fn drop(&mut self) {
+                // Wiped bytes must never reach typed destruction in the child.
+                assert_eq!(self.0, [42; 32]);
+            }
+        }
+        let mut allocation =
+            ProtectedAllocation::try_new(InlineSecret::new(Value([42; 32]))).unwrap();
+        // SAFETY: The child only executes explicit rejection/drop paths or creates
+        // independent storage. It never uses a borrowed inherited value.
+        let pid = unsafe { libc::fork() };
+        assert!(pid >= 0);
+        if pid == 0 {
+            // SAFETY: Alter only child-local metadata to model a numeric collision.
+            allocation.mapping.pid = unsafe { libc::getpid() };
+            match case {
+                "fork_collision_access" => {
+                    // Model forking during an overlapping read. Identity must be
+                    // rejected even when first-reader permission setup is skipped.
+                    *allocation.readers.lock() = 1;
+                    allocation.access(|_| ());
+                }
+                "fork_collision_locked" => {
+                    // A held inherited mutex must not be touched. An alarm turns
+                    // accidental blocking into a distinct, bounded test failure.
+                    let _held = allocation.readers.lock();
+                    // SAFETY: Set a child-local timeout for a potential deadlock.
+                    unsafe { libc::alarm(5) };
+                    allocation.access(|_| ());
+                }
+                "fork_collision_extract" => {
+                    let _ = allocation.extract();
+                }
+                "fork_collision_drop" => drop(allocation),
+                "fork_new_allocation" => {
+                    let fresh =
+                        HardenedSecret::try_from_inline(InlineSecret::new([73u8; 32])).unwrap();
+                    fresh.access(|bytes| assert_eq!(bytes, &[73; 32]));
+                    drop(fresh);
+                    assert!(!allocation.mapping.in_creator());
+                    drop(allocation);
+                }
+                _ => unreachable!(),
+            }
+            // SAFETY: Leave without running the inherited test harness.
+            unsafe { libc::_exit(0) };
+        }
+        let signal = if matches!(case, "fork_collision_drop" | "fork_new_allocation") {
+            None
+        } else {
+            Some(libc::SIGABRT)
+        };
+        wait_for_child(pid, signal);
+        allocation.access(|value| assert_eq!(value.0, [42; 32]));
     }
 }

--- a/cryptography/src/lib.rs
+++ b/cryptography/src/lib.rs
@@ -72,7 +72,9 @@ commonware_macros::stability_scope!(BETA {
     use rand_core::{CryptoRng, SeedableRng as _};
 
     pub mod secret;
-    pub use crate::secret::Secret;
+    pub use crate::secret::{HardenError, Secret};
+    #[cfg(all(target_os = "linux", feature = "std"))]
+    mod hardened_secret;
 
     pub mod certificate;
     pub mod transcript;

--- a/cryptography/src/secp256r1/common.rs
+++ b/cryptography/src/secp256r1/common.rs
@@ -46,8 +46,15 @@ impl Eq for PrivateKeyInner {}
 
 impl PrivateKeyInner {
     pub fn new(key: SigningKey) -> Self {
+        let bytes = Zeroizing::new(key.to_bytes());
+        let mut raw = Zeroizing::new([0u8; PRIVATE_KEY_LENGTH]);
+        raw.copy_from_slice(bytes.as_slice());
+        Self::from_parts(raw, key)
+    }
+
+    /// Wraps a key together with its canonical encoding.
+    fn from_parts(raw: Zeroizing<[u8; PRIVATE_KEY_LENGTH]>, key: SigningKey) -> Self {
         let public = *key.verifying_key();
-        let raw = Zeroizing::new(<[u8; PRIVATE_KEY_LENGTH]>::from(key.to_bytes()));
         Self {
             inner: Secret::new(SigningValue { raw, key }),
             public,
@@ -99,7 +106,7 @@ impl Read for PrivateKeyInner {
         #[cfg(not(feature = "std"))]
         let key =
             key.map_err(|e| CodecError::Wrapped(CURVE_NAME, alloc::format!("{:?}", e).into()))?;
-        Ok(Self::new(key))
+        Ok(Self::from_parts(raw, key))
     }
 }
 

--- a/cryptography/src/secp256r1/common.rs
+++ b/cryptography/src/secp256r1/common.rs
@@ -1,4 +1,4 @@
-use crate::Secret;
+use crate::{HardenError, Secret};
 use bytes::{Buf, BufMut};
 use commonware_codec::{Error as CodecError, FixedArray, FixedSize, Read, ReadExt, Write};
 use commonware_formatting::Hex;
@@ -44,9 +44,17 @@ impl PrivateKeyInner {
         }
     }
 
+    /// Protects both the cached key bytes and the private signing state.
+    pub fn try_harden(self) -> Result<Self, HardenError> {
+        Ok(Self {
+            raw: self.raw.try_harden()?,
+            key: self.key.try_harden()?,
+        })
+    }
+
     /// Returns the `VerifyingKey` corresponding to this private key.
     pub fn verifying_key(&self) -> VerifyingKey {
-        self.key.expose(|key| *key.verifying_key())
+        self.key.access(|key| *key.verifying_key())
     }
 }
 
@@ -58,7 +66,7 @@ impl Random for PrivateKeyInner {
 
 impl Write for PrivateKeyInner {
     fn write(&self, buf: &mut impl BufMut) {
-        self.raw.expose(|raw| raw.write(buf));
+        self.raw.access(|raw| raw.write(buf));
     }
 }
 
@@ -208,6 +216,18 @@ impl arbitrary::Arbitrary<'_> for PublicKeyInner {
 /// Macro to implement newtype wrapper traits for PrivateKey.
 macro_rules! impl_private_key_wrapper {
     ($name:ident) => {
+        impl $name {
+            /// Moves the private key into hardened storage.
+            ///
+            /// Clones share storage, erased when its last owner drops. Already hardened
+            /// keys are unchanged. Earlier copies and exported material remain unprotected.
+            ///
+            /// Returns an error if hardening is unsupported or its protections cannot be established.
+            pub fn try_harden(self) -> Result<Self, crate::secret::HardenError> {
+                self.0.try_harden().map(Self)
+            }
+        }
+
         impl crate::PrivateKey for $name {}
 
         impl commonware_math::algebra::Random for $name {

--- a/cryptography/src/secp256r1/common.rs
+++ b/cryptography/src/secp256r1/common.rs
@@ -33,15 +33,11 @@ struct SigningValue {
 #[derive(Clone, Debug)]
 pub struct PrivateKeyInner {
     inner: Secret<SigningValue>,
-    // SigningKey keeps its own public point. This copy avoids opening private
-    // pages when only the public key is requested.
     public: VerifyingKey,
 }
 
 impl PartialEq for PrivateKeyInner {
     fn eq(&self, other: &Self) -> bool {
-        // SigningKey compares its private scalars with subtle's constant-time
-        // implementation. Secret's generic equality uses a different trait.
         self.access(|key| other.access(|other| key.ct_eq(other).into()))
     }
 }
@@ -63,9 +59,13 @@ impl PrivateKeyInner {
         self.inner.access(|value| f(&value.key))
     }
 
-    /// Protects the signing state according to [Secret::try_harden].
+    /// Moves the secret material into hardened storage.
     ///
-    /// The cached public key stays accessible without opening private pages.
+    /// See [crate::Secret::try_harden] for requirements and guarantees.
+    ///
+    /// # Errors
+    ///
+    /// Consumes `self` on failure, including when hardening is unsupported.
     pub fn try_harden(self) -> Result<Self, HardenError> {
         Ok(Self {
             inner: self.inner.try_harden()?,
@@ -238,14 +238,13 @@ impl arbitrary::Arbitrary<'_> for PublicKeyInner {
 macro_rules! impl_private_key_wrapper {
     ($name:ident) => {
         impl $name {
-            /// Moves the private key into hardened storage.
+            /// Moves the secret material into hardened storage.
             ///
-            /// Clones share the protected allocation. Public-key access leaves it sealed.
-            /// See [crate::Secret::try_harden] for the protections, costs, and ownership contract.
+            /// See [crate::Secret::try_harden] for requirements and guarantees.
             ///
             /// # Errors
             ///
-            /// Consumes the key on failure, including when hardening is unsupported.
+            /// Consumes `self` on failure, including when hardening is unsupported.
             pub fn try_harden(self) -> Result<Self, crate::secret::HardenError> {
                 self.0.try_harden().map(Self)
             }

--- a/cryptography/src/secp256r1/common.rs
+++ b/cryptography/src/secp256r1/common.rs
@@ -25,7 +25,7 @@ pub const PUBLIC_KEY_LENGTH: usize = 33; // Y-Parity || X
 /// Both fields remain immutable and occupy the same protected value after hardening.
 #[derive(Clone)]
 struct SigningValue {
-    raw: Zeroizing<[u8; PRIVATE_KEY_LENGTH]>,
+    raw: [u8; PRIVATE_KEY_LENGTH],
     key: SigningKey,
 }
 
@@ -47,13 +47,13 @@ impl Eq for PrivateKeyInner {}
 impl PrivateKeyInner {
     pub fn new(key: SigningKey) -> Self {
         let bytes = Zeroizing::new(key.to_bytes());
-        let mut raw = Zeroizing::new([0u8; PRIVATE_KEY_LENGTH]);
+        let mut raw = [0u8; PRIVATE_KEY_LENGTH];
         raw.copy_from_slice(bytes.as_slice());
         Self::from_parts(raw, key)
     }
 
     /// Wraps a key together with its canonical encoding.
-    fn from_parts(raw: Zeroizing<[u8; PRIVATE_KEY_LENGTH]>, key: SigningKey) -> Self {
+    fn from_parts(raw: [u8; PRIVATE_KEY_LENGTH], key: SigningKey) -> Self {
         let public = *key.verifying_key();
         Self {
             inner: Secret::new(SigningValue { raw, key }),
@@ -106,7 +106,7 @@ impl Read for PrivateKeyInner {
         #[cfg(not(feature = "std"))]
         let key =
             key.map_err(|e| CodecError::Wrapped(CURVE_NAME, alloc::format!("{:?}", e).into()))?;
-        Ok(Self::from_parts(raw, key))
+        Ok(Self::from_parts(*raw, key))
     }
 }
 

--- a/cryptography/src/secp256r1/common.rs
+++ b/cryptography/src/secp256r1/common.rs
@@ -65,12 +65,9 @@ impl PrivateKeyInner {
     ///
     /// # Errors
     ///
-    /// Consumes `self` on failure, including when hardening is unsupported.
-    pub fn try_harden(self) -> Result<Self, HardenError> {
-        Ok(Self {
-            inner: self.inner.try_harden()?,
-            public: self.public,
-        })
+    /// Leaves `self` unchanged on failure, including when hardening is unsupported.
+    pub fn try_harden(&mut self) -> Result<(), HardenError> {
+        self.inner.try_harden()
     }
 
     /// Returns the `VerifyingKey` corresponding to this private key.
@@ -244,9 +241,9 @@ macro_rules! impl_private_key_wrapper {
             ///
             /// # Errors
             ///
-            /// Consumes `self` on failure, including when hardening is unsupported.
-            pub fn try_harden(self) -> Result<Self, crate::secret::HardenError> {
-                self.0.try_harden().map(Self)
+            /// Leaves `self` unchanged on failure, including when hardening is unsupported.
+            pub fn try_harden(&mut self) -> Result<(), crate::secret::HardenError> {
+                self.0.try_harden()
             }
         }
 

--- a/cryptography/src/secp256r1/common.rs
+++ b/cryptography/src/secp256r1/common.rs
@@ -11,7 +11,7 @@ use core::{
 };
 use p256::{
     ecdsa::{SigningKey, VerifyingKey},
-    elliptic_curve::Generate,
+    elliptic_curve::{Generate, subtle::ConstantTimeEq},
 };
 use rand_core::CryptoRng;
 use zeroize::Zeroizing;
@@ -20,16 +20,29 @@ pub const CURVE_NAME: &str = "secp256r1";
 pub const PRIVATE_KEY_LENGTH: usize = 32;
 pub const PUBLIC_KEY_LENGTH: usize = 33; // Y-Parity || X
 
+/// A signing key and its canonical private encoding.
+///
+/// Both fields remain immutable and occupy the same protected value after hardening.
+#[derive(Clone)]
+struct SigningValue {
+    raw: Zeroizing<[u8; PRIVATE_KEY_LENGTH]>,
+    key: SigningKey,
+}
+
 /// Internal Secp256r1 Private Key storage.
 #[derive(Clone, Debug)]
 pub struct PrivateKeyInner {
-    raw: Secret<[u8; PRIVATE_KEY_LENGTH]>,
-    pub(crate) key: Secret<SigningKey>,
+    inner: Secret<SigningValue>,
+    // SigningKey keeps its own public point. This copy avoids opening private
+    // pages when only the public key is requested.
+    public: VerifyingKey,
 }
 
 impl PartialEq for PrivateKeyInner {
     fn eq(&self, other: &Self) -> bool {
-        self.raw == other.raw
+        // SigningKey compares its private scalars with subtle's constant-time
+        // implementation. Secret's generic equality uses a different trait.
+        self.access(|key| other.access(|other| key.ct_eq(other).into()))
     }
 }
 
@@ -37,24 +50,32 @@ impl Eq for PrivateKeyInner {}
 
 impl PrivateKeyInner {
     pub fn new(key: SigningKey) -> Self {
-        let raw = Zeroizing::new(key.to_bytes().into());
+        let public = *key.verifying_key();
+        let raw = Zeroizing::new(<[u8; PRIVATE_KEY_LENGTH]>::from(key.to_bytes()));
         Self {
-            raw: Secret::new(*raw),
-            key: Secret::new(key),
+            inner: Secret::new(SigningValue { raw, key }),
+            public,
         }
     }
 
-    /// Protects both the cached key bytes and the private signing state.
+    /// Lends the signing key for the duration of `f`.
+    pub(super) fn access<R>(&self, f: impl for<'a> FnOnce(&'a SigningKey) -> R) -> R {
+        self.inner.access(|value| f(&value.key))
+    }
+
+    /// Protects the signing state according to [Secret::try_harden].
+    ///
+    /// The cached public key stays accessible without opening private pages.
     pub fn try_harden(self) -> Result<Self, HardenError> {
         Ok(Self {
-            raw: self.raw.try_harden()?,
-            key: self.key.try_harden()?,
+            inner: self.inner.try_harden()?,
+            public: self.public,
         })
     }
 
     /// Returns the `VerifyingKey` corresponding to this private key.
-    pub fn verifying_key(&self) -> VerifyingKey {
-        self.key.access(|key| *key.verifying_key())
+    pub const fn verifying_key(&self) -> VerifyingKey {
+        self.public
     }
 }
 
@@ -66,7 +87,7 @@ impl Random for PrivateKeyInner {
 
 impl Write for PrivateKeyInner {
     fn write(&self, buf: &mut impl BufMut) {
-        self.raw.access(|raw| raw.write(buf));
+        self.inner.access(|value| value.raw.write(buf));
     }
 }
 
@@ -219,10 +240,12 @@ macro_rules! impl_private_key_wrapper {
         impl $name {
             /// Moves the private key into hardened storage.
             ///
-            /// Clones share storage, erased when its last owner drops. Already hardened
-            /// keys are unchanged. Earlier copies and exported material remain unprotected.
+            /// Clones share the protected allocation. Public-key access leaves it sealed.
+            /// See [crate::Secret::try_harden] for the protections, costs, and ownership contract.
             ///
-            /// Returns an error if hardening is unsupported or its protections cannot be established.
+            /// # Errors
+            ///
+            /// Consumes the key on failure, including when hardening is unsupported.
             pub fn try_harden(self) -> Result<Self, crate::secret::HardenError> {
                 self.0.try_harden().map(Self)
             }

--- a/cryptography/src/secp256r1/recoverable.rs
+++ b/cryptography/src/secp256r1/recoverable.rs
@@ -50,7 +50,7 @@ impl PrivateKey {
             Cow::Owned(union_unique(namespace, msg))
         });
         let (mut signature, mut recovery_id) =
-            self.0.key.expose(|key| key.sign_recoverable(&payload));
+            self.0.key.access(|key| key.sign_recoverable(&payload));
 
         // The signing algorithm generates k, then calculates r <- x(k * G). Normalizing s by negating it is equivalent
         // to negating k. This has no effect on x(k * G) but y(-k * G) = -y(k * G), hence the need to flip the bit if

--- a/cryptography/src/secp256r1/recoverable.rs
+++ b/cryptography/src/secp256r1/recoverable.rs
@@ -49,8 +49,7 @@ impl PrivateKey {
         let payload = namespace.map_or(Cow::Borrowed(msg), |namespace| {
             Cow::Owned(union_unique(namespace, msg))
         });
-        let (mut signature, mut recovery_id) =
-            self.0.key.access(|key| key.sign_recoverable(&payload));
+        let (mut signature, mut recovery_id) = self.0.access(|key| key.sign_recoverable(&payload));
 
         // The signing algorithm generates k, then calculates r <- x(k * G). Normalizing s by negating it is equivalent
         // to negating k. This has no effect on x(k * G) but y(-k * G) = -y(k * G), hence the need to flip the bit if

--- a/cryptography/src/secp256r1/standard.rs
+++ b/cryptography/src/secp256r1/standard.rs
@@ -51,7 +51,7 @@ impl PrivateKey {
         let payload = namespace.map_or(Cow::Borrowed(msg), |namespace| {
             Cow::Owned(union_unique(namespace, msg))
         });
-        let signature: p256::ecdsa::Signature = self.0.key.expose(|key| key.sign(&payload));
+        let signature: p256::ecdsa::Signature = self.0.key.access(|key| key.sign(&payload));
         let signature = signature.normalize_s();
         Signature::try_from(signature).expect("freshly signed signature is valid")
     }

--- a/cryptography/src/secp256r1/standard.rs
+++ b/cryptography/src/secp256r1/standard.rs
@@ -51,7 +51,7 @@ impl PrivateKey {
         let payload = namespace.map_or(Cow::Borrowed(msg), |namespace| {
             Cow::Owned(union_unique(namespace, msg))
         });
-        let signature: p256::ecdsa::Signature = self.0.key.access(|key| key.sign(&payload));
+        let signature: p256::ecdsa::Signature = self.0.access(|key| key.sign(&payload));
         let signature = signature.normalize_s();
         Signature::try_from(signature).expect("freshly signed signature is valid")
     }

--- a/cryptography/src/secret.rs
+++ b/cryptography/src/secret.rs
@@ -53,8 +53,8 @@
 //! Hardening requires Linux with `std` and support for `MADV_WIPEONFORK`, introduced
 //! in Linux 4.14. Construction must establish every required protection. It may
 //! fail under the process's actual locked-memory allowance or syscall policy.
-//! Hardening consumes and drops its input on any error, including unsupported
-//! platforms. Earlier inline clones and previously exported bytes are unaffected.
+//! Hardening leaves the value and its storage unchanged on error, including on
+//! unsupported platforms. Earlier inline clones and exported bytes are unaffected.
 //! Hardening an already hardened value keeps its existing allocation.
 //!
 //! | Measure | Protection and limits |
@@ -109,8 +109,8 @@
 //! Cleanup of those allocations depends on `T`'s destructor.
 //!
 //! Each inline value is destroyed and then erased. A panicking inline destructor
-//! can prevent that erasure, including during a failed hardening attempt. In
-//! hardened storage, the final owner destroys `T`, then erases and unmaps the data.
+//! can prevent that erasure. In hardened storage, the final owner destroys `T`,
+//! then erases and unmaps the data.
 //! The raw mapping owner still performs cleanup if `T`'s destructor or a byte-array
 //! initializer unwinds, provided cleanup succeeds and the process keeps unwinding.
 //! Dropping a shared handle does not erase storage still owned by another handle.
@@ -455,7 +455,7 @@ impl<T> Secret<T> {
     /// including when `T`'s alignment exceeds the system page size. Mapping and
     /// memory-protection failures return an operating-system error. Locking is
     /// subject to the process's `RLIMIT_MEMLOCK` allowance.
-    /// An error consumes and drops the input instead of returning it to the caller.
+    /// An error leaves the value and its storage unchanged.
     ///
     /// Allocating shared ownership metadata follows the ordinary Rust allocator's
     /// allocation-failure behavior. Cleanup failures abort as described in the
@@ -467,23 +467,31 @@ impl<T> Secret<T> {
     /// use commonware_cryptography::{HardenError, Secret};
     ///
     /// # fn main() -> Result<(), HardenError> {
-    /// let secret = Secret::new([42u8; 32]).try_harden()?;
+    /// let mut secret = Secret::new([42u8; 32]);
+    /// secret.try_harden()?;
     /// assert!(secret.is_hardened());
     /// secret.access(|bytes| assert_eq!(bytes[0], 42));
     /// # Ok(())
     /// # }
     /// ```
-    pub fn try_harden(self) -> Result<Self, HardenError> {
+    pub fn try_harden(&mut self) -> Result<(), HardenError> {
         #[cfg(all(target_os = "linux", feature = "std"))]
         {
-            match self.storage {
-                Storage::Inline(value) => {
-                    HardenedSecret::try_from_inline(value).map(|value| Self {
-                        storage: Storage::Hardened(value),
-                    })
-                }
-                Storage::Hardened(_) => Ok(self),
+            let hardened = match &mut self.storage {
+                // SAFETY: On success, the source is erased and overwritten below
+                // without dropping its value or invoking any code that can panic.
+                Storage::Inline(value) => unsafe { HardenedSecret::try_from_inline(value)? },
+                Storage::Hardened(_) => return Ok(()),
+            };
+            let storage = &raw mut self.storage;
+            // SAFETY: The sealed allocation now owns T. Erase the entire old
+            // storage, including padding, without dropping T. Use the raw pointer
+            // to replace the temporarily invalid bytes without forming a reference.
+            unsafe {
+                zeroize_ptr(storage);
+                storage.write(Storage::Hardened(hardened));
             }
+            Ok(())
         }
         #[cfg(not(all(target_os = "linux", feature = "std")))]
         {
@@ -605,31 +613,6 @@ unsafe fn zeroize_ptr<T>(ptr: *mut T) {
 pub(crate) struct InlineSecret<T>(ManuallyDrop<T>);
 
 impl<T> InlineSecret<T> {
-    /// Transfers `T` into caller-owned storage and erases this consumed wrapper.
-    ///
-    /// Does not run `T`'s destructor. Locations left by earlier moves of the wrapper
-    /// are outside this operation's control.
-    ///
-    /// # Safety
-    ///
-    /// `destination` must be non-null, aligned for `T`, and writable for
-    /// `size_of::<T>()` bytes. Non-nullness and alignment also apply to zero-sized
-    /// types. The destination must accept a new `T` without dropping its previous
-    /// contents. It must not overlap the source or be accessed through any other
-    /// pointer or reference during the transfer. The caller takes ownership of
-    /// the initialized `T` and must arrange its destruction.
-    #[cfg(all(target_os = "linux", feature = "std"))]
-    pub(crate) unsafe fn move_into(self, destination: *mut T) {
-        let mut value = ManuallyDrop::new(self);
-        let source = &raw mut *value.0;
-        // SAFETY: The caller supplies valid, disjoint storage. The source stays
-        // at its original address until wiped and is never moved or dropped again.
-        unsafe {
-            core::ptr::copy_nonoverlapping(source, destination, 1);
-            zeroize_ptr(source);
-        }
-    }
-
     /// Takes ownership of `value` and stores it inline.
     #[inline]
     pub const fn new(value: T) -> Self {
@@ -688,6 +671,16 @@ mod tests {
     use super::*;
     use core::cell::Cell;
 
+    #[cfg(not(all(target_os = "linux", feature = "std")))]
+    #[test]
+    fn test_harden_unsupported_preserves_value() {
+        struct Value([u8; 32]);
+        let mut secret = Secret::new(Value([42; 32]));
+        assert!(matches!(secret.try_harden(), Err(HardenError::Unsupported)));
+        assert!(!secret.is_hardened());
+        secret.access(|value| assert_eq!(value.0, [42; 32]));
+    }
+
     #[test]
     fn test_traits() {
         fn assert_traits<
@@ -745,37 +738,6 @@ mod tests {
         }
     }
 
-    #[cfg(all(target_os = "linux", feature = "std"))]
-    #[test]
-    fn test_inline_move_transfers_non_clone_ownership() {
-        struct Value<'a> {
-            bytes: Box<[u8; 32]>,
-            drops: &'a Cell<usize>,
-        }
-        impl Drop for Value<'_> {
-            fn drop(&mut self) {
-                self.drops.set(self.drops.get() + 1);
-            }
-        }
-
-        let drops = Cell::new(0);
-        let source = InlineSecret::new(Value {
-            bytes: Box::new([42; 32]),
-            drops: &drops,
-        });
-        let mut destination = MaybeUninit::uninit();
-        // SAFETY: Destination is disjoint, aligned, uninitialized storage. The
-        // move initializes it exactly once and transfers ownership to this test.
-        let value = unsafe {
-            source.move_into(destination.as_mut_ptr());
-            destination.assume_init()
-        };
-        assert_eq!(*value.bytes, [42; 32]);
-        assert_eq!(drops.get(), 0);
-        drop(value);
-        assert_eq!(drops.get(), 1);
-    }
-
     #[test]
     fn test_try_extract_non_clone() {
         // Owning a heap value detects premature destruction during extraction.
@@ -808,15 +770,14 @@ mod tests {
             &drops,
         );
         #[cfg(all(target_os = "linux", feature = "std", not(miri)))]
-        check(
-            Secret::new(Value {
+        {
+            let mut secret = Secret::new(Value {
                 bytes: Box::new([42; 32]),
                 drops: &drops,
-            })
-            .try_harden()
-            .unwrap(),
-            &drops,
-        );
+            });
+            secret.try_harden().unwrap();
+            check(secret, &drops);
+        }
     }
 
     #[test]
@@ -857,12 +818,11 @@ mod tests {
 
         #[cfg(all(target_os = "linux", feature = "std", not(miri)))]
         {
-            let secret = Secret::new(Value {
+            let mut secret = Secret::new(Value {
                 clones: &clones,
                 drops: &drops,
-            })
-            .try_harden()
-            .unwrap();
+            });
+            secret.try_harden().unwrap();
             let shared = secret.clone();
             assert_eq!(clones.get(), 0);
 

--- a/cryptography/src/secret.rs
+++ b/cryptography/src/secret.rs
@@ -562,6 +562,7 @@ mod tests {
         fn assert_sync<T: Sync>() {}
         fn assert_unwind_safe<T: core::panic::UnwindSafe>() {}
         fn assert_ref_unwind_safe<T: core::panic::RefUnwindSafe>() {}
+
         assert_send::<Cell<u8>>();
         assert_sync::<std::sync::MutexGuard<'static, ()>>();
         assert_unwind_safe::<Box<Cell<u8>>>();
@@ -572,6 +573,23 @@ mod tests {
         let secret = Secret::new(Cell::new(7));
         secret.access(|value| value.set(9));
         assert_eq!(secret.access(Cell::get), 9);
+    }
+
+    #[test]
+    fn test_inline_value_semantics() {
+        let secret = Secret::new([1u8, 2, 3, 4]);
+        assert!(!secret.is_hardened());
+
+        // Every access sees the stored value, and inline access keeps no state
+        // between calls.
+        secret.access(|value| assert_eq!(value, &[1, 2, 3, 4]));
+        secret.access(|value| assert_eq!(value[3], 4));
+
+        // An inline clone is an independent copy, and equality is by value.
+        let cloned = secret.clone();
+        secret.access(|a| cloned.access(|b| assert!(!core::ptr::eq(a, b))));
+        assert_eq!(secret, cloned);
+        assert_ne!(secret, Secret::new([5u8, 6, 7, 8]));
     }
 
     #[test]
@@ -589,6 +607,7 @@ mod tests {
             second: 0x12345678,
         }));
         let address = storage.as_mut_ptr();
+
         // SAFETY: The value is initialized and uniquely owned. The MaybeUninit
         // allocation stays live after destruction and does not drop it again.
         unsafe {
@@ -615,6 +634,7 @@ mod tests {
             }
         }
 
+        // Extraction hands the value over intact without running its destructor.
         fn check(secret: Secret<Value<'_>>, drops: &Cell<usize>) {
             let before = drops.get();
             let value = secret.try_extract().unwrap();
@@ -624,6 +644,7 @@ mod tests {
             assert_eq!(drops.get(), before + 1);
         }
 
+        // Inline and hardened storage behave the same through the public API.
         let drops = Cell::new(0);
         check(
             Secret::new(Value {
@@ -632,6 +653,7 @@ mod tests {
             }),
             &drops,
         );
+
         #[cfg(all(target_os = "linux", feature = "std", not(miri)))]
         {
             let mut secret = Secret::new(Value {
@@ -667,6 +689,7 @@ mod tests {
             }
         }
 
+        // A uniquely owned inline value moves out without cloning.
         let clones = Cell::new(0);
         let drops = Cell::new(0);
         let secret = Secret::new(Value {
@@ -681,6 +704,9 @@ mod tests {
 
         #[cfg(all(target_os = "linux", feature = "std", not(miri)))]
         {
+            // A shared hardened value cannot be moved out. Extraction fails without
+            // touching it, and extract_or_clone clones it instead while the other
+            // handle keeps its storage.
             let mut secret = Secret::new(Value {
                 clones: &clones,
                 drops: &drops,
@@ -717,48 +743,5 @@ mod tests {
     fn test_display_redacted() {
         let secret = Secret::new([1u8, 2, 3, 4]);
         assert_eq!(format!("{}", secret), "[REDACTED]");
-    }
-
-    #[test]
-    fn test_access() {
-        let secret = Secret::new([1u8, 2, 3, 4]);
-        secret.access(|v| {
-            assert_eq!(v, &[1u8, 2, 3, 4]);
-        });
-    }
-
-    #[test]
-    fn test_clone() {
-        let secret = Secret::new([1u8, 2, 3, 4]);
-        let cloned = secret.clone();
-        secret.access(|a| {
-            cloned.access(|b| {
-                assert_eq!(a, b);
-            });
-        });
-    }
-
-    #[test]
-    fn test_equality() {
-        let s1 = Secret::new([1u8, 2, 3, 4]);
-        let s2 = Secret::new([1u8, 2, 3, 4]);
-        let s3 = Secret::new([5u8, 6, 7, 8]);
-        assert_eq!(s1, s2);
-        assert_ne!(s1, s3);
-    }
-
-    #[test]
-    fn test_multiple_access() {
-        let secret = Secret::new([42u8; 32]);
-
-        // First access
-        secret.access(|v| {
-            assert_eq!(v[0], 42);
-        });
-
-        // Second access
-        secret.access(|v| {
-            assert_eq!(v[31], 42);
-        });
     }
 }

--- a/cryptography/src/secret.rs
+++ b/cryptography/src/secret.rs
@@ -1,112 +1,389 @@
-//! A wrapper type for secret values that prevents accidental leakage.
+//! Secret values with explicit access and erasure on drop.
 //!
-//! `Secret<T>` provides the following guarantees:
-//! - Debug and Display always show `[REDACTED]` instead of the actual value
-//! - The inner value is zeroized on drop
-//! - Access to the inner value requires an explicit `expose()` call
-//! - Comparisons use constant-time operations to prevent timing attacks
+//! - [Secret] supports inline and hardened storage through a single public wrapper.
+//!   It starts inline and can be converted to hardened storage with [Secret::try_harden].
+//!   Conversion consumes the wrapper, including on failure. Existing clones and
+//!   previously exported values are unaffected.
+//! - `InlineSecret<T>` is the private implementation of inline storage. Dropping
+//!   the wrapper destroys `T`, then zeroizes its storage. Cloning calls `T::clone`
+//!   and places the result in a separate wrapper.
+//! - `HardenedSecret<T>` is the private implementation of hardened storage.
+//!   It stores `T` in locked memory excluded from core dumps.
+//!   The allocation is read-only during `access()` calls and inaccessible between
+//!   them. Clones share the allocation, which is erased when the last owner drops.
+//!   Hardened storage is available on Linux with `std`.
 //!
-//! # Type Constraints
+//! All three redact `Debug` output and provide access to `T` through a closure taking `&T`.
+//! Borrows into the stored value cannot escape that closure. Copies, raw pointers,
+//! and references already stored inside `T` can escape. The wrappers do not erase
+//! or protect values copied out by the caller. When `T: CtEq`, equality delegates
+//! to `T`'s constant-time comparison.
 //!
-//! **Important**: `Secret<T>` is designed for flat data types without pointers
-//! (e.g. `[u8; N]`). It does NOT provide full protection for types with
-//! indirection. Types like `Vec<T>`, `String`, or `Box<T>` will only have their
-//! metadata (pointer, length, capacity) zeroized, the referenced data remains
-//! intact. Do not use `Secret` with types that contain pointers.
+//! [Secret::try_extract] and [Secret::extract_or_clone] consume the wrapper and
+//! return an ordinary, unprotected `T`. The caller becomes responsible for its
+//! erasure. Moving a value out erases the source storage without destroying `T`.
+//! If hardened storage is shared, `try_extract` returns the wrapper unchanged,
+//! while `extract_or_clone` clones the value through `access()`.
+//!
+//! # Choosing the stored type
+//!
+//! Store sensitive bytes directly in `T`, for example in an array or a struct of
+//! arrays. Protection covers the storage occupied by `T`, including its padding.
+//! It does not extend to memory reached through pointers. Wrapping a `Vec`,
+//! `String`, or `Box` does not make its heap allocation protected or zeroize it.
+//! Any cleanup of referenced allocations depends on `T`'s own destructor.
+//!
+//! For hardened storage, operations on `&T` must not write to its storage, even
+//! through interior mutability. The pages are read-only during access, so such
+//! writes can terminate the process. `T`'s destructor must not panic, since a
+//! panic can interrupt erasure of inline storage, including during a failed
+//! hardening attempt. Callers must choose types that meet these requirements.
+//!
+//! # Limits of erasure
+//!
+//! Erasure covers the wrapper's current storage. Moving a value can leave bytes
+//! at earlier locations, and computations can leave copies in registers or on
+//! the stack. Those copies are outside the wrapper's control. Explicitly manage
+//! exported sensitive values, for example with [zeroize::Zeroizing]. Cleanup
+//! also requires the wrapper to be dropped, so leaking it or terminating the
+//! process without running destructors prevents erasure by the wrapper.
+//!
+//! # Hardened storage
+//!
+//! Hardening requires Linux with `std` and a kernel supporting `MADV_WIPEONFORK`
+//! (Linux 4.14 or later). Construction establishes all required protections before
+//! storing sensitive bytes in the allocation:
+//!
+//! - [mlock](https://man7.org/linux/man-pages/man2/mlock.2.html) keeps data pages
+//!   resident, preventing them from being swapped out.
+//! - [MADV_DONTDUMP](https://man7.org/linux/man-pages/man2/madvise.2.html) excludes
+//!   them from kernel-generated core dumps.
+//! - `mprotect` grants read-only access during the callback and revokes it afterward.
+//!   Initialization, extraction, and destruction have write access.
+//! - Guard pages surround the data region. A random canary before the value detects
+//!   writes that change it when the canary is next checked.
+//!
+//! Each allocation locks at least one data page and reserves two virtual guard
+//! pages, even for a zero-sized value. Clones share this allocation. `access()` calls
+//! synchronize a reader count and change permissions when the first call begins
+//! and the last ends. The allocation stays readable throughout overlapping calls,
+//! including those through other clones.
+//!
+//! Dropping the last owner destroys the value, zeroizes the entire data region, and
+//! releases the mapping. Erasure also runs if that destructor unwinds. Failures
+//! to change permissions after construction, detected canary corruption, or
+//! failures to restore write access or release memory during cleanup abort the
+//! process. Aborting does not run destructors or guarantee erasure.
+//!
+//! During an `access()` call, the pages are readable throughout the process. Hardening
+//! does not defend against arbitrary code execution, privileged memory
+//! inspection, or hibernation images.
+//!
+//! # Forking with hardened storage
+//!
+//! `MADV_WIPEONFORK` replaces the child's data pages with zeroes. Accessing or moving
+//! out an inherited hardened value aborts before touching its reader mutex or
+//! reading `T`. The final release in the child only unmaps its copy, without calling
+//! `T`'s destructor on the wiped bytes. The parent's allocation is unaffected.
+//!
+//! A caller using an unsafe fork API during an `access()` call must ensure that the child
+//! never uses references into the inherited allocation. Its bytes have been wiped
+//! and may no longer represent a valid `T`. Returning through an inherited
+//! read guard also aborts in the child. These restrictions do not replace
+//! the fork API's own safety requirements.
 
+#[cfg(all(target_os = "linux", feature = "std"))]
+use crate::hardened_secret::HardenedSecret;
 use core::{
     fmt::{Debug, Display, Formatter},
-    mem::ManuallyDrop,
+    mem::{ManuallyDrop, MaybeUninit},
 };
 use ctutils::CtEq;
+use thiserror::Error;
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
-/// Zeroize memory at the given pointer using volatile writes.
+/// Failure to construct hardened secret storage.
 ///
-/// # Safety
-///
-/// `ptr` must point to allocated, writable memory of at least `size_of::<T>()` bytes.
-#[inline]
-unsafe fn zeroize_ptr<T>(ptr: *mut T) {
-    // SAFETY: The caller guarantees that `ptr` is valid for writes of `size_of::<T>()` bytes.
-    unsafe {
-        let slice = core::slice::from_raw_parts_mut(ptr as *mut u8, core::mem::size_of::<T>());
-        slice.zeroize();
-    }
+/// These errors report failures during setup. Once hardened storage has been
+/// constructed, failures to change its memory permissions abort the process.
+#[derive(Debug, Error)]
+pub enum HardenError {
+    /// Hardening was requested without both Linux and the `std` feature.
+    ///
+    /// A Linux kernel that rejects a required operation produces an operating-system
+    /// error instead.
+    #[error("memory hardening requires Linux and the std feature")]
+    Unsupported,
+    /// The allocator cannot represent a valid mapping for the value.
+    ///
+    /// This includes unsupported page sizes or alignment, size overflow, and
+    /// mappings that exceed Rust's address or allocation-size constraints.
+    #[cfg(all(target_os = "linux", feature = "std"))]
+    #[error("unsupported protected allocation layout")]
+    Layout,
+    /// Allocation, canary generation, or a required memory protection failed.
+    #[cfg(all(target_os = "linux", feature = "std"))]
+    #[error("{operation}: {source}")]
+    System {
+        /// The operation that failed, including the advice flag for `madvise`.
+        operation: &'static str,
+        /// The error reported by that operation.
+        #[source]
+        source: std::io::Error,
+    },
 }
 
-/// A wrapper for secret values that prevents accidental leakage.
+/// A secret stored inline or in protected memory.
 ///
-/// - Debug and Display show `[REDACTED]`
-/// - Zeroized on drop
-/// - Access requires explicit `expose()` call
+/// [Self::new] stores values inline without allocating. After successful [Self::try_harden],
+/// clones share a protected allocation. Inline clones instead call `T::clone`.
+/// `Debug` prints `Secret([REDACTED])` and `Display` prints `[REDACTED]`.
+/// See the [module documentation](self) for requirements on `T`.
 ///
-/// # Type Constraints
+/// # Examples
 ///
-/// Only use with flat data types that have no pointers (e.g. `[u8; N]`).
-/// See [module-level documentation](self) for details.
-pub struct Secret<T>(ManuallyDrop<T>);
+/// ```
+/// use commonware_cryptography::Secret;
+///
+/// let secret = Secret::new([42u8; 32]);
+/// assert!(!secret.is_hardened());
+/// secret.access(|bytes| assert_eq!(bytes.len(), 32));
+/// let cloned = secret.clone();
+/// assert_eq!(secret, cloned);
+/// ```
+#[derive(Clone)]
+pub struct Secret<T> {
+    storage: Storage<T>,
+}
+
+/// Storage selection kept private so callers access values through Secret's methods.
+#[derive(Clone)]
+enum Storage<T> {
+    /// A value stored directly in this enum, without OS memory protections.
+    Inline(InlineSecret<T>),
+    /// A handle to shared, protected storage.
+    #[cfg(all(target_os = "linux", feature = "std"))]
+    Hardened(HardenedSecret<T>),
+}
 
 impl<T> Secret<T> {
-    /// Creates a new `Secret` wrapping the given value.
-    #[inline]
+    /// Stores `value` inline. No protected allocation is made until hardening.
     pub const fn new(value: T) -> Self {
-        Self(ManuallyDrop::new(value))
+        Self {
+            storage: Storage::Inline(InlineSecret::new(value)),
+        }
     }
 
-    /// Exposes the secret value for read-only access within a closure.
+    /// Returns whether this value uses hardened storage.
     ///
-    /// # Note
-    ///
-    /// The closure uses a higher-ranked trait bound (`for<'a>`) to prevent
-    /// the returned value from containing references to the secret data.
-    /// This ensures the reference cannot escape the closure scope. However,
-    /// this does not prevent copying or cloning the secret value within
-    /// the closure (e.g., `secret.expose(|s| s.clone())`). Callers should
-    /// avoid leaking secrets through such patterns.
-    ///
-    /// Additionally, any temporaries derived from the secret (e.g.
-    /// `s.as_slice()`) may leave secret data on the stack that will not be
-    /// automatically zeroized. Callers should wrap such temporaries in
-    /// [`zeroize::Zeroizing`] if they contain sensitive data.
+    /// Does not access the value, allocate, or change memory permissions. Always
+    /// returns `false` on builds without Linux and `std`.
     #[inline]
-    pub fn expose<R>(&self, f: impl for<'a> FnOnce(&'a T) -> R) -> R {
-        f(&self.0)
+    pub const fn is_hardened(&self) -> bool {
+        match &self.storage {
+            Storage::Inline(_) => false,
+            #[cfg(all(target_os = "linux", feature = "std"))]
+            Storage::Hardened(_) => true,
+        }
     }
 
-    /// Consumes the [Secret] and returns the inner value, zeroizing the original
-    /// memory location.
+    /// Grants `f` temporary access to the stored value, making hardened storage read-only.
     ///
-    /// Use this when you need to transfer ownership of the secret value (e.g.,
-    /// for APIs that consume the value).
+    /// Borrows into the stored value cannot escape the closure. Copied values,
+    /// raw pointers, and references already stored inside `T` can escape and
+    /// receive no additional protection.
+    ///
+    /// For hardened storage, nested and concurrent calls through any clone
+    /// keep the allocation readable until the last call ends. Returning from
+    /// one callback does not revoke access while another remains active. Shared
+    /// access must not write to hardened storage, even through interior mutability.
+    ///
+    /// # Panics
+    ///
+    /// A panic from `f` propagates. During unwinding, hardened storage becomes
+    /// inaccessible if no other call remains active. Failed permission changes
+    /// or detected canary corruption abort the process.
+    ///
+    /// # Examples
+    ///
+    /// A borrow into the stored value cannot be returned:
+    ///
+    /// ```compile_fail
+    /// use commonware_cryptography::Secret;
+    ///
+    /// let secret = Secret::new([42u8; 32]);
+    /// let bytes = secret.access(|value| &value[..]);
+    /// ```
     #[inline]
-    pub fn expose_unwrap(mut self) -> T {
-        let ptr = &raw mut *self.0;
-        // SAFETY:
-        // Pointer obtained while self.0 is still initialized,
-        // self.0 is initialized and we have exclusive access
-        let value = unsafe { ManuallyDrop::take(&mut self.0) };
+    pub fn access<R>(&self, f: impl for<'a> FnOnce(&'a T) -> R) -> R {
+        match &self.storage {
+            Storage::Inline(value) => value.access(f),
+            #[cfg(all(target_os = "linux", feature = "std"))]
+            Storage::Hardened(value) => value.access(f),
+        }
+    }
 
-        // Prevent Secret::drop from running (would double-zeroize or double-free on panic)
-        core::mem::forget(self);
+    /// Consumes the wrapper and moves out `T` if its storage is uniquely owned.
+    ///
+    /// The returned value is ordinary, unprotected `T`. The caller is responsible
+    /// for its erasure. The source storage is erased without running `T`'s destructor.
+    /// Inline storage always succeeds. Hardened storage also releases its allocation
+    /// on success. This method never clones `T`.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err(self)` unchanged if another handle shares the hardened allocation.
+    /// In that case, no value is read and no memory permissions are changed.
+    /// Use [Self::extract_or_clone] to clone the value when shared and `T: Clone`.
+    ///
+    /// Permission failures, canary corruption, or moving out an inherited fork-child
+    /// value abort the process, as described in the [module documentation](self).
+    ///
+    /// # Examples
+    ///
+    /// Extraction does not require `Clone`:
+    ///
+    /// ```
+    /// use commonware_cryptography::Secret;
+    ///
+    /// struct Value([u8; 32]);
+    /// let secret = Secret::new(Value([42; 32]));
+    /// let value = secret.try_extract().unwrap();
+    /// assert_eq!(value.0, [42; 32]);
+    /// ```
+    pub fn try_extract(self) -> Result<T, Self> {
+        match self.storage {
+            Storage::Inline(value) => Ok(value.extract()),
+            #[cfg(all(target_os = "linux", feature = "std"))]
+            Storage::Hardened(value) => value.try_extract().map_err(|value| Self {
+                storage: Storage::Hardened(value),
+            }),
+        }
+    }
 
-        // SAFETY: uses raw pointer (not reference) to zero memory after drop
-        unsafe { zeroize_ptr(ptr) };
+    /// Consumes the wrapper, moving out `T` when uniquely owned or cloning it otherwise.
+    ///
+    /// The returned value is ordinary, unprotected `T`. The caller is responsible
+    /// for its erasure. Inline and uniquely owned hardened values follow
+    /// [Self::try_extract], which erases the source storage. Shared hardened values
+    /// call `T::clone` through [Self::access], then release this handle. Other handles
+    /// keep their protected storage.
+    ///
+    /// # Panics
+    ///
+    /// A panic from `T::clone` propagates after the access call ends and this handle
+    /// is released. Permission failures, canary corruption, and cleanup failures
+    /// abort as described in the [module documentation](self).
+    ///
+    /// # Examples
+    ///
+    /// Use [zeroize::Zeroizing] to erase the extracted bytes when they are dropped:
+    ///
+    /// ```
+    /// use commonware_cryptography::Secret;
+    /// use zeroize::Zeroizing;
+    ///
+    /// let secret = Secret::new([42u8; 32]);
+    /// let bytes = Zeroizing::new(secret.extract_or_clone());
+    /// assert_eq!(*bytes, [42; 32]);
+    /// ```
+    pub fn extract_or_clone(self) -> T
+    where
+        T: Clone,
+    {
+        self.try_extract()
+            .unwrap_or_else(|secret| secret.access(Clone::clone))
+    }
 
-        value
+    /// Moves an inline value into hardened storage, or keeps an existing allocation.
+    ///
+    /// Hardening an already hardened value performs no allocation or permission
+    /// change. Other wrappers, including earlier inline clones, are unaffected.
+    ///
+    /// # Errors
+    ///
+    /// Returns [HardenError::Unsupported] without Linux and `std`. On supported
+    /// builds, returns a layout error if a suitable mapping cannot be represented,
+    /// including when `T`'s alignment exceeds the system page size. Mapping,
+    /// canary generation, and memory-protection failures return an operating-system
+    /// error. Locking is subject to the process's `RLIMIT_MEMLOCK` allowance.
+    /// An error consumes and drops the input instead of returning it to the caller.
+    ///
+    /// Allocating shared ownership metadata follows the ordinary Rust allocator's
+    /// allocation-failure behavior. Cleanup failures abort as described in the
+    /// [module documentation](self).
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use commonware_cryptography::{HardenError, Secret};
+    ///
+    /// # fn main() -> Result<(), HardenError> {
+    /// let secret = Secret::new([42u8; 32]).try_harden()?;
+    /// assert!(secret.is_hardened());
+    /// secret.access(|bytes| assert_eq!(bytes[0], 42));
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn try_harden(self) -> Result<Self, HardenError> {
+        #[cfg(all(target_os = "linux", feature = "std"))]
+        {
+            match self.storage {
+                Storage::Inline(value) => HardenedSecret::try_from_inline(value).map(|value| Self {
+                    storage: Storage::Hardened(value),
+                }),
+                Storage::Hardened(_) => Ok(self),
+            }
+        }
+        #[cfg(not(all(target_os = "linux", feature = "std")))]
+        {
+            Err(HardenError::Unsupported)
+        }
     }
 }
 
-impl<T> Drop for Secret<T> {
-    fn drop(&mut self) {
-        let ptr = &raw mut *self.0;
-        // SAFETY:
-        // - Pointer obtained while self.0 is still initialized
-        // - ManuallyDrop::drop: self.0 is initialized and we have exclusive access
-        // - zeroize_ptr: uses raw pointer (not reference) to zero memory after drop
-        unsafe {
-            ManuallyDrop::drop(&mut self.0);
-            zeroize_ptr(ptr);
+impl<const N: usize> Secret<[u8; N]> {
+    /// Initializes a byte array directly in hardened storage.
+    ///
+    /// Calls `f` with a zeroed array after locking its pages and excluding them
+    /// from core dumps. The array is writable during initialization and inaccessible
+    /// when construction completes. Untouched bytes remain zero. The closure's
+    /// own temporaries are outside the allocation.
+    ///
+    /// # Errors
+    ///
+    /// Returns the same construction errors as [Self::try_harden]. The initializer
+    /// is not called if hardening is unsupported or initial setup fails. If a later
+    /// step fails, the array is erased before returning the error.
+    ///
+    /// # Panics
+    ///
+    /// A panic from `f` propagates. During unwinding, the allocation is erased
+    /// and released. Cleanup failures abort as described in the [module documentation](self).
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use commonware_cryptography::{HardenError, Secret};
+    ///
+    /// # fn main() -> Result<(), HardenError> {
+    /// let secret = Secret::<[u8; 32]>::try_init(|bytes| bytes.fill(42))?;
+    /// assert!(secret.is_hardened());
+    /// secret.access(|bytes| assert_eq!(bytes[0], 42));
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn try_init(f: impl FnOnce(&mut [u8; N])) -> Result<Self, HardenError> {
+        #[cfg(all(target_os = "linux", feature = "std"))]
+        {
+            HardenedSecret::try_init(f).map(|value| Self {
+                storage: Storage::Hardened(value),
+            })
+        }
+        #[cfg(not(all(target_os = "linux", feature = "std")))]
+        {
+            let _ = f;
+            Err(HardenError::Unsupported)
         }
     }
 }
@@ -123,25 +400,263 @@ impl<T> Display for Secret<T> {
     }
 }
 
-impl<T> ZeroizeOnDrop for Secret<T> {}
-
-impl<T: Clone> Clone for Secret<T> {
-    fn clone(&self) -> Self {
-        self.expose(|v| Self::new(v.clone()))
-    }
-}
-
 impl<T: CtEq> PartialEq for Secret<T> {
     fn eq(&self, other: &Self) -> bool {
-        self.expose(|a| other.expose(|b| a.ct_eq(b).into()))
+        self.access(|a| other.access(|b| a.ct_eq(b).into()))
     }
 }
 
 impl<T: CtEq> Eq for Secret<T> {}
 
+/// Erases the storage for `T`, including padding, using volatile writes.
+///
+/// This does not run `T`'s destructor and need not leave a valid `T` behind.
+///
+/// # Safety
+///
+/// `ptr` must be non-null and permit exclusive writes to `size_of::<T>()` bytes
+/// within one live allocation. Those bytes may be uninitialized. No live value
+/// may subsequently be read or dropped from that storage without reinitialization.
+#[inline]
+unsafe fn zeroize_ptr<T>(ptr: *mut T) {
+    // SAFETY: The caller guarantees that `ptr` is valid for writes of `size_of::<T>()` bytes.
+    // MaybeUninit permits erasing padding without reading uninitialized bytes.
+    unsafe {
+        let slice = core::slice::from_raw_parts_mut(
+            ptr.cast::<MaybeUninit<u8>>(),
+            core::mem::size_of::<T>(),
+        );
+        slice.zeroize();
+    }
+}
+
+/// A value stored inline with explicit access and erasure on drop.
+///
+/// The wrapper adds no allocation or OS memory protections. It calls `T`'s
+/// destructor, then zeroizes the bytes occupied by `T`, including padding.
+/// `Debug` prints `InlineSecret([REDACTED])` and `Display` prints `[REDACTED]`.
+/// Cloning calls `T::clone` and stores the result in a separate wrapper.
+///
+/// Store sensitive bytes directly in `T`. Referenced allocations are not erased
+/// by this wrapper. `T`'s destructor must not panic, since that would skip the
+/// subsequent erasure. Earlier copies and locations left behind by moves are
+/// also outside its control. See the [module documentation](self) for details.
+///
+pub(crate) struct InlineSecret<T>(ManuallyDrop<T>);
+
+impl<T> InlineSecret<T> {
+    /// Transfers `T` into caller-owned storage and erases this consumed wrapper.
+    ///
+    /// Does not run `T`'s destructor. Locations left by earlier moves of the wrapper
+    /// are outside this operation's control.
+    ///
+    /// # Safety
+    ///
+    /// `destination` must be non-null, aligned for `T`, and writable for
+    /// `size_of::<T>()` bytes. Non-nullness and alignment also apply to zero-sized
+    /// types. The destination must accept a new `T` without dropping its previous
+    /// contents. It must not overlap the source or be accessed through any other
+    /// pointer or reference during the transfer. The caller takes ownership of
+    /// the initialized `T` and must arrange its destruction.
+    #[cfg(all(target_os = "linux", feature = "std"))]
+    pub(crate) unsafe fn move_into(self, destination: *mut T) {
+        let mut value = ManuallyDrop::new(self);
+        let source = &raw mut *value.0;
+        // SAFETY: The caller supplies valid, disjoint storage. The source stays
+        // at its original address until wiped and is never moved or dropped again.
+        unsafe {
+            core::ptr::copy_nonoverlapping(source, destination, 1);
+            zeroize_ptr(source);
+        }
+    }
+
+    /// Takes ownership of `value` and stores it inline.
+    #[inline]
+    pub const fn new(value: T) -> Self {
+        Self(ManuallyDrop::new(value))
+    }
+
+    /// Passes a shared reference to the stored value to `f` and returns its result.
+    ///
+    /// The borrow of the stored value is limited to the call. The closure can
+    /// still copy values or raw pointers out, or return references already stored
+    /// inside `T`. Such results receive no protection from this wrapper.
+    /// Shared access also permits any interior mutability provided by `T`.
+    ///
+    #[inline]
+    pub fn access<R>(&self, f: impl for<'a> FnOnce(&'a T) -> R) -> R {
+        f(&self.0)
+    }
+
+    /// Moves out `T` and erases this wrapper's storage without destroying the value.
+    #[inline]
+    fn extract(self) -> T {
+        let mut this = ManuallyDrop::new(self);
+        let source = &raw mut *this.0;
+        // SAFETY: We exclusively own an initialized T. ManuallyDrop prevents
+        // destroying the moved-out value, and its source storage stays writable
+        // until erasure completes.
+        unsafe {
+            let value = source.read();
+            zeroize_ptr(source);
+            value
+        }
+    }
+}
+
+impl<T> Drop for InlineSecret<T> {
+    fn drop(&mut self) {
+        let ptr = &raw mut *self.0;
+        // SAFETY: We exclusively own an initialized T and keep its storage live
+        // until erasure finishes. After destruction, zeroize_ptr accesses only
+        // raw storage and does not require a valid T.
+        unsafe {
+            core::ptr::drop_in_place(ptr);
+            zeroize_ptr(ptr);
+        }
+    }
+}
+
+impl<T> Debug for InlineSecret<T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        f.write_str("InlineSecret([REDACTED])")
+    }
+}
+
+impl<T> Display for InlineSecret<T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+        f.write_str("[REDACTED]")
+    }
+}
+
+impl<T> ZeroizeOnDrop for InlineSecret<T> {}
+
+impl<T: Clone> Clone for InlineSecret<T> {
+    fn clone(&self) -> Self {
+        self.access(|v| Self::new(v.clone()))
+    }
+}
+
+impl<T: CtEq> PartialEq for InlineSecret<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.access(|a| other.access(|b| a.ct_eq(b).into()))
+    }
+}
+
+impl<T: CtEq> Eq for InlineSecret<T> {}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use core::cell::Cell;
+
+    #[test]
+    fn test_try_extract_non_clone() {
+        // Owning a heap value detects premature destruction during extraction.
+        struct Value<'a> {
+            bytes: Box<[u8; 32]>,
+            drops: &'a Cell<usize>,
+        }
+
+        impl Drop for Value<'_> {
+            fn drop(&mut self) {
+                self.drops.set(self.drops.get() + 1);
+            }
+        }
+
+        fn check(secret: Secret<Value<'_>>, drops: &Cell<usize>) {
+            let before = drops.get();
+            let value = secret.try_extract().unwrap();
+            assert_eq!(*value.bytes, [42; 32]);
+            assert_eq!(drops.get(), before);
+            drop(value);
+            assert_eq!(drops.get(), before + 1);
+        }
+
+        let drops = Cell::new(0);
+        check(
+            Secret::new(Value {
+                bytes: Box::new([42; 32]),
+                drops: &drops,
+            }),
+            &drops,
+        );
+        #[cfg(all(target_os = "linux", feature = "std"))]
+        check(
+            Secret::new(Value {
+                bytes: Box::new([42; 32]),
+                drops: &drops,
+            })
+            .try_harden()
+            .unwrap(),
+            &drops,
+        );
+    }
+
+    #[test]
+    fn test_extract_or_clone() {
+        #[derive(Debug)]
+        struct Value<'a> {
+            clones: &'a Cell<usize>,
+            drops: &'a Cell<usize>,
+        }
+
+        impl Clone for Value<'_> {
+            fn clone(&self) -> Self {
+                self.clones.set(self.clones.get() + 1);
+                Self {
+                    clones: self.clones,
+                    drops: self.drops,
+                }
+            }
+        }
+
+        impl Drop for Value<'_> {
+            fn drop(&mut self) {
+                self.drops.set(self.drops.get() + 1);
+            }
+        }
+
+        let clones = Cell::new(0);
+        let drops = Cell::new(0);
+        let secret = Secret::new(Value {
+            clones: &clones,
+            drops: &drops,
+        });
+        let value = secret.extract_or_clone();
+        assert_eq!(clones.get(), 0);
+        assert_eq!(drops.get(), 0);
+        drop(value);
+        assert_eq!(drops.get(), 1);
+
+        #[cfg(all(target_os = "linux", feature = "std"))]
+        {
+            let secret = Secret::new(Value {
+                clones: &clones,
+                drops: &drops,
+            })
+            .try_harden()
+            .unwrap();
+            let shared = secret.clone();
+            assert_eq!(clones.get(), 0);
+
+            let secret = secret.try_extract().unwrap_err();
+            assert!(secret.is_hardened());
+            secret.access(|value| assert!(core::ptr::eq(value.clones, &clones)));
+
+            let copied = secret.extract_or_clone();
+            assert_eq!(clones.get(), 1);
+            assert_eq!(drops.get(), 1);
+
+            // Releasing the other handle makes the remaining value movable.
+            let moved = shared.extract_or_clone();
+            assert_eq!(clones.get(), 1);
+            assert_eq!(drops.get(), 1);
+            drop(copied);
+            drop(moved);
+            assert_eq!(drops.get(), 3);
+        }
+    }
 
     #[test]
     fn test_debug_redacted() {
@@ -156,26 +671,19 @@ mod tests {
     }
 
     #[test]
-    fn test_expose() {
+    fn test_access() {
         let secret = Secret::new([1u8, 2, 3, 4]);
-        secret.expose(|v| {
+        secret.access(|v| {
             assert_eq!(v, &[1u8, 2, 3, 4]);
         });
-    }
-
-    #[test]
-    fn test_expose_unwrap() {
-        let secret = Secret::new([1u8, 2, 3, 4]);
-        let value = secret.expose_unwrap();
-        assert_eq!(value, [1u8, 2, 3, 4]);
     }
 
     #[test]
     fn test_clone() {
         let secret = Secret::new([1u8, 2, 3, 4]);
         let cloned = secret.clone();
-        secret.expose(|a| {
-            cloned.expose(|b| {
+        secret.access(|a| {
+            cloned.access(|b| {
                 assert_eq!(a, b);
             });
         });
@@ -191,16 +699,16 @@ mod tests {
     }
 
     #[test]
-    fn test_multiple_expose() {
+    fn test_multiple_access() {
         let secret = Secret::new([42u8; 32]);
 
-        // First expose
-        secret.expose(|v| {
+        // First access
+        secret.access(|v| {
             assert_eq!(v[0], 42);
         });
 
-        // Second expose
-        secret.expose(|v| {
+        // Second access
+        secret.access(|v| {
             assert_eq!(v[31], 42);
         });
     }

--- a/cryptography/src/secret.rs
+++ b/cryptography/src/secret.rs
@@ -1,102 +1,247 @@
-//! Secret values with explicit access and erasure on drop.
+//! Secret values with explicit access and erasure of their retained storage.
 //!
-//! - [Secret] supports inline and hardened storage through a single public wrapper.
-//!   It starts inline and can be converted to hardened storage with [Secret::try_harden].
-//!   Conversion consumes the wrapper, including on failure. Existing clones and
-//!   previously exported values are unaffected.
-//! - `InlineSecret<T>` is the private implementation of inline storage. Dropping
-//!   the wrapper destroys `T`, then zeroizes its storage. Cloning calls `T::clone`
-//!   and places the result in a separate wrapper.
-//! - `HardenedSecret<T>` is the private implementation of hardened storage.
-//!   It stores `T` in locked memory excluded from core dumps.
-//!   The allocation is read-only during `access()` calls and inaccessible between
-//!   them. Clones share the allocation, which is erased when the last owner drops.
-//!   Hardened storage is available on Linux with `std`.
+//! [Secret] provides two storage modes through one wrapper. [Secret::new] stores
+//! `T` inline without allocating. [Secret::try_harden] moves it into protected
+//! memory on Linux with `std`. [Secret::try_init] initializes a byte array directly
+//! in that memory. [Secret::is_hardened] reports the mode without accessing the
+//! value or changing permissions.
 //!
-//! All three redact `Debug` output and provide access to `T` through a closure taking `&T`.
-//! Borrows into the stored value cannot escape that closure. Copies, raw pointers,
-//! and references already stored inside `T` can escape. The wrappers do not erase
-//! or protect values copied out by the caller. When `T: CtEq`, equality delegates
-//! to `T`'s constant-time comparison.
+//! # Ownership and access
 //!
-//! [Secret::try_extract] and [Secret::extract_or_clone] consume the wrapper and
-//! return an ordinary, unprotected `T`. The caller becomes responsible for its
-//! erasure. Moving a value out erases the source storage without destroying `T`.
-//! If hardened storage is shared, `try_extract` returns the wrapper unchanged,
-//! while `extract_or_clone` clones the value through `access()`.
+//! Inline clones call `T::clone` and own separate values. Hardened clones share
+//! one allocation without copying `T` or changing its permissions. The public
+//! `Secret<T>: Clone` implementation requires `T: Clone` for both modes.
 //!
-//! # Choosing the stored type
+//! ```text
+//! Inline storage                         Hardened storage
 //!
-//! Store sensitive bytes directly in `T`, for example in an array or a struct of
-//! arrays. Protection covers the storage occupied by `T`, including its padding.
-//! It does not extend to memory reached through pointers. Wrapping a `Vec`,
-//! `String`, or `Box` does not make its heap allocation protected or zeroize it.
-//! Any cleanup of referenced allocations depends on `T`'s own destructor.
+//! Secret A       Secret B                Secret A       Secret B
+//! +----------+   +----------+             +--------+     +--------+
+//! | T        |   | T::clone |             | handle |     | handle |
+//! +----------+   +----------+             +----+---+     +---+----+
+//!                                             |             |
+//! Separate values, each with                  +------+------+
+//! its own destruction and erasure                    |
+//!                                                    v
+//!                                         shared allocation metadata
+//!                                                    |
+//!                                                    v
+//!                                      protected data containing one T
+//!                                      erased on final release
+//! ```
 //!
-//! For hardened storage, operations on `&T` must not write to its storage, even
-//! through interior mutability. The pages are read-only during access, so such
-//! writes can terminate the process. `T`'s destructor must not panic, since a
-//! panic can interrupt erasure of inline storage, including during a failed
-//! hardening attempt. Callers must choose types that meet these requirements.
+//! Allocation metadata lives in ordinary memory. The secret-storage protections
+//! apply to the data containing `T`. A separate readable page records fork
+//! identity, contains no secret, and is not locked. Public cached values belong
+//! outside protected data.
 //!
-//! # Limits of erasure
+//! [Secret::access] lends `&T` to a closure. Borrows into `T` cannot escape, but
+//! copies, raw pointers, and references already stored inside `T` can escape.
+//! These results receive no protection. The wrapper redacts its own `Debug` and
+//! `Display` output. Callers can still print the value inside the closure.
+//! Equality uses `T`'s constant-time comparison when `T: CtEq`.
 //!
-//! Erasure covers the wrapper's current storage. Moving a value can leave bytes
-//! at earlier locations, and computations can leave copies in registers or on
-//! the stack. Those copies are outside the wrapper's control. Explicitly manage
-//! exported sensitive values, for example with [zeroize::Zeroizing]. Cleanup
-//! also requires the wrapper to be dropped, so leaking it or terminating the
-//! process without running destructors prevents erasure by the wrapper.
+//! [Secret::try_extract] consumes a uniquely owned wrapper, moves out ordinary
+//! `T`, erases its source, and releases any protected allocation. It never clones.
+//! If hardened storage is shared, it returns `Err(self)` unchanged without
+//! reading `T` or changing permissions. [Secret::extract_or_clone] instead clones
+//! through an access callback when shared. Both produce an unprotected value
+//! whose cleanup belongs to the caller, for example through [zeroize::Zeroizing].
 //!
 //! # Hardened storage
 //!
-//! Hardening requires Linux with `std` and a kernel supporting `MADV_WIPEONFORK`
-//! (Linux 4.14 or later). Construction establishes all required protections before
-//! storing sensitive bytes in the allocation:
+//! Hardening requires Linux with `std` and support for `MADV_WIPEONFORK`, introduced
+//! in Linux 4.14. Construction must establish every required protection. It may
+//! fail under the process's actual locked-memory allowance or syscall policy.
+//! Hardening consumes and drops its input on any error, including unsupported
+//! platforms. Earlier inline clones and previously exported bytes are unaffected.
+//! Hardening an already hardened value keeps its existing allocation.
 //!
-//! - [mlock](https://man7.org/linux/man-pages/man2/mlock.2.html) keeps data pages
-//!   resident, preventing them from being swapped out.
-//! - [MADV_DONTDUMP](https://man7.org/linux/man-pages/man2/madvise.2.html) excludes
-//!   them from kernel-generated core dumps.
-//! - `mprotect` grants read-only access during the callback and revokes it afterward.
-//!   Initialization, extraction, and destruction have write access.
-//! - Guard pages surround the data region. A random canary before the value detects
-//!   writes that change it when the canary is next checked.
+//! | Measure | Protection and limits |
+//! |---|---|
+//! | [mlock](https://man7.org/linux/man-pages/man2/mlock.2.html) | Keeps data pages out of swap, without protecting earlier copies or hibernation images. |
+//! | [MADV_DONTDUMP](https://man7.org/linux/man-pages/man2/madvise.2.html) | Excludes these data pages from kernel-generated core dumps, leaving stack, heap, and computation copies unaffected. |
+//! | `MADV_WIPEONFORK` and allocation identity | Wipe inherited bytes and reject typed use of invalid wiped values in descendants. |
+//! | [mprotect](https://man7.org/linux/man-pages/man2/mprotect.2.html) | Blocks ordinary loads while idle and permits read-only access during callbacks. |
+//! | Guard pages | Fault accesses reaching either data-region boundary, without catching all underruns within unused data bytes or arbitrary pointer jumps. |
+//! | Erasure and unmapping | Clear current retained storage during cleanup, subject to the limits below. |
 //!
-//! Each allocation locks at least one data page and reserves two virtual guard
-//! pages, even for a zero-sized value. Clones share this allocation. `access()` calls
-//! synchronize a reader count and change permissions when the first call begins
-//! and the last ends. The allocation stays readable throughout overlapping calls,
-//! including those through other clones.
+//! The first active callback makes the data pages readable. Nested or concurrent
+//! callbacks through any clone keep them readable until the last callback ends.
+//! Pages are readable throughout the process during that interval, including to
+//! other threads. Shared access must not write to the stored value, even through
+//! interior mutability, because the read-only mapping can make such writes fatal.
 //!
-//! Dropping the last owner destroys the value, zeroizes the entire data region, and
-//! releases the mapping. Erasure also runs if that destructor unwinds. Failures
-//! to change permissions after construction, detected canary corruption, or
-//! failures to restore write access or release memory during cleanup abort the
-//! process. Aborting does not run destructors or guarantee erasure.
+//! These measures do not promise protection against arbitrary code execution,
+//! general speculative-execution attacks, or authorized debugger-style inspection.
+//! Page permissions are not the debugger access-control boundary. Same-user
+//! inspection depends on credentials, dumpability, capabilities, and security
+//! policy. See [Linux ptrace access checks](https://man7.org/linux/man-pages/man2/ptrace.2.html).
 //!
-//! During an `access()` call, the pages are readable throughout the process. Hardening
-//! does not defend against arbitrary code execution, privileged memory
-//! inspection, or hibernation images.
+//! # Forking and failures
 //!
-//! # Forking with hardened storage
+//! Fork children inherit zeroed data. Each allocation also has a read-only marker
+//! that is wiped in descendants and never reset. This rejects inherited handles
+//! even if PID reuse or PID namespaces produce a numeric creator-PID match. New
+//! allocations in a child have independent markers and remain usable.
 //!
-//! `MADV_WIPEONFORK` replaces the child's data pages with zeroes. Accessing or moving
-//! out an inherited hardened value aborts before touching its reader mutex or
-//! reading `T`. The final release in the child only unmaps its copy, without calling
-//! `T`'s destructor on the wiped bytes. The parent's allocation is unaffected.
+//! Inherited access and unique extraction abort before touching the reader mutex
+//! or interpreting wiped bytes as `T`. Returning through an inherited access guard
+//! or initializer also aborts. Shared `try_extract` may return `Err(self)` without
+//! accessing the allocation. Final release in a child unmaps its copy without
+//! calling `T`'s destructor. The parent's allocation remains usable.
 //!
-//! A caller using an unsafe fork API during an `access()` call must ensure that the child
-//! never uses references into the inherited allocation. Its bytes have been wiped
-//! and may no longer represent a valid `T`. Returning through an inherited
-//! read guard also aborts in the child. These restrictions do not replace
-//! the fork API's own safety requirements.
+//! A caller using an unsafe fork API must obey that API's safety rules and must
+//! never use an inherited reference into `T` in the child. Wiped bytes may no
+//! longer represent a valid value. These checks cannot revoke references already
+//! handed to a callback.
+//!
+//! Construction returns [HardenError] if setup or final sealing fails and cleanup
+//! succeeds. After publication, permission failures, reader-count overflow, and
+//! inherited typed use abort. Cleanup also aborts if it cannot restore write access
+//! or release mappings. Abort does not run destructors or guarantee erasure.
+//!
+//! # Stored types and erasure
+//!
+//! Store sensitive bytes directly in `T`, for example in an array or a struct of
+//! arrays. Protection and erasure cover `T`'s own storage, including padding. They
+//! do not extend to allocations behind `Vec`, `String`, `Box`, or other pointers.
+//! Cleanup of those allocations depends on `T`'s destructor.
+//!
+//! Each inline value is destroyed and then erased. A panicking inline destructor
+//! can prevent that erasure, including during a failed hardening attempt. In
+//! hardened storage, the final owner destroys `T`, then erases and unmaps the data.
+//! The raw mapping owner still performs cleanup if `T`'s destructor or a byte-array
+//! initializer unwinds, provided cleanup succeeds and the process keeps unwinding.
+//! Dropping a shared handle does not erase storage still owned by another handle.
+//! [Secret] implements [zeroize::ZeroizeOnDrop] for this erasure on final release,
+//! without requiring a zeroization trait on `T`.
+//!
+//! Moves, registers, stacks, serialized exports, and cryptographic scratch memory
+//! can contain other copies outside the wrapper's control. Leaks and termination
+//! without cleanup also prevent erasure. Protecting retained storage does not
+//! protect every step of a computation that uses it.
+//!
+//! # Costs and trait bounds
+//!
+//! Each allocation locks `round_up(max(size_of::<T>(), 1), page_size)` data bytes,
+//! reserves two additional virtual guard pages, and allocates one unlocked page
+//! for fork identity. Mappings also consume kernel bookkeeping and address space.
+//! With 4 KiB pages, a 64 KiB lock allowance, and no other locked memory, sixteen
+//! one-data-page allocations exhaust that allowance. Actual allowances vary.
+//!
+//! Hardened access synchronizes a reader count and changes permissions on first
+//! entry and last exit. Inline access uses neither synchronization nor syscalls.
+//! The inline variant keeps even hardened handles proportional to `size_of::<T>()`.
+//!
+//! Trait bounds are the same on every platform, including builds without `std`:
+//!
+//! | Trait on `Secret<T>` | Required traits on `T` |
+//! |---|---|
+//! | `Clone` | `Clone` |
+//! | `Debug`, `Display`, `ZeroizeOnDrop` | None |
+//! | `PartialEq`, `Eq` | `CtEq` |
+//! | `Send`, `Sync` | `Send + Sync` |
+//! | `Unpin` | `Unpin` |
+//! | `RefUnwindSafe` | `RefUnwindSafe` |
+//! | `UnwindSafe` | `UnwindSafe + RefUnwindSafe` |
+//!
+//! Sending or sharing a secret between threads requires both thread traits because
+//! hardened handles can share ownership. Non-thread-safe values remain usable
+//! locally, but the wrapper cannot be sent or shared across threads:
+//!
+//! ```compile_fail
+//! use commonware_cryptography::Secret;
+//! use core::cell::Cell;
+//!
+//! fn require_send<T: Send>() {}
+//! require_send::<Secret<Cell<u8>>>();
+//! ```
+//!
+//! ```compile_fail
+//! use commonware_cryptography::Secret;
+//! use core::cell::Cell;
+//!
+//! fn require_sync<T: Sync>() {}
+//! require_sync::<Secret<Cell<u8>>>();
+//! ```
+//!
+//! A payload that supports shared access but cannot move between threads, such
+//! as a mutex guard, also prevents either thread trait on the wrapper:
+//!
+//! ```compile_fail
+//! use commonware_cryptography::Secret;
+//! use std::sync::MutexGuard;
+//!
+//! fn require_send<T: Send>() {}
+//! fn require_sync<T: Sync>() {}
+//! require_sync::<MutexGuard<'static, ()>>();
+//! require_send::<Secret<MutexGuard<'static, ()>>>();
+//! ```
+//!
+//! ```compile_fail
+//! use commonware_cryptography::Secret;
+//! use std::sync::MutexGuard;
+//!
+//! fn require_sync<T: Sync>() {}
+//! require_sync::<MutexGuard<'static, ()>>();
+//! require_sync::<Secret<MutexGuard<'static, ()>>>();
+//! ```
+//!
+//! Access guards restore the reader count and permissions during unwinding. They
+//! do not repair invariants inside `T`. Even when a closure owns its handle,
+//! another hardened clone can observe the same value after a caught panic, so
+//! owned unwind safety also requires `T: RefUnwindSafe`:
+//!
+//! ```compile_fail
+//! use commonware_cryptography::Secret;
+//! use core::{cell::Cell, panic::UnwindSafe};
+//!
+//! fn require_unwind_safe<T: UnwindSafe>() {}
+//! require_unwind_safe::<Box<Cell<u8>>>();
+//! require_unwind_safe::<Secret<Box<Cell<u8>>>>();
+//! ```
+//!
+//! Borrowed access likewise retains `T`'s unwind-safety requirement:
+//!
+//! ```compile_fail
+//! use commonware_cryptography::Secret;
+//! use core::{cell::Cell, panic::RefUnwindSafe};
+//!
+//! fn require_ref_unwind_safe<T: RefUnwindSafe>() {}
+//! require_ref_unwind_safe::<Secret<Cell<u8>>>();
+//! ```
+//!
+//! Owned unwind safety additionally preserves `T: UnwindSafe`. A mutable
+//! reference can satisfy the borrowed bound while failing the owned bound:
+//!
+//! ```compile_fail
+//! use commonware_cryptography::Secret;
+//! use core::panic::{RefUnwindSafe, UnwindSafe};
+//!
+//! fn require_ref_unwind_safe<T: RefUnwindSafe>() {}
+//! fn require_unwind_safe<T: UnwindSafe>() {}
+//! require_ref_unwind_safe::<Secret<&'static mut ()>>();
+//! require_unwind_safe::<Secret<&'static mut ()>>();
+//! ```
+//!
+//! Inline storage contains `T` directly, so the wrapper also preserves its
+//! pinning requirements:
+//!
+//! ```compile_fail
+//! use commonware_cryptography::Secret;
+//! use core::marker::PhantomPinned;
+//!
+//! fn require_unpin<T: Unpin>() {}
+//! require_unpin::<Secret<PhantomPinned>>();
+//! ```
 
 #[cfg(all(target_os = "linux", feature = "std"))]
 use crate::hardened_secret::HardenedSecret;
 use core::{
     fmt::{Debug, Display, Formatter},
     mem::{ManuallyDrop, MaybeUninit},
+    panic::{RefUnwindSafe, UnwindSafe},
 };
 use ctutils::CtEq;
 use thiserror::Error;
@@ -106,6 +251,9 @@ use zeroize::{Zeroize, ZeroizeOnDrop};
 ///
 /// These errors report failures during setup. Once hardened storage has been
 /// constructed, failures to change its memory permissions abort the process.
+///
+/// `Layout` and `System` are available only on Linux with `std`. `Unsupported`
+/// is available on every platform, including builds where it is never returned.
 #[derive(Debug, Error)]
 pub enum HardenError {
     /// Hardening was requested without both Linux and the `std` feature.
@@ -121,7 +269,7 @@ pub enum HardenError {
     #[cfg(all(target_os = "linux", feature = "std"))]
     #[error("unsupported protected allocation layout")]
     Layout,
-    /// Allocation, canary generation, or a required memory protection failed.
+    /// Allocation or a required memory protection failed.
     #[cfg(all(target_os = "linux", feature = "std"))]
     #[error("{operation}: {source}")]
     System {
@@ -202,7 +350,7 @@ impl<T> Secret<T> {
     ///
     /// A panic from `f` propagates. During unwinding, hardened storage becomes
     /// inaccessible if no other call remains active. Failed permission changes
-    /// or detected canary corruption abort the process.
+    /// abort the process.
     ///
     /// # Examples
     ///
@@ -236,8 +384,8 @@ impl<T> Secret<T> {
     /// In that case, no value is read and no memory permissions are changed.
     /// Use [Self::extract_or_clone] to clone the value when shared and `T: Clone`.
     ///
-    /// Permission failures, canary corruption, or moving out an inherited fork-child
-    /// value abort the process, as described in the [module documentation](self).
+    /// Permission failures or moving out an inherited fork-child value abort the
+    /// process, as described in the [module documentation](self).
     ///
     /// # Examples
     ///
@@ -272,8 +420,8 @@ impl<T> Secret<T> {
     /// # Panics
     ///
     /// A panic from `T::clone` propagates after the access call ends and this handle
-    /// is released. Permission failures, canary corruption, and cleanup failures
-    /// abort as described in the [module documentation](self).
+    /// is released. Permission and cleanup failures abort as described in the
+    /// [module documentation](self).
     ///
     /// # Examples
     ///
@@ -304,9 +452,9 @@ impl<T> Secret<T> {
     ///
     /// Returns [HardenError::Unsupported] without Linux and `std`. On supported
     /// builds, returns a layout error if a suitable mapping cannot be represented,
-    /// including when `T`'s alignment exceeds the system page size. Mapping,
-    /// canary generation, and memory-protection failures return an operating-system
-    /// error. Locking is subject to the process's `RLIMIT_MEMLOCK` allowance.
+    /// including when `T`'s alignment exceeds the system page size. Mapping and
+    /// memory-protection failures return an operating-system error. Locking is
+    /// subject to the process's `RLIMIT_MEMLOCK` allowance.
     /// An error consumes and drops the input instead of returning it to the caller.
     ///
     /// Allocating shared ownership metadata follows the ordinary Rust allocator's
@@ -329,9 +477,11 @@ impl<T> Secret<T> {
         #[cfg(all(target_os = "linux", feature = "std"))]
         {
             match self.storage {
-                Storage::Inline(value) => HardenedSecret::try_from_inline(value).map(|value| Self {
-                    storage: Storage::Hardened(value),
-                }),
+                Storage::Inline(value) => {
+                    HardenedSecret::try_from_inline(value).map(|value| Self {
+                        storage: Storage::Hardened(value),
+                    })
+                }
                 Storage::Hardened(_) => Ok(self),
             }
         }
@@ -408,6 +558,24 @@ impl<T: CtEq> PartialEq for Secret<T> {
 
 impl<T: CtEq> Eq for Secret<T> {}
 
+impl<T> ZeroizeOnDrop for Secret<T> {}
+
+// SAFETY: Inline ownership can move across threads when T is Send. Hardened
+// handles share ownership, so T must also be Sync even when moving one handle.
+unsafe impl<T: Send + Sync> Send for Secret<T> {}
+
+// SAFETY: Inline shared access requires T: Sync. Hardened handles may outlive
+// each other on different threads, so transferring final ownership also needs Send.
+unsafe impl<T: Send + Sync> Sync for Secret<T> {}
+
+// User code runs outside the reader mutex, and read guards restore its count
+// and permissions during unwinding. Invariants inside T still require RefUnwindSafe.
+impl<T: RefUnwindSafe> RefUnwindSafe for Secret<T> {}
+
+// An owned hardened handle can leave other clones observing T after a panic.
+// Both inline ownership and shared observation must be unwind-safe.
+impl<T: UnwindSafe + RefUnwindSafe> UnwindSafe for Secret<T> {}
+
 /// Erases the storage for `T`, including padding, using volatile writes.
 ///
 /// This does not run `T`'s destructor and need not leave a valid `T` behind.
@@ -430,18 +598,10 @@ unsafe fn zeroize_ptr<T>(ptr: *mut T) {
     }
 }
 
-/// A value stored inline with explicit access and erasure on drop.
+/// Owns inline `T` so moving between storage variants preserves automatic cleanup.
 ///
-/// The wrapper adds no allocation or OS memory protections. It calls `T`'s
-/// destructor, then zeroizes the bytes occupied by `T`, including padding.
-/// `Debug` prints `InlineSecret([REDACTED])` and `Display` prints `[REDACTED]`.
-/// Cloning calls `T::clone` and stores the result in a separate wrapper.
-///
-/// Store sensitive bytes directly in `T`. Referenced allocations are not erased
-/// by this wrapper. `T`'s destructor must not panic, since that would skip the
-/// subsequent erasure. Earlier copies and locations left behind by moves are
-/// also outside its control. See the [module documentation](self) for details.
-///
+/// Drop destroys the value, then erases its bytes and padding. A destructor panic
+/// skips erasure. Clone creates an independent value. No OS protections apply.
 pub(crate) struct InlineSecret<T>(ManuallyDrop<T>);
 
 impl<T> InlineSecret<T> {
@@ -517,38 +677,104 @@ impl<T> Drop for InlineSecret<T> {
     }
 }
 
-impl<T> Debug for InlineSecret<T> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
-        f.write_str("InlineSecret([REDACTED])")
-    }
-}
-
-impl<T> Display for InlineSecret<T> {
-    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
-        f.write_str("[REDACTED]")
-    }
-}
-
-impl<T> ZeroizeOnDrop for InlineSecret<T> {}
-
 impl<T: Clone> Clone for InlineSecret<T> {
     fn clone(&self) -> Self {
         self.access(|v| Self::new(v.clone()))
     }
 }
 
-impl<T: CtEq> PartialEq for InlineSecret<T> {
-    fn eq(&self, other: &Self) -> bool {
-        self.access(|a| other.access(|b| a.ct_eq(b).into()))
-    }
-}
-
-impl<T: CtEq> Eq for InlineSecret<T> {}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use core::cell::Cell;
+
+    #[test]
+    fn test_traits() {
+        fn assert_traits<
+            T: Clone
+                + Debug
+                + Display
+                + Eq
+                + Send
+                + Sync
+                + Unpin
+                + core::panic::UnwindSafe
+                + core::panic::RefUnwindSafe
+                + zeroize::ZeroizeOnDrop,
+        >() {
+        }
+        assert_traits::<Secret<[u8; 32]>>();
+
+        // Erasure and redaction impose no requirements on the stored type.
+        fn assert_unbounded<T>() {
+            fn check<U: Debug + Display + zeroize::ZeroizeOnDrop>() {}
+            check::<Secret<T>>();
+        }
+        assert_unbounded::<Cell<u8>>();
+
+        // Thread bounds do not prevent local use of interior-mutable values.
+        let secret = Secret::new(Cell::new(7));
+        secret.access(|value| value.set(9));
+        assert_eq!(secret.access(Cell::get), 9);
+    }
+
+    #[test]
+    fn test_inline_drop_erases_padding() {
+        #[repr(C)]
+        struct Padded {
+            first: u8,
+            second: u32,
+        }
+
+        // A typed write need not initialize padding. Cleanup must handle it as
+        // MaybeUninit bytes, then leave every storage byte initialized to zero.
+        let mut storage = MaybeUninit::new(InlineSecret::new(Padded {
+            first: 0x71,
+            second: 0x12345678,
+        }));
+        let address = storage.as_mut_ptr();
+        // SAFETY: The value is initialized and uniquely owned. The MaybeUninit
+        // allocation stays live after destruction and does not drop it again.
+        unsafe {
+            core::ptr::drop_in_place(address);
+            let erased = core::slice::from_raw_parts(
+                address.cast::<u8>(),
+                core::mem::size_of::<InlineSecret<Padded>>(),
+            );
+            assert!(erased.iter().all(|byte| *byte == 0));
+        }
+    }
+
+    #[cfg(all(target_os = "linux", feature = "std"))]
+    #[test]
+    fn test_inline_move_transfers_non_clone_ownership() {
+        struct Value<'a> {
+            bytes: Box<[u8; 32]>,
+            drops: &'a Cell<usize>,
+        }
+        impl Drop for Value<'_> {
+            fn drop(&mut self) {
+                self.drops.set(self.drops.get() + 1);
+            }
+        }
+
+        let drops = Cell::new(0);
+        let source = InlineSecret::new(Value {
+            bytes: Box::new([42; 32]),
+            drops: &drops,
+        });
+        let mut destination = MaybeUninit::uninit();
+        // SAFETY: Destination is disjoint, aligned, uninitialized storage. The
+        // move initializes it exactly once and transfers ownership to this test.
+        let value = unsafe {
+            source.move_into(destination.as_mut_ptr());
+            destination.assume_init()
+        };
+        assert_eq!(*value.bytes, [42; 32]);
+        assert_eq!(drops.get(), 0);
+        drop(value);
+        assert_eq!(drops.get(), 1);
+    }
 
     #[test]
     fn test_try_extract_non_clone() {
@@ -581,7 +807,7 @@ mod tests {
             }),
             &drops,
         );
-        #[cfg(all(target_os = "linux", feature = "std"))]
+        #[cfg(all(target_os = "linux", feature = "std", not(miri)))]
         check(
             Secret::new(Value {
                 bytes: Box::new([42; 32]),
@@ -629,7 +855,7 @@ mod tests {
         drop(value);
         assert_eq!(drops.get(), 1);
 
-        #[cfg(all(target_os = "linux", feature = "std"))]
+        #[cfg(all(target_os = "linux", feature = "std", not(miri)))]
         {
             let secret = Secret::new(Value {
                 clones: &clones,

--- a/cryptography/src/secret.rs
+++ b/cryptography/src/secret.rs
@@ -87,11 +87,12 @@
 //!
 //! # Failure modes
 //!
-//! Construction returns [HardenError] when setup or final sealing fails and
-//! cleanup succeeds. Cleanup that cannot restore write access or release
-//! mappings aborts the process, as do failures after publication: a failed
-//! permission change or reader-count overflow. Abort runs no destructors and
-//! guarantees no erasure.
+//! [Secret::try_harden] is the only fallible operation. It returns [HardenError]
+//! when setting up or sealing the allocation fails and cleanup succeeds, and it
+//! leaves the inline value in place. Cleanup that cannot restore write access
+//! or release mappings aborts the process, as do failures once a value is
+//! hardened: a failed permission change or reader-count overflow. Abort runs no
+//! destructors and guarantees no erasure.
 //!
 //! Panics unwind normally. Access guards restore the reader count and
 //! permissions, and the pages are still erased and unmapped when `T`'s
@@ -102,18 +103,19 @@
 //! not cross `fork`. Inline values are copied into the child like any other
 //! memory. Nothing detects the child, and an inherited hardened handle must not
 //! be accessed or dropped there: its pages hold zeros, and it shares the
-//! parent's reader mutex state as of the fork. A child that keeps running should
-//! `exec`, call `_exit`, or forget its handles first. The parent's allocation is
-//! unaffected, and new allocations in the child work normally.
+//! parent's reader mutex state as of the fork. A child that goes on to run
+//! destructors, rather than calling `exec` or `_exit`, must forget its handles
+//! first. The parent's allocation is unaffected, and new allocations in the
+//! child work normally.
 //!
 //! # Costs
 //!
 //! Each hardened allocation locks `round_up(max(size_of::<T>(), 1), page_size)`
 //! bytes and reserves two guard pages of address space, plus kernel
 //! bookkeeping. Locked bytes count against
-//! `RLIMIT_MEMLOCK`, so many small secrets exhaust a small allowance quickly.
-//! The wrapper is an enum over both storage modes, so a hardened wrapper still
-//! occupies at least `size_of::<T>()` bytes.
+//! `RLIMIT_MEMLOCK`, so many small secrets may exhaust a small allowance
+//! quickly. The wrapper is an enum over both storage modes, so a hardened
+//! wrapper still occupies at least `size_of::<T>()` bytes.
 //!
 //! Hardened access takes a mutex and changes page permissions on the first
 //! entry and last exit of an access interval. Inline access costs nothing extra.
@@ -151,10 +153,10 @@ use ctutils::CtEq;
 use thiserror::Error;
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
-/// Failure to construct hardened storage.
+/// Failure to move a value into hardened storage.
 ///
-/// `Layout` and `System` exist only on Linux. Failures after construction abort
-/// the process instead of returning an error.
+/// `Layout` and `System` exist only on Linux. Failures after hardening abort the
+/// process instead of returning an error.
 #[derive(Debug, Error)]
 pub enum HardenError {
     /// Hardening was requested on an unsupported system.
@@ -185,7 +187,8 @@ pub enum HardenError {
 /// `Debug` prints `Secret([REDACTED])` and `Display` prints `[REDACTED]`. The
 /// value is reachable only through [Self::access] and the extraction methods.
 /// [Self::new] stores it inline, and on Linux [Self::try_harden] moves it into
-/// protected memory that clones then share.
+/// protected memory. Clones of an inline value each own a copy. Clones of a
+/// hardened value share its single allocation.
 ///
 /// Protection covers `T`'s own bytes only. Memory behind pointers inside `T`,
 /// copies made outside the wrapper, and values inherited by fork children are
@@ -195,7 +198,7 @@ pub enum HardenError {
 /// # Examples
 ///
 /// ```
-/// use commonware_cryptography::{HardenError, Secret};
+/// use commonware_cryptography::{HardenError, Hasher, Secret, Sha256};
 /// use zeroize::Zeroizing;
 ///
 /// # fn main() -> Result<(), HardenError> {
@@ -206,12 +209,14 @@ pub enum HardenError {
 ///     Err(HardenError::Unsupported) => assert!(!secret.is_hardened()),
 ///     Err(error) => return Err(error),
 /// }
-/// secret.access(|bytes| assert_eq!(bytes[0], 42));
-/// assert_eq!(secret, secret.clone());
+///
+/// // Use the value inside the callback. Equality on the wrapper is constant time.
+/// let digest = secret.access(|key| Sha256::hash(&[key]));
+/// assert_eq!(secret, Secret::new([42u8; 32]));
 ///
 /// // Extracted values leave the wrapper. Erase them separately.
-/// let bytes = Zeroizing::new(secret.extract_or_clone());
-/// assert_eq!(*bytes, [42; 32]);
+/// let key = Zeroizing::new(secret.extract_or_clone());
+/// assert_eq!(Sha256::hash(&[key.as_slice()]), digest);
 /// # Ok(())
 /// # }
 /// ```
@@ -301,11 +306,12 @@ impl<T> Secret<T> {
     ///
     /// ```
     /// use commonware_cryptography::Secret;
+    /// use ctutils::CtEq;
     ///
     /// struct Value([u8; 32]);
     /// let secret = Secret::new(Value([42; 32]));
     /// let value = secret.try_extract().unwrap();
-    /// assert_eq!(value.0, [42; 32]);
+    /// assert!(bool::from(value.0.ct_eq(&[42; 32])));
     /// ```
     pub fn try_extract(self) -> Result<T, Self> {
         match self.storage {
@@ -317,7 +323,8 @@ impl<T> Secret<T> {
         }
     }
 
-    /// Consumes the wrapper, moving out `T` when uniquely owned and cloning it otherwise.
+    /// Consumes the wrapper, moving out `T` when uniquely owned and cloning it
+    /// otherwise.
     ///
     /// Uniquely owned storage follows [Self::try_extract]. Shared hardened
     /// storage clones `T` through [Self::access] and releases this handle,
@@ -330,11 +337,12 @@ impl<T> Secret<T> {
     ///
     /// ```
     /// use commonware_cryptography::Secret;
+    /// use ctutils::CtEq;
     /// use zeroize::Zeroizing;
     ///
     /// let secret = Secret::new([42u8; 32]);
     /// let bytes = Zeroizing::new(secret.extract_or_clone());
-    /// assert_eq!(*bytes, [42; 32]);
+    /// assert!(bool::from(bytes.ct_eq(&[42; 32])));
     /// ```
     pub fn extract_or_clone(self) -> T
     where
@@ -414,86 +422,19 @@ impl<T: CtEq> Eq for Secret<T> {}
 /// and a panicking inline destructor skips erasure of that value.
 impl<T> ZeroizeOnDrop for Secret<T> {}
 
-/// Hardened handles share ownership, so a wrapper is `Send` only when `T` is
-/// also `Sync`:
-///
-/// ```compile_fail,E0277
-/// use commonware_cryptography::Secret;
-/// use core::cell::Cell;
-///
-/// fn require_send<T: Send>() {}
-/// require_send::<Secret<Cell<u8>>>();
-/// ```
-///
-/// `T: Send` is still required:
-///
-/// ```compile_fail,E0277
-/// use commonware_cryptography::Secret;
-/// use std::sync::MutexGuard;
-///
-/// fn require_send<T: Send>() {}
-/// require_send::<Secret<MutexGuard<'static, ()>>>();
-/// ```
 // SAFETY: Inline ownership can move across threads when T is Send. Hardened
 // handles share ownership, so T must also be Sync even when moving one handle.
 unsafe impl<T: Send + Sync> Send for Secret<T> {}
 
-/// Hardened handles can be released on different threads, so a wrapper is
-/// `Sync` only when `T` is also `Send`:
-///
-/// ```compile_fail,E0277
-/// use commonware_cryptography::Secret;
-/// use std::sync::MutexGuard;
-///
-/// fn require_sync<T: Sync>() {}
-/// require_sync::<Secret<MutexGuard<'static, ()>>>();
-/// ```
-///
-/// `T: Sync` is still required:
-///
-/// ```compile_fail,E0277
-/// use commonware_cryptography::Secret;
-/// use core::cell::Cell;
-///
-/// fn require_sync<T: Sync>() {}
-/// require_sync::<Secret<Cell<u8>>>();
-/// ```
 // SAFETY: Inline shared access requires T: Sync. Hardened handles may outlive
 // each other on different threads, so transferring final ownership also needs Send.
 unsafe impl<T: Send + Sync> Sync for Secret<T> {}
 
 /// Access guards restore the reader count and permissions during unwinding.
-/// Invariants inside `T` remain `T`'s own:
-///
-/// ```compile_fail,E0277
-/// use commonware_cryptography::Secret;
-/// use core::{cell::Cell, panic::RefUnwindSafe};
-///
-/// fn require_ref_unwind_safe<T: RefUnwindSafe>() {}
-/// require_ref_unwind_safe::<Secret<Cell<u8>>>();
-/// ```
 impl<T: RefUnwindSafe> RefUnwindSafe for Secret<T> {}
 
 /// An owned hardened handle can leave other handles observing `T` after a
-/// caught panic, so owned unwind safety also requires `T: RefUnwindSafe`:
-///
-/// ```compile_fail,E0277
-/// use commonware_cryptography::Secret;
-/// use core::{cell::Cell, panic::UnwindSafe};
-///
-/// fn require_unwind_safe<T: UnwindSafe>() {}
-/// require_unwind_safe::<Secret<Box<Cell<u8>>>>();
-/// ```
-///
-/// `T: UnwindSafe` is still required:
-///
-/// ```compile_fail,E0277
-/// use commonware_cryptography::Secret;
-/// use core::panic::UnwindSafe;
-///
-/// fn require_unwind_safe<T: UnwindSafe>() {}
-/// require_unwind_safe::<Secret<&'static mut ()>>();
-/// ```
+/// caught panic, so owned unwind safety also requires `T: RefUnwindSafe`.
 impl<T: UnwindSafe + RefUnwindSafe> UnwindSafe for Secret<T> {}
 
 /// Erases the storage for `T`, including padding, using volatile writes.
@@ -523,15 +464,7 @@ unsafe fn zeroize_ptr<T>(ptr: *mut T) {
 /// Drop destroys the value, then erases its bytes and padding. A destructor
 /// panic skips erasure. Clone creates an independent value, and no OS
 /// protections apply. Holding `T` directly also makes the wrapper inherit its
-/// pinning requirement:
-///
-/// ```compile_fail,E0277
-/// use commonware_cryptography::Secret;
-/// use core::marker::PhantomPinned;
-///
-/// fn require_unpin<T: Unpin>() {}
-/// require_unpin::<Secret<PhantomPinned>>();
-/// ```
+/// pinning requirement.
 pub(crate) struct InlineSecret<T>(ManuallyDrop<T>);
 
 impl<T> InlineSecret<T> {

--- a/cryptography/src/secret.rs
+++ b/cryptography/src/secret.rs
@@ -1,140 +1,126 @@
-//! Secret values with explicit access and erasure of their retained storage.
+//! Secret values with scoped access and erasure on drop.
 //!
-//! [Secret] provides two storage modes through one wrapper. [Secret::new] stores
-//! `T` inline without allocating. [Secret::try_harden] moves it into protected
-//! memory on Linux with `std`. [Secret::try_init] initializes a byte array directly
-//! in that memory. [Secret::is_hardened] reports the mode without accessing the
-//! value or changing permissions.
+//! [Secret] redacts its `Debug` and `Display` output, lends its value only to
+//! closures passed to [Secret::access], and erases its storage when the last
+//! owner is dropped. The value lives inline by default. On Linux,
+//! [Secret::try_harden] moves it into locked, non-dumpable memory that is
+//! unreadable between accesses.
 //!
-//! # Ownership and access
+//! # What is protected
 //!
-//! Inline clones call `T::clone` and own separate values. Hardened clones share
-//! one allocation without copying `T` or changing its permissions. The public
-//! `Secret<T>: Clone` implementation requires `T: Clone` for both modes.
+//! Both storage modes cover only `T`'s own storage, including padding. Anything
+//! `T` reaches through a pointer, such as the contents of a `Vec`, `String`, or
+//! `Box`, is ordinary memory that the wrapper neither locks, hides, nor erases,
+//! and its cleanup depends on `T`'s destructor. Store sensitive bytes directly
+//! in `T` as arrays or structs of arrays, and keep public derived values such as
+//! cached public keys outside it.
 //!
-//! ```text
-//! Inline storage                         Hardened storage
+//! Only the retained value is covered. Moves, registers, stacks, serialized
+//! exports, and cryptographic scratch memory can hold other copies, and the
+//! location a value was moved in from is not erased. Whatever a closure returns
+//! from [Secret::access], whether a copy, a raw pointer, or a reference already
+//! stored inside `T`, receives no protection, and the closure can print the
+//! value it is given. Leaks and termination without cleanup also prevent erasure.
 //!
-//! Secret A       Secret B                Secret A       Secret B
-//! +----------+   +----------+             +--------+     +--------+
-//! | T        |   | T::clone |             | handle |     | handle |
-//! +----------+   +----------+             +----+---+     +---+----+
-//!                                             |             |
-//! Separate values, each with                  +------+------+
-//! its own destruction and erasure                    |
-//!                                                    v
-//!                                         shared allocation metadata
-//!                                                    |
-//!                                                    v
-//!                                      protected data containing one T
-//!                                      erased on final release
-//! ```
-//!
-//! Allocation metadata lives in ordinary memory. The secret-storage protections
-//! apply to the data containing `T`. A separate readable page records fork
-//! identity, contains no secret, and is not locked. Public cached values belong
-//! outside protected data.
-//!
-//! [Secret::access] lends `&T` to a closure. Borrows into `T` cannot escape, but
-//! copies, raw pointers, and references already stored inside `T` can escape.
-//! These results receive no protection. The wrapper redacts its own `Debug` and
-//! `Display` output. Callers can still print the value inside the closure.
-//! Equality uses `T`'s constant-time comparison when `T: CtEq`.
-//!
-//! [Secret::try_extract] consumes a uniquely owned wrapper, moves out ordinary
-//! `T`, erases its source, and releases any protected allocation. It never clones.
-//! If hardened storage is shared, it returns `Err(self)` unchanged without
-//! reading `T` or changing permissions. [Secret::extract_or_clone] instead clones
-//! through an access callback when shared. Both produce an unprotected value
-//! whose cleanup belongs to the caller, for example through [zeroize::Zeroizing].
-//!
-//! # Hardened storage
-//!
-//! Hardening requires Linux with `std` and support for `MADV_WIPEONFORK`, introduced
-//! in Linux 4.14. Construction must establish every required protection. It may
-//! fail under the process's actual locked-memory allowance or syscall policy.
-//! Hardening leaves the value and its storage unchanged on error, including on
-//! unsupported platforms. Earlier inline clones and exported bytes are unaffected.
-//! Hardening an already hardened value keeps its existing allocation.
+//! Inline storage adds only redaction, scoped access, and erasure on drop.
+//! Hardening also reduces the exposure of the idle value to swap, kernel core
+//! dumps, fork children, and memory-disclosure bugs elsewhere in the process:
 //!
 //! | Measure | Protection and limits |
 //! |---|---|
-//! | [mlock](https://man7.org/linux/man-pages/man2/mlock.2.html) | Keeps data pages out of swap, without protecting earlier copies or hibernation images. |
-//! | [MADV_DONTDUMP](https://man7.org/linux/man-pages/man2/madvise.2.html) | Excludes these data pages from kernel-generated core dumps, leaving stack, heap, and computation copies unaffected. |
-//! | `MADV_WIPEONFORK` and allocation identity | Wipe inherited bytes and reject typed use of invalid wiped values in descendants. |
+//! | [mlock](https://man7.org/linux/man-pages/man2/mlock.2.html) | Keeps the data pages out of swap. Earlier copies and hibernation images are unaffected. |
+//! | [MADV_DONTDUMP](https://man7.org/linux/man-pages/man2/madvise.2.html) | Excludes the data pages from kernel core dumps. Stack, heap, and computation copies remain. |
+//! | [MADV_WIPEONFORK](https://man7.org/linux/man-pages/man2/madvise.2.html) | Zeroes the data pages in fork children. |
 //! | [mprotect](https://man7.org/linux/man-pages/man2/mprotect.2.html) | Blocks ordinary loads while idle and permits read-only access during callbacks. |
-//! | Guard pages | Fault accesses reaching either data-region boundary, without catching all underruns within unused data bytes or arbitrary pointer jumps. |
-//! | Erasure and unmapping | Clear current retained storage during cleanup, subject to the limits below. |
+//! | Guard pages | Fault accesses that cross either boundary of the data region. Underruns into unused data bytes and arbitrary pointer jumps are not caught. |
+//! | Erasure and unmapping | Clear the retained storage during cleanup, within the limits described below. |
 //!
-//! The first active callback makes the data pages readable. Nested or concurrent
-//! callbacks through any clone keep them readable until the last callback ends.
-//! Pages are readable throughout the process during that interval, including to
-//! other threads. Shared access must not write to the stored value, even through
-//! interior mutability, because the read-only mapping can make such writes fatal.
-//!
-//! These measures do not promise protection against arbitrary code execution,
-//! general speculative-execution attacks, or authorized debugger-style inspection.
-//! Page permissions are not the debugger access-control boundary. Same-user
-//! inspection depends on credentials, dumpability, capabilities, and security
+//! None of this defends against arbitrary code execution, speculative-execution
+//! attacks, or debugger-style inspection. Page permissions are not the `ptrace`
+//! access-control boundary. Whether another same-user process can read this
+//! one's memory depends on credentials, dumpability, capabilities, and security
 //! policy. See [Linux ptrace access checks](https://man7.org/linux/man-pages/man2/ptrace.2.html).
 //!
-//! # Forking and failures
+//! # Inline and hardened storage
 //!
-//! Fork children inherit zeroed data. Each allocation also has a read-only marker
-//! that is wiped in descendants and never reset. This rejects inherited handles
-//! even if PID reuse or PID namespaces produce a numeric creator-PID match. New
-//! allocations in a child have independent markers and remain usable.
+//! ```text
+//! Inline (every platform)               Hardened (Linux)
 //!
-//! Inherited access and unique extraction abort before touching the reader mutex
-//! or interpreting wiped bytes as `T`. Returning through an inherited access guard
-//! or initializer also aborts. Shared `try_extract` may return `Err(self)` without
-//! accessing the allocation. Final release in a child unmaps its copy without
-//! calling `T`'s destructor. The parent's allocation remains usable.
+//! Secret A     Secret B (clone)         Secret A     Secret B (clone)
+//! +--------+   +----------+             +--------+   +--------+
+//! | T      |   | T::clone |             | handle |   | handle |
+//! +--------+   +----------+             +---+----+   +---+----+
+//!                                           |            |
+//! Each wrapper owns and                     +-----+------+
+//! erases its own value                            v
+//!                                       +---------------------+
+//!                                       | protected data      |
+//!                                       | pages holding one T |
+//!                                       +---------------------+
+//!                                       erased when the last
+//!                                       handle is released
+//! ```
 //!
-//! A caller using an unsafe fork API must obey that API's safety rules and must
-//! never use an inherited reference into `T` in the child. Wiped bytes may no
-//! longer represent a valid value. These checks cannot revoke references already
-//! handed to a callback.
+//! Inline storage holds `T` in the wrapper. Cloning calls `T::clone`, access is
+//! a plain borrow, and each wrapper destroys and erases its own value.
 //!
-//! Construction returns [HardenError] if setup or final sealing fails and cleanup
-//! succeeds. After publication, permission failures, reader-count overflow, and
-//! inherited typed use abort. Cleanup also aborts if it cannot restore write access
-//! or release mappings. Abort does not run destructors or guarantee erasure.
+//! Hardened clones are handles to one shared allocation. Cloning copies nothing
+//! and changes no permissions. The first active callback makes the data pages
+//! readable, and they stay readable to every thread in the process until the
+//! last nested or concurrent callback through any handle ends. Callbacks must
+//! not write to the value, even through interior mutability, because the pages
+//! are mapped read-only. The last handle destroys `T`, then erases and unmaps
+//! the pages. Dropping a shared handle erases nothing.
 //!
-//! # Stored types and erasure
+//! Hardening is all or nothing. It requires `MADV_WIPEONFORK`, introduced in
+//! Linux 4.14, and may fail under the process's locked-memory allowance or
+//! syscall policy. On error, including on unsupported platforms, the inline
+//! value and its storage are unchanged. Hardening an already hardened value
+//! keeps its allocation. Earlier inline clones and exported bytes are never
+//! affected.
 //!
-//! Store sensitive bytes directly in `T`, for example in an array or a struct of
-//! arrays. Protection and erasure cover `T`'s own storage, including padding. They
-//! do not extend to allocations behind `Vec`, `String`, `Box`, or other pointers.
-//! Cleanup of those allocations depends on `T`'s destructor.
+//! [Secret::try_extract] moves `T` out of uniquely owned storage without
+//! cloning, erases the source, and releases any allocation. Shared hardened
+//! storage returns `Err(self)` without reading `T` or changing permissions.
+//! [Secret::extract_or_clone] clones through a callback instead. Both hand the
+//! caller an unprotected value whose erasure is the caller's responsibility.
 //!
-//! Each inline value is destroyed and then erased. A panicking inline destructor
-//! can prevent that erasure. In hardened storage, the final owner destroys `T`,
-//! then erases and unmaps the data.
-//! The raw mapping owner still performs cleanup if `T`'s destructor or a byte-array
-//! initializer unwinds, provided cleanup succeeds and the process keeps unwinding.
-//! Dropping a shared handle does not erase storage still owned by another handle.
-//! [Secret] implements [zeroize::ZeroizeOnDrop] for this erasure on final release,
-//! without requiring a zeroization trait on `T`.
+//! # Failure modes
 //!
-//! Moves, registers, stacks, serialized exports, and cryptographic scratch memory
-//! can contain other copies outside the wrapper's control. Leaks and termination
-//! without cleanup also prevent erasure. Protecting retained storage does not
-//! protect every step of a computation that uses it.
+//! Construction returns [HardenError] when setup or final sealing fails and
+//! cleanup succeeds. Cleanup that cannot restore write access or release
+//! mappings aborts the process, as do failures after publication: a failed
+//! permission change or reader-count overflow. Abort runs no destructors and
+//! guarantees no erasure.
 //!
-//! # Costs and trait bounds
+//! Panics unwind normally. Access guards restore the reader count and
+//! permissions, and the pages are still erased and unmapped when `T`'s
+//! destructor unwinds, provided cleanup succeeds. A panicking inline
+//! destructor skips erasure of that value.
 //!
-//! Each allocation locks `round_up(max(size_of::<T>(), 1), page_size)` data bytes,
-//! reserves two additional virtual guard pages, and allocates one unlocked page
-//! for fork identity. Mappings also consume kernel bookkeeping and address space.
-//! With 4 KiB pages, a 64 KiB lock allowance, and no other locked memory, sixteen
-//! one-data-page allocations exhaust that allowance. Actual allowances vary.
+//! Hardened data pages are zeroed in fork children, so the hardened value does
+//! not cross `fork`. Inline values are copied into the child like any other
+//! memory. Nothing detects the child, and an inherited hardened handle must not
+//! be accessed or dropped there: its pages hold zeros, and it shares the
+//! parent's reader mutex state as of the fork. A child that keeps running should
+//! `exec`, call `_exit`, or forget its handles first. The parent's allocation is
+//! unaffected, and new allocations in the child work normally.
 //!
-//! Hardened access synchronizes a reader count and changes permissions on first
-//! entry and last exit. Inline access uses neither synchronization nor syscalls.
-//! The inline variant keeps even hardened handles proportional to `size_of::<T>()`.
+//! # Costs
 //!
-//! Trait bounds are the same on every platform, including builds without `std`:
+//! Each hardened allocation locks `round_up(max(size_of::<T>(), 1), page_size)`
+//! bytes and reserves two guard pages of address space, plus kernel
+//! bookkeeping. Locked bytes count against
+//! `RLIMIT_MEMLOCK`, so many small secrets exhaust a small allowance quickly.
+//! The wrapper is an enum over both storage modes, so a hardened wrapper still
+//! occupies at least `size_of::<T>()` bytes.
+//!
+//! Hardened access takes a mutex and changes page permissions on the first
+//! entry and last exit of an access interval. Inline access costs nothing extra.
+//!
+//! # Trait bounds
+//!
+//! Bounds are the same on every platform:
 //!
 //! | Trait on `Secret<T>` | Required traits on `T` |
 //! |---|---|
@@ -146,98 +132,16 @@
 //! | `RefUnwindSafe` | `RefUnwindSafe` |
 //! | `UnwindSafe` | `UnwindSafe + RefUnwindSafe` |
 //!
-//! Sending or sharing a secret between threads requires both thread traits because
-//! hardened handles can share ownership. Non-thread-safe values remain usable
-//! locally, but the wrapper cannot be sent or shared across threads:
-//!
-//! ```compile_fail
-//! use commonware_cryptography::Secret;
-//! use core::cell::Cell;
-//!
-//! fn require_send<T: Send>() {}
-//! require_send::<Secret<Cell<u8>>>();
-//! ```
-//!
-//! ```compile_fail
-//! use commonware_cryptography::Secret;
-//! use core::cell::Cell;
-//!
-//! fn require_sync<T: Sync>() {}
-//! require_sync::<Secret<Cell<u8>>>();
-//! ```
-//!
-//! A payload that supports shared access but cannot move between threads, such
-//! as a mutex guard, also prevents either thread trait on the wrapper:
-//!
-//! ```compile_fail
-//! use commonware_cryptography::Secret;
-//! use std::sync::MutexGuard;
-//!
-//! fn require_send<T: Send>() {}
-//! fn require_sync<T: Sync>() {}
-//! require_sync::<MutexGuard<'static, ()>>();
-//! require_send::<Secret<MutexGuard<'static, ()>>>();
-//! ```
-//!
-//! ```compile_fail
-//! use commonware_cryptography::Secret;
-//! use std::sync::MutexGuard;
-//!
-//! fn require_sync<T: Sync>() {}
-//! require_sync::<MutexGuard<'static, ()>>();
-//! require_sync::<Secret<MutexGuard<'static, ()>>>();
-//! ```
-//!
-//! Access guards restore the reader count and permissions during unwinding. They
-//! do not repair invariants inside `T`. Even when a closure owns its handle,
-//! another hardened clone can observe the same value after a caught panic, so
-//! owned unwind safety also requires `T: RefUnwindSafe`:
-//!
-//! ```compile_fail
-//! use commonware_cryptography::Secret;
-//! use core::{cell::Cell, panic::UnwindSafe};
-//!
-//! fn require_unwind_safe<T: UnwindSafe>() {}
-//! require_unwind_safe::<Box<Cell<u8>>>();
-//! require_unwind_safe::<Secret<Box<Cell<u8>>>>();
-//! ```
-//!
-//! Borrowed access likewise retains `T`'s unwind-safety requirement:
-//!
-//! ```compile_fail
-//! use commonware_cryptography::Secret;
-//! use core::{cell::Cell, panic::RefUnwindSafe};
-//!
-//! fn require_ref_unwind_safe<T: RefUnwindSafe>() {}
-//! require_ref_unwind_safe::<Secret<Cell<u8>>>();
-//! ```
-//!
-//! Owned unwind safety additionally preserves `T: UnwindSafe`. A mutable
-//! reference can satisfy the borrowed bound while failing the owned bound:
-//!
-//! ```compile_fail
-//! use commonware_cryptography::Secret;
-//! use core::panic::{RefUnwindSafe, UnwindSafe};
-//!
-//! fn require_ref_unwind_safe<T: RefUnwindSafe>() {}
-//! fn require_unwind_safe<T: UnwindSafe>() {}
-//! require_ref_unwind_safe::<Secret<&'static mut ()>>();
-//! require_unwind_safe::<Secret<&'static mut ()>>();
-//! ```
-//!
-//! Inline storage contains `T` directly, so the wrapper also preserves its
-//! pinning requirements:
-//!
-//! ```compile_fail
-//! use commonware_cryptography::Secret;
-//! use core::marker::PhantomPinned;
-//!
-//! fn require_unpin<T: Unpin>() {}
-//! require_unpin::<Secret<PhantomPinned>>();
-//! ```
+//! Hardened handles share ownership, so sending or sharing a wrapper across
+//! threads requires both thread traits, and an owned wrapper can leave other
+//! handles observing `T` after a caught panic, so owned unwind safety also
+//! requires `RefUnwindSafe`. Values that fail these bounds remain usable on one
+//! thread. Equality is constant time through `CtEq`, and erasure needs no
+//! zeroization trait on `T`.
 
 #[cfg(all(target_os = "linux", feature = "std"))]
 use crate::hardened_secret::HardenedSecret;
+use cfg_if::cfg_if;
 use core::{
     fmt::{Debug, Display, Formatter},
     mem::{ManuallyDrop, MaybeUninit},
@@ -247,25 +151,19 @@ use ctutils::CtEq;
 use thiserror::Error;
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
-/// Failure to construct hardened secret storage.
+/// Failure to construct hardened storage.
 ///
-/// These errors report failures during setup. Once hardened storage has been
-/// constructed, failures to change its memory permissions abort the process.
-///
-/// `Layout` and `System` are available only on Linux with `std`. `Unsupported`
-/// is available on every platform, including builds where it is never returned.
+/// `Layout` and `System` exist only on Linux. Failures after construction abort
+/// the process instead of returning an error.
 #[derive(Debug, Error)]
 pub enum HardenError {
-    /// Hardening was requested without both Linux and the `std` feature.
-    ///
-    /// A Linux kernel that rejects a required operation produces an operating-system
-    /// error instead.
-    #[error("memory hardening requires Linux and the std feature")]
+    /// Hardening was requested on an unsupported system.
+    #[error("hardening is not supported on this system")]
     Unsupported,
-    /// The allocator cannot represent a valid mapping for the value.
+    /// No valid mapping layout exists for the value.
     ///
-    /// This includes unsupported page sizes or alignment, size overflow, and
-    /// mappings that exceed Rust's address or allocation-size constraints.
+    /// The page size or `T`'s alignment is unsupported, or the mapping size
+    /// overflows.
     #[cfg(all(target_os = "linux", feature = "std"))]
     #[error("unsupported protected allocation layout")]
     Layout,
@@ -273,9 +171,10 @@ pub enum HardenError {
     #[cfg(all(target_os = "linux", feature = "std"))]
     #[error("{operation}: {source}")]
     System {
-        /// The operation that failed, including the advice flag for `madvise`.
+        /// The failed call: `mmap`, `mprotect`, `madvise(MADV_DONTDUMP)`,
+        /// `madvise(MADV_WIPEONFORK)`, or `mlock`.
         operation: &'static str,
-        /// The error reported by that operation.
+        /// The error it reported.
         #[source]
         source: std::io::Error,
     },
@@ -283,31 +182,48 @@ pub enum HardenError {
 
 /// A secret stored inline or in protected memory.
 ///
-/// [Self::new] stores values inline without allocating. After successful [Self::try_harden],
-/// clones share a protected allocation. Inline clones instead call `T::clone`.
-/// `Debug` prints `Secret([REDACTED])` and `Display` prints `[REDACTED]`.
-/// See the [module documentation](self) for requirements on `T`.
+/// `Debug` prints `Secret([REDACTED])` and `Display` prints `[REDACTED]`. The
+/// value is reachable only through [Self::access] and the extraction methods.
+/// [Self::new] stores it inline, and on Linux [Self::try_harden] moves it into
+/// protected memory that clones then share.
+///
+/// Protection covers `T`'s own bytes only. Memory behind pointers inside `T`,
+/// copies made outside the wrapper, and values inherited by fork children are
+/// outside it. The [module documentation](self) states the full contract,
+/// including failure modes, costs, and trait bounds.
 ///
 /// # Examples
 ///
 /// ```
-/// use commonware_cryptography::Secret;
+/// use commonware_cryptography::{HardenError, Secret};
+/// use zeroize::Zeroizing;
 ///
-/// let secret = Secret::new([42u8; 32]);
-/// assert!(!secret.is_hardened());
-/// secret.access(|bytes| assert_eq!(bytes.len(), 32));
-/// let cloned = secret.clone();
-/// assert_eq!(secret, cloned);
+/// # fn main() -> Result<(), HardenError> {
+/// let mut secret = Secret::new([42u8; 32]);
+/// match secret.try_harden() {
+///     Ok(()) => assert!(secret.is_hardened()),
+///     // Unsupported platforms keep the inline value.
+///     Err(HardenError::Unsupported) => assert!(!secret.is_hardened()),
+///     Err(error) => return Err(error),
+/// }
+/// secret.access(|bytes| assert_eq!(bytes[0], 42));
+/// assert_eq!(secret, secret.clone());
+///
+/// // Extracted values leave the wrapper. Erase them separately.
+/// let bytes = Zeroizing::new(secret.extract_or_clone());
+/// assert_eq!(*bytes, [42; 32]);
+/// # Ok(())
+/// # }
 /// ```
 #[derive(Clone)]
 pub struct Secret<T> {
     storage: Storage<T>,
 }
 
-/// Storage selection kept private so callers access values through Secret's methods.
+/// Storage mode, private so that values are reached only through `Secret`'s methods.
 #[derive(Clone)]
 enum Storage<T> {
-    /// A value stored directly in this enum, without OS memory protections.
+    /// The value itself, without OS memory protections.
     Inline(InlineSecret<T>),
     /// A handle to shared, protected storage.
     #[cfg(all(target_os = "linux", feature = "std"))]
@@ -315,17 +231,16 @@ enum Storage<T> {
 }
 
 impl<T> Secret<T> {
-    /// Stores `value` inline. No protected allocation is made until hardening.
+    /// Stores `value` inline.
+    ///
+    /// The location `value` is moved in from is not erased.
     pub const fn new(value: T) -> Self {
         Self {
             storage: Storage::Inline(InlineSecret::new(value)),
         }
     }
 
-    /// Returns whether this value uses hardened storage.
-    ///
-    /// Does not access the value, allocate, or change memory permissions. Always
-    /// returns `false` on builds without Linux and `std`.
+    /// Returns whether the value is in hardened storage. Always `false` outside Linux.
     #[inline]
     pub const fn is_hardened(&self) -> bool {
         match &self.storage {
@@ -335,22 +250,19 @@ impl<T> Secret<T> {
         }
     }
 
-    /// Grants `f` temporary access to the stored value, making hardened storage read-only.
+    /// Lends the stored value to `f`.
     ///
-    /// Borrows into the stored value cannot escape the closure. Copied values,
-    /// raw pointers, and references already stored inside `T` can escape and
-    /// receive no additional protection.
-    ///
-    /// For hardened storage, nested and concurrent calls through any clone
-    /// keep the allocation readable until the last call ends. Returning from
-    /// one callback does not revoke access while another remains active. Shared
-    /// access must not write to hardened storage, even through interior mutability.
+    /// Borrows into the value cannot escape the closure. Copies, raw pointers,
+    /// and references already stored inside `T` can, and receive no protection.
+    /// Hardened data pages stay readable until the last nested or concurrent
+    /// call through any handle ends. `f` must not write through interior
+    /// mutability: inline storage tolerates it, but hardened pages are read-only,
+    /// the write is fatal, and whether a value is hardened is decided at runtime.
     ///
     /// # Panics
     ///
-    /// A panic from `f` propagates. During unwinding, hardened storage becomes
-    /// inaccessible if no other call remains active. Failed permission changes
-    /// abort the process.
+    /// A panic from `f` propagates after the access interval is closed. A failed
+    /// permission change aborts the process.
     ///
     /// # Examples
     ///
@@ -373,19 +285,15 @@ impl<T> Secret<T> {
 
     /// Consumes the wrapper and moves out `T` if its storage is uniquely owned.
     ///
-    /// The returned value is ordinary, unprotected `T`. The caller is responsible
-    /// for its erasure. The source storage is erased without running `T`'s destructor.
-    /// Inline storage always succeeds. Hardened storage also releases its allocation
-    /// on success. This method never clones `T`.
+    /// The source storage is erased without running `T`'s destructor, and a
+    /// hardened allocation is released. The returned value is unprotected, and
+    /// its erasure is the caller's responsibility.
     ///
     /// # Errors
     ///
-    /// Returns `Err(self)` unchanged if another handle shares the hardened allocation.
-    /// In that case, no value is read and no memory permissions are changed.
-    /// Use [Self::extract_or_clone] to clone the value when shared and `T: Clone`.
-    ///
-    /// Permission failures or moving out an inherited fork-child value abort the
-    /// process, as described in the [module documentation](self).
+    /// Returns `Err(self)` unchanged when another handle shares the hardened
+    /// allocation. Nothing is read and no permissions change. Use
+    /// [Self::extract_or_clone] to clone in that case.
     ///
     /// # Examples
     ///
@@ -409,23 +317,16 @@ impl<T> Secret<T> {
         }
     }
 
-    /// Consumes the wrapper, moving out `T` when uniquely owned or cloning it otherwise.
+    /// Consumes the wrapper, moving out `T` when uniquely owned and cloning it otherwise.
     ///
-    /// The returned value is ordinary, unprotected `T`. The caller is responsible
-    /// for its erasure. Inline and uniquely owned hardened values follow
-    /// [Self::try_extract], which erases the source storage. Shared hardened values
-    /// call `T::clone` through [Self::access], then release this handle. Other handles
-    /// keep their protected storage.
-    ///
-    /// # Panics
-    ///
-    /// A panic from `T::clone` propagates after the access call ends and this handle
-    /// is released. Permission and cleanup failures abort as described in the
-    /// [module documentation](self).
+    /// Uniquely owned storage follows [Self::try_extract]. Shared hardened
+    /// storage clones `T` through [Self::access] and releases this handle,
+    /// leaving the others intact. The returned value is unprotected, and its
+    /// erasure is the caller's responsibility.
     ///
     /// # Examples
     ///
-    /// Use [zeroize::Zeroizing] to erase the extracted bytes when they are dropped:
+    /// Use [zeroize::Zeroizing] to erase the extracted bytes on drop:
     ///
     /// ```
     /// use commonware_cryptography::Secret;
@@ -443,106 +344,45 @@ impl<T> Secret<T> {
             .unwrap_or_else(|secret| secret.access(Clone::clone))
     }
 
-    /// Moves an inline value into hardened storage, or keeps an existing allocation.
+    /// Moves an inline value into hardened storage.
     ///
-    /// Hardening an already hardened value performs no allocation or permission
-    /// change. Other wrappers, including earlier inline clones, are unaffected.
+    /// An already hardened value is left as is. Other wrappers, including
+    /// earlier inline clones, are unaffected.
+    ///
+    /// Only `T`'s own bytes move into protected memory, and protection covers
+    /// the retained value rather than copies made while computing with it. Fork
+    /// children inherit zeroed pages and must not access or drop the value. See
+    /// the [module documentation](self) for the full contract.
     ///
     /// # Errors
     ///
-    /// Returns [HardenError::Unsupported] without Linux and `std`. On supported
-    /// builds, returns a layout error if a suitable mapping cannot be represented,
-    /// including when `T`'s alignment exceeds the system page size. Mapping and
-    /// memory-protection failures return an operating-system error. Locking is
-    /// subject to the process's `RLIMIT_MEMLOCK` allowance.
-    /// An error leaves the value and its storage unchanged.
-    ///
-    /// Allocating shared ownership metadata follows the ordinary Rust allocator's
-    /// allocation-failure behavior. Cleanup failures abort as described in the
-    /// [module documentation](self).
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// use commonware_cryptography::{HardenError, Secret};
-    ///
-    /// # fn main() -> Result<(), HardenError> {
-    /// let mut secret = Secret::new([42u8; 32]);
-    /// secret.try_harden()?;
-    /// assert!(secret.is_hardened());
-    /// secret.access(|bytes| assert_eq!(bytes[0], 42));
-    /// # Ok(())
-    /// # }
-    /// ```
+    /// Returns [HardenError::Unsupported] outside Linux, `HardenError::Layout`
+    /// when `T`'s alignment exceeds the page size or no valid mapping size
+    /// exists, and `HardenError::System` when a mapping or protection call
+    /// fails, including `mlock` beyond the `RLIMIT_MEMLOCK` allowance. On error
+    /// the value and its storage are unchanged.
     #[allow(clippy::missing_const_for_fn)]
     pub fn try_harden(&mut self) -> Result<(), HardenError> {
-        #[cfg(all(target_os = "linux", feature = "std"))]
-        {
-            let hardened = match &mut self.storage {
-                // SAFETY: On success, the source is erased and overwritten below
-                // without dropping its value or invoking any code that can panic.
-                Storage::Inline(value) => unsafe { HardenedSecret::try_from_inline(value)? },
-                Storage::Hardened(_) => return Ok(()),
-            };
-            let storage = &raw mut self.storage;
-            // SAFETY: The sealed allocation now owns T. Erase the entire old
-            // storage, including padding, without dropping T. Use the raw pointer
-            // to replace the temporarily invalid bytes without forming a reference.
-            unsafe {
-                zeroize_ptr(storage);
-                storage.write(Storage::Hardened(hardened));
+        cfg_if! {
+            if #[cfg(all(target_os = "linux", feature = "std"))] {
+                let hardened = match &mut self.storage {
+                    // SAFETY: On success, the source is erased and overwritten below
+                    // without dropping its value or invoking any code that can panic.
+                    Storage::Inline(value) => unsafe { HardenedSecret::try_from_inline(value)? },
+                    Storage::Hardened(_) => return Ok(()),
+                };
+                let storage = &raw mut self.storage;
+                // SAFETY: The sealed allocation now owns T. Erase the entire old
+                // storage, including padding, without dropping T. Use the raw pointer
+                // to replace the temporarily invalid bytes without forming a reference.
+                unsafe {
+                    zeroize_ptr(storage);
+                    storage.write(Storage::Hardened(hardened));
+                }
+                Ok(())
+            } else {
+                Err(HardenError::Unsupported)
             }
-            Ok(())
-        }
-        #[cfg(not(all(target_os = "linux", feature = "std")))]
-        {
-            Err(HardenError::Unsupported)
-        }
-    }
-}
-
-impl<const N: usize> Secret<[u8; N]> {
-    /// Initializes a byte array directly in hardened storage.
-    ///
-    /// Calls `f` with a zeroed array after locking its pages and excluding them
-    /// from core dumps. The array is writable during initialization and inaccessible
-    /// when construction completes. Untouched bytes remain zero. The closure's
-    /// own temporaries are outside the allocation.
-    ///
-    /// # Errors
-    ///
-    /// Returns the same construction errors as [Self::try_harden]. The initializer
-    /// is not called if hardening is unsupported or initial setup fails. If a later
-    /// step fails, the array is erased before returning the error.
-    ///
-    /// # Panics
-    ///
-    /// A panic from `f` propagates. During unwinding, the allocation is erased
-    /// and released. Cleanup failures abort as described in the [module documentation](self).
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// use commonware_cryptography::{HardenError, Secret};
-    ///
-    /// # fn main() -> Result<(), HardenError> {
-    /// let secret = Secret::<[u8; 32]>::try_init(|bytes| bytes.fill(42))?;
-    /// assert!(secret.is_hardened());
-    /// secret.access(|bytes| assert_eq!(bytes[0], 42));
-    /// # Ok(())
-    /// # }
-    /// ```
-    pub fn try_init(f: impl FnOnce(&mut [u8; N])) -> Result<Self, HardenError> {
-        #[cfg(all(target_os = "linux", feature = "std"))]
-        {
-            HardenedSecret::try_init(f).map(|value| Self {
-                storage: Storage::Hardened(value),
-            })
-        }
-        #[cfg(not(all(target_os = "linux", feature = "std")))]
-        {
-            let _ = f;
-            Err(HardenError::Unsupported)
         }
     }
 }
@@ -559,6 +399,8 @@ impl<T> Display for Secret<T> {
     }
 }
 
+/// Compares in constant time through `CtEq`. Both operands are accessed, so
+/// hardened pages are readable for the duration.
 impl<T: CtEq> PartialEq for Secret<T> {
     fn eq(&self, other: &Self) -> bool {
         self.access(|a| other.access(|b| a.ct_eq(b).into()))
@@ -567,22 +409,91 @@ impl<T: CtEq> PartialEq for Secret<T> {
 
 impl<T: CtEq> Eq for Secret<T> {}
 
+/// Erasure of `T`'s own storage when the last owner drops, without requiring a
+/// zeroization trait on `T`. Dropping a shared hardened handle erases nothing,
+/// and a panicking inline destructor skips erasure of that value.
 impl<T> ZeroizeOnDrop for Secret<T> {}
 
+/// Hardened handles share ownership, so a wrapper is `Send` only when `T` is
+/// also `Sync`:
+///
+/// ```compile_fail,E0277
+/// use commonware_cryptography::Secret;
+/// use core::cell::Cell;
+///
+/// fn require_send<T: Send>() {}
+/// require_send::<Secret<Cell<u8>>>();
+/// ```
+///
+/// `T: Send` is still required:
+///
+/// ```compile_fail,E0277
+/// use commonware_cryptography::Secret;
+/// use std::sync::MutexGuard;
+///
+/// fn require_send<T: Send>() {}
+/// require_send::<Secret<MutexGuard<'static, ()>>>();
+/// ```
 // SAFETY: Inline ownership can move across threads when T is Send. Hardened
 // handles share ownership, so T must also be Sync even when moving one handle.
 unsafe impl<T: Send + Sync> Send for Secret<T> {}
 
+/// Hardened handles can be released on different threads, so a wrapper is
+/// `Sync` only when `T` is also `Send`:
+///
+/// ```compile_fail,E0277
+/// use commonware_cryptography::Secret;
+/// use std::sync::MutexGuard;
+///
+/// fn require_sync<T: Sync>() {}
+/// require_sync::<Secret<MutexGuard<'static, ()>>>();
+/// ```
+///
+/// `T: Sync` is still required:
+///
+/// ```compile_fail,E0277
+/// use commonware_cryptography::Secret;
+/// use core::cell::Cell;
+///
+/// fn require_sync<T: Sync>() {}
+/// require_sync::<Secret<Cell<u8>>>();
+/// ```
 // SAFETY: Inline shared access requires T: Sync. Hardened handles may outlive
 // each other on different threads, so transferring final ownership also needs Send.
 unsafe impl<T: Send + Sync> Sync for Secret<T> {}
 
-// User code runs outside the reader mutex, and read guards restore its count
-// and permissions during unwinding. Invariants inside T still require RefUnwindSafe.
+/// Access guards restore the reader count and permissions during unwinding.
+/// Invariants inside `T` remain `T`'s own:
+///
+/// ```compile_fail,E0277
+/// use commonware_cryptography::Secret;
+/// use core::{cell::Cell, panic::RefUnwindSafe};
+///
+/// fn require_ref_unwind_safe<T: RefUnwindSafe>() {}
+/// require_ref_unwind_safe::<Secret<Cell<u8>>>();
+/// ```
 impl<T: RefUnwindSafe> RefUnwindSafe for Secret<T> {}
 
-// An owned hardened handle can leave other clones observing T after a panic.
-// Both inline ownership and shared observation must be unwind-safe.
+/// An owned hardened handle can leave other handles observing `T` after a
+/// caught panic, so owned unwind safety also requires `T: RefUnwindSafe`:
+///
+/// ```compile_fail,E0277
+/// use commonware_cryptography::Secret;
+/// use core::{cell::Cell, panic::UnwindSafe};
+///
+/// fn require_unwind_safe<T: UnwindSafe>() {}
+/// require_unwind_safe::<Secret<Box<Cell<u8>>>>();
+/// ```
+///
+/// `T: UnwindSafe` is still required:
+///
+/// ```compile_fail,E0277
+/// use commonware_cryptography::Secret;
+/// use core::panic::UnwindSafe;
+///
+/// fn require_unwind_safe<T: UnwindSafe>() {}
+/// require_unwind_safe::<Secret<&'static mut ()>>();
+/// ```
 impl<T: UnwindSafe + RefUnwindSafe> UnwindSafe for Secret<T> {}
 
 /// Erases the storage for `T`, including padding, using volatile writes.
@@ -607,26 +518,30 @@ unsafe fn zeroize_ptr<T>(ptr: *mut T) {
     }
 }
 
-/// Owns inline `T` so moving between storage variants preserves automatic cleanup.
+/// Owns an inline `T` so that both storage modes share automatic cleanup.
 ///
-/// Drop destroys the value, then erases its bytes and padding. A destructor panic
-/// skips erasure. Clone creates an independent value. No OS protections apply.
+/// Drop destroys the value, then erases its bytes and padding. A destructor
+/// panic skips erasure. Clone creates an independent value, and no OS
+/// protections apply. Holding `T` directly also makes the wrapper inherit its
+/// pinning requirement:
+///
+/// ```compile_fail,E0277
+/// use commonware_cryptography::Secret;
+/// use core::marker::PhantomPinned;
+///
+/// fn require_unpin<T: Unpin>() {}
+/// require_unpin::<Secret<PhantomPinned>>();
+/// ```
 pub(crate) struct InlineSecret<T>(ManuallyDrop<T>);
 
 impl<T> InlineSecret<T> {
-    /// Takes ownership of `value` and stores it inline.
+    /// Stores `value` inline.
     #[inline]
     pub const fn new(value: T) -> Self {
         Self(ManuallyDrop::new(value))
     }
 
-    /// Passes a shared reference to the stored value to `f` and returns its result.
-    ///
-    /// The borrow of the stored value is limited to the call. The closure can
-    /// still copy values or raw pointers out, or return references already stored
-    /// inside `T`. Such results receive no protection from this wrapper.
-    /// Shared access also permits any interior mutability provided by `T`.
-    ///
+    /// Lends the stored value to `f`.
     #[inline]
     pub fn access<R>(&self, f: impl for<'a> FnOnce(&'a T) -> R) -> R {
         f(&self.0)
@@ -705,6 +620,17 @@ mod tests {
             check::<Secret<T>>();
         }
         assert_unbounded::<Cell<u8>>();
+
+        // Payload traits that the compile-fail examples on the trait impls rely on.
+        fn assert_send<T: Send>() {}
+        fn assert_sync<T: Sync>() {}
+        fn assert_unwind_safe<T: core::panic::UnwindSafe>() {}
+        fn assert_ref_unwind_safe<T: core::panic::RefUnwindSafe>() {}
+        assert_send::<Cell<u8>>();
+        assert_sync::<std::sync::MutexGuard<'static, ()>>();
+        assert_unwind_safe::<Box<Cell<u8>>>();
+        assert_ref_unwind_safe::<&'static mut ()>();
+        assert_ref_unwind_safe::<Secret<&'static mut ()>>();
 
         // Thread bounds do not prevent local use of interior-mutable values.
         let secret = Secret::new(Cell::new(7));

--- a/cryptography/src/secret.rs
+++ b/cryptography/src/secret.rs
@@ -238,7 +238,10 @@ enum Storage<T> {
 impl<T> Secret<T> {
     /// Stores `value` inline.
     ///
-    /// The location `value` is moved in from is not erased.
+    /// The location `value` is moved in from is not erased. An optimizing build
+    /// usually inlines this and constructs `value` in place, but that is best
+    /// effort.
+    #[inline]
     pub const fn new(value: T) -> Self {
         Self {
             storage: Storage::Inline(InlineSecret::new(value)),

--- a/cryptography/src/secret.rs
+++ b/cryptography/src/secret.rs
@@ -241,7 +241,7 @@ impl<T> Secret<T> {
     /// The location `value` is moved in from is not erased. An optimizing build
     /// usually inlines this and constructs `value` in place, but that is best
     /// effort.
-    #[inline]
+    #[inline(always)]
     pub const fn new(value: T) -> Self {
         Self {
             storage: Storage::Inline(InlineSecret::new(value)),
@@ -472,7 +472,7 @@ pub(crate) struct InlineSecret<T>(ManuallyDrop<T>);
 
 impl<T> InlineSecret<T> {
     /// Stores `value` inline.
-    #[inline]
+    #[inline(always)]
     pub const fn new(value: T) -> Self {
         Self(ManuallyDrop::new(value))
     }

--- a/cryptography/src/secret.rs
+++ b/cryptography/src/secret.rs
@@ -474,6 +474,7 @@ impl<T> Secret<T> {
     /// # Ok(())
     /// # }
     /// ```
+    #[allow(clippy::missing_const_for_fn)]
     pub fn try_harden(&mut self) -> Result<(), HardenError> {
         #[cfg(all(target_os = "linux", feature = "std"))]
         {


### PR DESCRIPTION
This PR adds opt-in hardened storage to `Secret<T>` on Linux. Secrets remain inline by default, and callers can use `try_harden()` to protect selected values. The API provides closure-based `access()` (previously named `expose()`), storage inspection through `is_hardened()`, and explicit extraction through `try_extract()` or `extract_or_clone()`.

Hardened storage uses anonymous `mmap` allocations with one permanently inaccessible guard page on each side of the data region. The secret sits immediately before the trailing guard, so an access immediately past its end faults instead of reaching adjacent memory. The guards remain inaccessible during callbacks and reserve virtual address space without requiring physical data pages. `mlock` keeps secret pages out of swap, while `madvise` with `MADV_DONTDUMP` excludes them from kernel-generated core dumps and `MADV_WIPEONFORK` zeroes inherited contents in forked children. Fork-identity checks prevent inherited handles from interpreting wiped bytes as valid values. `mprotect` keeps secret pages inaccessible (`PROT_NONE`) while idle and read-only (`PROT_READ`) during `access()` callbacks, restoring protection when the callback ends. Hardened clones share one allocation, which is erased and unmapped on final release. Setup failures return `HardenError` when cleanup succeeds.

It might be worth exploring `memfd_secret()` as a backend in the future, which removes secret pages from the kernel's direct map and blocks common kernel-mediated access paths, making some memory-disclosure attacks even harder. We would still use `mprotect` to restrict access between operations. The complications include availability (only enabled by default since 6.5), restrictions on passing secret memory directly as syscall buffers, and inhibition of system hibernation while secret allocations exist.

Related https://github.com/commonwarexyz/monorepo/pull/2710.