### PR TITLE
[storage] Simplify parallel snapshot init

### DIFF
--- a/runtime/src/utils/handle.rs
+++ b/runtime/src/utils/handle.rs
@@ -51,7 +51,8 @@ where
     },
 }
 
-/// Aborts every owned handle when a group is no longer supervised.
+/// Signals all aborts before dropping any handle, whose result or completion future may wake
+/// other tasks in the group during destruction.
 struct HandleGroup<T>(Vec<Handle<T>>)
 where
     T: Send + 'static;
@@ -280,53 +281,45 @@ where
         }
     }
 
-    /// Wrap this handle so the task is aborted if the wrapper is dropped before being joined.
-    #[commonware_macros::stability(ALPHA)]
+    /// Wrap this handle so dropping the wrapper calls [`Handle::abort`].
     pub const fn abort_on_drop(self) -> AbortOnDrop<T> {
-        AbortOnDrop(Some(self))
+        AbortOnDrop(self)
     }
 }
 
-/// Aborts a task if dropped before being joined.
+/// Calls [`Handle::abort`] when dropped.
 ///
 /// Supervision ties spawned tasks to their spawning task's lifetime, but work spawned from a plain
 /// future outlives that future's drop. Wrapping the handle (see [`Handle::abort_on_drop`]) ties the
-/// task to the guard instead, so cancelling the future holding it cannot leave the task running.
-/// Dropping the guard only signals the abort. Use [`AbortOnDrop::abort`] to also await the
-/// task's exit.
-#[commonware_macros::stability(ALPHA)]
-pub struct AbortOnDrop<T: Send + 'static>(Option<Handle<T>>);
+/// task's cancellation to the guard instead. Dropping the guard signals cancellation; use
+/// [`AbortOnDrop::abort`] to also join the handle. Completion handles only stop waiting and do
+/// not cancel the underlying work (see [`Handle`]).
+pub struct AbortOnDrop<T: Send + 'static>(Handle<T>);
 
-#[commonware_macros::stability(ALPHA)]
 impl<T: Send + 'static> AbortOnDrop<T> {
-    /// Abort the task, then join it.
+    /// Abort and join the handle. Completion handles only stop waiting for the underlying work.
     pub async fn abort(mut self) {
-        let handle = self.0.take().expect("handle joined once");
-        handle.abort();
-        let _ = handle.await;
+        self.0.abort();
+        let _ = (&mut self.0).await;
     }
 
-    /// Join the task.
+    /// Join the handle.
     pub async fn join(mut self) -> Result<T, Error> {
         // Poll the handle by reference: the guard must keep owning it so dropping this future
         // mid-join still aborts the task.
-        let handle = self.0.as_mut().expect("handle joined once");
-        let result = handle.await;
-        self.0 = None;
-        result
+        (&mut self.0).await
     }
 }
 
-#[commonware_macros::stability(ALPHA)]
 impl<T, E1> AbortOnDrop<Result<T, E1>>
 where
     T: Send + 'static,
     E1: Send + 'static,
 {
     /// Join `guards` in order, collecting each task's output. On the first failure (a task
-    /// error or a failed join), abort and join every remaining guard before surfacing it,
-    /// so no task outlives the failure (dropping a guard only signals the abort without
-    /// awaiting it). Joining in order makes the surfaced failure deterministic.
+    /// error or a failed join), abort and join every remaining guard before surfacing it.
+    /// Spawned tasks are cancelled and joined; completion handles only stop waiting for their
+    /// underlying work. Joining in order makes the surfaced failure deterministic.
     pub async fn join_all<E2>(guards: Vec<Self>) -> Result<Vec<T>, E2>
     where
         E2: From<E1> + From<Error>,
@@ -348,12 +341,9 @@ where
     }
 }
 
