### PR TITLE
[storage/qmdb] Skip ancestor neighbor scans for update-only batches

### DIFF
--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -29,6 +29,7 @@ use commonware_parallel::Strategy;
 use commonware_utils::{bitmap, iter::zip_eq};
 use core::{cmp::Ordering, ops::Range};
 use std::{
+    borrow::Cow,
     collections::{BTreeMap, hash_map},
     iter, mem,
     sync::{Arc, Weak},
@@ -2161,7 +2162,7 @@ where
         // `prev_candidates` are built as unsorted `Vec`s here and sorted+deduped once below,
         // before `find_next_key` / `find_prev_key_mut` binary-search them.
         let mut next_candidates: Vec<K> = Vec::new();
-        let mut prev_candidates: PrevCandidates<K, F, V::Value> = Vec::new();
+        let mut prev_candidates: PrevCandidates<K, F, Cow<'_, V::Value>> = Vec::new();
         let mut deleted: Vec<(K, Location<F>)> = Vec::new();
         let mut updated: Vec<(K, V::Value, Location<F>)> = Vec::new();
 
@@ -2195,7 +2196,7 @@ where
             }
 
             next_candidates.push(next_key);
-            prev_candidates.push((key.clone(), (Some(value), old_loc)));
+            prev_candidates.push((key.clone(), (Some(Cow::Owned(value)), old_loc)));
 
             let Some(mutation) = mutations.remove(&key) else {
                 // Snapshot index collision: this operation's key does not match
@@ -2272,7 +2273,7 @@ where
                 continue;
             }
             next_candidates.push(data.next_key);
-            prev_candidates.push((data.key, (Some(data.value), old_loc)));
+            prev_candidates.push((data.key, (Some(Cow::Owned(data.value)), old_loc)));
         }
 
         // Add ancestor-diff keys that may be predecessors or successors of this batch's mutations
@@ -2291,15 +2292,24 @@ where
         // advances three cursors in a sorted merge instead of three binary searches per key.
         // Each diff records only its owning batch's changes, so active operations
         // can be read directly from that batch's journal suffix.
-        let track_shadow = m.ancestors.len() > 1;
+        // Existing-key updates preserve membership, so the classifier's successors suffice and
+        // no predecessor is rewritten. Its candidates passed the stale-ancestor guard, so the
+        // deleted-key filter below has nothing to remove either.
+        let changes_membership = !created.is_empty() || !deleted.is_empty();
+        let candidate_ancestors = if changes_membership {
+            m.ancestors.as_slice()
+        } else {
+            &[][..]
+        };
+        let track_shadow = candidate_ancestors.len() > 1;
         let seen_cap = if track_shadow {
-            m.ancestors.iter().map(|a| a.diff.len()).sum()
+            candidate_ancestors.iter().map(|a| a.diff.len()).sum()
         } else {
             0
         };
         let mut seen: AHashSet<&K> = AHashSet::with_capacity(seen_cap);
         let mut ancestor_deleted: Vec<&K> = Vec::new();
