### PR TITLE
[storage/qmdb] Expose standalone proof helpers

### DIFF
--- a/glue/src/stateful/db/current.rs
+++ b/glue/src/stateful/db/current.rs
@@ -1371,11 +1371,7 @@ mod tests {
             assert_eq!(guard.get(&key).await.unwrap(), Some(value));
 
             let proof = guard.exclusion_proof(&missing).await.unwrap();
-            assert!(OrderedFixedDb::verify_exclusion_proof(
-                &missing,
-                &proof,
-                &guard.root(),
-            ));
+            assert!(proof.verify::<Sha256>(&missing, &guard.root()));
         });
     }
 
@@ -1494,11 +1490,7 @@ mod tests {
             assert_eq!(guard.get(&key).await.unwrap(), Some(value));
 
             let proof = guard.exclusion_proof(&missing).await.unwrap();
-            assert!(OrderedVariableDb::verify_exclusion_proof(
-                &missing,
-                &proof,
-                &guard.root(),
-            ));
+            assert!(proof.verify::<Sha256>(&missing, &guard.root()));
         });
     }
 

--- a/storage/conformance.toml
+++ b/storage/conformance.toml
@@ -426,6 +426,30 @@ hash = "182b01f2749b189e6a4c14c3a5c10e1c06600c6aedf01496c119cd01fbd5ba0e"
 n_cases = 64
 hash = "a023b1399b8656e8e113787f935d10013606440d43c8cb7c818749f6f09fc2fd"
 
+["commonware_storage::qmdb::current::ordered::tests::conformance::CodecConformance<constant::ExclusionProof<mmb::Family,U64,\nFixedEncoding<U64>,Sha256Digest,32>>"]
+n_cases = 65536
+hash = "9ced33c6c456eeabb2e47016c7ad438c2429e8c1e76034b05b9dd93c4a8f2d5c"
+
+["commonware_storage::qmdb::current::ordered::tests::conformance::CodecConformance<constant::ExclusionProof<mmb::Family,U64,\nVariableEncoding<Vec<u8>>,Sha256Digest,32>>"]
+n_cases = 65536
+hash = "e5beea0589a13b1e3264c12fcbe214c00cc5ba70478c6f548da70446b66ed345"
+
+["commonware_storage::qmdb::current::ordered::tests::conformance::CodecConformance<constant::ExclusionProof<mmr::Family,U64,\nFixedEncoding<U64>,Sha256Digest,32>>"]
+n_cases = 65536
+hash = "353bae61f8ccda093b598afec8ffc7f0bc14dd04cdd9ea539f900f3798da014e"
+
+["commonware_storage::qmdb::current::ordered::tests::conformance::CodecConformance<constant::ExclusionProof<mmr::Family,U64,\nVariableEncoding<Vec<u8>>,Sha256Digest,32>>"]
+n_cases = 65536
+hash = "174780dc9c7222d4dd2214b498b45a84b67ccb81f7312c2e60499227b1ed26b6"
+
+["commonware_storage::qmdb::current::ordered::tests::conformance::CodecConformance<constant::KeyValueProof<mmb::Family,U64,\nSha256Digest,32>>"]
+n_cases = 65536
+hash = "aa8a5d5a918ab588f8870c046d8249b043b94d18dbc92729cdc54e5930aa54db"
+
+["commonware_storage::qmdb::current::ordered::tests::conformance::CodecConformance<constant::KeyValueProof<mmr::Family,U64,\nSha256Digest,32>>"]
+n_cases = 65536
+hash = "55fef10c4a2282360e8d77c2e4d622ef80a7450db236835875d70fe1f847d79e"
+
 ["commonware_storage::qmdb::current::ordered::tests::conformance::CodecConformance<dynamic::ExclusionProof<mmb::Family,U64,\nFixedEncoding<U64>,Sha256Digest>>"]
 n_cases = 65536
 hash = "7a0ae471ea0f8a8de437fe9da09ac048e4ea4b10718093d71efa774344083fed"
@@ -450,30 +474,6 @@ hash = "9537952cca9b88ed629cced4a501b2dfd32a03f12c04cf15ff414e5230083892"
 n_cases = 65536
 hash = "6db0bf1cc653bad59f69a69752409d82c0da6731b1e5a9a7341abc4dcfdcbad3"
 
-["commonware_storage::qmdb::current::ordered::tests::conformance::CodecConformance<fixed::ExclusionProof<mmb::Family,U64,\nVariableEncoding<Vec<u8>>,Sha256Digest,32>>"]
-n_cases = 65536
-hash = "e5beea0589a13b1e3264c12fcbe214c00cc5ba70478c6f548da70446b66ed345"
-
-["commonware_storage::qmdb::current::ordered::tests::conformance::CodecConformance<fixed::ExclusionProof<mmb::Family,U64,FixedEncoding\n<U64>,Sha256Digest,32>>"]
-n_cases = 65536
-hash = "9ced33c6c456eeabb2e47016c7ad438c2429e8c1e76034b05b9dd93c4a8f2d5c"
-
-["commonware_storage::qmdb::current::ordered::tests::conformance::CodecConformance<fixed::ExclusionProof<mmr::Family,U64,\nVariableEncoding<Vec<u8>>,Sha256Digest,32>>"]
-n_cases = 65536
-hash = "174780dc9c7222d4dd2214b498b45a84b67ccb81f7312c2e60499227b1ed26b6"
-
-["commonware_storage::qmdb::current::ordered::tests::conformance::CodecConformance<fixed::ExclusionProof<mmr::Family,U64,FixedEncoding\n<U64>,Sha256Digest,32>>"]
-n_cases = 65536
-hash = "353bae61f8ccda093b598afec8ffc7f0bc14dd04cdd9ea539f900f3798da014e"
-
-["commonware_storage::qmdb::current::ordered::tests::conformance::CodecConformance<fixed::KeyValueProof<mmb::Family,U64,Sha256Digest,\n32>>"]
-n_cases = 65536
-hash = "aa8a5d5a918ab588f8870c046d8249b043b94d18dbc92729cdc54e5930aa54db"
-
-["commonware_storage::qmdb::current::ordered::tests::conformance::CodecConformance<fixed::KeyValueProof<mmr::Family,U64,Sha256Digest,\n32>>"]
-n_cases = 65536
-hash = "55fef10c4a2282360e8d77c2e4d622ef80a7450db236835875d70fe1f847d79e"
-
 ["commonware_storage::qmdb::current::proof::tests::conformance::CodecConformance<OpsRootWitness<mmb::Family,Sha256Digest>>"]
 n_cases = 65536
 hash = "36ed963e4bd5b6036c92469012f0017422865a150087c4b513aed412ff2e1d7b"
@@ -490,6 +490,14 @@ hash = "21375f68b817719323839af311b70dcd01925b413d3e2557fd4bbe75fd47008b"
 n_cases = 65536
 hash = "39ea177ae9f1c765339b4bfb88f0adb97812ab421daad405c041241324796f11"
 
+["commonware_storage::qmdb::current::proof::tests::conformance::CodecConformance<constant::OperationProof<mmb::Family,Sha256Digest,\n32>>"]
+n_cases = 65536
+hash = "bf4a4809cb3e2b26be0993fded18542541e20b85267b83ee5e2a63d5b9db08ca"
+
+["commonware_storage::qmdb::current::proof::tests::conformance::CodecConformance<constant::OperationProof<mmr::Family,Sha256Digest,\n32>>"]
+n_cases = 65536
+hash = "5aaae48dbe172c0e919f39bdaf6b3706704a2c027474202cde232555cdc26d66"
+
 ["commonware_storage::qmdb::current::proof::tests::conformance::CodecConformance<dynamic::OperationProof<mmb::Family,Sha256Digest>>"]
 n_cases = 65536
 hash = "9998fd0f05b90d7e4ef82369cb86c418476a259d7a3d1f5148c8cd13d75af73e"
@@ -497,14 +505,6 @@ hash = "9998fd0f05b90d7e4ef82369cb86c418476a259d7a3d1f5148c8cd13d75af73e"
 ["commonware_storage::qmdb::current::proof::tests::conformance::CodecConformance<dynamic::OperationProof<mmr::Family,Sha256Digest>>"]
 n_cases = 65536
 hash = "97d39f285e3cd575318130a3b64d5da8cc830f050beab6d465701be7e018784e"
-
-["commonware_storage::qmdb::current::proof::tests::conformance::CodecConformance<fixed::OperationProof<mmb::Family,Sha256Digest,32>\n>"]
-n_cases = 65536
-hash = "bf4a4809cb3e2b26be0993fded18542541e20b85267b83ee5e2a63d5b9db08ca"
-
-["commonware_storage::qmdb::current::proof::tests::conformance::CodecConformance<fixed::OperationProof<mmr::Family,Sha256Digest,32>\n>"]
-n_cases = 65536
-hash = "5aaae48dbe172c0e919f39bdaf6b3706704a2c027474202cde232555cdc26d66"
 
 ["commonware_storage::qmdb::immutable::operation::fixed::tests::conformance::CodecConformance<FixedOp>"]
 n_cases = 65536

--- a/storage/conformance.toml
+++ b/storage/conformance.toml
@@ -450,6 +450,30 @@ hash = "aa8a5d5a918ab588f8870c046d8249b043b94d18dbc92729cdc54e5930aa54db"
 n_cases = 65536
 hash = "55fef10c4a2282360e8d77c2e4d622ef80a7450db236835875d70fe1f847d79e"
 
+["commonware_storage::qmdb::current::ordered::tests::conformance::CodecConformance<RuntimeExclusionProof<mmb::Family,U64,\nVariableEncoding<Vec<u8>>,Sha256Digest>>"]
+n_cases = 65536
+hash = "cff54f8a5331d12c4ac83b38885d5ba56ce52974e5694dd1e2929898a71774c0"
+
+["commonware_storage::qmdb::current::ordered::tests::conformance::CodecConformance<RuntimeExclusionProof<mmb::Family,U64,FixedEncoding<\nU64>,Sha256Digest>>"]
+n_cases = 65536
+hash = "7a0ae471ea0f8a8de437fe9da09ac048e4ea4b10718093d71efa774344083fed"
+
+["commonware_storage::qmdb::current::ordered::tests::conformance::CodecConformance<RuntimeExclusionProof<mmr::Family,U64,\nVariableEncoding<Vec<u8>>,Sha256Digest>>"]
+n_cases = 65536
+hash = "6ab65fd27d7b56fca6588a649fb2b65e5de1a014cfa3ecd807d41d54be482521"
+
+["commonware_storage::qmdb::current::ordered::tests::conformance::CodecConformance<RuntimeExclusionProof<mmr::Family,U64,FixedEncoding<\nU64>,Sha256Digest>>"]
+n_cases = 65536
+hash = "f2530a1e7f0026f9c20523bfed7aae4e074f1b93b1af73141187cb486311bf59"
+
+["commonware_storage::qmdb::current::ordered::tests::conformance::CodecConformance<RuntimeKeyValueProof<mmb::Family,U64,Sha256Digest>>"]
+n_cases = 65536
+hash = "9537952cca9b88ed629cced4a501b2dfd32a03f12c04cf15ff414e5230083892"
+
+["commonware_storage::qmdb::current::ordered::tests::conformance::CodecConformance<RuntimeKeyValueProof<mmr::Family,U64,Sha256Digest>>"]
+n_cases = 65536
+hash = "6db0bf1cc653bad59f69a69752409d82c0da6731b1e5a9a7341abc4dcfdcbad3"
+
 ["commonware_storage::qmdb::current::proof::tests::conformance::CodecConformance<OperationProof<mmb::Family,Sha256Digest,32>>"]
 n_cases = 65536
 hash = "bf4a4809cb3e2b26be0993fded18542541e20b85267b83ee5e2a63d5b9db08ca"
@@ -473,6 +497,14 @@ hash = "21375f68b817719323839af311b70dcd01925b413d3e2557fd4bbe75fd47008b"
 ["commonware_storage::qmdb::current::proof::tests::conformance::CodecConformance<RangeProof<mmr::Family,Sha256Digest>>"]
 n_cases = 65536
 hash = "39ea177ae9f1c765339b4bfb88f0adb97812ab421daad405c041241324796f11"
+
+["commonware_storage::qmdb::current::proof::tests::conformance::CodecConformance<RuntimeOperationProof<mmb::Family,Sha256Digest>>"]
+n_cases = 65536
+hash = "9998fd0f05b90d7e4ef82369cb86c418476a259d7a3d1f5148c8cd13d75af73e"
+
+["commonware_storage::qmdb::current::proof::tests::conformance::CodecConformance<RuntimeOperationProof<mmr::Family,Sha256Digest>>"]
+n_cases = 65536
+hash = "97d39f285e3cd575318130a3b64d5da8cc830f050beab6d465701be7e018784e"
 
 ["commonware_storage::qmdb::immutable::operation::fixed::tests::conformance::CodecConformance<FixedOp>"]
 n_cases = 65536

--- a/storage/conformance.toml
+++ b/storage/conformance.toml
@@ -426,61 +426,53 @@ hash = "182b01f2749b189e6a4c14c3a5c10e1c06600c6aedf01496c119cd01fbd5ba0e"
 n_cases = 64
 hash = "a023b1399b8656e8e113787f935d10013606440d43c8cb7c818749f6f09fc2fd"
 
-["commonware_storage::qmdb::current::ordered::tests::conformance::CodecConformance<ExclusionProof<mmb::Family,U64,FixedEncoding<U64>\n,Sha256Digest,32>>"]
-n_cases = 65536
-hash = "9ced33c6c456eeabb2e47016c7ad438c2429e8c1e76034b05b9dd93c4a8f2d5c"
-
-["commonware_storage::qmdb::current::ordered::tests::conformance::CodecConformance<ExclusionProof<mmb::Family,U64,VariableEncoding<Vec\n<u8>>,Sha256Digest,32>>"]
-n_cases = 65536
-hash = "e5beea0589a13b1e3264c12fcbe214c00cc5ba70478c6f548da70446b66ed345"
-
-["commonware_storage::qmdb::current::ordered::tests::conformance::CodecConformance<ExclusionProof<mmr::Family,U64,FixedEncoding<U64>\n,Sha256Digest,32>>"]
-n_cases = 65536
-hash = "353bae61f8ccda093b598afec8ffc7f0bc14dd04cdd9ea539f900f3798da014e"
-
-["commonware_storage::qmdb::current::ordered::tests::conformance::CodecConformance<ExclusionProof<mmr::Family,U64,VariableEncoding<Vec\n<u8>>,Sha256Digest,32>>"]
-n_cases = 65536
-hash = "174780dc9c7222d4dd2214b498b45a84b67ccb81f7312c2e60499227b1ed26b6"
-
-["commonware_storage::qmdb::current::ordered::tests::conformance::CodecConformance<KeyValueProof<mmb::Family,U64,Sha256Digest,32>>"]
-n_cases = 65536
-hash = "aa8a5d5a918ab588f8870c046d8249b043b94d18dbc92729cdc54e5930aa54db"
-
-["commonware_storage::qmdb::current::ordered::tests::conformance::CodecConformance<KeyValueProof<mmr::Family,U64,Sha256Digest,32>>"]
-n_cases = 65536
-hash = "55fef10c4a2282360e8d77c2e4d622ef80a7450db236835875d70fe1f847d79e"
-
-["commonware_storage::qmdb::current::ordered::tests::conformance::CodecConformance<RuntimeExclusionProof<mmb::Family,U64,\nVariableEncoding<Vec<u8>>,Sha256Digest>>"]
-n_cases = 65536
-hash = "cff54f8a5331d12c4ac83b38885d5ba56ce52974e5694dd1e2929898a71774c0"
-
-["commonware_storage::qmdb::current::ordered::tests::conformance::CodecConformance<RuntimeExclusionProof<mmb::Family,U64,FixedEncoding<\nU64>,Sha256Digest>>"]
+["commonware_storage::qmdb::current::ordered::tests::conformance::CodecConformance<dynamic::ExclusionProof<mmb::Family,U64,\nFixedEncoding<U64>,Sha256Digest>>"]
 n_cases = 65536
 hash = "7a0ae471ea0f8a8de437fe9da09ac048e4ea4b10718093d71efa774344083fed"
 
-["commonware_storage::qmdb::current::ordered::tests::conformance::CodecConformance<RuntimeExclusionProof<mmr::Family,U64,\nVariableEncoding<Vec<u8>>,Sha256Digest>>"]
+["commonware_storage::qmdb::current::ordered::tests::conformance::CodecConformance<dynamic::ExclusionProof<mmb::Family,U64,\nVariableEncoding<Vec<u8>>,Sha256Digest>>"]
 n_cases = 65536
-hash = "6ab65fd27d7b56fca6588a649fb2b65e5de1a014cfa3ecd807d41d54be482521"
+hash = "cff54f8a5331d12c4ac83b38885d5ba56ce52974e5694dd1e2929898a71774c0"
 
-["commonware_storage::qmdb::current::ordered::tests::conformance::CodecConformance<RuntimeExclusionProof<mmr::Family,U64,FixedEncoding<\nU64>,Sha256Digest>>"]
+["commonware_storage::qmdb::current::ordered::tests::conformance::CodecConformance<dynamic::ExclusionProof<mmr::Family,U64,\nFixedEncoding<U64>,Sha256Digest>>"]
 n_cases = 65536
 hash = "f2530a1e7f0026f9c20523bfed7aae4e074f1b93b1af73141187cb486311bf59"
 
-["commonware_storage::qmdb::current::ordered::tests::conformance::CodecConformance<RuntimeKeyValueProof<mmb::Family,U64,Sha256Digest>>"]
+["commonware_storage::qmdb::current::ordered::tests::conformance::CodecConformance<dynamic::ExclusionProof<mmr::Family,U64,\nVariableEncoding<Vec<u8>>,Sha256Digest>>"]
+n_cases = 65536
+hash = "6ab65fd27d7b56fca6588a649fb2b65e5de1a014cfa3ecd807d41d54be482521"
+
+["commonware_storage::qmdb::current::ordered::tests::conformance::CodecConformance<dynamic::KeyValueProof<mmb::Family,U64,Sha256Digest\n>>"]
 n_cases = 65536
 hash = "9537952cca9b88ed629cced4a501b2dfd32a03f12c04cf15ff414e5230083892"
 
-["commonware_storage::qmdb::current::ordered::tests::conformance::CodecConformance<RuntimeKeyValueProof<mmr::Family,U64,Sha256Digest>>"]
+["commonware_storage::qmdb::current::ordered::tests::conformance::CodecConformance<dynamic::KeyValueProof<mmr::Family,U64,Sha256Digest\n>>"]
 n_cases = 65536
 hash = "6db0bf1cc653bad59f69a69752409d82c0da6731b1e5a9a7341abc4dcfdcbad3"
 
-["commonware_storage::qmdb::current::proof::tests::conformance::CodecConformance<OperationProof<mmb::Family,Sha256Digest,32>>"]
+["commonware_storage::qmdb::current::ordered::tests::conformance::CodecConformance<fixed::ExclusionProof<mmb::Family,U64,\nVariableEncoding<Vec<u8>>,Sha256Digest,32>>"]
 n_cases = 65536
-hash = "bf4a4809cb3e2b26be0993fded18542541e20b85267b83ee5e2a63d5b9db08ca"
+hash = "e5beea0589a13b1e3264c12fcbe214c00cc5ba70478c6f548da70446b66ed345"
 
-["commonware_storage::qmdb::current::proof::tests::conformance::CodecConformance<OperationProof<mmr::Family,Sha256Digest,32>>"]
+["commonware_storage::qmdb::current::ordered::tests::conformance::CodecConformance<fixed::ExclusionProof<mmb::Family,U64,FixedEncoding\n<U64>,Sha256Digest,32>>"]
 n_cases = 65536
-hash = "5aaae48dbe172c0e919f39bdaf6b3706704a2c027474202cde232555cdc26d66"
+hash = "9ced33c6c456eeabb2e47016c7ad438c2429e8c1e76034b05b9dd93c4a8f2d5c"
+
+["commonware_storage::qmdb::current::ordered::tests::conformance::CodecConformance<fixed::ExclusionProof<mmr::Family,U64,\nVariableEncoding<Vec<u8>>,Sha256Digest,32>>"]
+n_cases = 65536
+hash = "174780dc9c7222d4dd2214b498b45a84b67ccb81f7312c2e60499227b1ed26b6"
+
+["commonware_storage::qmdb::current::ordered::tests::conformance::CodecConformance<fixed::ExclusionProof<mmr::Family,U64,FixedEncoding\n<U64>,Sha256Digest,32>>"]
+n_cases = 65536
+hash = "353bae61f8ccda093b598afec8ffc7f0bc14dd04cdd9ea539f900f3798da014e"
+
+["commonware_storage::qmdb::current::ordered::tests::conformance::CodecConformance<fixed::KeyValueProof<mmb::Family,U64,Sha256Digest,\n32>>"]
+n_cases = 65536
+hash = "aa8a5d5a918ab588f8870c046d8249b043b94d18dbc92729cdc54e5930aa54db"
+
+["commonware_storage::qmdb::current::ordered::tests::conformance::CodecConformance<fixed::KeyValueProof<mmr::Family,U64,Sha256Digest,\n32>>"]
+n_cases = 65536
+hash = "55fef10c4a2282360e8d77c2e4d622ef80a7450db236835875d70fe1f847d79e"
 
 ["commonware_storage::qmdb::current::proof::tests::conformance::CodecConformance<OpsRootWitness<mmb::Family,Sha256Digest>>"]
 n_cases = 65536
@@ -498,13 +490,21 @@ hash = "21375f68b817719323839af311b70dcd01925b413d3e2557fd4bbe75fd47008b"
 n_cases = 65536
 hash = "39ea177ae9f1c765339b4bfb88f0adb97812ab421daad405c041241324796f11"
 
-["commonware_storage::qmdb::current::proof::tests::conformance::CodecConformance<RuntimeOperationProof<mmb::Family,Sha256Digest>>"]
+["commonware_storage::qmdb::current::proof::tests::conformance::CodecConformance<dynamic::OperationProof<mmb::Family,Sha256Digest>>"]
 n_cases = 65536
 hash = "9998fd0f05b90d7e4ef82369cb86c418476a259d7a3d1f5148c8cd13d75af73e"
 
-["commonware_storage::qmdb::current::proof::tests::conformance::CodecConformance<RuntimeOperationProof<mmr::Family,Sha256Digest>>"]
+["commonware_storage::qmdb::current::proof::tests::conformance::CodecConformance<dynamic::OperationProof<mmr::Family,Sha256Digest>>"]
 n_cases = 65536
 hash = "97d39f285e3cd575318130a3b64d5da8cc830f050beab6d465701be7e018784e"
+
+["commonware_storage::qmdb::current::proof::tests::conformance::CodecConformance<fixed::OperationProof<mmb::Family,Sha256Digest,32>\n>"]
+n_cases = 65536
+hash = "bf4a4809cb3e2b26be0993fded18542541e20b85267b83ee5e2a63d5b9db08ca"
+
+["commonware_storage::qmdb::current::proof::tests::conformance::CodecConformance<fixed::OperationProof<mmr::Family,Sha256Digest,32>\n>"]
+n_cases = 65536
+hash = "5aaae48dbe172c0e919f39bdaf6b3706704a2c027474202cde232555cdc26d66"
 
 ["commonware_storage::qmdb::immutable::operation::fixed::tests::conformance::CodecConformance<FixedOp>"]
 n_cases = 65536