-#[commonware_macros::stability(ALPHA)]
 impl<T: Send + 'static> Drop for AbortOnDrop<T> {
     fn drop(&mut self) {
-        if let Some(handle) = &self.0 {
-            handle.abort();
-        }
+        self.0.abort();
     }
 }
 
@@ -513,10 +503,10 @@ impl Aborter {
 
 #[cfg(test)]
 mod tests {
-    use super::Handle;
+    use super::{AbortOnDrop, Handle};
     use crate::{Error, Metrics as _, Runner, Spawner, Supervisor as _, deterministic};
     use commonware_utils::channel::oneshot;
-    use futures::future;
+    use futures::{FutureExt as _, future, poll};
 
     const METRIC_PREFIX: &str = "runtime_tasks_running{";
 
@@ -674,6 +664,71 @@ mod tests {
 
             assert!(sender.send(Ok(())).is_ok());
             assert!(matches!(handle.await, Err(Error::Aborted)));
+        });
+    }
+
+    #[test]
+    fn abort_on_drop_cancels_pending_join() {
+        for poll_join in [false, true] {
+            deterministic::Runner::default().start(|context| async move {
+                let (held, released) = oneshot::channel::<()>();
+                let guard = context
+                    .child("guarded")
+                    .spawn(move |_| async move {
+                        let _held = held;
+                        future::pending::<()>().await;
+                    })
+                    .abort_on_drop();
+                let mut join = Box::pin(guard.join());
+                if poll_join {
+                    assert!(poll!(&mut join).is_pending());
+                }
+                drop(join);
+                assert!(released.await.is_err());
+            });
+        }
+    }
+
+    #[test]
+    fn abort_on_drop_join_all_drains_pending_task() {
+        deterministic::Runner::default().start(|context| async move {
+            let (held, released) = oneshot::channel::<()>();
+            let pending = context
+                .child("pending")
+                .spawn(move |_| async move {
+                    let _held = held;
+                    future::pending::<Result<(), Error>>().await
+                })
+                .abort_on_drop();
+            let failed = Handle::ready(Ok(Err(Error::Closed))).abort_on_drop();
+            let result = AbortOnDrop::join_all::<Error>(vec![failed, pending]).await;
+            assert!(matches!(result, Err(Error::Closed)));
+            assert!(
+                released
+                    .now_or_never()
+                    .expect("task still owns sender")
+                    .is_err()
+            );
+        });
+    }
+
+    #[test]
+    fn abort_on_drop_completion_leaves_producer_running() {
+        deterministic::Runner::default().start(|context| async move {
+            let (release, wait) = oneshot::channel::<()>();
+            let (sender, receiver) = oneshot::channel();
+            let mut producer = context.child("producer").spawn(move |_| async move {
+                wait.await.unwrap();
+                let _ = sender.send(Ok(()));
+            });
+
+            Handle::from_receiver(receiver)
+                .abort_on_drop()
+                .abort()
+                .await;
+            assert!(poll!(&mut producer).is_pending());
+            release.send(()).unwrap();
+            producer.await.unwrap();
         });
     }
 

--- a/runtime/src/utils/mod.rs
+++ b/runtime/src/utils/mod.rs
@@ -17,10 +17,8 @@ pub(crate) mod thread;
 
 mod handle;
 #[commonware_macros::stability(ALPHA)]
-pub use handle::AbortOnDrop;
-pub use handle::Handle;
-#[commonware_macros::stability(ALPHA)]
 pub(crate) use handle::Panicked;
+pub use handle::{AbortOnDrop, Handle};
 pub(crate) use handle::{Aborter, MetricHandle, Panicker};
 
 mod cell;

