### PR TITLE
[storage/journal] Specialize replay decoding

### DIFF
--- a/storage/src/journal/contiguous/blobs.rs
+++ b/storage/src/journal/contiguous/blobs.rs
@@ -2,10 +2,13 @@
 
 use crate::{
     Context, SyncCompletion,
-    journal::{Error, frame::FrameReader},
+    journal::{
+        Error,
+        frame::{FrameReader, decode_item, decode_length_prefix},
+    },
 };
 use bytes::Bytes;
-use commonware_codec::{Buf, Error as CodecError, ReadExt};
+use commonware_codec::{Buf, Codec, Error as CodecError, ReadExt};
 use commonware_formatting::hex;
 use commonware_runtime::{
     Blob as RBlob, Buf as _, Error as RError, Handle, IoBuf, IoBufMut, IoBufs, ReadOptions,
@@ -635,6 +638,10 @@ impl<B: RBlob> FrameReader for Blob<'_, B> {
 }
 
 /// Sequential replay over either a sealed paged blob or a live writer view.
+///
+/// Decoding methods select a concrete backing buffer before reading fields so the
+/// compiler can specialize length checks and field-copy loops. Only the concrete
+/// buffers implement [`Buf`], keeping codec readers behind this dispatch.
 pub(super) struct Replay<'a, B: RBlob> {
     inner: ReplayInner<'a, B>,
 }
@@ -649,14 +656,32 @@ enum ReplayInner<'a, B: RBlob> {
 
 impl<'a, B: RBlob> Replay<'a, B> {
     /// Decode an item through its concrete backing buffer.
-    ///
-    /// The whole `A::read` call stays inside the match so the compiler can specialize
-    /// its length checks and field-copy loops for each backing type. Fixed replay
-    /// relies on this specialization for throughput.
     pub(super) fn read<A: ReadExt>(&mut self) -> Result<A, CodecError> {
         match &mut self.inner {
             ReplayInner::Paged(replay) => A::read(replay),
             ReplayInner::View(replay) => A::read(replay),
+        }
+    }
+
+    /// Decode a frame length through its concrete backing buffer.
+    #[inline]
+    pub(super) fn read_length(&mut self) -> Result<(usize, usize), Error> {
+        match &mut self.inner {
+            ReplayInner::Paged(replay) => decode_length_prefix(replay),
+            ReplayInner::View(replay) => decode_length_prefix(replay),
+        }
+    }
+
+    /// Decode a frame payload bounded to `len` bytes through its concrete backing buffer.
+    pub(super) fn decode<V: Codec>(
+        &mut self,
+        len: usize,
+        cfg: &V::Cfg,
+        compressed: bool,
+    ) -> Result<V, Error> {
+        match &mut self.inner {
+            ReplayInner::Paged(replay) => decode_item::<V>(replay.take(len), cfg, compressed),
+            ReplayInner::View(replay) => decode_item::<V>(replay.take(len), cfg, compressed),
         }
     }
 
@@ -692,8 +717,6 @@ impl<'a, B: RBlob> Replay<'a, B> {
         }
     }
 }
