### PR TITLE
[coding/zoda] Fix overflow in Topology::reckon

### DIFF
--- a/coding/src/zoda/mod.rs
+++ b/coding/src/zoda/mod.rs
@@ -390,7 +390,7 @@ impl<D: Digest> CheckingData<D> {
         root: D,
         checksum: &Matrix<F>,
     ) -> Result<Self, Error> {
-        let topology = Topology::reckon(config, data_bytes);
+        let topology = Topology::reckon(config, data_bytes)?;
         let mut transcript = Transcript::new(NAMESPACE, Version::V1);
         transcript.commit(namespace);
         transcript.commit((topology.data_bytes as u64).encode());
@@ -488,6 +488,8 @@ pub enum Error {
     InvalidWeakShard,
     #[error("invalid index {0}")]
     InvalidIndex(u16),
+    #[error("no secure topology exists for this configuration and data size")]
+    InvalidConfig,
     #[error("insufficient shards {0} < {1}")]
     InsufficientShards(usize, usize),
     #[error("insufficient unique rows {0} < {1}")]
@@ -532,7 +534,7 @@ impl<H: Hasher> PhasedScheme for Zoda<H> {
     ) -> Result<(Self::Commitment, Vec<Self::StrongShard>), Self::Error> {
         // Step 1: arrange the data as a matrix.
         let data_bytes = data.remaining();
-        let topology = Topology::reckon(config, data_bytes);
+        let topology = Topology::reckon(config, data_bytes)?;
         let data = Matrix::init(
             topology.data_rows,
             topology.data_cols,

--- a/coding/src/zoda/topology.rs
+++ b/coding/src/zoda/topology.rs
@@ -4,6 +4,8 @@ use commonware_math::fields::goldilocks::F;
 use commonware_utils::BigRationalExt as _;
 use num_rational::BigRational;
 
+// Target security for row and column sampling. Using 126 bits requires two
+// Goldilocks checksum elements; F::bits_to_elements counts 63 bits per element.
 const SECURITY_BITS: usize = 126;
 // Fractional precision (in binary digits) for the fixed-precision log2 bound
 // in `required_samples`. We use the next power of 2 above SECURITY_BITS

--- a/coding/src/zoda/topology.rs
+++ b/coding/src/zoda/topology.rs
@@ -5,10 +5,22 @@ use commonware_utils::BigRationalExt as _;
 use num_rational::BigRational;
 
 const SECURITY_BITS: usize = 126;
-// Fractional precision for log2 calculations when computing required samples.
-// We use the next power of 2 above SECURITY_BITS (128 = 2^7), which provides
-// 1/128 fractional precision, sufficient for these security calculations.
+// Fractional precision (in binary digits) for the fixed-precision log2 bound
+// in `required_samples`. We use the next power of 2 above SECURITY_BITS
+// (128 = 2^7), which provides 1/128 fractional precision. Computing log2 costs
+// exponentially more with each digit, so this cannot be raised much.
 const LOG2_PRECISION: usize = SECURITY_BITS.next_power_of_two().trailing_zeros() as usize;
+// The fixed-precision bound in `required_samples` has an absolute error of at
+// most 2^-LOG2_PRECISION. Below this threshold its relative error exceeds 1/16,
+// so we refine it with the (more expensive) series bound.
+const SERIES_THRESHOLD_LOG2: usize = LOG2_PRECISION - 4;
+// Number of terms of the Taylor series of -ln(1 - f) used for the series bound
+// in `required_samples`. Every term is positive, so truncating the series gives
+// a lower bound on the log term. With f <= 1/2, the relative error of this
+// bound is below 0.1%.
+const LN_TERMS: usize = 8;
+// A rational upper bound on ln(2), as (numerator, denominator).
+const LN2_UPPER: (u64, u64) = (6_931_471_806, 10_000_000_000);
 
 /// Contains the sizes of various objects in the protocol.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -48,36 +60,66 @@ impl Topology {
         }
     }
 
-    pub(crate) fn required_samples(&self) -> usize {
-        let k = BigRational::from_usize(self.encoded_rows - self.data_rows);
-        let m = BigRational::from_usize(self.encoded_rows);
-        let fraction = (&k + BigRational::from_u64(1)) / (BigRational::from_usize(2) * &m);
+    /// Compute how many row samples are needed for [SECURITY_BITS] of security.
+    ///
+    /// Returns `None` if the encoding provides no security at all, which
+    /// cannot happen for a topology with more encoded rows than data rows.
+    pub(crate) fn required_samples(&self) -> Option<usize> {
+        // A single sample of an incorrectly encoded matrix passes with
+        // probability at most 1 - f, where f = (m - n + 1) / (2 m) is half the
+        // relative distance of a code with n data rows and m encoded rows.
+        // We need s samples such that (1 - f)^s <= 2^-SECURITY_BITS, i.e.
+        // s >= SECURITY_BITS / -log2(1 - f).
+        let distance = self.encoded_rows.checked_sub(self.data_rows)?;
+        let fraction = (BigRational::from_usize(distance) + BigRational::from_u64(1))
+            / (BigRational::from_usize(2) * BigRational::from_usize(self.encoded_rows));
 
-        // Compute log2(one_minus). When m is close to n, one_minus is close to 1, making log2(one_minus)
-        // a small negative value that requires sufficient precision to correctly capture the sign.
+        // We lower bound -log2(1 - f), which over-estimates the required
+        // samples. The fixed-precision ceiling of log2(1 - f), negated, is
+        // cheap and tight when f is not small, and exact when 1 - f is a power
+        // of two. When m is close to n, f is small, and this bound loses all
+        // precision and can even round to zero. In that case, we take the
+        // larger of it and a truncation of -ln(1 - f) = sum_{i >= 1} f^i / i,
+        // divided by an upper bound on ln(2), which stays tight for small f.
         let one_minus = BigRational::from_usize(1) - &fraction;
-        let log_term = one_minus.log2_ceil(LOG2_PRECISION);
-        if log_term >= BigRational::from_u64(0) {
-            return usize::MAX;
+        let mut log_term = -one_minus.log2_ceil(LOG2_PRECISION);
+        if log_term < BigRational::from_frac_u64(1, 1 << SERIES_THRESHOLD_LOG2) {
+            let mut series_bound = BigRational::from_u64(0);
+            let mut power = BigRational::from_u64(1);
+            for i in 1..=LN_TERMS {
+                power *= &fraction;
+                series_bound += &power / BigRational::from_usize(i);
+            }
+            series_bound /= BigRational::from_frac_u64(LN2_UPPER.0, LN2_UPPER.1);
+            log_term = log_term.max(series_bound);
+        }
+        if log_term <= BigRational::from_u64(0) {
+            return None;
         }
 
-        let required = BigRational::from_usize(SECURITY_BITS) / -log_term;
-        required.ceil_to_u128().unwrap_or(u128::MAX) as usize
+        let required = BigRational::from_usize(SECURITY_BITS) / log_term;
+        usize::try_from(required.ceil_to_u128()?).ok()
     }
 
-    fn correct_column_samples(&mut self) {
+    /// Set the number of column samples so that the topology provides
+    /// [SECURITY_BITS] of security, even if the row samples alone do not.
+    fn correct_column_samples(&mut self) -> Option<()> {
         // We make sure we have enough column samples to get 126 bits of security.
         //
         // This effectively does two elements per column. To get strictly greater
         // than 128 bits, we would need to add another column per column_sample.
         // We also have less than 128 bits in other places because of the bounds
         // on the messages encoded size.
-        self.column_samples =
-            F::bits_to_elements(SECURITY_BITS) * self.required_samples().div_ceil(self.samples);
+        self.column_samples = F::bits_to_elements(SECURITY_BITS)
+            .checked_mul(self.required_samples()?.div_ceil(self.samples))?;
+        Some(())
     }
 
     /// Figure out what size different values will have, based on the config and the data.
-    pub fn reckon(config: &Config, data_bytes: usize) -> Self {
+    ///
+    /// Returns [Error::InvalidConfig] if no secure topology exists for this
+    /// configuration and data size.
+    pub fn reckon(config: &Config, data_bytes: usize) -> Result<Self, Error> {
         let n = config.minimum_shards.get() as usize;
         let k = config.extra_shards.get() as usize;
         // The following calculations don't tolerate data_bytes = 0, so we
@@ -105,7 +147,9 @@ impl Topology {
         let mut out = Self::with_cols(corrected_data_bytes, n, k, 1);
         loop {
             let attempt = Self::with_cols(corrected_data_bytes, n, k, out.data_cols + 1);
-            let required_samples = attempt.required_samples();
+            let Some(required_samples) = attempt.required_samples() else {
+                break;
+            };
             if required_samples.saturating_mul(n + k) <= attempt.encoded_rows {
                 out = Self {
                     samples: required_samples.max(attempt.samples),
@@ -115,9 +159,9 @@ impl Topology {
                 break;
             }
         }
-        out.correct_column_samples();
+        out.correct_column_samples().ok_or(Error::InvalidConfig)?;
         out.data_bytes = data_bytes;
-        out
+        Ok(out)
     }
 
     pub fn check_index(&self, i: u16) -> Result<(), Error> {
@@ -139,7 +183,7 @@ mod tests {
             minimum_shards: NZU16!(3),
             extra_shards: NZU16!(1),
         };
-        let topology = Topology::reckon(&config, 16);
+        let topology = Topology::reckon(&config, 16).unwrap();
         assert_eq!(topology.min_shards, 3);
         assert_eq!(topology.total_shards, 4);
 
@@ -147,11 +191,80 @@ mod tests {
         // When the loop in reckon() exits without finding a multi-column config,
         // correct_column_samples() must compensate by adding column samples.
         assert_eq!(topology.data_cols, 1);
-        let required = topology.required_samples();
+        let required = topology.required_samples().unwrap();
         let provided = topology.samples * (topology.column_samples / 2);
         assert!(
             provided >= required,
             "security invariant violated: provided {provided} < required {required}"
         );
+    }
+
+    #[test]
+    fn reckon_small_extra_shards_exact_power_of_two() {
+        // With k = 1 and (n + k) * samples an exact power of two, the encoded
+        // rows barely exceed the data rows, so the log2 term in
+        // `required_samples` is tiny. With insufficient precision it rounds
+        // to zero, which used to overflow when computing `column_samples`.
+        // See https://github.com/commonwarexyz/monorepo/issues/4681.
+        let config = Config {
+            minimum_shards: NZU16!(511),
+            extra_shards: NZU16!(1),
+        };
+        let topology = Topology::reckon(&config, 4000).unwrap();
+        assert_eq!(topology.data_rows, 508);
+        assert_eq!(topology.encoded_rows, 512);
+        assert_eq!(topology.samples, 1);
+        let required = topology.required_samples().unwrap();
+        // The exact value is 126 / -log2(1019 / 1024), which is about 17842.9.
+        assert!(
+            (17_843..17_860).contains(&required),
+            "required = {required}"
+        );
+        let provided = topology.samples * (topology.column_samples / 2);
+        assert!(
+            provided >= required,
+            "security invariant violated: provided {provided} < required {required}"
+        );
+    }
+
+    #[test]
+    fn required_samples_is_close_to_exact() {
+        // Check that the precision used for the log2 term keeps the rounding
+        // error on the required samples small, across a range of encoded
+        // row counts approaching the data row count.
+        for lg in 3..=20 {
+            let encoded_rows = 1usize << lg;
+            for data_rows in [1, encoded_rows / 2, encoded_rows - 4, encoded_rows - 1] {
+                let topology = Topology {
+                    data_bytes: 0,
+                    data_cols: 1,
+                    data_rows,
+                    encoded_rows,
+                    samples: 1,
+                    column_samples: 0,
+                    min_shards: 1,
+                    total_shards: 2,
+                };
+                let required = topology.required_samples().unwrap();
+                let fraction = (encoded_rows - data_rows + 1) as f64 / (2.0 * encoded_rows as f64);
+                let exact = SECURITY_BITS as f64 / -(1.0 - fraction).log2();
+                assert!(
+                    required as f64 >= exact,
+                    "required {required} below exact {exact} for m={encoded_rows} n={data_rows}"
+                );
+                // Above the series threshold, only the fixed-precision bound
+                // applies, with a relative error of up to 1/16.
+                let tolerance =
+                    if exact > SECURITY_BITS as f64 * (1 << SERIES_THRESHOLD_LOG2) as f64 {
+                        1.001
+                    } else {
+                        1.0625
+                    };
+                assert!(
+                    required as f64 <= exact * tolerance + 1.0,
+                    "required {required} too far above exact {exact} for m={encoded_rows} n={data_rows}"
+                );
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes #4681.

When `extra_shards` is small relative to `minimum_shards` and `(n + k) * samples` lands on a power of two, the log term in `required_samples` fell below the 1/128 precision of `log2_ceil` and rounded to 0. We returned `usize::MAX` as a sentinel, and `correct_column_samples` multiplied it (e.g. n=511, k=1, 4000 bytes).

Now `required_samples` returns an `Option`, and `reckon` returns `Error::InvalidConfig` instead of panicking. When the fixed precision bound is small, we also take a lower bound from the Taylor series of `-ln(1 - f)`, which stays tight there. This is gated behind a threshold since it's ~10x more expensive than `log2_ceil`; above it, results are unchanged, so no conformance fixtures change.

The attached fuzz input doesn't reproduce with our harness, which forces `recovery >= min`. Added a unit test for the failing config instead.