--- a/storage/src/qmdb/any/mod.rs
+++ b/storage/src/qmdb/any/mod.rs
@@ -1676,9 +1676,7 @@ pub(crate) mod test {
             drop(db);
 
             {
-                // Poll the reopen just enough for the build's tasks to spawn. Workers and
-                // decoders only progress while the coordinator (inside this future) is
-                // polled, so pausing here holds the build mid-flight.
+                // Poll until snapshot tasks own the pending build, then cancel before init returns.
                 let init = UnorderedFixedP1::init(ctx.child("storage"), cfg());
                 pin_mut!(init);
                 let mut spawned = false;

--- a/storage/src/qmdb/any/ordered/fixed.rs
+++ b/storage/src/qmdb/any/ordered/fixed.rs
@@ -785,11 +785,8 @@ pub(crate) mod test {
                 OneCap,
             );
 
-            // Every read now fails, and the failure necessarily surfaces through the replay
-            // stream: the reopened journal's page cache is fresh (only the buffer pool is shared
-            // across configs, never cached pages), so replay's first item forces a storage read,
-            // and with far fewer ops than the routing batch size no batch reaches a worker, so
-            // workers never read the log themselves.
+            // The reopened journal has a fresh page cache, so replay's first item requires a read.
+            // Failing that read leaves workers idle because no batches have been routed.
             context.storage_fault_config().write().read_rate = Some(probability!(1.0));
             let result = index
                 .build_snapshot(

--- a/storage/src/qmdb/any/unordered/fixed.rs
+++ b/storage/src/qmdb/any/unordered/fixed.rs
@@ -903,11 +903,8 @@ pub(crate) mod test {
                 OneCap,
             );
 
-            // Every read now fails, and the failure necessarily surfaces through the replay
-            // stream: the reopened journal's page cache is fresh (only the buffer pool is shared
-            // across configs, never cached pages), so replay's first item forces a storage read,
-            // and with far fewer ops than the routing batch size no batch reaches a worker, so
-            // workers never read the log themselves.
+            // The reopened journal has a fresh page cache, so replay's first item requires a read.
+            // Failing that read leaves workers idle because no batches have been routed.
             context.storage_fault_config().write().read_rate = Some(probability!(1.0));
             let result = index
                 .build_snapshot(

--- a/storage/src/qmdb/mod.rs
+++ b/storage/src/qmdb/mod.rs
@@ -479,17 +479,7 @@ const SNAPSHOT_CHANNEL_DEPTH: usize = 4;
 /// location, and whether it is a delete.
 type RoutedBatch<K> = Vec<(K, u64, bool)>;
 
-/// Sends `(worker, batch)` pairs from a decode task to the routing coordinator.
-type RoutedSender<K> = mpsc::Sender<(usize, RoutedBatch<K>)>;
-
-/// Whether the routing loop delivered every batch or stopped early on a closed worker
-/// channel.
-enum RoutingOutcome {
-    Completed,
-    CutShort,
-}
-
-/// Parameters shared by every decode chunk of one parallel build.
+/// Parameters shared by the inline replay and decode chunks of one parallel build.
 #[derive(Clone, Copy)]
 struct SnapshotRouting {
     /// Number of insert workers routed to.
@@ -513,38 +503,34 @@ const SNAPSHOT_ROUTE_BATCH: usize = 3;
 /// Operations per decode chunk in a parallel build. Decoding the replay stream is the build's
 /// serial bottleneck at large sizes, so contiguous chunks of this many locations are decoded (and
 /// partition-routed) on concurrent tasks while the coordinator forwards finished chunks in position
-/// order. Together with the decoder count this bounds the routed operations a build can hold in
-/// memory at once. Small in tests so ordinary logs exercise chunk boundaries.
+/// order. Together with the decoder count this bounds the queued operations; each decoder also
+/// reserves one batch per worker. Small in tests so ordinary logs exercise chunk boundaries.
 #[cfg(not(test))]
 const SNAPSHOT_DECODE_CHUNK: u64 = 1 << 17;
 #[cfg(test)]
 const SNAPSHOT_DECODE_CHUNK: u64 = 64;
 
-/// Decode the `len` operations starting at `start` and stream each keyed op's routed batch
-/// (`partition_of(key) / range_size`) over `tx` in sub-batches of at most [SNAPSHOT_ROUTE_BATCH]
-/// ops. Returns without error if the receiver is dropped (routing was aborted).
-async fn decode_snapshot_chunk<F, C>(
-    log: Arc<C>,
-    start: u64,
-    len: u64,
+/// Replay `range` and send each worker's keyed operations in log order, in batches of at most
+/// [SNAPSHOT_ROUTE_BATCH] operations. Stops if `send` returns false; the caller owns the
+/// receiving tasks and observes their errors when joining them.
+async fn route_snapshot<F, C, Fut>(
+    log: &C,
+    range: Range<u64>,
     routing: SnapshotRouting,
-    tx: RoutedSender<<C::Item as Operation<F>>::Key>,
+    mut send: impl FnMut(usize, RoutedBatch<<C::Item as Operation<F>>::Key>) -> Fut + Send,
 ) -> Result<(), Error<F>>
 where
     F: Family,
     C: Contiguous<Item: Operation<F>>,
+    Fut: Future<Output = bool> + Send,
 {
+    let stream = log
+        .replay_range(range, routing.init_buffer, ReadOptions::default())
+        .await?;
+    pin_mut!(stream);
     let mut batches: Vec<RoutedBatch<_>> = (0..routing.workers)
         .map(|_| Vec::with_capacity(SNAPSHOT_ROUTE_BATCH))
         .collect();
-    let stream = log
-        .replay_range(
-            start..start + len,
-            routing.init_buffer,
-            ReadOptions::default(),
-        )
-        .await?;
-    pin_mut!(stream);
     while let Some(result) = stream.next().await {
         let (loc, op) = result?;
         let is_delete = op.is_delete();
@@ -554,15 +540,15 @@ where
         if batches[w].len() >= SNAPSHOT_ROUTE_BATCH {
             let batch =
                 std::mem::replace(&mut batches[w], Vec::with_capacity(SNAPSHOT_ROUTE_BATCH));
-            if tx.send((w, batch)).await.is_err() {
+            if !send(w, batch).await {
                 return Ok(());
             }
         }
     }
 
-    // Flush remaining batches before the channel closes.
+    // Flush remaining batches before the caller closes the channels.
     for (w, batch) in batches.into_iter().enumerate() {
-        if !batch.is_empty() && tx.send((w, batch)).await.is_err() {
+        if !batch.is_empty() && !send(w, batch).await {
             break;
         }
     }
@@ -765,54 +751,26 @@ where
     // resolving a collision). Routing stops on the first such send failure and the join below
     // surfaces that worker's error, rather than panicking on the send.
     let mut pending = VecDeque::new();
-    let routing_result: Result<RoutingOutcome, Error<F>> = async {
+    let routing = SnapshotRouting {
+        workers,
+        partition_of: I::partition_of,
+        range_size,
+        init_buffer,
+    };
+    let routing_result: Result<(), Error<F>> = async {
         // With no decode tasks, decode and route on this task over one continuous replay to avoid
         // per-chunk buffered-reader overhead (measured 265s vs 369s on a 1.66B-op log).
         if decoders == 0 {
-            let stream = log
-                .replay(floor, init_buffer, ReadOptions::default())
-                .await?;
-            pin_mut!(stream);
-            let mut batches: Vec<RoutedBatch<_>> = (0..workers)
-                .map(|_| Vec::with_capacity(SNAPSHOT_ROUTE_BATCH))
-                .collect();
-            while let Some(result) = stream.next().await {
-                let (loc, op) = result?;
-                let is_delete = op.is_delete();
-                let Some(key) = op.into_key() else { continue };
-                let w = I::partition_of(key.as_ref()) / range_size;
-                batches[w].push((key, loc, is_delete));
-                if batches[w].len() >= SNAPSHOT_ROUTE_BATCH {
-                    let batch = std::mem::replace(
-                        &mut batches[w],
-                        Vec::with_capacity(SNAPSHOT_ROUTE_BATCH),
-                    );
-                    if senders[w].send(batch).await.is_err() {
-                        return Ok(RoutingOutcome::CutShort);
-                    }
-                }
-            }
-
-            // Flush remaining batches before the channels close.
-            for (w, batch) in batches.into_iter().enumerate() {
-                if !batch.is_empty() && senders[w].send(batch).await.is_err() {
-                    return Ok(RoutingOutcome::CutShort);
-                }
-            }
-            return Ok(RoutingOutcome::Completed);
+            let senders = &senders;
+            return route_snapshot::<F, C, _>(&**log, floor..end, routing, |w, batch| async move {
+                senders[w].send(batch).await.is_ok()
+            })
+            .await;
         }
 
         // Each chunk's channel holds the whole chunk (full sub-batches plus a final partial per
-        // worker), so a decoder never blocks mid-chunk: in-flight memory stays bounded by the
-        // decoder count times the chunk size while every decode task makes progress regardless of
-        // which chunk is being forwarded.
+        // worker), so every decoder can finish regardless of which chunk is being forwarded.
         let chunk_capacity = SNAPSHOT_DECODE_CHUNK as usize / SNAPSHOT_ROUTE_BATCH + workers;
-        let routing = SnapshotRouting {
-            workers,
-            partition_of: I::partition_of,
-            range_size,
-            init_buffer,
-        };
         let mut starts = (floor..end)
             .step_by(usize::try_from(SNAPSHOT_DECODE_CHUNK).expect("chunk size fits usize"));
         let mut spawn_next = |pending: &mut VecDeque<_>| {
@@ -825,7 +783,16 @@ where
             let handle = context
                 .child("snapshot_decoder")
                 .dedicated()
-                .spawn(move |_| decode_snapshot_chunk::<F, C>(log, start, len, routing, tx));
+                .spawn(move |_| async move {
+                    let tx = &tx;
+                    route_snapshot::<F, C, _>(
+                        &*log,
+                        start..start + len,
+                        routing,
+                        |w, batch| async move { tx.send((w, batch)).await.is_ok() },
+                    )
+                    .await
+                });
             pending.push_back((rx, handle.abort_on_drop()));
             true
         };
@@ -839,14 +806,14 @@ where
         while let Some((rx, _)) = pending.front_mut() {
             while let Some((w, batch)) = rx.recv().await {
                 if senders[w].send(batch).await.is_err() {
-                    return Ok(RoutingOutcome::CutShort);
+                    return Ok(());
                 }
             }
             let (_, decoder) = pending.pop_front().expect("front exists");
             decoder.join().await??;
             spawn_next(&mut pending);
         }
-        Ok(RoutingOutcome::Completed)
+        Ok(())
     }
     .await;
 
@@ -861,17 +828,8 @@ where
 
     // Join workers before surfacing any replay failure, so none outlive a failed init.
     let joined = AbortOnDrop::join_all::<Error<F>>(handles).await;
-    let routing = routing_result?;
+    routing_result?;
     let joined = joined?;
-
-    // Routing stops on a closed worker channel so the join above can surface that worker's failure.
-    // Every clean join with cut-short routing therefore dropped routed operations. Fail rather than
-    // install a snapshot missing them.
-    if matches!(routing, RoutingOutcome::CutShort) {
-        return Err(Error::DataCorrupted(
-            "snapshot routing stopped without a worker failure",
-        ));
-    }
 
     // Install each worker's partition range into the snapshot and fold its active-key count in.
     let mut total_items = 0;


### PR DESCRIPTION
Cleanup for #4567: consolidate snapshot replay routing, remove redundant routing and guard state, and expose `AbortOnDrop` at BETA.

LOC (added/deleted, including comments and blank lines): production +65/-119; tests +70/-13.
