### PR TITLE
[runtime] Document native write coalescing results

### DIFF
--- a/experiments/write-coalescing/BACKEND_PROTOCOL.md
+++ b/experiments/write-coalescing/BACKEND_PROTOCOL.md
@@ -1,0 +1,210 @@
+# Measurement protocol and reproduction
+
+The decision addressed here is whether coalescing merits further investigation
+in the ordinary Tokio storage backend. The experiment compares three fixed
+policies while preserving input contents, completed work, concurrency, and the
+backend's selected synchronization contract.
+
+## Use the archived experiment checkout
+
+This document and the results report do not include the benchmark source or
+raw data. The complete experiment is preserved in the author's fork at commit
+`918838255e1d4bf106356e1d16118c28506467cc`.
+
+Start a separate checkout before running any command below:
+
+```bash
+git clone --no-checkout https://github.com/diegomrsantos/monorepo.git monorepo-write-coalescing
+cd monorepo-write-coalescing
+git checkout --detach 918838255e1d4bf106356e1d16118c28506467cc
+```
+
+All commands below run from the root of that archive checkout, not from an
+upstream checkout containing only these documents. The archived Rust sources,
+plans, and data retain the identities recorded in the build manifests.
+
+## Policies and workloads
+
+[build_backends.py](https://github.com/diegomrsantos/monorepo/blob/918838255e1d4bf106356e1d16118c28506467cc/experiments/write-coalescing/build_backends.py) builds the unchanged backend and two
+experimental variants. Heap coalescing calls `IoBufs::coalesce()` inside the
+existing blocking closure. Pool coalescing calls `coalesce_with_pool()` at the
+same location and captures the storage pool. The helper records exact patches,
+source hashes, build commands, and executable hashes, and restores the original
+backend in a `finally` block. Run it in a disposable checkout.
+
+All matrix commands pass `--strategy vectored` to the harness. The chosen
+binary supplies the policy, so the caller does not perform another coalescing
+step. Allocation, copying, destruction, and pool return remain inside timing.
+
+| Dimension | Frozen main plan |
+| --- | --- |
+| Total bytes per write | 4096, 65536, 1048576 |
+| Nonempty fragments | 1, 8, 32, 128, 256, 1024, 1025 |
+| Main source layout | One allocation divided into nearly equal borrowed slices |
+| Concurrency | One caller with one outstanding write |
+| File | 64 MiB, populated and synchronized before cyclic overwrites |
+| Trial | Fresh process, 200 ms warmup, requested 1000 ms measured interval |
+| Repetitions | Seven per case and variant |
+| Separation | 250 ms between trials |
+
+The 21 primary cases use buffered completion. Six controls synchronize each
+write, three use separate allocations for fragments, and two rotate through
+16 MiB of input. The [main plan](https://github.com/diegomrsantos/monorepo/blob/918838255e1d4bf106356e1d16118c28506467cc/experiments/write-coalescing/plans/backend-grid.json) contains all 32 cases.
+The [smoke plan](https://github.com/diegomrsantos/monorepo/blob/918838255e1d4bf106356e1d16118c28506467cc/experiments/write-coalescing/plans/backend-smoke.json) covers the same cases with shorter
+runs. The [baseline pilot](https://github.com/diegomrsantos/monorepo/blob/918838255e1d4bf106356e1d16118c28506467cc/experiments/write-coalescing/plans/backend-aa.json) compares the identical
+baseline executable under two labels in six blocks for each of three cases.
+
+Each measured operation clones its prepared fragment list, awaits the real
+`Blob::write_at`, and drops its buffers. Source generation and file preparation
+precede timing. Warmup uses different contents and finishes with synchronization.
+Final synchronization and readback follow timing for buffered cases. In
+synchronized cases, each measured write awaits the existing sync contract.
+
+Completed bytes are divided by actual elapsed time, including deadline
+overshoot. Process CPU time covers all process threads. Source cloning is a
+common cost that a producer transferring ownership might avoid.
+
+## Audit and analyze the existing measurements
+
+Run from the repository root. Python's standard library is sufficient for the
+audit and analysis. No benchmark executable or rented machine is needed.
+
+```bash
+experiment=experiments/write-coalescing
+output=$(mktemp -d)
+
+python3 "$experiment/check_archives.py" . "$output/archive-audit.json"
+
+python3 "$experiment/validate_native.py" \
+  "$experiment/results/native/linux/grid.jsonl" \
+  --plan "$experiment/plans/backend-grid.json" \
+  --manifest "$experiment/results/native/linux/binaries/manifest.json" \
+  --repo . --output "$output/linux-validation.json"
+python3 "$experiment/validate_native.py" \
+  "$experiment/results/native/macos/grid.jsonl" \
+  --plan "$experiment/plans/backend-grid.json" \
+  --manifest "$experiment/results/native/macos/manifest.json" \
+  --repo . --output "$output/macos-validation.json"
+
+python3 "$experiment/analyze_native.py" \
+  "$experiment/results/native/linux/grid.jsonl" \
+  --output "$output/linux-summary.json"
+python3 "$experiment/analyze_native.py" \
+  "$experiment/results/native/macos/grid.jsonl" \
+  --output "$output/macos-summary.json"
+
+python3 -m unittest discover -s "$experiment" -p 'test_*.py'
+rustc +1.98.0 --edition=2024 --test \
+  runtime/src/storage/benches/coalescing_checks.rs \
+  -o "$output/coalescing-checks"
+"$output/coalescing-checks"
+```
+
+[check_archives.py](https://github.com/diegomrsantos/monorepo/blob/918838255e1d4bf106356e1d16118c28506467cc/experiments/write-coalescing/check_archives.py) audits all nine retained datasets, covering
+1,716 trials, 143 paired comparisons, the main grids' measured source hashes,
+all six experimental patch hashes, and the inventory of 180 archived Linux
+correctness cases. It selects the matching manifest for each dataset, including
+the earlier macOS pilot. Its JSON output records each checked patch and manifest.
+The correctness audit checks retained records; it does not rerun fault injection.
+
+The complete archive command requires the measured sources and dependency
+lockfile. The individual validator's optional `--repo` check expects those same
+files. The source files and runtime manifest supplied with this experiment
+match that record. After a source change, retain the measured revision for the
+complete audit, or use the individual validator without `--repo` to audit only
+the recorded data. Never relabel historical measurements as results for a
+different revision.
+
+The audit expects a complete uniform plan with one writer. The main grid, smoke
+plan, and baseline pilot have that contract. Separate paged fixtures exercise
+correctness through the real paged writer.
+
+[analyze_native.py](https://github.com/diegomrsantos/monorepo/blob/918838255e1d4bf106356e1d16118c28506467cc/experiments/write-coalescing/analyze_native.py) reports geometric means of paired ratios,
+with each candidate value divided by its baseline value, and percentile 95%
+bootstrap intervals from 10,000 resamples of paired blocks. Analyze each platform
+separately. Absolute rates
+are medians; their quotient is not the paired estimator. Fewer than five blocks
+produce an estimate without a confidence interval.
+
+[render_native.py](https://github.com/diegomrsantos/monorepo/blob/918838255e1d4bf106356e1d16118c28506467cc/experiments/write-coalescing/render_native.py) regenerates the complete grid's table and
+figures from the platform summaries. It targets the seven repetition main grid.
+Its plotting dependency is Matplotlib; the archived figure used version 3.11.1.
+The raw measurements and numerical analysis do not require Matplotlib.
+
+## Build and collect a new comparison
+
+Use Rust 1.98.0 and locked dependencies. The harness follows the existing
+standalone storage benchmark pattern. It measures completed I/O over its own
+interval, independently of Criterion dashboard output.
+
+Set `work` to a new directory on the filesystem to measure. The 64 MiB fixture
+and rotating sources are bounded, but compiler output needs several GiB.
+Record hardware, filesystem, storage, power, CPU placement, and background
+activity. Use consistent affinity for all commands when applying a CPU mask.
+
+```bash
+experiment=experiments/write-coalescing
+work=/absolute/path/on/the/filesystem/to/measure
+mkdir -p "$work/data"
+
+python3 "$experiment/build_backends.py" --output "$work/binaries"
+python3 "$experiment/capture_native.py" \
+  --data-root "$work/data" --output "$work/environment-before.json"
+
+python3 "$experiment/run_matrix.py" \
+  --binary "$work/binaries/vectored" --binary-dir "$work/binaries" \
+  --plan "$experiment/plans/backend-smoke.json" \
+  --data-root "$work/data" --output "$work/smoke.jsonl"
+python3 "$experiment/run_matrix.py" \
+  --binary "$work/binaries/vectored" --binary-dir "$work/binaries" \
+  --plan "$experiment/plans/backend-aa.json" \
+  --data-root "$work/data" --output "$work/aa.jsonl"
+python3 "$experiment/analyze_native.py" "$work/aa.jsonl" \
+  --output "$work/aa-summary.json"
+```
+
+Inspect the pilot before the full grid. Unexpected drift warrants investigation;
+retain every pilot and document any environment change. The main plan has a
+fixed repetition budget independent of whether coalescing looks favorable.
+
+```bash
+python3 "$experiment/run_matrix.py" \
+  --binary "$work/binaries/vectored" --binary-dir "$work/binaries" \
+  --plan "$experiment/plans/backend-grid.json" \
+  --data-root "$work/data" --output "$work/grid.jsonl"
+python3 "$experiment/capture_native.py" \
+  --data-root "$work/data" --output "$work/environment-after.json"
+python3 "$experiment/validate_native.py" "$work/grid.jsonl" \
+  --plan "$experiment/plans/backend-grid.json" \
+  --manifest "$work/binaries/manifest.json" \
+  --repo . --output "$work/validation.json"
+python3 "$experiment/analyze_native.py" "$work/grid.jsonl" \
+  --output "$work/summary.json"
+```
+
+The runner refuses to overwrite a result file. Preserve raw trials and use a
+new output directory for each repetition of the experiment. The recorded Linux
+CPU placement and frozen RAID resynchronization are properties of that run,
+not generic preparation requirements.
+
+## Separate correctness diagnostics
+
+The Linux interposer injects missing, short, interrupted, and zero progress
+writes into paged fixtures and observes synchronization calls. Run it before
+performance measurement, using disposable data:
+
+```bash
+cc -shared -fPIC -O2 "$experiment/check_io.c" -ldl -o "$work/check_io.so"
+for variant in vectored coalesce pool; do
+  python3 "$experiment/check_harness.py" \
+    --binary "$work/binaries/$variant" --strategy vectored \
+    --data-root "$work/data" --io-check "$work/check_io.so" \
+    --output "$work/$variant-correctness.json"
+done
+```
+
+On macOS, omit `--io-check` to run the normal paged checks. The uniform smoke
+matrix checks the measured input shapes on both platforms. Never set
+`LD_PRELOAD` or `COMMONWARE_IO_FAULT` during performance measurement.
+These checks verify bytes and exercised syscall behavior; they are not power
+failure tests.

--- a/experiments/write-coalescing/NATIVE_RESULTS.md
+++ b/experiments/write-coalescing/NATIVE_RESULTS.md
@@ -1,0 +1,191 @@
+# Native write coalescing results
+
+Measured on 2026-09-06 against Commonware
+`73509b407aca65e3ad9bb2c6d34e4dc0e0c216a3`, using Rust 1.98.0 and locked
+dependencies. The comparison covers the ordinary Tokio storage backend and
+contributes evidence for [issue #3440](https://github.com/commonwarexyz/monorepo/issues/3440).
+
+**Coalescing helps some small writes with many fragments and hurts some larger
+writes.** Input allocation and reuse also change the result. The measurements
+identify regions worth investigating before choosing a heuristic; they do not
+establish a universal threshold or an application speedup.
+
+Three builds compare the existing backend with heap and pool coalescing inside
+its blocking closure. Allocation, copying, cleanup, and returning buffers to the
+pool are included. All variants receive the same prepared fragments and retain
+the backend's existing synchronization behavior.
+
+## Main observations
+
+Ratios are candidate throughput divided by vectored throughput. Values above
+1 favor coalescing. Brackets show percentile 95% bootstrap intervals from seven
+paired process repetitions. These examples use buffered writes and one reused
+input allocation.
+
+| Write shape | Linux heap | Linux pool | macOS heap | macOS pool |
+| --- | ---: | ---: | ---: | ---: |
+| 4 KiB, 256 segments | 1.600 [1.587, 1.613] | 1.665 [1.658, 1.671] | 1.753 [1.716, 1.797] | 1.924 [1.895, 1.950] |
+| 64 KiB, 256 segments | 1.256 [1.248, 1.264] | 1.243 [1.237, 1.249] | 1.282 [1.247, 1.322] | 1.091 [1.058, 1.120] |
+| 1 MiB, 256 segments | 0.889 [0.881, 0.896] | 0.885 [0.878, 0.890] | 0.819 [0.797, 0.840] | 0.811 [0.785, 0.837] |
+| 1 MiB, 1025 segments | 1.068 [1.059, 1.075] | 1.086 [1.077, 1.096] | 0.934 [0.907, 0.965] | 0.948 [0.914, 0.978] |
+
+![Throughput ratios across the primary matrix][chart]
+
+At 4 KiB with 256 segments, pool throughput increased by about 66% on Linux and
+92% on macOS. Process CPU cost per completed write fell to 0.602 and 0.519 of
+baseline. At 1 MiB with the same segment count, pool throughput fell by about
+12% and 19%, while CPU cost rose to 1.130 and 1.225 of baseline.
+[The full tables][tables] include baseline rates, CPU costs,
+and intervals for all 64 candidate comparisons per platform.
+
+The one segment controls remain close to baseline. One Linux heap control
+shows a 0.8% loss with an interval excluding 1. Small effects remain sensitive
+to build layout and residual variation.
+
+## Input allocation, reuse, and synchronization
+
+With 1 MiB and 1025 segments on macOS, heap coalescing changes from 0.934 of
+baseline with one reused source to 1.454 [1.389, 1.508] when rotating through
+16 MiB of input. Pool coalescing changes from 0.948 to 1.536 [1.492, 1.577].
+Separate allocations for the same fragments instead produce ratios of 0.760
+and 0.779. Total bytes and fragment count alone do not determine the outcome.
+
+Linux is less sensitive in that selected case: heap ratios are 1.068 for one
+reused allocation, 1.053 for rotating input, and 1.088 for separate allocations.
+These are observations about the complete machines and runtimes. The comparison
+does not isolate an operating system effect.
+
+### Possible mechanisms and implications
+
+Input allocation and reuse describe the source buffers, not reuse of the pool
+used for coalescing. The source fragments are prepared before timing. Separate
+allocations therefore do not mean that every measured write allocates fresh
+input fragments. The allocation and copying performed by coalescing remain
+inside timing.
+
+Changing where source bytes reside and which addresses are accessed on
+successive writes can change memory access costs even when byte count and
+fragment count are unchanged. Reusing one prepared input may favor cache
+residency. Separate allocations can change locality and buffer ownership
+bookkeeping. Rotating inputs changes the sequence and working set of source
+accesses.
+
+These are plausible mechanisms, not established causes of the observed
+reversal. The controls do not isolate cache residency, allocation layout, or
+ownership overhead. They show sensitivity to the input pattern, not which
+underlying cost caused it.
+
+Each ratio compares policies under the same input pattern. A larger ratio does
+not establish higher absolute throughput than a different input pattern.
+
+A rule based only on total bytes and fragment count would make the same
+decision for these input patterns, despite their different winners on macOS.
+This does not rule out a useful heuristic. Candidate thresholds need evaluation
+across representative input patterns, particularly around the decision
+boundary, before adoption.
+
+### Synchronization and control coverage
+
+Synchronized 4 KiB writes with 1025 segments reach ratios of 1.630 for heap and
+1.693 for pool on Linux. The macOS ratios are 1.039 and 1.049, with wider
+intervals. These six synchronization cases and five allocation and reuse
+controls vary selected workloads; they are not a full concurrency or cache
+matrix. Rotating 16 MiB does not guarantee that input is absent from every CPU
+cache.
+
+## Measurement conditions
+
+| Property | Native Linux | Native macOS |
+| --- | --- | --- |
+| CPU | AMD EPYC 8024P, 8 physical cores and 16 threads | Apple M1 Pro, 8 performance and 2 efficiency cores |
+| Memory | 64 GB class; no active swap | 32 GiB |
+| OS | Ubuntu 24.04 LTS, Linux 6.8.0-88-generic | macOS 26.5.2, build 25F84 |
+| Storage | Two 960 GB Dell DC NVMe PM9A3 drives, firmware 1.0.0; ext4 on MD RAID1 | Internal SSD with APFS; about 72 GiB free |
+| CPU placement | CPUs 4, 5, 6, 7, sharing one L3 cache | Ordinary scheduler placement |
+| Power and load | Performance governor; boost and SMT enabled | AC power; ordinary desktop applications remained running |
+| Execution | Dedicated physical server | Native executable |
+
+Each platform ran 32 cases, three policies, and seven repetitions, for 672
+trials. Each trial used a fresh process, 200 ms warmup, and a requested one
+second measured interval. One caller kept one write outstanding. The 64 MiB
+file was populated and synchronized before cyclic overwrites began. Main
+timings used no fault interposer or profiler.
+
+Completed bytes are divided by the actual elapsed interval, including deadline
+overshoot. Buffered rates describe this bounded cached overwrite workload. For
+example, the macOS baseline reaches about 9236 MiB/s for 1 MiB with 256 segments;
+that is not sustained SSD throughput. Process CPU time includes all process
+threads but excludes some background kernel and device work.
+
+## Pilots and uncertainty
+
+The initial Linux comparison of the baseline binary with itself exposed
+roughly 10% variation while the server was synchronizing its RAID mirror and
+the selected cores crossed two L3 caches. The mirror resynchronization was
+frozen, then CPU placement was restricted to four physical cores sharing one
+L3 cache. All three pilots are retained.
+
+| Linux pilot | Conditions | Individual throughput ratio range |
+| --- | --- | ---: |
+| `aa.jsonl` | Resynchronization active; CPUs 1, 2, 3, 4 | 0.888 to 1.107 |
+| `aa-isolated.jsonl` | Resynchronization frozen; same CPUs | 0.895 to 1.111 |
+| `aa-same-cache.jsonl` | Resynchronization frozen; CPUs 4, 5, 6, 7 | 0.994 to 1.005 |
+
+The final Linux pilot's synchronized case has interval [0.99491, 0.99861],
+excluding 1 even though both labels run the identical binary. Effects of a few
+tenths of a percent remain suspect. The environment changes preceded the main
+matrix; no main trial was excluded because it was slow or unfavorable.
+
+The RAID mirror remained incomplete and frozen throughout measurement, with
+both members present and writes using the RAID1 path. The retained preparation
+and final state records describe this condition. It limits transfer of the
+storage results to other configurations.
+
+The final macOS pilot has mean throughput ratios of 0.982 [0.959, 1.004],
+1.011 [0.999, 1.031], and 0.993 [0.970, 1.015] across its three cases. It used the
+same binaries as the grid. An earlier pilot before a lint cleanup and rebuild
+is retained with its own manifest. Small macOS effects deserve additional
+caution given the desktop load and storage state.
+
+The analysis resamples paired blocks 10,000 times and reports geometric mean
+ratios. Seven repetitions provide limited precision. Intervals are conditional
+on one build and one machine per platform; they are not simultaneous guarantees
+across the grid or intervals over a population of machines.
+
+## Correctness and interpretation
+
+Every main trial checked the expected contents of all final written slots and
+the exact logical file length. Warmup used different contents. Final readback
+cannot prove that every earlier overwrite occurred or establish crash
+durability.
+
+The native Linux records contain 180 correctness checks across three builds,
+covering paged inputs, two concurrency settings, both synchronization modes,
+and normal, missing, short, interrupted, and zero progress writes. Each
+platform also has 96 uniform smoke trials. Their timings are excluded from
+performance analysis.
+
+The complete dataset audit checks the frozen inventory and order, paired
+inputs, commands, recorded binary identities, verification counts, and metric
+arithmetic. Both main grids have passing archived audits.
+
+Linux synchronization follows the backend's existing `RWF_DSYNC` or final
+data synchronization path; macOS follows its existing write and `sync_all`
+path. The Linux device metadata reports no volatile write cache and write
+through queues. These observations describe the exercised software contract
+and visible storage configuration, without constituting a power failure test.
+
+The measured tradeoff includes copying, allocation, buffer ownership, runtime
+dispatch, and kernel work. It does not isolate each cost. Networking,
+`io_uring`, complete application performance, and heuristic selection remain
+outside this experiment.
+
+The [reproducibility archive][archive] preserves the full experiment at commit
+`918838255e1d4bf106356e1d16118c28506467cc`. See [the protocol][protocol] for commands
+and [the evidence inventory][inventory] for the retained records.
+
+[archive]: https://github.com/diegomrsantos/monorepo/tree/918838255e1d4bf106356e1d16118c28506467cc
+[chart]: https://raw.githubusercontent.com/diegomrsantos/monorepo/918838255e1d4bf106356e1d16118c28506467cc/experiments/write-coalescing/results/native/throughput-grid.png
+[tables]: https://github.com/diegomrsantos/monorepo/blob/918838255e1d4bf106356e1d16118c28506467cc/experiments/write-coalescing/results/native/TABLES.md
+[protocol]: BACKEND_PROTOCOL.md
+[inventory]: https://github.com/diegomrsantos/monorepo/blob/918838255e1d4bf106356e1d16118c28506467cc/experiments/write-coalescing/results/native/ARTIFACTS.md


### PR DESCRIPTION
Documents native Linux and macOS measurements for #3440, comparing the ordinary Tokio storage backend's vectored path with heap coalescing through `IoBufs::coalesce()` and pool coalescing through `coalesce_with_pool()`.

This PR adds a results report and reproduction guide. It changes no production code and introduces no coalescing heuristic.

## Findings

For buffered writes using one reused input allocation and 256 fragments:

- At 4 KiB, pool coalescing increased throughput by approximately 66% on Linux and 92% on macOS.
- At 1 MiB, pool coalescing reduced throughput by approximately 12% on Linux and 19% on macOS.

Changing input allocation and reuse can also reverse the preferred strategy without changing total bytes or fragment count. These results motivate further investigation before selecting heuristic thresholds.

The measurements use one outstanding write and a bounded cached overwrite workload. They do not establish sustained device throughput or an application speedup. The report documents measurement conditions, uncertainty, and limitations.

## Validation

Audited all 1,716 retained trials, recomputed 143 paired comparisons from the retained measurements, and checked six experimental patch hashes against their build manifests.

Related to #3440.