### PR TITLE
[codec/cryptography] Populate retained lazy keys during batch verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ _Primitives are designed for deployment in adversarial environments. If you find
 * [conformance](./conformance/README.md): Automatically assert the stability of encoding and mechanisms over time.
 * [consensus](./consensus/README.md): Order opaque messages in a Byzantine environment.
 * [cryptography](./cryptography/README.md): Generate keys, sign arbitrary messages, and deterministically verify signatures.
+* [cryptography/curve25519](./cryptography/curve25519/README.md): Perform Curve25519 arithmetic, Ed25519 signing and verification, and X25519 key exchange.
 * [deployer](./deployer/README.md): Deploy infrastructure across cloud providers.
 * [glue](./glue/README.md): Default constructions that span multiple primitives.
 * [math](./math/README.md): Create and manipulate mathematical objects.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ _Primitives are designed for deployment in adversarial environments. If you find
 * [conformance](./conformance/README.md): Automatically assert the stability of encoding and mechanisms over time.
 * [consensus](./consensus/README.md): Order opaque messages in a Byzantine environment.
 * [cryptography](./cryptography/README.md): Generate keys, sign arbitrary messages, and deterministically verify signatures.
-* [cryptography/curve25519](./cryptography/curve25519/README.md): Perform Curve25519 arithmetic, Ed25519 signing and verification, and X25519 key exchange.
 * [deployer](./deployer/README.md): Deploy infrastructure across cloud providers.
 * [glue](./glue/README.md): Default constructions that span multiple primitives.
 * [math](./math/README.md): Create and manipulate mathematical objects.
@@ -84,6 +83,8 @@ RUSTFLAGS="--cfg commonware_stability_BETA" cargo build -p my-app
 ## Platform Compatibility
 
 The Commonware Library supports Linux and macOS, although only Linux is recommended for production use. Select primitives also support `wasm32-unknown-unknown` and `no_std` (for browsers and zkVMs).
+
+x86-64 SIMD extensions (AVX2, AVX-512) are detected at runtime. AArch64 builds assume NEON.
 
 _Windows is not a supported target. Running the Commonware Library on Windows may result in undefined behavior._
 