--- a/storage/fuzz/fuzz_targets/qmdb_current_ordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_current_ordered_operations.rs
@@ -7,7 +7,10 @@ use commonware_runtime::{Runner, Supervisor as _, buffer::paged::CacheRef, deter
 use commonware_storage::{
     journal::contiguous::fixed::Config as FConfig,
     merkle::{Graftable, Location, full::Config as MerkleConfig, mmb, mmr},
-    qmdb::current::{FixedConfig as Config, ordered::fixed::Db as CurrentDb},
+    qmdb::{
+        any::value::FixedEncoding,
+        current::{FixedConfig as Config, ordered::fixed::Db as CurrentDb},
+    },
     translator::TwoCap,
 };
 use commonware_utils::{NZU16, NZU64, NZUsize, sequence::FixedBytes};
@@ -421,12 +424,7 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
                     match db.key_value_proof(k.clone()).await {
                         Ok(proof) => {
                             let value = db.get(&k).await.expect("get should not fail").expect("key should exist");
-                            let verification_result = Db::<F>::verify_key_value_proof(
-                                k,
-                                value,
-                                &proof,
-                                &current_root,
-                            );
+                            let verification_result = proof.verify::<Sha256, FixedEncoding<Value>>(k, value, &current_root);
                             assert!(verification_result, "Key value proof verification failed for key {key:?}");
                         }
                         Err(commonware_storage::qmdb::Error::KeyNotFound) => {
@@ -451,11 +449,7 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
 
                     match db.exclusion_proof(&k).await {
                         Ok(proof) => {
-                            let verification_result = Db::<F>::verify_exclusion_proof(
-                                &k,
-                                &proof,
-                                &current_root,
-                            );
+                            let verification_result = proof.verify::<Sha256>(&k, &current_root);
                             assert!(verification_result, "Exclusion proof verification failed for key {key:?}");
                         }
                         Err(commonware_storage::qmdb::Error::KeyExists) => {

--- a/storage/src/qmdb/any/operation/mod.rs
+++ b/storage/src/qmdb/any/operation/mod.rs
@@ -12,9 +12,12 @@ pub(crate) mod update;
 pub(crate) mod variable;
 pub use update::Update;
 
-pub(crate) const DELETE_CONTEXT: u8 = 0xD1;
-pub(crate) const UPDATE_CONTEXT: u8 = 0xD2;
-pub(crate) const COMMIT_CONTEXT: u8 = 0xD3;
+/// Wire tag for [Operation::Delete].
+pub const DELETE_CONTEXT: u8 = 0xD1;
+/// Wire tag for [Operation::Update].
+pub const UPDATE_CONTEXT: u8 = 0xD2;
+/// Wire tag for [Operation::CommitFloor].
+pub const COMMIT_CONTEXT: u8 = 0xD3;
 
 pub type Ordered<F, K, V> = Operation<F, update::Ordered<K, V>>;
 pub type Unordered<F, K, V> = Operation<F, update::Unordered<K, V>>;

--- a/storage/src/qmdb/any/ordered/mod.rs
+++ b/storage/src/qmdb/any/ordered/mod.rs
@@ -21,6 +21,17 @@ pub mod variable;
 
 pub use crate::qmdb::any::operation::{Ordered as Operation, update::Ordered as Update};
 
+/// Whether the cyclic span from `span_start` (inclusive) to `span_end` (exclusive) contains `key`.
+///
+/// Equal endpoints define a span containing every key.
+pub fn span_contains<K: Ord>(span_start: &K, span_end: &K, key: &K) -> bool {
+    if span_start >= span_end {
+        key >= span_start || key < span_end
+    } else {
+        key >= span_start && key < span_end
+    }
+}
+
 /// Type alias for a location and its associated key data.
 type LocatedKey<F, K, V> = Option<(Location<F>, Update<K, V>)>;
 
@@ -48,23 +59,6 @@ where
         }
     }
 
-    /// Whether the span defined by `span_start` and `span_end` contains `key`.
-    pub fn span_contains(span_start: &K, span_end: &K, key: &K) -> bool {
-        if span_start >= span_end {
-            // cyclic span case
-            if key >= span_start || key < span_end {
-                return true;
-            }
-        } else {
-            // normal span case
-            if key >= span_start && key < span_end {
-                return true;
-            }
-        }
-
-        false
-    }
-
     /// Find the span produced by the provided locations that contains `key`, if any.
     async fn find_span(
         &self,
@@ -74,7 +68,7 @@ where
         for loc in locs {
             // Iterate over conflicts in the snapshot entry to find the span.
             let data = Self::get_update_op(&self.log, loc).await?;
-            if Self::span_contains(&data.key, &data.next_key, key) {
+            if span_contains(&data.key, &data.next_key, key) {
                 return Ok(Some((loc, data)));
             }
         }
@@ -326,6 +320,24 @@ mod test {
     use commonware_utils::{sequence::FixedBytes, test_rng};
     use core::{future::Future, pin::Pin};
     use rand::RngExt as _;
+
+    #[test]
+    fn span_contains_boundaries() {
+        assert!(!span_contains(&2, &6, &1));
+        assert!(span_contains(&2, &6, &2));
+        assert!(span_contains(&2, &6, &5));
+        assert!(!span_contains(&2, &6, &6));
+
+        assert!(span_contains(&6, &2, &1));
+        assert!(!span_contains(&6, &2, &2));
+        assert!(!span_contains(&6, &2, &5));
+        assert!(span_contains(&6, &2, &6));
+        assert!(span_contains(&6, &2, &7));
+
+        assert!(span_contains(&3, &3, &2));
+        assert!(span_contains(&3, &3, &3));
+        assert!(span_contains(&3, &3, &4));
+    }
 
     /// [`find_next_key_ascending`] must return exactly what [`find_next_key`] returns for any
     /// ascending query sequence, including queries past the last candidate (cyclic wrap).

--- a/storage/src/qmdb/current/db.rs
+++ b/storage/src/qmdb/current/db.rs
@@ -40,6 +40,7 @@ use commonware_runtime::{
     },
 };
 use commonware_utils::{
+    Widen as _,
     bitmap::{self, Readable as _},
     sequence::prefixed_u64::U64,
 };
@@ -916,10 +917,11 @@ pub(super) fn pending_chunk<F: merkle::Graftable, B: bitmap::Readable<N>, const 
     ops_leaves: Location<F>,
     grafting_height: u32,
 ) -> Result<Option<[u8; N]>, Error<F>> {
+    #[allow(unstable_name_collisions)]
     let (complete, graftable) = graftable_chunk_window(
         ops_leaves,
-        bitmap.complete_chunks() as u64,
-        bitmap.pruned_chunks() as u64,
+        bitmap.complete_chunks().widen(),
+        bitmap.pruned_chunks().widen(),
         grafting_height,
     )?;
     if complete - graftable != 1 {
@@ -1084,10 +1086,11 @@ pub(super) async fn compute_grafted_root<
 
     // Validate bitmap invariants (pending <= 1, pruned <= graftable).
     let grafting_height = grafting::height::<N>();
+    #[allow(unstable_name_collisions)]
     let (_complete_chunks, _graftable_chunks) = graftable_chunk_window(
         ops_leaves,
-        status.complete_chunks() as u64,
-        status.pruned_chunks() as u64,
+        status.complete_chunks().widen(),
+        status.pruned_chunks().widen(),
         grafting_height,
     )?;
 

--- a/storage/src/qmdb/current/db.rs
+++ b/storage/src/qmdb/current/db.rs
@@ -23,7 +23,7 @@ use crate::{
         current::{
             batch::BitmapBatch,
             grafting,
-            proof::{OpsRootWitness, RangeProof, RangeProofSpec, fixed::OperationProof},
+            proof::{OpsRootWitness, RangeProof, RangeProofSpec, constant::OperationProof},
         },
         operation::Floored as _,
     },

--- a/storage/src/qmdb/current/db.rs
+++ b/storage/src/qmdb/current/db.rs
@@ -40,7 +40,7 @@ use commonware_runtime::{
     },
 };
 use commonware_utils::{
-    Widen as _,
+    Widen,
     bitmap::{self, Readable as _},
     sequence::prefixed_u64::U64,
 };
@@ -875,7 +875,7 @@ pub(super) fn partial_chunk<B: bitmap::Readable<N>, const N: usize>(
     Some((last_chunk, next_bit))
 }
 
-/// Return complete and graftable chunk counts, enforcing the pending and pruning invariants.
+/// Return the graftable chunk count, enforcing the pending and pruning invariants.
 ///
 /// Returns [`Error::DataCorrupted`] if `complete` and `ops_leaves` imply more than one
 /// pending chunk, or if pruning has advanced past the graftable chunk boundary.
@@ -884,7 +884,7 @@ pub(super) fn graftable_chunk_window<F: merkle::Graftable>(
     complete: u64,
     pruned: u64,
     grafting_height: u32,
-) -> Result<(u64, u64), Error<F>> {
+) -> Result<u64, Error<F>> {
     let graftable = grafting::graftable_chunks::<F>(*ops_leaves, grafting_height).min(complete);
     let pending = complete - graftable;
     if pending > 1 {
@@ -897,7 +897,7 @@ pub(super) fn graftable_chunk_window<F: merkle::Graftable>(
         ));
     }
 
-    Ok((complete, graftable))
+    Ok(graftable)
 }
 
 /// Returns the bytes of the "pending" chunk if the bitmap currently has one, else `None`.
@@ -917,11 +917,11 @@ pub(super) fn pending_chunk<F: merkle::Graftable, B: bitmap::Readable<N>, const 
     ops_leaves: Location<F>,
     grafting_height: u32,
 ) -> Result<Option<[u8; N]>, Error<F>> {
-    #[allow(unstable_name_collisions)]
-    let (complete, graftable) = graftable_chunk_window(
+    let complete = Widen::widen(bitmap.complete_chunks());
+    let graftable = graftable_chunk_window(
         ops_leaves,
-        bitmap.complete_chunks().widen(),
-        bitmap.pruned_chunks().widen(),
+        complete,
+        Widen::widen(bitmap.pruned_chunks()),
         grafting_height,
     )?;
     if complete - graftable != 1 {
@@ -1086,11 +1086,10 @@ pub(super) async fn compute_grafted_root<
 
     // Validate bitmap invariants (pending <= 1, pruned <= graftable).
     let grafting_height = grafting::height::<N>();
-    #[allow(unstable_name_collisions)]
-    let (_complete_chunks, _graftable_chunks) = graftable_chunk_window(
+    graftable_chunk_window(
         ops_leaves,
-        status.complete_chunks().widen(),
-        status.pruned_chunks().widen(),
+        Widen::widen(status.complete_chunks()),
+        Widen::widen(status.pruned_chunks()),
         grafting_height,
     )?;
 

--- a/storage/src/qmdb/current/db.rs
+++ b/storage/src/qmdb/current/db.rs
@@ -23,7 +23,7 @@ use crate::{
         current::{
             batch::BitmapBatch,
             grafting,
-            proof::{OperationProof, OpsRootWitness, RangeProof, RangeProofSpec},
+            proof::{OpsRootWitness, RangeProof, RangeProofSpec, fixed::OperationProof},
         },
         operation::Floored as _,
     },

--- a/storage/src/qmdb/current/db.rs
+++ b/storage/src/qmdb/current/db.rs
@@ -876,21 +876,20 @@ pub(super) fn partial_chunk<B: bitmap::Readable<N>, const N: usize>(
 
 /// Return complete and graftable chunk counts, enforcing the pending and pruning invariants.
 ///
-/// Returns [`Error::DataCorrupted`] if `bitmap` and `ops_leaves` imply more than one
+/// Returns [`Error::DataCorrupted`] if `complete` and `ops_leaves` imply more than one
 /// pending chunk, or if pruning has advanced past the graftable chunk boundary.
-fn graftable_chunk_window<F: merkle::Graftable, B: bitmap::Readable<N>, const N: usize>(
-    bitmap: &B,
+pub(super) fn graftable_chunk_window<F: merkle::Graftable>(
     ops_leaves: Location<F>,
+    complete: u64,
+    pruned: u64,
     grafting_height: u32,
 ) -> Result<(u64, u64), Error<F>> {
-    let complete = bitmap.complete_chunks() as u64;
     let graftable = grafting::graftable_chunks::<F>(*ops_leaves, grafting_height).min(complete);
     let pending = complete - graftable;
     if pending > 1 {
         return Err(Error::DataCorrupted("multiple pending bitmap chunks"));
     }
 
-    let pruned = bitmap.pruned_chunks() as u64;
     if pruned > graftable {
         return Err(Error::DataCorrupted(
             "pruned chunks exceed graftable chunks",
@@ -917,8 +916,12 @@ pub(super) fn pending_chunk<F: merkle::Graftable, B: bitmap::Readable<N>, const 
     ops_leaves: Location<F>,
     grafting_height: u32,
 ) -> Result<Option<[u8; N]>, Error<F>> {
-    let (complete, graftable) =
-        graftable_chunk_window::<F, B, N>(bitmap, ops_leaves, grafting_height)?;
+    let (complete, graftable) = graftable_chunk_window(
+        ops_leaves,
+        bitmap.complete_chunks() as u64,
+        bitmap.pruned_chunks() as u64,
+        grafting_height,
+    )?;
     if complete - graftable != 1 {
         return Ok(None);
     }
@@ -1081,8 +1084,12 @@ pub(super) async fn compute_grafted_root<
 
     // Validate bitmap invariants (pending <= 1, pruned <= graftable).
     let grafting_height = grafting::height::<N>();
-    let (_complete_chunks, _graftable_chunks) =
-        graftable_chunk_window::<F, B, N>(status, ops_leaves, grafting_height)?;
+    let (_complete_chunks, _graftable_chunks) = graftable_chunk_window(
+        ops_leaves,
+        status.complete_chunks() as u64,
+        status.pruned_chunks() as u64,
+        grafting_height,
+    )?;
 
     let inactive_peaks =
         grafting::chunk_aligned_inactive_peaks::<F>(leaves, inactivity_floor, grafting_height)?;

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -1796,9 +1796,7 @@ pub mod tests {
             // [b, a), which cyclically covered `c` and verified).
             let kvp = db.key_value_proof(b.clone()).await.unwrap();
             let forged = ordered::ExclusionProof::KeyValue(kvp.proof, span_b);
-            assert!(!ForgedExclusionDb::verify_exclusion_proof(
-                &c, &forged, &root
-            ));
+            assert!(!forged.verify::<Sha256>(&c, &root));
 
             db.destroy().await.unwrap();
         });

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -302,7 +302,7 @@
 //!   the ops-tree topology but substitutes graftable chunks at height `gh`. When no chunks are
 //!   graftable, `grafted_root` still reflects the ops-tree peak structure. Used for proofs about
 //!   operation values and their activity status. See [RangeProof](proof::RangeProof) and
-//!   [OperationProof](proof::OperationProof).
+//!   [OperationProof](proof::fixed::OperationProof).
 //!
 //! - **Pending chunk digest** (optional): `H(pending_chunk_bytes)` when a chunk's bits are complete
 //!   but its height-`gh` ancestor has not yet been born in the ops tree. Absent in MMR and in the
@@ -1795,7 +1795,7 @@ pub mod tests {
             // span [b, c) does not cover `c`, so the verifier rejects it (pre-fix the span was
             // [b, a), which cyclically covered `c` and verified).
             let kvp = db.key_value_proof(b.clone()).await.unwrap();
-            let forged = ordered::ExclusionProof::KeyValue(kvp.proof, span_b);
+            let forged = ordered::proof::fixed::ExclusionProof::KeyValue(kvp.proof, span_b);
             assert!(!forged.verify::<Sha256>(&c, &root));
 
             db.destroy().await.unwrap();

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -302,7 +302,7 @@
 //!   the ops-tree topology but substitutes graftable chunks at height `gh`. When no chunks are
 //!   graftable, `grafted_root` still reflects the ops-tree peak structure. Used for proofs about
 //!   operation values and their activity status. See [RangeProof](proof::RangeProof) and
-//!   [OperationProof](proof::fixed::OperationProof).
+//!   [OperationProof](proof::constant::OperationProof).
 //!
 //! - **Pending chunk digest** (optional): `H(pending_chunk_bytes)` when a chunk's bits are complete
 //!   but its height-`gh` ancestor has not yet been born in the ops tree. Absent in MMR and in the
@@ -1795,7 +1795,7 @@ pub mod tests {
             // span [b, c) does not cover `c`, so the verifier rejects it (pre-fix the span was
             // [b, a), which cyclically covered `c` and verified).
             let kvp = db.key_value_proof(b.clone()).await.unwrap();
-            let forged = ordered::proof::fixed::ExclusionProof::KeyValue(kvp.proof, span_b);
+            let forged = ordered::proof::constant::ExclusionProof::KeyValue(kvp.proof, span_b);
             assert!(!forged.verify::<Sha256>(&c, &root));
 
             db.destroy().await.unwrap();

--- a/storage/src/qmdb/current/ordered/db.rs
+++ b/storage/src/qmdb/current/ordered/db.rs
@@ -26,9 +26,6 @@ use futures::stream::Stream;
 pub type KeyValueProof<F, K, D, const N: usize> = super::proof::KeyValueProof<F, K, D, [u8; N]>;
 
 /// Proof information for verifying a key has a particular value, with a runtime-sized bitmap chunk.
-///
-/// The decoder configuration is `((chunk_size, max_digests), key_cfg)`.
-/// The chunk size is in bytes and is not encoded in the proof.
 pub type RuntimeKeyValueProof<F, K, D> = super::proof::KeyValueProof<F, K, D, bytes::Bytes>;
 
 /// The generic Db type for ordered Current QMDB variants.

--- a/storage/src/qmdb/current/ordered/db.rs
+++ b/storage/src/qmdb/current/ordered/db.rs
@@ -14,89 +14,22 @@ use crate::{
             ValueEncoding,
             ordered::{Operation, Update},
         },
-        current::proof::OperationProof,
         operation::Key,
     },
 };
-use bytes::{Buf, BufMut};
-use commonware_codec::{Codec, EncodeSize, Read, Write};
-use commonware_cryptography::{Digest, Hasher};
+use commonware_codec::Codec;
+use commonware_cryptography::Hasher;
 use commonware_parallel::Strategy;
 use futures::stream::Stream;
 
-/// Proof information for verifying a key has a particular value in the database.
-#[derive(Clone, Eq, PartialEq, Debug)]
-pub struct KeyValueProof<F: merkle::Graftable, K: Key, D: Digest, const N: usize> {
-    pub proof: OperationProof<F, D, N>,
-    pub next_key: K,
-}
+/// Proof information for verifying a key has a particular value, with a fixed-size bitmap chunk.
+pub type KeyValueProof<F, K, D, const N: usize> = super::proof::KeyValueProof<F, K, D, [u8; N]>;
 
-impl<F: merkle::Graftable, K: Key, D: Digest, const N: usize> KeyValueProof<F, K, D, N> {
-    /// Return true if the proof authenticates that `key` currently has `value` in the database
-    /// with the provided `root`.
-    ///
-    /// `V` selects the fixed or variable value encoding used by the database.
-    pub fn verify<H, V>(&self, key: K, value: V::Value, root: &D) -> bool
-    where
-        H: Hasher<Digest = D>,
-        V: ValueEncoding,
-        Operation<F, K, V>: Codec,
-    {
-        let op = Operation::<F, K, V>::Update(Update {
-            key,
-            value,
-            next_key: self.next_key.clone(),
-        });
-
-        self.proof.verify::<H, _>(op, root)
-    }
-}
-
-impl<F: merkle::Graftable, K: Key, D: Digest, const N: usize> Write for KeyValueProof<F, K, D, N> {
-    fn write(&self, buf: &mut impl BufMut) {
-        self.proof.write(buf);
-        self.next_key.write(buf);
-    }
-}
-
-impl<F: merkle::Graftable, K: Key, D: Digest, const N: usize> EncodeSize
-    for KeyValueProof<F, K, D, N>
-{
-    fn encode_size(&self) -> usize {
-        self.proof.encode_size() + self.next_key.encode_size()
-    }
-}
-
-impl<F: merkle::Graftable, K: Key, D: Digest, const N: usize> Read for KeyValueProof<F, K, D, N> {
-    /// `(max_digests, key_cfg)`: the Merkle digest cap forwarded to the embedded operation
-    /// proof and the read configuration for the key type.
-    type Cfg = (usize, <K as Read>::Cfg);
-
-    fn read_cfg(
-        buf: &mut impl Buf,
-        (max_digests, key_cfg): &Self::Cfg,
-    ) -> Result<Self, commonware_codec::Error> {
-        let proof = OperationProof::<F, D, N>::read_cfg(buf, max_digests)?;
-        let next_key = K::read_cfg(buf, key_cfg)?;
-        Ok(Self { proof, next_key })
-    }
-}
-
-#[cfg(feature = "arbitrary")]
-impl<F: merkle::Graftable, K: Key, D: Digest, const N: usize> arbitrary::Arbitrary<'_>
-    for KeyValueProof<F, K, D, N>
-where
-    K: for<'a> arbitrary::Arbitrary<'a>,
-    D: for<'a> arbitrary::Arbitrary<'a>,
-    F::PendingChunk<D>: for<'a> arbitrary::Arbitrary<'a>,
-{
-    fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
-        Ok(Self {
-            proof: u.arbitrary()?,
-            next_key: u.arbitrary()?,
-        })
-    }
-}
+/// Proof information for verifying a key has a particular value, with a runtime-sized bitmap chunk.
+///
+/// The decoder configuration is `((chunk_size, max_digests), key_cfg)`.
+/// The chunk size is in bytes and is not encoded in the proof.
+pub type RuntimeKeyValueProof<F, K, D> = super::proof::KeyValueProof<F, K, D, bytes::Bytes>;
 
 /// The generic Db type for ordered Current QMDB variants.
 ///

--- a/storage/src/qmdb/current/ordered/db.rs
+++ b/storage/src/qmdb/current/ordered/db.rs
@@ -3,7 +3,7 @@
 //! This module contains impl blocks that are generic over `ValueEncoding`, allowing them to be
 //! used by both fixed and variable ordered QMDB implementations.
 
-use super::proof::fixed::{ExclusionProof, KeyValueProof};
+use super::proof::constant::{ExclusionProof, KeyValueProof};
 use crate::{
     Context,
     index::Ordered as OrderedIndex,

--- a/storage/src/qmdb/current/ordered/db.rs
+++ b/storage/src/qmdb/current/ordered/db.rs
@@ -31,6 +31,27 @@ pub struct KeyValueProof<F: merkle::Graftable, K: Key, D: Digest, const N: usize
     pub next_key: K,
 }
 
+impl<F: merkle::Graftable, K: Key, D: Digest, const N: usize> KeyValueProof<F, K, D, N> {
+    /// Return true if the proof authenticates that `key` currently has `value` in the database
+    /// with the provided `root`.
+    ///
+    /// `V` selects the fixed or variable value encoding used by the database.
+    pub fn verify<H, V>(&self, key: K, value: V::Value, root: &D) -> bool
+    where
+        H: Hasher<Digest = D>,
+        V: ValueEncoding,
+        Operation<F, K, V>: Codec,
+    {
+        let op = Operation::<F, K, V>::Update(Update {
+            key,
+            value,
+            next_key: self.next_key.clone(),
+        });
+
+        self.proof.verify::<H, _>(op, root)
+    }
+}
+
 impl<F: merkle::Graftable, K: Key, D: Digest, const N: usize> Write for KeyValueProof<F, K, D, N> {
     fn write(&self, buf: &mut impl BufMut) {
         self.proof.write(buf);
@@ -104,23 +125,6 @@ where
         self.any.get(key).await
     }
 
-    /// Return true if the proof authenticates that `key` currently has value `value` in the db with
-    /// the provided `root`.
-    pub fn verify_key_value_proof(
-        key: K,
-        value: V::Value,
-        proof: &KeyValueProof<F, K, H::Digest, N>,
-        root: &H::Digest,
-    ) -> bool {
-        let op = Operation::Update(Update {
-            key,
-            value,
-            next_key: proof.next_key.clone(),
-        });
-
-        proof.proof.verify::<H, _>(op, root)
-    }
-
     /// Get the operation that currently defines the span whose range contains `key`, or None if the
     /// DB is empty.
     pub async fn get_span(&self, key: &K) -> Result<Option<(Location<F>, Update<K, V>)>, Error<F>> {
@@ -137,46 +141,6 @@ where
         V: 'a,
     {
         self.any.stream_range(start).await
-    }
-
-    /// Return true if the proof authenticates that `key` does _not_ exist in the db with the
-    /// provided `root`.
-    pub fn verify_exclusion_proof(
-        key: &K,
-        proof: &super::ExclusionProof<F, K, V, H::Digest, N>,
-        root: &H::Digest,
-    ) -> bool {
-        let (op_proof, op) = match proof {
-            super::ExclusionProof::KeyValue(op_proof, data) => {
-                if data.key == *key {
-                    // The provided `key` is in the DB if it matches the start of the span.
-                    return false;
-                }
-                if !crate::qmdb::any::db::Db::<F, E, C, I, H, Update<K, V>, N, S>::span_contains(
-                    &data.key,
-                    &data.next_key,
-                    key,
-                ) {
-                    // If the key is not within the span, then this proof cannot prove its
-                    // exclusion.
-                    return false;
-                }
-
-                (op_proof, Operation::Update(data.clone()))
-            }
-            super::ExclusionProof::Commit(op_proof, metadata) => {
-                // Handle the case where the proof shows the db is empty, hence any key is proven
-                // excluded. For the db to be empty, the floor must equal the commit operation's
-                // location.
-                let floor_loc = op_proof.loc;
-                (
-                    op_proof,
-                    Operation::CommitFloor(metadata.clone(), floor_loc),
-                )
-            }
-        };
-
-        op_proof.verify::<H, _>(op, root)
     }
 }
 

--- a/storage/src/qmdb/current/ordered/db.rs
+++ b/storage/src/qmdb/current/ordered/db.rs
@@ -3,6 +3,7 @@
 //! This module contains impl blocks that are generic over `ValueEncoding`, allowing them to be
 //! used by both fixed and variable ordered QMDB implementations.
 
+use super::proof::fixed::{ExclusionProof, KeyValueProof};
 use crate::{
     Context,
     index::Ordered as OrderedIndex,
@@ -21,12 +22,6 @@ use commonware_codec::Codec;
 use commonware_cryptography::Hasher;
 use commonware_parallel::Strategy;
 use futures::stream::Stream;
-
-/// Proof information for verifying a key has a particular value, with a fixed-size bitmap chunk.
-pub type KeyValueProof<F, K, D, const N: usize> = super::proof::KeyValueProof<F, K, D, [u8; N]>;
-
-/// Proof information for verifying a key has a particular value, with a runtime-sized bitmap chunk.
-pub type RuntimeKeyValueProof<F, K, D> = super::proof::KeyValueProof<F, K, D, bytes::Bytes>;
 
 /// The generic Db type for ordered Current QMDB variants.
 ///
@@ -119,7 +114,7 @@ where
     pub async fn exclusion_proof(
         &self,
         key: &K,
-    ) -> Result<super::ExclusionProof<F, K, V, H::Digest, N>, Error<F>> {
+    ) -> Result<ExclusionProof<F, K, V, H::Digest, N>, Error<F>> {
         match self.any.get_span(key).await? {
             Some((loc, key_data)) => {
                 if key_data.key == *key {
@@ -127,7 +122,7 @@ where
                     return Err(Error::<F>::KeyExists);
                 }
                 let op_proof = self.operation_proof(loc).await?;
-                Ok(super::ExclusionProof::KeyValue(op_proof, key_data))
+                Ok(ExclusionProof::KeyValue(op_proof, key_data))
             }
             None => {
                 // The DB is empty. Use the last CommitFloor to prove emptiness. The Commit proof
@@ -143,7 +138,7 @@ where
                     self.any.last_commit_loc, floor
                 );
                 let op_proof = self.operation_proof(self.any.last_commit_loc).await?;
-                Ok(super::ExclusionProof::Commit(op_proof, value))
+                Ok(ExclusionProof::Commit(op_proof, value))
             }
         }
     }

--- a/storage/src/qmdb/current/ordered/fixed.rs
+++ b/storage/src/qmdb/current/ordered/fixed.rs
@@ -5,9 +5,9 @@
 //! proofs (proving a key is currently inactive). Use [crate::qmdb::current::unordered::fixed] if
 //! exclusion proofs are not needed.
 //!
-//! See [Db] for the main database type and [super::ExclusionProof] for proving key inactivity.
+//! See [Db] for the main database type and
+//! [ExclusionProof](super::proof::fixed::ExclusionProof) for proving key inactivity.
 
-pub use super::db::{KeyValueProof, RuntimeKeyValueProof};
 use crate::{
     Context,
     index::ordered::Index,
@@ -201,17 +201,17 @@ pub mod test {
     }
 
     #[test_traced("DEBUG")]
-    fn test_current_db_runtime_key_value_proof_mmb() {
+    fn test_current_db_dynamic_key_value_proof_mmb() {
         shared::test_key_value_proof(open_db::<mmb::Family>);
     }
 
     #[test_traced("DEBUG")]
-    fn test_current_db_runtime_exclusion_proofs_mmb() {
+    fn test_current_db_dynamic_exclusion_proofs_mmb() {
         shared::test_exclusion_proofs(open_db::<mmb::Family>);
     }
 
     #[test_traced("DEBUG")]
-    fn test_current_db_runtime_inactive_proof_mmb() {
+    fn test_current_db_dynamic_inactive_proof_mmb() {
         shared::test_verify_proof_over_bits_in_uncommitted_chunk(open_db::<mmb::Family>);
     }
 

--- a/storage/src/qmdb/current/ordered/fixed.rs
+++ b/storage/src/qmdb/current/ordered/fixed.rs
@@ -6,7 +6,7 @@
 //! exclusion proofs are not needed.
 //!
 //! See [Db] for the main database type and
-//! [ExclusionProof](super::proof::fixed::ExclusionProof) for proving key inactivity.
+//! [ExclusionProof](super::proof::constant::ExclusionProof) for proving key inactivity.
 
 use crate::{
     Context,

--- a/storage/src/qmdb/current/ordered/fixed.rs
+++ b/storage/src/qmdb/current/ordered/fixed.rs
@@ -7,7 +7,7 @@
 //!
 //! See [Db] for the main database type and [super::ExclusionProof] for proving key inactivity.
 
-pub use super::db::KeyValueProof;
+pub use super::db::{KeyValueProof, RuntimeKeyValueProof};
 use crate::{
     Context,
     index::ordered::Index,
@@ -106,7 +106,8 @@ pub mod partitioned {
 pub mod test {
     use super::*;
     use crate::{
-        mmr,
+        merkle::Graftable,
+        mmb, mmr,
         qmdb::{
             Error,
             current::{
@@ -126,23 +127,26 @@ pub mod test {
     };
 
     /// A type alias for the concrete [Db] type used in these unit tests.
-    type CurrentTest =
-        Db<mmr::Family, deterministic::Context, Digest, Digest, Sha256, OneCap, 32, Sequential>;
+    type CurrentTest<F = mmr::Family> =
+        Db<F, deterministic::Context, Digest, Digest, Sha256, OneCap, 32, Sequential>;
 
     /// Return an [Db] database initialized with a fixed config.
-    async fn open_db(context: deterministic::Context, partition_prefix: String) -> CurrentTest {
+    async fn open_db<F: Graftable>(
+        context: deterministic::Context,
+        partition_prefix: String,
+    ) -> CurrentTest<F> {
         let cfg = fixed_config::<OneCap>(&partition_prefix, &context);
-        CurrentTest::init(context, cfg).await.unwrap()
+        CurrentTest::<F>::init(context, cfg).await.unwrap()
     }
 
     #[test_traced("DEBUG")]
     pub fn test_current_db_verify_proof_over_bits_in_uncommitted_chunk() {
-        shared::test_verify_proof_over_bits_in_uncommitted_chunk(open_db);
+        shared::test_verify_proof_over_bits_in_uncommitted_chunk(open_db::<mmr::Family>);
     }
 
     #[test_traced("DEBUG")]
     pub fn test_current_db_range_proofs() {
-        shared::test_range_proofs(open_db);
+        shared::test_range_proofs(open_db::<mmr::Family>);
     }
 
     /// Regression test: requesting a range proof for a location in a pruned bitmap chunk
@@ -152,7 +156,7 @@ pub mod test {
         let executor = deterministic::Runner::default();
         executor.start(|context| async move {
             let partition = "range-proofs-pruned".to_string();
-            let mut db = open_db(context.child("db"), partition).await;
+            let mut db = open_db::<mmr::Family>(context.child("db"), partition).await;
 
             let chunk_bits = BitMap::<32>::CHUNK_SIZE_BITS;
 
@@ -193,22 +197,37 @@ pub mod test {
 
     #[test_traced("DEBUG")]
     pub fn test_current_db_key_value_proof() {
-        shared::test_key_value_proof(open_db);
+        shared::test_key_value_proof(open_db::<mmr::Family>);
+    }
+
+    #[test_traced("DEBUG")]
+    fn test_current_db_runtime_key_value_proof_mmb() {
+        shared::test_key_value_proof(open_db::<mmb::Family>);
+    }
+
+    #[test_traced("DEBUG")]
+    fn test_current_db_runtime_exclusion_proofs_mmb() {
+        shared::test_exclusion_proofs(open_db::<mmb::Family>);
+    }
+
+    #[test_traced("DEBUG")]
+    fn test_current_db_runtime_inactive_proof_mmb() {
+        shared::test_verify_proof_over_bits_in_uncommitted_chunk(open_db::<mmb::Family>);
     }
 
     #[test_traced("WARN")]
     pub fn test_current_db_proving_repeated_updates() {
-        shared::test_proving_repeated_updates(open_db);
+        shared::test_proving_repeated_updates(open_db::<mmr::Family>);
     }
 
     #[test_traced("DEBUG")]
     pub fn test_current_db_exclusion_proofs() {
-        shared::test_exclusion_proofs(open_db);
+        shared::test_exclusion_proofs(open_db::<mmr::Family>);
     }
 
     crate::qmdb::current::tests::staged_merkleize_parity_test!(
         test_current_ordered_fixed_staged_merkleize_parity,
-        open_db
+        open_db::<mmr::Family>
     );
 
     /// Build a `P`-partitioned current db with churny ops across two commits (so the second commit's

--- a/storage/src/qmdb/current/ordered/mod.rs
+++ b/storage/src/qmdb/current/ordered/mod.rs
@@ -1,8 +1,8 @@
 //! _Ordered_ variants of a [crate::qmdb::current] authenticated database.
 //!
 //! These variants maintain the lexicographic-next active key for each active key, enabling
-//! exclusion proofs via [ExclusionProof]. This adds overhead compared to [super::unordered]
-//! variants.
+//! exclusion proofs via [ExclusionProof](proof::fixed::ExclusionProof). This adds overhead
+//! compared to [super::unordered] variants.
 //!
 //! Variants:
 //! - [fixed]: Variant optimized for values of fixed size.
@@ -15,25 +15,20 @@ pub mod proof;
 mod test_trait_impls;
 pub mod variable;
 
-/// Proof that a key has no assigned value in the database, with a fixed-size bitmap chunk.
-///
-/// Verify using [ExclusionProof::verify].
-pub type ExclusionProof<F, K, V, D, const N: usize> = proof::ExclusionProof<F, K, V, D, [u8; N]>;
-
-/// Proof that a key has no assigned value in the database, with a runtime-sized bitmap chunk.
-pub type RuntimeExclusionProof<F, K, V, D> = proof::ExclusionProof<F, K, V, D, bytes::Bytes>;
-
-/// Wire tag for [ExclusionProof::KeyValue].
+/// Wire tag for [proof::fixed::ExclusionProof::KeyValue].
 pub const KEY_VALUE_CONTEXT: u8 = 0;
 
-/// Wire tag for [ExclusionProof::Commit].
+/// Wire tag for [proof::fixed::ExclusionProof::Commit].
 pub const COMMIT_CONTEXT: u8 = 1;
 
 #[cfg(test)]
 pub mod tests {
     //! Shared test utilities for ordered Current QMDB variants.
 
-    use super::{ExclusionProof, RuntimeExclusionProof, db};
+    use super::{
+        db,
+        proof::{dynamic, fixed},
+    };
     use crate::{
         index::ordered::Index,
         journal::contiguous::{Contiguous as _, Mutable},
@@ -49,7 +44,7 @@ pub mod tests {
             },
             current::{
                 BitmapPrunedBits,
-                proof::{OperationProof, RangeProof},
+                proof::{RangeProof, fixed::OperationProof},
                 tests::apply_random_ops,
             },
             store::tests::{TestKey, TestValue},
@@ -247,8 +242,8 @@ pub mod tests {
             // Create a proof of the now-inactive update operation assigning v1 to k against the
             // current root.
             let (p, _, chunks) = db.range_proof(op_loc, NZU64!(1)).await.unwrap();
-            let proof_inactive = db::KeyValueProof {
-                proof: crate::qmdb::current::proof::OperationProof {
+            let proof_inactive = fixed::KeyValueProof {
+                proof: crate::qmdb::current::proof::fixed::OperationProof {
                     loc: op_loc,
                     chunk: chunks[0],
                     range_proof: p,
@@ -273,7 +268,7 @@ pub mod tests {
             // But this proof should *not* verify as a key value proof, since verification will see
             // that the operation is inactive.
             assert!(!proof_inactive.verify::<Sha256, V>(k, v1, &root));
-            let runtime_inactive = db::RuntimeKeyValueProof::<F, Digest, Digest>::decode_cfg(
+            let dynamic_inactive = dynamic::KeyValueProof::<F, Digest, Digest>::decode_cfg(
                 proof_inactive.encode(),
                 &(
                     (32, proof_inactive.proof.range_proof.proof.digests.len()),
@@ -281,7 +276,7 @@ pub mod tests {
                 ),
             )
             .unwrap();
-            assert!(!runtime_inactive.verify::<Sha256, V>(k, v1, &root));
+            assert!(!dynamic_inactive.verify::<Sha256, V>(k, v1, &root));
 
             // Attempt #1 to "fool" the verifier:  change the location to that of an active
             // operation. This should not fool the verifier if we're properly validating the
@@ -432,7 +427,7 @@ pub mod tests {
                 let proof = db.key_value_proof(key).await.unwrap();
                 let max_digests = proof.proof.range_proof.proof.digests.len();
                 let encoded = proof.encode();
-                let proof = db::RuntimeKeyValueProof::<F, Digest, Digest>::decode_cfg(
+                let proof = dynamic::KeyValueProof::<F, Digest, Digest>::decode_cfg(
                     encoded.clone(),
                     &((32, max_digests), ()),
                 )
@@ -514,9 +509,9 @@ pub mod tests {
         });
     }
 
-    fn runtime_exclusion_proof<F, V>(
-        proof: ExclusionProof<F, Digest, V, Digest, 32>,
-    ) -> RuntimeExclusionProof<F, Digest, V, Digest>
+    fn dynamic_exclusion_proof<F, V>(
+        proof: fixed::ExclusionProof<F, Digest, V, Digest, 32>,
+    ) -> dynamic::ExclusionProof<F, Digest, V, Digest>
     where
         F: Graftable,
         V: ValueEncoding<Value = Digest>,
@@ -524,18 +519,18 @@ pub mod tests {
         <Update<Digest, V> as Read>::Cfg: Default,
     {
         let max_digests = match &proof {
-            ExclusionProof::KeyValue(proof, _) | ExclusionProof::Commit(proof, _) => {
+            fixed::ExclusionProof::KeyValue(proof, _) | fixed::ExclusionProof::Commit(proof, _) => {
                 proof.range_proof.proof.digests.len()
             }
         };
         let encoded = proof.encode();
-        let runtime = RuntimeExclusionProof::<F, Digest, V, Digest>::decode_cfg(
+        let dynamic = dynamic::ExclusionProof::<F, Digest, V, Digest>::decode_cfg(
             encoded.clone(),
             &((32, max_digests), Default::default(), ()),
         )
         .unwrap();
-        assert_eq!(runtime.encode(), encoded);
-        runtime
+        assert_eq!(dynamic.encode(), encoded);
+        dynamic
     }
 
     /// Build a tiny database and confirm exclusion proofs work as expected.
@@ -565,7 +560,7 @@ pub mod tests {
             // We should be able to prove exclusion for any key against an empty db.
             let empty_root = db.root();
             let empty_proof =
-                runtime_exclusion_proof(db.exclusion_proof(&key_exists_1).await.unwrap());
+                dynamic_exclusion_proof(db.exclusion_proof(&key_exists_1).await.unwrap());
             assert!(empty_proof.verify::<Sha256>(&key_exists_1, &empty_root));
 
             // Add `key_exists_1` and test exclusion proving over the single-key database case.
@@ -586,8 +581,8 @@ pub mod tests {
             // Generate some valid exclusion proofs for keys on either side.
             let greater_key = Sha256::fill(0xFF);
             let lesser_key = Sha256::fill(0x00);
-            let proof = runtime_exclusion_proof(db.exclusion_proof(&greater_key).await.unwrap());
-            let proof2 = runtime_exclusion_proof(db.exclusion_proof(&lesser_key).await.unwrap());
+            let proof = dynamic_exclusion_proof(db.exclusion_proof(&greater_key).await.unwrap());
+            let proof2 = dynamic_exclusion_proof(db.exclusion_proof(&lesser_key).await.unwrap());
 
             // Since there's only one span in the DB, the two exclusion proofs should be identical,
             // and the proof should verify any key but the one that exists in the db.
@@ -616,7 +611,7 @@ pub mod tests {
             let lesser_key = Sha256::fill(0x0F); // < k1=0x10
             let greater_key = Sha256::fill(0x31); // > k2=0x30
             let middle_key = Sha256::fill(0x20); // between k1=0x10 and k2=0x30
-            let proof = runtime_exclusion_proof(db.exclusion_proof(&greater_key).await.unwrap());
+            let proof = dynamic_exclusion_proof(db.exclusion_proof(&greater_key).await.unwrap());
             // Test the "cycle around" span. This should prove exclusion of greater_key & lesser
             // key, but fail on middle_key.
             assert!(proof.verify::<Sha256>(&greater_key, &root));
@@ -624,11 +619,11 @@ pub mod tests {
             assert!(!proof.verify::<Sha256>(&middle_key, &root));
 
             // Due to the cycle, lesser & greater keys should produce the same proof.
-            let new_proof = runtime_exclusion_proof(db.exclusion_proof(&lesser_key).await.unwrap());
+            let new_proof = dynamic_exclusion_proof(db.exclusion_proof(&lesser_key).await.unwrap());
             assert_eq!(proof, new_proof);
 
             // Test the inner span [k, k2).
-            let proof = runtime_exclusion_proof(db.exclusion_proof(&middle_key).await.unwrap());
+            let proof = dynamic_exclusion_proof(db.exclusion_proof(&middle_key).await.unwrap());
             // `k` should fail since it's in the db.
             assert!(!proof.verify::<Sha256>(&key_exists_1, &root));
             // `middle_key` should succeed since it's in range.
@@ -660,7 +655,7 @@ pub mod tests {
             assert_ne!(db.bounds().end, 0);
             assert_ne!(root, empty_root);
 
-            let proof = runtime_exclusion_proof(db.exclusion_proof(&key_exists_1).await.unwrap());
+            let proof = dynamic_exclusion_proof(db.exclusion_proof(&key_exists_1).await.unwrap());
             assert!(proof.verify::<Sha256>(&key_exists_1, &root));
             assert!(proof.verify::<Sha256>(&key_exists_2, &root));
 
@@ -694,8 +689,8 @@ pub mod tests {
     }
 
     type CodecExclusionProof =
-        ExclusionProof<mmb::Family, Digest, FixedEncoding<Digest>, Digest, 32>;
-    type CodecKeyValueProof = db::KeyValueProof<mmb::Family, Digest, Digest, 32>;
+        fixed::ExclusionProof<mmb::Family, Digest, FixedEncoding<Digest>, Digest, 32>;
+    type CodecKeyValueProof = fixed::KeyValueProof<mmb::Family, Digest, Digest, 32>;
     const MAX_DIGESTS: usize = 64;
 
     #[test]
@@ -788,10 +783,10 @@ pub mod tests {
         assert!(result.is_err());
     }
 
-    fn check_runtime_codec<P: Codec>(encoded: Bytes, cfg: &P::Cfg, limited: &P::Cfg) {
-        let runtime = P::decode_cfg(encoded.clone(), cfg).unwrap();
-        assert_eq!(runtime.encode(), encoded);
-        assert_eq!(runtime.encode_size(), encoded.len());
+    fn check_dynamic_codec<P: Codec>(encoded: Bytes, cfg: &P::Cfg, limited: &P::Cfg) {
+        let dynamic = P::decode_cfg(encoded.clone(), cfg).unwrap();
+        assert_eq!(dynamic.encode(), encoded);
+        assert_eq!(dynamic.encode_size(), encoded.len());
         assert!(P::decode_cfg(encoded.clone(), limited).is_err());
         for end in 0..encoded.len() {
             assert!(P::decode_cfg(&encoded[..end], cfg).is_err());
@@ -801,26 +796,23 @@ pub mod tests {
         assert!(P::decode_cfg(trailing.as_slice(), cfg).is_err());
     }
 
-    fn check_runtime_ordered_codecs<F: Graftable>() {
-        let proof = db::KeyValueProof::<F, Digest, Digest, 32> {
+    fn check_dynamic_ordered_codecs<F: Graftable>() {
+        let proof = fixed::KeyValueProof::<F, Digest, Digest, 32> {
             proof: sample_op_proof(),
             next_key: Sha256::hash(&[b"next-key"]),
         };
-        check_runtime_codec::<db::RuntimeKeyValueProof<F, Digest, Digest>>(
+        check_dynamic_codec::<dynamic::KeyValueProof<F, Digest, Digest>>(
             proof.encode(),
             &((32, 1), ()),
             &((32, 0), ()),
         );
         assert!(
-            db::RuntimeKeyValueProof::<F, Digest, Digest>::decode_cfg(
-                proof.encode(),
-                &((3, 1), ()),
-            )
-            .is_err()
+            dynamic::KeyValueProof::<F, Digest, Digest>::decode_cfg(proof.encode(), &((3, 1), ()),)
+                .is_err()
         );
 
         let cases = [
-            ExclusionProof::<F, Digest, FixedEncoding<Digest>, Digest, 32>::KeyValue(
+            fixed::ExclusionProof::<F, Digest, FixedEncoding<Digest>, Digest, 32>::KeyValue(
                 sample_op_proof(),
                 Update {
                     key: Sha256::hash(&[b"key"]),
@@ -828,17 +820,17 @@ pub mod tests {
                     next_key: Sha256::hash(&[b"next-key"]),
                 },
             ),
-            ExclusionProof::Commit(sample_op_proof(), Some(Sha256::hash(&[b"metadata"]))),
-            ExclusionProof::Commit(sample_op_proof(), None),
+            fixed::ExclusionProof::Commit(sample_op_proof(), Some(Sha256::hash(&[b"metadata"]))),
+            fixed::ExclusionProof::Commit(sample_op_proof(), None),
         ];
         for proof in cases {
-            check_runtime_codec::<RuntimeExclusionProof<F, Digest, FixedEncoding<Digest>, Digest>>(
+            check_dynamic_codec::<dynamic::ExclusionProof<F, Digest, FixedEncoding<Digest>, Digest>>(
                 proof.encode(),
                 &((32, 1), (), ()),
                 &((32, 0), (), ()),
             );
             assert!(
-                RuntimeExclusionProof::<F, Digest, FixedEncoding<Digest>, Digest>::decode_cfg(
+                dynamic::ExclusionProof::<F, Digest, FixedEncoding<Digest>, Digest>::decode_cfg(
                     proof.encode(),
                     &((3, 1), (), ()),
                 )
@@ -847,7 +839,7 @@ pub mod tests {
             let mut unknown_tag = proof.encode().to_vec();
             unknown_tag[0] = 2;
             assert!(matches!(
-                RuntimeExclusionProof::<F, Digest, FixedEncoding<Digest>, Digest>::decode_cfg(
+                dynamic::ExclusionProof::<F, Digest, FixedEncoding<Digest>, Digest>::decode_cfg(
                     unknown_tag.as_slice(),
                     &((32, 1), (), ()),
                 ),
@@ -858,7 +850,7 @@ pub mod tests {
         let value_cfg = ((..=3).into(), ());
         let update_cfg = ((), value_cfg);
         let cases = [
-            ExclusionProof::<F, Digest, VariableEncoding<Vec<u8>>, Digest, 32>::KeyValue(
+            fixed::ExclusionProof::<F, Digest, VariableEncoding<Vec<u8>>, Digest, 32>::KeyValue(
                 sample_op_proof(),
                 Update {
                     key: Sha256::hash(&[b"key"]),
@@ -866,11 +858,11 @@ pub mod tests {
                     next_key: Sha256::hash(&[b"next-key"]),
                 },
             ),
-            ExclusionProof::Commit(sample_op_proof(), Some(vec![1, 2, 3])),
+            fixed::ExclusionProof::Commit(sample_op_proof(), Some(vec![1, 2, 3])),
         ];
         for proof in cases {
-            check_runtime_codec::<
-                RuntimeExclusionProof<F, Digest, VariableEncoding<Vec<u8>>, Digest>,
+            check_dynamic_codec::<
+                dynamic::ExclusionProof<F, Digest, VariableEncoding<Vec<u8>>, Digest>,
             >(
                 proof.encode(),
                 &((32, 1), update_cfg, value_cfg),
@@ -878,7 +870,7 @@ pub mod tests {
             );
             let short_value_cfg = ((..=2).into(), ());
             assert!(
-                RuntimeExclusionProof::<F, Digest, VariableEncoding<Vec<u8>>, Digest>::decode_cfg(
+                dynamic::ExclusionProof::<F, Digest, VariableEncoding<Vec<u8>>, Digest>::decode_cfg(
                     proof.encode(),
                     &((32, 1), ((), short_value_cfg), short_value_cfg),
                 )
@@ -888,9 +880,9 @@ pub mod tests {
     }
 
     #[test]
-    fn test_runtime_ordered_codecs() {
-        check_runtime_ordered_codecs::<mmr::Family>();
-        check_runtime_ordered_codecs::<mmb::Family>();
+    fn test_dynamic_ordered_codecs() {
+        check_dynamic_ordered_codecs::<mmr::Family>();
+        check_dynamic_ordered_codecs::<mmb::Family>();
     }
 
     #[cfg(feature = "arbitrary")]
@@ -899,10 +891,7 @@ pub mod tests {
             merkle::{mmb, mmr},
             qmdb::{
                 any::value::{FixedEncoding, VariableEncoding},
-                current::ordered::{
-                    ExclusionProof, RuntimeExclusionProof,
-                    db::{KeyValueProof, RuntimeKeyValueProof},
-                },
+                current::ordered::proof::{dynamic, fixed},
             },
         };
         use commonware_codec::conformance::CodecConformance;
@@ -910,18 +899,18 @@ pub mod tests {
         use commonware_utils::sequence::U64;
 
         commonware_conformance::conformance_tests! {
-            CodecConformance<KeyValueProof<mmr::Family, U64, Sha256Digest, 32>>,
-            CodecConformance<KeyValueProof<mmb::Family, U64, Sha256Digest, 32>>,
-            CodecConformance<ExclusionProof<mmr::Family, U64, FixedEncoding<U64>, Sha256Digest, 32>>,
-            CodecConformance<ExclusionProof<mmr::Family, U64, VariableEncoding<Vec<u8>>, Sha256Digest, 32>>,
-            CodecConformance<ExclusionProof<mmb::Family, U64, FixedEncoding<U64>, Sha256Digest, 32>>,
-            CodecConformance<ExclusionProof<mmb::Family, U64, VariableEncoding<Vec<u8>>, Sha256Digest, 32>>,
-            CodecConformance<RuntimeKeyValueProof<mmr::Family, U64, Sha256Digest>>,
-            CodecConformance<RuntimeKeyValueProof<mmb::Family, U64, Sha256Digest>>,
-            CodecConformance<RuntimeExclusionProof<mmr::Family, U64, FixedEncoding<U64>, Sha256Digest>>,
-            CodecConformance<RuntimeExclusionProof<mmr::Family, U64, VariableEncoding<Vec<u8>>, Sha256Digest>>,
-            CodecConformance<RuntimeExclusionProof<mmb::Family, U64, FixedEncoding<U64>, Sha256Digest>>,
-            CodecConformance<RuntimeExclusionProof<mmb::Family, U64, VariableEncoding<Vec<u8>>, Sha256Digest>>,
+            CodecConformance<fixed::KeyValueProof<mmr::Family, U64, Sha256Digest, 32>>,
+            CodecConformance<fixed::KeyValueProof<mmb::Family, U64, Sha256Digest, 32>>,
+            CodecConformance<fixed::ExclusionProof<mmr::Family, U64, FixedEncoding<U64>, Sha256Digest, 32>>,
+            CodecConformance<fixed::ExclusionProof<mmr::Family, U64, VariableEncoding<Vec<u8>>, Sha256Digest, 32>>,
+            CodecConformance<fixed::ExclusionProof<mmb::Family, U64, FixedEncoding<U64>, Sha256Digest, 32>>,
+            CodecConformance<fixed::ExclusionProof<mmb::Family, U64, VariableEncoding<Vec<u8>>, Sha256Digest, 32>>,
+            CodecConformance<dynamic::KeyValueProof<mmr::Family, U64, Sha256Digest>>,
+            CodecConformance<dynamic::KeyValueProof<mmb::Family, U64, Sha256Digest>>,
+            CodecConformance<dynamic::ExclusionProof<mmr::Family, U64, FixedEncoding<U64>, Sha256Digest>>,
+            CodecConformance<dynamic::ExclusionProof<mmr::Family, U64, VariableEncoding<Vec<u8>>, Sha256Digest>>,
+            CodecConformance<dynamic::ExclusionProof<mmb::Family, U64, FixedEncoding<U64>, Sha256Digest>>,
+            CodecConformance<dynamic::ExclusionProof<mmb::Family, U64, VariableEncoding<Vec<u8>>, Sha256Digest>>,
         }
     }
 }

--- a/storage/src/qmdb/current/ordered/mod.rs
+++ b/storage/src/qmdb/current/ordered/mod.rs
@@ -8,46 +8,23 @@
 //! - [fixed]: Variant optimized for values of fixed size.
 //! - [variable]: Variant for values of variable size.
 
-use crate::{
-    merkle::Graftable,
-    qmdb::{
-        any::{
-            ValueEncoding,
-            ordered::{Operation, Update, span_contains},
-        },
-        current::proof::OperationProof,
-        operation::Key,
-    },
-};
-use bytes::{Buf, BufMut};
-use commonware_codec::{Codec, EncodeSize, Read, ReadExt as _, Write};
-use commonware_cryptography::{Digest, Hasher};
-
 pub mod db;
 pub mod fixed;
+pub mod proof;
 #[cfg(any(test, feature = "test-traits"))]
 mod test_trait_impls;
 pub mod variable;
 
-/// Proof that a key has no assigned value in the database.
+/// Proof that a key has no assigned value in the database, with a fixed-size bitmap chunk.
 ///
-/// When the database has active keys, exclusion is proven by showing the key falls within a span
-/// between two adjacent active keys. Otherwise exclusion is proven by showing the database contains
-/// no active keys through the most recent commit operation.
-///
-/// Verify using [Self::verify].
-#[derive(Clone, Eq, PartialEq, Debug)]
-pub enum ExclusionProof<F: Graftable, K: Key, V: ValueEncoding, D: Digest, const N: usize> {
-    /// Proves that two keys are active in the database and adjacent to each other in the key
-    /// ordering. Any key falling between them (non-inclusively) can be proven excluded.
-    KeyValue(OperationProof<F, D, N>, Update<K, V>),
+/// Verify using [ExclusionProof::verify].
+pub type ExclusionProof<F, K, V, D, const N: usize> = proof::ExclusionProof<F, K, V, D, [u8; N]>;
 
-    /// Proves that the database has no active keys, allowing any key to be proven excluded.
-    /// Specifically, the proof establishes the most recent Commit operation has an activity floor
-    /// equal to its own location, which is a necessary and sufficient condition for an empty
-    /// database.
-    Commit(OperationProof<F, D, N>, Option<V::Value>),
-}
+/// Proof that a key has no assigned value in the database, with a runtime-sized bitmap chunk.
+///
+/// The decoder configuration is `((chunk_size, max_digests), update_cfg, value_cfg)`.
+/// The chunk size is in bytes and is not encoded in the proof.
+pub type RuntimeExclusionProof<F, K, V, D> = proof::ExclusionProof<F, K, V, D, bytes::Bytes>;
 
 /// Wire tag for [ExclusionProof::KeyValue].
 pub const KEY_VALUE_CONTEXT: u8 = 0;
@@ -55,150 +32,23 @@ pub const KEY_VALUE_CONTEXT: u8 = 0;
 /// Wire tag for [ExclusionProof::Commit].
 pub const COMMIT_CONTEXT: u8 = 1;
 
-impl<F, K, V, D, const N: usize> ExclusionProof<F, K, V, D, N>
-where
-    F: Graftable,
-    K: Key,
-    V: ValueEncoding,
-    D: Digest,
-    Operation<F, K, V>: Codec,
-{
-    /// Return true if the proof authenticates that `key` does not exist in the database with
-    /// the provided `root`.
-    pub fn verify<H: Hasher<Digest = D>>(&self, key: &K, root: &D) -> bool {
-        let (op_proof, op) = match self {
-            Self::KeyValue(op_proof, data) => {
-                if data.key == *key || !span_contains(&data.key, &data.next_key, key) {
-                    return false;
-                }
-
-                (op_proof, Operation::Update(data.clone()))
-            }
-            Self::Commit(op_proof, metadata) => {
-                // An empty database's commit floor equals the commit operation's location
-                (
-                    op_proof,
-                    Operation::CommitFloor(metadata.clone(), op_proof.loc),
-                )
-            }
-        };
-
-        op_proof.verify::<H, _>(op, root)
-    }
-}
-
-impl<F, K, V, D, const N: usize> Write for ExclusionProof<F, K, V, D, N>
-where
-    F: Graftable,
-    K: Key,
-    V: ValueEncoding,
-    D: Digest,
-    Update<K, V>: Write,
-{
-    fn write(&self, buf: &mut impl BufMut) {
-        match self {
-            Self::KeyValue(op_proof, update) => {
-                KEY_VALUE_CONTEXT.write(buf);
-                op_proof.write(buf);
-                update.write(buf);
-            }
-            Self::Commit(op_proof, value) => {
-                COMMIT_CONTEXT.write(buf);
-                op_proof.write(buf);
-                value.write(buf);
-            }
-        }
-    }
-}
-
-impl<F, K, V, D, const N: usize> EncodeSize for ExclusionProof<F, K, V, D, N>
-where
-    F: Graftable,
-    K: Key,
-    V: ValueEncoding,
-    D: Digest,
-    Update<K, V>: EncodeSize,
-{
-    fn encode_size(&self) -> usize {
-        1 + match self {
-            Self::KeyValue(op_proof, update) => op_proof.encode_size() + update.encode_size(),
-            Self::Commit(op_proof, value) => op_proof.encode_size() + value.encode_size(),
-        }
-    }
-}
-
-impl<F, K, V, D, const N: usize> Read for ExclusionProof<F, K, V, D, N>
-where
-    F: Graftable,
-    K: Key,
-    V: ValueEncoding,
-    D: Digest,
-    Update<K, V>: Read,
-{
-    /// `(max_digests, update_cfg, value_cfg)`: Merkle digest cap forwarded to the embedded
-    /// operation proof, the read configuration for [Update], and the read configuration for the
-    /// value type.
-    type Cfg = (usize, <Update<K, V> as Read>::Cfg, <V::Value as Read>::Cfg);
-
-    fn read_cfg(
-        buf: &mut impl Buf,
-        (max_digests, update_cfg, value_cfg): &Self::Cfg,
-    ) -> Result<Self, commonware_codec::Error> {
-        match u8::read(buf)? {
-            KEY_VALUE_CONTEXT => {
-                let op_proof = OperationProof::<F, D, N>::read_cfg(buf, max_digests)?;
-                let update = Update::<K, V>::read_cfg(buf, update_cfg)?;
-                Ok(Self::KeyValue(op_proof, update))
-            }
-            COMMIT_CONTEXT => {
-                let op_proof = OperationProof::<F, D, N>::read_cfg(buf, max_digests)?;
-                let value = Option::<V::Value>::read_cfg(buf, value_cfg)?;
-                Ok(Self::Commit(op_proof, value))
-            }
-            tag => Err(commonware_codec::Error::InvalidEnum(tag)),
-        }
-    }
-}
-
-#[cfg(feature = "arbitrary")]
-impl<F, K, V, D, const N: usize> arbitrary::Arbitrary<'_> for ExclusionProof<F, K, V, D, N>
-where
-    F: Graftable,
-    K: Key,
-    V: ValueEncoding,
-    D: Digest,
-    K: for<'a> arbitrary::Arbitrary<'a>,
-    V::Value: for<'a> arbitrary::Arbitrary<'a>,
-    D: for<'a> arbitrary::Arbitrary<'a>,
-    F::PendingChunk<D>: for<'a> arbitrary::Arbitrary<'a>,
-{
-    fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
-        let op_proof = u.arbitrary()?;
-        if u.arbitrary()? {
-            Ok(Self::KeyValue(op_proof, u.arbitrary()?))
-        } else {
-            Ok(Self::Commit(op_proof, u.arbitrary()?))
-        }
-    }
-}
-
 #[cfg(test)]
 pub mod tests {
     //! Shared test utilities for ordered Current QMDB variants.
 
-    use super::{ExclusionProof, db};
+    use super::{ExclusionProof, RuntimeExclusionProof, db};
     use crate::{
         index::ordered::Index,
         journal::contiguous::{Contiguous as _, Mutable},
         merkle::{Graftable, Location, Proof},
-        mmb,
+        mmb, mmr,
         qmdb::{
             Error,
             any::{
                 ValueEncoding,
                 ordered::{Operation, Update},
                 traits::{DbAny, UnmerkleizedBatch as _},
-                value::FixedEncoding,
+                value::{FixedEncoding, VariableEncoding},
             },
             current::{
                 BitmapPrunedBits,
@@ -209,7 +59,8 @@ pub mod tests {
         },
         translator::OneCap,
     };
-    use commonware_codec::{Codec, Decode as _, Encode as _, EncodeSize as _};
+    use bytes::Bytes;
+    use commonware_codec::{Codec, Decode as _, Encode as _, EncodeSize as _, Read};
     use commonware_cryptography::{Digest as _, Hasher as _, Sha256, sha256::Digest};
     use commonware_runtime::{
         Runner as _, Supervisor as _,
@@ -425,6 +276,15 @@ pub mod tests {
             // But this proof should *not* verify as a key value proof, since verification will see
             // that the operation is inactive.
             assert!(!proof_inactive.verify::<Sha256, V>(k, v1, &root));
+            let runtime_inactive = db::RuntimeKeyValueProof::<F, Digest, Digest>::decode_cfg(
+                proof_inactive.encode(),
+                &(
+                    (32, proof_inactive.proof.range_proof.proof.digests.len()),
+                    (),
+                ),
+            )
+            .unwrap();
+            assert!(!runtime_inactive.verify::<Sha256, V>(k, v1, &root));
 
             // Attempt #1 to "fool" the verifier:  change the location to that of an active
             // operation. This should not fool the verifier if we're properly validating the
@@ -574,11 +434,13 @@ pub mod tests {
                 };
                 let proof = db.key_value_proof(key).await.unwrap();
                 let max_digests = proof.proof.range_proof.proof.digests.len();
-                let proof = db::KeyValueProof::<F, Digest, Digest, 32>::decode_cfg(
-                    proof.encode(),
-                    &(max_digests, ()),
+                let encoded = proof.encode();
+                let proof = db::RuntimeKeyValueProof::<F, Digest, Digest>::decode_cfg(
+                    encoded.clone(),
+                    &((32, max_digests), ()),
                 )
                 .unwrap();
+                assert_eq!(proof.encode(), encoded);
 
                 // Proof should validate against the current value and correct root.
                 assert!(proof.verify::<Sha256, V>(key, value, &root));
@@ -655,6 +517,30 @@ pub mod tests {
         });
     }
 
+    fn runtime_exclusion_proof<F, V>(
+        proof: ExclusionProof<F, Digest, V, Digest, 32>,
+    ) -> RuntimeExclusionProof<F, Digest, V, Digest>
+    where
+        F: Graftable,
+        V: ValueEncoding<Value = Digest>,
+        Update<Digest, V>: Codec,
+        <Update<Digest, V> as Read>::Cfg: Default,
+    {
+        let max_digests = match &proof {
+            ExclusionProof::KeyValue(proof, _) | ExclusionProof::Commit(proof, _) => {
+                proof.range_proof.proof.digests.len()
+            }
+        };
+        let encoded = proof.encode();
+        let runtime = RuntimeExclusionProof::<F, Digest, V, Digest>::decode_cfg(
+            encoded.clone(),
+            &((32, max_digests), Default::default(), ()),
+        )
+        .unwrap();
+        assert_eq!(runtime.encode(), encoded);
+        runtime
+    }
+
     /// Build a tiny database and confirm exclusion proofs work as expected.
     ///
     /// Tests empty-db exclusion, single-key exclusion, two-key exclusion with cycle-around
@@ -666,6 +552,8 @@ pub mod tests {
         C: Mutable<Item = Operation<F, Digest, V>> + 'static,
         V: ValueEncoding<Value = Digest> + PartialEq + core::fmt::Debug + 'static,
         Operation<F, Digest, V>: Codec,
+        Update<Digest, V>: Codec,
+        <Update<Digest, V> as Read>::Cfg: Default,
         TestDb<F, C, V>: DbAny<F, Key = Digest, Value = Digest, Digest = Digest> + 'static,
         Fn: FnMut(Context, String) -> Fut + 'static,
         Fut: Future<Output = TestDb<F, C, V>>,
@@ -679,7 +567,8 @@ pub mod tests {
 
             // We should be able to prove exclusion for any key against an empty db.
             let empty_root = db.root();
-            let empty_proof = db.exclusion_proof(&key_exists_1).await.unwrap();
+            let empty_proof =
+                runtime_exclusion_proof(db.exclusion_proof(&key_exists_1).await.unwrap());
             assert!(empty_proof.verify::<Sha256>(&key_exists_1, &empty_root));
 
             // Add `key_exists_1` and test exclusion proving over the single-key database case.
@@ -700,8 +589,8 @@ pub mod tests {
             // Generate some valid exclusion proofs for keys on either side.
             let greater_key = Sha256::fill(0xFF);
             let lesser_key = Sha256::fill(0x00);
-            let proof = db.exclusion_proof(&greater_key).await.unwrap();
-            let proof2 = db.exclusion_proof(&lesser_key).await.unwrap();
+            let proof = runtime_exclusion_proof(db.exclusion_proof(&greater_key).await.unwrap());
+            let proof2 = runtime_exclusion_proof(db.exclusion_proof(&lesser_key).await.unwrap());
 
             // Since there's only one span in the DB, the two exclusion proofs should be identical,
             // and the proof should verify any key but the one that exists in the db.
@@ -730,7 +619,7 @@ pub mod tests {
             let lesser_key = Sha256::fill(0x0F); // < k1=0x10
             let greater_key = Sha256::fill(0x31); // > k2=0x30
             let middle_key = Sha256::fill(0x20); // between k1=0x10 and k2=0x30
-            let proof = db.exclusion_proof(&greater_key).await.unwrap();
+            let proof = runtime_exclusion_proof(db.exclusion_proof(&greater_key).await.unwrap());
             // Test the "cycle around" span. This should prove exclusion of greater_key & lesser
             // key, but fail on middle_key.
             assert!(proof.verify::<Sha256>(&greater_key, &root));
@@ -738,11 +627,11 @@ pub mod tests {
             assert!(!proof.verify::<Sha256>(&middle_key, &root));
 
             // Due to the cycle, lesser & greater keys should produce the same proof.
-            let new_proof = db.exclusion_proof(&lesser_key).await.unwrap();
+            let new_proof = runtime_exclusion_proof(db.exclusion_proof(&lesser_key).await.unwrap());
             assert_eq!(proof, new_proof);
 
             // Test the inner span [k, k2).
-            let proof = db.exclusion_proof(&middle_key).await.unwrap();
+            let proof = runtime_exclusion_proof(db.exclusion_proof(&middle_key).await.unwrap());
             // `k` should fail since it's in the db.
             assert!(!proof.verify::<Sha256>(&key_exists_1, &root));
             // `middle_key` should succeed since it's in range.
@@ -774,7 +663,7 @@ pub mod tests {
             assert_ne!(db.bounds().end, 0);
             assert_ne!(root, empty_root);
 
-            let proof = db.exclusion_proof(&key_exists_1).await.unwrap();
+            let proof = runtime_exclusion_proof(db.exclusion_proof(&key_exists_1).await.unwrap());
             assert!(proof.verify::<Sha256>(&key_exists_1, &root));
             assert!(proof.verify::<Sha256>(&key_exists_2, &root));
 
@@ -784,20 +673,20 @@ pub mod tests {
         });
     }
 
-    fn sample_op_proof() -> OperationProof<mmb::Family, Digest, 32> {
+    fn sample_op_proof<F: Graftable>() -> OperationProof<F, Digest, 32> {
         let range_proof = RangeProof {
-            proof: Proof::<mmb::Family, Digest> {
-                leaves: mmb::Location::new(7),
+            proof: Proof::<F, Digest> {
+                leaves: Location::<F>::new(7),
                 inactive_peaks: 0,
                 digests: vec![Sha256::hash(&[b"sib"])],
             },
-            pending_chunk_digest: None,
+            pending_chunk_digest: None.try_into().unwrap(),
             partial_chunk_digest: None,
             ops_root: Sha256::hash(&[b"ops"]),
         };
         let chunk: [u8; 32] = core::array::from_fn(|i| i as u8);
         OperationProof {
-            loc: mmb::Location::new(5),
+            loc: Location::<F>::new(5),
             chunk,
             range_proof,
         }
@@ -902,13 +791,121 @@ pub mod tests {
         assert!(result.is_err());
     }
 
+    fn check_runtime_codec<P: Codec>(encoded: Bytes, cfg: &P::Cfg, limited: &P::Cfg) {
+        let runtime = P::decode_cfg(encoded.clone(), cfg).unwrap();
+        assert_eq!(runtime.encode(), encoded);
+        assert_eq!(runtime.encode_size(), encoded.len());
+        assert!(P::decode_cfg(encoded.clone(), limited).is_err());
+        for end in 0..encoded.len() {
+            assert!(P::decode_cfg(&encoded[..end], cfg).is_err());
+        }
+        let mut trailing = encoded.to_vec();
+        trailing.push(0);
+        assert!(P::decode_cfg(trailing.as_slice(), cfg).is_err());
+    }
+
+    fn check_runtime_ordered_codecs<F: Graftable>() {
+        let proof = db::KeyValueProof::<F, Digest, Digest, 32> {
+            proof: sample_op_proof(),
+            next_key: Sha256::hash(&[b"next-key"]),
+        };
+        check_runtime_codec::<db::RuntimeKeyValueProof<F, Digest, Digest>>(
+            proof.encode(),
+            &((32, 1), ()),
+            &((32, 0), ()),
+        );
+        assert!(
+            db::RuntimeKeyValueProof::<F, Digest, Digest>::decode_cfg(
+                proof.encode(),
+                &((3, 1), ()),
+            )
+            .is_err()
+        );
+
+        let cases = [
+            ExclusionProof::<F, Digest, FixedEncoding<Digest>, Digest, 32>::KeyValue(
+                sample_op_proof(),
+                Update {
+                    key: Sha256::hash(&[b"key"]),
+                    value: Sha256::hash(&[b"value"]),
+                    next_key: Sha256::hash(&[b"next-key"]),
+                },
+            ),
+            ExclusionProof::Commit(sample_op_proof(), Some(Sha256::hash(&[b"metadata"]))),
+            ExclusionProof::Commit(sample_op_proof(), None),
+        ];
+        for proof in cases {
+            check_runtime_codec::<RuntimeExclusionProof<F, Digest, FixedEncoding<Digest>, Digest>>(
+                proof.encode(),
+                &((32, 1), (), ()),
+                &((32, 0), (), ()),
+            );
+            assert!(
+                RuntimeExclusionProof::<F, Digest, FixedEncoding<Digest>, Digest>::decode_cfg(
+                    proof.encode(),
+                    &((3, 1), (), ()),
+                )
+                .is_err()
+            );
+            let mut unknown_tag = proof.encode().to_vec();
+            unknown_tag[0] = 2;
+            assert!(matches!(
+                RuntimeExclusionProof::<F, Digest, FixedEncoding<Digest>, Digest>::decode_cfg(
+                    unknown_tag.as_slice(),
+                    &((32, 1), (), ()),
+                ),
+                Err(commonware_codec::Error::InvalidEnum(2)),
+            ));
+        }
+
+        let value_cfg = ((..=3).into(), ());
+        let update_cfg = ((), value_cfg);
+        let cases = [
+            ExclusionProof::<F, Digest, VariableEncoding<Vec<u8>>, Digest, 32>::KeyValue(
+                sample_op_proof(),
+                Update {
+                    key: Sha256::hash(&[b"key"]),
+                    value: vec![1, 2, 3],
+                    next_key: Sha256::hash(&[b"next-key"]),
+                },
+            ),
+            ExclusionProof::Commit(sample_op_proof(), Some(vec![1, 2, 3])),
+        ];
+        for proof in cases {
+            check_runtime_codec::<
+                RuntimeExclusionProof<F, Digest, VariableEncoding<Vec<u8>>, Digest>,
+            >(
+                proof.encode(),
+                &((32, 1), update_cfg, value_cfg),
+                &((32, 0), update_cfg, value_cfg),
+            );
+            let short_value_cfg = ((..=2).into(), ());
+            assert!(
+                RuntimeExclusionProof::<F, Digest, VariableEncoding<Vec<u8>>, Digest>::decode_cfg(
+                    proof.encode(),
+                    &((32, 1), ((), short_value_cfg), short_value_cfg),
+                )
+                .is_err()
+            );
+        }
+    }
+
+    #[test]
+    fn test_runtime_ordered_codecs() {
+        check_runtime_ordered_codecs::<mmr::Family>();
+        check_runtime_ordered_codecs::<mmb::Family>();
+    }
+
     #[cfg(feature = "arbitrary")]
     mod conformance {
         use crate::{
             merkle::{mmb, mmr},
             qmdb::{
                 any::value::{FixedEncoding, VariableEncoding},
-                current::ordered::{ExclusionProof, db::KeyValueProof},
+                current::ordered::{
+                    ExclusionProof, RuntimeExclusionProof,
+                    db::{KeyValueProof, RuntimeKeyValueProof},
+                },
             },
         };
         use commonware_codec::conformance::CodecConformance;
@@ -922,6 +919,12 @@ pub mod tests {
             CodecConformance<ExclusionProof<mmr::Family, U64, VariableEncoding<Vec<u8>>, Sha256Digest, 32>>,
             CodecConformance<ExclusionProof<mmb::Family, U64, FixedEncoding<U64>, Sha256Digest, 32>>,
             CodecConformance<ExclusionProof<mmb::Family, U64, VariableEncoding<Vec<u8>>, Sha256Digest, 32>>,
+            CodecConformance<RuntimeKeyValueProof<mmr::Family, U64, Sha256Digest>>,
+            CodecConformance<RuntimeKeyValueProof<mmb::Family, U64, Sha256Digest>>,
+            CodecConformance<RuntimeExclusionProof<mmr::Family, U64, FixedEncoding<U64>, Sha256Digest>>,
+            CodecConformance<RuntimeExclusionProof<mmr::Family, U64, VariableEncoding<Vec<u8>>, Sha256Digest>>,
+            CodecConformance<RuntimeExclusionProof<mmb::Family, U64, FixedEncoding<U64>, Sha256Digest>>,
+            CodecConformance<RuntimeExclusionProof<mmb::Family, U64, VariableEncoding<Vec<u8>>, Sha256Digest>>,
         }
     }
 }

--- a/storage/src/qmdb/current/ordered/mod.rs
+++ b/storage/src/qmdb/current/ordered/mod.rs
@@ -21,9 +21,6 @@ pub mod variable;
 pub type ExclusionProof<F, K, V, D, const N: usize> = proof::ExclusionProof<F, K, V, D, [u8; N]>;
 
 /// Proof that a key has no assigned value in the database, with a runtime-sized bitmap chunk.
-///
-/// The decoder configuration is `((chunk_size, max_digests), update_cfg, value_cfg)`.
-/// The chunk size is in bytes and is not encoded in the proof.
 pub type RuntimeExclusionProof<F, K, V, D> = proof::ExclusionProof<F, K, V, D, bytes::Bytes>;
 
 /// Wire tag for [ExclusionProof::KeyValue].

--- a/storage/src/qmdb/current/ordered/mod.rs
+++ b/storage/src/qmdb/current/ordered/mod.rs
@@ -1,7 +1,7 @@
 //! _Ordered_ variants of a [crate::qmdb::current] authenticated database.
 //!
 //! These variants maintain the lexicographic-next active key for each active key, enabling
-//! exclusion proofs via [ExclusionProof](proof::fixed::ExclusionProof). This adds overhead
+//! exclusion proofs via [ExclusionProof](proof::constant::ExclusionProof). This adds overhead
 //! compared to [super::unordered] variants.
 //!
 //! Variants:
@@ -15,10 +15,10 @@ pub mod proof;
 mod test_trait_impls;
 pub mod variable;
 
-/// Wire tag for [proof::fixed::ExclusionProof::KeyValue].
+/// Wire tag for [proof::constant::ExclusionProof::KeyValue].
 pub const KEY_VALUE_CONTEXT: u8 = 0;
 
-/// Wire tag for [proof::fixed::ExclusionProof::Commit].
+/// Wire tag for [proof::constant::ExclusionProof::Commit].
 pub const COMMIT_CONTEXT: u8 = 1;
 
 #[cfg(test)]
@@ -27,7 +27,7 @@ pub mod tests {
 
     use super::{
         db,
-        proof::{dynamic, fixed},
+        proof::{constant, dynamic},
     };
     use crate::{
         index::ordered::Index,
@@ -44,7 +44,7 @@ pub mod tests {
             },
             current::{
                 BitmapPrunedBits,
-                proof::{RangeProof, fixed::OperationProof},
+                proof::{RangeProof, constant::OperationProof},
                 tests::apply_random_ops,
             },
             store::tests::{TestKey, TestValue},
@@ -242,8 +242,8 @@ pub mod tests {
             // Create a proof of the now-inactive update operation assigning v1 to k against the
             // current root.
             let (p, _, chunks) = db.range_proof(op_loc, NZU64!(1)).await.unwrap();
-            let proof_inactive = fixed::KeyValueProof {
-                proof: crate::qmdb::current::proof::fixed::OperationProof {
+            let proof_inactive = constant::KeyValueProof {
+                proof: crate::qmdb::current::proof::constant::OperationProof {
                     loc: op_loc,
                     chunk: chunks[0],
                     range_proof: p,
@@ -510,7 +510,7 @@ pub mod tests {
     }
 
     fn dynamic_exclusion_proof<F, V>(
-        proof: fixed::ExclusionProof<F, Digest, V, Digest, 32>,
+        proof: constant::ExclusionProof<F, Digest, V, Digest, 32>,
     ) -> dynamic::ExclusionProof<F, Digest, V, Digest>
     where
         F: Graftable,
@@ -519,9 +519,8 @@ pub mod tests {
         <Update<Digest, V> as Read>::Cfg: Default,
     {
         let max_digests = match &proof {
-            fixed::ExclusionProof::KeyValue(proof, _) | fixed::ExclusionProof::Commit(proof, _) => {
-                proof.range_proof.proof.digests.len()
-            }
+            constant::ExclusionProof::KeyValue(proof, _)
+            | constant::ExclusionProof::Commit(proof, _) => proof.range_proof.proof.digests.len(),
         };
         let encoded = proof.encode();
         let dynamic = dynamic::ExclusionProof::<F, Digest, V, Digest>::decode_cfg(
@@ -689,8 +688,8 @@ pub mod tests {
     }
 
     type CodecExclusionProof =
-        fixed::ExclusionProof<mmb::Family, Digest, FixedEncoding<Digest>, Digest, 32>;
-    type CodecKeyValueProof = fixed::KeyValueProof<mmb::Family, Digest, Digest, 32>;
+        constant::ExclusionProof<mmb::Family, Digest, FixedEncoding<Digest>, Digest, 32>;
+    type CodecKeyValueProof = constant::KeyValueProof<mmb::Family, Digest, Digest, 32>;
     const MAX_DIGESTS: usize = 64;
 
     #[test]
@@ -797,7 +796,7 @@ pub mod tests {
     }
 
     fn check_dynamic_ordered_codecs<F: Graftable>() {
-        let proof = fixed::KeyValueProof::<F, Digest, Digest, 32> {
+        let proof = constant::KeyValueProof::<F, Digest, Digest, 32> {
             proof: sample_op_proof(),
             next_key: Sha256::hash(&[b"next-key"]),
         };
@@ -812,7 +811,7 @@ pub mod tests {
         );
 
         let cases = [
-            fixed::ExclusionProof::<F, Digest, FixedEncoding<Digest>, Digest, 32>::KeyValue(
+            constant::ExclusionProof::<F, Digest, FixedEncoding<Digest>, Digest, 32>::KeyValue(
                 sample_op_proof(),
                 Update {
                     key: Sha256::hash(&[b"key"]),
@@ -820,8 +819,8 @@ pub mod tests {
                     next_key: Sha256::hash(&[b"next-key"]),
                 },
             ),
-            fixed::ExclusionProof::Commit(sample_op_proof(), Some(Sha256::hash(&[b"metadata"]))),
-            fixed::ExclusionProof::Commit(sample_op_proof(), None),
+            constant::ExclusionProof::Commit(sample_op_proof(), Some(Sha256::hash(&[b"metadata"]))),
+            constant::ExclusionProof::Commit(sample_op_proof(), None),
         ];
         for proof in cases {
             check_dynamic_codec::<dynamic::ExclusionProof<F, Digest, FixedEncoding<Digest>, Digest>>(
@@ -850,7 +849,7 @@ pub mod tests {
         let value_cfg = ((..=3).into(), ());
         let update_cfg = ((), value_cfg);
         let cases = [
-            fixed::ExclusionProof::<F, Digest, VariableEncoding<Vec<u8>>, Digest, 32>::KeyValue(
+            constant::ExclusionProof::<F, Digest, VariableEncoding<Vec<u8>>, Digest, 32>::KeyValue(
                 sample_op_proof(),
                 Update {
                     key: Sha256::hash(&[b"key"]),
@@ -858,7 +857,7 @@ pub mod tests {
                     next_key: Sha256::hash(&[b"next-key"]),
                 },
             ),
-            fixed::ExclusionProof::Commit(sample_op_proof(), Some(vec![1, 2, 3])),
+            constant::ExclusionProof::Commit(sample_op_proof(), Some(vec![1, 2, 3])),
         ];
         for proof in cases {
             check_dynamic_codec::<
@@ -891,7 +890,7 @@ pub mod tests {
             merkle::{mmb, mmr},
             qmdb::{
                 any::value::{FixedEncoding, VariableEncoding},
-                current::ordered::proof::{dynamic, fixed},
+                current::ordered::proof::{constant, dynamic},
             },
         };
         use commonware_codec::conformance::CodecConformance;
@@ -899,12 +898,12 @@ pub mod tests {
         use commonware_utils::sequence::U64;
 
         commonware_conformance::conformance_tests! {
-            CodecConformance<fixed::KeyValueProof<mmr::Family, U64, Sha256Digest, 32>>,
-            CodecConformance<fixed::KeyValueProof<mmb::Family, U64, Sha256Digest, 32>>,
-            CodecConformance<fixed::ExclusionProof<mmr::Family, U64, FixedEncoding<U64>, Sha256Digest, 32>>,
-            CodecConformance<fixed::ExclusionProof<mmr::Family, U64, VariableEncoding<Vec<u8>>, Sha256Digest, 32>>,
-            CodecConformance<fixed::ExclusionProof<mmb::Family, U64, FixedEncoding<U64>, Sha256Digest, 32>>,
-            CodecConformance<fixed::ExclusionProof<mmb::Family, U64, VariableEncoding<Vec<u8>>, Sha256Digest, 32>>,
+            CodecConformance<constant::KeyValueProof<mmr::Family, U64, Sha256Digest, 32>>,
+            CodecConformance<constant::KeyValueProof<mmb::Family, U64, Sha256Digest, 32>>,
+            CodecConformance<constant::ExclusionProof<mmr::Family, U64, FixedEncoding<U64>, Sha256Digest, 32>>,
+            CodecConformance<constant::ExclusionProof<mmr::Family, U64, VariableEncoding<Vec<u8>>, Sha256Digest, 32>>,
+            CodecConformance<constant::ExclusionProof<mmb::Family, U64, FixedEncoding<U64>, Sha256Digest, 32>>,
+            CodecConformance<constant::ExclusionProof<mmb::Family, U64, VariableEncoding<Vec<u8>>, Sha256Digest, 32>>,
             CodecConformance<dynamic::KeyValueProof<mmr::Family, U64, Sha256Digest>>,
             CodecConformance<dynamic::KeyValueProof<mmb::Family, U64, Sha256Digest>>,
             CodecConformance<dynamic::ExclusionProof<mmr::Family, U64, FixedEncoding<U64>, Sha256Digest>>,

--- a/storage/src/qmdb/current/ordered/mod.rs
+++ b/storage/src/qmdb/current/ordered/mod.rs
@@ -11,14 +11,17 @@
 use crate::{
     merkle::Graftable,
     qmdb::{
-        any::{ValueEncoding, ordered::Update},
+        any::{
+            ValueEncoding,
+            ordered::{Operation, Update, span_contains},
+        },
         current::proof::OperationProof,
         operation::Key,
     },
 };
 use bytes::{Buf, BufMut};
-use commonware_codec::{EncodeSize, Read, ReadExt as _, Write};
-use commonware_cryptography::Digest;
+use commonware_codec::{Codec, EncodeSize, Read, ReadExt as _, Write};
+use commonware_cryptography::{Digest, Hasher};
 
 pub mod db;
 pub mod fixed;
@@ -32,7 +35,7 @@ pub mod variable;
 /// between two adjacent active keys. Otherwise exclusion is proven by showing the database contains
 /// no active keys through the most recent commit operation.
 ///
-/// Verify using [Db::verify_exclusion_proof](fixed::Db::verify_exclusion_proof).
+/// Verify using [Self::verify].
 #[derive(Clone, Eq, PartialEq, Debug)]
 pub enum ExclusionProof<F: Graftable, K: Key, V: ValueEncoding, D: Digest, const N: usize> {
     /// Proves that two keys are active in the database and adjacent to each other in the key
@@ -46,8 +49,43 @@ pub enum ExclusionProof<F: Graftable, K: Key, V: ValueEncoding, D: Digest, const
     Commit(OperationProof<F, D, N>, Option<V::Value>),
 }
 
-const KEY_VALUE_CONTEXT: u8 = 0;
-const COMMIT_CONTEXT: u8 = 1;
+/// Wire tag for [ExclusionProof::KeyValue].
+pub const KEY_VALUE_CONTEXT: u8 = 0;
+
+/// Wire tag for [ExclusionProof::Commit].
+pub const COMMIT_CONTEXT: u8 = 1;
+
+impl<F, K, V, D, const N: usize> ExclusionProof<F, K, V, D, N>
+where
+    F: Graftable,
+    K: Key,
+    V: ValueEncoding,
+    D: Digest,
+    Operation<F, K, V>: Codec,
+{
+    /// Return true if the proof authenticates that `key` does not exist in the database with
+    /// the provided `root`.
+    pub fn verify<H: Hasher<Digest = D>>(&self, key: &K, root: &D) -> bool {
+        let (op_proof, op) = match self {
+            Self::KeyValue(op_proof, data) => {
+                if data.key == *key || !span_contains(&data.key, &data.next_key, key) {
+                    return false;
+                }
+
+                (op_proof, Operation::Update(data.clone()))
+            }
+            Self::Commit(op_proof, metadata) => {
+                // An empty database's commit floor equals the commit operation's location
+                (
+                    op_proof,
+                    Operation::CommitFloor(metadata.clone(), op_proof.loc),
+                )
+            }
+        };
+
+        op_proof.verify::<H, _>(op, root)
+    }
+}
 
 impl<F, K, V, D, const N: usize> Write for ExclusionProof<F, K, V, D, N>
 where
@@ -328,24 +366,15 @@ pub mod tests {
 
             // Proof should be verifiable against current root.
             let root = db.root();
-            assert!(TestDb::<F, C, V>::verify_key_value_proof(
-                k, v1, &proof, &root,
-            ));
+            assert!(proof.verify::<Sha256, V>(k, v1, &root));
 
             let v2 = Sha256::fill(0xA2);
             // Proof should not verify against a different value.
-            assert!(!TestDb::<F, C, V>::verify_key_value_proof(
-                k, v2, &proof, &root,
-            ));
+            assert!(!proof.verify::<Sha256, V>(k, v2, &root));
             // Proof should not verify against a mangled next_key.
             let mut mangled_proof = proof.clone();
             mangled_proof.next_key = Sha256::fill(0xFF);
-            assert!(!TestDb::<F, C, V>::verify_key_value_proof(
-                k,
-                v1,
-                &mangled_proof,
-                &root,
-            ));
+            assert!(!mangled_proof.verify::<Sha256, V>(k, v1, &root));
 
             // Update the key to a new value (v2), which inactivates the previous operation.
             let merkleized = db
@@ -358,20 +387,14 @@ pub mod tests {
             let root = db.root();
 
             // New value should not be verifiable against the old proof.
-            assert!(!TestDb::<F, C, V>::verify_key_value_proof(
-                k, v2, &proof, &root,
-            ));
+            assert!(!proof.verify::<Sha256, V>(k, v2, &root));
 
             // But the new value should verify against a new proof.
             let proof = db.key_value_proof(k).await.unwrap();
-            assert!(TestDb::<F, C, V>::verify_key_value_proof(
-                k, v2, &proof, &root,
-            ));
+            assert!(proof.verify::<Sha256, V>(k, v2, &root));
 
             // Old value will not verify against new proof.
-            assert!(!TestDb::<F, C, V>::verify_key_value_proof(
-                k, v1, &proof, &root,
-            ));
+            assert!(!proof.verify::<Sha256, V>(k, v1, &root));
 
             // Create a proof of the now-inactive update operation assigning v1 to k against the
             // current root.
@@ -401,12 +424,7 @@ pub mod tests {
 
             // But this proof should *not* verify as a key value proof, since verification will see
             // that the operation is inactive.
-            assert!(!TestDb::<F, C, V>::verify_key_value_proof(
-                k,
-                v1,
-                &proof_inactive,
-                &root,
-            ));
+            assert!(!proof_inactive.verify::<Sha256, V>(k, v1, &root));
 
             // Attempt #1 to "fool" the verifier:  change the location to that of an active
             // operation. This should not fool the verifier if we're properly validating the
@@ -420,12 +438,7 @@ pub mod tests {
             );
             let mut fake_proof = proof_inactive.clone();
             fake_proof.proof.loc = active_loc;
-            assert!(!TestDb::<F, C, V>::verify_key_value_proof(
-                k,
-                v1,
-                &fake_proof,
-                &root,
-            ));
+            assert!(!fake_proof.verify::<Sha256, V>(k, v1, &root));
 
             // Attempt #2 to "fool" the verifier: Modify the chunk in the proof info to make it
             // look like the operation is active by flipping its corresponding bit to 1. This
@@ -439,12 +452,7 @@ pub mod tests {
 
             let mut fake_proof = proof_inactive.clone();
             fake_proof.proof.chunk = modified_chunk;
-            assert!(!TestDb::<F, C, V>::verify_key_value_proof(
-                k,
-                v1,
-                &fake_proof,
-                &root,
-            ));
+            assert!(!fake_proof.verify::<Sha256, V>(k, v1, &root));
 
             db.destroy().await.unwrap();
         });
@@ -565,37 +573,30 @@ pub mod tests {
                     _ => unreachable!("expected update or commit floor operation"),
                 };
                 let proof = db.key_value_proof(key).await.unwrap();
+                let max_digests = proof.proof.range_proof.proof.digests.len();
+                let proof = db::KeyValueProof::<F, Digest, Digest, 32>::decode_cfg(
+                    proof.encode(),
+                    &(max_digests, ()),
+                )
+                .unwrap();
 
                 // Proof should validate against the current value and correct root.
-                assert!(TestDb::<F, C, V>::verify_key_value_proof(
-                    key, value, &proof, &root
-                ));
+                assert!(proof.verify::<Sha256, V>(key, value, &root));
                 // Proof should fail against the wrong value. Use hash instead of fill to ensure
                 // the value differs from any key/value created by TestKey::from_seed (which uses
                 // fill patterns).
                 let wrong_val = Sha256::hash(&[&[0xFF]]);
-                assert!(!TestDb::<F, C, V>::verify_key_value_proof(
-                    key, wrong_val, &proof, &root
-                ));
+                assert!(!proof.verify::<Sha256, V>(key, wrong_val, &root));
                 // Proof should fail against the wrong key.
                 let wrong_key = Sha256::hash(&[&[0xEE]]);
-                assert!(!TestDb::<F, C, V>::verify_key_value_proof(
-                    wrong_key, value, &proof, &root
-                ));
+                assert!(!proof.verify::<Sha256, V>(wrong_key, value, &root));
                 // Proof should fail against the wrong root.
                 let wrong_root = Sha256::hash(&[&[0xDD]]);
-                assert!(!TestDb::<F, C, V>::verify_key_value_proof(
-                    key,
-                    value,
-                    &proof,
-                    &wrong_root,
-                ));
+                assert!(!proof.verify::<Sha256, V>(key, value, &wrong_root));
                 // Proof should fail with the wrong next-key.
                 let mut bad_proof = proof.clone();
                 bad_proof.next_key = wrong_key;
-                assert!(!TestDb::<F, C, V>::verify_key_value_proof(
-                    key, value, &bad_proof, &root,
-                ));
+                assert!(!bad_proof.verify::<Sha256, V>(key, value, &root));
             }
 
             db.destroy().await.unwrap();
@@ -639,12 +640,12 @@ pub mod tests {
                 // Create a proof for the current value of k.
                 let proof = db.key_value_proof(k).await.unwrap();
                 assert!(
-                    TestDb::<F, C, V>::verify_key_value_proof(k, v, &proof, &root),
+                    proof.verify::<Sha256, V>(k, v, &root),
                     "proof of update {i} failed to verify"
                 );
                 // Ensure the proof does NOT verify if we use the previous value.
                 assert!(
-                    !TestDb::<F, C, V>::verify_key_value_proof(k, old_val, &proof, &root,),
+                    !proof.verify::<Sha256, V>(k, old_val, &root),
                     "proof of update {i} verified when it should not have"
                 );
                 old_val = v;
@@ -679,11 +680,7 @@ pub mod tests {
             // We should be able to prove exclusion for any key against an empty db.
             let empty_root = db.root();
             let empty_proof = db.exclusion_proof(&key_exists_1).await.unwrap();
-            assert!(TestDb::<F, C, V>::verify_exclusion_proof(
-                &key_exists_1,
-                &empty_proof,
-                &empty_root,
-            ));
+            assert!(empty_proof.verify::<Sha256>(&key_exists_1, &empty_root));
 
             // Add `key_exists_1` and test exclusion proving over the single-key database case.
             let v1 = Sha256::fill(0xA1);
@@ -710,22 +707,10 @@ pub mod tests {
             // and the proof should verify any key but the one that exists in the db.
             assert_eq!(proof, proof2);
             // Any key except the one that exists should verify against this proof.
-            assert!(TestDb::<F, C, V>::verify_exclusion_proof(
-                &greater_key,
-                &proof,
-                &root,
-            ));
-            assert!(TestDb::<F, C, V>::verify_exclusion_proof(
-                &lesser_key,
-                &proof,
-                &root,
-            ));
+            assert!(proof.verify::<Sha256>(&greater_key, &root));
+            assert!(proof.verify::<Sha256>(&lesser_key, &root));
             // Exclusion should fail if we test it on a key that exists.
-            assert!(!TestDb::<F, C, V>::verify_exclusion_proof(
-                &key_exists_1,
-                &proof,
-                &root,
-            ));
+            assert!(!proof.verify::<Sha256>(&key_exists_1, &root));
 
             // Add a second key and test exclusion proving over the two-key database case.
             let key_exists_2 = Sha256::fill(0x30);
@@ -748,21 +733,9 @@ pub mod tests {
             let proof = db.exclusion_proof(&greater_key).await.unwrap();
             // Test the "cycle around" span. This should prove exclusion of greater_key & lesser
             // key, but fail on middle_key.
-            assert!(TestDb::<F, C, V>::verify_exclusion_proof(
-                &greater_key,
-                &proof,
-                &root,
-            ));
-            assert!(TestDb::<F, C, V>::verify_exclusion_proof(
-                &lesser_key,
-                &proof,
-                &root,
-            ));
-            assert!(!TestDb::<F, C, V>::verify_exclusion_proof(
-                &middle_key,
-                &proof,
-                &root,
-            ));
+            assert!(proof.verify::<Sha256>(&greater_key, &root));
+            assert!(proof.verify::<Sha256>(&lesser_key, &root));
+            assert!(!proof.verify::<Sha256>(&middle_key, &root));
 
             // Due to the cycle, lesser & greater keys should produce the same proof.
             let new_proof = db.exclusion_proof(&lesser_key).await.unwrap();
@@ -771,41 +744,17 @@ pub mod tests {
             // Test the inner span [k, k2).
             let proof = db.exclusion_proof(&middle_key).await.unwrap();
             // `k` should fail since it's in the db.
-            assert!(!TestDb::<F, C, V>::verify_exclusion_proof(
-                &key_exists_1,
-                &proof,
-                &root,
-            ));
+            assert!(!proof.verify::<Sha256>(&key_exists_1, &root));
             // `middle_key` should succeed since it's in range.
-            assert!(TestDb::<F, C, V>::verify_exclusion_proof(
-                &middle_key,
-                &proof,
-                &root,
-            ));
-            assert!(!TestDb::<F, C, V>::verify_exclusion_proof(
-                &key_exists_2,
-                &proof,
-                &root,
-            ));
+            assert!(proof.verify::<Sha256>(&middle_key, &root));
+            assert!(!proof.verify::<Sha256>(&key_exists_2, &root));
 
             let conflicting_middle_key = Sha256::fill(0x11); // between k1=0x10 and k2=0x30
-            assert!(TestDb::<F, C, V>::verify_exclusion_proof(
-                &conflicting_middle_key,
-                &proof,
-                &root,
-            ));
+            assert!(proof.verify::<Sha256>(&conflicting_middle_key, &root));
 
             // Using lesser/greater keys for the middle-proof should fail.
-            assert!(!TestDb::<F, C, V>::verify_exclusion_proof(
-                &greater_key,
-                &proof,
-                &root,
-            ));
-            assert!(!TestDb::<F, C, V>::verify_exclusion_proof(
-                &lesser_key,
-                &proof,
-                &root,
-            ));
+            assert!(!proof.verify::<Sha256>(&greater_key, &root));
+            assert!(!proof.verify::<Sha256>(&lesser_key, &root));
 
             // Make the DB empty again by deleting the keys and check the empty case
             // again.
@@ -826,28 +775,12 @@ pub mod tests {
             assert_ne!(root, empty_root);
 
             let proof = db.exclusion_proof(&key_exists_1).await.unwrap();
-            assert!(TestDb::<F, C, V>::verify_exclusion_proof(
-                &key_exists_1,
-                &proof,
-                &root,
-            ));
-            assert!(TestDb::<F, C, V>::verify_exclusion_proof(
-                &key_exists_2,
-                &proof,
-                &root,
-            ));
+            assert!(proof.verify::<Sha256>(&key_exists_1, &root));
+            assert!(proof.verify::<Sha256>(&key_exists_2, &root));
 
             // Try fooling the verifier with improper values.
-            assert!(!TestDb::<F, C, V>::verify_exclusion_proof(
-                &key_exists_1,
-                &empty_proof, // wrong proof
-                &root,
-            ));
-            assert!(!TestDb::<F, C, V>::verify_exclusion_proof(
-                &key_exists_1,
-                &proof,
-                &empty_root, // wrong root
-            ));
+            assert!(!empty_proof.verify::<Sha256>(&key_exists_1, &root));
+            assert!(!proof.verify::<Sha256>(&key_exists_1, &empty_root));
         });
     }
 

--- a/storage/src/qmdb/current/ordered/proof.rs
+++ b/storage/src/qmdb/current/ordered/proof.rs
@@ -17,7 +17,7 @@ use commonware_codec::{Codec, EncodeSize, Read, ReadExt as _, Write};
 use commonware_cryptography::{Digest, Hasher};
 
 /// Proofs with fixed-size bitmap chunks.
-pub mod fixed {
+pub mod constant {
     /// Proof information for verifying a key has a particular value in the database.
     pub type KeyValueProof<F, K, D, const N: usize> = super::KeyValueProof<F, K, D, [u8; N]>;
 

--- a/storage/src/qmdb/current/ordered/proof.rs
+++ b/storage/src/qmdb/current/ordered/proof.rs
@@ -1,0 +1,244 @@
+//! Ordered current proofs with fixed-size or runtime-sized bitmap chunks.
+
+use super::{COMMIT_CONTEXT, KEY_VALUE_CONTEXT};
+use crate::{
+    merkle::Graftable,
+    qmdb::{
+        any::{
+            ValueEncoding,
+            ordered::{Operation, Update, span_contains},
+        },
+        current::proof::operation::Proof as OperationProof,
+        operation::Key,
+    },
+};
+use bytes::{Buf, BufMut};
+use commonware_codec::{Codec, EncodeSize, Read, ReadExt as _, Write};
+use commonware_cryptography::{Digest, Hasher};
+
+/// Proof information for verifying a key has a particular value in the database.
+///
+/// `C` stores the embedded operation proof's bitmap chunk.
+#[derive(Clone, Eq, PartialEq, Debug)]
+pub struct KeyValueProof<F: Graftable, K: Key, D: Digest, C> {
+    /// The proof authenticating the active update operation.
+    pub proof: OperationProof<F, D, C>,
+
+    /// The next active key in lexicographic order, wrapping at the end.
+    pub next_key: K,
+}
+
+impl<F: Graftable, K: Key, D: Digest, C: AsRef<[u8]>> KeyValueProof<F, K, D, C> {
+    /// Return true if the proof authenticates that `key` currently has `value` in the database
+    /// with the provided `root`.
+    ///
+    /// `V` selects the fixed or variable value encoding used by the database.
+    pub fn verify<H, V>(&self, key: K, value: V::Value, root: &D) -> bool
+    where
+        H: Hasher<Digest = D>,
+        V: ValueEncoding,
+        Operation<F, K, V>: Codec,
+    {
+        let op = Operation::<F, K, V>::Update(Update {
+            key,
+            value,
+            next_key: self.next_key.clone(),
+        });
+
+        self.proof.verify::<H, _>(op, root)
+    }
+}
+
+impl<F: Graftable, K: Key, D: Digest, C: AsRef<[u8]>> Write for KeyValueProof<F, K, D, C> {
+    fn write(&self, buf: &mut impl BufMut) {
+        self.proof.write(buf);
+        self.next_key.write(buf);
+    }
+}
+
+impl<F: Graftable, K: Key, D: Digest, C: AsRef<[u8]>> EncodeSize for KeyValueProof<F, K, D, C> {
+    fn encode_size(&self) -> usize {
+        self.proof.encode_size() + self.next_key.encode_size()
+    }
+}
+
+impl<F: Graftable, K: Key, D: Digest, C> Read for KeyValueProof<F, K, D, C>
+where
+    OperationProof<F, D, C>: Read,
+{
+    /// `(proof_cfg, key_cfg)`: the read configurations for the embedded operation proof and key.
+    type Cfg = (<OperationProof<F, D, C> as Read>::Cfg, <K as Read>::Cfg);
+
+    fn read_cfg(
+        buf: &mut impl Buf,
+        (proof_cfg, key_cfg): &Self::Cfg,
+    ) -> Result<Self, commonware_codec::Error> {
+        let proof = OperationProof::<F, D, C>::read_cfg(buf, proof_cfg)?;
+        let next_key = K::read_cfg(buf, key_cfg)?;
+        Ok(Self { proof, next_key })
+    }
+}
+
+#[cfg(feature = "arbitrary")]
+impl<F: Graftable, K: Key, D: Digest, C> arbitrary::Arbitrary<'_> for KeyValueProof<F, K, D, C>
+where
+    K: for<'a> arbitrary::Arbitrary<'a>,
+    OperationProof<F, D, C>: for<'a> arbitrary::Arbitrary<'a>,
+{
+    fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
+        Ok(Self {
+            proof: u.arbitrary()?,
+            next_key: u.arbitrary()?,
+        })
+    }
+}
+
+/// Proof that a key has no assigned value in the database.
+///
+/// When the database has active keys, exclusion is proven by showing the key falls within a span
+/// between two adjacent active keys. Otherwise exclusion is proven by showing the database contains
+/// no active keys through the most recent commit operation.
+///
+/// `C` stores the embedded operation proof's bitmap chunk. Verify using [Self::verify].
+#[derive(Clone, Eq, PartialEq, Debug)]
+pub enum ExclusionProof<F: Graftable, K: Key, V: ValueEncoding, D: Digest, C> {
+    /// Proves that two keys are active in the database and adjacent to each other in the key
+    /// ordering. Any key falling between them (non-inclusively) can be proven excluded.
+    KeyValue(OperationProof<F, D, C>, Update<K, V>),
+
+    /// Proves that the database has no active keys, allowing any key to be proven excluded.
+    /// The commit operation's activity floor must equal its own location.
+    Commit(OperationProof<F, D, C>, Option<V::Value>),
+}
+
+impl<F, K, V, D, C> ExclusionProof<F, K, V, D, C>
+where
+    F: Graftable,
+    K: Key,
+    V: ValueEncoding,
+    D: Digest,
+    C: AsRef<[u8]>,
+    Operation<F, K, V>: Codec,
+{
+    /// Return true if the proof authenticates that `key` does not exist in the database with
+    /// the provided `root`.
+    pub fn verify<H: Hasher<Digest = D>>(&self, key: &K, root: &D) -> bool {
+        let (op_proof, op) = match self {
+            Self::KeyValue(op_proof, data) => {
+                if data.key == *key || !span_contains(&data.key, &data.next_key, key) {
+                    return false;
+                }
+
+                (op_proof, Operation::Update(data.clone()))
+            }
+            Self::Commit(op_proof, metadata) => {
+                // An empty database's commit floor equals the commit operation's location
+                (
+                    op_proof,
+                    Operation::CommitFloor(metadata.clone(), op_proof.loc),
+                )
+            }
+        };
+
+        op_proof.verify::<H, _>(op, root)
+    }
+}
+
+impl<F, K, V, D, C> Write for ExclusionProof<F, K, V, D, C>
+where
+    F: Graftable,
+    K: Key,
+    V: ValueEncoding,
+    D: Digest,
+    C: AsRef<[u8]>,
+    Update<K, V>: Write,
+{
+    fn write(&self, buf: &mut impl BufMut) {
+        match self {
+            Self::KeyValue(op_proof, update) => {
+                KEY_VALUE_CONTEXT.write(buf);
+                op_proof.write(buf);
+                update.write(buf);
+            }
+            Self::Commit(op_proof, value) => {
+                COMMIT_CONTEXT.write(buf);
+                op_proof.write(buf);
+                value.write(buf);
+            }
+        }
+    }
+}
+
+impl<F, K, V, D, C> EncodeSize for ExclusionProof<F, K, V, D, C>
+where
+    F: Graftable,
+    K: Key,
+    V: ValueEncoding,
+    D: Digest,
+    C: AsRef<[u8]>,
+    Update<K, V>: EncodeSize,
+{
+    fn encode_size(&self) -> usize {
+        1 + match self {
+            Self::KeyValue(op_proof, update) => op_proof.encode_size() + update.encode_size(),
+            Self::Commit(op_proof, value) => op_proof.encode_size() + value.encode_size(),
+        }
+    }
+}
+
+impl<F, K, V, D, C> Read for ExclusionProof<F, K, V, D, C>
+where
+    F: Graftable,
+    K: Key,
+    V: ValueEncoding,
+    D: Digest,
+    OperationProof<F, D, C>: Read,
+    Update<K, V>: Read,
+{
+    /// `(proof_cfg, update_cfg, value_cfg)`: the read configurations for the embedded operation
+    /// proof, [Update], and commit metadata value.
+    type Cfg = (
+        <OperationProof<F, D, C> as Read>::Cfg,
+        <Update<K, V> as Read>::Cfg,
+        <V::Value as Read>::Cfg,
+    );
+
+    fn read_cfg(
+        buf: &mut impl Buf,
+        (proof_cfg, update_cfg, value_cfg): &Self::Cfg,
+    ) -> Result<Self, commonware_codec::Error> {
+        match u8::read(buf)? {
+            KEY_VALUE_CONTEXT => {
+                let op_proof = OperationProof::<F, D, C>::read_cfg(buf, proof_cfg)?;
+                let update = Update::<K, V>::read_cfg(buf, update_cfg)?;
+                Ok(Self::KeyValue(op_proof, update))
+            }
+            COMMIT_CONTEXT => {
+                let op_proof = OperationProof::<F, D, C>::read_cfg(buf, proof_cfg)?;
+                let value = Option::<V::Value>::read_cfg(buf, value_cfg)?;
+                Ok(Self::Commit(op_proof, value))
+            }
+            tag => Err(commonware_codec::Error::InvalidEnum(tag)),
+        }
+    }
+}
+
+#[cfg(feature = "arbitrary")]
+impl<F, K, V, D, C> arbitrary::Arbitrary<'_> for ExclusionProof<F, K, V, D, C>
+where
+    F: Graftable,
+    K: Key + for<'a> arbitrary::Arbitrary<'a>,
+    V: ValueEncoding,
+    D: Digest,
+    V::Value: for<'a> arbitrary::Arbitrary<'a>,
+    OperationProof<F, D, C>: for<'a> arbitrary::Arbitrary<'a>,
+{
+    fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
+        let op_proof = u.arbitrary()?;
+        if u.arbitrary()? {
+            Ok(Self::KeyValue(op_proof, u.arbitrary()?))
+        } else {
+            Ok(Self::Commit(op_proof, u.arbitrary()?))
+        }
+    }
+}

--- a/storage/src/qmdb/current/ordered/proof.rs
+++ b/storage/src/qmdb/current/ordered/proof.rs
@@ -16,6 +16,25 @@ use bytes::{Buf, BufMut};
 use commonware_codec::{Codec, EncodeSize, Read, ReadExt as _, Write};
 use commonware_cryptography::{Digest, Hasher};
 
+/// Proofs with fixed-size bitmap chunks.
+pub mod fixed {
+    /// Proof information for verifying a key has a particular value in the database.
+    pub type KeyValueProof<F, K, D, const N: usize> = super::KeyValueProof<F, K, D, [u8; N]>;
+
+    /// Proof that a key has no assigned value in the database.
+    pub type ExclusionProof<F, K, V, D, const N: usize> =
+        super::ExclusionProof<F, K, V, D, [u8; N]>;
+}
+
+/// Proofs with runtime-sized bitmap chunks.
+pub mod dynamic {
+    /// Proof information for verifying a key has a particular value in the database.
+    pub type KeyValueProof<F, K, D> = super::KeyValueProof<F, K, D, bytes::Bytes>;
+
+    /// Proof that a key has no assigned value in the database.
+    pub type ExclusionProof<F, K, V, D> = super::ExclusionProof<F, K, V, D, bytes::Bytes>;
+}
+
 /// Proof information for verifying a key has a particular value in the database.
 ///
 /// `C` stores the embedded operation proof's bitmap chunk.

--- a/storage/src/qmdb/current/ordered/variable.rs
+++ b/storage/src/qmdb/current/ordered/variable.rs
@@ -4,9 +4,9 @@
 //! proofs (proving a key is currently inactive). Use [crate::qmdb::current::unordered::variable] if
 //! exclusion proofs are not needed.
 //!
-//! See [Db] for the main database type and [super::ExclusionProof] for proving key inactivity.
+//! See [Db] for the main database type and
+//! [ExclusionProof](super::proof::fixed::ExclusionProof) for proving key inactivity.
 
-pub use super::db::{KeyValueProof, RuntimeKeyValueProof};
 use crate::{
     Context,
     index::ordered::Index,
@@ -168,17 +168,17 @@ mod test {
     }
 
     #[test_traced("DEBUG")]
-    fn test_current_db_runtime_key_value_proof_mmb() {
+    fn test_current_db_dynamic_key_value_proof_mmb() {
         shared::test_key_value_proof(open_db::<mmb::Family>);
     }
 
     #[test_traced("DEBUG")]
-    fn test_current_db_runtime_exclusion_proofs_mmb() {
+    fn test_current_db_dynamic_exclusion_proofs_mmb() {
         shared::test_exclusion_proofs(open_db::<mmb::Family>);
     }
 
     #[test_traced("DEBUG")]
-    fn test_current_db_runtime_inactive_proof_mmb() {
+    fn test_current_db_dynamic_inactive_proof_mmb() {
         shared::test_verify_proof_over_bits_in_uncommitted_chunk(open_db::<mmb::Family>);
     }
 

--- a/storage/src/qmdb/current/ordered/variable.rs
+++ b/storage/src/qmdb/current/ordered/variable.rs
@@ -5,7 +5,7 @@
 //! exclusion proofs are not needed.
 //!
 //! See [Db] for the main database type and
-//! [ExclusionProof](super::proof::fixed::ExclusionProof) for proving key inactivity.
+//! [ExclusionProof](super::proof::constant::ExclusionProof) for proving key inactivity.
 
 use crate::{
     Context,

--- a/storage/src/qmdb/current/ordered/variable.rs
+++ b/storage/src/qmdb/current/ordered/variable.rs
@@ -6,7 +6,7 @@
 //!
 //! See [Db] for the main database type and [super::ExclusionProof] for proving key inactivity.
 
-pub use super::db::KeyValueProof;
+pub use super::db::{KeyValueProof, RuntimeKeyValueProof};
 use crate::{
     Context,
     index::ordered::Index,
@@ -112,7 +112,8 @@ pub mod partitioned {
 #[cfg(test)]
 mod test {
     use crate::{
-        mmr,
+        merkle::Graftable,
+        mmb, mmr,
         qmdb::current::{ordered::tests as shared, tests::variable_config},
         translator::OneCap,
     };
@@ -121,8 +122,8 @@ mod test {
     use commonware_runtime::deterministic;
 
     /// A type alias for the concrete [Db] type used in these unit tests.
-    type CurrentTest = super::Db<
-        mmr::Family,
+    type CurrentTest<F = mmr::Family> = super::Db<
+        F,
         deterministic::Context,
         Digest,
         Digest,
@@ -143,33 +144,51 @@ mod test {
     }
 
     /// Return a [Db] database initialized with a variable config.
-    async fn open_db(context: deterministic::Context, partition_prefix: String) -> CurrentTest {
+    async fn open_db<F: Graftable>(
+        context: deterministic::Context,
+        partition_prefix: String,
+    ) -> CurrentTest<F> {
         let cfg = variable_config::<OneCap>(&partition_prefix, &context);
-        CurrentTest::init(context, cfg).await.unwrap()
+        CurrentTest::<F>::init(context, cfg).await.unwrap()
     }
 
     #[test_traced("DEBUG")]
     pub fn test_current_db_verify_proof_over_bits_in_uncommitted_chunk() {
-        shared::test_verify_proof_over_bits_in_uncommitted_chunk(open_db);
+        shared::test_verify_proof_over_bits_in_uncommitted_chunk(open_db::<mmr::Family>);
     }
 
     #[test_traced("DEBUG")]
     pub fn test_current_db_range_proofs() {
-        shared::test_range_proofs(open_db);
+        shared::test_range_proofs(open_db::<mmr::Family>);
     }
 
     #[test_traced("DEBUG")]
     pub fn test_current_db_key_value_proof() {
-        shared::test_key_value_proof(open_db);
+        shared::test_key_value_proof(open_db::<mmr::Family>);
+    }
+
+    #[test_traced("DEBUG")]
+    fn test_current_db_runtime_key_value_proof_mmb() {
+        shared::test_key_value_proof(open_db::<mmb::Family>);
+    }
+
+    #[test_traced("DEBUG")]
+    fn test_current_db_runtime_exclusion_proofs_mmb() {
+        shared::test_exclusion_proofs(open_db::<mmb::Family>);
+    }
+
+    #[test_traced("DEBUG")]
+    fn test_current_db_runtime_inactive_proof_mmb() {
+        shared::test_verify_proof_over_bits_in_uncommitted_chunk(open_db::<mmb::Family>);
     }
 
     #[test_traced("WARN")]
     pub fn test_current_db_proving_repeated_updates() {
-        shared::test_proving_repeated_updates(open_db);
+        shared::test_proving_repeated_updates(open_db::<mmr::Family>);
     }
 
     #[test_traced("DEBUG")]
     pub fn test_current_db_exclusion_proofs() {
-        shared::test_exclusion_proofs(open_db);
+        shared::test_exclusion_proofs(open_db::<mmr::Family>);
     }
 }

--- a/storage/src/qmdb/current/proof/dynamic_tests.rs
+++ b/storage/src/qmdb/current/proof/dynamic_tests.rs
@@ -1,4 +1,4 @@
-use super::{OperationProof, RuntimeOperationProof, tests::current_range_proof_fixture};
+use super::{dynamic, fixed, tests::current_range_proof_fixture};
 use crate::{
     merkle::{Graftable, Location},
     mmb, mmr,
@@ -14,7 +14,7 @@ fn invalid_chunk_sizes() -> impl Iterator<Item = usize> {
         .chain(usize::try_from(1u64 << 60).ok())
 }
 
-async fn check_runtime_proofs<F: Graftable, const N: usize>() {
+async fn check_dynamic_proofs<F: Graftable, const N: usize>() {
     let chunk_bits = (N * 8) as u64;
     let height = chunk_bits.trailing_zeros() as u64;
     for leaves in [
@@ -42,7 +42,7 @@ async fn check_runtime_proofs<F: Graftable, const N: usize>() {
         for loc in [start, Location::new(leaves - 1)] {
             let (_, range_proof, operations, chunks, root, _) =
                 current_range_proof_fixture::<F, N>(leaves, loc..loc + 1).await;
-            let native = OperationProof::<F, Digest, N> {
+            let native = fixed::OperationProof::<F, Digest, N> {
                 loc,
                 chunk: chunks[0],
                 range_proof,
@@ -50,18 +50,20 @@ async fn check_runtime_proofs<F: Graftable, const N: usize>() {
             assert!(native.verify::<Sha256, _>(operations[0], &root));
             let encoded = native.encode();
             let max_digests = native.range_proof.proof.digests.len();
-            let runtime =
-                RuntimeOperationProof::<F, Digest>::decode_cfg(encoded.clone(), &(N, max_digests))
-                    .unwrap();
-            assert_eq!(runtime.encode(), encoded);
-            assert_eq!(runtime.encode_size(), encoded.len());
-            assert_eq!(runtime.loc, loc);
-            assert_eq!(runtime.chunk.as_ref(), native.chunk.as_slice());
-            assert!(runtime.verify::<Sha256, _>(operations[0], &root));
-            assert!(!runtime.verify::<Sha256, _>(Sha256::hash(&[b"wrong operation"]), &root,));
-            assert!(!runtime.verify::<Sha256, _>(operations[0], &Sha256::hash(&[b"wrong root"]),));
+            let dynamic = dynamic::OperationProof::<F, Digest>::decode_cfg(
+                encoded.clone(),
+                &(N, max_digests),
+            )
+            .unwrap();
+            assert_eq!(dynamic.encode(), encoded);
+            assert_eq!(dynamic.encode_size(), encoded.len());
+            assert_eq!(dynamic.loc, loc);
+            assert_eq!(dynamic.chunk.as_ref(), native.chunk.as_slice());
+            assert!(dynamic.verify::<Sha256, _>(operations[0], &root));
+            assert!(!dynamic.verify::<Sha256, _>(Sha256::hash(&[b"wrong operation"]), &root,));
+            assert!(!dynamic.verify::<Sha256, _>(operations[0], &Sha256::hash(&[b"wrong root"]),));
 
-            let mut inactive = runtime;
+            let mut inactive = dynamic;
             let mut chunk = inactive.chunk.to_vec();
             let bit = (*loc % chunk_bits) as usize;
             chunk[bit / 8] &= !(1 << (bit % 8));
@@ -72,20 +74,20 @@ async fn check_runtime_proofs<F: Graftable, const N: usize>() {
 }
 
 #[test_async]
-async fn runtime_proofs_match_native_mmr() {
-    check_runtime_proofs::<mmr::Family, 1>().await;
-    check_runtime_proofs::<mmr::Family, 32>().await;
-    check_runtime_proofs::<mmr::Family, 64>().await;
+async fn dynamic_proofs_match_native_mmr() {
+    check_dynamic_proofs::<mmr::Family, 1>().await;
+    check_dynamic_proofs::<mmr::Family, 32>().await;
+    check_dynamic_proofs::<mmr::Family, 64>().await;
 }
 
 #[test_async]
-async fn runtime_proofs_match_native_mmb() {
-    check_runtime_proofs::<mmb::Family, 1>().await;
-    check_runtime_proofs::<mmb::Family, 32>().await;
-    check_runtime_proofs::<mmb::Family, 64>().await;
+async fn dynamic_proofs_match_native_mmb() {
+    check_dynamic_proofs::<mmb::Family, 1>().await;
+    check_dynamic_proofs::<mmb::Family, 32>().await;
+    check_dynamic_proofs::<mmb::Family, 64>().await;
 }
 
-async fn check_runtime_range_rejections<F: Graftable>() {
+async fn check_dynamic_range_rejections<F: Graftable>() {
     const N: usize = 1;
     let start = Location::<F>::new(6);
     let (_, proof, operations, chunks, root, _) =
@@ -167,17 +169,17 @@ async fn check_runtime_range_rejections<F: Graftable>() {
 }
 
 #[test_async]
-async fn runtime_range_rejects_malformed_inputs() {
-    check_runtime_range_rejections::<mmr::Family>().await;
-    check_runtime_range_rejections::<mmb::Family>().await;
+async fn dynamic_range_rejects_malformed_inputs() {
+    check_dynamic_range_rejections::<mmr::Family>().await;
+    check_dynamic_range_rejections::<mmb::Family>().await;
 }
 
-async fn check_runtime_operation_codec_rejections<F: Graftable>() {
+async fn check_dynamic_operation_codec_rejections<F: Graftable>() {
     const N: usize = 32;
     let loc = Location::<F>::new(14);
     let (_, range_proof, operations, chunks, root, _) =
         current_range_proof_fixture::<F, N>(18, loc..loc + 1).await;
-    let native = OperationProof::<F, Digest, N> {
+    let native = fixed::OperationProof::<F, Digest, N> {
         loc,
         chunk: chunks[0],
         range_proof,
@@ -186,12 +188,12 @@ async fn check_runtime_operation_codec_rejections<F: Graftable>() {
     let max_digests = native.range_proof.proof.digests.len();
     assert!(max_digests > 0);
     assert!(
-        RuntimeOperationProof::<F, Digest>::decode_cfg(encoded.clone(), &(N, max_digests - 1),)
+        dynamic::OperationProof::<F, Digest>::decode_cfg(encoded.clone(), &(N, max_digests - 1),)
             .is_err()
     );
     for end in 0..encoded.len() {
         assert!(
-            RuntimeOperationProof::<F, Digest>::decode_cfg(&encoded[..end], &(N, max_digests),)
+            dynamic::OperationProof::<F, Digest>::decode_cfg(&encoded[..end], &(N, max_digests),)
                 .is_err(),
             "truncated proof decoded at {end}"
         );
@@ -199,12 +201,12 @@ async fn check_runtime_operation_codec_rejections<F: Graftable>() {
     let mut trailing = encoded.to_vec();
     trailing.push(0);
     assert!(
-        RuntimeOperationProof::<F, Digest>::decode_cfg(trailing.as_slice(), &(N, max_digests),)
+        dynamic::OperationProof::<F, Digest>::decode_cfg(trailing.as_slice(), &(N, max_digests),)
             .is_err()
     );
     for chunk_size in invalid_chunk_sizes() {
         assert!(matches!(
-            RuntimeOperationProof::<F, Digest>::decode_cfg(
+            dynamic::OperationProof::<F, Digest>::decode_cfg(
                 encoded.clone(),
                 &(chunk_size, max_digests),
             ),
@@ -212,24 +214,24 @@ async fn check_runtime_operation_codec_rejections<F: Graftable>() {
         ));
     }
     for chunk_size in [1, N / 2, N * 2] {
-        if let Ok(runtime) = RuntimeOperationProof::<F, Digest>::decode_cfg(
+        if let Ok(dynamic) = dynamic::OperationProof::<F, Digest>::decode_cfg(
             encoded.clone(),
             &(chunk_size, max_digests),
         ) {
-            assert!(!runtime.verify::<Sha256, _>(operations[0], &root));
+            assert!(!dynamic.verify::<Sha256, _>(operations[0], &root));
         }
     }
-    let runtime =
-        RuntimeOperationProof::<F, Digest>::decode_cfg(encoded, &(N, max_digests)).unwrap();
+    let dynamic =
+        dynamic::OperationProof::<F, Digest>::decode_cfg(encoded, &(N, max_digests)).unwrap();
     for chunk in [Bytes::new(), Bytes::from_static(&[0; 3])] {
-        let mut malformed = runtime.clone();
+        let mut malformed = dynamic.clone();
         malformed.chunk = chunk;
         assert!(!malformed.verify::<Sha256, _>(operations[0], &root));
     }
 }
 
 #[test_async]
-async fn runtime_operation_codec_rejects_malformed_inputs() {
-    check_runtime_operation_codec_rejections::<mmr::Family>().await;
-    check_runtime_operation_codec_rejections::<mmb::Family>().await;
+async fn dynamic_operation_codec_rejects_malformed_inputs() {
+    check_dynamic_operation_codec_rejections::<mmr::Family>().await;
+    check_dynamic_operation_codec_rejections::<mmb::Family>().await;
 }

--- a/storage/src/qmdb/current/proof/dynamic_tests.rs
+++ b/storage/src/qmdb/current/proof/dynamic_tests.rs
@@ -1,4 +1,4 @@
-use super::{dynamic, fixed, tests::current_range_proof_fixture};
+use super::{constant, dynamic, tests::current_range_proof_fixture};
 use crate::{
     merkle::{Graftable, Location},
     mmb, mmr,
@@ -42,7 +42,7 @@ async fn check_dynamic_proofs<F: Graftable, const N: usize>() {
         for loc in [start, Location::new(leaves - 1)] {
             let (_, range_proof, operations, chunks, root, _) =
                 current_range_proof_fixture::<F, N>(leaves, loc..loc + 1).await;
-            let native = fixed::OperationProof::<F, Digest, N> {
+            let native = constant::OperationProof::<F, Digest, N> {
                 loc,
                 chunk: chunks[0],
                 range_proof,
@@ -179,7 +179,7 @@ async fn check_dynamic_operation_codec_rejections<F: Graftable>() {
     let loc = Location::<F>::new(14);
     let (_, range_proof, operations, chunks, root, _) =
         current_range_proof_fixture::<F, N>(18, loc..loc + 1).await;
-    let native = fixed::OperationProof::<F, Digest, N> {
+    let native = constant::OperationProof::<F, Digest, N> {
         loc,
         chunk: chunks[0],
         range_proof,

--- a/storage/src/qmdb/current/proof/mod.rs
+++ b/storage/src/qmdb/current/proof/mod.rs
@@ -3,7 +3,7 @@
 //! This module provides:
 //! - [OpsRootWitness]: Authenticates an ops root against a canonical `current` root.
 //! - [RangeProof]: Proves a range of operations exist in the database.
-//! - [fixed::OperationProof]: Proves a specific operation is active, with a fixed-size bitmap chunk.
+//! - [constant::OperationProof]: Proves a specific operation is active, with a fixed-size bitmap chunk.
 //! - [dynamic::OperationProof]: Uses a bitmap chunk size supplied when decoding.
 //!
 //! # Canonical root structure
@@ -69,7 +69,7 @@ pub(super) fn chunk_bits(chunk_size: usize) -> Result<u64, commonware_codec::Err
         ))
 }
 
-/// Bitmap chunk indices read by [RangeProof::new] or [fixed::OperationProof::new].
+/// Bitmap chunk indices read by [RangeProof::new] or [constant::OperationProof::new].
 ///
 /// Pass `None` for a range proof or the queried operation location for an operation proof.
 /// The returned indices are unique and increasing. At most three chunks are needed: the
@@ -633,7 +633,7 @@ where
 }
 
 /// Proofs with fixed-size bitmap chunks.
-pub mod fixed {
+pub mod constant {
     /// A proof that a specific operation is active, with a fixed-size bitmap chunk.
     pub type OperationProof<F, D, const N: usize> = super::operation::Proof<F, D, [u8; N]>;
 }
@@ -645,7 +645,7 @@ pub mod dynamic {
     /// Decoding takes `(chunk_size, max_digests)` as configuration. The chunk size must match
     /// the source database and satisfy [super::RangeProof::verify_with_chunk_size]'s size
     /// requirements. The bitmap chunk has no length prefix, so its wire encoding matches
-    /// [super::fixed::OperationProof].
+    /// [super::constant::OperationProof].
     /// The operation supplied to verification must use the source database's key and value codecs.
     ///
     /// # Examples
@@ -859,7 +859,7 @@ mod tests {
 
         let chunk: [u8; N] = core::array::from_fn(|i| i as u8);
 
-        let proof = fixed::OperationProof::<F, sha256::Digest, N> {
+        let proof = constant::OperationProof::<F, sha256::Digest, N> {
             loc: mmb::Location::new(5),
             chunk,
             range_proof,
@@ -868,7 +868,7 @@ mod tests {
         let encoded = proof.encode();
         assert_eq!(encoded.len(), proof.encode_size());
         let decoded =
-            fixed::OperationProof::<F, sha256::Digest, N>::decode_cfg(encoded, &MAX_DIGESTS)
+            constant::OperationProof::<F, sha256::Digest, N>::decode_cfg(encoded, &MAX_DIGESTS)
                 .unwrap();
         assert_eq!(decoded, proof);
     }
@@ -889,21 +889,21 @@ mod tests {
             ops_root: Sha256::hash(&[b"ops"]),
         };
         let total_digests = range_proof_digest_count(&range_proof);
-        let proof = fixed::OperationProof::<F, sha256::Digest, N> {
+        let proof = constant::OperationProof::<F, sha256::Digest, N> {
             loc: mmb::Location::new(5),
             chunk: core::array::from_fn(|i| i as u8),
             range_proof,
         };
 
         let encoded = proof.encode();
-        let decoded = fixed::OperationProof::<F, sha256::Digest, N>::decode_cfg(
+        let decoded = constant::OperationProof::<F, sha256::Digest, N>::decode_cfg(
             encoded.clone(),
             &total_digests,
         )
         .unwrap();
         assert_eq!(decoded, proof);
         assert!(
-            fixed::OperationProof::<F, sha256::Digest, N>::decode_cfg(
+            constant::OperationProof::<F, sha256::Digest, N>::decode_cfg(
                 encoded,
                 &(total_digests - 1)
             )
@@ -2179,7 +2179,7 @@ mod tests {
 
     #[cfg(feature = "arbitrary")]
     mod conformance {
-        use super::super::{OpsRootWitness, RangeProof, dynamic, fixed};
+        use super::super::{OpsRootWitness, RangeProof, constant, dynamic};
         use crate::merkle::{mmb, mmr};
         use commonware_codec::conformance::CodecConformance;
         use commonware_cryptography::sha256::Digest as Sha256Digest;
@@ -2189,8 +2189,8 @@ mod tests {
             CodecConformance<OpsRootWitness<mmb::Family, Sha256Digest>>,
             CodecConformance<RangeProof<mmr::Family, Sha256Digest>>,
             CodecConformance<RangeProof<mmb::Family, Sha256Digest>>,
-            CodecConformance<fixed::OperationProof<mmr::Family, Sha256Digest, 32>>,
-            CodecConformance<fixed::OperationProof<mmb::Family, Sha256Digest, 32>>,
+            CodecConformance<constant::OperationProof<mmr::Family, Sha256Digest, 32>>,
+            CodecConformance<constant::OperationProof<mmb::Family, Sha256Digest, 32>>,
             CodecConformance<dynamic::OperationProof<mmr::Family, Sha256Digest>>,
             CodecConformance<dynamic::OperationProof<mmb::Family, Sha256Digest>>,
         }

--- a/storage/src/qmdb/current/proof/mod.rs
+++ b/storage/src/qmdb/current/proof/mod.rs
@@ -36,7 +36,7 @@ use crate::{
     qmdb::{
         self, Error,
         current::{
-            db::{combine_roots, partial_chunk, pending_chunk},
+            db::{combine_roots, graftable_chunk_window, partial_chunk, pending_chunk},
             grafting,
         },
     },
@@ -48,6 +48,66 @@ use commonware_utils::bitmap::{Prunable as BitMap, Readable as BitmapReadable};
 use core::{num::NonZeroU64, ops::Range};
 use futures::future::try_join_all;
 use tracing::debug;
+
+#[cfg(test)]
+mod required_chunks_tests;
+
+/// Bitmap chunk indices read by [RangeProof::new] or [OperationProof::new].
+///
+/// Pass `None` for a range proof or the queried operation location for an operation proof.
+/// The returned indices are unique and increasing. At most three chunks are needed: the
+/// trailing partial chunk, a complete chunk awaiting its ops-tree ancestor, and the queried
+/// operation's chunk. This allows a storage adapter to preload bitmap bytes before exposing a
+/// synchronous [BitmapReadable] implementation.
+///
+/// `ops_leaves`, `bitmap_len`, and `pruned_chunks` must describe one consistent snapshot.
+/// `N` is the bitmap chunk size in bytes and must be a nonzero power of two.
+///
+/// # Errors
+///
+/// Returns [Error::DataCorrupted] if more than one complete chunk awaits its ancestor or
+/// pruning exceeds the graftable prefix. Returns [Error::OperationPruned] for a queried
+/// operation in a pruned chunk, and [merkle::Error::RangeOutOfBounds] for a queried operation
+/// outside the snapshot.
+pub fn required_chunks<F: Graftable, const N: usize>(
+    ops_leaves: Location<F>,
+    bitmap_len: u64,
+    pruned_chunks: u64,
+    location: Option<Location<F>>,
+) -> Result<impl Iterator<Item = u64>, Error<F>> {
+    const { assert!(N.is_power_of_two() && N <= usize::MAX / 8) };
+    let chunk_bits = BitMap::<N>::CHUNK_SIZE_BITS;
+    let (complete, graftable) = graftable_chunk_window(
+        ops_leaves,
+        bitmap_len / chunk_bits,
+        pruned_chunks,
+        grafting::height::<N>(),
+    )?;
+    let queried = if let Some(loc) = location {
+        if loc >= ops_leaves || *loc >= bitmap_len {
+            return Err(merkle::Error::RangeOutOfBounds(loc).into());
+        }
+        let chunk = *loc / chunk_bits;
+        if chunk < pruned_chunks {
+            return Err(Error::OperationPruned(loc));
+        }
+        Some(chunk)
+    } else {
+        None
+    };
+    let mut chunks = [
+        (!bitmap_len.is_multiple_of(chunk_bits)).then_some(complete),
+        (complete > graftable).then_some(graftable),
+        queried,
+    ];
+    chunks.sort_unstable();
+    let mut previous = None;
+    Ok(chunks.into_iter().flatten().filter(move |&chunk| {
+        let distinct = previous != Some(chunk);
+        previous = Some(chunk);
+        distinct
+    }))
+}
 
 /// Witness that a particular `ops_root` is committed by a `current` canonical root.
 ///

--- a/storage/src/qmdb/current/proof/mod.rs
+++ b/storage/src/qmdb/current/proof/mod.rs
@@ -3,8 +3,8 @@
 //! This module provides:
 //! - [OpsRootWitness]: Authenticates an ops root against a canonical `current` root.
 //! - [RangeProof]: Proves a range of operations exist in the database.
-//! - [OperationProof]: Proves a specific operation is active in the database.
-//! - [RuntimeOperationProof]: Decodes and verifies an operation proof with a runtime chunk size.
+//! - [fixed::OperationProof]: Proves a specific operation is active, with a fixed-size bitmap chunk.
+//! - [dynamic::OperationProof]: Uses a bitmap chunk size supplied when decoding.
 //!
 //! # Canonical root structure
 //!
@@ -51,9 +51,9 @@ use futures::future::try_join_all;
 use tracing::debug;
 
 #[cfg(test)]
-mod required_chunks_tests;
+mod dynamic_tests;
 #[cfg(test)]
-mod runtime_tests;
+mod required_chunks_tests;
 
 pub mod operation;
 
@@ -69,7 +69,7 @@ pub(super) fn chunk_bits(chunk_size: usize) -> Result<u64, commonware_codec::Err
         ))
 }
 
-/// Bitmap chunk indices read by [RangeProof::new] or [OperationProof::new].
+/// Bitmap chunk indices read by [RangeProof::new] or [fixed::OperationProof::new].
 ///
 /// Pass `None` for a range proof or the queried operation location for an operation proof.
 /// The returned indices are unique and increasing. At most three chunks are needed: the
@@ -632,40 +632,47 @@ where
     }
 }
 
-/// A proof that a specific operation is active, with a fixed-size bitmap chunk.
-pub type OperationProof<F, D, const N: usize> = operation::Proof<F, D, [u8; N]>;
+/// Proofs with fixed-size bitmap chunks.
+pub mod fixed {
+    /// A proof that a specific operation is active, with a fixed-size bitmap chunk.
+    pub type OperationProof<F, D, const N: usize> = super::operation::Proof<F, D, [u8; N]>;
+}
 
-/// An operation proof with a runtime-sized bitmap chunk.
-///
-/// Decoding takes `(chunk_size, max_digests)` as configuration. The chunk size must match
-/// the source database and satisfy [RangeProof::verify_with_chunk_size]'s size requirements.
-/// The bitmap chunk has no length prefix, so its wire encoding matches [OperationProof].
-/// The operation supplied to verification must use the source database's key and value codecs.
-///
-/// # Examples
-///
-/// ```
-/// use commonware_codec::{Codec, Decode};
-/// use commonware_cryptography::{Sha256, sha256::Digest};
-/// use commonware_storage::{merkle::mmr, qmdb::current::proof::RuntimeOperationProof};
-///
-/// fn verify<O: Codec>(
-///     encoded: &[u8],
-///     chunk_size: usize,
-///     max_digests: usize,
-///     operation: O,
-///     root: &Digest,
-/// ) -> bool {
-///     let Ok(proof) = RuntimeOperationProof::<mmr::Family, Digest>::decode_cfg(
-///         encoded,
-///         &(chunk_size, max_digests),
-///     ) else {
-///         return false;
-///     };
-///     proof.verify::<Sha256, _>(operation, root)
-/// }
-/// ```
-pub type RuntimeOperationProof<F, D> = operation::Proof<F, D, bytes::Bytes>;
+/// Proofs with runtime-sized bitmap chunks.
+pub mod dynamic {
+    /// An operation proof with a runtime-sized bitmap chunk.
+    ///
+    /// Decoding takes `(chunk_size, max_digests)` as configuration. The chunk size must match
+    /// the source database and satisfy [super::RangeProof::verify_with_chunk_size]'s size
+    /// requirements. The bitmap chunk has no length prefix, so its wire encoding matches
+    /// [super::fixed::OperationProof].
+    /// The operation supplied to verification must use the source database's key and value codecs.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use commonware_codec::{Codec, Decode};
+    /// use commonware_cryptography::{Sha256, sha256::Digest};
+    /// use commonware_storage::{merkle::mmr, qmdb::current::proof::dynamic::OperationProof};
+    ///
+    /// fn verify<O: Codec>(
+    ///     encoded: &[u8],
+    ///     chunk_size: usize,
+    ///     max_digests: usize,
+    ///     operation: O,
+    ///     root: &Digest,
+    /// ) -> bool {
+    ///     let Ok(proof) = OperationProof::<mmr::Family, Digest>::decode_cfg(
+    ///         encoded,
+    ///         &(chunk_size, max_digests),
+    ///     ) else {
+    ///         return false;
+    ///     };
+    ///     proof.verify::<Sha256, _>(operation, root)
+    /// }
+    /// ```
+    pub type OperationProof<F, D> = super::operation::Proof<F, D, bytes::Bytes>;
+}
 
 #[cfg(test)]
 mod tests {
@@ -852,7 +859,7 @@ mod tests {
 
         let chunk: [u8; N] = core::array::from_fn(|i| i as u8);
 
-        let proof = OperationProof::<F, sha256::Digest, N> {
+        let proof = fixed::OperationProof::<F, sha256::Digest, N> {
             loc: mmb::Location::new(5),
             chunk,
             range_proof,
@@ -861,7 +868,8 @@ mod tests {
         let encoded = proof.encode();
         assert_eq!(encoded.len(), proof.encode_size());
         let decoded =
-            OperationProof::<F, sha256::Digest, N>::decode_cfg(encoded, &MAX_DIGESTS).unwrap();
+            fixed::OperationProof::<F, sha256::Digest, N>::decode_cfg(encoded, &MAX_DIGESTS)
+                .unwrap();
         assert_eq!(decoded, proof);
     }
 
@@ -881,20 +889,25 @@ mod tests {
             ops_root: Sha256::hash(&[b"ops"]),
         };
         let total_digests = range_proof_digest_count(&range_proof);
-        let proof = OperationProof::<F, sha256::Digest, N> {
+        let proof = fixed::OperationProof::<F, sha256::Digest, N> {
             loc: mmb::Location::new(5),
             chunk: core::array::from_fn(|i| i as u8),
             range_proof,
         };
 
         let encoded = proof.encode();
-        let decoded =
-            OperationProof::<F, sha256::Digest, N>::decode_cfg(encoded.clone(), &total_digests)
-                .unwrap();
+        let decoded = fixed::OperationProof::<F, sha256::Digest, N>::decode_cfg(
+            encoded.clone(),
+            &total_digests,
+        )
+        .unwrap();
         assert_eq!(decoded, proof);
         assert!(
-            OperationProof::<F, sha256::Digest, N>::decode_cfg(encoded, &(total_digests - 1))
-                .is_err()
+            fixed::OperationProof::<F, sha256::Digest, N>::decode_cfg(
+                encoded,
+                &(total_digests - 1)
+            )
+            .is_err()
         );
     }
 
@@ -2166,7 +2179,7 @@ mod tests {
 
     #[cfg(feature = "arbitrary")]
     mod conformance {
-        use super::super::{OperationProof, OpsRootWitness, RangeProof, RuntimeOperationProof};
+        use super::super::{OpsRootWitness, RangeProof, dynamic, fixed};
         use crate::merkle::{mmb, mmr};
         use commonware_codec::conformance::CodecConformance;
         use commonware_cryptography::sha256::Digest as Sha256Digest;
@@ -2176,10 +2189,10 @@ mod tests {
             CodecConformance<OpsRootWitness<mmb::Family, Sha256Digest>>,
             CodecConformance<RangeProof<mmr::Family, Sha256Digest>>,
             CodecConformance<RangeProof<mmb::Family, Sha256Digest>>,
-            CodecConformance<OperationProof<mmr::Family, Sha256Digest, 32>>,
-            CodecConformance<OperationProof<mmb::Family, Sha256Digest, 32>>,
-            CodecConformance<RuntimeOperationProof<mmr::Family, Sha256Digest>>,
-            CodecConformance<RuntimeOperationProof<mmb::Family, Sha256Digest>>,
+            CodecConformance<fixed::OperationProof<mmr::Family, Sha256Digest, 32>>,
+            CodecConformance<fixed::OperationProof<mmb::Family, Sha256Digest, 32>>,
+            CodecConformance<dynamic::OperationProof<mmr::Family, Sha256Digest>>,
+            CodecConformance<dynamic::OperationProof<mmb::Family, Sha256Digest>>,
         }
     }
 }

--- a/storage/src/qmdb/current/proof/mod.rs
+++ b/storage/src/qmdb/current/proof/mod.rs
@@ -4,6 +4,7 @@
 //! - [OpsRootWitness]: Authenticates an ops root against a canonical `current` root.
 //! - [RangeProof]: Proves a range of operations exist in the database.
 //! - [OperationProof]: Proves a specific operation is active in the database.
+//! - [RuntimeOperationProof]: Decodes and verifies an operation proof with a runtime chunk size.
 //!
 //! # Canonical root structure
 //!
@@ -51,6 +52,22 @@ use tracing::debug;
 
 #[cfg(test)]
 mod required_chunks_tests;
+#[cfg(test)]
+mod runtime_tests;
+
+pub mod operation;
+
+/// Validate the chunk width before deriving bitmap indices or Merkle heights.
+pub(super) fn chunk_bits(chunk_size: usize) -> Result<u64, commonware_codec::Error> {
+    chunk_size
+        .checked_mul(8)
+        .and_then(|bits| u64::try_from(bits).ok())
+        .filter(|bits| bits.is_power_of_two() && bits.trailing_zeros() < 63)
+        .ok_or(commonware_codec::Error::Invalid(
+            "current proof",
+            "invalid bitmap chunk size",
+        ))
+}
 
 /// Bitmap chunk indices read by [RangeProof::new] or [OperationProof::new].
 ///
@@ -347,17 +364,19 @@ impl<F: Graftable, D: Digest> RangeProof<F, D> {
 
     /// Reconstruct the canonical current root, optionally collecting the positioned digests
     /// required to compute the peaks covering the proven range.
-    fn reconstruct_root<H, O, const N: usize>(
+    fn reconstruct_root<H, O>(
         &self,
         start_loc: Location<F>,
         ops: &[O],
-        chunks: &[[u8; N]],
+        chunks: &[impl AsRef<[u8]>],
+        chunk_size: usize,
         collected: Option<&mut Vec<(Position<F>, D)>>,
     ) -> Result<D, merkle::Error<F>>
     where
         H: Hasher<Digest = D>,
         O: Codec,
     {
+        let chunk_bits = chunk_bits(chunk_size).map_err(|_| merkle::Error::InvalidProof)?;
         if ops.is_empty() || chunks.is_empty() {
             debug!("verification failed, empty input");
             return Err(merkle::Error::InvalidProof);
@@ -378,7 +397,6 @@ impl<F: Graftable, D: Digest> RangeProof<F, D> {
         }
 
         // Validate the number of input chunks.
-        let chunk_bits = BitMap::<N>::CHUNK_SIZE_BITS;
         let start_chunk = *start_loc / chunk_bits;
         let end_chunk = (*end_loc - 1) / chunk_bits;
         let complete_chunks = *leaves / chunk_bits;
@@ -387,13 +405,20 @@ impl<F: Graftable, D: Digest> RangeProof<F, D> {
             debug!("verification failed, chunk metadata length mismatch");
             return Err(merkle::Error::InvalidProof);
         }
+        if chunks
+            .iter()
+            .any(|chunk| chunk.as_ref().len() != chunk_size)
+        {
+            debug!("verification failed, chunk size mismatch");
+            return Err(merkle::Error::InvalidProof);
+        }
 
         let next_bit = *leaves % chunk_bits;
         let has_partial_chunk = next_bit != 0;
 
         let elements = ops.iter().map(|op| op.encode()).collect::<Vec<_>>();
         let chunk_vec = chunks.iter().map(|c| c.as_ref()).collect::<Vec<_>>();
-        let grafting_height = grafting::height::<N>();
+        let grafting_height = chunk_bits.trailing_zeros();
 
         let graftable_chunks =
             grafting::graftable_chunks::<F>(*leaves, grafting_height).min(complete_chunks);
@@ -435,7 +460,7 @@ impl<F: Graftable, D: Digest> RangeProof<F, D> {
             // chunk provided by the caller matches the digest embedded in the proof.
             if end_chunk == complete_chunks {
                 let last_chunk = chunks.last().expect("chunks non-empty");
-                if last_chunk_digest != grafting_verifier.digest(last_chunk) {
+                if last_chunk_digest != grafting_verifier.digest(last_chunk.as_ref()) {
                     debug!("last chunk digest does not match expected value");
                     return Err(merkle::Error::InvalidProof);
                 }
@@ -463,7 +488,7 @@ impl<F: Graftable, D: Digest> RangeProof<F, D> {
                     );
                     return Err(merkle::Error::InvalidProof);
                 };
-                if *pending_digest != grafting_verifier.digest(pending_chunk_bytes) {
+                if *pending_digest != grafting_verifier.digest(pending_chunk_bytes.as_ref()) {
                     debug!("pending chunk digest does not match expected value");
                     return Err(merkle::Error::InvalidProof);
                 }
@@ -502,8 +527,28 @@ impl<F: Graftable, D: Digest> RangeProof<F, D> {
         chunks: &[[u8; N]],
         root: &H::Digest,
     ) -> bool {
+        self.verify_with_chunk_size::<H, O>(start_loc, ops, chunks, N, root)
+    }
+
+    /// Verify an operation range using bitmap chunks whose size is configured at runtime.
+    ///
+    /// `chunk_size` must match the source database. It must be a nonzero power of two,
+    /// its bit width must fit in `usize` and `u64`, and its grafting height must be below 63.
+    /// Every supplied chunk must contain exactly `chunk_size` bytes. Invalid sizes and
+    /// malformed proofs return `false`.
+    ///
+    /// This verifies the same proof and wire encoding as [Self::verify], accepting arrays,
+    /// byte slices, or owned byte buffers without copying their contents.
+    pub fn verify_with_chunk_size<H: Hasher<Digest = D>, O: Codec>(
+        &self,
+        start_loc: Location<F>,
+        ops: &[O],
+        chunks: &[impl AsRef<[u8]>],
+        chunk_size: usize,
+        root: &D,
+    ) -> bool {
         matches!(
-            self.reconstruct_root::<H, O, N>(start_loc, ops, chunks, None),
+            self.reconstruct_root::<H, O>(start_loc, ops, chunks, chunk_size, None),
             Ok(reconstructed_root) if reconstructed_root == *root
         )
     }
@@ -526,7 +571,7 @@ where
 {
     let mut collected = Vec::new();
     let reconstructed_root =
-        proof.reconstruct_root::<H, Op, N>(start_loc, operations, chunks, Some(&mut collected))?;
+        proof.reconstruct_root::<H, Op>(start_loc, operations, chunks, N, Some(&mut collected))?;
     if reconstructed_root != *target_root {
         debug!("verification failed, root mismatch");
         return Err(merkle::Error::RootMismatch);
@@ -590,113 +635,40 @@ where
     }
 }
 
-/// A proof that a specific operation is currently active in the database.
-#[derive(Clone, Eq, PartialEq, Debug)]
-pub struct OperationProof<F: Graftable, D: Digest, const N: usize> {
-    /// The location of the operation in the db.
-    pub loc: Location<F>,
+/// A proof that a specific operation is active, with a fixed-size bitmap chunk.
+pub type OperationProof<F, D, const N: usize> = operation::Proof<F, D, [u8; N]>;
 
-    /// The status bitmap chunk that contains the bit corresponding the operation's location.
-    pub chunk: [u8; N],
-
-    /// The range proof that incorporates activity status for the operation designated by `loc`.
-    pub range_proof: RangeProof<F, D>,
-}
-
-impl<F: Graftable, D: Digest, const N: usize> OperationProof<F, D, N> {
-    /// Return an inclusion proof that incorporates activity status for the operation designated by
-    /// `loc`.
-    ///
-    /// # Errors
-    ///
-    /// Returns [Error::OperationPruned] if `loc` falls in a pruned bitmap chunk.
-    pub async fn new<H: Hasher<Digest = D>, S: Storage<F, Digest = D>>(
-        status: &impl BitmapReadable<N>,
-        storage: &S,
-        inactivity_floor: Location<F>,
-        loc: Location<F>,
-        ops_root: D,
-    ) -> Result<Self, Error<F>> {
-        // Reject locations in pruned bitmap chunks.
-        if BitMap::<N>::to_chunk_index(*loc) < status.pruned_chunks() {
-            return Err(Error::OperationPruned(loc));
-        }
-        let range_proof =
-            RangeProof::new::<H, S, N>(status, storage, inactivity_floor, loc..loc + 1, ops_root)
-                .await?;
-        let chunk = status.get_chunk(BitMap::<N>::to_chunk_index(*loc));
-        Ok(Self {
-            loc,
-            chunk,
-            range_proof,
-        })
-    }
-
-    /// Verify that the proof proves that `operation` is active in the database with the given
-    /// `root`.
-    pub fn verify<H: Hasher<Digest = D>, O: Codec>(&self, operation: O, root: &D) -> bool {
-        // Make sure that the bit for the operation in the bitmap chunk is actually a 1 (indicating
-        // the operation is indeed active).
-        if !BitMap::<N>::get_bit_from_chunk(&self.chunk, *self.loc) {
-            debug!(
-                ?self.loc,
-                "proof verification failed, operation is inactive"
-            );
-            return false;
-        }
-
-        self.range_proof
-            .verify::<H, O, N>(self.loc, &[operation], &[self.chunk], root)
-    }
-}
-
-impl<F: Graftable, D: Digest, const N: usize> Write for OperationProof<F, D, N> {
-    fn write(&self, buf: &mut impl BufMut) {
-        self.loc.write(buf);
-        self.chunk.write(buf);
-        self.range_proof.write(buf);
-    }
-}
-
-impl<F: Graftable, D: Digest, const N: usize> EncodeSize for OperationProof<F, D, N> {
-    fn encode_size(&self) -> usize {
-        self.loc.encode_size() + self.chunk.encode_size() + self.range_proof.encode_size()
-    }
-}
-
-impl<F: Graftable, D: Digest, const N: usize> Read for OperationProof<F, D, N> {
-    /// The maximum number of digests forwarded to the embedded range proof.
-    type Cfg = usize;
-
-    fn read_cfg(
-        buf: &mut impl Buf,
-        max_digests: &Self::Cfg,
-    ) -> Result<Self, commonware_codec::Error> {
-        let loc = Location::<F>::read(buf)?;
-        let chunk = <[u8; N]>::read(buf)?;
-        let range_proof = RangeProof::<F, D>::read_cfg(buf, max_digests)?;
-        Ok(Self {
-            loc,
-            chunk,
-            range_proof,
-        })
-    }
-}
-
-#[cfg(feature = "arbitrary")]
-impl<F: Graftable, D: Digest, const N: usize> arbitrary::Arbitrary<'_> for OperationProof<F, D, N>
-where
-    D: for<'a> arbitrary::Arbitrary<'a>,
-    F::PendingChunk<D>: for<'a> arbitrary::Arbitrary<'a>,
-{
-    fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
-        Ok(Self {
-            loc: u.arbitrary()?,
-            chunk: u.arbitrary()?,
-            range_proof: u.arbitrary()?,
-        })
-    }
-}
+/// An operation proof with a runtime-sized bitmap chunk.
+///
+/// Decoding takes `(chunk_size, max_digests)` as configuration. The chunk size must match
+/// the source database and satisfy [RangeProof::verify_with_chunk_size]'s size requirements.
+/// The bitmap chunk has no length prefix, so its wire encoding matches [OperationProof].
+/// The operation supplied to verification must use the source database's key and value codecs.
+///
+/// # Examples
+///
+/// ```
+/// use commonware_codec::{Codec, Decode};
+/// use commonware_cryptography::{Sha256, sha256::Digest};
+/// use commonware_storage::{merkle::mmr, qmdb::current::proof::RuntimeOperationProof};
+///
+/// fn verify<O: Codec>(
+///     encoded: &[u8],
+///     chunk_size: usize,
+///     max_digests: usize,
+///     operation: O,
+///     root: &Digest,
+/// ) -> bool {
+///     let Ok(proof) = RuntimeOperationProof::<mmr::Family, Digest>::decode_cfg(
+///         encoded,
+///         &(chunk_size, max_digests),
+///     ) else {
+///         return false;
+///     };
+///     proof.verify::<Sha256, _>(operation, root)
+/// }
+/// ```
+pub type RuntimeOperationProof<F, D> = operation::Proof<F, D, bytes::Bytes>;
 
 #[cfg(test)]
 mod tests {
@@ -1309,7 +1281,7 @@ mod tests {
         assert!(!proof.verify::<Sha256, _, N>(loc, &[element], &[chunk], &root,));
     }
 
-    async fn current_range_proof_fixture<F: Graftable, const N: usize>(
+    pub(super) async fn current_range_proof_fixture<F: Graftable, const N: usize>(
         leaf_count: u64,
         range: Range<Location<F>>,
     ) -> (
@@ -2197,7 +2169,7 @@ mod tests {
 
     #[cfg(feature = "arbitrary")]
     mod conformance {
-        use super::super::{OperationProof, OpsRootWitness, RangeProof};
+        use super::super::{OperationProof, OpsRootWitness, RangeProof, RuntimeOperationProof};
         use crate::merkle::{mmb, mmr};
         use commonware_codec::conformance::CodecConformance;
         use commonware_cryptography::sha256::Digest as Sha256Digest;
@@ -2209,6 +2181,8 @@ mod tests {
             CodecConformance<RangeProof<mmb::Family, Sha256Digest>>,
             CodecConformance<OperationProof<mmr::Family, Sha256Digest, 32>>,
             CodecConformance<OperationProof<mmb::Family, Sha256Digest, 32>>,
+            CodecConformance<RuntimeOperationProof<mmr::Family, Sha256Digest>>,
+            CodecConformance<RuntimeOperationProof<mmb::Family, Sha256Digest>>,
         }
     }
 }

--- a/storage/src/qmdb/current/proof/mod.rs
+++ b/storage/src/qmdb/current/proof/mod.rs
@@ -94,12 +94,9 @@ pub fn required_chunks<F: Graftable, const N: usize>(
 ) -> Result<impl Iterator<Item = u64>, Error<F>> {
     const { assert!(N.is_power_of_two() && N <= usize::MAX / 8) };
     let chunk_bits = BitMap::<N>::CHUNK_SIZE_BITS;
-    let (complete, graftable) = graftable_chunk_window(
-        ops_leaves,
-        bitmap_len / chunk_bits,
-        pruned_chunks,
-        grafting::height::<N>(),
-    )?;
+    let complete = bitmap_len / chunk_bits;
+    let graftable =
+        graftable_chunk_window(ops_leaves, complete, pruned_chunks, grafting::height::<N>())?;
     let queried = if let Some(loc) = location {
         if loc >= ops_leaves || *loc >= bitmap_len {
             return Err(merkle::Error::RangeOutOfBounds(loc).into());

--- a/storage/src/qmdb/current/proof/operation.rs
+++ b/storage/src/qmdb/current/proof/operation.rs
@@ -1,0 +1,181 @@
+//! Operation proofs with fixed-size or runtime-sized bitmap chunks.
+
+use super::{RangeProof, chunk_bits};
+use crate::{
+    merkle::{Graftable, Location, storage::Storage},
+    qmdb::Error,
+};
+use bytes::{Buf, BufMut, Bytes};
+use commonware_codec::{Codec, EncodeSize, Read, ReadExt as _, Write, util::at_least};
+use commonware_cryptography::{Digest, Hasher};
+use commonware_utils::bitmap::{Prunable as BitMap, Readable as BitmapReadable};
+use tracing::debug;
+
+/// A proof that a specific operation is currently active in the database.
+///
+/// `C` stores the bitmap chunk. Arrays provide fixed-size storage, while [Bytes] supports a
+/// chunk size supplied when decoding. Both representations encode the chunk without a length
+/// prefix.
+#[derive(Clone, Eq, PartialEq, Debug)]
+pub struct Proof<F: Graftable, D: Digest, C> {
+    /// The location of the operation in the database.
+    pub loc: Location<F>,
+
+    /// The status bitmap chunk containing the operation's activity bit.
+    pub chunk: C,
+
+    /// The range proof authenticating the operation and its activity status.
+    pub range_proof: RangeProof<F, D>,
+}
+
+impl<F: Graftable, D: Digest, const N: usize> Proof<F, D, [u8; N]> {
+    /// Return an inclusion proof that incorporates activity status for the operation at `loc`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [Error::OperationPruned] if `loc` falls in a pruned bitmap chunk.
+    pub async fn new<H: Hasher<Digest = D>, S: Storage<F, Digest = D>>(
+        status: &impl BitmapReadable<N>,
+        storage: &S,
+        inactivity_floor: Location<F>,
+        loc: Location<F>,
+        ops_root: D,
+    ) -> Result<Self, Error<F>> {
+        // Reject locations in pruned bitmap chunks
+        if BitMap::<N>::to_chunk_index(*loc) < status.pruned_chunks() {
+            return Err(Error::OperationPruned(loc));
+        }
+        let range_proof =
+            RangeProof::new::<H, S, N>(status, storage, inactivity_floor, loc..loc + 1, ops_root)
+                .await?;
+        let chunk = status.get_chunk(BitMap::<N>::to_chunk_index(*loc));
+        Ok(Self {
+            loc,
+            chunk,
+            range_proof,
+        })
+    }
+}
+
+impl<F: Graftable, D: Digest, C: AsRef<[u8]>> Proof<F, D, C> {
+    /// Return true if the proof authenticates that `operation` is active in the database with
+    /// the provided `root`.
+    pub fn verify<H: Hasher<Digest = D>, O: Codec>(&self, operation: O, root: &D) -> bool {
+        let chunk = self.chunk.as_ref();
+        let Ok(bits) = chunk_bits(chunk.len()) else {
+            debug!("proof verification failed, invalid chunk size");
+            return false;
+        };
+
+        let bit = *self.loc % bits;
+        if chunk[(bit / 8) as usize] & (1 << (bit % 8)) == 0 {
+            debug!(?self.loc, "proof verification failed, operation is inactive");
+            return false;
+        }
+
+        self.range_proof.verify_with_chunk_size::<H, O>(
+            self.loc,
+            &[operation],
+            core::slice::from_ref(&self.chunk),
+            chunk.len(),
+            root,
+        )
+    }
+}
+
+impl<F: Graftable, D: Digest, C: AsRef<[u8]>> Write for Proof<F, D, C> {
+    fn write(&self, buf: &mut impl BufMut) {
+        self.loc.write(buf);
+        buf.put_slice(self.chunk.as_ref());
+        self.range_proof.write(buf);
+    }
+}
+
+impl<F: Graftable, D: Digest, C: AsRef<[u8]>> EncodeSize for Proof<F, D, C> {
+    fn encode_size(&self) -> usize {
+        self.loc.encode_size() + self.chunk.as_ref().len() + self.range_proof.encode_size()
+    }
+}
+
+impl<F: Graftable, D: Digest, C> Proof<F, D, C> {
+    fn read_with<B: Buf>(
+        buf: &mut B,
+        max_digests: &usize,
+        read_chunk: impl FnOnce(&mut B) -> Result<C, commonware_codec::Error>,
+    ) -> Result<Self, commonware_codec::Error> {
+        let loc = Location::<F>::read(buf)?;
+        let chunk = read_chunk(buf)?;
+        let range_proof = RangeProof::<F, D>::read_cfg(buf, max_digests)?;
+        Ok(Self {
+            loc,
+            chunk,
+            range_proof,
+        })
+    }
+}
+
+impl<F: Graftable, D: Digest, const N: usize> Read for Proof<F, D, [u8; N]> {
+    /// The maximum number of digests forwarded to the embedded range proof.
+    type Cfg = usize;
+
+    fn read_cfg(
+        buf: &mut impl Buf,
+        max_digests: &Self::Cfg,
+    ) -> Result<Self, commonware_codec::Error> {
+        Self::read_with(buf, max_digests, <[u8; N]>::read)
+    }
+}
+
+impl<F: Graftable, D: Digest> Read for Proof<F, D, Bytes> {
+    /// `(chunk_size, max_digests)`: the exact bitmap chunk size in bytes and the maximum number
+    /// of digests forwarded to the embedded range proof.
+    ///
+    /// The chunk size must be a nonzero power of two whose bit width has grafting height below
+    /// 63. It is supplied by the caller and is not encoded in the proof.
+    type Cfg = (usize, usize);
+
+    fn read_cfg(
+        buf: &mut impl Buf,
+        (chunk_size, max_digests): &Self::Cfg,
+    ) -> Result<Self, commonware_codec::Error> {
+        chunk_bits(*chunk_size)?;
+        Self::read_with(buf, max_digests, |buf| {
+            at_least(buf, *chunk_size)?;
+            Ok(buf.copy_to_bytes(*chunk_size))
+        })
+    }
+}
+
+#[cfg(feature = "arbitrary")]
+impl<F: Graftable, D: Digest, const N: usize> arbitrary::Arbitrary<'_> for Proof<F, D, [u8; N]>
+where
+    D: for<'a> arbitrary::Arbitrary<'a>,
+    F::PendingChunk<D>: for<'a> arbitrary::Arbitrary<'a>,
+{
+    fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
+        Ok(Self {
+            loc: u.arbitrary()?,
+            chunk: u.arbitrary()?,
+            range_proof: u.arbitrary()?,
+        })
+    }
+}
+
+#[cfg(feature = "arbitrary")]
+impl<F: Graftable, D: Digest> arbitrary::Arbitrary<'_> for Proof<F, D, Bytes>
+where
+    D: for<'a> arbitrary::Arbitrary<'a>,
+    F::PendingChunk<D>: for<'a> arbitrary::Arbitrary<'a>,
+{
+    fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
+        let loc = u.arbitrary()?;
+        let chunk_size = 1usize << u.int_in_range(0u8..=8)?;
+        let chunk = Bytes::copy_from_slice(u.bytes(chunk_size)?);
+        let range_proof = u.arbitrary()?;
+        Ok(Self {
+            loc,
+            chunk,
+            range_proof,
+        })
+    }
+}

--- a/storage/src/qmdb/current/proof/required_chunks_tests.rs
+++ b/storage/src/qmdb/current/proof/required_chunks_tests.rs
@@ -1,0 +1,239 @@
+use super::{OperationProof, RangeProof, required_chunks};
+use crate::{
+    merkle::{self, Graftable, Location, conformance::build_test_mem, mem::Mem},
+    mmb, mmr,
+    qmdb::{
+        self, Error,
+        current::{db, grafting},
+    },
+};
+use commonware_cryptography::{Sha256, sha256::Digest};
+use commonware_macros::test_async;
+use commonware_parallel::Sequential;
+use commonware_utils::{
+    bitmap::{Prunable as BitMap, Readable},
+    sync::Mutex,
+};
+use std::collections::{BTreeMap, BTreeSet};
+
+struct PreloadedBitmap<'a> {
+    bitmap: &'a BitMap<1>,
+    chunks: BTreeMap<usize, [u8; 1]>,
+    reads: Mutex<BTreeSet<usize>>,
+}
+
+impl Readable<1> for PreloadedBitmap<'_> {
+    fn complete_chunks(&self) -> usize {
+        self.bitmap.complete_chunks()
+    }
+
+    fn get_chunk(&self, chunk: usize) -> [u8; 1] {
+        self.reads.lock().insert(chunk);
+        self.chunks[&chunk]
+    }
+
+    fn last_chunk(&self) -> ([u8; 1], u64) {
+        let (_, bits) = self.bitmap.last_chunk();
+        let chunk = BitMap::<1>::to_chunk_index(self.len() - 1);
+        (self.get_chunk(chunk), bits)
+    }
+
+    fn pruned_chunks(&self) -> usize {
+        self.bitmap.pruned_chunks()
+    }
+
+    fn len(&self) -> u64 {
+        self.bitmap.len()
+    }
+}
+
+async fn fixture<F: Graftable>(
+    leaves: u64,
+    pruned: u64,
+) -> (BitMap<1>, Mem<F, Digest>, Mem<F, Digest>) {
+    let hasher = qmdb::hasher::<Sha256>();
+    let height = grafting::height::<1>();
+    let ops = build_test_mem(&hasher, Mem::<F, Digest>::new(), leaves);
+    let mut bitmap = BitMap::<1>::new();
+    for loc in 0..leaves {
+        bitmap.push(loc >= pruned * 8);
+    }
+    let chunks = (0..grafting::graftable_chunks::<F>(leaves, height))
+        .map(|chunk| (chunk as usize, *bitmap.get_chunk(chunk as usize)));
+    let mut digests =
+        db::compute_grafted_leaves::<F, Sha256, Sequential, 1>(&ops, chunks, &Sequential)
+            .await
+            .unwrap();
+    digests.sort_unstable_by_key(|(chunk, _)| *chunk);
+    let mut grafted = Mem::<F, Digest>::new();
+    if !digests.is_empty() {
+        let mut batch = grafted.new_batch();
+        for (_, digest) in digests {
+            batch = batch.add_leaf_digest(digest);
+        }
+        let hasher = grafting::GraftedHasher::<F, _>::new(hasher, height);
+        let batch = batch.merkleize(&grafted, &hasher);
+        grafted.apply_batch(&batch).unwrap();
+    }
+    bitmap.prune_to_bit(pruned * 8);
+    (bitmap, ops, grafted)
+}
+
+async fn check_constructor_reads<F: Graftable>() {
+    for leaves in [1, 7, 8, 9, 10, 11, 16, 17, 18, 24, 25] {
+        let graftable = grafting::graftable_chunks::<F>(leaves, grafting::height::<1>());
+        for pruned in 0..=graftable {
+            let floor = Location::<F>::new(pruned * 8);
+            if *floor == leaves {
+                continue;
+            }
+            let (bitmap, ops, grafted) = fixture::<F>(leaves, pruned).await;
+            let hasher = qmdb::hasher::<Sha256>();
+            let ops_root = ops.root(&hasher, 0).unwrap();
+            let storage =
+                grafting::Storage::<F, Sha256, _, _>::new(&grafted, grafting::height::<1>(), &ops);
+            let root = db::compute_db_root::<F, Sha256, _, _, 1>(
+                &bitmap,
+                &storage,
+                Location::new(leaves),
+                db::partial_chunk::<_, 1>(&bitmap),
+                floor,
+                &ops_root,
+            )
+            .await
+            .unwrap();
+            for location in
+                core::iter::once(None).chain((*floor..leaves).map(|loc| Some(Location::new(loc))))
+            {
+                let required =
+                    required_chunks::<F, 1>(Location::new(leaves), bitmap.len(), pruned, location)
+                        .unwrap()
+                        .collect::<Vec<_>>();
+                assert!(required.windows(2).all(|pair| pair[0] < pair[1]));
+                let preloaded = PreloadedBitmap {
+                    bitmap: &bitmap,
+                    chunks: required
+                        .iter()
+                        .map(|&chunk| (chunk as usize, *bitmap.get_chunk(chunk as usize)))
+                        .collect(),
+                    reads: Mutex::new(BTreeSet::new()),
+                };
+                if let Some(loc) = location {
+                    let proof = OperationProof::<F, Digest, 1>::new::<Sha256, _>(
+                        &preloaded, &storage, floor, loc, ops_root,
+                    )
+                    .await
+                    .unwrap();
+                    assert!(
+                        proof.verify::<Sha256, _>(hasher.digest(&(*loc).to_be_bytes()), &root,)
+                    );
+                } else {
+                    let proof = RangeProof::new::<Sha256, _, 1>(
+                        &preloaded,
+                        &storage,
+                        floor,
+                        floor..Location::new(leaves),
+                        ops_root,
+                    )
+                    .await
+                    .unwrap();
+                    let elements = (*floor..leaves)
+                        .map(|loc| hasher.digest(&loc.to_be_bytes()))
+                        .collect::<Vec<_>>();
+                    let chunks = (pruned..leaves.div_ceil(8))
+                        .map(|chunk| *bitmap.get_chunk(chunk as usize))
+                        .collect::<Vec<_>>();
+                    assert!(proof.verify::<Sha256, _, 1>(floor, &elements, &chunks, &root));
+                }
+                assert_eq!(
+                    preloaded
+                        .reads
+                        .into_inner()
+                        .into_iter()
+                        .map(|chunk| chunk as u64)
+                        .collect::<Vec<_>>(),
+                    required,
+                    "leaves={leaves}, pruned={pruned}, location={location:?}",
+                );
+            }
+        }
+    }
+}
+
+#[test_async]
+async fn required_chunks_match_constructor_reads() {
+    check_constructor_reads::<mmr::Family>().await;
+    check_constructor_reads::<mmb::Family>().await;
+}
+
+#[test]
+fn required_chunks_boundary_sets() {
+    for (leaves, mmr, mmb) in [
+        (0, vec![], vec![]),
+        (1, vec![0], vec![0]),
+        (7, vec![0], vec![0]),
+        (8, vec![], vec![0]),
+        (9, vec![1], vec![0, 1]),
+        (10, vec![1], vec![0, 1]),
+        (11, vec![1], vec![1]),
+        (16, vec![], vec![1]),
+        (17, vec![2], vec![1, 2]),
+        (18, vec![2], vec![1, 2]),
+        (24, vec![], vec![2]),
+        (25, vec![3], vec![2, 3]),
+    ] {
+        assert_eq!(
+            required_chunks::<mmr::Family, 1>(Location::new(leaves), leaves, 0, None)
+                .unwrap()
+                .collect::<Vec<_>>(),
+            mmr
+        );
+        assert_eq!(
+            required_chunks::<mmb::Family, 1>(Location::new(leaves), leaves, 0, None)
+                .unwrap()
+                .collect::<Vec<_>>(),
+            mmb
+        );
+    }
+    assert!(
+        required_chunks::<mmr::Family, 1>(Location::new(16), 16, 2, None)
+            .unwrap()
+            .next()
+            .is_none()
+    );
+}
+
+fn check_invalid_metadata<F: Graftable>() {
+    for (ops_leaves, bitmap_len, loc) in [(0, 0, 0), (16, 16, 16), (8, 9, 8), (9, 8, 8)] {
+        assert!(matches!(
+            required_chunks::<F, 1>(Location::new(ops_leaves), bitmap_len, 0, Some(Location::new(loc))),
+            Err(Error::Merkle(merkle::Error::RangeOutOfBounds(found))) if *found == loc
+        ));
+    }
+    assert!(matches!(
+        required_chunks::<F, 1>(Location::new(16), 16, 1, Some(Location::new(7))),
+        Err(Error::OperationPruned(loc)) if *loc == 7
+    ));
+    assert!(matches!(
+        required_chunks::<F, 1>(Location::new(0), 24, 0, None),
+        Err(Error::DataCorrupted("multiple pending bitmap chunks"))
+    ));
+    assert!(matches!(
+        required_chunks::<F, 1>(Location::new(8), 8, 2, None),
+        Err(Error::DataCorrupted(
+            "pruned chunks exceed graftable chunks"
+        ))
+    ));
+}
+
+#[test]
+fn required_chunks_reject_invalid_metadata() {
+    check_invalid_metadata::<mmr::Family>();
+    check_invalid_metadata::<mmb::Family>();
+    assert!(matches!(
+        required_chunks::<mmb::Family, 1>(Location::new(8), 8, 1, None),
+        Err(Error::DataCorrupted(
+            "pruned chunks exceed graftable chunks"
+        ))
+    ));
+}

--- a/storage/src/qmdb/current/proof/required_chunks_tests.rs
+++ b/storage/src/qmdb/current/proof/required_chunks_tests.rs
@@ -1,4 +1,4 @@
-use super::{RangeProof, dynamic, fixed, required_chunks};
+use super::{RangeProof, constant, dynamic, required_chunks};
 use crate::{
     merkle::{self, Graftable, Location, conformance::build_test_mem, mem::Mem},
     mmb, mmr,
@@ -121,7 +121,7 @@ async fn check_constructor_reads<F: Graftable>() {
                     reads: Mutex::new(BTreeSet::new()),
                 };
                 if let Some(loc) = location {
-                    let proof = fixed::OperationProof::<F, Digest, 1>::new::<Sha256, _>(
+                    let proof = constant::OperationProof::<F, Digest, 1>::new::<Sha256, _>(
                         &preloaded, &storage, floor, loc, ops_root,
                     )
                     .await

--- a/storage/src/qmdb/current/proof/required_chunks_tests.rs
+++ b/storage/src/qmdb/current/proof/required_chunks_tests.rs
@@ -1,4 +1,4 @@
-use super::{OperationProof, RangeProof, RuntimeOperationProof, required_chunks};
+use super::{RangeProof, dynamic, fixed, required_chunks};
 use crate::{
     merkle::{self, Graftable, Location, conformance::build_test_mem, mem::Mem},
     mmb, mmr,
@@ -121,7 +121,7 @@ async fn check_constructor_reads<F: Graftable>() {
                     reads: Mutex::new(BTreeSet::new()),
                 };
                 if let Some(loc) = location {
-                    let proof = OperationProof::<F, Digest, 1>::new::<Sha256, _>(
+                    let proof = fixed::OperationProof::<F, Digest, 1>::new::<Sha256, _>(
                         &preloaded, &storage, floor, loc, ops_root,
                     )
                     .await
@@ -130,7 +130,7 @@ async fn check_constructor_reads<F: Graftable>() {
                         proof.verify::<Sha256, _>(hasher.digest(&(*loc).to_be_bytes()), &root,)
                     );
                     let proof =
-                        RuntimeOperationProof::<F, Digest>::decode_cfg(proof.encode(), &(1, 64))
+                        dynamic::OperationProof::<F, Digest>::decode_cfg(proof.encode(), &(1, 64))
                             .unwrap();
                     assert!(proof.verify::<Sha256, _>(hasher.digest(&(*loc).to_be_bytes()), &root));
                 } else {

--- a/storage/src/qmdb/current/proof/required_chunks_tests.rs
+++ b/storage/src/qmdb/current/proof/required_chunks_tests.rs
@@ -12,7 +12,7 @@ use commonware_cryptography::{Sha256, sha256::Digest};
 use commonware_macros::test_async;
 use commonware_parallel::Sequential;
 use commonware_utils::{
-    Widen as _,
+    Widen,
     bitmap::{Prunable as BitMap, Readable},
     sync::Mutex,
 };
@@ -156,12 +156,11 @@ async fn check_constructor_reads<F: Graftable>() {
                         )
                     );
                 }
-                #[allow(unstable_name_collisions)]
                 let read_chunks = preloaded
                     .reads
                     .into_inner()
                     .into_iter()
-                    .map(|chunk| chunk.widen())
+                    .map(Widen::widen)
                     .collect::<Vec<_>>();
                 assert_eq!(
                     read_chunks, required,

--- a/storage/src/qmdb/current/proof/required_chunks_tests.rs
+++ b/storage/src/qmdb/current/proof/required_chunks_tests.rs
@@ -1,4 +1,4 @@
-use super::{OperationProof, RangeProof, required_chunks};
+use super::{OperationProof, RangeProof, RuntimeOperationProof, required_chunks};
 use crate::{
     merkle::{self, Graftable, Location, conformance::build_test_mem, mem::Mem},
     mmb, mmr,
@@ -7,6 +7,7 @@ use crate::{
         current::{db, grafting},
     },
 };
+use commonware_codec::{Decode as _, Encode as _};
 use commonware_cryptography::{Sha256, sha256::Digest};
 use commonware_macros::test_async;
 use commonware_parallel::Sequential;
@@ -128,6 +129,10 @@ async fn check_constructor_reads<F: Graftable>() {
                     assert!(
                         proof.verify::<Sha256, _>(hasher.digest(&(*loc).to_be_bytes()), &root,)
                     );
+                    let proof =
+                        RuntimeOperationProof::<F, Digest>::decode_cfg(proof.encode(), &(1, 64))
+                            .unwrap();
+                    assert!(proof.verify::<Sha256, _>(hasher.digest(&(*loc).to_be_bytes()), &root));
                 } else {
                     let proof = RangeProof::new::<Sha256, _, 1>(
                         &preloaded,
@@ -145,6 +150,11 @@ async fn check_constructor_reads<F: Graftable>() {
                         .map(|chunk| *bitmap.get_chunk(chunk as usize))
                         .collect::<Vec<_>>();
                     assert!(proof.verify::<Sha256, _, 1>(floor, &elements, &chunks, &root));
+                    assert!(
+                        proof.verify_with_chunk_size::<Sha256, _>(
+                            floor, &elements, &chunks, 1, &root,
+                        )
+                    );
                 }
                 #[allow(unstable_name_collisions)]
                 let read_chunks = preloaded

--- a/storage/src/qmdb/current/proof/required_chunks_tests.rs
+++ b/storage/src/qmdb/current/proof/required_chunks_tests.rs
@@ -11,6 +11,7 @@ use commonware_cryptography::{Sha256, sha256::Digest};
 use commonware_macros::test_async;
 use commonware_parallel::Sequential;
 use commonware_utils::{
+    Widen as _,
     bitmap::{Prunable as BitMap, Readable},
     sync::Mutex,
 };
@@ -145,14 +146,15 @@ async fn check_constructor_reads<F: Graftable>() {
                         .collect::<Vec<_>>();
                     assert!(proof.verify::<Sha256, _, 1>(floor, &elements, &chunks, &root));
                 }
+                #[allow(unstable_name_collisions)]
+                let read_chunks = preloaded
+                    .reads
+                    .into_inner()
+                    .into_iter()
+                    .map(|chunk| chunk.widen())
+                    .collect::<Vec<_>>();
                 assert_eq!(
-                    preloaded
-                        .reads
-                        .into_inner()
-                        .into_iter()
-                        .map(|chunk| chunk as u64)
-                        .collect::<Vec<_>>(),
-                    required,
+                    read_chunks, required,
                     "leaves={leaves}, pruned={pruned}, location={location:?}",
                 );
             }

--- a/storage/src/qmdb/current/proof/runtime_tests.rs
+++ b/storage/src/qmdb/current/proof/runtime_tests.rs
@@ -1,0 +1,235 @@
+use super::{OperationProof, RuntimeOperationProof, tests::current_range_proof_fixture};
+use crate::{
+    merkle::{Graftable, Location},
+    mmb, mmr,
+};
+use bytes::Bytes;
+use commonware_codec::{Decode as _, Encode as _, EncodeSize as _};
+use commonware_cryptography::{Hasher as _, Sha256, sha256::Digest};
+use commonware_macros::test_async;
+
+fn invalid_chunk_sizes() -> impl Iterator<Item = usize> {
+    [0, 3, usize::MAX, 1 << (usize::BITS - 1)]
+        .into_iter()
+        .chain(usize::try_from(1u64 << 60).ok())
+}
+
+async fn check_runtime_proofs<F: Graftable, const N: usize>() {
+    let chunk_bits = (N * 8) as u64;
+    let height = chunk_bits.trailing_zeros() as u64;
+    for leaves in [
+        chunk_bits - 1,
+        chunk_bits,
+        chunk_bits + 1,
+        chunk_bits + height,
+        chunk_bits * 2,
+        chunk_bits * 2 + 2,
+    ] {
+        let start = Location::<F>::new(chunk_bits - 2);
+        let (_, proof, operations, chunks, root, _) =
+            current_range_proof_fixture::<F, N>(leaves, start..Location::new(leaves)).await;
+        assert!(proof.verify::<Sha256, _, N>(start, &operations, &chunks, &root));
+        let slices = chunks.iter().map(<[u8; N]>::as_slice).collect::<Vec<_>>();
+        assert!(proof.verify_with_chunk_size::<Sha256, _>(start, &operations, &slices, N, &root));
+        assert!(!proof.verify_with_chunk_size::<Sha256, _>(
+            start,
+            &operations,
+            &slices,
+            N,
+            &Sha256::hash(&[b"wrong root"]),
+        ));
+
+        for loc in [start, Location::new(leaves - 1)] {
+            let (_, range_proof, operations, chunks, root, _) =
+                current_range_proof_fixture::<F, N>(leaves, loc..loc + 1).await;
+            let native = OperationProof::<F, Digest, N> {
+                loc,
+                chunk: chunks[0],
+                range_proof,
+            };
+            assert!(native.verify::<Sha256, _>(operations[0], &root));
+            let encoded = native.encode();
+            let max_digests = native.range_proof.proof.digests.len();
+            let runtime =
+                RuntimeOperationProof::<F, Digest>::decode_cfg(encoded.clone(), &(N, max_digests))
+                    .unwrap();
+            assert_eq!(runtime.encode(), encoded);
+            assert_eq!(runtime.encode_size(), encoded.len());
+            assert_eq!(runtime.loc, loc);
+            assert_eq!(runtime.chunk.as_ref(), native.chunk.as_slice());
+            assert!(runtime.verify::<Sha256, _>(operations[0], &root));
+            assert!(!runtime.verify::<Sha256, _>(Sha256::hash(&[b"wrong operation"]), &root,));
+            assert!(!runtime.verify::<Sha256, _>(operations[0], &Sha256::hash(&[b"wrong root"]),));
+
+            let mut inactive = runtime;
+            let mut chunk = inactive.chunk.to_vec();
+            let bit = (*loc % chunk_bits) as usize;
+            chunk[bit / 8] &= !(1 << (bit % 8));
+            inactive.chunk = Bytes::from(chunk);
+            assert!(!inactive.verify::<Sha256, _>(operations[0], &root));
+        }
+    }
+}
+
+#[test_async]
+async fn runtime_proofs_match_native_mmr() {
+    check_runtime_proofs::<mmr::Family, 1>().await;
+    check_runtime_proofs::<mmr::Family, 32>().await;
+    check_runtime_proofs::<mmr::Family, 64>().await;
+}
+
+#[test_async]
+async fn runtime_proofs_match_native_mmb() {
+    check_runtime_proofs::<mmb::Family, 1>().await;
+    check_runtime_proofs::<mmb::Family, 32>().await;
+    check_runtime_proofs::<mmb::Family, 64>().await;
+}
+
+async fn check_runtime_range_rejections<F: Graftable>() {
+    const N: usize = 1;
+    let start = Location::<F>::new(6);
+    let (_, proof, operations, chunks, root, _) =
+        current_range_proof_fixture::<F, N>(18, start..Location::new(18)).await;
+    let chunks = chunks
+        .iter()
+        .map(|chunk| chunk.to_vec())
+        .collect::<Vec<_>>();
+    for chunk_size in invalid_chunk_sizes() {
+        assert!(!proof.verify_with_chunk_size::<Sha256, _>(
+            start,
+            &operations,
+            &chunks,
+            chunk_size,
+            &root,
+        ));
+    }
+    assert!(!proof.verify_with_chunk_size::<Sha256, _>(start, &operations, &chunks, 2, &root));
+    assert!(!proof.verify_with_chunk_size::<Sha256, _>(start, &operations[..0], &chunks, N, &root));
+    assert!(!proof.verify_with_chunk_size::<Sha256, _>(start, &operations, &chunks[..0], N, &root));
+    assert!(!proof.verify_with_chunk_size::<Sha256, _>(
+        start,
+        &operations,
+        &chunks[..chunks.len() - 1],
+        N,
+        &root,
+    ));
+    assert!(!proof.verify_with_chunk_size::<Sha256, _>(
+        proof.proof.leaves,
+        &operations,
+        &chunks,
+        N,
+        &root,
+    ));
+    assert!(!proof.verify_with_chunk_size::<Sha256, _>(
+        F::MAX_LEAVES,
+        &operations,
+        &chunks,
+        N,
+        &root,
+    ));
+
+    let mut extra = chunks.clone();
+    extra.push(chunks[0].clone());
+    assert!(!proof.verify_with_chunk_size::<Sha256, _>(start, &operations, &extra, N, &root));
+    for chunk_len in [0, 2, 3] {
+        let mut malformed = chunks.clone();
+        malformed[1].resize(chunk_len, 0);
+        assert!(!proof.verify_with_chunk_size::<Sha256, _>(
+            start,
+            &operations,
+            &malformed,
+            N,
+            &root,
+        ));
+    }
+
+    let mut tampered = chunks.clone();
+    tampered.last_mut().unwrap()[0] ^= 1;
+    assert!(!proof.verify_with_chunk_size::<Sha256, _>(start, &operations, &tampered, N, &root));
+    let mut missing_partial = proof.clone();
+    assert!(missing_partial.partial_chunk_digest.take().is_some());
+    assert!(!missing_partial.verify_with_chunk_size::<Sha256, _>(
+        start,
+        &operations,
+        &chunks,
+        N,
+        &root,
+    ));
+    let mut wrong_operations = operations;
+    wrong_operations[0] = Sha256::hash(&[b"wrong operation"]);
+    assert!(!proof.verify_with_chunk_size::<Sha256, _>(
+        start,
+        &wrong_operations,
+        &chunks,
+        N,
+        &root,
+    ));
+}
+
+#[test_async]
+async fn runtime_range_rejects_malformed_inputs() {
+    check_runtime_range_rejections::<mmr::Family>().await;
+    check_runtime_range_rejections::<mmb::Family>().await;
+}
+
+async fn check_runtime_operation_codec_rejections<F: Graftable>() {
+    const N: usize = 32;
+    let loc = Location::<F>::new(14);
+    let (_, range_proof, operations, chunks, root, _) =
+        current_range_proof_fixture::<F, N>(18, loc..loc + 1).await;
+    let native = OperationProof::<F, Digest, N> {
+        loc,
+        chunk: chunks[0],
+        range_proof,
+    };
+    let encoded = native.encode();
+    let max_digests = native.range_proof.proof.digests.len();
+    assert!(max_digests > 0);
+    assert!(
+        RuntimeOperationProof::<F, Digest>::decode_cfg(encoded.clone(), &(N, max_digests - 1),)
+            .is_err()
+    );
+    for end in 0..encoded.len() {
+        assert!(
+            RuntimeOperationProof::<F, Digest>::decode_cfg(&encoded[..end], &(N, max_digests),)
+                .is_err(),
+            "truncated proof decoded at {end}"
+        );
+    }
+    let mut trailing = encoded.to_vec();
+    trailing.push(0);
+    assert!(
+        RuntimeOperationProof::<F, Digest>::decode_cfg(trailing.as_slice(), &(N, max_digests),)
+            .is_err()
+    );
+    for chunk_size in invalid_chunk_sizes() {
+        assert!(matches!(
+            RuntimeOperationProof::<F, Digest>::decode_cfg(
+                encoded.clone(),
+                &(chunk_size, max_digests),
+            ),
+            Err(commonware_codec::Error::Invalid(_, _)),
+        ));
+    }
+    for chunk_size in [1, N / 2, N * 2] {
+        if let Ok(runtime) = RuntimeOperationProof::<F, Digest>::decode_cfg(
+            encoded.clone(),
+            &(chunk_size, max_digests),
+        ) {
+            assert!(!runtime.verify::<Sha256, _>(operations[0], &root));
+        }
+    }
+    let runtime =
+        RuntimeOperationProof::<F, Digest>::decode_cfg(encoded, &(N, max_digests)).unwrap();
+    for chunk in [Bytes::new(), Bytes::from_static(&[0; 3])] {
+        let mut malformed = runtime.clone();
+        malformed.chunk = chunk;
+        assert!(!malformed.verify::<Sha256, _>(operations[0], &root));
+    }
+}
+
+#[test_async]
+async fn runtime_operation_codec_rejects_malformed_inputs() {
+    check_runtime_operation_codec_rejections::<mmr::Family>().await;
+    check_runtime_operation_codec_rejections::<mmb::Family>().await;
+}

--- a/storage/src/qmdb/current/unordered/db.rs
+++ b/storage/src/qmdb/current/unordered/db.rs
@@ -15,7 +15,7 @@ use crate::{
             operation::update::Unordered as UnorderedUpdate,
             unordered::{Operation, Update},
         },
-        current::proof::OperationProof,
+        current::proof::{OperationProof, RuntimeOperationProof},
         operation::Key,
     },
 };
@@ -25,6 +25,11 @@ use commonware_parallel::Strategy;
 
 /// Proof information for verifying a key has a particular value in the database.
 pub type KeyValueProof<F, D, const N: usize> = OperationProof<F, D, N>;
+
+/// A key-value proof with a runtime-sized bitmap chunk.
+///
+/// Decoding takes `(chunk_size, max_digests)` as configuration, as in [RuntimeOperationProof].
+pub type RuntimeKeyValueProof<F, D> = RuntimeOperationProof<F, D>;
 
 /// The generic Db type for unordered Current QMDB variants.
 ///

--- a/storage/src/qmdb/current/unordered/db.rs
+++ b/storage/src/qmdb/current/unordered/db.rs
@@ -3,7 +3,7 @@
 //! This module contains impl blocks that are generic over `ValueEncoding`, allowing them to be
 //! used by both fixed and variable unordered QMDB implementations.
 
-use super::proof::fixed::KeyValueProof;
+use super::proof::constant::KeyValueProof;
 use crate::{
     Context,
     index::Unordered as UnorderedIndex,

--- a/storage/src/qmdb/current/unordered/db.rs
+++ b/storage/src/qmdb/current/unordered/db.rs
@@ -27,8 +27,6 @@ use commonware_parallel::Strategy;
 pub type KeyValueProof<F, D, const N: usize> = OperationProof<F, D, N>;
 
 /// A key-value proof with a runtime-sized bitmap chunk.
-///
-/// Decoding takes `(chunk_size, max_digests)` as configuration, as in [RuntimeOperationProof].
 pub type RuntimeKeyValueProof<F, D> = RuntimeOperationProof<F, D>;
 
 /// The generic Db type for unordered Current QMDB variants.

--- a/storage/src/qmdb/current/unordered/db.rs
+++ b/storage/src/qmdb/current/unordered/db.rs
@@ -3,6 +3,7 @@
 //! This module contains impl blocks that are generic over `ValueEncoding`, allowing them to be
 //! used by both fixed and variable unordered QMDB implementations.
 
+use super::proof::fixed::KeyValueProof;
 use crate::{
     Context,
     index::Unordered as UnorderedIndex,
@@ -15,19 +16,12 @@ use crate::{
             operation::update::Unordered as UnorderedUpdate,
             unordered::{Operation, Update},
         },
-        current::proof::{OperationProof, RuntimeOperationProof},
         operation::Key,
     },
 };
 use commonware_codec::Codec;
 use commonware_cryptography::Hasher;
 use commonware_parallel::Strategy;
-
-/// Proof information for verifying a key has a particular value in the database.
-pub type KeyValueProof<F, D, const N: usize> = OperationProof<F, D, N>;
-
-/// A key-value proof with a runtime-sized bitmap chunk.
-pub type RuntimeKeyValueProof<F, D> = RuntimeOperationProof<F, D>;
 
 /// The generic Db type for unordered Current QMDB variants.
 ///

--- a/storage/src/qmdb/current/unordered/fixed.rs
+++ b/storage/src/qmdb/current/unordered/fixed.rs
@@ -6,7 +6,7 @@
 //!
 //! See [Db] for the main database type.
 
-pub use super::db::KeyValueProof;
+pub use super::db::{KeyValueProof, RuntimeKeyValueProof};
 use crate::{
     Context,
     index::unordered::Index,

--- a/storage/src/qmdb/current/unordered/fixed.rs
+++ b/storage/src/qmdb/current/unordered/fixed.rs
@@ -6,7 +6,6 @@
 //!
 //! See [Db] for the main database type.
 
-pub use super::db::{KeyValueProof, RuntimeKeyValueProof};
 use crate::{
     Context,
     index::unordered::Index,

--- a/storage/src/qmdb/current/unordered/mod.rs
+++ b/storage/src/qmdb/current/unordered/mod.rs
@@ -18,7 +18,7 @@ pub mod variable;
 pub mod tests {
     //! Shared test utilities for unordered Current QMDB variants.
 
-    use super::{db, proof::fixed};
+    use super::{db, proof::constant};
     use crate::{
         index::unordered::Index,
         journal::contiguous::{Contiguous as _, Mutable},
@@ -234,7 +234,7 @@ pub mod tests {
             // Create a proof of the now-inactive update operation assigning v1 to k against the
             // current root.
             let (range_proof, _, chunks) = db.range_proof(op_loc, NZU64!(1)).await.unwrap();
-            let proof_inactive = fixed::KeyValueProof {
+            let proof_inactive = constant::KeyValueProof {
                 loc: op_loc,
                 chunk: chunks[0],
                 range_proof,

--- a/storage/src/qmdb/current/unordered/mod.rs
+++ b/storage/src/qmdb/current/unordered/mod.rs
@@ -9,6 +9,7 @@
 
 pub mod db;
 pub mod fixed;
+pub mod proof;
 #[cfg(any(test, feature = "test-traits"))]
 mod test_trait_impls;
 pub mod variable;
@@ -17,7 +18,7 @@ pub mod variable;
 pub mod tests {
     //! Shared test utilities for unordered Current QMDB variants.
 
-    use super::db;
+    use super::{db, proof::fixed};
     use crate::{
         index::unordered::Index,
         journal::contiguous::{Contiguous as _, Mutable},
@@ -233,7 +234,7 @@ pub mod tests {
             // Create a proof of the now-inactive update operation assigning v1 to k against the
             // current root.
             let (range_proof, _, chunks) = db.range_proof(op_loc, NZU64!(1)).await.unwrap();
-            let proof_inactive = db::KeyValueProof {
+            let proof_inactive = fixed::KeyValueProof {
                 loc: op_loc,
                 chunk: chunks[0],
                 range_proof,

--- a/storage/src/qmdb/current/unordered/proof.rs
+++ b/storage/src/qmdb/current/unordered/proof.rs
@@ -1,10 +1,10 @@
 //! Unordered current proofs with fixed-size or runtime-sized bitmap chunks.
 
 /// Proofs with fixed-size bitmap chunks.
-pub mod fixed {
+pub mod constant {
     /// Proof information for verifying a key has a particular value in the database.
     pub type KeyValueProof<F, D, const N: usize> =
-        crate::qmdb::current::proof::fixed::OperationProof<F, D, N>;
+        crate::qmdb::current::proof::constant::OperationProof<F, D, N>;
 }
 
 /// Proofs with runtime-sized bitmap chunks.

--- a/storage/src/qmdb/current/unordered/proof.rs
+++ b/storage/src/qmdb/current/unordered/proof.rs
@@ -1,0 +1,14 @@
+//! Unordered current proofs with fixed-size or runtime-sized bitmap chunks.
+
+/// Proofs with fixed-size bitmap chunks.
+pub mod fixed {
+    /// Proof information for verifying a key has a particular value in the database.
+    pub type KeyValueProof<F, D, const N: usize> =
+        crate::qmdb::current::proof::fixed::OperationProof<F, D, N>;
+}
+
+/// Proofs with runtime-sized bitmap chunks.
+pub mod dynamic {
+    /// Proof information for verifying a key has a particular value in the database.
+    pub type KeyValueProof<F, D> = crate::qmdb::current::proof::dynamic::OperationProof<F, D>;
+}

--- a/storage/src/qmdb/current/unordered/variable.rs
+++ b/storage/src/qmdb/current/unordered/variable.rs
@@ -6,7 +6,7 @@
 //!
 //! See [Db] for the main database type.
 
-pub use super::db::KeyValueProof;
+pub use super::db::{KeyValueProof, RuntimeKeyValueProof};
 use crate::{
     Context,
     index::unordered::Index,

--- a/storage/src/qmdb/current/unordered/variable.rs
+++ b/storage/src/qmdb/current/unordered/variable.rs
@@ -6,7 +6,6 @@
 //!
 //! See [Db] for the main database type.
 
-pub use super::db::{KeyValueProof, RuntimeKeyValueProof};
 use crate::{
     Context,
     index::unordered::Index,

--- a/storage/src/qmdb/keyless/mod.rs
+++ b/storage/src/qmdb/keyless/mod.rs
@@ -72,7 +72,7 @@ pub use compact::{
     Config as CompactConfig, Db as CompactDb, MerkleizedBatch as CompactMerkleizedBatch,
     UnmerkleizedBatch as CompactUnmerkleizedBatch,
 };
-pub use operation::Operation;
+pub use operation::{APPEND_CONTEXT, COMMIT_CONTEXT, Operation};
 
 /// Compute the authenticated root of a newly initialized database without opening storage.
 ///

--- a/storage/src/qmdb/keyless/operation/mod.rs
+++ b/storage/src/qmdb/keyless/operation/mod.rs
@@ -13,9 +13,10 @@ use core::fmt::Display;
 pub(crate) mod fixed;
 pub(crate) mod variable;
 
-// Context byte prefixes for identifying the operation type.
-const COMMIT_CONTEXT: u8 = 0;
-const APPEND_CONTEXT: u8 = 1;
+/// Wire tag for [Operation::Commit].
+pub const COMMIT_CONTEXT: u8 = 0;
+/// Wire tag for [Operation::Append].
+pub const APPEND_CONTEXT: u8 = 1;
 
 /// Delegates Operation-level codec (Write, Read) to the value encoding.
 ///

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -13,8 +13,8 @@ commonware_macros::stability_scope!(BETA {
     #[cfg(not(feature = "std"))]
     extern crate alloc;
 
-    /// Lossless widening for nonzero integers, covering the conversions std provides no
-    /// [From] impl for (for example `NonZeroU16` into `u64`).
+    /// Lossless integer conversions that std provides no [From] impl for
+    /// (for example `NonZeroU16` or `usize` into `u64`).
     pub trait Widen<T> {
         /// Convert without loss.
         fn widen(self) -> T;
@@ -36,6 +36,14 @@ commonware_macros::stability_scope!(BETA {
         core::num::NonZeroU32 => u64, u128;
         core::num::NonZeroU64 => u128;
     );
+
+    impl Widen<u64> for usize {
+        #[inline]
+        fn widen(self) -> u64 {
+            const { assert!(Self::BITS <= u64::BITS) };
+            self as u64
+        }
+    }
 
     #[cfg(not(feature = "std"))]
     use alloc::{boxed::Box, vec::Vec};


### PR DESCRIPTION
Allow native and published WASM verifiers to reuse Commonware's QMDB proof codecs and verification, as needed by [Exoware PR #130](https://github.com/exowarexyz/monorepo/pull/130). Addresses #4689.

- Publish operation and exclusion-proof tags.
- Move ordered verification onto proof types and expose `span_contains` without database parameters.
- Expose `required_chunks` so storage adapters can preload the bitmap chunks used by proof construction.
- Add runtime-sized operation, key-value, and exclusion proofs, plus runtime chunk-size range verification. Const-generic arrays and runtime byte buffers share the codecs and verification logic, preserving the wire encoding.

### Why runtime `N`?

`N` is the number of bytes in an activity-bitmap chunk. It determines how many raw chunk bytes the proof decoder consumes, which activity bit is checked, and the bitmap grafting height. Native Rust callers can instantiate a verifier for their database's `N`. A published WASM binary cannot instantiate new Rust const generics when a JavaScript caller supplies a chunk size. A default or a finite list of compiled sizes would restrict which database configurations that binary can verify. Supplying `N` when decoding avoids that restriction without encoding another size field.

Keys and values can remain behind codecs that preserve the source database's exact bytes and ordering. Exoware's variable key/value query paths already use `Vec<u8>` and can call the high-level runtime proof helpers directly. Arbitrary fixed layouts retain payload parsing and request binding around the shared operation/range verifier, since the high-level fixed codecs still require compile-time sizes. Merkle families and hashes remain a finite set of compiled implementations. For these supported formats, `N` is the missing runtime parameter in the proof layer.

Validation: 3,059 storage tests, eight current glue tests, 141 conformance tests, and 21 doctests pass. All 133 existing conformance fixtures are unchanged. Clippy, formatting, rustdoc, stability checks, ordered/unordered fuzz-target compilation, and the storage WASM build pass.
