### PR TITLE
[storage/qmdb] Move values out of Any batch reads

### DIFF
--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -1721,7 +1721,7 @@ where
         unresolved: Vec<PendingRead<'_, U::Key>>,
         db: &Db<F, E, C, I, H, U, N, S>,
         results: &mut [Option<U::Value>],
-        map: impl Fn(&U, Location<F>) -> T + Send + Sync,
+        map: impl Fn(U, Location<F>) -> T + Send + Sync,
         mut apply: impl FnMut(usize, T) -> U::Value,
     ) -> Result<(), crate::qmdb::Error<F>>
     where
@@ -1787,7 +1787,7 @@ where
             unresolved,
             db,
             &mut results,
-            |data, _| data.value().clone(),
+            |data, _| data.into_value(),
             |_, value| value,
         )
         .await?;
@@ -1880,7 +1880,10 @@ where
             unresolved,
             db,
             &mut results,
-            |data, loc| (data.value().clone(), loc, data.cached()),
+            |data, loc| {
+                let payload = data.cached();
+                (data.into_value(), loc, payload)
+            },
             |slot, (value, loc, payload)| {
                 resolutions[slot] = Some((StagedLoc::Committed(loc), payload));
                 value

--- a/storage/src/qmdb/any/db.rs
+++ b/storage/src/qmdb/any/db.rs
@@ -29,6 +29,11 @@ use std::{collections::HashMap, sync::Arc};
 /// keys plus `(global key index, position)` pairs for page-cache misses.
 type ShardReads<T> = (Vec<Option<T>>, Vec<(usize, u64)>);
 
+/// Whether two `(key index, position)` candidates share a position.
+fn same_position(a: &(usize, u64), b: &(usize, u64)) -> bool {
+    a.1 == b.1
+}
+
 /// Type alias for the authenticated journal used by [Db].
 pub(crate) type AuthenticatedLog<F, E, C, H, S> = authenticated::Journal<F, E, C, H, S>;
 
@@ -229,16 +234,16 @@ where
         &self,
         keys: &[&U::Key],
     ) -> Result<Vec<Option<U::Value>>, crate::qmdb::Error<F>> {
-        self.get_many_map(keys, |data, _| data.value().clone())
-            .await
+        self.get_many_map(keys, |data, _| data.into_value()).await
     }
 