--- a/codec/src/codec.rs
+++ b/codec/src/codec.rs
@@ -327,6 +327,22 @@ pub trait Decode: Read {
 // Automatically implement `Decode` for types that implement `Read`.
 impl<T: Read> Decode for T {}
 
+/// Decodes a value using reusable work owned by its implementation.
+///
+/// The context may avoid repeating expensive validation, for example when several values were
+/// validated together. It must not change the decoded value or which inputs are accepted.
+pub trait DecodeWith: Decode {
+    /// Reusable decoding work whose interpretation is defined by this implementation.
+    type Context;
+
+    /// Decodes `bytes` using `cfg` and reusable work from `context`.
+    ///
+    /// This must produce the same result as [`Decode::decode_cfg`] for every input and context,
+    /// including configuration checks and rejection of trailing bytes. An unrelated context must
+    /// not cause a valid input to fail or substitute a different value.
+    fn decode_with(bytes: &[u8], cfg: &Self::Cfg, context: &Self::Context) -> Result<Self, Error>;
+}
+
 /// Convenience trait combining [Encode] and [Decode].
 ///
 /// Represents types that can be both fully encoded and decoded.

--- a/codec/src/types/lazy.rs
+++ b/codec/src/types/lazy.rs
@@ -1,6 +1,6 @@
 //! This module exports the [`Lazy`] type.
 
-use crate::{BufsMut, Decode, Encode, EncodeSize, FixedSize, Read, Write};
+use crate::{BufsMut, Decode, DecodeWith, Encode, EncodeSize, FixedSize, Read, Write};
 use bytes::{Buf, Bytes};
 use core::hash::Hash;
 #[cfg(feature = "std")]
@@ -125,29 +125,73 @@ impl<T: Read> Lazy<T> {
 }
 
 impl<T: Read> Lazy<T> {
-    /// Force decoding of the underlying value.
-    ///
-    /// This will return `None` only if decoding the value fails.
-    ///
-    /// This function wil incur the cost of decoding the value only once,
-    /// so there's no need to cache its output.
+    /// Initializes the cache using the pending bytes and configuration.
     #[cfg(feature = "std")]
-    pub fn get(&self) -> Option<&T> {
+    fn initialize_with(
+        &self,
+        decode: impl FnOnce(&[u8], &T::Cfg) -> Result<T, crate::Error>,
+    ) -> Option<&T> {
         self.value
             .get_or_init(|| {
                 let Pending { bytes, cfg } = self
                     .pending
                     .as_ref()
                     .expect("Lazy should have pending if value is not initialized");
-                T::decode_cfg(bytes.as_ref(), cfg).ok()
+                decode(bytes.as_ref(), cfg).ok()
             })
             .as_ref()
+    }
+
+    /// Force decoding of the underlying value.
+    ///
+    /// This will return `None` only if decoding the value fails.
+    ///
+    /// This function will incur the cost of decoding the value only once,
+    /// so there's no need to cache its output.
+    #[cfg(feature = "std")]
+    pub fn get(&self) -> Option<&T> {
+        self.initialize_with(|bytes, cfg| T::decode_cfg(bytes, cfg))
     }
 
     /// Returns a reference to the underlying value, or `None` if decoding failed.
     #[cfg(not(feature = "std"))]
     pub const fn get(&self) -> Option<&T> {
         self.value.as_ref()
+    }
+
+    /// Returns the cached decoding result without initializing it.
+    ///
+    /// `None` means decoding has not completed, `Some(None)` means decoding failed, and
+    /// `Some(Some(value))` contains the decoded value. Without `std`, decoding is eager, so this
+    /// always returns `Some`.
+    pub fn get_cached(&self) -> Option<Option<&T>> {
+        #[cfg(feature = "std")]
+        {
+            self.value.get().map(Option::as_ref)
+        }
+        #[cfg(not(feature = "std"))]
+        {
+            Some(self.value.as_ref())
+        }
+    }
+}
+
+impl<T: DecodeWith> Lazy<T> {
+    /// Accesses the value, reusing decoding work when the cache is uninitialized.
+    ///
+    /// This shares its cache with [`Self::get`], including failed decoding. The context must
+    /// preserve ordinary decoding semantics as required by [`DecodeWith`]. Without `std`, this
+    /// returns the value decoded eagerly at construction.
+    pub fn get_with(&self, context: &T::Context) -> Option<&T> {
+        #[cfg(feature = "std")]
+        {
+            self.initialize_with(|bytes, cfg| T::decode_with(bytes, cfg, context))
+        }
+        #[cfg(not(feature = "std"))]
+        {
+            let _ = context;
+            self.value.as_ref()
+        }
     }
 }
 
@@ -259,8 +303,14 @@ impl<T: Read + core::fmt::Debug> core::fmt::Debug for Lazy<T> {
 #[cfg(test)]
 mod test {
     use super::Lazy;
-    use crate::{DecodeExt, Encode, FixedSize, Read, Write};
+    use crate::{Decode, DecodeExt, DecodeWith, Encode, Error, FixedSize, Read, Write};
     use proptest::prelude::*;
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+    #[cfg(feature = "std")]
+    use std::{sync::Barrier, thread};
 
     /// A byte that's always <= 100
     #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
@@ -294,6 +344,235 @@ mod test {
 
         fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
             (0..=100u8).prop_map(Small).boxed()
+        }
+    }
+
+    #[derive(Default)]
+    struct DecodeCalls {
+        ordinary: AtomicUsize,
+        contextual: AtomicUsize,
+    }
+
+    #[derive(Clone)]
+    struct CountingCfg {
+        max: u8,
+        calls: Arc<DecodeCalls>,
+    }
+
+    impl CountingCfg {
+        fn new(max: u8) -> Self {
+            Self {
+                max,
+                calls: Arc::default(),
+            }
+        }
+
+        fn counts(&self) -> (usize, usize) {
+            (
+                self.calls.ordinary.load(Ordering::Relaxed),
+                self.calls.contextual.load(Ordering::Relaxed),
+            )
+        }
+    }
+
+    /// A configured byte that also accepts encodings with the high bit set.
+    #[derive(Debug, PartialEq, Eq)]
+    struct CachedByte(u8);
+
+    impl FixedSize for CachedByte {
+        const SIZE: usize = 1;
+    }
+
+    impl Write for CachedByte {
+        fn write(&self, buf: &mut impl bytes::BufMut) {
+            self.0.write(buf);
+        }
+    }
+
+    impl Read for CachedByte {
+        type Cfg = CountingCfg;
+
+        fn read_cfg(buf: &mut impl bytes::Buf, cfg: &Self::Cfg) -> Result<Self, Error> {
+            cfg.calls.ordinary.fetch_add(1, Ordering::Relaxed);
+            let value = u8::read_cfg(buf, &())? & 0x7f;
+            if value > cfg.max {
+                return Err(Error::Invalid("CachedByte", "value exceeds maximum"));
+            }
+            Ok(Self(value))
+        }
+    }
+
+    struct ByteContext {
+        encoding: u8,
+        value: u8,
+    }
+
+    impl ByteContext {
+        fn new(encoding: u8) -> Self {
+            Self {
+                encoding,
+                value: encoding & 0x7f,
+            }
+        }
+    }
+
+    impl DecodeWith for CachedByte {
+        type Context = ByteContext;
+
+        fn decode_with(
+            bytes: &[u8],
+            cfg: &Self::Cfg,
+            context: &Self::Context,
+        ) -> Result<Self, Error> {
+            cfg.calls.contextual.fetch_add(1, Ordering::Relaxed);
+            if bytes.first() != Some(&context.encoding) {
+                return Self::decode_cfg(bytes, cfg);
+            }
+            if context.value > cfg.max {
+                return Err(Error::Invalid("CachedByte", "value exceeds maximum"));
+            }
+            if bytes.len() > Self::SIZE {
+                return Err(Error::ExtraData(bytes.len() - Self::SIZE));
+            }
+            Ok(Self(context.value))
+        }
+    }
+
+    #[test]
+    fn contextual_and_ordinary_access_share_cache() {
+        for contextual_first in [false, true] {
+            let cfg = CountingCfg::new(10);
+            let lazy = Lazy::<CachedByte>::deferred(&mut &[0x87][..], cfg.clone());
+            let context = ByteContext::new(0x87);
+            if cfg!(feature = "std") {
+                assert_eq!(lazy.get_cached(), None);
+                assert_eq!(cfg.counts(), (0, 0));
+            } else {
+                assert_eq!(lazy.get_cached(), Some(Some(&CachedByte(7))));
+                assert_eq!(cfg.counts(), (1, 0));
+            }
+
+            let value = if contextual_first {
+                lazy.get_with(&context)
+            } else {
+                lazy.get()
+            }
+            .unwrap();
+            assert_eq!(value, &CachedByte(7));
+            assert!(core::ptr::eq(value, lazy.get().unwrap()));
+            assert!(core::ptr::eq(value, lazy.get_with(&context).unwrap()));
+            assert_eq!(lazy.get_cached(), Some(Some(value)));
+            let expected = if cfg!(feature = "std") && contextual_first {
+                (0, 1)
+            } else {
+                (1, 0)
+            };
+            assert_eq!(cfg.counts(), expected);
+        }
+
+        let lazy = Lazy::new(CachedByte(7));
+        assert_eq!(lazy.get_cached(), Some(Some(&CachedByte(7))));
+        assert_eq!(lazy.get_with(&ByteContext::new(12)), Some(&CachedByte(7)));
+    }
+
+    #[test]
+    fn contextual_and_ordinary_access_cache_failures() {
+        for contextual_first in [false, true] {
+            let cfg = CountingCfg::new(6);
+            let lazy = Lazy::<CachedByte>::deferred(&mut &[7][..], cfg.clone());
+            let context = ByteContext::new(7);
+            if contextual_first {
+                assert_eq!(lazy.get_with(&context), None);
+            } else {
+                assert_eq!(lazy.get(), None);
+            }
+            assert_eq!(lazy.get_cached(), Some(None));
+            assert_eq!(lazy.get(), None);
+            assert_eq!(lazy.get_with(&context), None);
+            let expected = if cfg!(feature = "std") && contextual_first {
+                (0, 1)
+            } else {
+                (1, 0)
+            };
+            assert_eq!(cfg.counts(), expected);
+        }
+    }
+
+    #[test]
+    fn contextual_decode_matches_ordinary_constraints() {
+        let inputs: &[&[u8]] = &[&[], &[7], &[0x87], &[12], &[7, 0], &[12, 0]];
+        for bytes in inputs {
+            for max in [7, 20] {
+                for encoding in [7, 0x87, 12] {
+                    let cfg = CountingCfg::new(max);
+                    let context = ByteContext::new(encoding);
+                    let expected =
+                        CachedByte::decode_cfg(*bytes, &cfg).map_err(|error| error.to_string());
+                    let actual = CachedByte::decode_with(bytes, &cfg, &context)
+                        .map_err(|error| error.to_string());
+                    assert_eq!(actual, expected);
+
+                    let mut encoded = *bytes;
+                    let lazy = Lazy::<CachedByte>::deferred(&mut encoded, cfg);
+                    assert_eq!(lazy.get_with(&context), expected.ok().as_ref());
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn unrelated_context_falls_back_to_ordinary_decode() {
+        let cfg = CountingCfg::new(10);
+        let lazy = Lazy::<CachedByte>::deferred(&mut &[7][..], cfg.clone());
+        assert_eq!(lazy.get_with(&ByteContext::new(8)), Some(&CachedByte(7)));
+        assert_eq!(cfg.counts(), (1, usize::from(cfg!(feature = "std"))));
+        assert_eq!(lazy.get(), Some(&CachedByte(7)));
+        assert_eq!(cfg.counts(), (1, usize::from(cfg!(feature = "std"))));
+    }
+
+    #[test]
+    fn contextual_decode_preserves_original_serialization() {
+        for max in [6, 7] {
+            let lazy = Lazy::<CachedByte>::deferred(&mut &[0x87][..], CountingCfg::new(max));
+            assert_eq!(lazy.encode().as_ref(), &[0x87]);
+            let value = lazy.get_with(&ByteContext::new(0x87));
+            assert_eq!(value.is_some(), max == 7);
+            assert_eq!(lazy.encode().as_ref(), &[0x87]);
+            if let Some(value) = value {
+                assert_eq!(value.encode().as_ref(), &[7]);
+            }
+        }
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn concurrent_contextual_and_ordinary_access_initialize_once() {
+        for max in [6, 7] {
+            let cfg = CountingCfg::new(max);
+            let lazy = Lazy::<CachedByte>::deferred(&mut &[7][..], cfg.clone());
+            let context = ByteContext::new(7);
+            let barrier = Barrier::new(3);
+            thread::scope(|scope| {
+                let ordinary = scope.spawn(|| {
+                    barrier.wait();
+                    lazy.get()
+                });
+                let contextual = scope.spawn(|| {
+                    barrier.wait();
+                    lazy.get_with(&context)
+                });
+                barrier.wait();
+                let ordinary = ordinary.join().unwrap();
+                let contextual = contextual.join().unwrap();
+                assert_eq!(ordinary, contextual);
+                assert_eq!(ordinary.is_some(), max == 7);
+                if let Some(ordinary) = ordinary {
+                    assert!(core::ptr::eq(ordinary, contextual.unwrap()));
+                }
+            });
+            let (ordinary, contextual) = cfg.counts();
+            assert_eq!(ordinary + contextual, 1);
+            assert_eq!(lazy.get_cached().unwrap().is_some(), max == 7);
         }
     }
 

--- a/cryptography/README.md
+++ b/cryptography/README.md
@@ -5,6 +5,8 @@
 
 Generate keys, sign arbitrary messages, and deterministically verify untrusted signatures.
 
+The [curve25519](./curve25519/README.md) crate provides native Curve25519 arithmetic, Ed25519 signing and verification, and X25519 key exchange at ALPHA stability.
+
 ## Status 
 
 Stability varies by primitive. See [README](https://github.com/commonwarexyz/monorepo#stability) for details.

--- a/cryptography/README.md
+++ b/cryptography/README.md
@@ -5,8 +5,6 @@
 
 Generate keys, sign arbitrary messages, and deterministically verify untrusted signatures.
 
-The [curve25519](./curve25519/README.md) crate provides native Curve25519 arithmetic, Ed25519 signing and verification, and X25519 key exchange at ALPHA stability.
-
 ## Status 
 
 Stability varies by primitive. See [README](https://github.com/commonwarexyz/monorepo#stability) for details.

--- a/cryptography/curve25519/Cargo.toml
+++ b/cryptography/curve25519/Cargo.toml
@@ -54,6 +54,7 @@ arbitrary = [
 	"commonware-math/arbitrary",
 	"commonware-utils/arbitrary",
 	"dep:arbitrary",
+	"std",
 ]
 fuzz = [
 	"arbitrary",

--- a/cryptography/curve25519/benches/batch_verify.rs
+++ b/cryptography/curve25519/benches/batch_verify.rs
@@ -1,7 +1,10 @@
-//! Throughput of the public batch-verification API across batch sizes. Each signature is from an
-//! independent key over an independent 32-byte message (no key/message reuse to amortize), the
-//! harder case for the underlying MSM. Fixture generation and verifier construction are not timed.
+//! Throughput of the public batch-verification API across batch sizes and signing-key counts.
+//! Regular batches use independent keys and exclude verifier construction from timing. Lazy
+//! batches measure queueing and verification with either deferred or already decoded keys.
+//! Fixture generation and constructing or dropping retained lazy wrappers are not timed. Messages
+//! are distinct 32-byte values in every workload.
 
+use commonware_codec::types::lazy::Lazy;
 use commonware_cryptography_curve25519::signing::{
     BatchVerifier, Signature, SigningKey, VerifyingKey,
 };
@@ -14,13 +17,16 @@ use std::hint::black_box;
 const NAMESPACE: &[u8] = b"_COMMONWARE_CRYPTOGRAPHY_CURVE25519_BATCH_VERIFY_BENCH";
 const MESSAGE_SIZE: usize = 32;
 
-/// Generates `n` valid `(verifying key, signature, message)` triples, signed by independent keys
-/// over independent 32-byte messages using the public API.
-fn generate_batch(n: usize) -> Vec<(VerifyingKey, Signature, Vec<u8>)> {
+/// Generates `n` valid `(verifying key, signature, message)` triples using `key_count` signing keys
+/// and distinct 32-byte messages.
+fn generate_batch(n: usize, key_count: usize) -> Vec<(VerifyingKey, Signature, Vec<u8>)> {
     let mut rng = test_rng();
+    let keys = (0..key_count)
+        .map(|_| SigningKey::random(&mut rng))
+        .collect::<Vec<_>>();
     (0..n)
         .map(|i| {
-            let signing_key = SigningKey::random(&mut rng);
+            let signing_key = &keys[i % key_count];
 
             let mut message = vec![0u8; MESSAGE_SIZE];
             message[..8].copy_from_slice(&(i as u64).to_le_bytes());
@@ -31,7 +37,7 @@ fn generate_batch(n: usize) -> Vec<(VerifyingKey, Signature, Vec<u8>)> {
         .collect()
 }
 
-fn batch_verifier(batch: &[(VerifyingKey, Signature, Vec<u8>)]) -> BatchVerifier {
+fn batch_verifier(batch: &[(VerifyingKey, Signature, Vec<u8>)]) -> BatchVerifier<'static> {
     let mut verifier = BatchVerifier::new(batch.len());
     for (verifying_key, signature, message) in batch {
         verifier.add(NAMESPACE, message, verifying_key, signature);
@@ -50,7 +56,7 @@ mod verify_batch_bytes_bench {
     pub fn bench(c: &mut Criterion) {
         let mut group = c.benchmark_group(module_path!());
         for n in [1, 10, 100, 1_000, 10_000, 16_384] {
-            let batch = generate_batch(n);
+            let batch = generate_batch(n, n);
             for concurrency in [1, 8, 16, 32] {
                 let rayon = (concurrency > 1).then(|| Rayon::new(NZUsize!(concurrency)).unwrap());
                 group.throughput(Throughput::Elements(n as u64));
@@ -73,9 +79,68 @@ mod verify_batch_bytes_bench {
     }
 }
 
+mod verify_lazy_batch_bench {
+    use super::{
+        BatchSize, BatchVerifier, Criterion, Lazy, NAMESPACE, NZUsize, Rayon, Sequential, TestRng,
+        Throughput, black_box, generate_batch,
+    };
+
+    pub fn bench(c: &mut Criterion) {
+        let mut group = c.benchmark_group(module_path!());
+        for n in [1_024, 16_384] {
+            group.throughput(Throughput::Elements(n as u64));
+            for key_count in [n, 64, 1] {
+                let batch = generate_batch(n, key_count);
+                for concurrency in [1, 8] {
+                    let rayon =
+                        (concurrency > 1).then(|| Rayon::new(NZUsize!(concurrency)).unwrap());
+                    for cache in ["cold", "warm"] {
+                        group.bench_function(
+                            format!("sigs={n} keys={key_count} conc={concurrency} cache={cache}"),
+                            |b| {
+                                b.iter_batched(
+                                    || {
+                                        let keys = batch
+                                            .iter()
+                                            .map(|(key, _, _)| {
+                                                if cache == "warm" {
+                                                    Lazy::new(key.clone())
+                                                } else {
+                                                    Lazy::deferred(&mut key.as_ref(), ())
+                                                }
+                                            })
+                                            .collect::<Vec<_>>();
+                                        (TestRng::new(1), keys)
+                                    },
+                                    |(mut rng, keys)| {
+                                        let mut verifier = BatchVerifier::new(batch.len());
+                                        for ((_, signature, message), key) in
+                                            batch.iter().zip(&keys)
+                                        {
+                                            verifier.add_lazy(NAMESPACE, message, key, signature);
+                                        }
+                                        #[allow(clippy::option_if_let_else)]
+                                        let verified = if let Some(rayon) = rayon.as_ref() {
+                                            black_box(verifier.verify(&mut rng, rayon))
+                                        } else {
+                                            black_box(verifier.verify(&mut rng, &Sequential))
+                                        };
+                                        (verified, keys)
+                                    },
+                                    BatchSize::SmallInput,
+                                );
+                            },
+                        );
+                    }
+                }
+            }
+        }
+    }
+}
+
 criterion_group! {
     name = benches;
     config = Criterion::default().sample_size(10);
-    targets = verify_batch_bytes_bench::bench
+    targets = verify_batch_bytes_bench::bench, verify_lazy_batch_bench::bench
 }
 criterion_main!(benches);

--- a/cryptography/curve25519/conformance.toml
+++ b/cryptography/curve25519/conformance.toml
@@ -12,4 +12,4 @@ hash = "e7b94402b6621a7345af31d64a348f1686ded896cd4eb999376d162a748f2d6f"
 
 ["commonware_cryptography_curve25519::signing::tests::conformance::CodecConformance<VerifyingKey>"]
 n_cases = 65536
-hash = "c0501d4a691d1fccec7c5906e8608228569d24164150edd215838593e3b77512"
+hash = "07f0a3201f8d78b28cfb111074e364599688c9ae06bccb87eac1f48a1edf431c"

--- a/cryptography/curve25519/src/curve.rs
+++ b/cryptography/curve25519/src/curve.rs
@@ -781,7 +781,11 @@ impl GAffineVec {
     }
 
     /// Untransposes backend lanes into scalar affine points.
-    #[cfg(any(test, feature = "fuzz", not(target_arch = "aarch64")))]
+    #[cfg(any(
+        test,
+        feature = "fuzz",
+        not(all(target_arch = "aarch64", target_feature = "neon"))
+    ))]
     pub fn untranspose(self) -> [GAffine; LANES] {
         let x = self.x.untranspose();
         let y = self.y.untranspose();
@@ -886,9 +890,13 @@ pub mod montgomery;
 // Now, a module for each backend.
 #[cfg(all(target_arch = "x86_64", any(feature = "std", test)))]
 mod avx512;
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
 mod neon;
-#[cfg(any(test, feature = "fuzz", not(target_arch = "aarch64")))]
+#[cfg(any(
+    test,
+    feature = "fuzz",
+    not(all(target_arch = "aarch64", target_feature = "neon"))
+))]
 mod portable;
 #[cfg(any(test, feature = "fuzz"))]
 pub mod test;
@@ -902,8 +910,9 @@ pub fn test_backend() -> impl Backend {
 /// Run a computation with the best [`Backend`] this CPU supports.
 ///
 /// This is the only way to gain access to a backend. AVX-512 requires runtime feature detection;
-/// AArch64 includes NEON in its baseline ISA. Every use is forced through this single gate so an
-/// accelerated backend is only constructed where its instructions are guaranteed to be available.
+/// NEON is selected only when enabled by the AArch64 target. Every use is forced through this
+/// single gate so an accelerated backend is only constructed where its instructions are
+/// guaranteed to be available.
 pub fn with_backend<F: WithBackend>(f: F) -> F::Output {
     #[cfg(all(target_arch = "x86_64", any(feature = "std", test)))]
     {
@@ -913,12 +922,12 @@ pub fn with_backend<F: WithBackend>(f: F) -> F::Output {
             return unsafe { backend.call(f) };
         }
     }
-    #[cfg(target_arch = "aarch64")]
+    #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
     {
-        // NEON is part of the AArch64 baseline, so no runtime feature check is needed.
+        // The target guarantees NEON support, so no runtime feature check is needed.
         f.call(neon::Backend::new())
     }
-    #[cfg(not(target_arch = "aarch64"))]
+    #[cfg(not(all(target_arch = "aarch64", target_feature = "neon")))]
     {
         // Portable fallback, available everywhere.
         f.call(portable::Backend::new())

--- a/cryptography/curve25519/src/curve.rs
+++ b/cryptography/curve25519/src/curve.rs
@@ -99,7 +99,8 @@ impl F {
             l[i + 1] += l[i] >> 51;
             l[i] &= MASK_51;
         }
-        l[0] += (l[4] >> 51) * 19;
+        let high = l[4] >> 51;
+        l[0] += (high << 4) + (high << 1) + high;
         l[4] &= MASK_51;
         Self(l)
     }
@@ -188,7 +189,8 @@ impl F {
             c[i + 1] += c[i] >> 51;
             c[i] &= MASK;
         }
-        c[0] += 19 * (c[4] >> 51);
+        let high = c[4] >> 51;
+        c[0] += (high << 4) + (high << 1) + high;
         c[4] &= MASK;
         c[1] += c[0] >> 51;
         c[0] &= MASK;
@@ -209,7 +211,8 @@ impl F {
         }
         let (low, high) = c.split_at_mut(5);
         for (low, high) in low.iter_mut().zip(high) {
-            *low += 19 * *high;
+            // Checked u128 multiplication by 19 can emit operand-dependent branches on AArch64.
+            *low += (*high << 4) + (*high << 1) + *high;
         }
         Self::from_wide([c[0], c[1], c[2], c[3], c[4]])
     }

--- a/cryptography/curve25519/src/curve.rs
+++ b/cryptography/curve25519/src/curve.rs
@@ -106,6 +106,8 @@ impl F {
     }
 
     /// Carry-propagates the limbs for canonical serialization.
+    ///
+    /// All limbs are below `2^51`, except limb 1, which may equal `2^51`.
     fn carry(&self) -> Self {
         let mut l = Self::reduce(self.0).0;
         l[1] += l[0] >> 51;
@@ -149,11 +151,15 @@ impl F {
     }
 
     /// Returns whether two canonical representatives are equal.
+    ///
+    /// Variable-time; use only with public field elements.
     pub fn eq(&self, other: &Self) -> bool {
         self.to_bytes() == other.to_bytes()
     }
 
     /// Returns whether the canonical representative is zero.
+    ///
+    /// Variable-time; use only with public field elements.
     pub fn is_zero(&self) -> bool {
         self.eq(&Self::ZERO)
     }
@@ -337,6 +343,8 @@ impl FVec {
     }
 
     /// Selects `other` in lanes whose corresponding mask is true.
+    ///
+    /// Variable-time; the mask must be public.
     fn select_lanes(self, other: Self, select_other: &[bool; LANES]) -> Self {
         let masks = select_other.map(|select| 0u64.wrapping_sub(select as u64));
         Self {
@@ -435,8 +443,8 @@ impl G {
         //   C = 2d * T1 * T2                 G = D + C        Z3 = F*G
         //   D = 2 * Z1 * Z2                  H = B + A        T3 = E*H
         //
-        // The formula is complete because d is non-square. The extended-coordinate invariant
-        // holds identically: (E*H)*(F*G) = (E*F)*(G*H).
+        // The formula is complete because a = -1 is a square and d is non-square. The
+        // extended-coordinate invariant holds identically: (E*H)*(F*G) = (E*F)*(G*H).
         let a = self.y.sub(self.x).mul(rhs.y.sub(rhs.x));
         let b = self.y.add(self.x).mul(rhs.y.add(rhs.x));
         let c = self.t.mul(rhs.t).mul(F::EDWARDS_D2);
@@ -577,6 +585,8 @@ impl GAffine {
     };
 
     /// Decompresses a point encoding, accepting non-canonical `y` values per ZIP215.
+    ///
+    /// Also accepts `x = 0` with the sign bit set (negative zero), as ZIP215 requires.
     pub fn decompress(bytes: &[u8; 32]) -> Option<Self> {
         let sign = bytes[31] >> 7;
         let y = F::from_bytes(bytes);
@@ -798,6 +808,8 @@ impl GAffineVec {
     }
 
     /// Packs affine points, negating the selected lanes.
+    ///
+    /// Variable-time; the lane signs must be public.
     pub fn from_signed_lanes<B: FBackend>(
         backend: B,
         lanes: &[GAffine; LANES],

--- a/cryptography/curve25519/src/curve.rs
+++ b/cryptography/curve25519/src/curve.rs
@@ -900,7 +900,7 @@ pub trait WithBackend {
 // Scalar multiplication on the Montgomery form of the curve, for X25519.
 pub mod montgomery;
 
-/// Backend bucket kernels for MSM. Signing owns digit recoding and scheduling.
+// Backend bucket kernels for MSM. Signing owns digit recoding and scheduling.
 pub mod msm;
 
 // Now, a module for each backend.

--- a/cryptography/curve25519/src/curve.rs
+++ b/cryptography/curve25519/src/curve.rs
@@ -369,6 +369,14 @@ impl FVec {
 
 /// Abstracts over base field operations.
 pub trait FBackend: Copy {
+    /// Negates the selected lanes and preserves the other lanes' limb representations.
+    ///
+    /// Variable-time, so the mask must be public.
+    #[inline(always)]
+    fn conditional_neg(self, value: FVec, negative: &[bool; LANES]) -> FVec {
+        value.select_lanes(self.neg(value), negative)
+    }
+
     /// a + b.
     fn add(self, a: FVec, b: FVec) -> FVec;
 
@@ -834,9 +842,9 @@ impl GAffineVec {
         }
 
         Self {
-            x: packed.x.select_lanes(backend.neg(packed.x), negative),
+            x: backend.conditional_neg(packed.x, negative),
             y: packed.y,
-            t2d: packed.t2d.select_lanes(backend.neg(packed.t2d), negative),
+            t2d: backend.conditional_neg(packed.t2d, negative),
         }
     }
 }

--- a/cryptography/curve25519/src/curve.rs
+++ b/cryptography/curve25519/src/curve.rs
@@ -1,9 +1,14 @@
 use core::array;
 use subtle::{Choice, ConditionallySelectable};
 
-/// Number of independent field or group elements carried by a vector
+/// Number of independent field or group elements carried by a vector for SIMD operations.
 ///
-/// Backends may process these lanes in smaller native tiles
+/// This targets AVX-512's eight 64-bit lanes, the widest native vector used by these backends.
+/// Backends with narrower registers emulate this lane count by processing smaller native tiles,
+/// such as NEON's two-lane tiles.
+///
+/// A larger logical lane count can increase memory pressure, so operations that do not need
+/// all lanes can use smaller tiles directly.
 pub const LANES: usize = 8;
 
 /// The low 51 bits: what a limb holds once carries have been propagated out of it.

--- a/cryptography/curve25519/src/curve.rs
+++ b/cryptography/curve25519/src/curve.rs
@@ -449,6 +449,16 @@ impl G {
         bytes
     }
 
+    /// Converts this point to affine coordinates for mixed addition.
+    pub fn to_affine(self) -> GAffine {
+        let z_inverse = self.z.invert();
+        GAffine {
+            x: self.x.mul(z_inverse),
+            y: self.y.mul(z_inverse),
+            t2d: self.t.mul(z_inverse).mul(F::EDWARDS_D2),
+        }
+    }
+
     /// Negates this point.
     pub fn negate(self) -> Self {
         Self {
@@ -579,6 +589,13 @@ pub struct GAffine {
 }
 
 impl GAffine {
+    /// Compresses this point to its canonical Ed25519 encoding.
+    pub fn to_bytes(self) -> [u8; 32] {
+        let mut bytes = self.y.to_bytes();
+        bytes[31] |= u8::from(self.x.is_odd()) << 7;
+        bytes
+    }
+
     /// The neutral element, `(0, 1)`.
     pub const IDENTITY: Self = Self {
         x: F::ZERO,

--- a/cryptography/curve25519/src/curve.rs
+++ b/cryptography/curve25519/src/curve.rs
@@ -1,3 +1,4 @@
+use self::msm::Backend as MBackend;
 use core::array;
 use subtle::{Choice, ConditionallySelectable};
 
@@ -879,7 +880,7 @@ pub trait GBackend: FBackend {
 }
 
 /// Abstracts over field and group operations.
-pub trait Backend: FBackend + GBackend + msm::MsmBackend + Send + Sync + 'static {}
+pub trait Backend: FBackend + GBackend + MBackend + Send + Sync + 'static {}
 
 /// A computation which can run over an arbitrary [`Backend`].
 ///

--- a/cryptography/curve25519/src/curve.rs
+++ b/cryptography/curve25519/src/curve.rs
@@ -1,15 +1,9 @@
 use core::array;
 use subtle::{Choice, ConditionallySelectable};
 
-/// How many parallel operations we try and do via SIMD.
+/// Number of independent field or group elements carried by a vector
 ///
-/// This is set to the highest realistic number, targeting AVX-512.
-/// On other backends, this is larger than necessary.
-///
-/// This should not be harmful to performance, because a larger lane count
-/// can be emulated with a smaller lane count.
-/// An exception to this would be if the memory pressure were particularly bad,
-/// but given how small this value is, this shouldn't be an issue.
+/// Backends may process these lanes in smaller native tiles
 pub const LANES: usize = 8;
 
 /// The low 51 bits: what a limb holds once carries have been propagated out of it.
@@ -382,6 +376,15 @@ pub trait FBackend: Copy {
     /// a * a.
     fn square(self, a: FVec) -> FVec {
         self.mul(a, a)
+    }
+
+    /// Squares every lane `k` times, returning `a` unchanged when `k` is zero.
+    #[inline(always)]
+    fn pow2k(self, mut a: FVec, k: u32) -> FVec {
+        for _ in 0..k {
+            a = self.square(a);
+        }
+        a
     }
 
     /// a - b.
@@ -833,14 +836,6 @@ impl GAffineVec {
     }
 }
 
-/// Squares `value` `k` times.
-fn pow2k<B: FBackend>(backend: B, mut value: FVec, k: u32) -> FVec {
-    for _ in 0..k {
-        value = backend.square(value);
-    }
-    value
-}
-
 /// Raises every lane to `2^250 - 1` using the standard addition chain.
 fn pow_2_250_minus_1<B: FBackend>(backend: B, value: FVec) -> FVec {
     let a = backend.square(value);
@@ -849,18 +844,18 @@ fn pow_2_250_minus_1<B: FBackend>(backend: B, value: FVec) -> FVec {
     let c = backend.mul(a, b);
     let d = backend.square(c);
     let e = backend.mul(b, d);
-    let f = backend.mul(pow2k(backend, e, 5), e);
-    let g = backend.mul(pow2k(backend, f, 10), f);
-    let h = backend.mul(pow2k(backend, g, 20), g);
-    let i = backend.mul(pow2k(backend, h, 10), f);
-    let j = backend.mul(pow2k(backend, i, 50), i);
-    let k = backend.mul(pow2k(backend, j, 100), j);
-    backend.mul(pow2k(backend, k, 50), i)
+    let f = backend.mul(backend.pow2k(e, 5), e);
+    let g = backend.mul(backend.pow2k(f, 10), f);
+    let h = backend.mul(backend.pow2k(g, 20), g);
+    let i = backend.mul(backend.pow2k(h, 10), f);
+    let j = backend.mul(backend.pow2k(i, 50), i);
+    let k = backend.mul(backend.pow2k(j, 100), j);
+    backend.mul(backend.pow2k(k, 50), i)
 }
 
 /// Raises every lane to `(p - 5) / 8 = 2^252 - 3` for point decompression.
 fn pow_p58<B: FBackend>(backend: B, value: FVec) -> FVec {
-    backend.mul(value, pow2k(backend, pow_2_250_minus_1(backend, value), 2))
+    backend.mul(value, backend.pow2k(pow_2_250_minus_1(backend, value), 2))
 }
 
 /// Abstracts over group operations.
@@ -876,6 +871,28 @@ pub trait GBackend: FBackend {
     ///
     /// This can be faster than [`Self::g_add`].
     fn g_add_mixed(self, a: GVec, b: GAffineVec) -> GVec;
+
+    /// Adds a signed affine point to each of two extended points
+    ///
+    /// Each result is `a[i] + b[i]` or `a[i] - b[i]` according to `negative[i]`.
+    /// Variable-time, so the signs must be public
+    #[cfg(target_arch = "aarch64")]
+    #[inline(always)]
+    fn g_add_mixed_pair(self, a: [G; 2], b: [GAffine; 2], negative: [bool; 2]) -> [G; 2] {
+        let mut current = [G::IDENTITY; LANES];
+        let mut incoming = [GAffine::IDENTITY; LANES];
+        let mut signs = [false; LANES];
+        current[..2].copy_from_slice(&a);
+        incoming[..2].copy_from_slice(&b);
+        signs[..2].copy_from_slice(&negative);
+        let updated = self
+            .g_add_mixed(
+                GVec::transpose(current),
+                GAffineVec::from_signed_lanes(self, &incoming, &signs),
+            )
+            .untranspose();
+        [updated[0], updated[1]]
+    }
 
     /// Add a point to itself.
     fn g_double(self, a: GVec) -> GVec {

--- a/cryptography/curve25519/src/curve.rs
+++ b/cryptography/curve25519/src/curve.rs
@@ -815,19 +815,6 @@ impl GAffineVec {
         }
     }
 
-    /// Untransposes backend lanes into scalar affine points.
-    #[cfg(any(test, feature = "fuzz", not(target_arch = "aarch64")))]
-    pub fn untranspose(self) -> [GAffine; LANES] {
-        let x = self.x.untranspose();
-        let y = self.y.untranspose();
-        let t2d = self.t2d.untranspose();
-        array::from_fn(|i| GAffine {
-            x: x[i],
-            y: y[i],
-            t2d: t2d[i],
-        })
-    }
-
     /// Packs affine points, negating the selected lanes.
     ///
     /// Variable-time, so the lane signs must be public.
@@ -885,28 +872,6 @@ pub trait GBackend: FBackend {
     /// This can be faster than [`Self::g_add`].
     fn g_add_mixed(self, a: GVec, b: GAffineVec) -> GVec;
 
-    /// Adds a signed affine point to each of two extended points.
-    ///
-    /// Each result is `a[i] + b[i]` or `a[i] - b[i]` according to `negative[i]`.
-    /// Variable-time, so the signs must be public.
-    #[cfg(target_arch = "aarch64")]
-    #[inline(always)]
-    fn g_add_mixed_pair(self, a: [G; 2], b: [GAffine; 2], negative: [bool; 2]) -> [G; 2] {
-        let mut current = [G::IDENTITY; LANES];
-        let mut incoming = [GAffine::IDENTITY; LANES];
-        let mut signs = [false; LANES];
-        current[..2].copy_from_slice(&a);
-        incoming[..2].copy_from_slice(&b);
-        signs[..2].copy_from_slice(&negative);
-        let updated = self
-            .g_add_mixed(
-                GVec::transpose(current),
-                GAffineVec::from_signed_lanes(self, &incoming, &signs),
-            )
-            .untranspose();
-        [updated[0], updated[1]]
-    }
-
     /// Add a point to itself.
     fn g_double(self, a: GVec) -> GVec {
         self.g_add(a, a)
@@ -914,7 +879,7 @@ pub trait GBackend: FBackend {
 }
 
 /// Abstracts over field and group operations.
-pub trait Backend: FBackend + GBackend + Send + Sync + 'static {}
+pub trait Backend: FBackend + GBackend + msm::MsmBackend + Send + Sync + 'static {}
 
 /// A computation which can run over an arbitrary [`Backend`].
 ///
@@ -933,6 +898,9 @@ pub trait WithBackend {
 
 // Scalar multiplication on the Montgomery form of the curve, for X25519.
 pub mod montgomery;
+
+/// Backend bucket kernels for MSM. Signing owns digit recoding and scheduling.
+pub mod msm;
 
 // Now, a module for each backend.
 #[cfg(all(target_arch = "x86_64", any(feature = "std", test)))]

--- a/cryptography/curve25519/src/curve.rs
+++ b/cryptography/curve25519/src/curve.rs
@@ -877,10 +877,10 @@ pub trait GBackend: FBackend {
     /// This can be faster than [`Self::g_add`].
     fn g_add_mixed(self, a: GVec, b: GAffineVec) -> GVec;
 
-    /// Adds a signed affine point to each of two extended points
+    /// Adds a signed affine point to each of two extended points.
     ///
     /// Each result is `a[i] + b[i]` or `a[i] - b[i]` according to `negative[i]`.
-    /// Variable-time, so the signs must be public
+    /// Variable-time, so the signs must be public.
     #[cfg(target_arch = "aarch64")]
     #[inline(always)]
     fn g_add_mixed_pair(self, a: [G; 2], b: [GAffine; 2], negative: [bool; 2]) -> [G; 2] {

--- a/cryptography/curve25519/src/curve.rs
+++ b/cryptography/curve25519/src/curve.rs
@@ -99,15 +99,18 @@ impl F {
             l[i + 1] += l[i] >> 51;
             l[i] &= MASK_51;
         }
-        let high = l[4] >> 51;
-        l[0] += (high << 4) + (high << 1) + high;
+
+        // The carry out of limb 4 has at most 13 bits, so the fold stays below the `2^52` limb
+        // bound for every input and the compiler drops the multiply's overflow check.
+        const _: () = assert!(MASK_51 + (u64::MAX >> 51) * 19 < 1 << 52);
+        l[0] += (l[4] >> 51) * 19;
         l[4] &= MASK_51;
         Self(l)
     }
 
     /// Carry-propagates the limbs for canonical serialization.
     ///
-    /// All limbs are below `2^51`, except limb 1, which may equal `2^51`.
+    /// The returned limbs are below `2^51`, except limb 1, which may equal `2^51`.
     fn carry(&self) -> Self {
         let mut l = Self::reduce(self.0).0;
         l[1] += l[0] >> 51;
@@ -152,14 +155,14 @@ impl F {
 
     /// Returns whether two canonical representatives are equal.
     ///
-    /// Variable-time; use only with public field elements.
+    /// Variable-time, so use only with public field elements.
     pub fn eq(&self, other: &Self) -> bool {
         self.to_bytes() == other.to_bytes()
     }
 
     /// Returns whether the canonical representative is zero.
     ///
-    /// Variable-time; use only with public field elements.
+    /// Variable-time, so use only with public field elements.
     pub fn is_zero(&self) -> bool {
         self.eq(&Self::ZERO)
     }
@@ -195,8 +198,12 @@ impl F {
             c[i + 1] += c[i] >> 51;
             c[i] &= MASK;
         }
-        let high = c[4] >> 51;
-        c[0] += (high << 4) + (high << 1) + high;
+
+        // The carry out of column 4 has at most 77 bits, so the fold stays below `2^102` for
+        // every input, the final carry keeps limb 1 below the `2^52` limb bound, and the compiler
+        // drops the multiply's overflow check.
+        const _: () = assert!(MASK + (u128::MAX >> 51) * 19 < 1 << 102);
+        c[0] += 19 * (c[4] >> 51);
         c[4] &= MASK;
         c[1] += c[0] >> 51;
         c[0] &= MASK;
@@ -217,8 +224,11 @@ impl F {
         }
         let (low, high) = c.split_at_mut(5);
         for (low, high) in low.iter_mut().zip(high) {
-            // Checked u128 multiplication by 19 can emit operand-dependent branches on AArch64.
-            *low += (*high << 4) + (*high << 1) + *high;
+            // On AArch64, a checked u128 multiply lowers to a branch on the operand's magnitude.
+            // Every column stays below `2^107` at the input bound, so assert that bound and
+            // multiply without a check.
+            assert!(*high < 1 << 107);
+            *low += high.wrapping_mul(19);
         }
         Self::from_wide([c[0], c[1], c[2], c[3], c[4]])
     }
@@ -344,7 +354,7 @@ impl FVec {
 
     /// Selects `other` in lanes whose corresponding mask is true.
     ///
-    /// Variable-time; the mask must be public.
+    /// Variable-time, so the mask must be public.
     fn select_lanes(self, other: Self, select_other: &[bool; LANES]) -> Self {
         let masks = select_other.map(|select| 0u64.wrapping_sub(select as u64));
         Self {
@@ -584,9 +594,8 @@ impl GAffine {
         ]),
     };
 
-    /// Decompresses a point encoding, accepting non-canonical `y` values per ZIP215.
-    ///
-    /// Also accepts `x = 0` with the sign bit set (negative zero), as ZIP215 requires.
+    /// Decompresses a point encoding, accepting non-canonical `y` values and negative zero
+    /// (`x = 0` with the sign bit set) per ZIP215.
     pub fn decompress(bytes: &[u8; 32]) -> Option<Self> {
         let sign = bytes[31] >> 7;
         let y = F::from_bytes(bytes);
@@ -791,11 +800,7 @@ impl GAffineVec {
     }
 
     /// Untransposes backend lanes into scalar affine points.
-    #[cfg(any(
-        test,
-        feature = "fuzz",
-        not(all(target_arch = "aarch64", target_feature = "neon"))
-    ))]
+    #[cfg(any(test, feature = "fuzz", not(target_arch = "aarch64")))]
     pub fn untranspose(self) -> [GAffine; LANES] {
         let x = self.x.untranspose();
         let y = self.y.untranspose();
@@ -809,7 +814,7 @@ impl GAffineVec {
 
     /// Packs affine points, negating the selected lanes.
     ///
-    /// Variable-time; the lane signs must be public.
+    /// Variable-time, so the lane signs must be public.
     pub fn from_signed_lanes<B: FBackend>(
         backend: B,
         lanes: &[GAffine; LANES],
@@ -902,13 +907,9 @@ pub mod montgomery;
 // Now, a module for each backend.
 #[cfg(all(target_arch = "x86_64", any(feature = "std", test)))]
 mod avx512;
-#[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+#[cfg(target_arch = "aarch64")]
 mod neon;
-#[cfg(any(
-    test,
-    feature = "fuzz",
-    not(all(target_arch = "aarch64", target_feature = "neon"))
-))]
+#[cfg(any(test, feature = "fuzz", not(target_arch = "aarch64")))]
 mod portable;
 #[cfg(any(test, feature = "fuzz"))]
 pub mod test;
@@ -921,10 +922,9 @@ pub fn test_backend() -> impl Backend {
 
 /// Run a computation with the best [`Backend`] this CPU supports.
 ///
-/// This is the only way to gain access to a backend. AVX-512 requires runtime feature detection;
-/// NEON is selected only when enabled by the AArch64 target. Every use is forced through this
-/// single gate so an accelerated backend is only constructed where its instructions are
-/// guaranteed to be available.
+/// This is the only way to gain access to a backend. AVX-512 requires runtime feature detection.
+/// Every use is forced through this single gate so an accelerated backend is only constructed
+/// where its instructions are guaranteed to be available.
 pub fn with_backend<F: WithBackend>(f: F) -> F::Output {
     #[cfg(all(target_arch = "x86_64", any(feature = "std", test)))]
     {
@@ -934,12 +934,11 @@ pub fn with_backend<F: WithBackend>(f: F) -> F::Output {
             return unsafe { backend.call(f) };
         }
     }
-    #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
+    #[cfg(target_arch = "aarch64")]
     {
-        // The target guarantees NEON support, so no runtime feature check is needed.
         f.call(neon::Backend::new())
     }
-    #[cfg(not(all(target_arch = "aarch64", target_feature = "neon")))]
+    #[cfg(not(target_arch = "aarch64"))]
     {
         // Portable fallback, available everywhere.
         f.call(portable::Backend::new())

--- a/cryptography/curve25519/src/curve/avx512.rs
+++ b/cryptography/curve25519/src/curve/avx512.rs
@@ -63,7 +63,7 @@ fn store(regs: [__m512i; 5]) -> [[u64; LANES]; 5] {
 ///
 /// # Correctness
 ///
-/// `z` must be less than `2^60` per lane so the shifts do not discard significant bits.
+/// `z` must be less than `2^59` per lane so `19*z` fits in `u64`.
 #[target_feature(enable = "avx512f")]
 fn mul19(z: __m512i) -> __m512i {
     _mm512_add_epi64(

--- a/cryptography/curve25519/src/curve/avx512.rs
+++ b/cryptography/curve25519/src/curve/avx512.rs
@@ -471,7 +471,7 @@ impl Backend {
 
 impl super::Backend for Backend {}
 
-impl super::msm::MsmBackend for Backend {}
+impl super::msm::Backend for Backend {}
 
 impl GBackend for Backend {
     #[inline(always)]

--- a/cryptography/curve25519/src/curve/avx512.rs
+++ b/cryptography/curve25519/src/curve/avx512.rs
@@ -255,37 +255,37 @@ impl Backend {
 impl FBackend for Backend {
     #[inline(always)]
     fn add(self, a: FVec, b: FVec) -> FVec {
-        // SAFETY: `Backend` construction checks AVX-512F and AVX-512 IFMA support
+        // SAFETY: `Backend` construction checks AVX-512F and AVX-512 IFMA support.
         unsafe { self.add_field(a, b) }
     }
 
     #[inline(always)]
     fn neg(self, a: FVec) -> FVec {
-        // SAFETY: `Backend` construction checks AVX-512F and AVX-512 IFMA support
+        // SAFETY: `Backend` construction checks AVX-512F and AVX-512 IFMA support.
         unsafe { self.neg_field(a) }
     }
 
     #[inline(always)]
     fn sub(self, a: FVec, b: FVec) -> FVec {
-        // SAFETY: `Backend` construction checks AVX-512F and AVX-512 IFMA support
+        // SAFETY: `Backend` construction checks AVX-512F and AVX-512 IFMA support.
         unsafe { self.sub_field(a, b) }
     }
 
     #[inline(always)]
     fn mul(self, a: FVec, b: FVec) -> FVec {
-        // SAFETY: `Backend` construction checks AVX-512F and AVX-512 IFMA support
+        // SAFETY: `Backend` construction checks AVX-512F and AVX-512 IFMA support.
         unsafe { self.mul_field(a, b) }
     }
 
     #[inline(always)]
     fn pow2k(self, a: FVec, k: u32) -> FVec {
-        // SAFETY: `Backend` construction checks AVX-512F and AVX-512 IFMA support
+        // SAFETY: `Backend` construction checks AVX-512F and AVX-512 IFMA support.
         unsafe { self.pow2k_field(a, k) }
     }
 
     #[inline(always)]
     fn square(self, a: FVec) -> FVec {
-        // SAFETY: `Backend` construction checks AVX-512F and AVX-512 IFMA support
+        // SAFETY: `Backend` construction checks AVX-512F and AVX-512 IFMA support.
         unsafe { self.square_field(a) }
     }
 }
@@ -432,19 +432,19 @@ impl super::Backend for Backend {}
 impl GBackend for Backend {
     #[inline(always)]
     fn g_add(self, p: GVec, q: GVec) -> GVec {
-        // SAFETY: `Backend` construction checks AVX-512F and AVX-512 IFMA support
+        // SAFETY: `Backend` construction checks AVX-512F and AVX-512 IFMA support.
         unsafe { self.add_points(p, q) }
     }
 
     #[inline(always)]
     fn g_add_mixed(self, p: GVec, q: GAffineVec) -> GVec {
-        // SAFETY: `Backend` construction checks AVX-512F and AVX-512 IFMA support
+        // SAFETY: `Backend` construction checks AVX-512F and AVX-512 IFMA support.
         unsafe { self.add_mixed_points(p, q) }
     }
 
     #[inline(always)]
     fn g_double(self, p: GVec) -> GVec {
-        // SAFETY: `Backend` construction checks AVX-512F and AVX-512 IFMA support
+        // SAFETY: `Backend` construction checks AVX-512F and AVX-512 IFMA support.
         unsafe { self.double_points(p) }
     }
 }

--- a/cryptography/curve25519/src/curve/avx512.rs
+++ b/cryptography/curve25519/src/curve/avx512.rs
@@ -199,9 +199,6 @@ fn sub_raw(a: [__m512i; 5], b: [__m512i; 5]) -> [__m512i; 5] {
     })
 }
 
-// Complete operations carry their own target features so arithmetic stays fused even when
-// generic callers are outlined outside the feature-enabled dispatch function
-
 /// # Correctness
 ///
 /// Every input must satisfy [`FVec`]'s limb bound. That bound keeps raw field arithmetic within

--- a/cryptography/curve25519/src/curve/avx512.rs
+++ b/cryptography/curve25519/src/curve/avx512.rs
@@ -64,12 +64,29 @@ fn store(regs: [__m512i; 5]) -> [[u64; LANES]; 5] {
 /// # Correctness
 ///
 /// `z` must be less than `2^59` per lane so `19*z` fits in `u64`.
+///
+/// The explicit instruction sequence prevents LLVM from recognizing a packed `u64` multiplication
+/// and expanding it into two packed 32-bit multiplications, two shifts, and an addition. These
+/// four AVX-512F instructions preserve the shift-and-add calculation directly.
 #[target_feature(enable = "avx512f")]
 fn mul19(z: __m512i) -> __m512i {
-    _mm512_add_epi64(
-        _mm512_add_epi64(_mm512_slli_epi64(z, 4), _mm512_slli_epi64(z, 1)),
-        z,
-    )
+    let result;
+    // SAFETY: AVX-512F is enabled. The instructions only read their register input, write
+    // their register outputs, preserve flags, and stay within the documented limb bound.
+    unsafe {
+        core::arch::asm!(
+            "vpsllq {times16}, {z}, 4",
+            "vpsllq {doubled}, {z}, 1",
+            "vpaddq {doubled}, {doubled}, {times16}",
+            "vpaddq {result}, {doubled}, {z}",
+            z = in(zmm_reg) z,
+            times16 = out(zmm_reg) _,
+            doubled = out(zmm_reg) _,
+            result = lateout(zmm_reg) result,
+            options(pure, nomem, nostack, preserves_flags),
+        );
+    }
+    result
 }
 
 /// Reduces each radix-`2^51` lane with one parallel carry pass.
@@ -80,12 +97,13 @@ fn mul19(z: __m512i) -> __m512i {
 /// # Correctness
 ///
 /// Inputs must have limbs below `2^63`. Outputs then have limbs below `2^52`.
-#[target_feature(enable = "avx512f")]
+#[target_feature(enable = "avx512f,avx512ifma")]
 fn reduce_regs(l: [__m512i; 5]) -> [__m512i; 5] {
     let mask = _mm512_set1_epi64(MASK_51 as i64);
     let c: [__m512i; 5] = core::array::from_fn(|i| _mm512_srli_epi64(l[i], 51));
+    // Each carry is below 2^12, so IFMA computes the folded carry exactly.
     [
-        _mm512_add_epi64(_mm512_and_si512(l[0], mask), mul19(c[4])),
+        _mm512_madd52lo_epu64(_mm512_and_si512(l[0], mask), c[4], _mm512_set1_epi64(19)),
         _mm512_add_epi64(_mm512_and_si512(l[1], mask), c[0]),
         _mm512_add_epi64(_mm512_and_si512(l[2], mask), c[1]),
         _mm512_add_epi64(_mm512_and_si512(l[3], mask), c[2]),
@@ -204,6 +222,23 @@ fn sub_raw(a: [__m512i; 5], b: [__m512i; 5]) -> [__m512i; 5] {
 /// Every input must satisfy [`FVec`]'s limb bound. That bound keeps raw field arithmetic within
 /// its documented ranges and keeps every IFMA operand below its `2^52` ceiling.
 impl Backend {
+    /// Negates selected lanes with reduced output while preserving every unselected limb.
+    #[target_feature(enable = "avx512f,avx512ifma")]
+    fn conditional_neg_field(self, value: FVec, negative: &[bool; LANES]) -> FVec {
+        let mask = negative
+            .iter()
+            .enumerate()
+            .fold(0u8, |mask, (lane, &select)| mask | ((select as u8) << lane));
+        let value = load(&value.limbs);
+        let zero = [_mm512_setzero_si512(); 5];
+        let negated = reduce_regs(sub_raw(zero, value));
+        FVec {
+            limbs: store(core::array::from_fn(|limb| {
+                _mm512_mask_blend_epi64(mask, value[limb], negated[limb])
+            })),
+        }
+    }
+
     #[target_feature(enable = "avx512f,avx512ifma")]
     fn add_field(self, a: FVec, b: FVec) -> FVec {
         FVec {
@@ -253,6 +288,12 @@ impl Backend {
 }
 
 impl FBackend for Backend {
+    #[inline(always)]
+    fn conditional_neg(self, value: FVec, negative: &[bool; LANES]) -> FVec {
+        // SAFETY: `Backend` construction checks AVX-512F and AVX-512 IFMA support.
+        unsafe { self.conditional_neg_field(value, negative) }
+    }
+
     #[inline(always)]
     fn add(self, a: FVec, b: FVec) -> FVec {
         // SAFETY: `Backend` construction checks AVX-512F and AVX-512 IFMA support.

--- a/cryptography/curve25519/src/curve/avx512.rs
+++ b/cryptography/curve25519/src/curve/avx512.rs
@@ -199,161 +199,195 @@ fn sub_raw(a: [__m512i; 5], b: [__m512i; 5]) -> [__m512i; 5] {
     })
 }
 
+// Complete operations carry their own target features so arithmetic stays fused even when
+// generic callers are outlined outside the feature-enabled dispatch function
+
 /// # Correctness
 ///
 /// Every input must satisfy [`FVec`]'s limb bound. That bound keeps raw field arithmetic within
 /// its documented ranges and keeps every IFMA operand below its `2^52` ceiling.
-impl FBackend for Backend {
-    fn add(self, a: FVec, b: FVec) -> FVec {
-        // SAFETY: `Backend` can only be constructed when AVX-512F and AVX-512 IFMA are available.
-        unsafe {
-            FVec {
-                limbs: store(reduce_regs(add_raw(load(&a.limbs), load(&b.limbs)))),
-            }
+impl Backend {
+    #[target_feature(enable = "avx512f,avx512ifma")]
+    fn add_field(self, a: FVec, b: FVec) -> FVec {
+        FVec {
+            limbs: store(reduce_regs(add_raw(load(&a.limbs), load(&b.limbs)))),
         }
     }
 
-    fn neg(self, a: FVec) -> FVec {
-        // SAFETY: `Backend` can only be constructed when AVX-512F and AVX-512 IFMA are available.
-        unsafe {
-            let zero = [_mm512_setzero_si512(); 5];
-            FVec {
-                limbs: store(reduce_regs(sub_raw(zero, load(&a.limbs)))),
-            }
+    #[target_feature(enable = "avx512f,avx512ifma")]
+    fn neg_field(self, a: FVec) -> FVec {
+        let zero = [_mm512_setzero_si512(); 5];
+        FVec {
+            limbs: store(reduce_regs(sub_raw(zero, load(&a.limbs)))),
         }
     }
 
-    fn sub(self, a: FVec, b: FVec) -> FVec {
-        // SAFETY: `Backend` can only be constructed when AVX-512F and AVX-512 IFMA are available.
-        unsafe {
-            FVec {
-                limbs: store(reduce_regs(sub_raw(load(&a.limbs), load(&b.limbs)))),
-            }
+    #[target_feature(enable = "avx512f,avx512ifma")]
+    fn sub_field(self, a: FVec, b: FVec) -> FVec {
+        FVec {
+            limbs: store(reduce_regs(sub_raw(load(&a.limbs), load(&b.limbs)))),
         }
     }
 
-    fn mul(self, a: FVec, b: FVec) -> FVec {
-        // SAFETY: `Backend` can only be constructed when AVX-512F and AVX-512 IFMA are available.
-        unsafe {
-            FVec {
-                limbs: store(mul_regs(load(&a.limbs), load(&b.limbs))),
-            }
+    #[target_feature(enable = "avx512f,avx512ifma")]
+    fn mul_field(self, a: FVec, b: FVec) -> FVec {
+        FVec {
+            limbs: store(mul_regs(load(&a.limbs), load(&b.limbs))),
         }
     }
 
-    fn square(self, a: FVec) -> FVec {
-        // SAFETY: `Backend` can only be constructed when AVX-512F and AVX-512 IFMA are available.
-        unsafe {
-            FVec {
-                limbs: store(square_regs(load(&a.limbs))),
-            }
+    #[target_feature(enable = "avx512f,avx512ifma")]
+    fn pow2k_field(self, a: FVec, k: u32) -> FVec {
+        let mut value = load(&a.limbs);
+        for _ in 0..k {
+            value = square_regs(value);
+        }
+        FVec {
+            limbs: store(value),
+        }
+    }
+
+    #[target_feature(enable = "avx512f,avx512ifma")]
+    fn square_field(self, a: FVec) -> FVec {
+        FVec {
+            limbs: store(square_regs(load(&a.limbs))),
         }
     }
 }
 
-// These methods need forced inlining: without it, optimized `WithBackend` computations retain a
-// call to each group operation across the target-feature boundary.
-impl GBackend for Backend {
-    /// Fused point addition with every intermediate held in registers.
+impl FBackend for Backend {
+    #[inline(always)]
+    fn add(self, a: FVec, b: FVec) -> FVec {
+        // SAFETY: `Backend` construction checks AVX-512F and AVX-512 IFMA support
+        unsafe { self.add_field(a, b) }
+    }
+
+    #[inline(always)]
+    fn neg(self, a: FVec) -> FVec {
+        // SAFETY: `Backend` construction checks AVX-512F and AVX-512 IFMA support
+        unsafe { self.neg_field(a) }
+    }
+
+    #[inline(always)]
+    fn sub(self, a: FVec, b: FVec) -> FVec {
+        // SAFETY: `Backend` construction checks AVX-512F and AVX-512 IFMA support
+        unsafe { self.sub_field(a, b) }
+    }
+
+    #[inline(always)]
+    fn mul(self, a: FVec, b: FVec) -> FVec {
+        // SAFETY: `Backend` construction checks AVX-512F and AVX-512 IFMA support
+        unsafe { self.mul_field(a, b) }
+    }
+
+    #[inline(always)]
+    fn pow2k(self, a: FVec, k: u32) -> FVec {
+        // SAFETY: `Backend` construction checks AVX-512F and AVX-512 IFMA support
+        unsafe { self.pow2k_field(a, k) }
+    }
+
+    #[inline(always)]
+    fn square(self, a: FVec) -> FVec {
+        // SAFETY: `Backend` construction checks AVX-512F and AVX-512 IFMA support
+        unsafe { self.square_field(a) }
+    }
+}
+
+impl Backend {
+    /// Fused point addition.
     ///
     /// # Correctness
     ///
     /// All input limbs satisfy `FVec`'s bound; every loose intermediate stays below
     /// `reduce_regs`'s `2^63` bound, and every right operand of `sub_raw` is reduced below
     /// `2^52`.
-    #[inline(always)]
-    fn g_add(self, p: GVec, q: GVec) -> GVec {
-        // SAFETY: `Backend` can only be constructed when AVX-512F and AVX-512 IFMA are available.
-        unsafe {
-            let (x1, y1, z1, t1) = (
-                load(&p.x.limbs),
-                load(&p.y.limbs),
-                load(&p.z.limbs),
-                load(&p.t.limbs),
-            );
-            let (x2, y2, z2, t2) = (
-                load(&q.x.limbs),
-                load(&q.y.limbs),
-                load(&q.z.limbs),
-                load(&q.t.limbs),
-            );
-            let two_d = load(&EDWARDS_D2.limbs);
+    #[target_feature(enable = "avx512f,avx512ifma")]
+    fn add_points(self, p: GVec, q: GVec) -> GVec {
+        let (x1, y1, z1, t1) = (
+            load(&p.x.limbs),
+            load(&p.y.limbs),
+            load(&p.z.limbs),
+            load(&p.t.limbs),
+        );
+        let (x2, y2, z2, t2) = (
+            load(&q.x.limbs),
+            load(&q.y.limbs),
+            load(&q.z.limbs),
+            load(&q.t.limbs),
+        );
+        let two_d = load(&EDWARDS_D2.limbs);
 
-            // Unified extended-coordinates addition (Hisil-Wong-Carter-Dawson):
-            //
-            //   A = (Y1 - X1) * (Y2 - X2)        E = B - A        X3 = E*F
-            //   B = (Y1 + X1) * (Y2 + X2)        F = D - C        Y3 = G*H
-            //   C = 2d * T1 * T2                 G = D + C        Z3 = F*G
-            //   D = 2 * Z1 * Z2                  H = B + A        T3 = E*H
-            let a = mul_regs(reduce_regs(sub_raw(y1, x1)), reduce_regs(sub_raw(y2, x2)));
-            let b = mul_regs_loose(reduce_regs(add_raw(y1, x1)), reduce_regs(add_raw(y2, x2)));
-            let c = mul_regs(mul_regs(t1, t2), two_d);
-            let zz = mul_regs_loose(z1, z2);
-            let d = add_raw(zz, zz);
-            let e = reduce_regs(sub_raw(b, a));
-            let f = reduce_regs(sub_raw(d, c));
-            let g = reduce_regs(add_raw(d, c));
-            let h = reduce_regs(add_raw(b, a));
+        // Unified extended-coordinates addition (Hisil-Wong-Carter-Dawson):
+        //
+        //   A = (Y1 - X1) * (Y2 - X2)        E = B - A        X3 = E*F
+        //   B = (Y1 + X1) * (Y2 + X2)        F = D - C        Y3 = G*H
+        //   C = 2d * T1 * T2                 G = D + C        Z3 = F*G
+        //   D = 2 * Z1 * Z2                  H = B + A        T3 = E*H
+        let a = mul_regs(reduce_regs(sub_raw(y1, x1)), reduce_regs(sub_raw(y2, x2)));
+        let b = mul_regs_loose(reduce_regs(add_raw(y1, x1)), reduce_regs(add_raw(y2, x2)));
+        let c = mul_regs(mul_regs(t1, t2), two_d);
+        let zz = mul_regs_loose(z1, z2);
+        let d = add_raw(zz, zz);
+        let e = reduce_regs(sub_raw(b, a));
+        let f = reduce_regs(sub_raw(d, c));
+        let g = reduce_regs(add_raw(d, c));
+        let h = reduce_regs(add_raw(b, a));
 
-            GVec {
-                x: FVec {
-                    limbs: store(mul_regs(e, f)),
-                },
-                y: FVec {
-                    limbs: store(mul_regs(g, h)),
-                },
-                t: FVec {
-                    limbs: store(mul_regs(e, h)),
-                },
-                z: FVec {
-                    limbs: store(mul_regs(f, g)),
-                },
-            }
+        GVec {
+            x: FVec {
+                limbs: store(mul_regs(e, f)),
+            },
+            y: FVec {
+                limbs: store(mul_regs(g, h)),
+            },
+            t: FVec {
+                limbs: store(mul_regs(e, h)),
+            },
+            z: FVec {
+                limbs: store(mul_regs(f, g)),
+            },
         }
     }
 
-    /// Fused mixed point addition with every intermediate held in registers.
+    /// Fused mixed point addition.
     ///
     /// # Correctness
     ///
     /// All input limbs satisfy `FVec`'s bound; every loose intermediate stays below
     /// `reduce_regs`'s `2^63` bound, and every right operand of `sub_raw` is reduced below
     /// `2^52`.
-    #[inline(always)]
-    fn g_add_mixed(self, p: GVec, q: GAffineVec) -> GVec {
-        // SAFETY: `Backend` can only be constructed when AVX-512F and AVX-512 IFMA are available.
-        unsafe {
-            let (x1, y1, z1, t1) = (
-                load(&p.x.limbs),
-                load(&p.y.limbs),
-                load(&p.z.limbs),
-                load(&p.t.limbs),
-            );
-            let (x2, y2, t2d) = (load(&q.x.limbs), load(&q.y.limbs), load(&q.t2d.limbs));
+    #[target_feature(enable = "avx512f,avx512ifma")]
+    fn add_mixed_points(self, p: GVec, q: GAffineVec) -> GVec {
+        let (x1, y1, z1, t1) = (
+            load(&p.x.limbs),
+            load(&p.y.limbs),
+            load(&p.z.limbs),
+            load(&p.t.limbs),
+        );
+        let (x2, y2, t2d) = (load(&q.x.limbs), load(&q.y.limbs), load(&q.t2d.limbs));
 
-            let a = mul_regs(reduce_regs(sub_raw(y1, x1)), reduce_regs(sub_raw(y2, x2)));
-            let b = mul_regs_loose(reduce_regs(add_raw(y1, x1)), reduce_regs(add_raw(y2, x2)));
-            let c = mul_regs(t1, t2d);
-            let d = add_raw(z1, z1);
-            let e = reduce_regs(sub_raw(b, a));
-            let f = reduce_regs(sub_raw(d, c));
-            let g = reduce_regs(add_raw(d, c));
-            let h = reduce_regs(add_raw(b, a));
+        let a = mul_regs(reduce_regs(sub_raw(y1, x1)), reduce_regs(sub_raw(y2, x2)));
+        let b = mul_regs_loose(reduce_regs(add_raw(y1, x1)), reduce_regs(add_raw(y2, x2)));
+        let c = mul_regs(t1, t2d);
+        let d = add_raw(z1, z1);
+        let e = reduce_regs(sub_raw(b, a));
+        let f = reduce_regs(sub_raw(d, c));
+        let g = reduce_regs(add_raw(d, c));
+        let h = reduce_regs(add_raw(b, a));
 
-            GVec {
-                x: FVec {
-                    limbs: store(mul_regs(e, f)),
-                },
-                y: FVec {
-                    limbs: store(mul_regs(g, h)),
-                },
-                t: FVec {
-                    limbs: store(mul_regs(e, h)),
-                },
-                z: FVec {
-                    limbs: store(mul_regs(f, g)),
-                },
-            }
+        GVec {
+            x: FVec {
+                limbs: store(mul_regs(e, f)),
+            },
+            y: FVec {
+                limbs: store(mul_regs(g, h)),
+            },
+            t: FVec {
+                limbs: store(mul_regs(e, h)),
+            },
+            z: FVec {
+                limbs: store(mul_regs(f, g)),
+            },
         }
     }
 
@@ -364,39 +398,56 @@ impl GBackend for Backend {
     /// All input limbs satisfy `FVec`'s bound; every loose intermediate stays below
     /// `reduce_regs`'s `2^63` bound, and every right operand of `sub_raw` is reduced below
     /// `2^52`.
-    #[inline(always)]
-    fn g_double(self, p: GVec) -> GVec {
-        // SAFETY: `Backend` can only be constructed when AVX-512F and AVX-512 IFMA are available.
-        unsafe {
-            let (x, y, z) = (load(&p.x.limbs), load(&p.y.limbs), load(&p.z.limbs));
+    #[target_feature(enable = "avx512f,avx512ifma")]
+    fn double_points(self, p: GVec) -> GVec {
+        let (x, y, z) = (load(&p.x.limbs), load(&p.y.limbs), load(&p.z.limbs));
 
-            let a = square_regs(x);
-            let b = square_regs(y);
-            let c0 = square_regs_loose(z);
-            let c = reduce_regs(add_raw(c0, c0));
-            let xy2 = square_regs_loose(reduce_regs(add_raw(x, y)));
-            let e = reduce_regs(sub_raw(sub_raw(xy2, a), b));
-            let g = reduce_regs(sub_raw(b, a));
-            let f = reduce_regs(sub_raw(g, c));
-            let zero = [_mm512_setzero_si512(); 5];
-            let h = reduce_regs(sub_raw(sub_raw(zero, a), b));
+        let a = square_regs(x);
+        let b = square_regs(y);
+        let c0 = square_regs_loose(z);
+        let c = reduce_regs(add_raw(c0, c0));
+        let xy2 = square_regs_loose(reduce_regs(add_raw(x, y)));
+        let e = reduce_regs(sub_raw(sub_raw(xy2, a), b));
+        let g = reduce_regs(sub_raw(b, a));
+        let f = reduce_regs(sub_raw(g, c));
+        let zero = [_mm512_setzero_si512(); 5];
+        let h = reduce_regs(sub_raw(sub_raw(zero, a), b));
 
-            GVec {
-                x: FVec {
-                    limbs: store(mul_regs(e, f)),
-                },
-                y: FVec {
-                    limbs: store(mul_regs(g, h)),
-                },
-                t: FVec {
-                    limbs: store(mul_regs(e, h)),
-                },
-                z: FVec {
-                    limbs: store(mul_regs(f, g)),
-                },
-            }
+        GVec {
+            x: FVec {
+                limbs: store(mul_regs(e, f)),
+            },
+            y: FVec {
+                limbs: store(mul_regs(g, h)),
+            },
+            t: FVec {
+                limbs: store(mul_regs(e, h)),
+            },
+            z: FVec {
+                limbs: store(mul_regs(f, g)),
+            },
         }
     }
 }
 
 impl super::Backend for Backend {}
+
+impl GBackend for Backend {
+    #[inline(always)]
+    fn g_add(self, p: GVec, q: GVec) -> GVec {
+        // SAFETY: `Backend` construction checks AVX-512F and AVX-512 IFMA support
+        unsafe { self.add_points(p, q) }
+    }
+
+    #[inline(always)]
+    fn g_add_mixed(self, p: GVec, q: GAffineVec) -> GVec {
+        // SAFETY: `Backend` construction checks AVX-512F and AVX-512 IFMA support
+        unsafe { self.add_mixed_points(p, q) }
+    }
+
+    #[inline(always)]
+    fn g_double(self, p: GVec) -> GVec {
+        // SAFETY: `Backend` construction checks AVX-512F and AVX-512 IFMA support
+        unsafe { self.double_points(p) }
+    }
+}

--- a/cryptography/curve25519/src/curve/avx512.rs
+++ b/cryptography/curve25519/src/curve/avx512.rs
@@ -101,6 +101,7 @@ fn mul19(z: __m512i) -> __m512i {
 fn reduce_regs(l: [__m512i; 5]) -> [__m512i; 5] {
     let mask = _mm512_set1_epi64(MASK_51 as i64);
     let c: [__m512i; 5] = core::array::from_fn(|i| _mm512_srli_epi64(l[i], 51));
+
     // Each carry is below 2^12, so IFMA computes the folded carry exactly.
     [
         _mm512_madd52lo_epu64(_mm512_and_si512(l[0], mask), c[4], _mm512_set1_epi64(19)),
@@ -469,6 +470,8 @@ impl Backend {
 }
 
 impl super::Backend for Backend {}
+
+impl super::msm::MsmBackend for Backend {}
 
 impl GBackend for Backend {
     #[inline(always)]

--- a/cryptography/curve25519/src/curve/msm.rs
+++ b/cryptography/curve25519/src/curve/msm.rs
@@ -13,7 +13,7 @@ use alloc::vec::Vec;
 ///
 /// The defaults use one bucket stripe per logical lane and vector point arithmetic. Backends
 /// with narrower physical tiles can override these kernels without changing MSM scheduling.
-pub trait MsmBackend: GBackend {
+pub trait Backend: GBackend {
     /// Independent bucket stripes, indexed by `stripe * nb + abs(digit) - 1`.
     ///
     /// Override [`Self::fill_buckets`] when changing this from [`LANES`]. The default fold
@@ -128,7 +128,7 @@ pub fn fill_buckets<const STRIPES: usize, T>(
 ///
 /// Lanes without a stripe contribute the identity. Untouched top buckets can be skipped
 /// because their identity values leave both running sums unchanged.
-pub fn fold_buckets<B: MsmBackend>(
+pub fn fold_buckets<B: Backend>(
     backend: B,
     result: GVec,
     buckets: &[G],

--- a/cryptography/curve25519/src/curve/msm.rs
+++ b/cryptography/curve25519/src/curve/msm.rs
@@ -1,0 +1,199 @@
+//! Backend bucket arithmetic for variable-time multi-scalar multiplication.
+//!
+//! Backends own the bucket geometry and point arithmetic. Digit recoding, range partitioning,
+//! and scheduling remain independent of that choice.
+
+use super::{G, GAffine, GAffineVec, GBackend, GVec, LANES};
+#[cfg(not(feature = "std"))]
+use alloc::vec;
+#[cfg(all(test, not(feature = "std")))]
+use alloc::vec::Vec;
+
+/// Bucket filling, weighted folding, and window recombination for public scalar digits.
+///
+/// The defaults use one bucket stripe per logical lane and vector point arithmetic. Backends
+/// with narrower physical tiles can override these kernels without changing MSM scheduling.
+pub trait MsmBackend: GBackend {
+    /// Independent bucket stripes, indexed by `stripe * nb + abs(digit) - 1`.
+    ///
+    /// Override [`Self::fill_buckets`] when changing this from [`LANES`]. The default fold
+    /// supports at most [`LANES`] stripes.
+    const STRIPES: usize = LANES;
+
+    /// Adds the projected points and signed digits to `Self::STRIPES * nb` buckets.
+    ///
+    /// Digits must have magnitude at most `nb`. Each wave assigns one term to each stripe,
+    /// so updates within a wave cannot collide.
+    fn fill_buckets<T>(
+        self,
+        buckets: &mut [G],
+        nb: usize,
+        terms: &[T],
+        term: impl Fn(&T) -> (GAffine, i16),
+    ) {
+        fill_buckets(
+            |current, incoming, negative| {
+                self.g_add_mixed(
+                    GVec::transpose(current),
+                    GAffineVec::from_signed_lanes(self, &incoming, &negative),
+                )
+                .untranspose()
+            },
+            buckets,
+            nb,
+            terms,
+            term,
+        );
+    }
+
+    /// Returns lanes whose sum weights each bucket by its index plus one, across all stripes.
+    ///
+    /// `used <= nb` is the largest nonzero digit magnitude. Buckets above it contribute nothing.
+    fn fold_buckets(self, buckets: &[G], nb: usize, used: usize) -> GVec {
+        fold_buckets(self, GVec::identity(), buckets, nb, used)
+    }
+
+    /// Sums `(window, point)` partials, then Horner-folds the windows with `width` doublings.
+    ///
+    /// Window indices must be less than `windows`. Partials are added in their iteration order.
+    fn combine_windows(
+        self,
+        partials: impl IntoIterator<Item = (usize, G)>,
+        windows: usize,
+        width: u32,
+    ) -> G {
+        let mut window_sums = vec![GVec::identity(); windows];
+        for (window, partial) in partials {
+            window_sums[window] = self.g_add(window_sums[window], GVec::splat(partial));
+        }
+        let mut result = GVec::identity();
+        for window in window_sums.iter().rev() {
+            for _ in 0..width {
+                result = self.g_double(result);
+            }
+            result = self.g_add(result, *window);
+        }
+        result.untranspose()[0]
+    }
+}
+
+/// Adds each run in waves of one term per bucket stripe.
+///
+/// Missing or zero-digit lanes use identity inputs and never scatter a result. Entirely
+/// zero waves skip group arithmetic, including the high windows of short coefficients.
+/// Each piece may restart stripe assignment because the fold sums every stripe.
+#[allow(clippy::needless_range_loop)]
+pub fn fill_buckets<const STRIPES: usize, T>(
+    add: impl Fn([G; STRIPES], [GAffine; STRIPES], [bool; STRIPES]) -> [G; STRIPES],
+    buckets: &mut [G],
+    nb: usize,
+    terms: &[T],
+    term: impl Fn(&T) -> (GAffine, i16),
+) {
+    let identity_point = GAffine::IDENTITY;
+    for wave in terms.chunks(STRIPES) {
+        let mut incoming = [identity_point; STRIPES];
+        let mut negative = [false; STRIPES];
+        let mut current = [G::IDENTITY; STRIPES];
+        let mut bucket_index = [None::<usize>; STRIPES];
+        let mut any = false;
+        for (lane, item) in wave.iter().enumerate() {
+            let (point, digit) = term(item);
+            if digit > 0 {
+                bucket_index[lane] = Some(digit as usize - 1);
+                incoming[lane] = point;
+            } else if digit < 0 {
+                bucket_index[lane] = Some(digit.unsigned_abs() as usize - 1);
+                incoming[lane] = point;
+                negative[lane] = true;
+            }
+            if let Some(i) = bucket_index[lane] {
+                current[lane] = buckets[lane * nb + i];
+                any = true;
+            }
+        }
+        if !any {
+            continue;
+        }
+        let updated = add(current, incoming, negative);
+        for lane in 0..STRIPES {
+            if let Some(i) = bucket_index[lane] {
+                buckets[lane * nb + i] = updated[lane];
+            }
+        }
+    }
+}
+
+/// Folds each bucket stripe into its corresponding result lane with a running sum.
+///
+/// Lanes without a stripe contribute the identity. Untouched top buckets can be skipped
+/// because their identity values leave both running sums unchanged.
+pub fn fold_buckets<B: MsmBackend>(
+    backend: B,
+    result: GVec,
+    buckets: &[G],
+    nb: usize,
+    used: usize,
+) -> GVec {
+    let mut sum = GVec::identity();
+    let mut window_sum = GVec::identity();
+    for d in (0..used).rev() {
+        let bucket_group: [G; LANES] = core::array::from_fn(|lane| {
+            if lane < B::STRIPES {
+                buckets[lane * nb + d]
+            } else {
+                G::IDENTITY
+            }
+        });
+        sum = backend.g_add(sum, GVec::transpose(bucket_group));
+        window_sum = backend.g_add(window_sum, sum);
+    }
+    backend.g_add(result, window_sum)
+}
+
+#[cfg(test)]
+#[test]
+fn fold_preserves_every_bucket_weight() {
+    struct Check;
+    impl crate::curve::WithBackend for Check {
+        type Output = ();
+        fn call<B: crate::curve::Backend>(self, backend: B) {
+            let base = GAffine::BASEPOINT.to_extended();
+            let torsion = GAffine::decompress(&[0; 32]).unwrap().to_extended();
+            for width in [6, 7, 8, 9, 10] {
+                let nb = 1usize << (width - 1);
+                let mut point = base;
+                let buckets: Vec<G> = (0..B::STRIPES * nb)
+                    .map(|i| {
+                        point = point.add(base);
+                        match i % 7 {
+                            0 => torsion,
+                            1 => point.add(torsion),
+                            2 => point.negate(),
+                            3 => G::IDENTITY,
+                            _ => point,
+                        }
+                    })
+                    .collect();
+                let mut expected = G::IDENTITY;
+                for used in 0..=nb {
+                    if used != 0 {
+                        let bucket = (0..B::STRIPES).fold(G::IDENTITY, |sum, stripe| {
+                            sum.add(buckets[stripe * nb + used - 1])
+                        });
+                        let weighted = bucket
+                            .scalar_mul((0..usize::BITS).rev().map(|bit| used & (1 << bit) != 0));
+                        expected = expected.add(weighted);
+                    }
+                    let actual = backend.fold_buckets(&buckets, nb, used).sum_lanes(backend);
+                    assert!(
+                        actual.add(expected.negate()).is_identity(),
+                        "width={width} used={used}"
+                    );
+                }
+            }
+        }
+    }
+    crate::curve::WithBackend::call(Check, crate::curve::test_backend());
+    crate::curve::with_backend(Check);
+}

--- a/cryptography/curve25519/src/curve/msm.rs
+++ b/cryptography/curve25519/src/curve/msm.rs
@@ -31,6 +31,7 @@ pub trait Backend: GBackend {
         terms: &[T],
         term: impl Fn(&T) -> (GAffine, i16),
     ) {
+        const { assert!(Self::STRIPES == LANES) };
         fill_buckets(
             |current, incoming, negative| {
                 self.g_add_mixed(
@@ -135,6 +136,7 @@ pub fn fold_buckets<B: Backend>(
     nb: usize,
     used: usize,
 ) -> GVec {
+    const { assert!(B::STRIPES <= LANES) };
     let mut sum = GVec::identity();
     let mut window_sum = GVec::identity();
     for d in (0..used).rev() {
@@ -151,7 +153,6 @@ pub fn fold_buckets<B: Backend>(
     backend.g_add(result, window_sum)
 }
 
-#[cfg(test)]
 #[test]
 fn fold_preserves_every_bucket_weight() {
     struct Check;

--- a/cryptography/curve25519/src/curve/neon.rs
+++ b/cryptography/curve25519/src/curve/neon.rs
@@ -23,7 +23,8 @@ type Regs = [uint64x2_t; 5];
 
 /// The NEON backend token.
 ///
-/// NEON is part of the AArch64 baseline, so the token needs no runtime feature check.
+/// This module is compiled only when the AArch64 target enables NEON, so the token needs no
+/// runtime feature check.
 #[derive(Clone, Copy)]
 pub(super) struct Backend;
 

--- a/cryptography/curve25519/src/curve/neon.rs
+++ b/cryptography/curve25519/src/curve/neon.rs
@@ -3,8 +3,9 @@
 //! The generic field kernels stay entirely in NEON. A scalar-plus-NEON design only becomes useful
 //! when independent operations are scheduled across a complete point formula; dividing one
 //! [`super::FVec`] operation between both domains adds setup and synchronization costs on Apple
-//! M-series CPUs. Products split radix-`2^51` limbs into alternating 26/25-bit digits only while
-//! multiplying, keeping the surrounding group formulas in their compact five-limb representation.
+//! M-series CPUs. Products split radix-`2^51` limbs into digits at alternating 26/25-bit offsets
+//! only while multiplying; loose input digits can each occupy 26 bits. The surrounding group
+//! formulas keep their compact five-limb representation.
 
 use super::{BIAS_16P as SUB_BIAS, F, FBackend, FVec, GAffineVec, GBackend, GVec, LANES, MASK_51};
 use core::arch::aarch64::*;
@@ -62,7 +63,7 @@ fn store(regs: Regs, limbs: &mut [[u64; LANES]; 5], tile: usize) {
 ///
 /// # Correctness
 ///
-/// `z` must be less than `2^59` per lane so the shifts do not discard significant bits.
+/// `z` must be less than `2^59` per lane so `19*z` fits in `u64`.
 ///
 /// The explicit instruction sequence prevents LLVM from recognizing a packed `u64` multiplication
 /// and scalarizing it through general-purpose registers. NEON has no packed `u64` multiply, while

--- a/cryptography/curve25519/src/curve/neon.rs
+++ b/cryptography/curve25519/src/curve/neon.rs
@@ -795,7 +795,7 @@ impl msm::Backend for Backend {
         weighted
     }
 
-    // Scalar recombination computes each point once, avoiding duplicate SIMD lanes.
+    /// Scalar recombination computes each point once, avoiding duplicate SIMD lanes.
     fn combine_windows(
         self,
         partials: impl IntoIterator<Item = (usize, G)>,

--- a/cryptography/curve25519/src/curve/neon.rs
+++ b/cryptography/curve25519/src/curve/neon.rs
@@ -8,8 +8,12 @@
 //! formulas keep their compact five-limb representation.
 
 use super::{
-    BIAS_16P as SUB_BIAS, F, FBackend, FVec, G, GAffine, GAffineVec, GBackend, GVec, LANES, MASK_51,
+    BIAS_16P as SUB_BIAS, F, FBackend, FVec, G, GAffine, GAffineVec, GBackend, GVec, LANES,
+    MASK_51,
+    msm::{self, MsmBackend},
 };
+#[cfg(not(feature = "std"))]
+use alloc::vec;
 use core::arch::aarch64::*;
 
 /// `2d` in every lane, for the `C = 2d*T1*T2` term of point addition.
@@ -559,7 +563,7 @@ fn unpack_pair(regs: Regs) -> [F; 2] {
 
 /// Applies the complete mixed-addition formula to two independent register lanes.
 ///
-/// Extended inputs and outputs use `[x, y, t, z]`; affine inputs use `[x, y, t2d]`.
+/// Extended inputs and outputs use `[x, y, t, z]`. Affine inputs use `[x, y, t2d]`.
 #[inline(always)]
 fn add_mixed_regs(p: [Regs; 4], q: [Regs; 3]) -> [Regs; 4] {
     let [x1, y1, t1, z1] = p;
@@ -641,43 +645,6 @@ impl GBackend for Backend {
         p
     }
 
-    #[inline(always)]
-    fn g_add_mixed_pair(self, p: [G; 2], q: [GAffine; 2], negative: [bool; 2]) -> [G; 2] {
-        let mut x2 = pack_pair(q.map(|point| point.x));
-        let mut t2d = pack_pair(q.map(|point| point.t2d));
-        if negative.iter().any(|&sign| sign) {
-            // SAFETY: AArch64 targets provide NEON, and the mask array has two complete lanes.
-            unsafe {
-                let masks = negative.map(|sign| 0u64.wrapping_sub(u64::from(sign)));
-                let mask = vld1q_u64(masks.as_ptr());
-                let zero = [vdupq_n_u64(0); 5];
-                let neg_x = reduce_regs(sub_raw(zero, x2));
-                let neg_t2d = reduce_regs(sub_raw(zero, t2d));
-                x2 = core::array::from_fn(|i| vbslq_u64(mask, neg_x[i], x2[i]));
-                t2d = core::array::from_fn(|i| vbslq_u64(mask, neg_t2d[i], t2d[i]));
-            }
-        }
-        let [x, y, t, z] = add_mixed_regs(
-            [
-                pack_pair(p.map(|point| point.x)),
-                pack_pair(p.map(|point| point.y)),
-                pack_pair(p.map(|point| point.t)),
-                pack_pair(p.map(|point| point.z)),
-            ],
-            [x2, pack_pair(q.map(|point| point.y)), t2d],
-        );
-        let x = unpack_pair(x);
-        let y = unpack_pair(y);
-        let t = unpack_pair(t);
-        let z = unpack_pair(z);
-        core::array::from_fn(|i| G {
-            x: x[i],
-            y: y[i],
-            t: t[i],
-            z: z[i],
-        })
-    }
-
     /// Fused point doubling using the dedicated `dbl-2008-hwcd` formula.
     #[inline(always)]
     fn g_double(self, mut p: GVec) -> GVec {
@@ -708,3 +675,225 @@ impl GBackend for Backend {
 }
 
 impl super::Backend for Backend {}
+
+/// Adds a signed affine point to each of two extended points.
+///
+/// Each result is `p[i] + q[i]` or `p[i] - q[i]` according to `negative[i]`.
+/// Variable-time, so the signs must be public.
+#[inline(always)]
+fn g_add_mixed_pair(p: [G; 2], q: [GAffine; 2], negative: [bool; 2]) -> [G; 2] {
+    let mut x2 = pack_pair(q.map(|point| point.x));
+    let mut t2d = pack_pair(q.map(|point| point.t2d));
+    if negative.iter().any(|&sign| sign) {
+        // SAFETY: AArch64 targets provide NEON, and the mask array has two complete lanes.
+        unsafe {
+            let masks = negative.map(|sign| 0u64.wrapping_sub(u64::from(sign)));
+            let mask = vld1q_u64(masks.as_ptr());
+            let zero = [vdupq_n_u64(0); 5];
+            let neg_x = reduce_regs(sub_raw(zero, x2));
+            let neg_t2d = reduce_regs(sub_raw(zero, t2d));
+            x2 = core::array::from_fn(|i| vbslq_u64(mask, neg_x[i], x2[i]));
+            t2d = core::array::from_fn(|i| vbslq_u64(mask, neg_t2d[i], t2d[i]));
+        }
+    }
+    let [x, y, t, z] = add_mixed_regs(
+        [
+            pack_pair(p.map(|point| point.x)),
+            pack_pair(p.map(|point| point.y)),
+            pack_pair(p.map(|point| point.t)),
+            pack_pair(p.map(|point| point.z)),
+        ],
+        [x2, pack_pair(q.map(|point| point.y)), t2d],
+    );
+    let x = unpack_pair(x);
+    let y = unpack_pair(y);
+    let t = unpack_pair(t);
+    let z = unpack_pair(z);
+    core::array::from_fn(|i| G {
+        x: x[i],
+        y: y[i],
+        t: t[i],
+        z: z[i],
+    })
+}
+
+impl MsmBackend for Backend {
+    // One stripe per physical mixed-addition lane keeps wave updates independent. Folds retain
+    // LANES independent bucket indices.
+    const STRIPES: usize = WIDTH;
+
+    fn fill_buckets<T>(
+        self,
+        buckets: &mut [G],
+        nb: usize,
+        terms: &[T],
+        term: impl Fn(&T) -> (GAffine, i16),
+    ) {
+        msm::fill_buckets(g_add_mixed_pair, buckets, nb, terms, term);
+    }
+
+    /// Returns lanes whose sum is the weighted sum of all bucket stripes.
+    ///
+    /// Let `B[k, lane]` sum the stripes at bucket index `k*LANES + lane`. The descending pass
+    /// builds `sum[lane] = sum_k B[k, lane]` and `rows[lane] = sum_k k*B[k, lane]`.
+    /// Final weighting gives `LANES*rows[lane] + (lane + 1)*sum[lane]`, assigning each bucket
+    /// its index-plus-one weight. The lane count is a power of two.
+    fn fold_buckets(self, buckets: &[G], nb: usize, used: usize) -> GVec {
+        // A single used bucket has weight one, so return the stripes without weighting.
+        if used == 1 {
+            return GVec::transpose(core::array::from_fn(|lane| {
+                if lane < Self::STRIPES {
+                    buckets[lane * nb]
+                } else {
+                    G::IDENTITY
+                }
+            }));
+        }
+        let mut sum = GVec::identity();
+        let mut rows = GVec::identity();
+        for block in (0..used.div_ceil(LANES)).rev() {
+            let gather = |stripe: usize| {
+                GVec::transpose(core::array::from_fn(|lane| {
+                    let digit = block * LANES + lane;
+                    if digit < used {
+                        buckets[stripe * nb + digit]
+                    } else {
+                        G::IDENTITY
+                    }
+                }))
+            };
+            let mut combined = gather(0);
+            for stripe in 1..Self::STRIPES {
+                combined = self.g_add(combined, gather(stripe));
+            }
+            rows = self.g_add(rows, sum);
+            sum = self.g_add(sum, combined);
+        }
+
+        // Seed the row weight and the high bit of lane + 1. Doubling shifts both together.
+        let lanes = sum.untranspose();
+        let mut weighted = self.g_add(
+            rows,
+            GVec::transpose(core::array::from_fn(|lane| {
+                if lane == LANES - 1 {
+                    lanes[lane]
+                } else {
+                    G::IDENTITY
+                }
+            })),
+        );
+        for bit in (0..LANES.ilog2()).rev() {
+            weighted = self.g_double(weighted);
+            let selected = core::array::from_fn(|lane| {
+                if (lane + 1) & (1 << bit) != 0 {
+                    lanes[lane]
+                } else {
+                    G::IDENTITY
+                }
+            });
+            weighted = self.g_add(weighted, GVec::transpose(selected));
+        }
+        weighted
+    }
+
+    // Scalar recombination computes each point once, avoiding duplicate SIMD lanes.
+    fn combine_windows(
+        self,
+        partials: impl IntoIterator<Item = (usize, G)>,
+        windows: usize,
+        width: u32,
+    ) -> G {
+        let mut window_sums = vec![G::IDENTITY; windows];
+        for (window, partial) in partials {
+            window_sums[window] = window_sums[window].add(partial);
+        }
+        let mut result = G::IDENTITY;
+        for window in window_sums.iter().rev() {
+            for _ in 0..width {
+                result = result.double();
+            }
+            result = result.add(*window);
+        }
+        result
+    }
+}
+
+#[cfg(test)]
+#[test]
+fn mixed_pair_matches_full_width() {
+    let reference = super::portable::Backend::new();
+    let torsion = GAffine::decompress(&[0; 32]).unwrap();
+    let mixed = GAffine::decompress(
+        &GAffine::BASEPOINT
+            .to_extended()
+            .add(torsion.to_extended())
+            .to_bytes(),
+    )
+    .unwrap();
+    let points = [GAffine::IDENTITY, GAffine::BASEPOINT, torsion, mixed];
+    let max = F([(1 << 52) - 1; 5]);
+    let loose = G {
+        x: max,
+        y: max,
+        t: max,
+        z: max,
+    };
+    let loose_affine = GAffine {
+        x: max,
+        y: max,
+        t2d: max,
+    };
+    for i in 0..points.len() {
+        for j in 0..points.len() {
+            let current = [points[i].to_extended(), points[j].to_extended()];
+            let current = core::array::from_fn(|lane| {
+                let factor = F([lane as u64 + 2, 0, 0, 0, 0]);
+                G {
+                    x: current[lane].x.mul(factor),
+                    y: current[lane].y.mul(factor),
+                    t: current[lane].t.mul(factor),
+                    z: current[lane].z.mul(factor),
+                }
+            });
+            let incoming = [points[j], points[(i + 1) % points.len()]];
+            for (current, incoming) in [
+                (current, incoming),
+                ([loose, current[1]], [loose_affine, incoming[1]]),
+            ] {
+                for negative in [[false, false], [false, true], [true, false], [true, true]] {
+                    let mut packed_current = [G::IDENTITY; LANES];
+                    let mut packed_incoming = [GAffine::IDENTITY; LANES];
+                    let mut packed_negative = [false; LANES];
+                    packed_current[..WIDTH].copy_from_slice(&current);
+                    packed_incoming[..WIDTH].copy_from_slice(&incoming);
+                    packed_negative[..WIDTH].copy_from_slice(&negative);
+                    let expected = reference
+                        .g_add_mixed(
+                            GVec::transpose(packed_current),
+                            GAffineVec::from_signed_lanes(
+                                reference,
+                                &packed_incoming,
+                                &packed_negative,
+                            ),
+                        )
+                        .untranspose();
+                    let actual = g_add_mixed_pair(current, incoming, negative);
+                    for lane in 0..2 {
+                        for (actual, expected) in [
+                            (actual[lane].x, expected[lane].x),
+                            (actual[lane].y, expected[lane].y),
+                            (actual[lane].t, expected[lane].t),
+                            (actual[lane].z, expected[lane].z),
+                        ] {
+                            super::test::assert_f_eq(
+                                FVec::splat(actual),
+                                FVec::splat(expected),
+                                "mixed pair coordinate",
+                            );
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/cryptography/curve25519/src/curve/neon.rs
+++ b/cryptography/curve25519/src/curve/neon.rs
@@ -177,6 +177,7 @@ fn reduce_columns(c: [uint64x2_t; 10]) -> Regs {
                 vshlq_n_u64(vandq_u64(paired[i], mask25), 26),
             )
         });
+
         // Column 8 is at most 51*M^2 and column 9 at most 10*M^2, so the top carry fits
         // below 2^31 and can narrow losslessly. Its 19-fold and every other carry are
         // below 2^35, leaving each output below 2^51 + 2^35 < 2^52 without another pass

--- a/cryptography/curve25519/src/curve/neon.rs
+++ b/cryptography/curve25519/src/curve/neon.rs
@@ -7,7 +7,9 @@
 //! only while multiplying. Loose input digits can each occupy 26 bits. The surrounding group
 //! formulas keep their compact five-limb representation.
 
-use super::{BIAS_16P as SUB_BIAS, F, FBackend, FVec, GAffineVec, GBackend, GVec, LANES, MASK_51};
+use super::{
+    BIAS_16P as SUB_BIAS, F, FBackend, FVec, G, GAffine, GAffineVec, GBackend, GVec, LANES, MASK_51,
+};
 use core::arch::aarch64::*;
 
 /// `2d` in every lane, for the `C = 2d*T1*T2` term of point addition.
@@ -155,48 +157,35 @@ fn digit_product(a: uint32x2_t, b: uint32x2_t) -> uint64x2_t {
     unsafe { vmull_u32(a, b) }
 }
 
+/// Reduces ten alternating 26/25-bit product columns into five loose radix-`2^51` limbs
+///
+/// With `M = 2^26 - 1`, column bounds are `M^2` times
+/// `[267, 154, 213, 118, 159, 82, 105, 46, 51, 10]`.
+/// Each pair satisfies `c[2*i] + 2^26*c[2*i + 1] = low[i] + 2^51*carry[i]`, with
+/// `low[i] < 2^51`. Carries move to the next limb, wrapping the top carry by `2^255 = 19 (mod p)`
 #[inline(always)]
-fn reduce_columns(mut c: [uint64x2_t; 10]) -> Regs {
-    // SAFETY: AArch64 targets provide NEON. All accumulators and carry additions fit in `u64`.
+fn reduce_columns(c: [uint64x2_t; 10]) -> Regs {
+    // SAFETY: AArch64 targets provide NEON. Paired columns and carry additions fit in u64
     unsafe {
         let mask26 = vdupq_n_u64((1 << 26) - 1);
         let mask25 = vdupq_n_u64((1 << 25) - 1);
-        c[1] = vaddq_u64(c[1], vshrq_n_u64(c[0], 26));
-        c[0] = vandq_u64(c[0], mask26);
-        c[2] = vaddq_u64(c[2], vshrq_n_u64(c[1], 25));
-        c[1] = vandq_u64(c[1], mask25);
-        c[3] = vaddq_u64(c[3], vshrq_n_u64(c[2], 26));
-        c[2] = vandq_u64(c[2], mask26);
-        c[4] = vaddq_u64(c[4], vshrq_n_u64(c[3], 25));
-        c[3] = vandq_u64(c[3], mask25);
-        c[5] = vaddq_u64(c[5], vshrq_n_u64(c[4], 26));
-        c[4] = vandq_u64(c[4], mask26);
-        c[6] = vaddq_u64(c[6], vshrq_n_u64(c[5], 25));
-        c[5] = vandq_u64(c[5], mask25);
-        c[7] = vaddq_u64(c[7], vshrq_n_u64(c[6], 26));
-        c[6] = vandq_u64(c[6], mask26);
-        c[8] = vaddq_u64(c[8], vshrq_n_u64(c[7], 25));
-        c[7] = vandq_u64(c[7], mask25);
-        c[9] = vaddq_u64(c[9], vshrq_n_u64(c[8], 26));
-        c[8] = vandq_u64(c[8], mask26);
-        // Narrowing this carry is lossless, which needs a tighter bound than the worst-case
-        // column (`267 * (2^26 - 1)^2 < 2^61`): column 9 is where terms fold *from*, never
-        // *into*, so it accumulates at most ten unscaled products plus column 8's carry,
-        // `c[9] < 10 * (2^26 - 1)^2 + 2^32 < 2^56`, making the carry `c[9] >> 25` less than
-        // `2^31`. Narrowing enables one widening multiply instead of the longer packed-u64
-        // shift/add sequence.
-        let top = vmovn_u64(vshrq_n_u64(c[9], 25));
-        c[0] = vaddq_u64(c[0], vmull_n_u32(top, 19));
-        c[9] = vandq_u64(c[9], mask25);
-        c[1] = vaddq_u64(c[1], vshrq_n_u64(c[0], 26));
-        c[0] = vandq_u64(c[0], mask26);
-        [
-            vorrq_u64(c[0], vshlq_n_u64(c[1], 26)),
-            vorrq_u64(c[2], vshlq_n_u64(c[3], 26)),
-            vorrq_u64(c[4], vshlq_n_u64(c[5], 26)),
-            vorrq_u64(c[6], vshlq_n_u64(c[7], 26)),
-            vorrq_u64(c[8], vshlq_n_u64(c[9], 26)),
-        ]
+        let paired: Regs =
+            core::array::from_fn(|i| vaddq_u64(c[2 * i + 1], vshrq_n_u64(c[2 * i], 26)));
+        let mut out: Regs = core::array::from_fn(|i| {
+            vorrq_u64(
+                vandq_u64(c[2 * i], mask26),
+                vshlq_n_u64(vandq_u64(paired[i], mask25), 26),
+            )
+        });
+        // Column 8 is at most 51*M^2 and column 9 at most 10*M^2, so the top carry fits
+        // below 2^31 and can narrow losslessly. Its 19-fold and every other carry are
+        // below 2^35, leaving each output below 2^51 + 2^35 < 2^52 without another pass
+        let top = vmovn_u64(vshrq_n_u64(paired[4], 25));
+        out[0] = vaddq_u64(out[0], vmull_n_u32(top, 19));
+        for i in 1..5 {
+            out[i] = vaddq_u64(out[i], vshrq_n_u64(paired[i - 1], 25));
+        }
+        out
     }
 }
 
@@ -546,23 +535,54 @@ impl FBackend for Backend {
     }
 }
 
-/// Returns an all-zero point used as fully overwritten output storage.
+/// Packs two independent field elements into register lanes
 #[inline(always)]
-const fn empty_gvec() -> GVec {
-    let zero = FVec::splat(F::ZERO);
-    GVec {
-        x: zero,
-        y: zero,
-        t: zero,
-        z: zero,
+fn pack_pair(values: [F; 2]) -> Regs {
+    // SAFETY: AArch64 targets provide NEON, and the selected lane is within the two-lane register
+    unsafe {
+        core::array::from_fn(|i| vsetq_lane_u64(values[1].0[i], vdupq_n_u64(values[0].0[i]), 1))
     }
+}
+
+/// Unpacks both register lanes into independent field elements
+#[inline(always)]
+fn unpack_pair(regs: Regs) -> [F; 2] {
+    // SAFETY: AArch64 targets provide NEON, and both lane indices are within the register
+    unsafe {
+        [
+            F(regs.map(|reg| vgetq_lane_u64(reg, 0))),
+            F(regs.map(|reg| vgetq_lane_u64(reg, 1))),
+        ]
+    }
+}
+
+/// Applies the complete mixed-addition formula to two independent register lanes
+///
+/// Extended inputs and outputs use `[x, y, t, z]`; affine inputs use `[x, y, t2d]`
+#[inline(always)]
+fn add_mixed_regs(p: [Regs; 4], q: [Regs; 3]) -> [Regs; 4] {
+    let [x1, y1, t1, z1] = p;
+    let [x2, y2, t2d] = q;
+    let a = mul_regs(reduce_regs(sub_raw(y1, x1)), reduce_regs(sub_raw(y2, x2)));
+    let b = mul_regs(reduce_regs(add_raw(y1, x1)), reduce_regs(add_raw(y2, x2)));
+    let c = mul_regs(t1, t2d);
+    let d = add_raw(z1, z1);
+    let e = reduce_regs(sub_raw(b, a));
+    let f = reduce_regs(sub_raw(d, c));
+    let g = reduce_regs(add_raw(d, c));
+    let h = reduce_regs(add_raw(b, a));
+    [
+        mul_regs(e, f),
+        mul_regs(g, h),
+        mul_regs(e, h),
+        mul_regs(f, g),
+    ]
 }
 
 impl GBackend for Backend {
     /// Fused point addition, processed two lanes at a time to keep the working set in registers.
     #[inline(always)]
-    fn g_add(self, p: GVec, q: GVec) -> GVec {
-        let mut result = empty_gvec();
+    fn g_add(self, mut p: GVec, q: GVec) -> GVec {
         for tile in 0..TILES {
             // Unified extended-coordinates addition (Hisil-Wong-Carter-Dawson):
             //
@@ -581,51 +601,85 @@ impl GBackend for Backend {
                 load(&EDWARDS_D2.limbs, tile),
             );
             let zz = mul_regs(load(&p.z.limbs, tile), load(&q.z.limbs, tile));
-            let d = reduce_regs(add_raw(zz, zz));
+            let d = add_raw(zz, zz);
             let e = reduce_regs(sub_raw(b, a));
             let f = reduce_regs(sub_raw(d, c));
             let g = reduce_regs(add_raw(d, c));
             let h = reduce_regs(add_raw(b, a));
 
-            store(mul_regs(e, f), &mut result.x.limbs, tile);
-            store(mul_regs(g, h), &mut result.y.limbs, tile);
-            store(mul_regs(e, h), &mut result.t.limbs, tile);
-            store(mul_regs(f, g), &mut result.z.limbs, tile);
+            store(mul_regs(e, f), &mut p.x.limbs, tile);
+            store(mul_regs(g, h), &mut p.y.limbs, tile);
+            store(mul_regs(e, h), &mut p.t.limbs, tile);
+            store(mul_regs(f, g), &mut p.z.limbs, tile);
         }
-        result
+        p
     }
 
     /// Fused mixed point addition, processed two lanes at a time.
     #[inline(always)]
-    fn g_add_mixed(self, p: GVec, q: GAffineVec) -> GVec {
-        let mut result = empty_gvec();
+    fn g_add_mixed(self, mut p: GVec, q: GAffineVec) -> GVec {
         for tile in 0..TILES {
-            let x1 = load(&p.x.limbs, tile);
-            let y1 = load(&p.y.limbs, tile);
-            let x2 = load(&q.x.limbs, tile);
-            let y2 = load(&q.y.limbs, tile);
-            let a = mul_regs(reduce_regs(sub_raw(y1, x1)), reduce_regs(sub_raw(y2, x2)));
-            let b = mul_regs(reduce_regs(add_raw(y1, x1)), reduce_regs(add_raw(y2, x2)));
-            let c = mul_regs(load(&p.t.limbs, tile), load(&q.t2d.limbs, tile));
-            let z1 = load(&p.z.limbs, tile);
-            let d = reduce_regs(add_raw(z1, z1));
-            let e = reduce_regs(sub_raw(b, a));
-            let f = reduce_regs(sub_raw(d, c));
-            let g = reduce_regs(add_raw(d, c));
-            let h = reduce_regs(add_raw(b, a));
-
-            store(mul_regs(e, f), &mut result.x.limbs, tile);
-            store(mul_regs(g, h), &mut result.y.limbs, tile);
-            store(mul_regs(e, h), &mut result.t.limbs, tile);
-            store(mul_regs(f, g), &mut result.z.limbs, tile);
+            let [x, y, t, z] = add_mixed_regs(
+                [
+                    load(&p.x.limbs, tile),
+                    load(&p.y.limbs, tile),
+                    load(&p.t.limbs, tile),
+                    load(&p.z.limbs, tile),
+                ],
+                [
+                    load(&q.x.limbs, tile),
+                    load(&q.y.limbs, tile),
+                    load(&q.t2d.limbs, tile),
+                ],
+            );
+            store(x, &mut p.x.limbs, tile);
+            store(y, &mut p.y.limbs, tile);
+            store(t, &mut p.t.limbs, tile);
+            store(z, &mut p.z.limbs, tile);
         }
-        result
+        p
+    }
+
+    #[inline(always)]
+    fn g_add_mixed_pair(self, p: [G; 2], q: [GAffine; 2], negative: [bool; 2]) -> [G; 2] {
+        let mut x2 = pack_pair(q.map(|point| point.x));
+        let mut t2d = pack_pair(q.map(|point| point.t2d));
+        if negative.iter().any(|&sign| sign) {
+            // SAFETY: AArch64 targets provide NEON, and the mask array has two complete lanes
+            unsafe {
+                let masks = negative.map(|sign| 0u64.wrapping_sub(u64::from(sign)));
+                let mask = vld1q_u64(masks.as_ptr());
+                let zero = [vdupq_n_u64(0); 5];
+                let neg_x = reduce_regs(sub_raw(zero, x2));
+                let neg_t2d = reduce_regs(sub_raw(zero, t2d));
+                x2 = core::array::from_fn(|i| vbslq_u64(mask, neg_x[i], x2[i]));
+                t2d = core::array::from_fn(|i| vbslq_u64(mask, neg_t2d[i], t2d[i]));
+            }
+        }
+        let [x, y, t, z] = add_mixed_regs(
+            [
+                pack_pair(p.map(|point| point.x)),
+                pack_pair(p.map(|point| point.y)),
+                pack_pair(p.map(|point| point.t)),
+                pack_pair(p.map(|point| point.z)),
+            ],
+            [x2, pack_pair(q.map(|point| point.y)), t2d],
+        );
+        let x = unpack_pair(x);
+        let y = unpack_pair(y);
+        let t = unpack_pair(t);
+        let z = unpack_pair(z);
+        core::array::from_fn(|i| G {
+            x: x[i],
+            y: y[i],
+            t: t[i],
+            z: z[i],
+        })
     }
 
     /// Fused point doubling using the dedicated `dbl-2008-hwcd` formula.
     #[inline(always)]
-    fn g_double(self, p: GVec) -> GVec {
-        let mut result = empty_gvec();
+    fn g_double(self, mut p: GVec) -> GVec {
         for tile in 0..TILES {
             let x = load(&p.x.limbs, tile);
             let y = load(&p.y.limbs, tile);
@@ -643,12 +697,12 @@ impl GBackend for Backend {
             let zero = unsafe { [vdupq_n_u64(0); 5] };
             let h = reduce_regs(sub_raw(sub_raw(zero, a), b));
 
-            store(mul_regs(e, f), &mut result.x.limbs, tile);
-            store(mul_regs(g, h), &mut result.y.limbs, tile);
-            store(mul_regs(e, h), &mut result.t.limbs, tile);
-            store(mul_regs(f, g), &mut result.z.limbs, tile);
+            store(mul_regs(e, f), &mut p.x.limbs, tile);
+            store(mul_regs(g, h), &mut p.y.limbs, tile);
+            store(mul_regs(e, h), &mut p.t.limbs, tile);
+            store(mul_regs(f, g), &mut p.z.limbs, tile);
         }
-        result
+        p
     }
 }
 

--- a/cryptography/curve25519/src/curve/neon.rs
+++ b/cryptography/curve25519/src/curve/neon.rs
@@ -4,7 +4,7 @@
 //! when independent operations are scheduled across a complete point formula; dividing one
 //! [`super::FVec`] operation between both domains adds setup and synchronization costs on Apple
 //! M-series CPUs. Products split radix-`2^51` limbs into digits at alternating 26/25-bit offsets
-//! only while multiplying; loose input digits can each occupy 26 bits. The surrounding group
+//! only while multiplying. Loose input digits can each occupy 26 bits. The surrounding group
 //! formulas keep their compact five-limb representation.
 
 use super::{BIAS_16P as SUB_BIAS, F, FBackend, FVec, GAffineVec, GBackend, GVec, LANES, MASK_51};
@@ -23,9 +23,6 @@ const TILES: usize = LANES / WIDTH;
 type Regs = [uint64x2_t; 5];
 
 /// The NEON backend token.
-///
-/// This module is compiled only when the AArch64 target enables NEON, so the token needs no
-/// runtime feature check.
 #[derive(Clone, Copy)]
 pub(super) struct Backend;
 

--- a/cryptography/curve25519/src/curve/neon.rs
+++ b/cryptography/curve25519/src/curve/neon.rs
@@ -728,7 +728,7 @@ impl msm::Backend for Backend {
         terms: &[T],
         term: impl Fn(&T) -> (GAffine, i16),
     ) {
-        msm::fill_buckets(g_add_mixed_pair, buckets, nb, terms, term);
+        msm::fill_buckets::<{ Self::STRIPES }, T>(g_add_mixed_pair, buckets, nb, terms, term);
     }
 
     /// Returns lanes whose sum is the weighted sum of all bucket stripes.
@@ -817,7 +817,6 @@ impl msm::Backend for Backend {
     }
 }
 
-#[cfg(test)]
 #[test]
 fn mixed_pair_matches_full_width() {
     let reference = super::portable::Backend::new();
@@ -830,7 +829,7 @@ fn mixed_pair_matches_full_width() {
     )
     .unwrap();
     let points = [GAffine::IDENTITY, GAffine::BASEPOINT, torsion, mixed];
-    let max = F([(1 << 52) - 1; 5]);
+    let max = F([super::test::MASK_52; 5]);
     let loose = G {
         x: max,
         y: max,

--- a/cryptography/curve25519/src/curve/neon.rs
+++ b/cryptography/curve25519/src/curve/neon.rs
@@ -157,15 +157,15 @@ fn digit_product(a: uint32x2_t, b: uint32x2_t) -> uint64x2_t {
     unsafe { vmull_u32(a, b) }
 }
 
-/// Reduces ten alternating 26/25-bit product columns into five loose radix-`2^51` limbs
+/// Reduces ten alternating 26/25-bit product columns into five loose radix-`2^51` limbs.
 ///
 /// With `M = 2^26 - 1`, column bounds are `M^2` times
 /// `[267, 154, 213, 118, 159, 82, 105, 46, 51, 10]`.
 /// Each pair satisfies `c[2*i] + 2^26*c[2*i + 1] = low[i] + 2^51*carry[i]`, with
-/// `low[i] < 2^51`. Carries move to the next limb, wrapping the top carry by `2^255 = 19 (mod p)`
+/// `low[i] < 2^51`. Carries move to the next limb, wrapping the top carry by `2^255 = 19 (mod p)`.
 #[inline(always)]
 fn reduce_columns(c: [uint64x2_t; 10]) -> Regs {
-    // SAFETY: AArch64 targets provide NEON. Paired columns and carry additions fit in u64
+    // SAFETY: AArch64 targets provide NEON. Paired columns and carry additions fit in u64.
     unsafe {
         let mask26 = vdupq_n_u64((1 << 26) - 1);
         let mask25 = vdupq_n_u64((1 << 25) - 1);
@@ -180,7 +180,7 @@ fn reduce_columns(c: [uint64x2_t; 10]) -> Regs {
 
         // Column 8 is at most 51*M^2 and column 9 at most 10*M^2, so the top carry fits
         // below 2^31 and can narrow losslessly. Its 19-fold and every other carry are
-        // below 2^35, leaving each output below 2^51 + 2^35 < 2^52 without another pass
+        // below 2^35, leaving each output below 2^51 + 2^35 < 2^52 without another pass.
         let top = vmovn_u64(vshrq_n_u64(paired[4], 25));
         out[0] = vaddq_u64(out[0], vmull_n_u32(top, 19));
         for i in 1..5 {
@@ -536,19 +536,19 @@ impl FBackend for Backend {
     }
 }
 
-/// Packs two independent field elements into register lanes
+/// Packs two independent field elements into register lanes.
 #[inline(always)]
 fn pack_pair(values: [F; 2]) -> Regs {
-    // SAFETY: AArch64 targets provide NEON, and the selected lane is within the two-lane register
+    // SAFETY: AArch64 targets provide NEON, and the selected lane is within the two-lane register.
     unsafe {
         core::array::from_fn(|i| vsetq_lane_u64(values[1].0[i], vdupq_n_u64(values[0].0[i]), 1))
     }
 }
 
-/// Unpacks both register lanes into independent field elements
+/// Unpacks both register lanes into independent field elements.
 #[inline(always)]
 fn unpack_pair(regs: Regs) -> [F; 2] {
-    // SAFETY: AArch64 targets provide NEON, and both lane indices are within the register
+    // SAFETY: AArch64 targets provide NEON, and both lane indices are within the register.
     unsafe {
         [
             F(regs.map(|reg| vgetq_lane_u64(reg, 0))),
@@ -557,9 +557,9 @@ fn unpack_pair(regs: Regs) -> [F; 2] {
     }
 }
 
-/// Applies the complete mixed-addition formula to two independent register lanes
+/// Applies the complete mixed-addition formula to two independent register lanes.
 ///
-/// Extended inputs and outputs use `[x, y, t, z]`; affine inputs use `[x, y, t2d]`
+/// Extended inputs and outputs use `[x, y, t, z]`; affine inputs use `[x, y, t2d]`.
 #[inline(always)]
 fn add_mixed_regs(p: [Regs; 4], q: [Regs; 3]) -> [Regs; 4] {
     let [x1, y1, t1, z1] = p;
@@ -646,7 +646,7 @@ impl GBackend for Backend {
         let mut x2 = pack_pair(q.map(|point| point.x));
         let mut t2d = pack_pair(q.map(|point| point.t2d));
         if negative.iter().any(|&sign| sign) {
-            // SAFETY: AArch64 targets provide NEON, and the mask array has two complete lanes
+            // SAFETY: AArch64 targets provide NEON, and the mask array has two complete lanes.
             unsafe {
                 let masks = negative.map(|sign| 0u64.wrapping_sub(u64::from(sign)));
                 let mask = vld1q_u64(masks.as_ptr());

--- a/cryptography/curve25519/src/curve/neon.rs
+++ b/cryptography/curve25519/src/curve/neon.rs
@@ -9,8 +9,7 @@
 
 use super::{
     BIAS_16P as SUB_BIAS, F, FBackend, FVec, G, GAffine, GAffineVec, GBackend, GVec, LANES,
-    MASK_51,
-    msm::{self, MsmBackend},
+    MASK_51, msm,
 };
 #[cfg(not(feature = "std"))]
 use alloc::vec;
@@ -717,7 +716,7 @@ fn g_add_mixed_pair(p: [G; 2], q: [GAffine; 2], negative: [bool; 2]) -> [G; 2] {
     })
 }
 
-impl MsmBackend for Backend {
+impl msm::Backend for Backend {
     // One stripe per physical mixed-addition lane keeps wave updates independent. Folds retain
     // LANES independent bucket indices.
     const STRIPES: usize = WIDTH;

--- a/cryptography/curve25519/src/curve/portable.rs
+++ b/cryptography/curve25519/src/curve/portable.rs
@@ -98,4 +98,4 @@ impl GAffineVec {
     }
 }
 
-impl super::msm::MsmBackend for Backend {}
+impl super::msm::Backend for Backend {}

--- a/cryptography/curve25519/src/curve/portable.rs
+++ b/cryptography/curve25519/src/curve/portable.rs
@@ -1,6 +1,6 @@
 //! Plain-Rust lane adapter over scalar field and group arithmetic.
 
-use super::{F, FBackend, FVec, G, GAffineVec, GBackend, GVec};
+use super::{F, FBackend, FVec, G, GAffine, GAffineVec, GBackend, GVec, LANES};
 use core::array;
 
 /// The portable backend token.
@@ -83,3 +83,19 @@ impl GBackend for Backend {
 }
 
 impl super::Backend for Backend {}
+
+impl GAffineVec {
+    /// Untransposes backend lanes into scalar affine points.
+    fn untranspose(self) -> [GAffine; LANES] {
+        let x = self.x.untranspose();
+        let y = self.y.untranspose();
+        let t2d = self.t2d.untranspose();
+        array::from_fn(|i| GAffine {
+            x: x[i],
+            y: y[i],
+            t2d: t2d[i],
+        })
+    }
+}
+
+impl super::msm::MsmBackend for Backend {}

--- a/cryptography/curve25519/src/curve/test.rs
+++ b/cryptography/curve25519/src/curve/test.rs
@@ -1,7 +1,12 @@
 //! Property suites shared by field and group backends.
 
-use super::{Backend, F, FBackend, FVec, GAffineVec, GBackend, GVec, LANES, MASK_51, WithBackend};
+use super::{
+    Backend, F, FBackend, FVec, G, GAffine, GAffineVec, GBackend, GVec, LANES, MASK_51, WithBackend,
+};
+#[cfg(test)]
+use crate::test::ZIP215_POINTS;
 use arbitrary::{Arbitrary, Unstructured};
+use core::array;
 
 const MASK_52: u64 = (1 << 52) - 1;
 
@@ -350,6 +355,36 @@ fn backend_at_bounds() {
                 backend.square(max),
                 "backend square at bound",
             );
+            // These coordinates need not form a curve point: compare the complete formulas
+            // coordinate-wise to exercise their loose-intermediate bounds.
+            let point = GVec {
+                x: max,
+                y: max,
+                t: max,
+                z: max,
+            };
+            let affine = GAffineVec {
+                x: max,
+                y: max,
+                t2d: max,
+            };
+            for (actual, expected) in [
+                (backend.g_add(point, point), reference.g_add(point, point)),
+                (
+                    backend.g_add_mixed(point, affine),
+                    reference.g_add_mixed(point, affine),
+                ),
+                (backend.g_double(point), reference.g_double(point)),
+            ] {
+                for (actual, expected) in [
+                    (actual.x, expected.x),
+                    (actual.y, expected.y),
+                    (actual.t, expected.t),
+                    (actual.z, expected.z),
+                ] {
+                    assert_f_eq(actual, expected, "group formula at bound");
+                }
+            }
         }
     }
 
@@ -419,14 +454,31 @@ fn fuzz_group_matches_portable<B: Backend>(
     backend: B,
 ) -> arbitrary::Result<()> {
     let reference = super::portable::Backend::new();
-    let scalar = u.arbitrary::<u16>()?;
-    let basepoint = basepoint(reference);
-    let point = scale(reference, basepoint, u32::from(scalar));
-    let affine_basepoint = GAffineVec {
-        x: basepoint.x,
-        y: basepoint.y,
-        t2d: reference.mul(basepoint.t, FVec::splat(F::EDWARDS_D2)),
-    };
+    let encodings: [[u8; 32]; LANES] = u.arbitrary()?;
+    let decoded = GAffine::decompress_batch(backend, &encodings);
+    let lanes = array::from_fn(|i| {
+        let scalar = GAffine::decompress(&encodings[i]);
+        assert_eq!(
+            decoded[i].map(|point| point.to_extended().to_bytes()),
+            scalar.map(|point| point.to_extended().to_bytes()),
+            "decompression lane {i}",
+        );
+        scalar.unwrap_or(GAffine::IDENTITY)
+    });
+    let affine = GAffineVec::transpose(lanes);
+    let rhs = GVec::transpose(lanes.map(GAffine::to_extended));
+    let scales = arbitrary_fvec(u)?
+        .untranspose()
+        .map(|scale| if scale.is_zero() { F::ONE } else { scale });
+    let point = GVec::transpose(array::from_fn(|i| {
+        let point = lanes[(i + 1) % LANES].to_extended();
+        G {
+            x: point.x.mul(scales[i]),
+            y: point.y.mul(scales[i]),
+            t: point.t.mul(scales[i]),
+            z: point.z.mul(scales[i]),
+        }
+    }));
     assert_g_eq(
         reference,
         reference.g_double(point),
@@ -435,17 +487,118 @@ fn fuzz_group_matches_portable<B: Backend>(
     );
     assert_g_eq(
         reference,
-        reference.g_add(point, basepoint),
-        backend.g_add(point, basepoint),
+        reference.g_add(point, rhs),
+        backend.g_add(point, rhs),
         "backend addition",
     );
     assert_g_eq(
         reference,
-        reference.g_add_mixed(point, affine_basepoint),
-        backend.g_add_mixed(point, affine_basepoint),
+        reference.g_add_mixed(point, affine),
+        backend.g_add_mixed(point, affine),
         "backend mixed addition",
     );
     Ok(())
+}
+
+#[cfg(test)]
+#[test]
+fn noncanonical_field_encodings() {
+    let mut p = [0xff; 32];
+    p[0] = 0xed;
+    p[31] = 0x7f;
+    for offset in 0..19 {
+        let mut canonical = [0; 32];
+        canonical[0] = offset;
+        for sign in [0, 0x80] {
+            let mut encoded = p;
+            encoded[0] += offset;
+            encoded[31] |= sign;
+            assert_eq!(F::from_bytes(&encoded).to_bytes(), canonical);
+        }
+    }
+    let mut p_minus_one = p;
+    p_minus_one[0] -= 1;
+    assert_eq!(F::from_bytes(&p_minus_one).to_bytes(), p_minus_one);
+    assert_eq!(F::ZERO.sub(F::ONE).to_bytes(), p_minus_one);
+}
+
+#[cfg(test)]
+#[test]
+fn zip215_decompression_and_group_laws() {
+    struct Check;
+
+    impl WithBackend for Check {
+        type Output = ();
+
+        fn call<B: Backend>(self, backend: B) {
+            let reference = super::portable::Backend::new();
+            let mut encodings = ZIP215_POINTS.to_vec();
+            for offset in 0..19 {
+                for sign in [0, 0x80] {
+                    let mut encoding = [0xff; 32];
+                    encoding[0] = 0xed + offset;
+                    encoding[31] = 0x7f | sign;
+                    encodings.push(encoding);
+                }
+            }
+            for chunk in encodings.chunks(LANES) {
+                let bytes = array::from_fn(|i| chunk[i % chunk.len()]);
+                let decoded = GAffine::decompress_batch(backend, &bytes);
+                let lanes = array::from_fn(|i| {
+                    let scalar = GAffine::decompress(&bytes[i]);
+                    assert_eq!(
+                        decoded[i].map(|p| p.to_extended().to_bytes()),
+                        scalar.map(|p| p.to_extended().to_bytes())
+                    );
+                    scalar.unwrap_or(GAffine::IDENTITY)
+                });
+                let p = GVec::transpose(lanes.map(GAffine::to_extended));
+                let q = GVec::transpose(array::from_fn(|i| lanes[(i + 1) % LANES].to_extended()));
+                assert_g_eq(
+                    reference,
+                    backend.g_add(p, q),
+                    reference.g_add(p, q),
+                    "ZIP215 addition",
+                );
+                assert_g_eq(
+                    reference,
+                    backend.g_double(p),
+                    reference.g_double(p),
+                    "ZIP215 doubling",
+                );
+                assert_g_eq(
+                    reference,
+                    backend.g_add_mixed(q, GAffineVec::transpose(lanes)),
+                    reference.g_add(q, p),
+                    "ZIP215 mixed addition",
+                );
+            }
+        }
+    }
+
+    Check.call(super::portable::Backend::new());
+    super::with_backend(Check);
+}
+
+#[cfg(test)]
+#[test]
+fn secret_scalar_multiplication_matches_public() {
+    commonware_invariants::minifuzz::Builder::default()
+        .with_seed(0)
+        .with_search_limit(32)
+        .test(|u| {
+            let scalar: [u8; 32] = u.arbitrary()?;
+            let torsion = GAffine::decompress(u.choose(&ZIP215_POINTS)?)
+                .unwrap()
+                .to_extended();
+            let point = GAffine::BASEPOINT.to_extended().add(torsion);
+            let bits = (0..256).rev().map(|i| scalar[i / 8] >> (i % 8) & 1 == 1);
+            assert_eq!(
+                point.scalar_mul_secret(&scalar).to_bytes(),
+                point.scalar_mul(bits).to_bytes()
+            );
+            Ok(())
+        });
 }
 
 /// Checks the runtime dispatch path as one multi-operation computation.

--- a/cryptography/curve25519/src/curve/test.rs
+++ b/cryptography/curve25519/src/curve/test.rs
@@ -318,6 +318,46 @@ fn fuzz_group<B: Backend>(u: &mut Unstructured<'_>, backend: B) -> arbitrary::Re
 
 #[cfg(test)]
 #[test]
+fn repeated_squaring_matches_scalar() {
+    #[derive(Clone, Copy)]
+    struct Check;
+
+    impl WithBackend for Check {
+        type Output = ();
+
+        fn call<B: Backend>(self, backend: B) -> Self::Output {
+            let max = FVec {
+                limbs: [[MASK_52; LANES]; 5],
+            };
+            let mixed = FVec::transpose([
+                F::ZERO,
+                F::ONE,
+                F([MASK_52; 5]),
+                F([MASK_51; 5]),
+                F([19, 0, 0, 0, 0]),
+                F([0, MASK_52, 0, MASK_52, 0]),
+                F([1 << 51; 5]),
+                F([0x123456789abcd, 7, MASK_52 - 1, 42, 1]),
+            ]);
+            for input in [max, mixed] {
+                for k in [0, 1, 2, 5, 10, 20, 50, 100] {
+                    let actual = backend.pow2k(input, k);
+                    if k == 0 {
+                        assert_eq!(actual.limbs, input.limbs);
+                    }
+                    let expected = FVec::transpose(input.untranspose().map(|v| v.pow2k(k)));
+                    assert_f_eq(actual, expected, "repeated squaring");
+                }
+            }
+        }
+    }
+
+    Check.call(super::portable::Backend::new());
+    super::with_backend(Check);
+}
+
+#[cfg(test)]
+#[test]
 fn backend_at_bounds() {
     struct CheckBackendAtBounds;
 
@@ -652,4 +692,81 @@ fn with_backend_matches_portable() {
         expected.1,
         "runtime-dispatched group computation",
     );
+}
+
+#[cfg(all(test, target_arch = "aarch64"))]
+#[test]
+fn mixed_pair_matches_full_width() {
+    struct Check;
+
+    impl WithBackend for Check {
+        type Output = ();
+
+        fn call<B: Backend>(self, backend: B) {
+            let reference = super::portable::Backend::new();
+            let torsion = GAffine::decompress(&[0; 32]).unwrap();
+            let mixed = GAffine::decompress(
+                &GAffine::BASEPOINT
+                    .to_extended()
+                    .add(torsion.to_extended())
+                    .to_bytes(),
+            )
+            .unwrap();
+            let points = [GAffine::IDENTITY, GAffine::BASEPOINT, torsion, mixed];
+            let max = F([MASK_52; 5]);
+            let loose = G {
+                x: max,
+                y: max,
+                t: max,
+                z: max,
+            };
+            let loose_affine = GAffine {
+                x: max,
+                y: max,
+                t2d: max,
+            };
+            for i in 0..points.len() {
+                for j in 0..points.len() {
+                    let current = [points[i].to_extended(), points[j].to_extended()];
+                    let current = array::from_fn(|lane| {
+                        let factor = F([lane as u64 + 2, 0, 0, 0, 0]);
+                        G {
+                            x: current[lane].x.mul(factor),
+                            y: current[lane].y.mul(factor),
+                            t: current[lane].t.mul(factor),
+                            z: current[lane].z.mul(factor),
+                        }
+                    });
+                    let incoming = [points[j], points[(i + 1) % points.len()]];
+                    for (current, incoming) in [
+                        (current, incoming),
+                        ([loose, current[1]], [loose_affine, incoming[1]]),
+                    ] {
+                        for negative in [[false, false], [false, true], [true, false], [true, true]]
+                        {
+                            let expected = reference.g_add_mixed_pair(current, incoming, negative);
+                            let actual = backend.g_add_mixed_pair(current, incoming, negative);
+                            for lane in 0..2 {
+                                for (actual, expected) in [
+                                    (actual[lane].x, expected[lane].x),
+                                    (actual[lane].y, expected[lane].y),
+                                    (actual[lane].t, expected[lane].t),
+                                    (actual[lane].z, expected[lane].z),
+                                ] {
+                                    assert_f_eq(
+                                        FVec::splat(actual),
+                                        FVec::splat(expected),
+                                        "mixed pair coordinate",
+                                    );
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Check.call(super::portable::Backend::new());
+    super::with_backend(Check);
 }

--- a/cryptography/curve25519/src/curve/test.rs
+++ b/cryptography/curve25519/src/curve/test.rs
@@ -8,7 +8,7 @@ use crate::test::ZIP215_POINTS;
 use arbitrary::{Arbitrary, Unstructured};
 use core::array;
 
-const MASK_52: u64 = (1 << 52) - 1;
+pub(super) const MASK_52: u64 = (1 << 52) - 1;
 
 /// A field or group arithmetic fuzzing operation.
 #[derive(Debug, Arbitrary)]

--- a/cryptography/curve25519/src/curve/test.rs
+++ b/cryptography/curve25519/src/curve/test.rs
@@ -96,7 +96,7 @@ fn assert_bounded(value: FVec) {
     );
 }
 
-fn assert_f_eq(actual: FVec, expected: FVec, property: &str) {
+pub(super) fn assert_f_eq(actual: FVec, expected: FVec, property: &str) {
     assert_bounded(actual);
     assert_bounded(expected);
     for lane in 0..LANES {
@@ -444,24 +444,18 @@ fn minifuzz_field() {
 #[cfg(test)]
 #[test]
 fn minifuzz_group() {
-    // The fully inlined NEON group formulas need more than the test harness's default stack in
-    // unoptimized builds.
-    let run = || {
-        commonware_invariants::minifuzz::Builder::default()
-            .with_seed(0)
-            .with_search_limit(100)
-            .test(|u| Plan::Group.run(u));
-    };
-    if cfg!(target_arch = "aarch64") {
-        std::thread::Builder::new()
-            .stack_size(8 * 1024 * 1024)
-            .spawn(run)
-            .unwrap()
-            .join()
-            .unwrap();
-    } else {
-        run();
-    }
+    // Fully inlined group formulas can exceed the test harness's default stack in debug builds.
+    std::thread::Builder::new()
+        .stack_size(8 * 1024 * 1024)
+        .spawn(|| {
+            commonware_invariants::minifuzz::Builder::default()
+                .with_seed(0)
+                .with_search_limit(100)
+                .test(|u| Plan::Group.run(u));
+        })
+        .unwrap()
+        .join()
+        .unwrap();
 }
 
 /// Checks that a backend's field operations match the portable backend.
@@ -692,83 +686,6 @@ fn with_backend_matches_portable() {
         expected.1,
         "runtime-dispatched group computation",
     );
-}
-
-#[cfg(all(test, target_arch = "aarch64"))]
-#[test]
-fn mixed_pair_matches_full_width() {
-    struct Check;
-
-    impl WithBackend for Check {
-        type Output = ();
-
-        fn call<B: Backend>(self, backend: B) {
-            let reference = super::portable::Backend::new();
-            let torsion = GAffine::decompress(&[0; 32]).unwrap();
-            let mixed = GAffine::decompress(
-                &GAffine::BASEPOINT
-                    .to_extended()
-                    .add(torsion.to_extended())
-                    .to_bytes(),
-            )
-            .unwrap();
-            let points = [GAffine::IDENTITY, GAffine::BASEPOINT, torsion, mixed];
-            let max = F([MASK_52; 5]);
-            let loose = G {
-                x: max,
-                y: max,
-                t: max,
-                z: max,
-            };
-            let loose_affine = GAffine {
-                x: max,
-                y: max,
-                t2d: max,
-            };
-            for i in 0..points.len() {
-                for j in 0..points.len() {
-                    let current = [points[i].to_extended(), points[j].to_extended()];
-                    let current = array::from_fn(|lane| {
-                        let factor = F([lane as u64 + 2, 0, 0, 0, 0]);
-                        G {
-                            x: current[lane].x.mul(factor),
-                            y: current[lane].y.mul(factor),
-                            t: current[lane].t.mul(factor),
-                            z: current[lane].z.mul(factor),
-                        }
-                    });
-                    let incoming = [points[j], points[(i + 1) % points.len()]];
-                    for (current, incoming) in [
-                        (current, incoming),
-                        ([loose, current[1]], [loose_affine, incoming[1]]),
-                    ] {
-                        for negative in [[false, false], [false, true], [true, false], [true, true]]
-                        {
-                            let expected = reference.g_add_mixed_pair(current, incoming, negative);
-                            let actual = backend.g_add_mixed_pair(current, incoming, negative);
-                            for lane in 0..2 {
-                                for (actual, expected) in [
-                                    (actual[lane].x, expected[lane].x),
-                                    (actual[lane].y, expected[lane].y),
-                                    (actual[lane].t, expected[lane].t),
-                                    (actual[lane].z, expected[lane].z),
-                                ] {
-                                    assert_f_eq(
-                                        FVec::splat(actual),
-                                        FVec::splat(expected),
-                                        "mixed pair coordinate",
-                                    );
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    Check.call(super::portable::Backend::new());
-    super::with_backend(Check);
 }
 
 #[test]

--- a/cryptography/curve25519/src/curve/test.rs
+++ b/cryptography/curve25519/src/curve/test.rs
@@ -770,3 +770,55 @@ fn mixed_pair_matches_full_width() {
     Check.call(super::portable::Backend::new());
     super::with_backend(Check);
 }
+
+#[test]
+fn backend_conditional_neg_matches_every_mask() {
+    struct Check;
+
+    impl WithBackend for Check {
+        type Output = ();
+
+        fn call<B: Backend>(self, backend: B) {
+            let mixed = FVec {
+                limbs: array::from_fn(|limb| {
+                    array::from_fn(|lane| {
+                        let offset = (limb * LANES + lane) as u64;
+                        if (limb + lane) & 1 == 0 {
+                            offset
+                        } else {
+                            MASK_52 - offset
+                        }
+                    })
+                }),
+            };
+            for value in [FVec::splat(F::ZERO), FVec::splat(F([MASK_52; 5])), mixed] {
+                let lanes = value.untranspose();
+                for mask in 0..1u16 << LANES {
+                    let negative = array::from_fn(|lane| mask & (1 << lane) != 0);
+                    let actual = backend.conditional_neg(value, &negative);
+                    let expected = FVec::transpose(array::from_fn(|lane| {
+                        if negative[lane] {
+                            lanes[lane].neg()
+                        } else {
+                            lanes[lane]
+                        }
+                    }));
+                    assert_f_eq(actual, expected, "conditional negation");
+                    for (lane, negative) in negative.into_iter().enumerate() {
+                        if !negative {
+                            for limb in 0..5 {
+                                assert_eq!(
+                                    actual.limbs[limb][lane], value.limbs[limb][lane],
+                                    "unselected limb {limb}, lane {lane}, mask {mask:#04x}"
+                                );
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Check.call(super::portable::Backend::new());
+    super::with_backend(Check);
+}

--- a/cryptography/curve25519/src/curve/test.rs
+++ b/cryptography/curve25519/src/curve/test.rs
@@ -355,6 +355,7 @@ fn backend_at_bounds() {
                 backend.square(max),
                 "backend square at bound",
             );
+
             // These coordinates need not form a curve point: compare the complete formulas
             // coordinate-wise to exercise their loose-intermediate bounds.
             let point = GVec {
@@ -459,8 +460,8 @@ fn fuzz_group_matches_portable<B: Backend>(
     let lanes = array::from_fn(|i| {
         let scalar = GAffine::decompress(&encodings[i]);
         assert_eq!(
-            decoded[i].map(|point| point.to_extended().to_bytes()),
-            scalar.map(|point| point.to_extended().to_bytes()),
+            decoded[i].map(|point| (point.to_extended().to_bytes(), point.t2d.to_bytes())),
+            scalar.map(|point| (point.to_extended().to_bytes(), point.t2d.to_bytes())),
             "decompression lane {i}",
         );
         scalar.unwrap_or(GAffine::IDENTITY)
@@ -547,8 +548,8 @@ fn zip215_decompression_and_group_laws() {
                 let lanes = array::from_fn(|i| {
                     let scalar = GAffine::decompress(&bytes[i]);
                     assert_eq!(
-                        decoded[i].map(|p| p.to_extended().to_bytes()),
-                        scalar.map(|p| p.to_extended().to_bytes())
+                        decoded[i].map(|p| (p.to_extended().to_bytes(), p.t2d.to_bytes())),
+                        scalar.map(|p| (p.to_extended().to_bytes(), p.t2d.to_bytes()))
                     );
                     scalar.unwrap_or(GAffine::IDENTITY)
                 });

--- a/cryptography/curve25519/src/key_exchange.rs
+++ b/cryptography/curve25519/src/key_exchange.rs
@@ -70,8 +70,8 @@ impl SecretKey {
     /// Performs a key exchange with the other party's public key, consuming this key.
     ///
     /// This returns `None` when the other party's key is a low-order point, which would force
-    /// the result to a value everybody can compute. An honestly generated public key fails
-    /// with negligible probability, so a failure means the other party misbehaved.
+    /// the result to a value everybody can compute. Keys produced by [`Self::public_key`] never
+    /// cause this failure.
     pub fn exchange(self, other: &PublicKey) -> Option<SharedSecret> {
         SharedSecret::from_x25519(montgomery::x25519(&self.bytes, &other.bytes))
     }
@@ -81,6 +81,7 @@ impl SecretKey {
 ///
 /// Equality compares decoded u-coordinates. Distinct encodings that X25519 processes as the same
 /// field element therefore compare equal, while serialization preserves the original bytes.
+/// Protocol transcripts should bind the transmitted bytes available through [`AsRef`].
 #[derive(Clone)]
 pub struct PublicKey {
     /// The little-endian u-coordinate of a point on the Montgomery form of the curve.
@@ -237,13 +238,13 @@ mod tests {
         // Every low-order point on the curve and its twist, plus the non-canonical encodings
         // of the first two, forces the exchange output to zero.
         let low_order = [
-            // The identity, u = 0.
+            // u = 0, the point (0, 0) of order 2.
             hex!("0x0000000000000000000000000000000000000000000000000000000000000000"),
             // u = 1, of order 4.
             hex!("0x0100000000000000000000000000000000000000000000000000000000000000"),
             // A point of order 8 on the curve.
             hex!("0xe0eb7a7c3b41b8ae1656e3faf19fc46ada098deb9c32b1fd866205165f49b800"),
-            // A point of order 8 on the twist.
+            // Another point of order 8 on the curve.
             hex!("0x5f9c95bca3508c24b1d0b1559c83ef5b04445cc4581c8e86d8224eddd09f1157"),
             // u = p - 1, of order 4 on the twist.
             hex!("0xecffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f"),

--- a/cryptography/curve25519/src/key_exchange.rs
+++ b/cryptography/curve25519/src/key_exchange.rs
@@ -20,7 +20,9 @@
 use crate::curve::{F, montgomery};
 use bytes::{Buf, BufMut};
 use commonware_codec::{FixedSize, Read, Write};
+use commonware_formatting::Hex;
 use commonware_math::algebra::Random;
+use core::fmt::{self, Debug, Display};
 use subtle::ConstantTimeEq;
 use zeroize::{ZeroizeOnDrop, Zeroizing};
 
@@ -95,6 +97,18 @@ impl PartialEq for PublicKey {
 }
 
 impl Eq for PublicKey {}
+
+impl Debug for PublicKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", Hex(&self.bytes))
+    }
+}
+
+impl Display for PublicKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", Hex(&self.bytes))
+    }
+}
 
 impl AsRef<[u8]> for PublicKey {
     fn as_ref(&self) -> &[u8] {
@@ -201,7 +215,7 @@ mod tests {
                 bytes: canonical_bytes,
             };
             let alias = PublicKey { bytes: alias_bytes };
-            assert!(canonical == alias);
+            assert_eq!(canonical, alias);
             assert_ne!(canonical.as_ref(), alias.as_ref());
 
             let canonical_shared = SecretKey { bytes: [42; 32] }.exchange(&canonical);
@@ -215,7 +229,7 @@ mod tests {
             }
         }
 
-        assert!(PublicKey { bytes: [0; 32] } != PublicKey { bytes: one });
+        assert_ne!(PublicKey { bytes: [0; 32] }, PublicKey { bytes: one });
     }
 
     #[test]

--- a/cryptography/curve25519/src/signing.rs
+++ b/cryptography/curve25519/src/signing.rs
@@ -13,8 +13,9 @@
 //! [`VerifyingKey::verify`] and [`BatchVerifier::verify`] apply the same criteria.
 //! A non-empty batch of at most `u32::MAX` signatures is always accepted when every signature
 //! verifies individually. Because batch verification checks a randomized linear combination, an
-//! invalid batch may be accepted with probability about `2^-128`. See [this post] for why these
-//! criteria matter.
+//! invalid batch may be accepted with probability about `2^-128`, provided each verification
+//! call draws a fresh seed from an RNG unpredictable to whoever assembled the batch. See
+//! [this post] for why these criteria matter.
 //!
 //! [this post]: https://hdevalence.ca/blog/2020-10-04-its-25519am
 //! [ZIP215]: https://zips.z.cash/zip-0215
@@ -45,6 +46,8 @@ use zeroize::{ZeroizeOnDrop, Zeroizing};
 /// An Ed25519 signing key.
 ///
 /// Secret material is zeroized when the key is dropped.
+/// Serialization writes the raw secret seed; callers must protect the encoded bytes as secret
+/// key material.
 #[derive(ZeroizeOnDrop)]
 pub struct SigningKey {
     /// When serializing, we want to just write the seed, so we keep it around.
@@ -187,6 +190,10 @@ impl SigningKey {
     /// message, so signing the same message twice yields the same signature and no randomness
     /// is consumed.
     ///
+    /// # Panics
+    ///
+    /// Panics if `namespace` is longer than `u32::MAX` bytes.
+    ///
     /// [RFC 8032]: https://www.rfc-editor.org/rfc/rfc8032
     pub fn sign(&self, namespace: &[u8], msg: &[u8]) -> Signature {
         let msg = union_unique(namespace, msg);
@@ -201,6 +208,11 @@ impl SigningKey {
 }
 
 /// A public key used to check signatures.
+///
+/// Decoding accepts any 32 bytes and defers point validation until signature verification.
+/// Encodings that do not represent a curve point can never verify a signature.
+/// Equality, ordering, and hashing use the original encoding: distinct encodings of the same
+/// point are distinct keys, and verification hashes the received bytes as required by ZIP215.
 #[derive(Clone)]
 pub struct VerifyingKey {
     /// The encoded point.
@@ -327,6 +339,10 @@ impl VerifyingKey {
 impl VerifyingKey {
     /// Verifies `sig` over the namespaced message, per the [module's validation
     /// criteria](self).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `namespace` is longer than `u32::MAX` bytes.
     #[must_use]
     pub fn verify(&self, namespace: &[u8], msg: &[u8], sig: &Signature) -> bool {
         let msg = union_unique(namespace, msg);
@@ -345,6 +361,9 @@ impl VerifyingKey {
 /// For an honestly generated [`VerifyingKey`], successful verification demonstrates approval by
 /// the holder of the corresponding [`SigningKey`]. A maliciously generated verifying key can
 /// admit a signature that verifies for any message.
+///
+/// Decoding accepts any 64 bytes. Point decoding and scalar canonicality are checked during
+/// verification. Equality, ordering, and hashing compare the original encoding.
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Signature {
     bytes: [u8; 64],
@@ -414,6 +433,9 @@ pub struct BatchVerifier {
 
 impl BatchVerifier {
     /// Creates a verifier with space for `capacity` signatures.
+    ///
+    /// `capacity` is a trusted allocation hint; bound externally supplied counts before passing
+    /// them here.
     pub fn new(capacity: usize) -> Self {
         Self {
             items: Vec::with_capacity(capacity),
@@ -421,6 +443,10 @@ impl BatchVerifier {
     }
 
     /// Queues a signature for verification over the namespaced message.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `namespace` is longer than `u32::MAX` bytes.
     pub fn add(
         &mut self,
         namespace: &[u8],
@@ -442,6 +468,10 @@ impl BatchVerifier {
     /// under the [module's validation criteria](self). Because this checks a randomized linear
     /// combination, an invalid batch may be accepted when the random weights make the combined
     /// equation hold, an event of negligible probability (about `2^-128`).
+    ///
+    /// This bound requires an RNG unpredictable to whoever assembled the batch. Each call draws
+    /// a fresh seed from `rng`; a predictable or reused seed can let an attacker construct an
+    /// invalid batch that passes verification.
     #[must_use]
     pub fn verify(self, rng: &mut impl CryptoRng, strategy: &impl Strategy) -> bool {
         let items = self

--- a/cryptography/curve25519/src/signing.rs
+++ b/cryptography/curve25519/src/signing.rs
@@ -461,6 +461,21 @@ impl BatchVerifier {
         });
     }
 
+    /// Queues an unframed message for raw Ed25519 test-vector checks.
+    #[cfg(test)]
+    pub(crate) fn add_raw(
+        &mut self,
+        message: &[u8],
+        public_key: &VerifyingKey,
+        signature: &Signature,
+    ) {
+        self.items.push(BatchItem {
+            message: message.to_vec(),
+            public_key: public_key.bytes,
+            signature: core::Signature::from_bytes(signature.bytes),
+        });
+    }
+
     /// Checks all the signatures in the batch.
     ///
     /// Empty batches and batches containing more than `u32::MAX` signatures are rejected. Within

--- a/cryptography/curve25519/src/signing.rs
+++ b/cryptography/curve25519/src/signing.rs
@@ -46,8 +46,8 @@ use zeroize::{ZeroizeOnDrop, Zeroizing};
 /// An Ed25519 signing key.
 ///
 /// Secret material is zeroized when the key is dropped.
-/// Serialization writes the raw secret seed; callers must protect the encoded bytes as secret
-/// key material.
+/// Serialization writes the raw secret seed, so callers must protect the encoded bytes as
+/// secret key material.
 #[derive(ZeroizeOnDrop)]
 pub struct SigningKey {
     /// When serializing, we want to just write the seed, so we keep it around.
@@ -434,7 +434,7 @@ pub struct BatchVerifier {
 impl BatchVerifier {
     /// Creates a verifier with space for `capacity` signatures.
     ///
-    /// `capacity` is a trusted allocation hint; bound externally supplied counts before passing
+    /// `capacity` is a trusted allocation hint. Bound externally supplied counts before passing
     /// them here.
     pub fn new(capacity: usize) -> Self {
         Self {
@@ -484,9 +484,8 @@ impl BatchVerifier {
     /// combination, an invalid batch may be accepted when the random weights make the combined
     /// equation hold, an event of negligible probability (about `2^-128`).
     ///
-    /// This bound requires an RNG unpredictable to whoever assembled the batch. Each call draws
-    /// a fresh seed from `rng`; a predictable or reused seed can let an attacker construct an
-    /// invalid batch that passes verification.
+    /// This bound requires an RNG unpredictable to whoever assembled the batch. A predictable
+    /// `rng` lets an attacker construct an invalid batch that passes verification.
     #[must_use]
     pub fn verify(self, rng: &mut impl CryptoRng, strategy: &impl Strategy) -> bool {
         let items = self

--- a/cryptography/curve25519/src/signing.rs
+++ b/cryptography/curve25519/src/signing.rs
@@ -23,7 +23,7 @@
 mod core;
 
 use self::core::Scalar;
-use crate::curve::{G, GAffine};
+use crate::curve::GAffine;
 use ::core::{
     fmt::{self, Debug, Display},
     hash::{Hash, Hasher},
@@ -31,7 +31,9 @@ use ::core::{
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 use bytes::{Buf, BufMut};
-use commonware_codec::{FixedSize, Read, Write};
+use commonware_codec::{
+    Decode, DecodeWith, EncodeSize, Error as CodecError, FixedSize, Read, Write, types::lazy::Lazy,
+};
 use commonware_formatting::Hex;
 use commonware_math::algebra::Random;
 use commonware_parallel::Strategy;
@@ -93,10 +95,11 @@ impl SigningKey {
         let scalar = Zeroizing::new(Scalar::from_bytes_mod_order_wide(&wide_scalar));
         let point = GAffine::BASEPOINT
             .to_extended()
-            .scalar_mul_secret(&scalar_le_bytes);
+            .scalar_mul_secret(&scalar_le_bytes)
+            .to_affine();
         let verifying_key = VerifyingKey {
             bytes: core::VerifyingKeyBytes::new(point.to_bytes()),
-            point: Some(point),
+            point,
         };
 
         Self {
@@ -209,19 +212,29 @@ impl SigningKey {
 
 /// A public key used to check signatures.
 ///
-/// Decoding accepts any 32 bytes and defers point validation until signature verification.
-/// Encodings that do not represent a curve point can never verify a signature.
+/// Decoding validates that the encoding represents a curve point under ZIP215.
+/// Use [`Lazy<VerifyingKey>`] to defer this validation and [`BatchVerifier::add_lazy`] to
+/// populate the lazy value's cache during batch verification.
 /// Equality, ordering, and hashing use the original encoding: distinct encodings of the same
 /// point are distinct keys, and verification hashes the received bytes as required by ZIP215.
 #[derive(Clone)]
 pub struct VerifyingKey {
     /// The encoded point.
     ///
-    /// When deserializing, we just have the bytes, deferring parsing of them until
-    /// signature verification, so that we can more efficiently parse them in batch.
+    /// Verification and key identity preserve this encoding, including non-canonical aliases.
     bytes: core::VerifyingKeyBytes,
-    /// If available, the point associated with these bytes.
-    point: Option<G>,
+    /// The validated point associated with these exact bytes.
+    point: GAffine,
+}
+
+/// A reusable point-decoding result for one exact public-key encoding.
+///
+/// This context preserves both successful and failed point decoding. It does not represent
+/// a signature-verification result. Contexts are constructed by the batch verifier, and a
+/// different input encoding always falls back to ordinary decoding.
+pub struct VerifyingKeyContext {
+    bytes: [u8; 32],
+    point: Option<GAffine>,
 }
 
 impl PartialEq for VerifyingKey {
@@ -281,25 +294,53 @@ impl FixedSize for VerifyingKey {
 impl Read for VerifyingKey {
     type Cfg = ();
 
-    fn read_cfg(buf: &mut impl Buf, cfg: &Self::Cfg) -> Result<Self, commonware_codec::Error> {
-        Ok(Self {
-            bytes: core::VerifyingKeyBytes::new(<[u8; Self::SIZE]>::read_cfg(buf, cfg)?),
-            point: None,
-        })
+    fn read_cfg(buf: &mut impl Buf, cfg: &Self::Cfg) -> Result<Self, CodecError> {
+        let bytes = <[u8; Self::SIZE]>::read_cfg(buf, cfg)?;
+        Self::from_point(bytes, GAffine::decompress(&bytes))
+    }
+}
+
+impl DecodeWith for VerifyingKey {
+    type Context = VerifyingKeyContext;
+
+    fn decode_with(
+        bytes: &[u8],
+        cfg: &Self::Cfg,
+        context: &Self::Context,
+    ) -> Result<Self, CodecError> {
+        if bytes == context.bytes {
+            Self::from_point(context.bytes, context.point)
+        } else {
+            Self::decode_cfg(bytes, cfg)
+        }
     }
 }
 
 #[cfg(feature = "arbitrary")]
 impl arbitrary::Arbitrary<'_> for VerifyingKey {
     fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
+        let bytes = u.arbitrary()?;
+        let point = GAffine::decompress(&bytes).ok_or(arbitrary::Error::IncorrectFormat)?;
         Ok(Self {
-            bytes: core::VerifyingKeyBytes::new(u.arbitrary()?),
-            point: None,
+            bytes: core::VerifyingKeyBytes::new(bytes),
+            point,
         })
     }
 }
 
 impl VerifyingKey {
+    /// Associates an exact encoding with its point-decoding result.
+    fn from_point(bytes: [u8; 32], point: Option<GAffine>) -> Result<Self, CodecError> {
+        let point = point.ok_or(CodecError::Invalid(
+            "curve25519::VerifyingKey",
+            "Invalid point encoding",
+        ))?;
+        Ok(Self {
+            bytes: core::VerifyingKeyBytes::new(bytes),
+            point,
+        })
+    }
+
     fn verify_message(&self, msg: &[u8], sig: &Signature) -> bool {
         let r_bytes: [u8; 32] = sig.bytes[..32].try_into().expect("signature is 64 bytes");
         let s_bytes: [u8; 32] = sig.bytes[32..].try_into().expect("signature is 64 bytes");
@@ -309,15 +350,7 @@ impl VerifyingKey {
         let Some(r) = GAffine::decompress(&r_bytes) else {
             return false;
         };
-        let a = match self.point {
-            Some(point) => point,
-            None => {
-                let Some(point) = GAffine::decompress(self.bytes.as_bytes()) else {
-                    return false;
-                };
-                point.to_extended()
-            }
-        };
+        let a = self.point.to_extended();
 
         let digest: [u8; 64] = sha2::Sha512::new()
             .chain(r_bytes)
@@ -418,8 +451,7 @@ impl arbitrary::Arbitrary<'_> for Signature {
 
 /// Inputs retained for batch verification.
 ///
-/// The encoded key is the batch pipeline's authoritative identity. Its optional decoded point is
-/// an individual-verification cache and is not part of the queued state.
+/// The encoded key is the batch pipeline's authoritative identity.
 struct BatchItem {
     message: Vec<u8>,
     public_key: core::VerifyingKeyBytes,
@@ -427,11 +459,34 @@ struct BatchItem {
 }
 
 /// A batch verification context.
-pub struct BatchVerifier {
+///
+/// Lazy keys are borrowed so point decoding can populate caches in the caller's retained objects.
+pub struct BatchVerifier<'a> {
     items: Vec<BatchItem>,
+    lazy_keys: Vec<Option<&'a Lazy<VerifyingKey>>>,
+    valid: bool,
 }
 
-impl BatchVerifier {
+impl core::KeyCache for BatchVerifier<'_> {
+    fn get(&self, index: usize) -> Option<Option<GAffine>> {
+        self.lazy_keys
+            .get(index)?
+            .as_ref()?
+            .get_cached()
+            .map(|key| key.map(|key| key.point))
+    }
+
+    fn store(&self, index: usize, bytes: &[u8; 32], point: Option<GAffine>) {
+        if let Some(Some(key)) = self.lazy_keys.get(index) {
+            key.get_with(&VerifyingKeyContext {
+                bytes: *bytes,
+                point,
+            });
+        }
+    }
+}
+
+impl<'a> BatchVerifier<'a> {
     /// Creates a verifier with space for `capacity` signatures.
     ///
     /// `capacity` is a trusted allocation hint. Bound externally supplied counts before passing
@@ -439,6 +494,8 @@ impl BatchVerifier {
     pub fn new(capacity: usize) -> Self {
         Self {
             items: Vec::with_capacity(capacity),
+            lazy_keys: Vec::new(),
+            valid: true,
         }
     }
 
@@ -461,19 +518,57 @@ impl BatchVerifier {
         });
     }
 
-    /// Queues an unframed message for raw Ed25519 test-vector checks.
-    #[cfg(test)]
-    pub(crate) fn add_raw(
+    /// Queues a signature without forcing decoding of its lazy public key.
+    ///
+    /// Verification caches each point-decoding result in the original lazy key. Repeated key
+    /// encodings share the decompression work, and later [`Lazy::get`] calls reuse the result.
+    /// A batch rejected before its point-processing phase can leave keys uninitialized.
+    /// Incorrectly sized encodings invalidate the batch.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `namespace` is longer than `u32::MAX` bytes.
+    pub fn add_lazy(
         &mut self,
+        namespace: &[u8],
         message: &[u8],
-        public_key: &VerifyingKey,
+        public_key: &'a Lazy<VerifyingKey>,
         signature: &Signature,
     ) {
+        self.add_lazy_message(union_unique(namespace, message), public_key, signature);
+    }
+
+    /// Queues the original key encoding and retains its cache destination.
+    fn add_lazy_message(
+        &mut self,
+        message: Vec<u8>,
+        public_key: &'a Lazy<VerifyingKey>,
+        signature: &Signature,
+    ) {
+        if public_key.encode_size() != VerifyingKey::SIZE {
+            self.valid = false;
+            return;
+        }
+        let mut bytes = [0u8; VerifyingKey::SIZE];
+        public_key.write(&mut bytes.as_mut_slice());
+        self.lazy_keys.resize(self.items.len(), None);
+        self.lazy_keys.push(Some(public_key));
         self.items.push(BatchItem {
-            message: message.to_vec(),
-            public_key: public_key.bytes,
+            message,
+            public_key: core::VerifyingKeyBytes::new(bytes),
             signature: core::Signature::from_bytes(signature.bytes),
         });
+    }
+
+    /// Queues an unframed message with a lazy key for raw Ed25519 test vectors.
+    #[cfg(test)]
+    pub(crate) fn add_lazy_raw(
+        &mut self,
+        message: &[u8],
+        public_key: &'a Lazy<VerifyingKey>,
+        signature: &Signature,
+    ) {
+        self.add_lazy_message(message.to_vec(), public_key, signature);
     }
 
     /// Checks all the signatures in the batch.
@@ -488,19 +583,28 @@ impl BatchVerifier {
     /// `rng` lets an attacker construct an invalid batch that passes verification.
     #[must_use]
     pub fn verify(self, rng: &mut impl CryptoRng, strategy: &impl Strategy) -> bool {
+        if !self.valid {
+            return false;
+        }
         let items = self
             .items
             .iter()
             .map(|item| (&item.public_key, &item.signature, item.message.as_slice()));
-        core::verify_batch_bytes(rng, items, strategy)
+        if self.lazy_keys.is_empty() {
+            core::verify_batch_bytes(rng, items, strategy)
+        } else {
+            core::verify_batch_bytes_cached(rng, items, strategy, &self)
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{BatchItem, BatchVerifier, SigningKey};
-    use commonware_parallel::Sequential;
-    use commonware_utils::test_rng;
+    use super::{BatchItem, BatchVerifier, SigningKey, VerifyingKey, VerifyingKeyContext};
+    use crate::curve::GAffine;
+    use commonware_codec::{DecodeExt, DecodeWith, Encode, types::lazy::Lazy};
+    use commonware_parallel::{Rayon, Sequential, Strategy};
+    use commonware_utils::{NZUsize, test_rng};
 
     #[test]
     fn batch_items_do_not_retain_decoded_key_cache() {
@@ -513,6 +617,102 @@ mod tests {
     #[test]
     fn empty_batch_is_invalid() {
         assert!(!BatchVerifier::new(0).verify(&mut test_rng(), &Sequential));
+    }
+
+    #[test]
+    fn contextual_key_decoding_preserves_the_exact_encoding() {
+        for bytes in crate::test::ZIP215_POINTS {
+            let context = VerifyingKeyContext {
+                bytes,
+                point: GAffine::decompress(&bytes),
+            };
+            let lazy = Lazy::<VerifyingKey>::deferred(&mut bytes.as_slice(), ());
+            let key = lazy.get_with(&context).unwrap();
+            assert_eq!(key.as_ref(), bytes);
+            assert_eq!(lazy.encode().as_ref(), bytes);
+            assert!(::core::ptr::eq(key, lazy.get().unwrap()));
+
+            let other_bytes = SigningKey::from_seed([42; 32]).verifying_key().encode();
+            let other = Lazy::<VerifyingKey>::deferred(&mut other_bytes.as_ref(), ());
+            assert_eq!(
+                other.get_with(&context),
+                VerifyingKey::decode(other_bytes).ok().as_ref(),
+            );
+
+            let mut malformed = [0u8; 32];
+            malformed[0] = 2;
+            assert!(VerifyingKey::decode_with(&malformed, &(), &context).is_err());
+            let mut trailing = bytes.to_vec();
+            trailing.push(0);
+            assert!(VerifyingKey::decode_with(&trailing, &(), &context).is_err());
+        }
+    }
+
+    #[test]
+    fn lazy_batch_populates_retained_keys_and_preserves_mixed_indices() {
+        const NAMESPACE: &[u8] = b"_COMMONWARE_CRYPTOGRAPHY_CURVE25519_LAZY_KEYS_TEST";
+        fn run(strategy: &impl Strategy) {
+            let fixtures = [42, 43, 44].map(|seed| {
+                let signing_key = SigningKey::from_seed([seed; 32]);
+                (
+                    signing_key.verifying_key(),
+                    signing_key.sign(NAMESPACE, b"message"),
+                )
+            });
+            let keys: Vec<_> = (0..17)
+                .map(|i| Lazy::<VerifyingKey>::deferred(&mut fixtures[i % 3].0.as_ref(), ()))
+                .collect();
+            for _ in 0..2 {
+                let mut batch = BatchVerifier::new(keys.len() * 2);
+                for (i, key) in keys.iter().enumerate() {
+                    let (public_key, signature) = &fixtures[(i + 1) % 3];
+                    batch.add(NAMESPACE, b"message", public_key, signature);
+                    batch.add_lazy(NAMESPACE, b"message", key, &fixtures[i % 3].1);
+                }
+                batch.add(NAMESPACE, b"message", &fixtures[0].0, &fixtures[0].1);
+                assert!(batch.verify(&mut test_rng(), strategy));
+                for (i, key) in keys.iter().enumerate() {
+                    let public_key = &fixtures[i % 3].0;
+                    assert_eq!(key.get_cached(), Some(Some(public_key)));
+                    assert_eq!(key.get(), Some(public_key));
+                }
+            }
+        }
+        run(&Sequential);
+        run(&Rayon::new(NZUsize!(4)).unwrap());
+    }
+
+    #[test]
+    fn lazy_batch_caches_malformed_points_and_rejects_wrong_lengths() {
+        const NAMESPACE: &[u8] = b"_COMMONWARE_CRYPTOGRAPHY_CURVE25519_LAZY_INVALID_TEST";
+        let signing_key = SigningKey::from_seed([42; 32]);
+        let public_key = signing_key.verifying_key();
+        let signature = signing_key.sign(NAMESPACE, b"message");
+        let mut malformed = [0u8; 32];
+        malformed[0] = 2;
+        let keys: Vec<_> = (0..17)
+            .map(|_| Lazy::<VerifyingKey>::deferred(&mut malformed.as_slice(), ()))
+            .collect();
+        for _ in 0..2 {
+            let mut batch = BatchVerifier::new(keys.len());
+            for key in &keys {
+                batch.add_lazy(NAMESPACE, b"message", key, &signature);
+            }
+            assert!(!batch.verify(&mut test_rng(), &Sequential));
+            for key in &keys {
+                assert_eq!(key.get_cached(), Some(None));
+                assert!(key.get().is_none());
+            }
+        }
+
+        for size in [0, 31, 33, 64] {
+            let bytes = vec![0u8; size];
+            let key = Lazy::<VerifyingKey>::deferred(&mut bytes.as_slice(), ());
+            let mut batch = BatchVerifier::new(2);
+            batch.add(NAMESPACE, b"message", &public_key, &signature);
+            batch.add_lazy(NAMESPACE, b"message", &key, &signature);
+            assert!(!batch.verify(&mut test_rng(), &Sequential));
+        }
     }
 
     #[test]

--- a/cryptography/curve25519/src/signing/core.rs
+++ b/cryptography/curve25519/src/signing/core.rs
@@ -428,15 +428,15 @@ mod tests {
         let a = batch_coefficients(&seed, 0);
         let b = batch_coefficients(&seed, 0);
         for k in 0..4 {
-            assert_eq!(a[k].0, b[k].0);
+            assert_eq!(a[k].to_bytes(), b[k].to_bytes());
         }
         assert_ne!(
-            batch_coefficients(&seed, 0)[0].0,
-            batch_coefficients(&seed, 1)[0].0
+            batch_coefficients(&seed, 0)[0].to_bytes(),
+            batch_coefficients(&seed, 1)[0].to_bytes()
         );
         assert_ne!(
-            batch_coefficients(&seed, 0)[0].0,
-            batch_coefficients(&[8u8; 32], 0)[0].0
+            batch_coefficients(&seed, 0)[0].to_bytes(),
+            batch_coefficients(&[8u8; 32], 0)[0].to_bytes()
         );
     }
 

--- a/cryptography/curve25519/src/signing/core.rs
+++ b/cryptography/curve25519/src/signing/core.rs
@@ -65,8 +65,8 @@ impl Signature {
 /// CSPRNG (and never revealed) are indistinguishable from exactly that. Deriving each signature's
 /// coefficient from its *position* rather than drawing all of them from the shared `rng` up
 /// front lets every thread compute its own signatures' coefficients locally -- and makes the
-/// batch's entire execution a deterministic function of `(items, seed)`, identical at every
-/// thread count.
+/// batch's coefficients and verdict deterministic functions of `(items, seed)`, identical at
+/// every thread count.
 fn batch_coefficients(seed: &[u8; 32], block: u64) -> [Scalar; 4] {
     let digest = sha512(&[seed, &block.to_le_bytes()]);
     core::array::from_fn(|k| {

--- a/cryptography/curve25519/src/signing/core.rs
+++ b/cryptography/curve25519/src/signing/core.rs
@@ -14,8 +14,8 @@ use sha2::{Digest, Sha512};
 
 /// The exact byte encoding used to identify an Ed25519 verifying key.
 ///
-/// Batch verification hashes and groups keys by this encoding, then decompresses each distinct
-/// key in its point-processing phase.
+/// Batch verification hashes and groups keys by this encoding, then reuses a cached point or
+/// decompresses each distinct key in its point-processing phase.
 #[derive(Copy, Clone, Eq, Hash, Ord, PartialEq, PartialOrd)]
 #[repr(transparent)]
 pub struct VerifyingKeyBytes([u8; 32]);
@@ -28,6 +28,29 @@ impl VerifyingKeyBytes {
     pub const fn as_bytes(&self) -> &[u8; 32] {
         &self.0
     }
+}
+
+/// Access to decoding results held by the batch's original key objects.
+///
+/// Indices refer to original batch positions. Results must describe the exact key encoding at
+/// that position. A cached failure is distinct from an uninitialized entry, and storing a result
+/// must preserve the original bytes.
+pub(super) trait KeyCache: Sync {
+    /// Returns an initialized entry, including a cached decoding failure.
+    fn get(&self, index: usize) -> Option<Option<GAffine>>;
+
+    /// Records a point or decoding failure for the exact encoding at `index`.
+    fn store(&self, index: usize, bytes: &[u8; 32], point: Option<GAffine>);
+}
+
+impl KeyCache for () {
+    /// Leaves every key in the decompression worklist.
+    fn get(&self, _: usize) -> Option<Option<GAffine>> {
+        None
+    }
+
+    /// Discards decoded points when no cache was supplied.
+    fn store(&self, _: usize, _: &[u8; 32], _: Option<GAffine>) {}
 }
 
 /// Computes `SHA-512(parts[0] || parts[1] || ...)`, the Ed25519 challenge hash `H(R || A || M)`.
@@ -165,29 +188,35 @@ fn scalar_phase(
     Some((blocks, s_sum))
 }
 
-/// The decompression phase: turns a flat worklist of `count` point encodings (resolved by index
-/// via `resolve`, which returns an encoding and its already-final MSM scalar) into MSM terms, in
-/// one parallel pass over [`LANES`]-sized units -- the finest split that keeps the sqrt kernel
-/// running 8-wide (see [`GAffine::decompress_batch`]), so the pool's demand-driven
-/// splitting balances the pass at ~7us granularity and a late-waking worker simply takes fewer
-/// units. Each fixed partition builds one exactly sized term vector, then the parallel fold joins
-/// validity and vectors of those buffers without shared state or copying point data. The final
-/// unit is padded with identity/zero terms, keeping decompression SIMD-wide without changing the
-/// MSM.
+/// Turns `count` point encodings and `cached_count` decoded keys into MSM terms in one parallel
+/// pass over [`LANES`]-sized units. `resolve` supplies encodings and their final MSM scalars,
+/// while `resolve_cached` builds terms directly from cached points. Encoded units run the sqrt
+/// kernel 8-wide (see [`GAffine::decompress_batch`]), and cached units skip decompression.
 ///
-/// Returns `None` if any encoding fails to decompress.
-fn decompress_phase<B, F>(
+/// The pool's demand-driven splitting balances both kinds of work. Each fixed partition builds
+/// one exactly sized term vector, then the parallel fold joins validity and vectors of those
+/// buffers without copying point data. The final encoded and cached units are padded with
+/// identity/zero terms, keeping decompression SIMD-wide without changing the MSM.
+///
+/// Calls `record` with each encoding's decoding result, including failures. Returns `None` if
+/// any encoding fails to decompress.
+fn decompress_phase<B, F, R, C>(
     backend: B,
     count: usize,
     resolve: F,
+    record: R,
+    (cached_count, resolve_cached): (usize, C),
     width: u32,
     strategy: &impl Strategy,
 ) -> Option<Vec<Vec<[Term; LANES]>>>
 where
     B: Backend,
     F: Fn(usize) -> ([u8; 32], Scalar) + Send + Sync,
+    R: Fn(usize, Option<GAffine>) + Send + Sync,
+    C: Fn(usize) -> Term + Send + Sync,
 {
-    let units = count.div_ceil(LANES);
+    let encoded_units = count.div_ceil(LANES);
+    let units = encoded_units + cached_count.div_ceil(LANES);
     if units == 0 {
         return Some(Vec::new());
     }
@@ -221,6 +250,17 @@ where
             let mut chunk_valid = true;
             let mut terms = Vec::with_capacity(range.len());
             for unit in range {
+                if unit >= encoded_units {
+                    let base = (unit - encoded_units) * LANES;
+                    terms.push(core::array::from_fn(|lane| {
+                        if base + lane < cached_count {
+                            resolve_cached(base + lane)
+                        } else {
+                            placeholder
+                        }
+                    }));
+                    continue;
+                }
                 let base = unit * LANES;
                 let mut resolved = [(identity_encoding, Scalar::ZERO); LANES];
                 for (lane, item) in resolved.iter_mut().enumerate() {
@@ -234,6 +274,7 @@ where
                     if base + lane >= count {
                         return placeholder;
                     }
+                    record(base + lane, points[lane]);
                     points[lane].map_or_else(
                         || {
                             chunk_valid = false;
@@ -261,10 +302,11 @@ where
 ///    and grouping becomes local information ([`group_ranges`]).
 /// 2. [`scalar_phase`]: coefficient derivation, hashing, and scalar arithmetic -- uniform per
 ///    signature, no curve points.
-/// 3. [`decompress_phase`] over a flat worklist containing every `R` and every distinct `A`, into
-///    contiguous term chunks. A signer's coalesced scalar (the sum of its signatures' `z*h` over
-///    a contiguous [`ScalarBlock`] run) is computed lazily by whichever unit resolves its `A`
-///    entry, so there is no separate group-sum pass.
+/// 3. Reuse cached keys within each group, then run [`decompress_phase`] over every `R` and
+///    every distinct `A`, building cached `A` terms directly in the same parallel pass. A
+///    signer's coalesced scalar (the sum of its signatures' `z*h` over a contiguous
+///    [`ScalarBlock`] run) is computed when its `A` term is built, and decoded keys populate
+///    every cache in their group.
 /// 4. One tile-parallel MSM over the term slices (with the coalesced basepoint term
 ///    `sum(z*s)·(-B)` riding along as one final term), then the cofactored identity check.
 fn verify_batch_inner<B: Backend>(
@@ -272,6 +314,7 @@ fn verify_batch_inner<B: Backend>(
     rng: &mut impl CryptoRng,
     items: &[(&VerifyingKeyBytes, &Signature, &[u8])],
     strategy: &impl Strategy,
+    cache: &impl KeyCache,
 ) -> bool {
     let n = items.len();
     if n == 0 {
@@ -303,23 +346,47 @@ fn verify_batch_inner<B: Backend>(
         return false;
     };
     let zr = |i: usize| blocks[i / 4].zr[i % 4];
-    // A signer's coalesced scalar: the sum of its contiguous sorted run's `z*h` scalars. Cheap
-    // mod-L additions, computed lazily (each group is resolved exactly once, by the worklist
-    // entry for its `A` term), so the summing itself rides inside a parallel phase. A batch
-    // dominated by one signer folds its whole run in that signer's single resolve call --
-    // acceptable, since even a 16k-signature run is far cheaper than one decompression unit's
-    // point arithmetic.
+    // A signer's coalesced scalar is the sum of its contiguous sorted run's `z*h` scalars.
+    // Compute it once when building the cached term or resolving the cold worklist entry.
     let group_scalar = |(start, end): (u32, u32)| {
         (start as usize..end as usize).fold(Scalar::ZERO, |acc, i| {
             acc.add_mod_l(&blocks[i / 4].zh[i % 4])
         })
     };
 
-    let groups = group_ranges(&order);
+    let mut groups = group_ranges(&order);
     // The MSM window width is a per-batch choice (see [`msm::width_for`]) and every term must
     // be recoded at the same width, so it is fixed here, before any term is built: the term
     // count is every `R`, every distinct `A`, and the basepoint.
     let width = msm::width_for(n + groups.len() + 1, strategy.parallelism());
+
+    let store_group = |(start, end): (u32, u32), point| {
+        for (bytes, index) in &order[start as usize..end as usize] {
+            cache.store(*index as usize, bytes.as_bytes(), point);
+        }
+    };
+    let mut cached_groups = Vec::new();
+    let mut valid = true;
+    groups.retain(|&group| {
+        let (start, end) = group;
+        let cached = order[start as usize..end as usize]
+            .iter()
+            .find_map(|(_, index)| cache.get(*index as usize));
+        let Some(point) = cached else {
+            return true;
+        };
+        match point {
+            Some(point) => cached_groups.push((group, point)),
+            None => {
+                store_group(group, None);
+                valid = false;
+            }
+        }
+        false
+    });
+    if !valid {
+        return false;
+    }
     let resolve_r = |i: usize| {
         let (_, sig, _) = items[order[i].1 as usize];
         (sig.r, zr(i))
@@ -337,7 +404,25 @@ fn verify_batch_inner<B: Backend>(
             (*order[group.0 as usize].0.as_bytes(), group_scalar(group))
         }
     };
-    let Some(terms) = decompress_phase(backend, n + groups.len(), resolve, width, strategy) else {
+    let record = |i: usize, point| {
+        if i >= n {
+            store_group(groups[i - n], point);
+        }
+    };
+    let resolve_cached = |i: usize| {
+        let (group, point) = cached_groups[i];
+        store_group(group, Some(point));
+        Term::new(point, &group_scalar(group), width)
+    };
+    let Some(terms) = decompress_phase(
+        backend,
+        n + groups.len(),
+        resolve,
+        record,
+        (cached_groups.len(), resolve_cached),
+        width,
+        strategy,
+    ) else {
         return false;
     };
     let mut chunks: Vec<&[Term]> = terms.iter().map(|chunk| chunk.as_flattened()).collect();
@@ -346,29 +431,32 @@ fn verify_batch_inner<B: Backend>(
     result.mul_by_cofactor().is_identity()
 }
 
-struct VerifyBatchCall<'a, 'b, R, S> {
+struct VerifyBatchCall<'a, 'b, R, S, C> {
     rng: &'a mut R,
     items: &'a [(&'b VerifyingKeyBytes, &'b Signature, &'b [u8])],
     strategy: &'a S,
+    cache: &'a C,
 }
 
-impl<R: CryptoRng, S: Strategy> WithBackend for VerifyBatchCall<'_, '_, R, S> {
+impl<R: CryptoRng, S: Strategy, C: KeyCache> WithBackend for VerifyBatchCall<'_, '_, R, S, C> {
     type Output = bool;
 
     fn call<B: Backend>(self, backend: B) -> Self::Output {
-        verify_batch_inner(backend, self.rng, self.items, self.strategy)
+        verify_batch_inner(backend, self.rng, self.items, self.strategy, self.cache)
     }
 }
 
-fn verify_batch_dispatch<'a, R: CryptoRng, S: Strategy>(
+fn verify_batch_dispatch<'a, R: CryptoRng, S: Strategy, C: KeyCache>(
     rng: &mut R,
     items: &[(&'a VerifyingKeyBytes, &'a Signature, &'a [u8])],
     strategy: &S,
+    cache: &C,
 ) -> bool {
     with_backend(VerifyBatchCall {
         rng,
         items,
         strategy,
+        cache,
     })
 }
 
@@ -385,8 +473,21 @@ pub(super) fn verify_batch_bytes<'a>(
     items: impl IntoIterator<Item = (&'a VerifyingKeyBytes, &'a Signature, &'a [u8])>,
     strategy: &impl Strategy,
 ) -> bool {
+    verify_batch_bytes_cached(rng, items, strategy, &())
+}
+
+/// Verifies a batch while reusing and populating decoded keys by original item index.
+///
+/// Only byte-identical keys share cached results. Cold keys remain fused with signature points
+/// in the same SIMD decompression pass, and a decoded key is cached even if verification fails.
+pub(super) fn verify_batch_bytes_cached<'a>(
+    rng: &mut impl CryptoRng,
+    items: impl IntoIterator<Item = (&'a VerifyingKeyBytes, &'a Signature, &'a [u8])>,
+    strategy: &impl Strategy,
+    cache: &impl KeyCache,
+) -> bool {
     let items: Vec<_> = items.into_iter().collect();
-    verify_batch_dispatch(rng, &items, strategy)
+    verify_batch_dispatch(rng, &items, strategy, cache)
 }
 
 #[cfg(test)]
@@ -397,6 +498,7 @@ mod tests {
     use commonware_parallel::Sequential;
     use commonware_utils::FuzzRng;
     use ed25519_consensus::SigningKey as RefSigningKey;
+    use std::sync::OnceLock;
 
     #[test]
     fn group_ranges_groups_adjacent_equal_keys() {
@@ -441,6 +543,108 @@ mod tests {
     }
 
     type BatchItem = (VerifyingKeyBytes, Signature, Vec<u8>);
+
+    struct Cache {
+        keys: Vec<VerifyingKeyBytes>,
+        entries: Vec<OnceLock<Option<GAffine>>>,
+    }
+
+    impl Cache {
+        /// Creates an empty cache for each original batch position.
+        fn new(batch: &[BatchItem]) -> Self {
+            Self {
+                keys: batch.iter().map(|item| item.0).collect(),
+                entries: (0..batch.len()).map(|_| OnceLock::new()).collect(),
+            }
+        }
+    }
+
+    impl KeyCache for Cache {
+        /// Returns a previously recorded decoding result.
+        fn get(&self, index: usize) -> Option<Option<GAffine>> {
+            self.entries[index].get().copied()
+        }
+
+        /// Checks that sorting retained the association with the original key encoding.
+        fn store(&self, index: usize, bytes: &[u8; 32], point: Option<GAffine>) {
+            assert_eq!(bytes, self.keys[index].as_bytes());
+            let expected = GAffine::decompress(bytes).map(GAffine::to_bytes);
+            assert_eq!(point.map(GAffine::to_bytes), expected);
+            let _ = self.entries[index].set(point);
+        }
+    }
+
+    #[test]
+    fn cached_batch_reuses_keys_and_populates_every_original_position() {
+        let signers = [RefSigningKey::from([3; 32]), RefSigningKey::from([7; 32])];
+        let batch: Vec<BatchItem> = (0..2 * LANES + 3)
+            .map(|i| {
+                let signer = &signers[i % signers.len()];
+                let message = vec![i as u8];
+                (
+                    VerifyingKeyBytes::new(signer.verification_key().to_bytes()),
+                    Signature::from_bytes(signer.sign(&message).to_bytes()),
+                    message,
+                )
+            })
+            .collect();
+        let cache = Cache::new(&batch);
+        let warm_index = batch.len() - 1;
+        cache.entries[warm_index]
+            .set(GAffine::decompress(batch[warm_index].0.as_bytes()))
+            .unwrap();
+
+        for _ in 0..2 {
+            let items = batch
+                .iter()
+                .map(|(key, sig, msg)| (key, sig, msg.as_slice()));
+            assert!(verify_batch_bytes_cached(
+                &mut FuzzRng::new(vec![1; 32]),
+                items,
+                &Sequential,
+                &cache,
+            ));
+            for entry in &cache.entries {
+                assert!(entry.get().unwrap().is_some());
+            }
+        }
+    }
+
+    #[test]
+    fn cached_batch_propagates_cold_and_warm_key_failures() {
+        let mut invalid = [0; 32];
+        invalid[0] = 2;
+        assert!(GAffine::decompress(&invalid).is_none());
+        let mut signature = [0; 64];
+        signature[0] = 1;
+        let batch = vec![
+            (
+                VerifyingKeyBytes::new(invalid),
+                Signature::from_bytes(signature),
+                Vec::new(),
+            );
+            LANES + 3
+        ];
+
+        for warm in [false, true] {
+            let cache = Cache::new(&batch);
+            if warm {
+                cache.entries[batch.len() - 1].set(None).unwrap();
+            }
+            let items = batch
+                .iter()
+                .map(|(key, sig, msg)| (key, sig, msg.as_slice()));
+            assert!(!verify_batch_bytes_cached(
+                &mut FuzzRng::new(vec![1; 32]),
+                items,
+                &Sequential,
+                &cache,
+            ));
+            for entry in &cache.entries {
+                assert!(entry.get().unwrap().is_none());
+            }
+        }
+    }
 
     /// A batch of both independent signers and a repeated signer, spanning multiple scalar-phase
     /// chunks and decompression chunks, verified under `Manual` -- which disables the adaptive
@@ -502,6 +706,24 @@ mod tests {
                     items,
                     &strategy,
                 ));
+
+                let cache = Cache::new(&batch);
+                cache.entries[batch.len() - 1]
+                    .set(GAffine::decompress(batch.last().unwrap().0.as_bytes()))
+                    .unwrap();
+                // The first pass initializes every key. The second spans multiple cached tiles.
+                for _ in 0..2 {
+                    let items = batch.iter().map(|(vk, sig, msg)| (vk, sig, msg.as_slice()));
+                    assert!(verify_batch_bytes_cached(
+                        &mut FuzzRng::new(rng_seed.to_vec()),
+                        items,
+                        &strategy,
+                        &cache,
+                    ));
+                    for entry in &cache.entries {
+                        assert!(entry.get().unwrap().is_some());
+                    }
+                }
                 Ok(())
             });
     }

--- a/cryptography/curve25519/src/signing/core.rs
+++ b/cryptography/curve25519/src/signing/core.rs
@@ -506,7 +506,7 @@ mod tests {
             });
     }
 
-    /// Batch verification's execution is a deterministic function of `(items, seed)` (see
+    /// Batch verification's verdict is a deterministic function of `(items, seed)` (see
     /// [`batch_coefficients`]), so serial and parallel strategies must agree on every batch --
     /// including invalid ones, where the accept/reject outcome depends on the derived
     /// coefficients.

--- a/cryptography/curve25519/src/signing/core/msm.rs
+++ b/cryptography/curve25519/src/signing/core/msm.rs
@@ -499,6 +499,20 @@ mod tests {
 
     #[test]
     fn matches_naive_double_and_add() {
+        struct Compute<'a> {
+            points: &'a [GAffine],
+            scalars: &'a [Scalar],
+            width: u32,
+        }
+
+        impl crate::curve::WithBackend for Compute<'_> {
+            type Output = G;
+
+            fn call<B: Backend>(self, backend: B) -> G {
+                multiscalar_mul_points_serial(backend, self.points, self.scalars, self.width)
+            }
+        }
+
         let backend = crate::curve::test_backend();
         Builder::default()
             .with_seed(0)
@@ -522,6 +536,12 @@ mod tests {
                     for width in TEST_WIDTHS {
                         let actual = multiscalar_mul_points_serial(backend, points, scalars, width);
                         assert!(points_equal(actual, expected), "n={n} width={width}");
+                        let accelerated = crate::curve::with_backend(Compute {
+                            points,
+                            scalars,
+                            width,
+                        });
+                        assert!(points_equal(accelerated, expected), "n={n} width={width}");
                     }
                 }
                 Ok(())
@@ -581,6 +601,7 @@ mod tests {
         // actual Rayon dispatch (rather than the policy falling back to serial for small inputs).
         let strategy = commonware_parallel::Rayon::new(commonware_utils::NZUsize!(4))
             .unwrap()
+            .with_parallelism(commonware_utils::NZUsize!(32))
             .manual();
 
         Builder::default()
@@ -589,6 +610,7 @@ mod tests {
             .test(|u| {
                 for width in [6, 8, 10] {
                     let terms = arbitrary_terms(u, 1000, width)?;
+                    assert!(range_count(terms.len(), num_windows(width), 32) > 1);
                     for n in [0, 1, 300, 600, 1000] {
                         let chunks =
                             split_terms(terms[..n].to_vec(), &[128, 128, 128, 128, 128, 128]);

--- a/cryptography/curve25519/src/signing/core/msm.rs
+++ b/cryptography/curve25519/src/signing/core/msm.rs
@@ -1,7 +1,7 @@
 //! Variable-time Pippenger multi-scalar multiplication for batch signature verification.
 //!
 //! [`Term`]s arrive decompressed and recoded into signed digits. The bucket kernel processes
-//! [`LANES`] terms at once, with one private bucket stripe per SIMD lane so updates never collide.
+//! one term per private bucket stripe at once, so updates within each wave never collide.
 //!
 //! [`multiscalar_mul`] exposes one execution shape for every [`Strategy`]: `(window, term range)`
 //! tiles. A window can be split across several point ranges when there are fewer windows than
@@ -9,7 +9,9 @@
 //! added together, and one short Horner fold positions the window sums.
 
 use super::scalar::Scalar;
-use crate::curve::{Backend, G, GAffine, GAffineVec, GVec, LANES};
+#[cfg(not(target_arch = "aarch64"))]
+use crate::curve::GAffineVec;
+use crate::curve::{Backend, G, GAffine, GVec, LANES};
 #[cfg(not(feature = "std"))]
 use alloc::{vec, vec::Vec};
 use commonware_parallel::Strategy;
@@ -44,7 +46,7 @@ const fn num_buckets(width: u32) -> usize {
 /// Fit to a measured sweep (width 6-10 x batch 1k-64k signatures x 1/32 threads, AMD EPYC 9354P,
 /// AVX-512): the optimum grows at almost exactly half a bit of width per bit of batch size --
 /// shallower than the textbook `log2(terms) - 4` rule, because the wide-window penalty on real
-/// hardware includes the per-lane bucket array (`8 * 2^(width-1)` points, ~320KB at width 9)
+/// hardware includes the AVX-512 bucket array (`8 * 2^(width-1)` points, ~320KB at width 9)
 /// spilling L2, not just the fold-count arithmetic. Parallel runs want one step narrower than
 /// serial: folds replicate once per tile range, and every concurrent tile holds its own bucket
 /// array. Every prediction below matched the sweep's measured optimum (or a runner-up within
@@ -122,32 +124,32 @@ fn used_buckets(chunks: &[&[Term]], start: usize, end: usize, window: usize) -> 
 }
 
 mod transposed {
-    use super::{Backend, G, GAffine, GAffineVec, GVec, LANES, Term};
+    #[cfg(not(target_arch = "aarch64"))]
+    use super::GAffineVec;
+    use super::{Backend, G, GAffine, GVec, LANES, Term};
+
+    // NEON fills one stripe per physical mixed-addition lane, keeping wave updates independent
+    // Folds retain LANES independent bucket indices
+    #[cfg(target_arch = "aarch64")]
+    const STRIPES: usize = 2;
+    #[cfg(not(target_arch = "aarch64"))]
+    const STRIPES: usize = LANES;
     #[cfg(not(feature = "std"))]
     use alloc::{vec, vec::Vec};
 
-    /// Every lane's buckets for one window, flattened lane-major (`buckets[lane * nb + m]`, with
-    /// `nb = num_buckets(width)`): within each piece, lane `l` owns the terms whose index is
-    /// `l mod LANES`, plus this private bucket stripe, so the wave loop below can update `LANES`
-    /// buckets with one vectorized addition and no two lanes ever collide on a bucket.
-    /// Heap-allocated because the width (and so the array size) is a per-batch runtime value.
+    /// Independent bucket stripes, indexed by `stripe * nb + abs(digit) - 1`
+    ///
+    /// Each wave assigns one term to each stripe, so updates within a wave cannot collide.
+    /// Heap allocation accommodates the per-batch bucket count
     pub(super) fn identity_buckets(nb: usize) -> Vec<G> {
-        vec![G::IDENTITY; LANES * nb]
+        vec![G::IDENTITY; STRIPES * nb]
     }
 
-    /// Adds one contiguous run of terms into one window's bucket stripes via vectorized "wave"
-    /// passes, one wave of `LANES` consecutive terms (one per lane) at a time: gather each
-    /// lane's current bucket value (a scalar array read, cheap and branch-free since a digit of
-    /// 0 just gathers-and-discards the identity), add the wave's incoming (possibly negated, for
-    /// a negative digit) points via one vectorized backend mixed addition, then scatter the
-    /// results back (again cheap scalar writes, skipped only for zero-digit lanes since there is
-    /// no bucket to write into). A wave whose digits are *all* zero is skipped outright before
-    /// any point arithmetic -- common, not rare: batch verification's `R` terms carry 128-bit
-    /// coefficients, so every window above ~128 bits has zero digits for half the term sequence.
-    /// The `terms.len() % LANES` tail rides as a short wave, its missing lanes no-op identity
-    /// additions -- so a caller filling from several pieces pays at most one short wave per
-    /// piece. Accumulating (rather than returning fresh buckets) is what lets those pieces share
-    /// one bucket set and one fold.
+    /// Adds each run in waves of one term per bucket stripe
+    ///
+    /// Missing or zero-digit lanes use identity inputs and never scatter a result. Entirely
+    /// zero waves skip group arithmetic, including the high windows of short coefficients.
+    /// Each piece may restart stripe assignment because the fold sums every stripe
     #[allow(clippy::needless_range_loop)]
     fn fill_buckets<B: Backend>(
         backend: B,
@@ -157,11 +159,11 @@ mod transposed {
         window: usize,
     ) {
         let identity_point = GAffine::IDENTITY;
-        for wave in terms.chunks(LANES) {
-            let mut incoming = [identity_point; LANES];
-            let mut negative = [false; LANES];
-            let mut current = [G::IDENTITY; LANES];
-            let mut bucket_index = [None::<usize>; LANES];
+        for wave in terms.chunks(STRIPES) {
+            let mut incoming = [identity_point; STRIPES];
+            let mut negative = [false; STRIPES];
+            let mut current = [G::IDENTITY; STRIPES];
+            let mut bucket_index = [None::<usize>; STRIPES];
             let mut any = false;
             for (lane, term) in wave.iter().enumerate() {
                 let digit = term.digits[window];
@@ -181,13 +183,16 @@ mod transposed {
             if !any {
                 continue;
             }
+            #[cfg(target_arch = "aarch64")]
+            let updated = backend.g_add_mixed_pair(current, incoming, negative);
+            #[cfg(not(target_arch = "aarch64"))]
             let updated = backend
                 .g_add_mixed(
                     GVec::transpose(current),
                     GAffineVec::from_signed_lanes(backend, &incoming, &negative),
                 )
                 .untranspose();
-            for lane in 0..LANES {
+            for lane in 0..STRIPES {
                 if let Some(i) = bucket_index[lane] {
                     buckets[lane * nb + i] = updated[lane];
                 }
@@ -195,9 +200,11 @@ mod transposed {
         }
     }
 
-    /// Folds `LANES` lanes' worth of one window's bucket stripes into `result` with the standard
-    /// running-sum trick: starting below untouched top buckets is exact because identity buckets
-    /// leave both the running sum and window sum unchanged.
+    /// Folds each bucket stripe into its corresponding result lane with a running sum
+    ///
+    /// Lanes without a stripe contribute the identity. Untouched top buckets can be skipped
+    /// because their identity values leave both running sums unchanged
+    #[cfg(any(test, not(target_arch = "aarch64")))]
     fn fold_buckets<B: Backend>(
         backend: B,
         result: GVec,
@@ -208,11 +215,133 @@ mod transposed {
         let mut sum = GVec::identity();
         let mut window_sum = GVec::identity();
         for d in (0..used).rev() {
-            let bucket_group: [G; LANES] = core::array::from_fn(|lane| buckets[lane * nb + d]);
+            let bucket_group: [G; LANES] = core::array::from_fn(|lane| {
+                if lane < STRIPES {
+                    buckets[lane * nb + d]
+                } else {
+                    G::IDENTITY
+                }
+            });
             sum = backend.g_add(sum, GVec::transpose(bucket_group));
             window_sum = backend.g_add(window_sum, sum);
         }
         backend.g_add(result, window_sum)
+    }
+
+    /// Returns lanes whose sum is the weighted sum of all bucket stripes.
+    ///
+    /// Let `B[k, lane]` sum the stripes at bucket index `k*LANES + lane`. The descending pass
+    /// builds `sum[lane] = sum_k B[k, lane]` and `rows[lane] = sum_k k*B[k, lane]`.
+    /// Final weighting gives `LANES*rows[lane] + (lane + 1)*sum[lane]`, assigning each bucket
+    /// its index-plus-one weight. The lane count is a power of two
+    #[cfg(target_arch = "aarch64")]
+    fn fold_buckets_merged<B: Backend>(backend: B, buckets: &[G], nb: usize, used: usize) -> GVec {
+        // A single used bucket has weight one, so return the stripes without weighting
+        if used == 1 {
+            return GVec::transpose(core::array::from_fn(|lane| {
+                if lane < STRIPES {
+                    buckets[lane * nb]
+                } else {
+                    G::IDENTITY
+                }
+            }));
+        }
+        let mut sum = GVec::identity();
+        let mut rows = GVec::identity();
+        for block in (0..used.div_ceil(LANES)).rev() {
+            let gather = |stripe: usize| {
+                GVec::transpose(core::array::from_fn(|lane| {
+                    let digit = block * LANES + lane;
+                    if digit < used {
+                        buckets[stripe * nb + digit]
+                    } else {
+                        G::IDENTITY
+                    }
+                }))
+            };
+            let mut combined = gather(0);
+            for stripe in 1..STRIPES {
+                combined = backend.g_add(combined, gather(stripe));
+            }
+            rows = backend.g_add(rows, sum);
+            sum = backend.g_add(sum, combined);
+        }
+
+        // Seed the high bit of lane + 1, then fold its remaining bits
+        let lanes = sum.untranspose();
+        let mut weighted = GVec::transpose(core::array::from_fn(|lane| {
+            if lane == LANES - 1 {
+                lanes[lane]
+            } else {
+                G::IDENTITY
+            }
+        }));
+        for bit in (0..3).rev() {
+            rows = backend.g_double(rows);
+            weighted = backend.g_double(weighted);
+            let selected = core::array::from_fn(|lane| {
+                if (lane + 1) & (1 << bit) != 0 {
+                    lanes[lane]
+                } else {
+                    G::IDENTITY
+                }
+            });
+            weighted = backend.g_add(weighted, GVec::transpose(selected));
+        }
+        backend.g_add(rows, weighted)
+    }
+
+    #[cfg(all(test, target_arch = "aarch64"))]
+    mod merged_tests {
+        use super::*;
+
+        #[test]
+        fn merged_fold_preserves_every_bucket_weight() {
+            struct Check;
+            impl crate::curve::WithBackend for Check {
+                type Output = ();
+                fn call<B: Backend>(self, backend: B) {
+                    let base = GAffine::BASEPOINT.to_extended();
+                    let torsion = GAffine::decompress(&[0; 32]).unwrap().to_extended();
+                    for width in [6, 7, 8, 9, 10] {
+                        let nb = super::super::num_buckets(width);
+                        let mut point = base;
+                        let buckets: Vec<G> = (0..STRIPES * nb)
+                            .map(|i| {
+                                point = point.add(base);
+                                match i % 7 {
+                                    0 => torsion,
+                                    1 => point.add(torsion),
+                                    2 => point.negate(),
+                                    3 => G::IDENTITY,
+                                    _ => point,
+                                }
+                            })
+                            .collect();
+                        let mut expected = G::IDENTITY;
+                        for used in 0..=nb {
+                            if used != 0 {
+                                let bucket = (0..STRIPES).fold(G::IDENTITY, |sum, stripe| {
+                                    sum.add(buckets[stripe * nb + used - 1])
+                                });
+                                let weighted = bucket.scalar_mul(
+                                    (0..usize::BITS).rev().map(|bit| used & (1 << bit) != 0),
+                                );
+                                expected = expected.add(weighted);
+                            }
+                            let actual =
+                                fold_buckets_merged(backend, &buckets, nb, used).sum_lanes(backend);
+                            assert!(
+                                actual.add(expected.negate()).is_identity(),
+                                "width={width} used={used}"
+                            );
+                        }
+                    }
+                }
+            }
+            crate::curve::WithBackend::call(Check, crate::curve::test_backend());
+            crate::curve::with_backend(Check);
+        }
     }
 
     /// One window's contribution to the MSM over global term range `[start, end)`, *before* the
@@ -229,13 +358,21 @@ mod transposed {
         buckets: &mut [G],
     ) -> G {
         let nb = super::num_buckets(width);
-        debug_assert_eq!(buckets.len(), LANES * nb);
-        buckets.fill(G::IDENTITY);
+        debug_assert_eq!(buckets.len(), STRIPES * nb);
         let used = super::used_buckets(chunks, start, end, window);
+        // An all-zero window contributes the identity without resetting or folding scratch
+        if used == 0 {
+            return G::IDENTITY;
+        }
+        buckets.fill(G::IDENTITY);
         for piece in super::pieces(chunks, start, end) {
             fill_buckets(backend, buckets, nb, piece, window);
         }
-        fold_buckets(backend, GVec::identity(), buckets, nb, used).sum_lanes(backend)
+        #[cfg(target_arch = "aarch64")]
+        let partial = fold_buckets_merged(backend, buckets, nb, used);
+        #[cfg(not(target_arch = "aarch64"))]
+        let partial = fold_buckets(backend, GVec::identity(), buckets, nb, used);
+        partial.sum_lanes(backend)
     }
 
     /// Computes the full MSM over `chunks` via the lane-transposed Pippenger bucket method,
@@ -295,7 +432,20 @@ fn multiscalar_mul_points_serial<B: Backend>(
 
 /// Horner-folds per-window partial sums into the final MSM result: from the top window down,
 /// `width` doublings shift everything accumulated so far up one window, then the next window's
-/// partial joins.
+/// partial joins. Scalar recombination computes each point once, avoiding duplicate SIMD lanes.
+#[cfg(target_arch = "aarch64")]
+fn fold_windows<B: Backend>(_: B, windows: &[G], width: u32) -> G {
+    let mut result = G::IDENTITY;
+    for window in windows.iter().rev() {
+        for _ in 0..width {
+            result = result.double();
+        }
+        result = result.add(*window);
+    }
+    result
+}
+
+#[cfg(not(target_arch = "aarch64"))]
 fn fold_windows<B: Backend>(backend: B, windows: &[G], width: u32) -> G {
     let mut result = GVec::identity();
     for window in windows.iter().rev() {
@@ -389,14 +539,25 @@ pub(super) fn multiscalar_mul<B: Backend>(
             (tile.window, partial)
         },
     );
-    let mut window_sums = vec![GVec::identity(); windows];
-    for (window, partial) in partials {
-        window_sums[window] = backend.g_add(window_sums[window], GVec::splat(partial));
-    }
-    let window_sums: Vec<G> = window_sums
-        .into_iter()
-        .map(|window| window.untranspose()[0])
-        .collect();
+    #[cfg(target_arch = "aarch64")]
+    let window_sums = {
+        let mut window_sums = vec![G::IDENTITY; windows];
+        for (window, partial) in partials {
+            window_sums[window] = window_sums[window].add(partial);
+        }
+        window_sums
+    };
+    #[cfg(not(target_arch = "aarch64"))]
+    let window_sums = {
+        let mut window_sums = vec![GVec::identity(); windows];
+        for (window, partial) in partials {
+            window_sums[window] = backend.g_add(window_sums[window], GVec::splat(partial));
+        }
+        window_sums
+            .into_iter()
+            .map(|window| window.untranspose()[0])
+            .collect::<Vec<_>>()
+    };
     fold_windows(backend, &window_sums, width)
 }
 
@@ -626,6 +787,35 @@ mod tests {
                 }
                 Ok(())
             });
+    }
+
+    #[test]
+    fn window_partials_reuse_scratch_across_zero_windows() {
+        let backend = crate::curve::test_backend();
+        let point = GAffine::BASEPOINT;
+        for width in TEST_WIDTHS {
+            let scalar = Scalar::from_u128((1u128 << (2 * width)) | 1);
+            let terms = [Term::new(point, &scalar, width)];
+            let mut buckets = transposed::identity_buckets(num_buckets(width));
+            for (window, expected) in [point.to_extended(), G::IDENTITY, point.to_extended()]
+                .into_iter()
+                .enumerate()
+            {
+                let actual = transposed::window_partial(
+                    backend,
+                    &[&terms],
+                    0,
+                    terms.len(),
+                    window,
+                    width,
+                    &mut buckets,
+                );
+                assert!(
+                    points_equal(actual, expected),
+                    "window={window} width={width}"
+                );
+            }
+        }
     }
 
     /// Splitting a window's bucket fill at an arbitrary global index (deliberately not a slice

--- a/cryptography/curve25519/src/signing/core/msm.rs
+++ b/cryptography/curve25519/src/signing/core/msm.rs
@@ -128,8 +128,8 @@ mod transposed {
     use super::GAffineVec;
     use super::{Backend, G, GAffine, GVec, LANES, Term};
 
-    // NEON fills one stripe per physical mixed-addition lane, keeping wave updates independent
-    // Folds retain LANES independent bucket indices
+    // NEON fills one stripe per physical mixed-addition lane, keeping wave updates independent.
+    // Folds retain LANES independent bucket indices.
     #[cfg(target_arch = "aarch64")]
     const STRIPES: usize = 2;
     #[cfg(not(target_arch = "aarch64"))]
@@ -137,19 +137,19 @@ mod transposed {
     #[cfg(not(feature = "std"))]
     use alloc::{vec, vec::Vec};
 
-    /// Independent bucket stripes, indexed by `stripe * nb + abs(digit) - 1`
+    /// Independent bucket stripes, indexed by `stripe * nb + abs(digit) - 1`.
     ///
     /// Each wave assigns one term to each stripe, so updates within a wave cannot collide.
-    /// Heap allocation accommodates the per-batch bucket count
+    /// Heap allocation accommodates the per-batch bucket count.
     pub(super) fn identity_buckets(nb: usize) -> Vec<G> {
         vec![G::IDENTITY; STRIPES * nb]
     }
 
-    /// Adds each run in waves of one term per bucket stripe
+    /// Adds each run in waves of one term per bucket stripe.
     ///
     /// Missing or zero-digit lanes use identity inputs and never scatter a result. Entirely
     /// zero waves skip group arithmetic, including the high windows of short coefficients.
-    /// Each piece may restart stripe assignment because the fold sums every stripe
+    /// Each piece may restart stripe assignment because the fold sums every stripe.
     #[allow(clippy::needless_range_loop)]
     fn fill_buckets<B: Backend>(
         backend: B,
@@ -200,10 +200,10 @@ mod transposed {
         }
     }
 
-    /// Folds each bucket stripe into its corresponding result lane with a running sum
+    /// Folds each bucket stripe into its corresponding result lane with a running sum.
     ///
     /// Lanes without a stripe contribute the identity. Untouched top buckets can be skipped
-    /// because their identity values leave both running sums unchanged
+    /// because their identity values leave both running sums unchanged.
     #[cfg(any(test, not(target_arch = "aarch64")))]
     fn fold_buckets<B: Backend>(
         backend: B,
@@ -233,10 +233,10 @@ mod transposed {
     /// Let `B[k, lane]` sum the stripes at bucket index `k*LANES + lane`. The descending pass
     /// builds `sum[lane] = sum_k B[k, lane]` and `rows[lane] = sum_k k*B[k, lane]`.
     /// Final weighting gives `LANES*rows[lane] + (lane + 1)*sum[lane]`, assigning each bucket
-    /// its index-plus-one weight. The lane count is a power of two
+    /// its index-plus-one weight. The lane count is a power of two.
     #[cfg(target_arch = "aarch64")]
     fn fold_buckets_merged<B: Backend>(backend: B, buckets: &[G], nb: usize, used: usize) -> GVec {
-        // A single used bucket has weight one, so return the stripes without weighting
+        // A single used bucket has weight one, so return the stripes without weighting.
         if used == 1 {
             return GVec::transpose(core::array::from_fn(|lane| {
                 if lane < STRIPES {
@@ -267,7 +267,7 @@ mod transposed {
             sum = backend.g_add(sum, combined);
         }
 
-        // Seed the high bit of lane + 1, then fold its remaining bits
+        // Seed the high bit of lane + 1, then fold its remaining bits.
         let lanes = sum.untranspose();
         let mut weighted = GVec::transpose(core::array::from_fn(|lane| {
             if lane == LANES - 1 {
@@ -360,8 +360,8 @@ mod transposed {
         let nb = super::num_buckets(width);
         debug_assert_eq!(buckets.len(), STRIPES * nb);
         let used = super::used_buckets(chunks, start, end, window);
-        // An all-zero window contributes the identity without resetting or folding scratch
         if used == 0 {
+            // An all-zero window contributes the identity without resetting or folding scratch.
             return G::IDENTITY;
         }
         buckets.fill(G::IDENTITY);

--- a/cryptography/curve25519/src/signing/core/msm.rs
+++ b/cryptography/curve25519/src/signing/core/msm.rs
@@ -9,9 +9,9 @@
 //! added together, and one short Horner fold positions the window sums.
 
 use super::scalar::Scalar;
-use crate::curve::{Backend, G, GAffine};
 #[cfg(test)]
-use crate::curve::{GVec, msm::Backend as _};
+use crate::curve::GVec;
+use crate::curve::{Backend, G, GAffine};
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 use commonware_parallel::Strategy;
@@ -462,24 +462,31 @@ mod tests {
     /// one contiguous slice.
     #[test]
     fn chunked_matches_single_chunk() {
-        let backend = crate::curve::test_backend();
-        Builder::default()
-            .with_seed(0)
-            .with_search_limit(8)
-            .test(|u| {
-                let terms = arbitrary_terms(u, 100, 7)?;
-                for n in [1, 2, 5, 8, 9, 32, 64, 100] {
-                    let terms = terms[..n].to_vec();
-                    let single = split_terms(terms.clone(), &[]);
-                    let mut chunks = split_terms(terms, &[1, 3, 7, 9, 24]);
-                    chunks.push(Vec::new());
+        struct Check;
+        impl crate::curve::WithBackend for Check {
+            type Output = ();
+            fn call<B: Backend>(self, backend: B) {
+                Builder::default()
+                    .with_seed(0)
+                    .with_search_limit(8)
+                    .test(|u| {
+                        let terms = arbitrary_terms(u, 100, 7)?;
+                        for n in [1, 2, 5, 8, 9, 32, 64, 100] {
+                            let terms = terms[..n].to_vec();
+                            let single = split_terms(terms.clone(), &[]);
+                            let mut chunks = split_terms(terms, &[1, 3, 7, 9, 24]);
+                            chunks.push(Vec::new());
 
-                    let expected = multiscalar_mul_terms_serial(backend, &refs(&single), 7);
-                    let actual = multiscalar_mul_terms_serial(backend, &refs(&chunks), 7);
-                    assert!(points_equal(actual, expected));
-                }
-                Ok(())
-            });
+                            let expected = multiscalar_mul_terms_serial(backend, &refs(&single), 7);
+                            let actual = multiscalar_mul_terms_serial(backend, &refs(&chunks), 7);
+                            assert!(points_equal(actual, expected));
+                        }
+                        Ok(())
+                    });
+            }
+        }
+        crate::curve::WithBackend::call(Check, crate::curve::test_backend());
+        crate::curve::with_backend(Check);
     }
 
     #[test]
@@ -603,57 +610,65 @@ mod tests {
     /// combine same-window tiles with a single addition.
     #[test]
     fn split_window_partials_match_whole_range() {
-        let backend = crate::curve::test_backend();
-        const WIDTH: u32 = 7;
-        Builder::default()
-            .with_seed(0)
-            .with_search_limit(8)
-            .test(|u| {
-                let terms = arbitrary_terms(u, 100, WIDTH)?;
-                for n in [1, 2, 5, 8, 9, 32, 64, 100] {
-                    let chunks = split_terms(terms[..n].to_vec(), &[n / 3, n / 3]);
-                    let chunks = refs(&chunks);
-                    let total = total_terms(&chunks);
-                    let mid = total / 2;
+        struct Check;
+        impl crate::curve::WithBackend for Check {
+            type Output = ();
+            fn call<B: Backend>(self, backend: B) {
+                const WIDTH: u32 = 7;
+                Builder::default()
+                    .with_seed(0)
+                    .with_search_limit(8)
+                    .test(|u| {
+                        let terms = arbitrary_terms(u, 100, WIDTH)?;
+                        for n in [1, 2, 5, 8, 9, 32, 64, 100] {
+                            let chunks = split_terms(terms[..n].to_vec(), &[n / 3, n / 3]);
+                            let chunks = refs(&chunks);
+                            let total = total_terms(&chunks);
+                            let mid = total / 2;
 
-                    let expected = multiscalar_mul_terms_serial(backend, &chunks, WIDTH);
+                            let expected = multiscalar_mul_terms_serial(backend, &chunks, WIDTH);
 
-                    let nw = num_windows(WIDTH);
-                    let mut transposed_windows = vec![G::IDENTITY; nw];
-                    let mut buckets = transposed::identity_buckets(backend, num_buckets(WIDTH));
-                    for (window, partial) in transposed_windows.iter_mut().enumerate() {
-                        let left = transposed::window_partial(
-                            backend,
-                            &chunks,
-                            0,
-                            mid,
-                            window,
-                            WIDTH,
-                            &mut buckets,
-                        );
-                        let right = transposed::window_partial(
-                            backend,
-                            &chunks,
-                            mid,
-                            total,
-                            window,
-                            WIDTH,
-                            &mut buckets,
-                        );
-                        *partial = left.add(right);
-                    }
+                            let nw = num_windows(WIDTH);
+                            let mut transposed_windows = vec![G::IDENTITY; nw];
+                            let mut buckets =
+                                transposed::identity_buckets(backend, num_buckets(WIDTH));
+                            for (window, partial) in transposed_windows.iter_mut().enumerate() {
+                                let left = transposed::window_partial(
+                                    backend,
+                                    &chunks,
+                                    0,
+                                    mid,
+                                    window,
+                                    WIDTH,
+                                    &mut buckets,
+                                );
+                                let right = transposed::window_partial(
+                                    backend,
+                                    &chunks,
+                                    mid,
+                                    total,
+                                    window,
+                                    WIDTH,
+                                    &mut buckets,
+                                );
+                                *partial = left.add(right);
+                            }
 
-                    assert!(points_equal(
-                        backend.combine_windows(
-                            transposed_windows.into_iter().enumerate(),
-                            nw,
-                            WIDTH
-                        ),
-                        expected,
-                    ));
-                }
-                Ok(())
-            });
+                            assert!(points_equal(
+                                backend.combine_windows(
+                                    transposed_windows.into_iter().enumerate(),
+                                    nw,
+                                    WIDTH
+                                ),
+                                expected,
+                            ));
+                        }
+                        Ok(())
+                    });
+            }
+        }
+        crate::curve::WithBackend::call(Check, crate::curve::test_backend());
+        crate::curve::with_backend(Check);
     }
 
     /// [`pieces`] must hand back exactly the requested global range, in order, for any cut --

--- a/cryptography/curve25519/src/signing/core/msm.rs
+++ b/cryptography/curve25519/src/signing/core/msm.rs
@@ -292,56 +292,52 @@ mod transposed {
     }
 
     #[cfg(all(test, target_arch = "aarch64"))]
-    mod merged_tests {
-        use super::*;
-
-        #[test]
-        fn merged_fold_preserves_every_bucket_weight() {
-            struct Check;
-            impl crate::curve::WithBackend for Check {
-                type Output = ();
-                fn call<B: Backend>(self, backend: B) {
-                    let base = GAffine::BASEPOINT.to_extended();
-                    let torsion = GAffine::decompress(&[0; 32]).unwrap().to_extended();
-                    for width in [6, 7, 8, 9, 10] {
-                        let nb = super::super::num_buckets(width);
-                        let mut point = base;
-                        let buckets: Vec<G> = (0..STRIPES * nb)
-                            .map(|i| {
-                                point = point.add(base);
-                                match i % 7 {
-                                    0 => torsion,
-                                    1 => point.add(torsion),
-                                    2 => point.negate(),
-                                    3 => G::IDENTITY,
-                                    _ => point,
-                                }
-                            })
-                            .collect();
-                        let mut expected = G::IDENTITY;
-                        for used in 0..=nb {
-                            if used != 0 {
-                                let bucket = (0..STRIPES).fold(G::IDENTITY, |sum, stripe| {
-                                    sum.add(buckets[stripe * nb + used - 1])
-                                });
-                                let weighted = bucket.scalar_mul(
-                                    (0..usize::BITS).rev().map(|bit| used & (1 << bit) != 0),
-                                );
-                                expected = expected.add(weighted);
+    #[test]
+    fn merged_fold_preserves_every_bucket_weight() {
+        struct Check;
+        impl crate::curve::WithBackend for Check {
+            type Output = ();
+            fn call<B: Backend>(self, backend: B) {
+                let base = GAffine::BASEPOINT.to_extended();
+                let torsion = GAffine::decompress(&[0; 32]).unwrap().to_extended();
+                for width in [6, 7, 8, 9, 10] {
+                    let nb = super::num_buckets(width);
+                    let mut point = base;
+                    let buckets: Vec<G> = (0..STRIPES * nb)
+                        .map(|i| {
+                            point = point.add(base);
+                            match i % 7 {
+                                0 => torsion,
+                                1 => point.add(torsion),
+                                2 => point.negate(),
+                                3 => G::IDENTITY,
+                                _ => point,
                             }
-                            let actual =
-                                fold_buckets_merged(backend, &buckets, nb, used).sum_lanes(backend);
-                            assert!(
-                                actual.add(expected.negate()).is_identity(),
-                                "width={width} used={used}"
+                        })
+                        .collect();
+                    let mut expected = G::IDENTITY;
+                    for used in 0..=nb {
+                        if used != 0 {
+                            let bucket = (0..STRIPES).fold(G::IDENTITY, |sum, stripe| {
+                                sum.add(buckets[stripe * nb + used - 1])
+                            });
+                            let weighted = bucket.scalar_mul(
+                                (0..usize::BITS).rev().map(|bit| used & (1 << bit) != 0),
                             );
+                            expected = expected.add(weighted);
                         }
+                        let actual =
+                            fold_buckets_merged(backend, &buckets, nb, used).sum_lanes(backend);
+                        assert!(
+                            actual.add(expected.negate()).is_identity(),
+                            "width={width} used={used}"
+                        );
                     }
                 }
             }
-            crate::curve::WithBackend::call(Check, crate::curve::test_backend());
-            crate::curve::with_backend(Check);
         }
+        crate::curve::WithBackend::call(Check, crate::curve::test_backend());
+        crate::curve::with_backend(Check);
     }
 
     /// One window's contribution to the MSM over global term range `[start, end)`, *before* the

--- a/cryptography/curve25519/src/signing/core/msm.rs
+++ b/cryptography/curve25519/src/signing/core/msm.rs
@@ -11,7 +11,7 @@
 use super::scalar::Scalar;
 use crate::curve::{Backend, G, GAffine};
 #[cfg(test)]
-use crate::curve::{GVec, msm::MsmBackend};
+use crate::curve::{GVec, msm::Backend as _};
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 use commonware_parallel::Strategy;

--- a/cryptography/curve25519/src/signing/core/msm.rs
+++ b/cryptography/curve25519/src/signing/core/msm.rs
@@ -599,6 +599,8 @@ mod tests {
         let backend = crate::curve::test_backend();
         // `Manual` disables the adaptive serial/parallel policy, forcing every call through
         // actual Rayon dispatch (rather than the policy falling back to serial for small inputs).
+        // Planning parallelism above the pool size splits every width below into several term
+        // ranges, which the assertion inside the loop pins.
         let strategy = commonware_parallel::Rayon::new(commonware_utils::NZUsize!(4))
             .unwrap()
             .with_parallelism(commonware_utils::NZUsize!(32))
@@ -610,7 +612,9 @@ mod tests {
             .test(|u| {
                 for width in [6, 8, 10] {
                     let terms = arbitrary_terms(u, 1000, width)?;
-                    assert!(range_count(terms.len(), num_windows(width), 32) > 1);
+                    assert!(
+                        range_count(terms.len(), num_windows(width), strategy.parallelism()) > 1
+                    );
                     for n in [0, 1, 300, 600, 1000] {
                         let chunks =
                             split_terms(terms[..n].to_vec(), &[128, 128, 128, 128, 128, 128]);

--- a/cryptography/curve25519/src/signing/core/msm.rs
+++ b/cryptography/curve25519/src/signing/core/msm.rs
@@ -9,11 +9,11 @@
 //! added together, and one short Horner fold positions the window sums.
 
 use super::scalar::Scalar;
-#[cfg(not(target_arch = "aarch64"))]
-use crate::curve::GAffineVec;
-use crate::curve::{Backend, G, GAffine, GVec, LANES};
+use crate::curve::{Backend, G, GAffine};
+#[cfg(test)]
+use crate::curve::{GVec, msm::MsmBackend};
 #[cfg(not(feature = "std"))]
-use alloc::{vec, vec::Vec};
+use alloc::vec::Vec;
 use commonware_parallel::Strategy;
 
 /// Bounds on the per-batch window width [`width_for`] may pick. The lower bound sizes every
@@ -124,220 +124,17 @@ fn used_buckets(chunks: &[&[Term]], start: usize, end: usize, window: usize) -> 
 }
 
 mod transposed {
-    #[cfg(not(target_arch = "aarch64"))]
-    use super::GAffineVec;
-    use super::{Backend, G, GAffine, GVec, LANES, Term};
-
-    // NEON fills one stripe per physical mixed-addition lane, keeping wave updates independent.
-    // Folds retain LANES independent bucket indices.
-    #[cfg(target_arch = "aarch64")]
-    const STRIPES: usize = 2;
-    #[cfg(not(target_arch = "aarch64"))]
-    const STRIPES: usize = LANES;
+    #[cfg(test)]
+    use super::GVec;
+    use super::{Backend, G, Term};
+    #[cfg(test)]
+    use crate::curve::msm::fold_buckets;
     #[cfg(not(feature = "std"))]
     use alloc::{vec, vec::Vec};
 
-    /// Independent bucket stripes, indexed by `stripe * nb + abs(digit) - 1`.
-    ///
-    /// Each wave assigns one term to each stripe, so updates within a wave cannot collide.
-    /// Heap allocation accommodates the per-batch bucket count.
-    pub(super) fn identity_buckets(nb: usize) -> Vec<G> {
-        vec![G::IDENTITY; STRIPES * nb]
-    }
-
-    /// Adds each run in waves of one term per bucket stripe.
-    ///
-    /// Missing or zero-digit lanes use identity inputs and never scatter a result. Entirely
-    /// zero waves skip group arithmetic, including the high windows of short coefficients.
-    /// Each piece may restart stripe assignment because the fold sums every stripe.
-    #[allow(clippy::needless_range_loop)]
-    fn fill_buckets<B: Backend>(
-        backend: B,
-        buckets: &mut [G],
-        nb: usize,
-        terms: &[Term],
-        window: usize,
-    ) {
-        let identity_point = GAffine::IDENTITY;
-        for wave in terms.chunks(STRIPES) {
-            let mut incoming = [identity_point; STRIPES];
-            let mut negative = [false; STRIPES];
-            let mut current = [G::IDENTITY; STRIPES];
-            let mut bucket_index = [None::<usize>; STRIPES];
-            let mut any = false;
-            for (lane, term) in wave.iter().enumerate() {
-                let digit = term.digits[window];
-                if digit > 0 {
-                    bucket_index[lane] = Some(digit as usize - 1);
-                    incoming[lane] = term.point;
-                } else if digit < 0 {
-                    bucket_index[lane] = Some(digit.unsigned_abs() as usize - 1);
-                    incoming[lane] = term.point;
-                    negative[lane] = true;
-                }
-                if let Some(i) = bucket_index[lane] {
-                    current[lane] = buckets[lane * nb + i];
-                    any = true;
-                }
-            }
-            if !any {
-                continue;
-            }
-            #[cfg(target_arch = "aarch64")]
-            let updated = backend.g_add_mixed_pair(current, incoming, negative);
-            #[cfg(not(target_arch = "aarch64"))]
-            let updated = backend
-                .g_add_mixed(
-                    GVec::transpose(current),
-                    GAffineVec::from_signed_lanes(backend, &incoming, &negative),
-                )
-                .untranspose();
-            for lane in 0..STRIPES {
-                if let Some(i) = bucket_index[lane] {
-                    buckets[lane * nb + i] = updated[lane];
-                }
-            }
-        }
-    }
-
-    /// Folds each bucket stripe into its corresponding result lane with a running sum.
-    ///
-    /// Lanes without a stripe contribute the identity. Untouched top buckets can be skipped
-    /// because their identity values leave both running sums unchanged.
-    #[cfg(any(test, not(target_arch = "aarch64")))]
-    fn fold_buckets<B: Backend>(
-        backend: B,
-        result: GVec,
-        buckets: &[G],
-        nb: usize,
-        used: usize,
-    ) -> GVec {
-        let mut sum = GVec::identity();
-        let mut window_sum = GVec::identity();
-        for d in (0..used).rev() {
-            let bucket_group: [G; LANES] = core::array::from_fn(|lane| {
-                if lane < STRIPES {
-                    buckets[lane * nb + d]
-                } else {
-                    G::IDENTITY
-                }
-            });
-            sum = backend.g_add(sum, GVec::transpose(bucket_group));
-            window_sum = backend.g_add(window_sum, sum);
-        }
-        backend.g_add(result, window_sum)
-    }
-
-    /// Returns lanes whose sum is the weighted sum of all bucket stripes.
-    ///
-    /// Let `B[k, lane]` sum the stripes at bucket index `k*LANES + lane`. The descending pass
-    /// builds `sum[lane] = sum_k B[k, lane]` and `rows[lane] = sum_k k*B[k, lane]`.
-    /// Final weighting gives `LANES*rows[lane] + (lane + 1)*sum[lane]`, assigning each bucket
-    /// its index-plus-one weight. The lane count is a power of two.
-    #[cfg(target_arch = "aarch64")]
-    fn fold_buckets_merged<B: Backend>(backend: B, buckets: &[G], nb: usize, used: usize) -> GVec {
-        // A single used bucket has weight one, so return the stripes without weighting.
-        if used == 1 {
-            return GVec::transpose(core::array::from_fn(|lane| {
-                if lane < STRIPES {
-                    buckets[lane * nb]
-                } else {
-                    G::IDENTITY
-                }
-            }));
-        }
-        let mut sum = GVec::identity();
-        let mut rows = GVec::identity();
-        for block in (0..used.div_ceil(LANES)).rev() {
-            let gather = |stripe: usize| {
-                GVec::transpose(core::array::from_fn(|lane| {
-                    let digit = block * LANES + lane;
-                    if digit < used {
-                        buckets[stripe * nb + digit]
-                    } else {
-                        G::IDENTITY
-                    }
-                }))
-            };
-            let mut combined = gather(0);
-            for stripe in 1..STRIPES {
-                combined = backend.g_add(combined, gather(stripe));
-            }
-            rows = backend.g_add(rows, sum);
-            sum = backend.g_add(sum, combined);
-        }
-
-        // Seed the high bit of lane + 1, then fold its remaining bits.
-        let lanes = sum.untranspose();
-        let mut weighted = GVec::transpose(core::array::from_fn(|lane| {
-            if lane == LANES - 1 {
-                lanes[lane]
-            } else {
-                G::IDENTITY
-            }
-        }));
-        for bit in (0..3).rev() {
-            rows = backend.g_double(rows);
-            weighted = backend.g_double(weighted);
-            let selected = core::array::from_fn(|lane| {
-                if (lane + 1) & (1 << bit) != 0 {
-                    lanes[lane]
-                } else {
-                    G::IDENTITY
-                }
-            });
-            weighted = backend.g_add(weighted, GVec::transpose(selected));
-        }
-        backend.g_add(rows, weighted)
-    }
-
-    #[cfg(all(test, target_arch = "aarch64"))]
-    #[test]
-    fn merged_fold_preserves_every_bucket_weight() {
-        struct Check;
-        impl crate::curve::WithBackend for Check {
-            type Output = ();
-            fn call<B: Backend>(self, backend: B) {
-                let base = GAffine::BASEPOINT.to_extended();
-                let torsion = GAffine::decompress(&[0; 32]).unwrap().to_extended();
-                for width in [6, 7, 8, 9, 10] {
-                    let nb = super::num_buckets(width);
-                    let mut point = base;
-                    let buckets: Vec<G> = (0..STRIPES * nb)
-                        .map(|i| {
-                            point = point.add(base);
-                            match i % 7 {
-                                0 => torsion,
-                                1 => point.add(torsion),
-                                2 => point.negate(),
-                                3 => G::IDENTITY,
-                                _ => point,
-                            }
-                        })
-                        .collect();
-                    let mut expected = G::IDENTITY;
-                    for used in 0..=nb {
-                        if used != 0 {
-                            let bucket = (0..STRIPES).fold(G::IDENTITY, |sum, stripe| {
-                                sum.add(buckets[stripe * nb + used - 1])
-                            });
-                            let weighted = bucket.scalar_mul(
-                                (0..usize::BITS).rev().map(|bit| used & (1 << bit) != 0),
-                            );
-                            expected = expected.add(weighted);
-                        }
-                        let actual =
-                            fold_buckets_merged(backend, &buckets, nb, used).sum_lanes(backend);
-                        assert!(
-                            actual.add(expected.negate()).is_identity(),
-                            "width={width} used={used}"
-                        );
-                    }
-                }
-            }
-        }
-        crate::curve::WithBackend::call(Check, crate::curve::test_backend());
-        crate::curve::with_backend(Check);
+    /// Independent bucket stripes, with per-batch bucket counts allocated on the heap.
+    pub(super) fn identity_buckets<B: Backend>(_: B, nb: usize) -> Vec<G> {
+        vec![G::IDENTITY; B::STRIPES * nb]
     }
 
     /// One window's contribution to the MSM over global term range `[start, end)`, *before* the
@@ -354,7 +151,7 @@ mod transposed {
         buckets: &mut [G],
     ) -> G {
         let nb = super::num_buckets(width);
-        debug_assert_eq!(buckets.len(), STRIPES * nb);
+        debug_assert_eq!(buckets.len(), B::STRIPES * nb);
         let used = super::used_buckets(chunks, start, end, window);
         if used == 0 {
             // An all-zero window contributes the identity without resetting or folding scratch.
@@ -362,12 +159,9 @@ mod transposed {
         }
         buckets.fill(G::IDENTITY);
         for piece in super::pieces(chunks, start, end) {
-            fill_buckets(backend, buckets, nb, piece, window);
+            backend.fill_buckets(buckets, nb, piece, |term| (term.point, term.digits[window]));
         }
-        #[cfg(target_arch = "aarch64")]
-        let partial = fold_buckets_merged(backend, buckets, nb, used);
-        #[cfg(not(target_arch = "aarch64"))]
-        let partial = fold_buckets(backend, GVec::identity(), buckets, nb, used);
+        let partial = backend.fold_buckets(buckets, nb, used);
         partial.sum_lanes(backend)
     }
 
@@ -385,14 +179,16 @@ mod transposed {
         let nb = super::num_buckets(width);
         let total = super::total_terms(chunks);
         let mut result = GVec::identity();
-        let mut buckets = identity_buckets(nb);
+        let mut buckets = identity_buckets(backend, nb);
         for window in (0..super::num_windows(width)).rev() {
             for _ in 0..width {
                 result = backend.g_double(result);
             }
             let used = super::used_buckets(chunks, 0, total, window);
             for piece in super::pieces(chunks, 0, total) {
-                fill_buckets(backend, &mut buckets, nb, piece, window);
+                backend.fill_buckets(&mut buckets, nb, piece, |term| {
+                    (term.point, term.digits[window])
+                });
             }
             result = fold_buckets(backend, result, &buckets, nb, used);
             buckets.fill(G::IDENTITY);
@@ -424,33 +220,6 @@ fn multiscalar_mul_points_serial<B: Backend>(
         .map(|(point, scalar)| Term::new(*point, scalar, width))
         .collect();
     multiscalar_mul_terms_serial(backend, &[&terms], width)
-}
-
-/// Horner-folds per-window partial sums into the final MSM result: from the top window down,
-/// `width` doublings shift everything accumulated so far up one window, then the next window's
-/// partial joins. Scalar recombination computes each point once, avoiding duplicate SIMD lanes.
-#[cfg(target_arch = "aarch64")]
-fn fold_windows<B: Backend>(_: B, windows: &[G], width: u32) -> G {
-    let mut result = G::IDENTITY;
-    for window in windows.iter().rev() {
-        for _ in 0..width {
-            result = result.double();
-        }
-        result = result.add(*window);
-    }
-    result
-}
-
-#[cfg(not(target_arch = "aarch64"))]
-fn fold_windows<B: Backend>(backend: B, windows: &[G], width: u32) -> G {
-    let mut result = GVec::identity();
-    for window in windows.iter().rev() {
-        for _ in 0..width {
-            result = backend.g_double(result);
-        }
-        result = backend.g_add(result, GVec::splat(*window));
-    }
-    result.untranspose()[0]
 }
 
 /// Floor on terms per tile range: a shorter range's fixed per-tile cost (folding the bucket
@@ -494,7 +263,7 @@ fn partition_ranges(total: usize, ranges: usize) -> Vec<(usize, usize)> {
 /// Computes the full MSM over `chunks` (whose terms were recoded at `width`; see [`width_for`]
 /// and [`Term::new`]) with the bucket phase spread across `strategy`'s threads as
 /// `(window, global term range)` tiles. Each tile reduces to one point, same-window points are
-/// added, and [`fold_windows`] positions the resulting window sums.
+/// added, and the backend positions the resulting window sums.
 pub(super) fn multiscalar_mul<B: Backend>(
     backend: B,
     chunks: &[&[Term]],
@@ -521,7 +290,7 @@ pub(super) fn multiscalar_mul<B: Backend>(
     let buckets = num_buckets(width);
     let partials = strategy.map_init_collect_vec(
         tiles,
-        || transposed::identity_buckets(buckets),
+        || transposed::identity_buckets(backend, buckets),
         |scratch, tile| {
             let partial = transposed::window_partial(
                 backend,
@@ -535,31 +304,14 @@ pub(super) fn multiscalar_mul<B: Backend>(
             (tile.window, partial)
         },
     );
-    #[cfg(target_arch = "aarch64")]
-    let window_sums = {
-        let mut window_sums = vec![G::IDENTITY; windows];
-        for (window, partial) in partials {
-            window_sums[window] = window_sums[window].add(partial);
-        }
-        window_sums
-    };
-    #[cfg(not(target_arch = "aarch64"))]
-    let window_sums = {
-        let mut window_sums = vec![GVec::identity(); windows];
-        for (window, partial) in partials {
-            window_sums[window] = backend.g_add(window_sums[window], GVec::splat(partial));
-        }
-        window_sums
-            .into_iter()
-            .map(|window| window.untranspose()[0])
-            .collect::<Vec<_>>()
-    };
-    fold_windows(backend, &window_sums, width)
+    backend.combine_windows(partials, windows, width)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(not(feature = "std"))]
+    use alloc::vec;
     use arbitrary::Unstructured;
     use commonware_invariants::minifuzz::Builder;
     use commonware_parallel::Sequential;
@@ -732,86 +484,116 @@ mod tests {
 
     #[test]
     fn strategy_path_matches_serial() {
-        let backend = crate::curve::test_backend();
-        Builder::default()
-            .with_seed(0)
-            .with_search_limit(2)
-            .test(|u| {
-                for width in TEST_WIDTHS {
-                    let terms = arbitrary_terms(u, 600, width)?;
-                    for n in [0, 1, 2, 5, 32, 600] {
-                        let chunks = split_terms(terms[..n].to_vec(), &[64, 64, 64, 64]);
-                        let chunks = refs(&chunks);
-                        let expected = multiscalar_mul_terms_serial(backend, &chunks, width);
-                        let actual = multiscalar_mul(backend, &chunks, width, &Sequential);
-                        assert!(points_equal(actual, expected), "n={n} width={width}");
-                    }
-                }
-                Ok(())
-            });
+        struct Check;
+        impl crate::curve::WithBackend for Check {
+            type Output = ();
+            fn call<B: Backend>(self, backend: B) {
+                Builder::default()
+                    .with_seed(0)
+                    .with_search_limit(2)
+                    .test(|u| {
+                        for width in TEST_WIDTHS {
+                            let terms = arbitrary_terms(u, 600, width)?;
+                            for n in [0, 1, 2, 5, 32, 600] {
+                                let chunks = split_terms(terms[..n].to_vec(), &[64, 64, 64, 64]);
+                                let chunks = refs(&chunks);
+                                let expected =
+                                    multiscalar_mul_terms_serial(backend, &chunks, width);
+                                let actual = multiscalar_mul(backend, &chunks, width, &Sequential);
+                                assert!(points_equal(actual, expected), "n={n} width={width}");
+                            }
+                        }
+                        Ok(())
+                    });
+            }
+        }
+        crate::curve::WithBackend::call(Check, crate::curve::test_backend());
+        crate::curve::with_backend(Check);
     }
 
     #[test]
     fn tile_parallel_matches_serial_under_real_parallelism() {
-        let backend = crate::curve::test_backend();
-        // `Manual` disables the adaptive serial/parallel policy, forcing every call through
-        // actual Rayon dispatch (rather than the policy falling back to serial for small inputs).
-        // Planning parallelism above the pool size splits every width below into several term
-        // ranges, which the assertion inside the loop pins.
-        let strategy = commonware_parallel::Rayon::new(commonware_utils::NZUsize!(4))
-            .unwrap()
-            .with_parallelism(commonware_utils::NZUsize!(32))
-            .manual();
+        struct Check;
+        impl crate::curve::WithBackend for Check {
+            type Output = ();
+            fn call<B: Backend>(self, backend: B) {
+                // `Manual` disables the adaptive serial/parallel policy, forcing every call through
+                // actual Rayon dispatch (rather than the policy falling back to serial for small inputs).
+                // Planning parallelism above the pool size splits every width below into several term
+                // ranges, which the assertion inside the loop pins.
+                let strategy = commonware_parallel::Rayon::new(commonware_utils::NZUsize!(4))
+                    .unwrap()
+                    .with_parallelism(commonware_utils::NZUsize!(32))
+                    .manual();
 
-        Builder::default()
-            .with_seed(0)
-            .with_search_limit(2)
-            .test(|u| {
-                for width in [6, 8, 10] {
-                    let terms = arbitrary_terms(u, 1000, width)?;
-                    assert!(
-                        range_count(terms.len(), num_windows(width), strategy.parallelism()) > 1
-                    );
-                    for n in [0, 1, 300, 600, 1000] {
-                        let chunks =
-                            split_terms(terms[..n].to_vec(), &[128, 128, 128, 128, 128, 128]);
-                        let chunks = refs(&chunks);
-                        let expected = multiscalar_mul_terms_serial(backend, &chunks, width);
-                        let actual = multiscalar_mul(backend, &chunks, width, &strategy);
-                        assert!(points_equal(actual, expected), "n={n} width={width}");
-                    }
-                }
-                Ok(())
-            });
+                Builder::default()
+                    .with_seed(0)
+                    .with_search_limit(2)
+                    .test(|u| {
+                        for width in [6, 8, 10] {
+                            let terms = arbitrary_terms(u, 1000, width)?;
+                            assert!(
+                                range_count(
+                                    terms.len(),
+                                    num_windows(width),
+                                    strategy.parallelism()
+                                ) > 1
+                            );
+                            for n in [0, 1, 300, 600, 1000] {
+                                let chunks = split_terms(
+                                    terms[..n].to_vec(),
+                                    &[128, 128, 128, 128, 128, 128],
+                                );
+                                let chunks = refs(&chunks);
+                                let expected =
+                                    multiscalar_mul_terms_serial(backend, &chunks, width);
+                                let actual = multiscalar_mul(backend, &chunks, width, &strategy);
+                                assert!(points_equal(actual, expected), "n={n} width={width}");
+                            }
+                        }
+                        Ok(())
+                    });
+            }
+        }
+        crate::curve::WithBackend::call(Check, crate::curve::test_backend());
+        crate::curve::with_backend(Check);
     }
 
     #[test]
     fn window_partials_reuse_scratch_across_zero_windows() {
-        let backend = crate::curve::test_backend();
-        let point = GAffine::BASEPOINT;
-        for width in TEST_WIDTHS {
-            let scalar = Scalar::from_u128((1u128 << (2 * width)) | 1);
-            let terms = [Term::new(point, &scalar, width)];
-            let mut buckets = transposed::identity_buckets(num_buckets(width));
-            for (window, expected) in [point.to_extended(), G::IDENTITY, point.to_extended()]
-                .into_iter()
-                .enumerate()
-            {
-                let actual = transposed::window_partial(
-                    backend,
-                    &[&terms],
-                    0,
-                    terms.len(),
-                    window,
-                    width,
-                    &mut buckets,
-                );
-                assert!(
-                    points_equal(actual, expected),
-                    "window={window} width={width}"
-                );
+        struct Check;
+        impl crate::curve::WithBackend for Check {
+            type Output = ();
+            fn call<B: Backend>(self, backend: B) {
+                let point = GAffine::BASEPOINT;
+                for width in TEST_WIDTHS {
+                    let scalar = Scalar::from_u128((1u128 << (2 * width)) | 1);
+                    let terms = [Term::new(point, &scalar, width)];
+                    let mut buckets = transposed::identity_buckets(backend, num_buckets(width));
+                    for (window, expected) in
+                        [point.to_extended(), G::IDENTITY, point.to_extended()]
+                            .into_iter()
+                            .enumerate()
+                    {
+                        let actual = transposed::window_partial(
+                            backend,
+                            &[&terms],
+                            0,
+                            terms.len(),
+                            window,
+                            width,
+                            &mut buckets,
+                        );
+                        assert!(
+                            points_equal(actual, expected),
+                            "window={window} width={width}"
+                        );
+                    }
+                }
             }
         }
+        crate::curve::WithBackend::call(Check, crate::curve::test_backend());
+        crate::curve::with_backend(Check);
     }
 
     /// Splitting a window's bucket fill at an arbitrary global index (deliberately not a slice
@@ -838,7 +620,7 @@ mod tests {
 
                     let nw = num_windows(WIDTH);
                     let mut transposed_windows = vec![G::IDENTITY; nw];
-                    let mut buckets = transposed::identity_buckets(num_buckets(WIDTH));
+                    let mut buckets = transposed::identity_buckets(backend, num_buckets(WIDTH));
                     for (window, partial) in transposed_windows.iter_mut().enumerate() {
                         let left = transposed::window_partial(
                             backend,
@@ -862,7 +644,11 @@ mod tests {
                     }
 
                     assert!(points_equal(
-                        fold_windows(backend, &transposed_windows, WIDTH),
+                        backend.combine_windows(
+                            transposed_windows.into_iter().enumerate(),
+                            nw,
+                            WIDTH
+                        ),
                         expected,
                     ));
                 }

--- a/cryptography/curve25519/src/signing/core/scalar.rs
+++ b/cryptography/curve25519/src/signing/core/scalar.rs
@@ -13,7 +13,7 @@ const L: [u64; 4] = [
 ];
 
 /// `floor(2^512 / L)`, the Barrett reduction constant for reducing a 512-bit value modulo `L`
-/// (see [`barrett_reduce`]). `L` is just over `2^252`, so this is just over `2^260`, five
+/// (see [`barrett_reduce`]). `L` is just over `2^252`, so this is just under `2^260`, five
 /// little-endian 64-bit limbs.
 const MU: [u64; 5] = [
     0xed9ce5a30a2c131b,

--- a/cryptography/curve25519/src/signing/core/scalar.rs
+++ b/cryptography/curve25519/src/signing/core/scalar.rs
@@ -426,45 +426,91 @@ mod tests {
 
     #[test]
     fn signed_digits_reconstruct_value() {
-        const WIDTH: u32 = 6;
-        const N: usize = 256usize.div_ceil(WIDTH as usize) + 1;
+        const N: usize = 256usize.div_ceil(6) + 1;
 
         Builder::default()
             .with_seed(0)
             .with_search_limit(64)
             .test(|u| {
                 let s: Scalar = u.arbitrary()?;
-                let digits = s.signed_digits::<N>(WIDTH);
-
-                let base = Scalar::from_u128(1u128 << WIDTH);
-                let mut reconstructed = Scalar::ZERO;
-                let mut power = Scalar::from_u128(1);
-                for &digit in &digits {
-                    let magnitude = Scalar::from_u128(digit.unsigned_abs() as u128);
-                    let term = power.mul_mod_l(&magnitude);
-                    let term = if digit < 0 { term.neg_mod_l() } else { term };
-                    reconstructed = reconstructed.add_mod_l(&term);
-                    power = power.mul_mod_l(&base);
+                for width in 6..=10 {
+                    let digits = s.signed_digits::<N>(width);
+                    let base = Scalar::from_u128(1u128 << width);
+                    let mut reconstructed = Scalar::ZERO;
+                    let mut power = Scalar::from_u128(1);
+                    for &digit in &digits {
+                        let magnitude = Scalar::from_u128(digit.unsigned_abs() as u128);
+                        let term = power.mul_mod_l(&magnitude);
+                        let term = if digit < 0 { term.neg_mod_l() } else { term };
+                        reconstructed = reconstructed.add_mod_l(&term);
+                        power = power.mul_mod_l(&base);
+                    }
+                    assert_eq!(reconstructed.0, s.0, "width={width}");
                 }
-
-                assert_eq!(reconstructed.0, s.0);
                 Ok(())
             });
     }
 
     #[test]
     fn signed_digits_are_in_range() {
-        const WIDTH: u32 = 6;
-        const N: usize = 256usize.div_ceil(WIDTH as usize) + 1;
-        let half = 1i32 << (WIDTH - 1);
+        const N: usize = 256usize.div_ceil(6) + 1;
 
         Builder::default()
             .with_seed(0)
             .with_search_limit(64)
             .test(|u| {
                 let s: Scalar = u.arbitrary()?;
-                for digit in s.signed_digits::<N>(WIDTH) {
-                    assert!((-half..half).contains(&digit));
+                for width in 6..=10 {
+                    let half = 1i32 << (width - 1);
+                    let digits = s.signed_digits::<N>(width);
+                    for digit in digits {
+                        assert!((-half..half).contains(&digit));
+                    }
+                    let windows = 256usize.div_ceil(width as usize) + 1;
+                    assert!(digits[windows..].iter().all(|&digit| digit == 0));
+                }
+                Ok(())
+            });
+    }
+
+    #[test]
+    fn canonical_decoding_at_order_boundary() {
+        for (limbs, valid) in [
+            ([0; 4], true),
+            (limbs_sub(&L, &[1, 0, 0, 0]), true),
+            (L, false),
+            (super::limbs_add(&L, &[1, 0, 0, 0]), false),
+            ([u64::MAX; 4], false),
+        ] {
+            let bytes = Scalar(limbs).to_bytes();
+            let decoded = Scalar::from_canonical_bytes(&bytes);
+            assert_eq!(decoded.is_some(), valid);
+            if let Some(decoded) = decoded {
+                assert_eq!(decoded.to_bytes(), bytes);
+            }
+        }
+    }
+
+    #[test]
+    fn windows_match_bits_across_limb_boundaries() {
+        Builder::default()
+            .with_seed(0)
+            .with_search_limit(64)
+            .test(|u| {
+                let scalar: Scalar = u.arbitrary()?;
+                let bytes = scalar.to_bytes();
+                for width in 6..=10 {
+                    for index in 0..=256usize.div_ceil(width as usize) {
+                        let mut expected = 0;
+                        for offset in 0..width as usize {
+                            let bit = index * width as usize + offset;
+                            if bit < 256 {
+                                expected |=
+                                    usize::from((bytes[bit / 8] >> (bit % 8)) & 1) << offset;
+                            }
+                        }
+                        assert_eq!(scalar.window(index, width), expected);
+                    }
                 }
                 Ok(())
             });

--- a/cryptography/curve25519/src/signing/core/scalar.rs
+++ b/cryptography/curve25519/src/signing/core/scalar.rs
@@ -24,8 +24,9 @@ const MU: [u64; 5] = [
 ];
 
 /// An integer modulo `L`, always canonically reduced (`< L`).
-#[derive(Copy, Clone, Debug, Zeroize)]
-pub struct Scalar(pub [u64; 4]);
+#[derive(Copy, Clone, Zeroize)]
+#[cfg_attr(test, derive(Debug))]
+pub struct Scalar([u64; 4]);
 
 /// Returns `true` if `a < b`, comparing as 256-bit unsigned integers (little-endian limbs).
 fn limbs_lt(a: &[u64; 4], b: &[u64; 4]) -> bool {
@@ -168,11 +169,7 @@ impl Scalar {
 
     /// Returns the additive inverse modulo `L`.
     pub fn neg_mod_l(&self) -> Self {
-        if self.0 == Self::ZERO.0 {
-            *self
-        } else {
-            Self(limbs_sub(&L, &self.0))
-        }
+        Self(limbs_conditional_sub(&limbs_sub(&L, &self.0), &L))
     }
 
     /// Interprets `bytes` as a little-endian integer and rejects it unless it is already the
@@ -397,6 +394,32 @@ mod tests {
                 let expected = reduce_wide_naive(&bytes);
 
                 assert_eq!(a.mul_mod_l(&b).0, expected.0);
+                Ok(())
+            });
+    }
+
+    #[test]
+    fn neg_mod_l_is_canonical_additive_inverse() {
+        for scalar in [
+            Scalar::ZERO,
+            Scalar::from_u128(1),
+            Scalar(limbs_sub(&L, &[1, 0, 0, 0])),
+        ] {
+            let negative = scalar.neg_mod_l();
+            assert!(limbs_lt(&negative.0, &L));
+            assert_eq!(scalar.add_mod_l(&negative).0, Scalar::ZERO.0);
+            assert_eq!(negative.neg_mod_l().0, scalar.0);
+        }
+
+        Builder::default()
+            .with_seed(0)
+            .with_search_limit(64)
+            .test(|u| {
+                let scalar: Scalar = u.arbitrary()?;
+                let negative = scalar.neg_mod_l();
+                assert!(limbs_lt(&negative.0, &L));
+                assert_eq!(scalar.add_mod_l(&negative).0, Scalar::ZERO.0);
+                assert_eq!(negative.neg_mod_l().0, scalar.0);
                 Ok(())
             });
     }

--- a/cryptography/curve25519/src/signing/core/scalar.rs
+++ b/cryptography/curve25519/src/signing/core/scalar.rs
@@ -87,50 +87,22 @@ fn limbs_sub5(a: &[u64; 5], b: &[u64; 5]) -> [u64; 5] {
     limbs_sub_with_borrow(a, b).0
 }
 
-/// Returns the full 512-bit product `a * b` as eight little-endian 64-bit limbs, via the standard
+/// Returns the full product `a * b` as little-endian 64-bit limbs, via the standard
 /// schoolbook multiply-accumulate-with-carry ("Comba") method.
-fn limbs_mul_wide(a: &[u64; 4], b: &[u64; 4]) -> [u64; 8] {
-    let mut t = [0u64; 8];
-    for i in 0..4 {
+fn limbs_mul_wide<const A: usize, const B: usize, const OUT: usize>(
+    a: &[u64; A],
+    b: &[u64; B],
+) -> [u64; OUT] {
+    const { assert!(OUT == A + B) };
+    let mut t = [0u64; OUT];
+    for i in 0..A {
         let mut carry = 0u128;
-        for j in 0..4 {
+        for j in 0..B {
             let sum = t[i + j] as u128 + (a[i] as u128) * (b[j] as u128) + carry;
             t[i + j] = sum as u64;
             carry = sum >> 64;
         }
-        t[i + 4] = carry as u64;
-    }
-    t
-}
-
-/// Returns the full product `a * b` as ten little-endian 64-bit limbs, via the same
-/// schoolbook method as [`limbs_mul_wide`].
-fn mul5x5(a: &[u64; 5], b: &[u64; 5]) -> [u64; 10] {
-    let mut t = [0u64; 10];
-    for i in 0..5 {
-        let mut carry = 0u128;
-        for j in 0..5 {
-            let sum = t[i + j] as u128 + (a[i] as u128) * (b[j] as u128) + carry;
-            t[i + j] = sum as u64;
-            carry = sum >> 64;
-        }
-        t[i + 5] = carry as u64;
-    }
-    t
-}
-
-/// Returns the full product `a * b` as nine little-endian 64-bit limbs, via the same schoolbook
-/// method as [`limbs_mul_wide`].
-fn mul5x4(a: &[u64; 5], b: &[u64; 4]) -> [u64; 9] {
-    let mut t = [0u64; 9];
-    for i in 0..5 {
-        let mut carry = 0u128;
-        for j in 0..4 {
-            let sum = t[i + j] as u128 + (a[i] as u128) * (b[j] as u128) + carry;
-            t[i + j] = sum as u64;
-            carry = sum >> 64;
-        }
-        t[i + 4] = carry as u64;
+        t[i + B] = carry as u64;
     }
     t
 }
@@ -145,11 +117,11 @@ fn mul5x4(a: &[u64; 5], b: &[u64; 4]) -> [u64; 9] {
 /// at most two trial subtractions of `L` remain to reach the canonical residue.
 fn barrett_reduce(x: [u64; 8]) -> Scalar {
     let q1: [u64; 5] = x[3..8].try_into().expect("slice has 5 elements");
-    let q2 = mul5x5(&q1, &MU);
+    let q2 = limbs_mul_wide::<5, 5, 10>(&q1, &MU);
     let q3: [u64; 5] = q2[5..10].try_into().expect("slice has 5 elements");
 
     let r1: [u64; 5] = x[0..5].try_into().expect("slice has 5 elements");
-    let r2: [u64; 5] = mul5x4(&q3, &L)[0..5]
+    let r2: [u64; 5] = limbs_mul_wide::<5, 4, 9>(&q3, &L)[0..5]
         .try_into()
         .expect("slice has 5 elements");
     let mut r = limbs_sub5(&r1, &r2);
@@ -385,7 +357,7 @@ mod tests {
                 let a: Scalar = u.arbitrary()?;
                 let b: Scalar = u.arbitrary()?;
 
-                let wide = super::limbs_mul_wide(&a.0, &b.0);
+                let wide: [u64; 8] = super::limbs_mul_wide(&a.0, &b.0);
                 let mut bytes = [0u8; 64];
                 for (i, limb) in wide.iter().enumerate() {
                     bytes[i * 8..i * 8 + 8].copy_from_slice(&limb.to_le_bytes());

--- a/cryptography/curve25519/src/signing/core/scalar.rs
+++ b/cryptography/curve25519/src/signing/core/scalar.rs
@@ -25,7 +25,6 @@ const MU: [u64; 5] = [
 
 /// An integer modulo `L`, always canonically reduced (`< L`).
 #[derive(Copy, Clone, Zeroize)]
-#[cfg_attr(test, derive(Debug))]
 pub struct Scalar([u64; 4]);
 
 /// Returns `true` if `a < b`, comparing as 256-bit unsigned integers (little-endian limbs).

--- a/cryptography/curve25519/src/test.rs
+++ b/cryptography/curve25519/src/test.rs
@@ -22,6 +22,10 @@
 #[cfg(test)]
 mod vectors;
 
+/// ZIP215 point encodings shared with the curve property tests.
+#[cfg(test)]
+pub(crate) const ZIP215_POINTS: [[u8; 32]; 14] = vectors::ZIP215_POINTS;
+
 use crate::{
     key_exchange::{PublicKey as ExchangePublicKey, SecretKey},
     signing::{BatchVerifier, Signature, SigningKey, VerifyingKey},

--- a/cryptography/curve25519/src/test.rs
+++ b/cryptography/curve25519/src/test.rs
@@ -30,7 +30,7 @@ use arbitrary::{Arbitrary, Unstructured};
 use commonware_codec::DecodeExt as _;
 use commonware_formatting::hex;
 use commonware_math::algebra::Random as _;
-use commonware_parallel::Sequential;
+use commonware_parallel::{Sequential, Strategy};
 use commonware_utils::{FuzzRng, union_unique};
 use ed25519_consensus::SigningKey as ConsensusSigningKey;
 
@@ -142,7 +142,7 @@ struct SecretBytes([u8; 32]);
 
 impl Arbitrary<'_> for SecretBytes {
     fn arbitrary(u: &mut Unstructured<'_>) -> arbitrary::Result<Self> {
-        let bytes = if u.ratio(3, 4)? {
+        let bytes = if u.ratio(1, 4)? {
             *u.choose(&INTERESTING_SECRET_BYTES)?
         } else {
             u.arbitrary()?
@@ -404,8 +404,23 @@ impl Item {
     }
 
     fn verify(&self) -> bool {
-        self.verifying_key
-            .verify(&self.namespace, &self.message, &self.signature)
+        let actual = self
+            .verifying_key
+            .verify(&self.namespace, &self.message, &self.signature);
+        let decoded = VerifyingKey::decode(self.verifying_key.as_ref()).unwrap();
+        assert_eq!(
+            decoded.verify(&self.namespace, &self.message, &self.signature),
+            actual
+        );
+
+        let signature = ed25519_consensus::Signature::try_from(self.signature.as_ref()).unwrap();
+        let expected = ed25519_consensus::VerificationKey::try_from(self.verifying_key.as_ref())
+            .is_ok_and(|key| {
+                key.verify(&signature, &union_unique(&self.namespace, &self.message))
+                    .is_ok()
+            });
+        assert_eq!(actual, expected, "item: {self:#?}");
+        actual
     }
 }
 
@@ -470,7 +485,25 @@ impl Arbitrary<'_> for Batch {
 
 impl Batch {
     fn run(self) {
-        let expected = !self.items.is_empty() && self.items.iter().all(Item::verify);
+        let mut expected = !self.items.is_empty();
+        for item in &self.items {
+            expected &= item.verify();
+        }
+        assert_eq!(self.verify(&Sequential), expected, "batch: {self:#?}");
+        #[cfg(test)]
+        {
+            let strategy = commonware_parallel::Rayon::new(commonware_utils::NZUsize!(4))
+                .unwrap()
+                .manual();
+            assert_eq!(
+                self.verify(&strategy),
+                expected,
+                "parallel batch: {self:#?}"
+            );
+        }
+    }
+
+    fn verify(&self, strategy: &impl Strategy) -> bool {
         let mut batch = BatchVerifier::new(self.items.len());
         for item in &self.items {
             batch.add(
@@ -481,14 +514,13 @@ impl Batch {
             );
         }
         let SecretBytes(rng_seed) = self.rng_seed;
-        let actual = batch.verify(&mut FuzzRng::new(rng_seed.to_vec()), &Sequential);
-        assert_eq!(actual, expected, "batch: {self:#?}");
+        batch.verify(&mut FuzzRng::new(rng_seed.to_vec()), strategy)
     }
 }
 
 /// Fuzzing operations for public API invariants.
 pub mod fuzz {
-    use super::{Batch, KeyExchange, Signing};
+    use super::{Batch, Item, KeyExchange, Signing};
     use arbitrary::{Arbitrary, Unstructured};
 
     /// A public API fuzzing operation.
@@ -498,6 +530,8 @@ pub mod fuzz {
         BatchMatchesIndividual,
         /// Check that signing agrees with `ed25519-consensus`.
         SigningMatchesConsensus,
+        /// Check that verification agrees with `ed25519-consensus`.
+        VerificationMatchesConsensus,
         /// Check that key exchange agrees with `x25519-dalek`.
         KeyExchangeMatchesDalek,
     }
@@ -508,6 +542,9 @@ pub mod fuzz {
             match self {
                 Self::BatchMatchesIndividual => u.arbitrary::<Batch>()?.run(),
                 Self::SigningMatchesConsensus => u.arbitrary::<Signing>()?.run(),
+                Self::VerificationMatchesConsensus => {
+                    u.arbitrary::<Item>()?.verify();
+                }
                 Self::KeyExchangeMatchesDalek => u.arbitrary::<KeyExchange>()?.run(),
             }
             Ok(())
@@ -534,6 +571,15 @@ pub mod fuzz {
 
     #[cfg(test)]
     #[test]
+    fn minifuzz_verification_matches_consensus() {
+        commonware_invariants::minifuzz::Builder::default()
+            .with_seed(0)
+            .with_search_limit(100)
+            .test(|u| Plan::VerificationMatchesConsensus.run(u));
+    }
+
+    #[cfg(test)]
+    #[test]
     fn minifuzz_key_exchange_matches_dalek() {
         commonware_invariants::minifuzz::Builder::default()
             .with_seed(0)
@@ -551,8 +597,13 @@ mod tests {
             WYCHEPROOF_X25519, ZIP215_POINTS,
         },
     };
-    use crate::{key_exchange::SecretKey, signing::SigningKey};
+    use crate::{
+        key_exchange::SecretKey,
+        signing::{BatchVerifier, SigningKey},
+    };
     use commonware_codec::DecodeExt as _;
+    use commonware_parallel::{Rayon, Sequential, Strategy};
+    use commonware_utils::{NZUsize, test_rng};
 
     #[test]
     fn rfc8032_ed25519_vectors() {
@@ -570,6 +621,11 @@ mod tests {
                 "RFC 8032 test {} signature",
                 vector.name,
             );
+            let signature = Signature::decode(vector.signature.as_slice()).unwrap();
+            let cached = signing_key.verifying_key();
+            let decoded = VerifyingKey::decode(vector.public_key.as_slice()).unwrap();
+            assert!(cached.verify_raw(vector.message, &signature));
+            assert!(decoded.verify_raw(vector.message, &signature));
         }
     }
 
@@ -577,8 +633,21 @@ mod tests {
     fn wycheproof_ed25519_vectors() {
         for vector in WYCHEPROOF_ED25519 {
             let verifying_key = VerifyingKey::decode(vector.public_key.as_slice()).unwrap();
-            let valid = Signature::decode(vector.signature)
-                .is_ok_and(|signature| verifying_key.verify_raw(vector.message, &signature));
+            let valid = Signature::decode(vector.signature).is_ok_and(|signature| {
+                let valid = verifying_key.verify_raw(vector.message, &signature);
+                let batch = || {
+                    let mut batch = BatchVerifier::new(1);
+                    batch.add_raw(vector.message, &verifying_key, &signature);
+                    batch
+                };
+                assert_eq!(
+                    batch().verify(&mut test_rng(), &Sequential),
+                    vector.valid_zip215,
+                    "sequential Wycheproof test {}",
+                    vector.tc_id
+                );
+                valid
+            });
             assert_eq!(
                 valid, vector.valid_zip215,
                 "Wycheproof Ed25519 test {}",
@@ -638,6 +707,9 @@ mod tests {
         const NAMESPACE: &[u8] = b"_COMMONWARE_CRYPTOGRAPHY_CURVE25519_ZIP215_VECTORS";
 
         let message = b"Zcash";
+        let parallel = Rayon::new(NZUsize!(4)).unwrap().manual();
+        let mut all_sequential = BatchVerifier::new(196);
+        let mut all_parallel = BatchVerifier::new(196);
 
         // These are the 196 ZIP215 test vectors: every pairing of the eight canonical
         // low-order encodings and their six non-canonical aliases. With s = 0, each pair
@@ -653,7 +725,17 @@ mod tests {
                     verifying_key.verify(NAMESPACE, message, &signature),
                     "ZIP215 vector failed for A={public_key_bytes:?}, R={r_bytes:?}",
                 );
+                let batch = || {
+                    let mut batch = BatchVerifier::new(1);
+                    batch.add(NAMESPACE, message, &verifying_key, &signature);
+                    batch
+                };
+                assert!(batch().verify(&mut test_rng(), &Sequential));
+                all_sequential.add(NAMESPACE, message, &verifying_key, &signature);
+                all_parallel.add(NAMESPACE, message, &verifying_key, &signature);
             }
         }
+        assert!(all_sequential.verify(&mut test_rng(), &Sequential));
+        assert!(all_parallel.verify(&mut test_rng(), &parallel));
     }
 }

--- a/cryptography/curve25519/src/test.rs
+++ b/cryptography/curve25519/src/test.rs
@@ -414,7 +414,8 @@ impl Item {
         let decoded = VerifyingKey::decode(self.verifying_key.as_ref()).unwrap();
         assert_eq!(
             decoded.verify(&self.namespace, &self.message, &self.signature),
-            actual
+            actual,
+            "item: {self:#?}"
         );
 
         let signature = ed25519_consensus::Signature::try_from(self.signature.as_ref()).unwrap();
@@ -494,6 +495,8 @@ impl Batch {
             expected &= item.verify();
         }
         assert_eq!(self.verify(&Sequential), expected, "batch: {self:#?}");
+
+        // The fuzz target stays single-threaded, so only the unit test exercises the pool.
         #[cfg(test)]
         {
             let strategy = commonware_parallel::Rayon::new(commonware_utils::NZUsize!(4))

--- a/cryptography/curve25519/src/test.rs
+++ b/cryptography/curve25519/src/test.rs
@@ -31,7 +31,7 @@ use crate::{
     signing::{BatchVerifier, Signature, SigningKey, VerifyingKey},
 };
 use arbitrary::{Arbitrary, Unstructured};
-use commonware_codec::DecodeExt as _;
+use commonware_codec::{DecodeExt as _, Encode as _, types::lazy::Lazy};
 use commonware_formatting::hex;
 use commonware_math::algebra::Random as _;
 use commonware_parallel::{Sequential, Strategy};
@@ -309,7 +309,7 @@ impl KeyExchange {
 struct Item {
     namespace: Vec<u8>,
     message: Vec<u8>,
-    verifying_key: VerifyingKey,
+    verifying_key: Lazy<VerifyingKey>,
     signature: Signature,
 }
 
@@ -321,7 +321,7 @@ impl Item {
             None => u.arbitrary()?,
         };
         let signing_key = SigningKey::decode(seed.as_slice()).unwrap();
-        let verifying_key = signing_key.verifying_key();
+        let verifying_key = Lazy::new(signing_key.verifying_key());
         let signature = signing_key.sign(&namespace, &message);
         Ok(Self {
             namespace,
@@ -334,7 +334,7 @@ impl Item {
     fn low_order(u: &mut Unstructured<'_>) -> arbitrary::Result<Self> {
         let Payload { namespace, message } = u.arbitrary()?;
         let bytes = u.choose(&LOW_ORDER_ENCODINGS)?;
-        let verifying_key = VerifyingKey::decode(bytes.as_slice()).unwrap();
+        let verifying_key = Lazy::deferred(&mut bytes.as_slice(), ());
         let mut signature = [0; 64];
         signature[..32].copy_from_slice(u.choose(&LOW_ORDER_ENCODINGS)?);
         Ok(Self {
@@ -364,7 +364,7 @@ impl Item {
         Ok(Self {
             namespace,
             message,
-            verifying_key: VerifyingKey::decode(verifying_key.as_slice()).unwrap(),
+            verifying_key: Lazy::deferred(&mut verifying_key.as_slice(), ()),
             signature: Signature::decode(signature.as_slice()).unwrap(),
         })
     }
@@ -375,7 +375,7 @@ impl Item {
             1 => mutate_bytes(&mut self.message, u)?,
             2 => {
                 let EncodedPoint(bytes) = u.arbitrary()?;
-                self.verifying_key = VerifyingKey::decode(bytes.as_slice()).unwrap();
+                self.verifying_key = Lazy::deferred(&mut bytes.as_slice(), ());
             }
             3 => {
                 let EncodedPoint(r) = u.arbitrary()?;
@@ -408,22 +408,29 @@ impl Item {
     }
 
     fn verify(&self) -> bool {
-        let actual = self
-            .verifying_key
-            .verify(&self.namespace, &self.message, &self.signature);
-        let decoded = VerifyingKey::decode(self.verifying_key.as_ref()).unwrap();
+        let bytes = self.verifying_key.encode();
+        let decoded = VerifyingKey::decode(bytes.clone());
+        let consensus_key = ed25519_consensus::VerificationKey::try_from(bytes.as_ref());
         assert_eq!(
-            decoded.verify(&self.namespace, &self.message, &self.signature),
+            decoded.is_ok(),
+            consensus_key.is_ok(),
+            "public key decoding: {self:#?}"
+        );
+        let cached = self.verifying_key.get();
+        assert_eq!(cached, decoded.as_ref().ok(), "cached key: {self:#?}");
+        let actual =
+            cached.is_some_and(|key| key.verify(&self.namespace, &self.message, &self.signature));
+        assert_eq!(
+            decoded.is_ok_and(|key| key.verify(&self.namespace, &self.message, &self.signature)),
             actual,
             "item: {self:#?}"
         );
 
         let signature = ed25519_consensus::Signature::try_from(self.signature.as_ref()).unwrap();
-        let expected = ed25519_consensus::VerificationKey::try_from(self.verifying_key.as_ref())
-            .is_ok_and(|key| {
-                key.verify(&signature, &union_unique(&self.namespace, &self.message))
-                    .is_ok()
-            });
+        let expected = consensus_key.is_ok_and(|key| {
+            key.verify(&signature, &union_unique(&self.namespace, &self.message))
+                .is_ok()
+        });
         assert_eq!(actual, expected, "item: {self:#?}");
         actual
     }
@@ -489,21 +496,48 @@ impl Arbitrary<'_> for Batch {
 }
 
 impl Batch {
-    fn run(self) {
+    fn run(mut self) {
+        for item in &mut self.items {
+            item.verifying_key = Lazy::deferred(&mut item.verifying_key.encode(), ());
+        }
+
+        // Keep independent deferred wrappers so both strategies exercise batch decoding before
+        // individual verification initializes their caches.
+        #[cfg(test)]
+        let parallel_batch = Self {
+            rng_seed: self.rng_seed,
+            items: self.items.clone(),
+        };
+        let cold_sequential = self.verify(&Sequential);
+        #[cfg(test)]
+        let (strategy, cold_parallel) = {
+            let strategy = commonware_parallel::Rayon::new(commonware_utils::NZUsize!(4))
+                .unwrap()
+                .manual();
+            let verified = parallel_batch.verify(&strategy);
+            (strategy, verified)
+        };
+
         let mut expected = !self.items.is_empty();
         for item in &self.items {
             expected &= item.verify();
         }
+        assert_eq!(cold_sequential, expected, "cold batch: {self:#?}");
         assert_eq!(self.verify(&Sequential), expected, "batch: {self:#?}");
 
         // The fuzz target stays single-threaded, so only the unit test exercises the pool.
         #[cfg(test)]
         {
-            let strategy = commonware_parallel::Rayon::new(commonware_utils::NZUsize!(4))
-                .unwrap()
-                .manual();
+            assert_eq!(cold_parallel, expected, "cold parallel batch: {self:#?}");
+            for (item, parallel_item) in self.items.iter().zip(&parallel_batch.items) {
+                assert_eq!(
+                    item.verifying_key.get(),
+                    parallel_item.verifying_key.get(),
+                    "parallel cached key: {self:#?}"
+                );
+            }
             assert_eq!(
-                self.verify(&strategy),
+                parallel_batch.verify(&strategy),
                 expected,
                 "parallel batch: {self:#?}"
             );
@@ -513,7 +547,7 @@ impl Batch {
     fn verify(&self, strategy: &impl Strategy) -> bool {
         let mut batch = BatchVerifier::new(self.items.len());
         for item in &self.items {
-            batch.add(
+            batch.add_lazy(
                 &item.namespace,
                 &item.message,
                 &item.verifying_key,
@@ -521,7 +555,13 @@ impl Batch {
             );
         }
         let SecretBytes(rng_seed) = self.rng_seed;
-        batch.verify(&mut FuzzRng::new(rng_seed.to_vec()), strategy)
+        let verified = batch.verify(&mut FuzzRng::new(rng_seed.to_vec()), strategy);
+        if verified {
+            for item in &self.items {
+                assert!(matches!(item.verifying_key.get_cached(), Some(Some(_))));
+            }
+        }
+        verified
     }
 }
 
@@ -608,9 +648,39 @@ mod tests {
         key_exchange::SecretKey,
         signing::{BatchVerifier, SigningKey},
     };
-    use commonware_codec::DecodeExt as _;
+    use commonware_codec::{DecodeExt as _, types::lazy::Lazy};
     use commonware_parallel::{Rayon, Sequential, Strategy};
     use commonware_utils::{NZUsize, test_rng};
+    use rand_core::Rng as _;
+
+    #[test]
+    fn public_key_decoding_matches_consensus() {
+        let mut malformed = [0; 32];
+        malformed[0] = 2;
+        assert!(VerifyingKey::decode(malformed.as_slice()).is_err());
+
+        let mut rng = test_rng();
+        let random = (0..256).map(|_| {
+            let mut bytes = [0; 32];
+            rng.fill_bytes(&mut bytes);
+            bytes
+        });
+        for bytes in ZIP215_POINTS.into_iter().chain([malformed]).chain(random) {
+            let decoded = VerifyingKey::decode(bytes.as_slice());
+            let consensus = ed25519_consensus::VerificationKey::try_from(bytes.as_slice());
+            assert_eq!(decoded.is_ok(), consensus.is_ok(), "public key: {bytes:?}");
+            if let Ok(key) = decoded {
+                assert_eq!(key.as_ref(), bytes, "public key encoding must be preserved");
+            }
+        }
+
+        // Both decoders require the complete input to be exactly one public key.
+        for len in [0, 1, 31, 33, 64] {
+            let bytes = vec![0; len];
+            assert!(VerifyingKey::decode(bytes.as_slice()).is_err());
+            assert!(ed25519_consensus::VerificationKey::try_from(bytes.as_slice()).is_err());
+        }
+    }
 
     #[test]
     fn rfc8032_ed25519_vectors() {
@@ -639,22 +709,29 @@ mod tests {
     #[test]
     fn wycheproof_ed25519_vectors() {
         for vector in WYCHEPROOF_ED25519 {
-            let verifying_key = VerifyingKey::decode(vector.public_key.as_slice()).unwrap();
+            let verifying_key =
+                Lazy::<VerifyingKey>::deferred(&mut vector.public_key.as_slice(), ());
             let valid = Signature::decode(vector.signature).is_ok_and(|signature| {
-                let valid = verifying_key.verify_raw(vector.message, &signature);
-                let batch = || {
-                    let mut batch = BatchVerifier::new(1);
-                    batch.add_raw(vector.message, &verifying_key, &signature);
-                    batch
-                };
+                let mut batch = BatchVerifier::new(1);
+                batch.add_lazy_raw(vector.message, &verifying_key, &signature);
                 assert_eq!(
-                    batch().verify(&mut test_rng(), &Sequential),
+                    batch.verify(&mut test_rng(), &Sequential),
                     vector.valid_zip215,
                     "sequential Wycheproof test {}",
                     vector.tc_id
                 );
-                valid
+                verifying_key
+                    .get()
+                    .is_some_and(|key| key.verify_raw(vector.message, &signature))
             });
+            assert_eq!(
+                verifying_key.get(),
+                VerifyingKey::decode(vector.public_key.as_slice())
+                    .as_ref()
+                    .ok(),
+                "Wycheproof cached key {}",
+                vector.tc_id,
+            );
             assert_eq!(
                 valid, vector.valid_zip215,
                 "Wycheproof Ed25519 test {}",


### PR DESCRIPTION
Stacked on #4695.

Batch verification initializes the caller's retained `Lazy<VerifyingKey>` values from its SIMD point-decoding results. Later access and verification reuse those decoded keys.

- Add type-owned `DecodeWith` contexts and `Lazy::get_with` / `get_cached`, sharing the existing `Lazy` initialization state and preserving ordinary decoding outcomes, original encodings, and cached failures.
- Borrow lazy keys through `BatchVerifier::add_lazy`. Group identical encodings, populate every retained key, and process undecoded points and already decoded keys in one parallel pass. The keys themselves hold the results in affine form for MSM.
- Validate bare `VerifyingKey` decoding consistently with the existing Ed25519 implementation. Deferred validation is explicit through `Lazy`. Update the key conformance fixture for the validated input population; its 32-byte encoding is unchanged.

Validation: 143 codec tests, 58 curve tests with all features and without default features, four conformance checks, Clippy, documentation/doctests, formatting, stability checks, WASM build, and x86 cross-compilation. Differential checks cover ZIP215 encodings, malformed inputs, and cold/warm sequential and parallel verification. Native execution and performance measurements in this PR are on ARM.

Measured on Apple M5 Pro (6 performance and 12 efficiency cores), Rust 1.98.1 / LLVM 22.1.8, with runtime backend dispatch. Each cell compares the mean latency of two runs per build, serialized parent/candidate/candidate/parent, using 20 samples, one second of warmup, and a three-second target measurement period. One worker means `Sequential`.

These valid-batch fixtures have distinct 32-byte messages. Timing includes queueing and verification, excluding fixture generation and construction/destruction of retained lazy values. The baseline is #4695 at `a25b9f362874b025b1c743b26750959b77932c33`, with the same queue-and-verify harness using its regular `add` API. Deferred keys start uninitialized; decoded keys already contain their validated points. Initial key decoding and later application access are outside this measurement.

Latency reductions are positive when faster; negative values are regressions. Deferred-key overhead reaches 4.3% in this matrix. Already decoded distinct keys reduce latency by 10.8-19.7%. Small differences remain sensitive to measurement variation, and these results do not establish x86 performance.

| Signatures | Signing keys | Workers | Parent (ms) | Deferred keys (ms) | Reduction | Decoded keys (ms) | Reduction |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 1,024 | 1,024 | 1 | 7.127 | 7.122 | +0.06% | 5.835 | +18.13% |
| 1,024 | 1,024 | 8 | 1.497 | 1.497 | -0.02% | 1.335 | +10.80% |
| 1,024 | 64 | 1 | 3.720 | 3.678 | +1.14% | 3.595 | +3.37% |
| 1,024 | 64 | 8 | 0.981 | 1.023 | -4.28% | 0.979 | +0.19% |
| 1,024 | 1 | 1 | 3.383 | 3.458 | -2.23% | 3.432 | -1.47% |
| 1,024 | 1 | 8 | 0.901 | 0.924 | -2.61% | 0.909 | -0.92% |
| 16,384 | 16,384 | 1 | 94.380 | 97.439 | -3.24% | 75.781 | +19.71% |
| 16,384 | 16,384 | 8 | 17.084 | 17.770 | -4.02% | 14.781 | +13.48% |
| 16,384 | 64 | 1 | 44.783 | 45.757 | -2.18% | 44.402 | +0.85% |
| 16,384 | 64 | 8 | 9.278 | 9.645 | -3.96% | 9.106 | +1.86% |
| 16,384 | 1 | 1 | 43.105 | 43.141 | -0.08% | 42.873 | +0.54% |
| 16,384 | 1 | 8 | 8.783 | 8.860 | -0.88% | 8.734 | +0.56% |

<details>
<summary>Existing regular batch API</summary>

The existing benchmark uses distinct signing keys and times verification only, with verifier construction outside timing. The regular API remains within 1.8% of the parent in these checks.

| Signatures | Workers | Parent (ms) | Candidate (ms) | Reduction |
| ---: | ---: | ---: | ---: | ---: |
| 1,000 | 1 | 6.891 | 6.880 | +0.17% |
| 1,000 | 8 | 1.490 | 1.516 | -1.75% |
| 16,384 | 1 | 95.085 | 95.036 | +0.05% |
| 16,384 | 8 | 16.230 | 16.330 | -0.62% |

</details>