-        for batch in m.ancestors.iter() {
+        for batch in candidate_ancestors.iter() {
             let (mut ui, mut ci, mut di) = (0, 0, 0);
             for (key, entry) in batch.diff.iter() {
                 if track_shadow && !seen.insert(key) {
@@ -2330,7 +2340,8 @@ where
                         };
                         next_candidates.push(data.key.clone());
                         next_candidates.push(data.next_key.clone());
-                        prev_candidates.push((data.key.clone(), (Some(data.value.clone()), *loc)));
+                        prev_candidates
+                            .push((data.key.clone(), (Some(Cow::Borrowed(&data.value)), *loc)));
                     }
                     DiffEntry::Deleted { .. } => {
                         ancestor_deleted.push(key);
@@ -2343,19 +2354,6 @@ where
         // Sort + dedup candidate sets now so find_next_key/find_prev_key_mut can binary-search.
         db.strategy().sort_by(&mut next_candidates, |a, b| a.cmp(b));
         next_candidates.dedup();
-        // For `prev_candidates`, duplicates can occur when the same key is pushed from multiple
-        // sources (main scan, prev_results, ancestor walk). Later pushes carry the freshest state
-        // (ancestor walk runs last), so dedup keeps the LAST push per key. `dedup_by` retains the
-        // first of each consecutive run; swap so the retained slot holds the later push.
-        prev_candidates.sort_by(|a, b| a.0.cmp(&b.0));
-        prev_candidates.dedup_by(|a, b| {
-            if a.0 == b.0 {
-                std::mem::swap(a, b);
-                true
-            } else {
-                false
-            }
-        });
 
         // Remove all known-deleted keys from possible_* sets. The prev_translated_key lookup
         // already did this for this batch's deletes, but the ancestor diff incorporation may
@@ -2366,7 +2364,24 @@ where
                 || ancestor_deleted.binary_search(&k).is_ok()
         };
         next_candidates.retain(|k| !is_deleted(k));
-        prev_candidates.retain(|(k, _)| !is_deleted(k));
+
+        // `prev_candidates` is consulted only by the predecessor rewrites below. Duplicates can
+        // occur when the same key is pushed from multiple sources (main scan, prev_results,
+        // ancestor walk). Later pushes carry the freshest state (ancestor walk runs last), so
+        // dedup keeps the LAST push per key. `dedup_by` retains the first of each consecutive
+        // run; swap so the retained slot holds the later push.
+        if changes_membership {
+            prev_candidates.sort_by(|a, b| a.0.cmp(&b.0));
+            prev_candidates.dedup_by(|a, b| {
+                if a.0 == b.0 {
+                    std::mem::swap(a, b);
+                    true
+                } else {
+                    false
+                }
+            });
+            prev_candidates.retain(|(k, _)| !is_deleted(k));
+        }
 
         // Generate operations.
         let mut ops: Vec<Operation<F, update::Ordered<K, V>>> =
@@ -2459,6 +2474,7 @@ where
                 let Some(prev_value) = prev_value.take() else {
                     continue;
                 };
+                let prev_value = prev_value.into_owned();
 
                 // Preserve the ordered links across creates and deletes by rewriting the
                 // predecessor with its existing value and its successor in the final key set.
@@ -2484,6 +2500,9 @@ where
                 user_steps += 1;
             }
         }
+
+        // Release the candidate keys and values before the remaining phases run.
+        drop(prev_candidates);
 
         // Committed locations superseded by this batch, for the floor raise (`finish` sorts
         // the diff itself).
