### PR TITLE
[storage/qmdb] Reuse owned keys and values in ordered batches

### DIFF
--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -292,6 +292,8 @@ impl<B: RBlob, A: CodecFixedShared> super::ReplayBatchState for FixedReplayState
         };
         batch.reserve(count);
 
+        // Decode directly from the buffered bytes, keeping each item's journal position.
+        // Stop this blob on error because decoding may have consumed only part of an item.
         let base = self.pos;
         for i in 0..count {
             match A::read(&mut self.replay) {

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -291,8 +291,8 @@ impl<B: RBlob, V: CodecShared> super::ReplayBatchState for ReplayState<'_, B, V>
             };
             let item_len = next_offset - self.offset;
 
-            // `take(item_size)` advances past exactly the payload bytes after the header was
-            // consumed by `decode_length_prefix`.
+            // `decode_length_prefix` already consumed the header. Bound decoding to this payload
+            // so it cannot consume bytes from the next frame.
             match decode_item::<V>(
                 (&mut self.replay).take(item_size),
                 &self.codec_config,

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -2511,6 +2511,8 @@ where
                     continue;
                 };
 
+                // Preserve the ordered links across creates and deletes by rewriting the
+                // predecessor with its existing value and its successor in the final key set.
                 let prev_new_loc = m.base_state.size + ops.len() as u64;
                 let prev_next_key = find_next_key(prev_key, &next_candidates);
                 ops.push(Operation::Update(update::Ordered {

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -879,7 +879,7 @@ where
             for key in mutations.keys() {
                 match ancestors.resolve(key) {
                     Some(DiffEntry::Deleted { .. }) => {
-                        // Stale; handled via extract_parent_deleted_creates.
+                        // No live operation; resolve_creates handles any recreation.
                     }
                     Some(DiffEntry::Active {
                         loc, base_old_loc, ..
@@ -905,29 +905,23 @@ where
         locations
     }
 
-    /// Extract keys that were deleted by a parent batch but are being
-    /// re-created by this child batch. Removes those keys from `mutations`
-    /// and returns `(key, value, base_old_loc)` entries.
+    /// Resolve remaining mutations into creates in key order. Re-created keys inherit
+    /// the base location of the nearest ancestor deletion. Existing keys must already
+    /// be resolved and removed from `mutations`; deletes of absent keys are ignored.
     #[allow(clippy::type_complexity)]
-    fn extract_parent_deleted_creates(
+    fn resolve_creates(
         &self,
-        mutations: &mut BTreeMap<U::Key, Option<U::Value>>,
-    ) -> Vec<(U::Key, U::Value, Option<Location<F>>)> {
-        if self.ancestors.is_empty() {
-            return Vec::new();
-        }
+        mutations: BTreeMap<U::Key, Option<U::Value>>,
+    ) -> impl Iterator<Item = (U::Key, U::Value, Option<Location<F>>)> {
         let mut ancestors = DiffCursors::new(self.ancestors.iter().map(|a| a.diff.as_slice()));
-        let mut creates = Vec::new();
-        mutations.retain(|key, value| {
-            if let Some(DiffEntry::Deleted { base_old_loc }) = ancestors.resolve(key)
-                && let Some(v) = value.take()
-            {
-                creates.push((key.clone(), v, *base_old_loc));
-                return false;
-            }
-            true
-        });
-        creates
+        mutations.into_iter().filter_map(move |(key, value)| {
+            let value = value?;
+            let base_old_loc = match ancestors.resolve(&key) {
+                Some(DiffEntry::Deleted { base_old_loc }) => *base_old_loc,
+                _ => None,
+            };
+            Some((key, value, base_old_loc))
+        })
     }
 
     /// Shared final phases of merkleization: floor raise, CommitFloor, journal
@@ -2064,24 +2058,9 @@ where
             emit(key, staged_base_old_loc(sloc), mutation);
         }
 
-        // Handle parent-deleted keys that the child wants to re-create.
-        let parent_deleted_creates = m.extract_parent_deleted_creates(&mut mutations);
-
-        // Process creates: remaining mutations (fresh keys) plus parent-deleted
-        // keys being re-created. Both get an Update op and active_keys_delta += 1.
-        // Merge into a single sorted Vec so iteration order is deterministic
-        // regardless of whether the parent is pending or committed.
-        let mut creates: Vec<(K, V::Value, Option<Location<F>>)> =
-            Vec::with_capacity(mutations.len() + parent_deleted_creates.len());
-        for (key, value) in mutations {
-            if let Some(value) = value {
-                creates.push((key, value, None));
-            }
-        }
-        creates.extend(parent_deleted_creates);
-        db.strategy()
-            .sort_by(&mut creates, |(a, _, _), (b, _, _)| a.cmp(b));
-        for (key, value, base_old_loc) in creates {
+        // Process all creates in key order, including parent-deleted keys being
+        // re-created, so operation order is independent of ancestor commit state.
+        for (key, value, base_old_loc) in m.resolve_creates(mutations) {
             let new_loc = m.base_state.size + ops.len() as u64;
             superseded_locs.extend(base_old_loc);
             ops.push(Operation::Update(update::Unordered(
@@ -2205,10 +2184,10 @@ where
             // location. A stale snapshot collision (the pre-parent DB snapshot still
             // containing the key's old location) must contribute nothing: consuming its
             // mutation would misclassify a parent-deleted key's re-creation as an update
-            // (or its redundant delete as a live delete) before extract_parent_deleted_creates
-            // runs, and feeding its next_key or (key, old_loc) into the candidate sets would
-            // steer the predecessor rewrites only on the pending-ancestor path (the
-            // applied-ancestor path never reads the superseded op).
+            // (or its redundant delete as a live delete), and feeding its next_key or
+            // (key, old_loc) into the candidate sets would steer predecessor rewrites
+            // only on the pending-ancestor path (the applied-ancestor path never reads
+            // the superseded op).
             if let Some(entry) = resolve_in_ancestors(&m.ancestors, &key)
                 && entry.loc() != Some(old_loc)
             {
@@ -2251,28 +2230,14 @@ where
         db.strategy().sort_by(&mut deleted, |a, b| a.0.cmp(&b.0));
         db.strategy().sort_by(&mut updated, |a, b| a.0.cmp(&b.0));
 
-        // Handle parent-deleted keys that the child wants to re-create.
-        let parent_deleted_creates = m.extract_parent_deleted_creates(&mut mutations);
-
-        // Remaining mutations are creates. Each entry carries the value and
-        // base_old_loc (None for fresh creates, Some for parent-deleted recreates).
-        // Merge into a single sorted Vec so iteration order is deterministic
-        // regardless of whether the parent is pending or committed.
+        // Keep creates in key order for candidate lookups and operation emission,
+        // including keys re-created after an ancestor deleted them.
         let mut created: Vec<(K, V::Value, Option<Location<F>>)> =
-            Vec::with_capacity(mutations.len() + parent_deleted_creates.len());
-        for (key, value) in mutations {
-            let Some(value) = value else {
-                continue; // delete of non-existent key
-            };
-            next_candidates.push(key.clone());
-            created.push((key, value, None));
-        }
-        for (key, value, base_old_loc) in parent_deleted_creates {
+            Vec::with_capacity(mutations.len());
+        for (key, value, base_old_loc) in m.resolve_creates(mutations) {
             next_candidates.push(key.clone());
             created.push((key, value, base_old_loc));
         }
-        db.strategy()
-            .sort_by(&mut created, |(a, _, _), (b, _, _)| a.cmp(b));
 
         // Look up prev_translated_key for created/deleted keys.
         let mut prev_locations = Vec::new();
@@ -2324,8 +2289,8 @@ where
         //
         // Each diff is key-sorted, as are `updated`/`created`/`deleted`, so the handled check
         // advances three cursors in a sorted merge instead of three binary searches per key.
-        // Active entries are collected and read in one batch below instead of one awaited
-        // read per key.
+        // Each diff records only its owning batch's changes, so active operations
+        // can be read directly from that batch's journal suffix.
         let track_shadow = m.ancestors.len() > 1;
         let seen_cap = if track_shadow {
             m.ancestors.iter().map(|a| a.diff.len()).sum()
@@ -2334,7 +2299,6 @@ where
         };
         let mut seen: AHashSet<&K> = AHashSet::with_capacity(seen_cap);
         let mut ancestor_deleted: Vec<&K> = Vec::new();
-        let mut ancestor_locs: Vec<Location<F>> = Vec::new();
         for batch in m.ancestors.iter() {
             let (mut ui, mut ci, mut di) = (0, 0, 0);
             for (key, entry) in batch.diff.iter() {
@@ -2359,7 +2323,14 @@ where
                 }
                 match entry {
                     DiffEntry::Active { loc, .. } => {
-                        ancestor_locs.push(*loc);
+                        let index = (**loc - *batch.bounds.base.size) as usize;
+                        let data = match &batch.journal_batch.items()[index] {
+                            Operation::Update(data) => data,
+                            _ => unreachable!("ancestor diff Active should reference Update op"),
+                        };
+                        next_candidates.push(data.key.clone());
+                        next_candidates.push(data.next_key.clone());
+                        prev_candidates.push((data.key.clone(), (Some(data.value.clone()), *loc)));
                     }
                     DiffEntry::Deleted { .. } => {
                         ancestor_deleted.push(key);
@@ -2368,23 +2339,6 @@ where
             }
         }
         ancestor_deleted.sort();
-        ancestor_deleted.dedup();
-
-        // Batch-read the collected active entries' ops and emit their candidates.
-        for (op, loc) in m
-            .read_ops(&ancestor_locs, &[], &db.log)
-            .await?
-            .into_iter()
-            .zip(ancestor_locs)
-        {
-            let data = match op {
-                Operation::Update(data) => data,
-                _ => unreachable!("ancestor diff Active should reference Update op"),
-            };
-            next_candidates.push(data.key.clone());
-            next_candidates.push(data.next_key);
-            prev_candidates.push((data.key, (Some(data.value), loc)));
-        }
 
         // Sort + dedup candidate sets now so find_next_key/find_prev_key_mut can binary-search.
         db.strategy().sort_by(&mut next_candidates, |a, b| a.cmp(b));
@@ -2409,8 +2363,7 @@ where
         // base DB lookup may have added.
         let is_deleted = |k: &K| -> bool {
             deleted.binary_search_by(|(dk, _)| dk.cmp(k)).is_ok()
-                || (ancestor_deleted.binary_search(&k).is_ok()
-                    && created.binary_search_by(|(ck, _, _)| ck.cmp(k)).is_err())
+                || ancestor_deleted.binary_search(&k).is_ok()
         };
         next_candidates.retain(|k| !is_deleted(k));
         prev_candidates.retain(|(k, _)| !is_deleted(k));
@@ -2490,22 +2443,18 @@ where
 
         // Update predecessors of created and deleted keys.
         if !prev_candidates.is_empty() {
-            // The emitted mutation groups are individually key-sorted. Their ranges stay
-            // fixed as predecessor rewrites are appended to the diff.
-            let mutation_ranges = [deleted_range.clone(), updated_range, created_range.clone()];
+            // The create/delete ranges stay fixed as predecessor rewrites are appended.
             for idx in created_range.chain(deleted_range) {
                 let key = &diff[idx].0;
                 let (prev_key, (prev_value, prev_loc)) =
                     find_prev_key_mut(key, &mut prev_candidates);
 
-                if mutation_ranges
-                    .iter()
-                    .any(|range| lookup_sorted(&diff[range.clone()], prev_key).is_some())
-                {
+                // Only updated mutation keys can be candidates: creates have no live
+                // operation before this batch, and deletes are excluded from candidates.
+                if lookup_sorted(&diff[updated_range.clone()], prev_key).is_some() {
                     continue;
                 }
 
-                // Mutation keys, including staged keys without values, were skipped above.
                 // Taking the value ensures a shared predecessor is rewritten only once.
                 let Some(prev_value) = prev_value.take() else {
                     continue;
@@ -3586,89 +3535,115 @@ mod tests {
         }
     }
 
-    /// Test helper: same logic as `Merkleizer::extract_parent_deleted_creates`
-    /// but without requiring a full Merkleizer instance.
-    fn extract_parent_deleted_creates<K: Ord + Clone, V: Clone>(
-        mutations: &mut BTreeMap<K, Option<V>>,
-        base_diff: &[(K, DiffEntry<mmr::Family, V>)],
-    ) -> Vec<(K, V, Option<crate::mmr::Location>)> {
-        let creates: Vec<_> = mutations
-            .iter()
-            .filter_map(|(key, value)| {
-                if let Some(DiffEntry::Deleted { base_old_loc }) = lookup_sorted(base_diff, key)
-                    && let Some(value) = value
-                {
-                    return Some((key.clone(), value.clone(), *base_old_loc));
-                }
-                None
-            })
-            .collect();
-        for (key, _, _) in &creates {
-            mutations.remove(key);
-        }
-        creates
+    // Recreated keys replace their committed locations when a pending chain is applied.
+    // Fresh and recreated keys share key order; absent deletes do not change the batch.
+    macro_rules! recreated_keys_apply_pending_chain_test {
+        ($name:ident, $db:ident) => {
+            #[test]
+            fn $name() {
+                deterministic::Runner::default().start(|context| async move {
+                    type TestDb = $db<
+                        mmr::Family,
+                        deterministic::Context,
+                        sha256::Digest,
+                        sha256::Digest,
+                        Sha256,
+                        OneCap,
+                        Sequential,
+                    >;
+
+                    for existed in [false, true] {
+                        let context = context.child("db").with_attribute("existed", existed);
+                        let config = fixed_db_config::<OneCap>(stringify!($name), &context);
+                        let db = TestDb::init(context, config).await.unwrap();
+                        let key = |i| colliding_digest(0xA0, i);
+                        let value = |i| colliding_digest(0xB0, i);
+
+                        let mut seed = db
+                            .new_batch()
+                            .write(key(6), Some(value(6)))
+                            .write(key(8), Some(value(8)));
+                        if existed {
+                            seed = seed.write(key(2), Some(value(2)));
+                        }
+                        let seed = seed.merkleize(&db, None).await.unwrap();
+                        let base_loc = lookup_sorted(&seed.diff, &key(2)).and_then(DiffEntry::loc);
+                        assert_eq!(base_loc.is_some(), existed);
+                        let (db, _) = db.apply_batch(seed).await.unwrap();
+
+                        // The nearest ancestor deletes a key that an older ancestor updated
+                        // or created. Its recreation must retain the original committed base.
+                        let grandparent = db
+                            .new_batch()
+                            .write(key(2), Some(value(20)))
+                            .merkleize(&db, None)
+                            .await
+                            .unwrap();
+                        let parent = grandparent
+                            .new_batch::<Sha256>()
+                            .write(key(2), None)
+                            .write(key(6), None)
+                            .merkleize(&db, None)
+                            .await
+                            .unwrap();
+                        let creates = || {
+                            parent
+                                .new_batch::<Sha256>()
+                                .write(key(4), Some(value(34)))
+                                .write(key(2), Some(value(32)))
+                                .write(key(0), Some(value(30)))
+                        };
+                        let without_deletes = creates().merkleize(&db, None).await.unwrap();
+                        let child = creates()
+                            .write(key(3), None)
+                            .write(key(6), None)
+                            .merkleize(&db, None)
+                            .await
+                            .unwrap();
+
+                        let (_, ops) = child.operations();
+                        assert_eq!(child.root(), without_deletes.root());
+                        assert_eq!(*ops, *without_deletes.operations().1);
+                        assert_eq!(
+                            ops[..3].iter().map(OperationTrait::key).collect::<Vec<_>>(),
+                            vec![Some(&key(0)), Some(&key(2)), Some(&key(4))]
+                        );
+                        assert!(!ops.iter().any(OperationTrait::is_delete));
+
+                        // Apply the entire pending chain at once: applying the deletion first
+                        // would remove the committed location and mask a lost base location.
+                        let (db, _) = db.apply_batch(Arc::clone(&child)).await.unwrap();
+                        for i in [0, 2, 4] {
+                            assert_eq!(db.get(&key(i)).await.unwrap(), Some(value(30 + i)));
+                        }
+                        assert_eq!(db.get(&key(8)).await.unwrap(), Some(value(8)));
+                        for i in [3, 6] {
+                            assert_eq!(db.get(&key(i)).await.unwrap(), None);
+                        }
+                        assert_eq!(db.active_keys, 4);
+                        assert_eq!(db.snapshot.items(), 4);
+                        if let Some(base_loc) = base_loc {
+                            assert!(!db.bitmap.get_bit(*base_loc));
+                        }
+                        for (i, expected_base) in [(0, None), (2, base_loc), (4, None)] {
+                            let entry = lookup_sorted(&child.diff, &key(i)).unwrap();
+                            assert_eq!(entry.base_old_loc(), expected_base);
+                        }
+                        db.destroy().await.unwrap();
+                    }
+                });
+            }
+        };
     }
 
-    #[test]
-    fn extract_parent_deleted_creates_basic() {
-        let mut mutations: BTreeMap<u64, Option<u64>> = BTreeMap::new();
-        mutations.insert(1, Some(100)); // update over parent-deleted key
-        mutations.insert(2, None); // delete (not a create)
-        mutations.insert(3, Some(300)); // update, but not in base diff
-
-        let mut base_diff: Vec<(u64, DiffEntry<mmr::Family, u64>)> = vec![
-            (
-                1,
-                DiffEntry::Deleted {
-                    base_old_loc: Some(crate::mmr::Location::new(5)),
-                },
-            ),
-            (
-                4,
-                DiffEntry::Active {
-                    value: 400,
-                    loc: crate::mmr::Location::new(10),
-                    base_old_loc: None,
-                },
-            ),
-        ];
-        base_diff.sort_by_key(|a| a.0);
-
-        let creates = extract_parent_deleted_creates(&mut mutations, &base_diff);
-
-        // key1 extracted: value=100, base_old_loc=Some(5)
-        assert_eq!(creates.len(), 1);
-        let (key, value, base_old_loc) = creates.first().unwrap();
-        assert_eq!(*key, 1);
-        assert_eq!(*value, 100);
-        assert_eq!(*base_old_loc, Some(crate::mmr::Location::new(5)));
-
-        // key1 removed from mutations, key2 and key3 remain.
-        assert_eq!(mutations.len(), 2);
-        assert!(mutations.contains_key(&2));
-        assert!(mutations.contains_key(&3));
-    }
-
-    #[test]
-    fn extract_parent_deleted_creates_delete_not_extracted() {
-        let mut mutations: BTreeMap<u64, Option<u64>> = BTreeMap::new();
-        mutations.insert(1, None); // deleting a parent-deleted key
-
-        let base_diff: Vec<(u64, DiffEntry<mmr::Family, u64>)> = vec![(
-            1,
-            DiffEntry::Deleted {
-                base_old_loc: Some(crate::mmr::Location::new(5)),
-            },
-        )];
-
-        let creates = extract_parent_deleted_creates(&mut mutations, &base_diff);
-
-        // Delete of a deleted key is not a create.
-        assert!(creates.is_empty());
-        // Mutation unchanged.
-        assert_eq!(mutations.len(), 1);
-        assert!(mutations.contains_key(&1));
-    }
+    recreated_keys_apply_pending_chain_test!(
+        unordered_recreated_keys_apply_pending_chain,
+        UnorderedFixedDb
+    );
+    recreated_keys_apply_pending_chain_test!(
+        ordered_recreated_keys_apply_pending_chain,
+        OrderedFixedDb
+    );
 
     /// `operations()` must cover exactly the batch's own applied range and match the
     /// operations a post-apply `historical_proof` recovers from the log, including
@@ -5422,12 +5397,9 @@ mod tests {
     /// bucket in the committed snapshot, and the same loop pushes each entry it examines
     /// into the next/prev candidate sets that stitch the ordered links. In this scenario the
     /// child updates a sibling that collides with a parent-deleted key, so the scan pulls
-    /// the deleted key's stale committed location into the loop. The guard skips the stale
-    /// entry, and it must do so before the candidate pushes: a stale prev-candidate makes
-    /// `find_prev_key_mut`'s wrap-around land on the deleted key, whose rewrite is then skipped
-    /// as batch-created, and the true predecessor's rewrite is emitted at a different stream
-    /// position than on the committed path, so the roots diverge with identical key-value
-    /// data.
+    /// the deleted key's stale committed location into the loop. Excluding that operation
+    /// before candidate insertion keeps predecessor selection and operation order identical
+    /// between the pending and committed parent paths.
     #[test]
     fn ordered_stale_classifier_candidates_root_matches() {
         let runner = deterministic::Runner::default();

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -879,7 +879,7 @@ where
             for key in mutations.keys() {
                 match ancestors.resolve(key) {
                     Some(DiffEntry::Deleted { .. }) => {
-                        // No live operation; resolve_creates handles any recreation.
+                        // No live operation remains. resolve_creates handles any recreation.
                     }
                     Some(DiffEntry::Active {
                         loc, base_old_loc, ..
@@ -907,7 +907,7 @@ where
 
     /// Resolve remaining mutations into creates in key order. Re-created keys inherit
     /// the base location of the nearest ancestor deletion. Existing keys must already
-    /// be resolved and removed from `mutations`; deletes of absent keys are ignored.
+    /// be resolved and removed from `mutations`. Deletes of absent keys are ignored.
     #[allow(clippy::type_complexity)]
     fn resolve_creates(
         &self,
@@ -3536,7 +3536,7 @@ mod tests {
     }
 
     // Recreated keys replace their committed locations when a pending chain is applied.
-    // Fresh and recreated keys share key order; absent deletes do not change the batch.
+    // Fresh and recreated keys share key order. Absent deletes do not change the batch.
     macro_rules! recreated_keys_apply_pending_chain_test {
         ($name:ident, $db:ident) => {
             #[test]

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -13,7 +13,7 @@ use crate::{
             ValueEncoding,
             db::Db,
             operation::{Operation, update},
-            ordered::{find_next_key, find_next_key_ascending, find_prev_key},
+            ordered::{find_next_key, find_next_key_ascending, find_prev_key_mut},
         },
         batch_chain::{self, Bounds, Commitment},
         bitmap::Shared,
@@ -59,10 +59,9 @@ where
     next_scan: Location<F>,
 }
 
-/// Sorted `(key, (value, loc))` vec consulted by `find_prev_key` to find the predecessor
-/// of a given key during ordered merkleization. The value is `None` for staged-resolved
-/// keys: the predecessor-rewrite loop only reads a value for keys outside this batch's
-/// mutations, and staged-resolved keys are always in `updated`.
+/// Sorted `(key, (value, loc))` vec consulted by `find_prev_key_mut` during ordered merkleization.
+/// Values are `None` for staged-resolved keys (skipped as updates) and for predecessors whose
+/// values have already been consumed by a rewrite. Candidate keys remain unchanged.
 type PrevCandidates<K, F, V> = Vec<(K, (Option<V>, Location<F>))>;
 
 /// Where a staged read resolved: in the committed snapshot, or in an uncommitted
@@ -2181,7 +2180,7 @@ where
 
         // Classify mutations into deleted, created, updated. `next_candidates` and
         // `prev_candidates` are built as unsorted `Vec`s here and sorted+deduped once below,
-        // before `find_next_key` / `find_prev_key` binary-search them.
+        // before `find_next_key` / `find_prev_key_mut` binary-search them.
         let mut next_candidates: Vec<K> = Vec::new();
         let mut prev_candidates: PrevCandidates<K, F, V::Value> = Vec::new();
         let mut deleted: Vec<(K, Location<F>)> = Vec::new();
@@ -2334,8 +2333,8 @@ where
             0
         };
         let mut seen: AHashSet<&K> = AHashSet::with_capacity(seen_cap);
-        let mut ancestor_deleted: Vec<K> = Vec::new();
-        let mut ancestor_active: Vec<(&K, &V::Value, Location<F>)> = Vec::new();
+        let mut ancestor_deleted: Vec<&K> = Vec::new();
+        let mut ancestor_locs: Vec<Location<F>> = Vec::new();
         for batch in m.ancestors.iter() {
             let (mut ui, mut ci, mut di) = (0, 0, 0);
             for (key, entry) in batch.diff.iter() {
@@ -2359,11 +2358,11 @@ where
                     continue;
                 }
                 match entry {
-                    DiffEntry::Active { value, loc, .. } => {
-                        ancestor_active.push((key, value, *loc));
+                    DiffEntry::Active { loc, .. } => {
+                        ancestor_locs.push(*loc);
                     }
                     DiffEntry::Deleted { .. } => {
-                        ancestor_deleted.push(key.clone());
+                        ancestor_deleted.push(key);
                     }
                 }
             }
@@ -2372,24 +2371,22 @@ where
         ancestor_deleted.dedup();
 
         // Batch-read the collected active entries' ops and emit their candidates.
-        let ancestor_locs: Vec<Location<F>> =
-            ancestor_active.iter().map(|&(_, _, loc)| loc).collect();
-        for (op, (key, value, loc)) in m
+        for (op, loc) in m
             .read_ops(&ancestor_locs, &[], &db.log)
             .await?
             .into_iter()
-            .zip(ancestor_active)
+            .zip(ancestor_locs)
         {
             let data = match op {
                 Operation::Update(data) => data,
                 _ => unreachable!("ancestor diff Active should reference Update op"),
             };
-            next_candidates.push(key.clone());
+            next_candidates.push(data.key.clone());
             next_candidates.push(data.next_key);
-            prev_candidates.push((key.clone(), (Some(value.clone()), loc)));
+            prev_candidates.push((data.key, (Some(data.value), loc)));
         }
 
-        // Sort + dedup candidate sets now so find_next_key/find_prev_key can binary-search.
+        // Sort + dedup candidate sets now so find_next_key/find_prev_key_mut can binary-search.
         db.strategy().sort_by(&mut next_candidates, |a, b| a.cmp(b));
         next_candidates.dedup();
         // For `prev_candidates`, duplicates can occur when the same key is pushed from multiple
@@ -2412,7 +2409,7 @@ where
         // base DB lookup may have added.
         let is_deleted = |k: &K| -> bool {
             deleted.binary_search_by(|(dk, _)| dk.cmp(k)).is_ok()
-                || (ancestor_deleted.binary_search(k).is_ok()
+                || (ancestor_deleted.binary_search(&k).is_ok()
                     && created.binary_search_by(|(ck, _, _)| ck.cmp(k)).is_err())
         };
         next_candidates.retain(|k| !is_deleted(k));
@@ -2428,24 +2425,26 @@ where
 
         // Process deletes.
         let mut ancestors = DiffCursors::new(m.ancestors.iter().map(|a| a.diff.as_slice()));
-        for (key, old_loc) in &deleted {
+        for (key, old_loc) in deleted {
             ops.push(Operation::Delete(key.clone()));
 
             let base_old_loc = ancestors
-                .resolve(key)
-                .map_or(Some(*old_loc), DiffEntry::base_old_loc);
+                .resolve(&key)
+                .map_or(Some(old_loc), DiffEntry::base_old_loc);
 
-            diff.push((key.clone(), DiffEntry::Deleted { base_old_loc }));
+            diff.push((key, DiffEntry::Deleted { base_old_loc }));
             active_keys_delta -= 1;
             user_steps += 1;
         }
+        let deleted_range = 0..diff.len();
 
         // Process updates of existing keys.
+        let updated_range = diff.len()..diff.len() + updated.len();
         let mut ancestors = DiffCursors::new(m.ancestors.iter().map(|a| a.diff.as_slice()));
         let mut next_idx = 0;
-        for (key, value, old_loc) in &updated {
+        for (key, value, old_loc) in updated {
             let new_loc = m.base_state.size + ops.len() as u64;
-            let next_key = find_next_key_ascending(key, &next_candidates, &mut next_idx);
+            let next_key = find_next_key_ascending(&key, &next_candidates, &mut next_idx);
             ops.push(Operation::Update(update::Ordered {
                 key: key.clone(),
                 value: value.clone(),
@@ -2453,13 +2452,13 @@ where
             }));
 
             let base_old_loc = ancestors
-                .resolve(key)
-                .map_or(Some(*old_loc), DiffEntry::base_old_loc);
+                .resolve(&key)
+                .map_or(Some(old_loc), DiffEntry::base_old_loc);
 
             diff.push((
-                key.clone(),
+                key,
                 DiffEntry::Active {
-                    value: value.clone(),
+                    value,
                     loc: new_loc,
                     base_old_loc,
                 },
@@ -2468,21 +2467,22 @@ where
         }
 
         // Process creates.
+        let created_range = diff.len()..diff.len() + created.len();
         let mut next_idx = 0;
-        for (key, value, base_old_loc) in &created {
+        for (key, value, base_old_loc) in created {
             let new_loc = m.base_state.size + ops.len() as u64;
-            let next_key = find_next_key_ascending(key, &next_candidates, &mut next_idx);
+            let next_key = find_next_key_ascending(&key, &next_candidates, &mut next_idx);
             ops.push(Operation::Update(update::Ordered {
                 key: key.clone(),
                 value: value.clone(),
                 next_key,
             }));
             diff.push((
-                key.clone(),
+                key,
                 DiffEntry::Active {
-                    value: value.clone(),
+                    value,
                     loc: new_loc,
-                    base_old_loc: *base_old_loc,
+                    base_old_loc,
                 },
             ));
             active_keys_delta += 1;
@@ -2490,33 +2490,27 @@ where
 
         // Update predecessors of created and deleted keys.
         if !prev_candidates.is_empty() {
-            // Safe to use a HashSet here since we don't rely on iteration order.
-            let mut rewritten_predecessors = AHashSet::with_capacity(created.len() + deleted.len());
-            for key in created
-                .iter()
-                .map(|(k, _, _)| k)
-                .chain(deleted.iter().map(|(k, _)| k))
-            {
-                let (prev_key, (prev_value, prev_loc)) = find_prev_key(key, &prev_candidates);
+            // The emitted mutation groups are individually key-sorted. Their ranges stay
+            // fixed as predecessor rewrites are appended to the diff.
+            let mutation_ranges = [deleted_range.clone(), updated_range, created_range.clone()];
+            for idx in created_range.chain(deleted_range) {
+                let key = &diff[idx].0;
+                let (prev_key, (prev_value, prev_loc)) =
+                    find_prev_key_mut(key, &mut prev_candidates);
 
-                if deleted.binary_search_by(|(k, _)| k.cmp(prev_key)).is_ok()
-                    || updated
-                        .binary_search_by(|(k, _, _)| k.cmp(prev_key))
-                        .is_ok()
-                    || created
-                        .binary_search_by(|(k, _, _)| k.cmp(prev_key))
-                        .is_ok()
+                if mutation_ranges
+                    .iter()
+                    .any(|range| lookup_sorted(&diff[range.clone()], prev_key).is_some())
                 {
                     continue;
                 }
 
-                if !rewritten_predecessors.insert(prev_key.clone()) {
+                // Mutation keys, including staged keys without values, were skipped above.
+                // Taking the value ensures a shared predecessor is rewritten only once.
+                let Some(prev_value) = prev_value.take() else {
                     continue;
-                }
+                };
 
-                let prev_value = prev_value
-                    .as_ref()
-                    .expect("staged-resolved keys are skipped as updated");
                 let prev_new_loc = m.base_state.size + ops.len() as u64;
                 let prev_next_key = find_next_key(prev_key, &next_candidates);
                 ops.push(Operation::Update(update::Ordered {
@@ -2531,7 +2525,7 @@ where
                 diff.push((
                     prev_key.clone(),
                     DiffEntry::Active {
-                        value: prev_value.clone(),
+                        value: prev_value,
                         loc: prev_new_loc,
                         base_old_loc: prev_base_old_loc,
                     },
@@ -5428,7 +5422,7 @@ mod tests {
     /// child updates a sibling that collides with a parent-deleted key, so the scan pulls
     /// the deleted key's stale committed location into the loop. The guard skips the stale
     /// entry, and it must do so before the candidate pushes: a stale prev-candidate makes
-    /// `find_prev_key`'s wrap-around land on the deleted key, whose rewrite is then skipped
+    /// `find_prev_key_mut`'s wrap-around land on the deleted key, whose rewrite is then skipped
     /// as batch-created, and the true predecessor's rewrite is emitted at a different stream
     /// position than on the committed path, so the roots diverge with identical key-value
     /// data.

--- a/storage/src/qmdb/any/ordered/mod.rs
+++ b/storage/src/qmdb/any/ordered/mod.rs
@@ -256,22 +256,23 @@ pub(crate) fn find_next_key_ascending<K: Ord + Clone>(
         .clone()
 }
 
-/// Returns the previous key to `key` within `possible_previous` (sorted by `.0`, deduplicated).
+/// Returns the previous key to `key` and its mutable value within `possible_previous`
+/// (sorted by `.0`, deduplicated).
 /// The result will "cycle around" to the last entry if `key` is the first key.
 ///
 /// # Panics
 ///
 /// Panics if `possible_previous` is empty.
-pub(crate) fn find_prev_key<'a, K: Ord, V>(
+pub(crate) fn find_prev_key_mut<'a, K: Ord, V>(
     key: &K,
-    possible_previous: &'a [(K, V)],
-) -> (&'a K, &'a V) {
+    possible_previous: &'a mut [(K, V)],
+) -> (&'a K, &'a mut V) {
     let idx = possible_previous.partition_point(|(k, _)| k < key);
     let (k, v) = if idx > 0 {
-        &possible_previous[idx - 1]
+        &mut possible_previous[idx - 1]
     } else {
         possible_previous
-            .last()
+            .last_mut()
             .expect("possible_previous should not be empty")
     };
     (k, v)


### PR DESCRIPTION
Reduce redundant clones and temporary collections in ordered QMDB batches: move owned mutations into the diff, consume predecessor values once, and read ancestor candidates directly from their owning journal suffix. Ordered and unordered batches share one key-ordered create pass. Operation order, roots, and storage encoding are unchanged.

Production batch regressions replace copied-helper tests and cover recreation provenance, no-op deletes, operation order, and snapshot/bitmap state. Both catch deliberately broken location inheritance that the previous 41 batch tests missed, and mishandled absent deletes.

## Constantinople results

Ordered depth-3 latency improves **12.52% (`any`)** and **12.12% (`current`)** versus main. Final unordered depth-3 intervals include no change.

Measured 2026-09-09 on main `a0bd7aec` with and without the PR changes; commit `37aea78e` contains the measured production code plus later regression tests. Stock [Constantinople harness](https://github.com/commonwarexyz/monorepo/blob/a0bd7aec31e4959ac57cc2e73f815a3a49ec082e/storage/src/qmdb/benches/constantinople.rs), Apple M5 Pro (18 cores, 64 GiB), macOS 26.5.1, rustc 1.98.1, optimized bench profile. All cases use `fixed::mmb`, 1M keys, 32,768 read/update slots, 32-byte Digest keys/values, one stage chunk, 512-MiB cache, eight adaptive workers, and two runtime workers. Depth counts pending ancestor batches.

Times are means of six process medians: alternating run order, 128 iterations per process, first 32 discarded. Deltas and nominal 95% t-intervals use paired process results; negative means faster.

| Workload | Depth | Main ms | PR ms | Change ms | Change % [95% interval] |
| --- | ---: | ---: | ---: | ---: | ---: |
| any/ordered | 0 | 7.127 | 7.037 | -0.090 | -1.25% [-2.46, -0.05] |
| any/ordered | 3 | 27.672 | 24.206 | -3.466 | -12.52% [-13.92, -11.12] |
| any/unordered | 0 | 4.826 | 4.752 | -0.074 | -1.53% [-2.34, -0.73] |
| any/unordered | 3 | 6.693 | 6.699 | +0.006 | +0.09% [-0.40, +0.57] |
| current/ordered | 0 | 8.701 | 8.542 | -0.159 | -1.82% [-3.75, +0.12] |
| current/ordered | 3 | 30.843 | 27.104 | -3.739 | -12.12% [-13.67, -10.58] |
| current/unordered | 0 | 6.324 | 6.296 | -0.028 | -0.45% [-1.10, +0.20] |
| current/unordered | 3 | 9.129 | 9.138 | +0.009 | +0.11% [-1.62, +1.83] |

Timing covers staged load, merkleization, and root retrieval; excludes update generation, ancestor setup, apply/commit/sync, and destruction. This overwrite workload does not measure heap-value clone savings, creates, deletes, or predecessor rewrites. Adaptive convergence was not established. On the shared host, whole pairs were excluded using one-second process samples when competing compiler/test CPU reached 40%, or another process reached 150%.


All **44,544 accepted iteration roots matched** across the benchmark experiments. Local validation passed **43 batch tests and 3,075 storage library tests** (399 default-skipped), Clippy, formatting, and diff checks. WASM release passed on the same production code. One unrelated nextest leak warning did not recur on a focused rerun.