-    /// Like [`Self::get_many`] but maps each matched update through `map`, which also
-    /// receives the committed location the update was read from.
+    /// Like [`Self::get_many`] but maps each matched update through `map`, which takes the
+    /// update by value along with the committed location it was read from. A key repeated in
+    /// `keys` receives a clone of its update in every slot but the last.
     pub(crate) async fn get_many_map<T: Send>(
         &self,
         keys: &[&U::Key],
-        map: impl Fn(&U, Location<F>) -> T + Send + Sync,
+        map: impl Fn(U, Location<F>) -> T + Send + Sync,
     ) -> Result<Vec<Option<T>>, crate::qmdb::Error<F>> {
         if keys.is_empty() {
             return Ok(Vec::new());
@@ -282,11 +287,15 @@ where
         misses.sort_unstable_by_key(|&(_, pos)| pos);
         let positions = Self::dedup_positions(&misses);
         let ops = self.log.read_many(&positions).await?;
+        assert_eq!(
+            ops.len(),
+            positions.len(),
+            "read_many returns one operation per position"
+        );
         Self::match_read_ops(
             keys,
             &misses,
-            &positions,
-            |i| Some(&ops[i]),
+            ops.into_iter().map(Some),
             &map,
             &mut results,
             |_, pos| unreachable!("read_many returns one operation per position, pos={pos}"),
@@ -301,7 +310,7 @@ where
     fn resolve_cached<T: Send>(
         &self,
         keys: &[&U::Key],
-        map: &(impl Fn(&U, Location<F>) -> T + Send + Sync),
+        map: &(impl Fn(U, Location<F>) -> T + Send + Sync),
         base: usize,
     ) -> ShardReads<T> {
         // Probe the in-memory index. Each key may map to multiple locations due to hash
@@ -315,13 +324,17 @@ where
         let positions = Self::dedup_positions(&candidates);
 
         let served = self.log.try_read_many_sync(&positions);
+        assert_eq!(
+            served.len(),
+            positions.len(),
+            "try_read_many_sync returns one slot per position"
+        );
         let mut results: Vec<Option<T>> = (0..keys.len()).map(|_| None).collect();
         let mut misses: Vec<(usize, u64)> = Vec::new();
         Self::match_read_ops(
             keys,
             &candidates,
-            &positions,
-            |i| served[i].as_ref(),
+            served.into_iter(),
             map,
             &mut results,
             |key_idx, pos| misses.push((base + key_idx, pos)),
@@ -331,45 +344,51 @@ where
 
     /// Collapse position-sorted `(key index, position)` candidates into deduplicated positions.
     fn dedup_positions(candidates: &[(usize, u64)]) -> Vec<u64> {
-        let mut positions = Vec::with_capacity(candidates.len());
-        for &(_, pos) in candidates {
-            if positions.last() != Some(&pos) {
-                positions.push(pos);
-            }
-        }
-        positions
+        candidates
+            .chunk_by(same_position)
+            .map(|group| group[0].1)
+            .collect()
     }
 
-    /// Match operations read for deduplicated `positions` back to their position-sorted
-    /// `(key index, position)` candidates, filling each unresolved key slot whose operation
-    /// carries its exact key. `op` returns the operation read for a deduplicated position
-    /// index, or `None` when the page cache could not serve it, which is reported to `on_miss`
-    /// with the candidate's key index and position.
-    fn match_read_ops<'o, T>(
+    /// Match the operations read for the deduplicated positions of position-sorted
+    /// `(key index, position)` candidates back to those candidates, filling each unresolved key
+    /// slot whose operation carries its exact key. `ops` yields one slot per deduplicated
+    /// position, in order: the operation read there, or `None` when the page cache could not
+    /// serve it, which is reported to `on_miss` with each candidate's key index and position.
+    fn match_read_ops<T>(
         keys: &[&U::Key],
         candidates: &[(usize, u64)],
-        positions: &[u64],
-        op: impl Fn(usize) -> Option<&'o Operation<F, U>>,
-        map: &impl Fn(&U, Location<F>) -> T,
+        ops: impl Iterator<Item = Option<Operation<F, U>>>,
+        map: &impl Fn(U, Location<F>) -> T,
         results: &mut [Option<T>],
         mut on_miss: impl FnMut(usize, u64),
-    ) where
-        F: 'o,
-        U: 'o,
-    {
-        let mut op_idx = 0;
-        for &(key_idx, pos) in candidates {
-            while positions[op_idx] < pos {
-                op_idx += 1;
-            }
-            match op(op_idx) {
-                Some(Operation::Update(data)) => {
-                    if results[key_idx].is_none() && data.key() == keys[key_idx] {
-                        results[key_idx] = Some(map(data, Location::new(pos)));
-                    }
+    ) {
+        for (group, op) in candidates.chunk_by(same_position).zip(ops) {
+            let pos = group[0].1;
+            let Some(op) = op else {
+                for &(key_idx, _) in group {
+                    on_miss(key_idx, pos);
                 }
-                Some(_) => panic!("location does not reference update operation. loc={pos}"),
-                None => on_miss(key_idx, pos),
+                continue;
+            };
+            let Operation::Update(data) = op else {
+                panic!("location does not reference update operation. loc={pos}");
+            };
+            // The candidates sharing this position match the update only for repeated input
+            // keys. Defer each match so every slot but the last takes a clone and the last
+            // takes the update itself.
+            let loc = Location::new(pos);
+            let mut pending = None;
+            for &(key_idx, _) in group {
+                if results[key_idx].is_some() || data.key() != keys[key_idx] {
+                    continue;
+                }
+                if let Some(prev) = pending.replace(key_idx) {
+                    results[prev] = Some(map(data.clone(), loc));
+                }
+            }
+            if let Some(last) = pending {
+                results[last] = Some(map(data, loc));
             }
         }
     }

--- a/storage/src/qmdb/any/db.rs
+++ b/storage/src/qmdb/any/db.rs
@@ -30,7 +30,7 @@ use std::{collections::HashMap, sync::Arc};
 type ShardReads<T> = (Vec<Option<T>>, Vec<(usize, u64)>);
 
 /// Whether two `(key index, position)` candidates share a position.
-fn same_position(a: &(usize, u64), b: &(usize, u64)) -> bool {
+const fn same_position(a: &(usize, u64), b: &(usize, u64)) -> bool {
     a.1 == b.1
 }
 
@@ -344,10 +344,9 @@ where
 
     /// Collapse position-sorted `(key index, position)` candidates into deduplicated positions.
     fn dedup_positions(candidates: &[(usize, u64)]) -> Vec<u64> {
-        candidates
-            .chunk_by(same_position)
-            .map(|group| group[0].1)
-            .collect()
+        let mut positions = Vec::with_capacity(candidates.len());
+        positions.extend(candidates.chunk_by(same_position).map(|group| group[0].1));
+        positions
     }
 
     /// Match the operations read for the deduplicated positions of position-sorted
@@ -374,6 +373,7 @@ where
             let Operation::Update(data) = op else {
                 panic!("location does not reference update operation. loc={pos}");
             };
+
             // The candidates sharing this position match the update only for repeated input
             // keys. Defer each match so every slot but the last takes a clone and the last
             // takes the update itself.

--- a/storage/src/qmdb/any/unordered/fixed.rs
+++ b/storage/src/qmdb/any/unordered/fixed.rs
@@ -447,6 +447,11 @@ pub(crate) mod test {
             for _ in 0..100 {
                 keys.push(Digest::random(&mut rng));
             }
+            // Repeat present and absent keys, some more than once, so one operation resolves
+            // several slots in both the cached pass and the miss fallback.
+            let repeats: Vec<Digest> = keys.iter().step_by(37).copied().collect();
+            keys.extend_from_slice(&repeats);
+            keys.extend_from_slice(&repeats[..20]);
             let refs: Vec<&Digest> = keys.iter().collect();
             let fused = db.get_many(&refs).await.unwrap();
             assert_eq!(fused.len(), keys.len());

--- a/storage/src/qmdb/any/unordered/fixed.rs
+++ b/storage/src/qmdb/any/unordered/fixed.rs
@@ -447,6 +447,7 @@ pub(crate) mod test {
             for _ in 0..100 {
                 keys.push(Digest::random(&mut rng));
             }
+
             // Repeat present and absent keys, some more than once, so one operation resolves
             // several slots in both the cached pass and the miss fallback.
             let repeats: Vec<Digest> = keys.iter().step_by(37).copied().collect();


### PR DESCRIPTION
Stacked on #4677.

`Any::get_many` and the batch read paths still cloned every resolved value: `get_many_map` handed each matched update to its `map` closure by reference so that one operation could serve several candidates. Both read passes already own the operations they decode, so the matching step now walks candidates by position and passes each update to `map` by value. A key repeated in the input receives a clone in every slot but the last.

For variable-size values this removes one copy per resolved key on the batch read path that `Current::get_many` and the batch fallthrough share. Fixed-size values are unaffected. The fused sharded `get_many` test now includes repeated keys so one operation resolves several slots in both the cached pass and the miss fallback.