@@ -5630,6 +5649,96 @@ mod tests {
             assert_eq!(pending_child.root(), committed_child.root());
             assert_eq!(pending_child.total_active_keys, 1);
             assert_eq!(committed_child.total_active_keys, 1);
+
+            db.destroy().await.unwrap();
+        });
+    }
+
+    /// An update-only child skips ancestor neighbor discovery, so the successors it emits
+    /// must come from the resolved operations alone even when the pending parent changed
+    /// membership around the updated keys.
+    #[test]
+    fn ordered_update_only_child_on_membership_changing_parent_root_matches() {
+        let runner = deterministic::Runner::default();
+        runner.start(|context| async move {
+            type TestDb = OrderedFixedDb<
+                mmr::Family,
+                deterministic::Context,
+                sha256::Digest,
+                sha256::Digest,
+                Sha256,
+                OneCap,
+                Sequential,
+            >;
+
+            let config = fixed_db_config::<OneCap>("ordered-update-only-child", &context);
+            let db = TestDb::init(context, config).await.unwrap();
+
+            let v = |n| colliding_digest(0xB0, n);
+            let initial = db
+                .new_batch()
+                .write(colliding_digest(1, 9), Some(v(0)))
+                .write(colliding_digest(3, 10), Some(v(1)))
+                .write(colliding_digest(3, 20), Some(v(2)))
+                .write(colliding_digest(3, 31), Some(v(3)))
+                .merkleize(&db, None)
+                .await
+                .unwrap();
+            let (db, _) = db.apply_batch(initial).await.unwrap();
+            let db = db.commit().await.unwrap();
+
+            // Parent: delete the middle bucket-3 key and create a new smallest key, rewriting
+            // the successors of both remaining bucket-3 keys.
+            let parent = db
+                .new_batch()
+                .write(colliding_digest(3, 20), None)
+                .write(colliding_digest(0, 0), Some(v(4)))
+                .merkleize(&db, None)
+                .await
+                .unwrap();
+
+            // Child: overwrite only existing keys. Two resolve from the parent journal while
+            // their bucket scan reads the deleted key's stale committed op, one is the
+            // parent-created key, and one is untouched by the parent.
+            let pending_child = parent
+                .new_batch::<Sha256>()
+                .write(colliding_digest(0, 0), Some(v(5)))
+                .write(colliding_digest(1, 9), Some(v(6)))
+                .write(colliding_digest(3, 10), Some(v(7)))
+                .write(colliding_digest(3, 31), Some(v(8)))
+                .merkleize(&db, None)
+                .await
+                .unwrap();
+
+            let (db, _) = db.apply_batch(parent).await.unwrap();
+            let db = db.commit().await.unwrap();
+
+            let committed_child = db
+                .new_batch()
+                .write(colliding_digest(0, 0), Some(v(5)))
+                .write(colliding_digest(1, 9), Some(v(6)))
+                .write(colliding_digest(3, 10), Some(v(7)))
+                .write(colliding_digest(3, 31), Some(v(8)))
+                .merkleize(&db, None)
+                .await
+                .unwrap();
+
+            assert_eq!(
+                pending_child.root(),
+                committed_child.root(),
+                "child root depended on pending-vs-committed parent path"
+            );
+            assert_eq!(
+                pending_child.total_active_keys,
+                committed_child.total_active_keys
+            );
+
+            let (db, _) = db.apply_batch(pending_child).await.unwrap();
+            assert_eq!(
+                db.root(),
+                committed_child.root(),
+                "applied pending child root diverged"
+            );
 
             db.destroy().await.unwrap();
         });

--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -2290,11 +2290,11 @@ where
         //
         // Each diff is key-sorted, as are `updated`/`created`/`deleted`, so the handled check
         // advances three cursors in a sorted merge instead of three binary searches per key.
-        // Each diff records only its owning batch's changes, so active operations
-        // can be read directly from that batch's journal suffix.
-        // Existing-key updates preserve membership, so the classifier's successors suffice and
-        // no predecessor is rewritten. Its candidates passed the stale-ancestor guard, so the
-        // deleted-key filter below has nothing to remove either.
+        // Each diff records only its owning batch's changes, so active operations can be read
+        // directly from that batch's journal suffix.
+        //
+        // Existing-key updates preserve membership, so their resolved successors suffice and
+        // no predecessor is rewritten.
         let changes_membership = !created.is_empty() || !deleted.is_empty();
         let candidate_ancestors = if changes_membership {
             m.ancestors.as_slice()
@@ -2308,7 +2308,6 @@ where
             0
         };
         let mut seen: AHashSet<&K> = AHashSet::with_capacity(seen_cap);
-        let mut ancestor_deleted: Vec<&K> = Vec::new();
         for batch in candidate_ancestors.iter() {
             let (mut ui, mut ci, mut di) = (0, 0, 0);
             for (key, entry) in batch.diff.iter() {
@@ -2331,46 +2330,36 @@ where
                 {
                     continue;
                 }
-                match entry {
-                    DiffEntry::Active { loc, .. } => {
-                        let index = (**loc - *batch.bounds.base.size) as usize;
-                        let data = match &batch.journal_batch.items()[index] {
-                            Operation::Update(data) => data,
-                            _ => unreachable!("ancestor diff Active should reference Update op"),
-                        };
-                        next_candidates.push(data.key.clone());
-                        next_candidates.push(data.next_key.clone());
-                        prev_candidates
-                            .push((data.key.clone(), (Some(Cow::Borrowed(&data.value)), *loc)));
-                    }
-                    DiffEntry::Deleted { .. } => {
-                        ancestor_deleted.push(key);
-                    }
-                }
+                let DiffEntry::Active { loc, .. } = entry else {
+                    continue;
+                };
+                let index = (**loc - *batch.bounds.base.size) as usize;
+                let data = match &batch.journal_batch.items()[index] {
+                    Operation::Update(data) => data,
+                    _ => unreachable!("ancestor diff Active should reference Update op"),
+                };
+                next_candidates.push(data.key.clone());
+                next_candidates.push(data.next_key.clone());
+                prev_candidates.push((data.key.clone(), (Some(Cow::Borrowed(&data.value)), *loc)));
             }
         }
-        ancestor_deleted.sort();
 
-        // Sort + dedup candidate sets now so find_next_key/find_prev_key_mut can binary-search.
+        // Sort and deduplicate successor candidates for binary search.
         db.strategy().sort_by(&mut next_candidates, |a, b| a.cmp(b));
         next_candidates.dedup();
 
-        // Remove all known-deleted keys from possible_* sets. The prev_translated_key lookup
-        // already did this for this batch's deletes, but the ancestor diff incorporation may
-        // have re-added them via next_key references. Also remove parent-deleted keys that the
-        // base DB lookup may have added.
-        let is_deleted = |k: &K| -> bool {
-            deleted.binary_search_by(|(dk, _)| dk.cmp(k)).is_ok()
-                || ancestor_deleted.binary_search(&k).is_ok()
-        };
-        next_candidates.retain(|k| !is_deleted(k));
-
-        // `prev_candidates` is consulted only by the predecessor rewrites below. Duplicates can
-        // occur when the same key is pushed from multiple sources (main scan, prev_results,
-        // ancestor walk). Later pushes carry the freshest state (ancestor walk runs last), so
-        // dedup keeps the LAST push per key. `dedup_by` retains the first of each consecutive
-        // run; swap so the retained slot holds the later push.
+        // Only membership changes require filtering deleted successors and preparing
+        // predecessor candidates for rewrites.
         if changes_membership {
+            // Resolved operations can still reference keys deleted by this batch.
+            let is_deleted = |k: &K| deleted.binary_search_by(|(dk, _)| dk.cmp(k)).is_ok();
+            next_candidates.retain(|k| !is_deleted(k));
+
+            // `prev_candidates` is consulted only by the predecessor rewrites below. Duplicates
+            // can occur when the same key is pushed from multiple sources (main scan,
+            // prev_results, ancestor walk). Later pushes carry the freshest state (ancestor
+            // walk runs last), so dedup keeps the LAST push per key. `dedup_by` retains the
+            // first of each consecutive run; swap so the retained slot holds the later push.
             prev_candidates.sort_by(|a, b| a.0.cmp(&b.0));
             prev_candidates.dedup_by(|a, b| {
                 if a.0 == b.0 {
@@ -5697,9 +5686,8 @@ mod tests {
                 .await
                 .unwrap();
 
-            // Child: overwrite only existing keys. Two resolve from the parent journal while
-            // their bucket scan reads the deleted key's stale committed op, one is the
-            // parent-created key, and one is untouched by the parent.
+            // Child: overwrite only existing keys. Its bucket scan encounters the deleted
+            // key's stale committed op alongside keys created or rewritten by the parent.
             let pending_child = parent
                 .new_batch::<Sha256>()
                 .write(colliding_digest(0, 0), Some(v(5)))


### PR DESCRIPTION
Ordered batches scan pending ancestors for neighbor candidates even when the batch only overwrites existing keys. They also clone every ancestor candidate's value, although only predecessors that need rewriting require ownership.

Borrow ancestor operation values until a predecessor rewrite needs ownership. Committed operations retain their owned values.

Skip ancestor neighbor discovery when the resolved mutation sets contain no creates or deletes. Existing-key updates preserve membership, and each resolved operation already contributes its current successor. Testing the classified sets accounts for ancestor deletions, recreations, and stale index collisions. Ancestors still participate in mutation resolution and other batch processing. Update-only batches also skip sorting and filtering the predecessor candidates, which only the rewrite loop consults. Batches that change membership retain the existing neighbor-discovery path.

A regression test builds an update-only child on a pending parent that deleted and created neighbors of the updated keys, and checks that its root matches the committed-parent path. Without the walk, the classifier's stale-ancestor guard alone keeps parent-deleted keys out of the successor candidates, and disabling that guard fails the test.