-
-impl<B: RBlob> Buf for Replay<'_, B> {}
 
 impl<B: RBlob> bytes::Buf for Replay<'_, B> {
     fn copy_to_bytes(&mut self, len: usize) -> Bytes {
@@ -838,7 +861,7 @@ impl<'a, B: RBlob> Blobs<'a, B> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::utils::codec::View;
+    use crate::{journal::frame::encode_frame_into, utils::codec::View};
     use commonware_runtime::{IoBufMut, Runner as _, Storage as _, deterministic};
     use commonware_utils::{NZU16, NZUsize};
 
@@ -908,6 +931,88 @@ mod tests {
                 assert_eq!(first.as_ref(), b"abcdefgh");
                 assert_eq!(middle.as_ref(), b"ijklmnop");
                 assert_eq!(last.as_ref(), b"qrstuvwx");
+            }
+        });
+    }
+
+    #[test]
+    fn test_replay_decodes_bounded_frames() {
+        let executor = deterministic::Runner::default();
+        executor.start(|context| async move {
+            let items = [
+                Bytes::from_static(b"abcdefgh"),
+                Bytes::from_static(b"ijklmnop"),
+                Bytes::from_static(b"qrstuvwx"),
+            ];
+            for compression in [None, Some(1)] {
+                let mut encoded = Vec::new();
+                for item in &items {
+                    encode_frame_into(compression, item, &mut encoded).unwrap();
+                }
+                let cache = CacheRef::from_pooler(&context, NZU16!(64), NZUsize!(3));
+                let (blob, size) = context
+                    .open("replay-frames", &[compression.unwrap_or(0)])
+                    .await
+                    .unwrap();
+                let mut writer = Writer::new(blob, size, 128, cache).await.unwrap();
+                writer.append(&encoded).await.unwrap();
+                let snapshot = writer.snapshot().await.unwrap();
+
+                for source in [Blob::Writer(&writer), Blob::Sealed(snapshot)] {
+                    let mut replay = source
+                        .clone()
+                        .replay_from(0, NZUsize!(12), ReadOptions::default())
+                        .unwrap();
+                    let mut retained = Vec::new();
+                    for _ in &items {
+                        assert!(replay.ensure(1).await.unwrap());
+                        let (len, prefix_len) = replay.read_length().unwrap();
+                        assert_eq!(prefix_len, 1);
+                        assert!(replay.ensure(len).await.unwrap());
+                        let contiguous = replay.chunk().len() >= len;
+                        let range = replay.chunk().as_ptr_range();
+                        let item = replay
+                            .decode::<Bytes>(len, &(8..=8).into(), compression.is_some())
+                            .unwrap();
+                        if compression.is_none() && contiguous {
+                            assert!(range.contains(&item.as_ptr()));
+                        }
+                        retained.push(item);
+                    }
+                    assert!(!replay.ensure(1).await.unwrap());
+                    assert_eq!(replay.remaining(), 0);
+                    drop(replay);
+                    assert_eq!(retained, items);
+
+                    if compression.is_none() {
+                        for case in 0..3 {
+                            let mut replay = source
+                                .clone()
+                                .replay_from(0, NZUsize!(12), ReadOptions::default())
+                                .unwrap();
+                            assert!(replay.ensure(12).await.unwrap());
+                            let (len, _) = replay.read_length().unwrap();
+                            match case {
+                                0 => assert!(matches!(
+                                    replay.decode::<Bytes>(len, &(..=7).into(), false),
+                                    Err(Error::Codec(CodecError::InvalidLength(8)))
+                                )),
+                                1 => {
+                                    let remaining = replay.remaining();
+                                    assert!(matches!(
+                                        replay.decode::<u64>(1, &(), false),
+                                        Err(Error::Codec(CodecError::EndOfBuffer))
+                                    ));
+                                    assert_eq!(replay.remaining(), remaining);
+                                }
+                                _ => assert!(matches!(
+                                    replay.decode::<u8>(len, &(), false),
+                                    Err(Error::Codec(CodecError::ExtraData(8)))
+                                )),
+                            }
+                        }
+                    }
+                }
             }
         });
     }

--- a/storage/src/journal/contiguous/blobs.rs
+++ b/storage/src/journal/contiguous/blobs.rs
@@ -5,7 +5,7 @@ use crate::{
     journal::{Error, frame::FrameReader},
 };
 use bytes::Bytes;
-use commonware_codec::Buf;
+use commonware_codec::{Buf, Error as CodecError, ReadExt};
 use commonware_formatting::hex;
 use commonware_runtime::{
     Blob as RBlob, Buf as _, Error as RError, Handle, IoBuf, IoBufMut, IoBufs, ReadOptions,
@@ -648,6 +648,14 @@ enum ReplayInner<'a, B: RBlob> {
 }
 
 impl<'a, B: RBlob> Replay<'a, B> {
+    /// Decode an item through the concrete buffer so field reads avoid repeated dispatch.
+    pub(super) fn read<A: ReadExt>(&mut self) -> Result<A, CodecError> {
+        match &mut self.inner {
+            ReplayInner::Paged(replay) => A::read(replay),
+            ReplayInner::View(replay) => A::read(replay),
+        }
+    }
+
     /// Wrap a paged replay handle.
     const fn paged(replay: PagedReplay<B>) -> Self {
         Self {
@@ -826,6 +834,7 @@ impl<'a, B: RBlob> Blobs<'a, B> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::utils::codec::View;
     use commonware_runtime::{IoBufMut, Runner as _, Storage as _, deterministic};
     use commonware_utils::{NZU16, NZUsize};
 
@@ -868,32 +877,33 @@ mod tests {
             let cache = CacheRef::from_pooler(&context, NZU16!(64), NZUsize!(3));
             let (blob, size) = context.open("replay-views", b"blob").await.unwrap();
             let mut writer = Writer::new(blob, size, 128, cache).await.unwrap();
-            writer.append(b"abcdefgh").await.unwrap();
+            writer.append(b"abcdefghijklmnopqrstuvwx").await.unwrap();
             let snapshot = writer.snapshot().await.unwrap();
 
             for source in [Blob::Writer(&writer), Blob::Sealed(snapshot)] {
                 let paged = matches!(source, Blob::Sealed(_));
                 let mut replay = source
-                    .replay_from(0, NZUsize!(4), ReadOptions::default())
+                    .replay_from(0, NZUsize!(12), ReadOptions::default())
                     .unwrap();
-                assert!(replay.ensure(4).await.unwrap());
+                assert!(replay.ensure(12).await.unwrap());
                 let first_range = replay.chunk().as_ptr_range();
-                let first = replay.copy_to_bytes(2);
-                assert_eq!(first.as_ref(), b"ab");
+                let first = replay.read::<View>().unwrap().bytes;
                 assert!(first_range.contains(&first.as_ptr()));
 
-                assert!(replay.ensure(6).await.unwrap());
-                let middle = replay.copy_to_bytes(4);
-                assert_eq!(middle.as_ref(), b"cdef");
+                assert!(replay.ensure(16).await.unwrap());
+                let middle = replay.read::<View>().unwrap().bytes;
                 assert_eq!(first_range.contains(&middle.as_ptr()), paged);
 
                 let last_range = replay.chunk().as_ptr_range();
-                let last = replay.copy_to_bytes(2);
-                assert_eq!(last.as_ref(), b"gh");
+                let last = replay.copy_to_bytes(8);
                 assert!(last_range.contains(&last.as_ptr()));
                 assert_eq!(replay.remaining(), 0);
                 assert!(!replay.ensure(1).await.unwrap());
                 assert!(replay.is_exhausted());
+                drop(replay);
+                assert_eq!(first.as_ref(), b"abcdefgh");
+                assert_eq!(middle.as_ref(), b"ijklmnop");
+                assert_eq!(last.as_ref(), b"qrstuvwx");
             }
         });
     }

--- a/storage/src/journal/contiguous/blobs.rs
+++ b/storage/src/journal/contiguous/blobs.rs
@@ -648,7 +648,11 @@ enum ReplayInner<'a, B: RBlob> {
 }
 
 impl<'a, B: RBlob> Replay<'a, B> {
-    /// Decode an item through the concrete buffer so field reads avoid repeated dispatch.
+    /// Decode an item through its concrete backing buffer.
+    ///
+    /// The whole `A::read` call stays inside the match so the compiler can specialize
+    /// its length checks and field-copy loops for each backing type. Fixed replay
+    /// relies on this specialization for throughput.
     pub(super) fn read<A: ReadExt>(&mut self) -> Result<A, CodecError> {
         match &mut self.inner {
             ReplayInner::Paged(replay) => A::read(replay),

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -146,7 +146,7 @@ use crate::{
     },
 };
 use bytes::Bytes;
-use commonware_codec::{CodecFixedShared, Copying, DecodeExt as _, ReadExt as _};
+use commonware_codec::{CodecFixedShared, Copying, DecodeExt as _};
 use commonware_runtime::{
     Blob as RBlob, Buf, Handle, IoBuf, ReadOptions,
     buffer::paged::{CacheRef, Writer},
@@ -295,7 +295,7 @@ impl<B: RBlob, A: CodecFixedShared> super::ReplayBatchState for FixedReplayState
 
         let base = self.pos;
         for i in 0..count {
-            match A::read(&mut self.replay) {
+            match self.replay.read::<A>() {
                 Ok(item) => batch.push(Ok((base + i as u64, item))),
                 Err(err) => {
                     batch.push(Err(Error::Codec(err)));

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -293,6 +293,8 @@ impl<B: RBlob, A: CodecFixedShared> super::ReplayBatchState for FixedReplayState
         };
         batch.reserve(count);
 
+        // Decode whole records through the concrete buffer so the compiler can specialize
+        // their length checks and field copies.
         let base = self.pos;
         for i in 0..count {
             match self.replay.read::<A>() {

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -293,9 +293,7 @@ impl<B: RBlob, A: CodecFixedShared> super::ReplayBatchState for FixedReplayState
         };
         batch.reserve(count);
 
-        // Decode whole records through the concrete buffer so the compiler can specialize
-        // their length checks and field copies. Stop this blob on error because decoding
-        // may have consumed only part of a record.
+        // Stop this blob on error because decoding may have consumed only part of a record.
         let base = self.pos;
         for i in 0..count {
             match self.replay.read::<A>() {

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -256,7 +256,7 @@ impl<B: RBlob, V: CodecShared> super::ReplayBatchState for ReplayState<'_, B, V>
             }
 
             let before_remaining = self.replay.remaining();
-            let (item_size, varint_len) = match decode_length_prefix(&mut self.replay) {
+            let (item_size, varint_len) = match self.replay.read_length() {
                 Ok(result) => result,
                 Err(err) => {
                     if self.replay.is_exhausted() || before_remaining < MAX_U32_VARINT_SIZE {
@@ -300,13 +300,10 @@ impl<B: RBlob, V: CodecShared> super::ReplayBatchState for ReplayState<'_, B, V>
             };
             let item_len = next_offset - self.offset;
 
-            // `take(item_size)` advances past exactly the payload bytes after the header was
-            // consumed by `decode_length_prefix`.
-            match decode_item::<V>(
-                (&mut self.replay).take(item_size),
-                &self.codec_config,
-                self.compressed,
-            ) {
+            match self
+                .replay
+                .decode::<V>(item_size, &self.codec_config, self.compressed)
+            {
                 Ok(item) => {
                     let pos = self.pos;
                     let Some(next_pos) = self.pos.checked_add(1) else {

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -255,6 +255,8 @@ impl<B: RBlob, V: CodecShared> super::ReplayBatchState for ReplayState<'_, B, V>
                 }
             }
 
+            // Decode the frame length through the concrete buffer so its varint reads can be
+            // specialized. Keep the initial byte count for classifying a failed header read.
             let before_remaining = self.replay.remaining();
             let (item_size, varint_len) = match self.replay.read_length() {
                 Ok(result) => result,
@@ -300,6 +302,8 @@ impl<B: RBlob, V: CodecShared> super::ReplayBatchState for ReplayState<'_, B, V>
             };
             let item_len = next_offset - self.offset;
 
+            // The header is consumed; bound decoding to this frame's payload. Use the concrete
+            // buffer so the compiler can specialize the field reads.
             match self
                 .replay
                 .decode::<V>(item_size, &self.codec_config, self.compressed)

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -255,8 +255,7 @@ impl<B: RBlob, V: CodecShared> super::ReplayBatchState for ReplayState<'_, B, V>
                 }
             }
 
-            // Decode the frame length through the concrete buffer so its varint reads can be
-            // specialized. Keep the initial byte count for classifying a failed header read.
+            // Keep the initial byte count for classifying a failed header read.
             let before_remaining = self.replay.remaining();
             let (item_size, varint_len) = match self.replay.read_length() {
                 Ok(result) => result,
@@ -302,8 +301,7 @@ impl<B: RBlob, V: CodecShared> super::ReplayBatchState for ReplayState<'_, B, V>
             };
             let item_len = next_offset - self.offset;
 
-            // Read only this frame's payload. Select Paged or View once per record so field
-            // reads don't repeat that choice.
+            // Limit reads to this frame's payload so decoding cannot consume the next frame.
             match self
                 .replay
                 .decode::<V>(item_size, &self.codec_config, self.compressed)


### PR DESCRIPTION
Replaying fixed or variable contiguous journals currently instantiates record decoders for the outer `blobs::Replay` enum. This change selects `PagedReplay` or `ViewReplay` before entering each complete decoder: `A::read` for fixed records, and the decoders for the length prefix and bounded payload of variable frames. Rust can then specialize length checks and field-copy loops for each backing type.

The outer `Replay` no longer implements `commonware_codec::Buf`, so the former direct codec calls fail to compile. It retains raw `bytes::Buf` cursor operations; both concrete backings retain codec `Buf`. Variable payload decoding keeps its existing `Take` bound, value-specific configuration, decompression and exact-consumption check.

The fixed-replay profiling experiment showed the following machine-code difference:

- Before: the ordered-update decoder calls the outer `Replay::remaining` for each of its three 32-byte fields, then the outer `copy_to_slice`. That copy loop calls outer `chunk` and `advance` helpers, which select the backing variant again. Several helpers remain separate calls in the original binary; the paged path also pays the outer `advance` helper's register-save prologue.
- After: the paged decoder checks lengths with direct buffer-field comparisons and contains the field-copy loops itself. Those loops call the inner paged `chunk`, `memcpy`, and `advance` directly. The hot decoder has no calls to the outer `Replay` cursor/copy helpers. Digest copies and array initialization still occur.

Retained byte fields continue to use the existing buffer owners and `copy_to_bytes` paths. These methods select the concrete type used to instantiate each decoder; refill, CRC validation, batch bounds, and error handling retain their existing owners.

The fixed-replay measurements below compare #4667 at `dbf57ab62` with the fixed replay dispatch change alone. Its two source files at this branch's base (`a0bd7aec3`) match that baseline. These Linux `scale` measurements predate the variable-replay extension below and were not rerun for the final combined change.

The workload is ordered QMDB `scale` initialization over a fixture generated with 32M keys, 320M updates, and Zipf parameter 1. It replays 34,665,248 operations with inline SHA256 digest keys and values, using a 32M-entry key cache. Runs used an AWS r7a.8xlarge (AMD EPYC 9R14) and Rust 1.98.1, with separate build directories and the repository's bench profile. Warm/cold refers to the Linux filesystem cache. Times cover the existing `Db::init` timer, excluding fixture generation and subsequent destruction.

Elapsed times are medians of four unprofiled, counterbalanced runs per variant and case:

| Filesystem cache | Concurrency | Before | After | Reduction |
| --- | ---: | ---: | ---: | ---: |
| Warm | 1 | 32.455079 s | 32.063340 s | 0.391739 s (1.21%) |
| Warm | 8 | 8.451502 s | 7.475667 s | 0.975835 s (11.55%) |
| Cold | 1 | 42.010858 s | 41.864645 s | 0.146213 s (0.35%) |
| Cold | 8 | 16.920713 s | 16.340269 s | 0.580444 s (3.43%) |

Serial runs had mixed pair directions and overlapping ranges, so their lower medians do not establish a serial speedup. Every paired warm concurrency-8 comparison improved; all four changed cold concurrency-8 timings were below all four baseline timings.

A separate producer-only counter experiment, averaged over two runs per variant, measured:

| Producer metric | Before | After | Reduction |
| --- | ---: | ---: | ---: |
| CPU time | 7.252340 s | 6.333495 s | 0.918845 s (12.67%) |
| Retired instructions | 43.592799 billion | 35.406298 billion | 8.186502 billion (18.78%) |
| CPU cycles | 26.228756 billion | 22.843406 billion | 3.385350 billion (12.91%) |

These counters cover the initialization interval without worker threads, startup, or destruction, and ran without multiplexing. They are separate measurements from the unprofiled elapsed times above. The producer CPU saving averages about 27 ns per replayed operation, accumulating to almost a second over this fixture. At concurrency 8, one replay producer feeds seven workers; the similar producer-CPU and elapsed-time reductions are consistent with the producer limiting throughput.

The supported mechanism is specialization of the whole decoder, including its inlining and code layout. The experiment does not isolate every saved cycle to a particular branch or call. That fixed-replay benchmark executable's text section grows by 10,896 bytes (0.28%). This inline-digest workload does not measure throughput for large retained byte fields or cross-worker contention on a shared `Bytes` owner.

A separate local experiment measured the incremental variable-replay extension against `7504d9b21`, which already includes fixed-record specialization. The final measured prototype and `85d65dcc6` differ only in documentation. Runs used an Apple M5 Pro (18 physical cores, 64 GiB), macOS/aarch64, Rust 1.98.1, locked dependencies, the repository bench profile, and separate source/build directories with preserved binary hashes.

Each timed pass creates and drains a public journal replay, checks positions/count, and immediately drops decoded values. Initialization, snapshot creation, and final stream destruction are excluded. These are warmed, single-consumer journal measurements; they do not measure cold-disk reads, concurrent appends, long-lived consumer retention, or end-to-end QMDB initialization. A snapshot selects sealed Paged replay; direct replay of the reopened writable tail selects View. All records fit in one blob. The replay budget is 65,536 bytes, write/recovery buffers are 1,048,576 bytes, pages are 8,192 bytes, and the page cache holds 32,768 pages. Both paths use default read options; Paged replay bypasses the application page cache.

Each case has four fresh processes per variant in ABBA/BAAB order, with two untimed warmups and 20 timed replays per process. Values below are medians of process medians. Negative changes mean faster replay.

| Journal / record | Source | Records per replay | Before | After | Change (after - before) |
| --- | --- | ---: | ---: | ---: | ---: |
| Variable / 32-byte value | Paged | 1,000,000 | 40.151625 ms | 37.584052 ms | -2.567574 ms (-6.39%) |
| Variable / 32-byte value | View | 1,000,000 | 32.663989 ms | 30.847386 ms | -1.816604 ms (-5.56%) |
| Variable / three digests (96 bytes) | Paged | 1,000,000 | 76.000698 ms | 68.223323 ms | -7.777376 ms (-10.23%) |
| Variable / three digests (96 bytes) | View | 1,000,000 | 56.644719 ms | 53.017209 ms | -3.627510 ms (-6.40%) |
| Variable / 1 KiB Bytes + two digest keys | Paged | 100,000 | 25.257344 ms | 25.075302 ms | -0.182042 ms (-0.72%) |
| Variable / 1 KiB Bytes + two digest keys | View | 100,000 | 8.970781 ms | 9.002062 ms | +0.031281 ms (+0.35%) |
| Variable / compressed three digests | Paged | 100,000 | 98.164750 ms | 97.119583 ms | -1.045167 ms (-1.06%) |
| Variable / compressed three digests | View | 100,000 | 160.050011 ms | 160.515854 ms | +0.465843 ms (+0.29%) |
| Fixed control / three digests | Paged | 1,000,000 | 44.118490 ms | 44.732052 ms | +0.613563 ms (+1.39%) |
| Fixed control / three digests | View | 1,000,000 | 33.348073 ms | 27.850020 ms | -5.498053 ms (-16.49%) |

The multi-field records use the actual ordered QMDB `Update` type with SHA256 digests; the Bytes case retains a 1,024-byte field between two digest keys. The compressed case uses random 96-byte records and zstd level 1. Small and multi-field variable records improved consistently across the process runs. Bytes and compressed differences were small with overlapping ranges; these results do not establish an improvement there or prove zero regression. A separate 80-pass Bytes/View repeat measured 8.895989 ms before and 8.962333 ms after, a change of +0.066344 ms (+0.75%).

The fixed control's source is unchanged, but its generated View decoder also changed: adding concrete variable instantiations changed digest-decoder inlining. It is therefore not an independent control for machine noise, and its local improvement is not additional QMDB evidence. The measurements support specializing the whole decoder; their magnitude depends on the compiler and workload.

**The `Replay` annotation pattern is intentional: keep `#[inline]` on `read_length`; leave `read` and `decode` unannotated.** Rebenchmark fixed, variable, retained-Bytes, and compressed replay before changing this pattern. An attribute on one entry point can change shared digest-reader code in another path.

Direct comparisons against `7d32fd4ca` used the same warmed M5 Pro / Rust 1.98.1 journal harness and buffer configuration described above. Each variant changes only the named attribute. The rows below replay one million records through View and report medians of six fresh process medians in balanced order, with two untimed warmups and 20 timed passes per process for added hints, or 80 for the `read_length` removal.

| Attribute change | Replay case | Current PR | Variant | Change |
| --- | --- | ---: | ---: | ---: |
| Add `#[inline]` to `read` | Variable / three digests (96 bytes) | 55.249 ms | 61.032 ms | +5.783 ms (+10.47%) |
| Add `#[inline]` to `decode` | Fixed / three digests (96 bytes) | 27.691 ms | 32.831 ms | +5.140 ms (+18.56%) |
| Remove `#[inline]` from `read_length` | Variable / 32-byte value | 32.030 ms | 32.729 ms | +0.699 ms (+2.18%) |

Each comparison has nonoverlapping process-median ranges. `decode` already inlines without the hint; adding the annotation changes other optimization decisions. Adding the `read` hint removes its wrapper call without a demonstrated fixed-replay gain, while introducing separate digest-reader calls in variable decoding. Adding the `decode` hint changes fixed replay's digest-reader factoring. These assembly changes are consistent with the measured regressions; they do not isolate every lost cycle. Removing the `read_length` hint adds a prefix wrapper call with a 96-byte stack frame. Its clearest measured benefit is small-record replay; the direct retained-Bytes comparison remains inconclusive. These are compiler- and workload-specific results, not a general rule for inline annotations.

Ownership tests exercise live/sealed buffers, chunk crossings, retained values after refill/drop, compression, non-unit configurations, bounded underflow, and exact decoding. Temporarily restoring the former fixed and variable decoder entry calls produced the expected codec `Buf` trait errors. This guards the source-level entry boundary; functional tests do not guarantee performance, and the current CI benchmark gates cover QMDB merkleization rather than replay.

Local validation passed on the final source: 521 journal tests and 60 replay tests (overlapping selections), storage Clippy with all targets, repository formatting, the storage WASM release build using LLVM Clang, and independent correctness review. The full `just pre-pr` workflow has not completed.
