### PR TITLE
[utils] Add try_join_all with prompt error propagation

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -33,4 +33,6 @@ disallowed-macros = [
 
 disallowed-methods = [
     { path = "commonware_p2p::Blocker::block", reason = "use commonware_p2p::block! instead" },
+    { path = "futures::future::try_join_all", reason = "use commonware_utils::futures::try_join_all to avoid delaying errors behind pending futures" },
+    { path = "futures_util::future::try_join_all", reason = "use commonware_utils::futures::try_join_all to avoid delaying errors behind pending futures" },
 ]

--- a/deployer/Cargo.toml
+++ b/deployer/Cargo.toml
@@ -23,7 +23,7 @@ aws = [
 	"clap",
 	"commonware-cryptography",
 	"commonware-macros/std",
-	"commonware-utils",
+	"commonware-utils/std",
 	"futures",
 	"reqwest",
 	"serde_yaml",

--- a/deployer/src/aws/create.rs
+++ b/deployer/src/aws/create.rs
@@ -12,11 +12,8 @@ use crate::aws::{
 };
 use commonware_cryptography::{Hasher as _, Sha256};
 use commonware_macros::boxed;
-use commonware_utils::iter::zip_eq;
-use futures::{
-    future::try_join_all,
-    stream::{self, StreamExt, TryStreamExt},
-};
+use commonware_utils::{futures::try_join_all, iter::zip_eq};
+use futures::stream::{self, StreamExt, TryStreamExt};
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     fs::File,

--- a/deployer/src/aws/destroy.rs
+++ b/deployer/src/aws/destroy.rs
@@ -9,7 +9,7 @@ use crate::aws::{
         is_no_such_bucket_error,
     },
 };
-use futures::future::try_join_all;
+use commonware_utils::futures::try_join_all;
 use std::{
     collections::{HashMap, HashSet},
     fs::File,

--- a/deployer/src/aws/s3.rs
+++ b/deployer/src/aws/s3.rs
@@ -15,10 +15,8 @@ use aws_sdk_s3::{
     types::{BucketLocationConstraint, CreateBucketConfiguration, Delete, ObjectIdentifier},
 };
 use commonware_cryptography::{Hasher as _, Sha256};
-use futures::{
-    future::try_join_all,
-    stream::{self, StreamExt, TryStreamExt},
-};
+use commonware_utils::futures::try_join_all;
+use futures::stream::{self, StreamExt, TryStreamExt};
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap},
     io::Read,

--- a/deployer/src/aws/update.rs
+++ b/deployer/src/aws/update.rs
@@ -8,10 +8,8 @@ use crate::aws::{
     utils::*,
 };
 use aws_sdk_ec2::types::Filter;
-use futures::{
-    future::try_join_all,
-    stream::{self, StreamExt, TryStreamExt},
-};
+use commonware_utils::futures::try_join_all;
+use futures::stream::{self, StreamExt, TryStreamExt};
 use std::{collections::HashMap, fs::File, path::PathBuf};
 use tracing::{error, info};
 

--- a/examples/estimator/src/main.rs
+++ b/examples/estimator/src/main.rs
@@ -15,13 +15,13 @@ use commonware_runtime::{
 use commonware_utils::{
     NZUsize, Probability,
     channel::{mpsc, oneshot},
+    futures::try_join_all,
     probability,
 };
 use estimator::{
     Command, Distribution, Latencies, RegionConfig, calculate_proposer_region, calculate_threshold,
     count_peers, crate_version, get_latency_data, mean, median, parse_task, std_dev,
 };
-use futures::future::try_join_all;
 use rand_core::Rng;
 use std::{
     collections::{BTreeMap, BTreeSet},

--- a/glue/src/stateful/db/mod.rs
+++ b/glue/src/stateful/db/mod.rs
@@ -89,8 +89,10 @@ use commonware_utils::{
     sync::{AsyncRwLockReadGuard, AsyncRwLockWriteGuard, TracedAsyncRwLock},
 };
 use futures::{
-    future::{Either, pending, try_join_all},
+    StreamExt as _,
+    future::{Either, pending},
     join,
+    stream::FuturesUnordered,
 };
 use std::{
     collections::BTreeMap,
@@ -483,27 +485,27 @@ impl Barrier {
     /// non-durable state. Returns `false` only when runtime shutdown aborts
     /// or closes a sync handle.
     pub async fn durable(self) -> bool {
-        let syncs = self
+        let mut syncs = self
             .syncs
             .into_iter()
-            .map(|(db_type, index, handle)| async move {
-                match handle.await {
-                    Ok(()) => Ok(true),
-                    Err(RuntimeError::Closed | RuntimeError::Aborted) => {
-                        debug!(db_type, "runtime shutdown before database sync completed");
-                        Ok(false)
-                    }
-                    Err(err) => Err((db_type, index, err)),
-                }
-            });
+            .map(|(db_type, index, handle)| async move { (db_type, index, handle.await) })
+            .collect::<FuturesUnordered<_>>();
 
-        match try_join_all(syncs).await {
-            Ok(results) => results.into_iter().all(|durable| durable),
-            Err((db_type, index, err)) => {
-                let index = index.map_or(String::new(), |i| format!("index {i}, "));
-                panic!("database sync failed ({index}type {db_type}): {err}");
+        let mut durable = true;
+        while let Some((db_type, index, result)) = syncs.next().await {
+            match result {
+                Ok(()) => {}
+                Err(RuntimeError::Closed | RuntimeError::Aborted) => {
+                    debug!(db_type, "runtime shutdown before database sync completed");
+                    durable = false;
+                }
+                Err(err) => {
+                    let index = index.map_or(String::new(), |i| format!("index {i}, "));
+                    panic!("database sync failed ({index}type {db_type}): {err}");
+                }
             }
         }
+        durable
     }
 }
 
@@ -2005,6 +2007,7 @@ mod tests {
     use std::{
         convert::Infallible,
         num::{NonZeroU64, NonZeroUsize},
+        panic::AssertUnwindSafe,
         sync::{
             Arc,
             atomic::{AtomicBool, AtomicUsize, Ordering},
@@ -3790,6 +3793,105 @@ mod tests {
                 Handle::ready(Err(RuntimeError::WriteFailed)),
             ]);
             let _ = barrier.durable().await;
+        });
+    }
+
+    #[rstest::rstest]
+    #[case(30)]
+    #[case(31)]
+    #[case(64)]
+    fn barrier_panics_on_later_failure(
+        #[case] count: usize,
+        #[values(false, true)] shutdown: bool,
+    ) {
+        deterministic::Runner::default().start(|context| async move {
+            let (pending_tx, pending_rx) = oneshot::channel();
+            let mut handles = vec![Handle::from_receiver(pending_rx)];
+            handles.extend((1..count).map(|index| {
+                Handle::ready(if index == count - 1 {
+                    Err(RuntimeError::WriteFailed)
+                } else if shutdown && index == 1 {
+                    Err(RuntimeError::Closed)
+                } else {
+                    Ok(())
+                })
+            }));
+            let barrier = Barrier::from_handles::<TestDb>(handles);
+            let mut durable = Box::pin(AssertUnwindSafe(barrier.durable()).catch_unwind());
+            let result = select! {
+                result = &mut durable => result,
+                _ = context.sleep(Duration::from_secs(1)) => panic!("barrier hid a completed sync failure"),
+            };
+            let panic = result.expect_err("sync failure must panic, even after shutdown");
+            let message = panic.downcast_ref::<String>().expect("formatted panic");
+            assert!(message.contains(&format!(
+                "database sync failed (index {}, type {}):",
+                count - 1,
+                std::any::type_name::<TestDb>(),
+            )));
+            // Panic cleanup releases pending completion receivers before the outer future drops.
+            assert!(pending_tx.send(Ok(())).is_err());
+            drop(durable);
+        });
+    }
+
+    #[rstest::rstest]
+    #[case(1)]
+    #[case(30)]
+    #[case(31)]
+    #[case(64)]
+    fn barrier_waits_for_every_handle(#[case] count: usize, #[values(false, true)] shutdown: bool) {
+        deterministic::Runner::default().start(|context| async move {
+            let (pending_tx, pending_rx) = oneshot::channel();
+            let handles = std::iter::once(Handle::from_receiver(pending_rx))
+                .chain((1..count).map(|_| Handle::ready(Ok(()))));
+            let mut durable = Box::pin(Barrier::from_handles::<TestDb>(handles).durable());
+            assert!(durable.as_mut().now_or_never().is_none());
+            pending_tx
+                .send(if shutdown {
+                    Err(RuntimeError::Aborted)
+                } else {
+                    Ok(())
+                })
+                .unwrap();
+            let result = select! {
+                result = durable => result,
+                _ = context.sleep(Duration::from_secs(1)) => panic!("completed barrier stalled"),
+            };
+            assert_eq!(result, !shutdown);
+        });
+    }
+
+    #[rstest::rstest]
+    #[case(1)]
+    #[case(31)]
+    #[case(64)]
+    fn barrier_cancellation_releases_handles(
+        #[case] count: usize,
+        #[values(false, true)] poll: bool,
+    ) {
+        deterministic::Runner::default().start(|_context| async move {
+            let (senders, handles): (Vec<_>, Vec<_>) = (0..count)
+                .map(|_| {
+                    let (sender, receiver) = oneshot::channel();
+                    (sender, Handle::from_receiver(receiver))
+                })
+                .unzip();
+            let mut durable = Box::pin(Barrier::from_handles::<TestDb>(handles).durable());
+            if poll {
+                assert!(durable.as_mut().now_or_never().is_none());
+            }
+            drop(durable);
+            for sender in senders {
+                assert!(sender.send(Ok(())).is_err());
+            }
+        });
+    }
+
+    #[test]
+    fn barrier_empty_is_durable() {
+        deterministic::Runner::default().start(|_context| async move {
+            assert!(Barrier::from_handles::<TestDb>([]).durable().await);
         });
     }
 

--- a/glue/src/stateful/db/mod.rs
+++ b/glue/src/stateful/db/mod.rs
@@ -86,13 +86,12 @@ use commonware_runtime::{Error as RuntimeError, Handle, Metrics, Spawner, resche
 use commonware_storage::qmdb::sync::{self, FeedbackTx, Request, Response, Source};
 use commonware_utils::{
     channel::{fallible::AsyncFallibleExt, mpsc, oneshot, ring},
+    futures::try_join_all,
     sync::{AsyncRwLockReadGuard, AsyncRwLockWriteGuard, TracedAsyncRwLock},
 };
 use futures::{
-    StreamExt as _,
     future::{Either, pending},
     join,
-    stream::FuturesUnordered,
 };
 use std::{
     collections::BTreeMap,
@@ -485,27 +484,27 @@ impl Barrier {
     /// non-durable state. Returns `false` only when runtime shutdown aborts
     /// or closes a sync handle.
     pub async fn durable(self) -> bool {
-        let mut syncs = self
+        let syncs = self
             .syncs
             .into_iter()
-            .map(|(db_type, index, handle)| async move { (db_type, index, handle.await) })
-            .collect::<FuturesUnordered<_>>();
+            .map(|(db_type, index, handle)| async move {
+                match handle.await {
+                    Ok(()) => Ok(true),
+                    Err(RuntimeError::Closed | RuntimeError::Aborted) => {
+                        debug!(db_type, "runtime shutdown before database sync completed");
+                        Ok(false)
+                    }
+                    Err(err) => Err((db_type, index, err)),
+                }
+            });
 
-        let mut durable = true;
-        while let Some((db_type, index, result)) = syncs.next().await {
-            match result {
-                Ok(()) => {}
-                Err(RuntimeError::Closed | RuntimeError::Aborted) => {
-                    debug!(db_type, "runtime shutdown before database sync completed");
-                    durable = false;
-                }
-                Err(err) => {
-                    let index = index.map_or(String::new(), |i| format!("index {i}, "));
-                    panic!("database sync failed ({index}type {db_type}): {err}");
-                }
+        match try_join_all(syncs).await {
+            Ok(results) => results.into_iter().all(|durable| durable),
+            Err((db_type, index, err)) => {
+                let index = index.map_or(String::new(), |i| format!("index {i}, "));
+                panic!("database sync failed ({index}type {db_type}): {err}");
             }
         }
-        durable
     }
 }
 

--- a/storage/src/archive/benches/get.rs
+++ b/storage/src/archive/benches/get.rs
@@ -7,9 +7,8 @@ use commonware_runtime::{
     tokio::Config,
 };
 use commonware_storage::archive::{Archive as ArchiveTrait, Identifier};
-use commonware_utils::TestRng;
+use commonware_utils::{TestRng, futures::try_join_all};
 use criterion::{Criterion, criterion_group};
-use futures::future::try_join_all;
 use rand::RngExt as _;
 use std::{hint::black_box, time::Instant};
 

--- a/storage/src/freezer/benches/get.rs
+++ b/storage/src/freezer/benches/get.rs
@@ -5,9 +5,8 @@ use commonware_runtime::{
     tokio::Config,
 };
 use commonware_storage::freezer::Identifier;
-use commonware_utils::TestRng;
+use commonware_utils::{TestRng, futures::try_join_all};
 use criterion::{Criterion, criterion_group};
-use futures::future::try_join_all;
 use rand::RngExt as _;
 use std::{hint::black_box, time::Instant};
 

--- a/storage/src/journal/benches/fixed_read_random.rs
+++ b/storage/src/journal/benches/fixed_read_random.rs
@@ -5,9 +5,8 @@ use commonware_runtime::{
     tokio::{Config, Context, Runner},
 };
 use commonware_storage::journal::contiguous::{Contiguous as _, fixed::Journal};
-use commonware_utils::{NZU64, sequence::FixedBytes, test_rng};
+use commonware_utils::{NZU64, futures::try_join_all, sequence::FixedBytes, test_rng};
 use criterion::{Criterion, criterion_group};
-use futures::future::try_join_all;
 use rand::RngExt as _;
 use std::{
     hint::black_box,

--- a/storage/src/journal/benches/variable_read_random.rs
+++ b/storage/src/journal/benches/variable_read_random.rs
@@ -5,9 +5,8 @@ use commonware_runtime::{
     tokio::{Config, Context, Runner},
 };
 use commonware_storage::journal::contiguous::{Contiguous as _, variable::Journal};
-use commonware_utils::{NZU64, sequence::FixedBytes, test_rng};
+use commonware_utils::{NZU64, futures::try_join_all, sequence::FixedBytes, test_rng};
 use criterion::{Criterion, criterion_group};
-use futures::future::try_join_all;
 use rand::RngExt as _;
 use std::{
     hint::black_box,

--- a/storage/src/journal/contiguous/blobs.rs
+++ b/storage/src/journal/contiguous/blobs.rs
@@ -15,10 +15,7 @@ use commonware_runtime::{
     buffer::paged::{CacheRef, Replay as PagedReplay, Sealed, Writer},
     telemetry::metrics::{Counter, Gauge, GaugeExt as _, MetricsExt as _},
 };
-use futures::{
-    FutureExt as _,
-    future::{self, try_join_all},
-};
+use futures::{FutureExt as _, TryStreamExt as _, future, stream::FuturesUnordered};
 use std::{collections::BTreeMap, num::NonZeroUsize, sync::Arc};
 use tracing::debug;
 
@@ -192,7 +189,7 @@ impl<E: Context> Writable<E> {
         }
         let oldest = pending.keys().next().copied();
         let mut sealed = Vec::with_capacity(pending.len());
-        let mut syncs = Vec::with_capacity(pending.len());
+        let syncs = FuturesUnordered::new();
         let mut tail: Option<Writer<E::Blob>> = None;
         let mut expected = oldest;
         for (blob, writer) in pending {
@@ -210,7 +207,7 @@ impl<E: Context> Writable<E> {
                 sealed.push(sealed_blob);
             }
         }
-        try_join_all(syncs).await?;
+        syncs.try_collect::<()>().await?;
         let tail = match tail {
             Some(writer) => writer,
             None => partition.open(tail_blob).await?,

--- a/storage/src/journal/contiguous/blobs.rs
+++ b/storage/src/journal/contiguous/blobs.rs
@@ -15,7 +15,8 @@ use commonware_runtime::{
     buffer::paged::{CacheRef, Replay as PagedReplay, Sealed, Writer},
     telemetry::metrics::{Counter, Gauge, GaugeExt as _, MetricsExt as _},
 };
-use futures::{FutureExt as _, TryStreamExt as _, future, stream::FuturesUnordered};
+use commonware_utils::futures::try_join_all;
+use futures::{FutureExt as _, future};
 use std::{collections::BTreeMap, num::NonZeroUsize, sync::Arc};
 use tracing::debug;
 
@@ -189,7 +190,7 @@ impl<E: Context> Writable<E> {
         }
         let oldest = pending.keys().next().copied();
         let mut sealed = Vec::with_capacity(pending.len());
-        let syncs = FuturesUnordered::new();
+        let mut syncs = Vec::with_capacity(pending.len());
         let mut tail: Option<Writer<E::Blob>> = None;
         let mut expected = oldest;
         for (blob, writer) in pending {
@@ -207,7 +208,7 @@ impl<E: Context> Writable<E> {
                 sealed.push(sealed_blob);
             }
         }
-        syncs.try_collect::<()>().await?;
+        try_join_all(syncs).await?;
         let tail = match tail {
             Some(writer) => writer,
             None => partition.open(tail_blob).await?,

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -152,7 +152,7 @@ use commonware_runtime::{
     buffer::paged::{CacheRef, Writer},
 };
 use commonware_utils::Cached;
-use futures::{FutureExt as _, Stream, future::try_join_all};
+use futures::{FutureExt as _, Stream, TryStreamExt as _, future, stream::FuturesUnordered};
 use std::{
     collections::BTreeMap,
     future::Future,
@@ -1440,7 +1440,7 @@ impl<E: Context, A: CodecFixedShared> Reader<'_, E, A> {
 
         // The buffer is pre-sized for every position, so each group can own a disjoint slice and
         // all groups can read concurrently.
-        let mut reads = Vec::new();
+        let reads = FuturesUnordered::new();
         let mut remaining_buf = buf.as_mut_slice();
         for group in positions.chunk_by(|a, b| {
             super::position_to_blob(*a, items_per_blob)
@@ -1458,11 +1458,11 @@ impl<E: Context, A: CodecFixedShared> Reader<'_, E, A> {
                     .await
             });
         }
-        let hits: u64 = try_join_all(reads)
-            .await?
-            .into_iter()
-            .map(|group_hits| group_hits as u64)
-            .sum();
+        let hits = reads
+            .try_fold(0u64, |hits, group_hits| {
+                future::ready(Ok(hits + group_hits as u64))
+            })
+            .await?;
 
         let mut bytes = Bytes::from(buf);
         for _ in positions {

--- a/storage/src/journal/contiguous/fixed.rs
+++ b/storage/src/journal/contiguous/fixed.rs
@@ -151,8 +151,8 @@ use commonware_runtime::{
     Blob as RBlob, Buf, Handle, IoBuf, ReadOptions,
     buffer::paged::{CacheRef, Writer},
 };
-use commonware_utils::Cached;
-use futures::{FutureExt as _, Stream, TryStreamExt as _, future, stream::FuturesUnordered};
+use commonware_utils::{Cached, futures::try_join_all};
+use futures::{FutureExt as _, Stream};
 use std::{
     collections::BTreeMap,
     future::Future,
@@ -1440,7 +1440,7 @@ impl<E: Context, A: CodecFixedShared> Reader<'_, E, A> {
 
         // The buffer is pre-sized for every position, so each group can own a disjoint slice and
         // all groups can read concurrently.
-        let reads = FuturesUnordered::new();
+        let mut reads = Vec::new();
         let mut remaining_buf = buf.as_mut_slice();
         for group in positions.chunk_by(|a, b| {
             super::position_to_blob(*a, items_per_blob)
@@ -1458,11 +1458,11 @@ impl<E: Context, A: CodecFixedShared> Reader<'_, E, A> {
                     .await
             });
         }
-        let hits = reads
-            .try_fold(0u64, |hits, group_hits| {
-                future::ready(Ok(hits + group_hits as u64))
-            })
-            .await?;
+        let hits: u64 = try_join_all(reads)
+            .await?
+            .into_iter()
+            .map(|group_hits| group_hits as u64)
+            .sum();
 
         let mut bytes = Bytes::from(buf);
         for _ in positions {

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -39,8 +39,7 @@ use commonware_runtime::{
     buffer::paged::{CacheRef, Replay, Writer},
 };
 use futures::{
-    FutureExt as _, Stream,
-    future::{try_join, try_join_all},
+    FutureExt as _, Stream, TryStreamExt as _, future::try_join, stream::FuturesUnordered,
 };
 use std::{
     collections::BTreeMap,
@@ -724,11 +723,16 @@ impl<'a, E: Context, V: CodecShared> Reader<'a, E, V> {
             group_start = group_end;
         }
 
-        let run_items = try_join_all(runs.iter().map(|(run_start, run_end, blob, handle)| {
-            self.read_consecutive(handle, *blob, &miss_offsets[*run_start..*run_end])
-        }))
-        .await?;
-        for ((run_start, _, _, _), items) in runs.iter().zip(run_items) {
+        let mut reads = runs
+            .into_iter()
+            .map(|(run_start, run_end, blob, handle)| async move {
+                let items = self
+                    .read_consecutive(&handle, blob, &miss_offsets[run_start..run_end])
+                    .await?;
+                Ok::<_, Error>((run_start, items))
+            })
+            .collect::<FuturesUnordered<_>>();
+        while let Some((run_start, items)) = reads.try_next().await? {
             for (k, item) in items.into_iter().enumerate() {
                 let slot = miss_indices.map_or(run_start + k, |indices| indices[run_start + k]);
                 result[slot] = Some(item);
@@ -1955,12 +1959,12 @@ impl<E: Context, V: CodecShared> Inner<E, V> {
 
         let start_blob = position_to_blob(start_position, items_per_blob);
         let end_blob = position_to_blob(end_position - 1, items_per_blob);
-        futures::future::try_join_all(
-            pending
-                .range_mut(start_blob..=end_blob)
-                .map(|(_, writer)| writer.sync()),
-        )
-        .await?;
+        pending
+            .range_mut(start_blob..=end_blob)
+            .map(|(_, writer)| writer.sync())
+            .collect::<FuturesUnordered<_>>()
+            .try_collect::<()>()
+            .await?;
         Ok(())
     }
 

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -38,9 +38,8 @@ use commonware_runtime::{
     Blob as RBlob, Buf, Handle, IoBuf, ReadOptions,
     buffer::paged::{CacheRef, Replay, Writer},
 };
-use futures::{
-    FutureExt as _, Stream, TryStreamExt as _, future::try_join, stream::FuturesUnordered,
-};
+use commonware_utils::futures::try_join_all;
+use futures::{FutureExt as _, Stream, future::try_join};
 use std::{
     collections::BTreeMap,
     marker::PhantomData,
@@ -723,18 +722,11 @@ impl<'a, E: Context, V: CodecShared> Reader<'a, E, V> {
             group_start = group_end;
         }
 
-        // Avoid `try_join_all`: its ordered collector can hide errors behind pending reads.
-        // Restore completed runs to their requested slots without delaying error delivery.
-        let mut reads = runs
-            .into_iter()
-            .map(|(run_start, run_end, blob, handle)| async move {
-                let items = self
-                    .read_consecutive(&handle, blob, &miss_offsets[run_start..run_end])
-                    .await?;
-                Ok::<_, Error>((run_start, items))
-            })
-            .collect::<FuturesUnordered<_>>();
-        while let Some((run_start, items)) = reads.try_next().await? {
+        let run_items = try_join_all(runs.iter().map(|(run_start, run_end, blob, handle)| {
+            self.read_consecutive(handle, *blob, &miss_offsets[*run_start..*run_end])
+        }))
+        .await?;
+        for ((run_start, _, _, _), items) in runs.iter().zip(run_items) {
             for (k, item) in items.into_iter().enumerate() {
                 let slot = miss_indices.map_or(run_start + k, |indices| indices[run_start + k]);
                 result[slot] = Some(item);
@@ -1961,12 +1953,12 @@ impl<E: Context, V: CodecShared> Inner<E, V> {
 
         let start_blob = position_to_blob(start_position, items_per_blob);
         let end_blob = position_to_blob(end_position - 1, items_per_blob);
-        pending
-            .range_mut(start_blob..=end_blob)
-            .map(|(_, writer)| writer.sync())
-            .collect::<FuturesUnordered<_>>()
-            .try_collect::<()>()
-            .await?;
+        commonware_utils::futures::try_join_all(
+            pending
+                .range_mut(start_blob..=end_blob)
+                .map(|(_, writer)| writer.sync()),
+        )
+        .await?;
         Ok(())
     }
 

--- a/storage/src/journal/contiguous/variable.rs
+++ b/storage/src/journal/contiguous/variable.rs
@@ -723,6 +723,8 @@ impl<'a, E: Context, V: CodecShared> Reader<'a, E, V> {
             group_start = group_end;
         }
 
+        // Avoid `try_join_all`: its ordered collector can hide errors behind pending reads.
+        // Restore completed runs to their requested slots without delaying error delivery.
         let mut reads = runs
             .into_iter()
             .map(|(run_start, run_end, blob, handle)| async move {

--- a/storage/src/journal/segmented/manager.rs
+++ b/storage/src/journal/segmented/manager.rs
@@ -13,7 +13,7 @@ use commonware_runtime::{
     },
     telemetry::metrics::{Counter, Gauge, GaugeExt, MetricsExt as _},
 };
-use futures::future::{join_all, try_join_all};
+use futures::{TryStreamExt as _, future::join_all, stream::FuturesUnordered};
 use std::{
     collections::{BTreeMap, BTreeSet},
     future::Future,
@@ -209,9 +209,12 @@ impl<E: Storage + Metrics, F: BufferFactory<E::Blob>> Manager<E, F> {
     where
         F::Buffer: 'a,
     {
-        try_join_all(blobs.into_iter().map(|blob| blob.wait_for_sync()))
+        blobs
+            .into_iter()
+            .map(|blob| blob.wait_for_sync())
+            .collect::<FuturesUnordered<_>>()
+            .try_collect::<()>()
             .await
-            .map(|_| ())
             .map_err(Error::Runtime)
     }
 
@@ -293,14 +296,14 @@ impl<E: Storage + Metrics, F: BufferFactory<E::Blob>> Manager<E, F> {
         for &section in &sections {
             self.prune_guard(section)?;
         }
-        let futures: Vec<_> = self
+        let futures: FuturesUnordered<_> = self
             .blobs
             .iter_mut()
             .filter(|(section, _)| sections.contains(section))
             .map(|(_, blob)| blob.sync())
             .collect();
         let count = futures.len() as u64;
-        try_join_all(futures).await.map_err(Error::Runtime)?;
+        futures.try_collect::<()>().await.map_err(Error::Runtime)?;
         self.synced.inc_by(count);
         Ok(())
     }
@@ -335,14 +338,22 @@ impl<E: Storage + Metrics, F: BufferFactory<E::Blob>> Manager<E, F> {
         self.synced.inc_by(futures.len() as u64);
         let handles = join_all(futures).await;
         Ok(Handle::from_future(async move {
-            try_join_all(handles).await.map(|_| ())
+            handles
+                .into_iter()
+                .collect::<FuturesUnordered<_>>()
+                .try_collect::<()>()
+                .await
         }))
     }
 
     /// Sync all sections to storage.
     pub async fn sync_all(&mut self) -> Result<(), Error> {
         let count = self.blobs.len() as u64;
-        try_join_all(self.blobs.values_mut().map(|b| b.sync()))
+        self.blobs
+            .values_mut()
+            .map(|b| b.sync())
+            .collect::<FuturesUnordered<_>>()
+            .try_collect::<()>()
             .await
             .map_err(Error::Runtime)?;
         self.synced.inc_by(count);
@@ -548,7 +559,9 @@ impl<E: Storage + Metrics, F: BufferFactory<E::Blob>> Manager<E, F> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use commonware_runtime::{Runner as _, Spawner as _, Supervisor as _, deterministic};
+    use commonware_runtime::{
+        Clock as _, Runner as _, Spawner as _, Supervisor as _, deterministic,
+    };
     use commonware_utils::{channel::oneshot, sync::Mutex};
     use futures::{
         FutureExt as _,
@@ -650,6 +663,50 @@ mod tests {
             pending.remove(0)
         };
         let _ = sender.send(result);
+    }
+
+    #[rstest::rstest]
+    #[case(30)]
+    #[case(31)]
+    #[case(64)]
+    fn test_concurrent_sync_reports_later_error(
+        #[case] count: u64,
+        #[values(false, true)] clear: bool,
+    ) {
+        deterministic::Runner::default().start(|context| async move {
+            let pending = Arc::new(Mutex::new(Vec::new()));
+            let cfg = test_config(pending.clone(), Arc::new(AtomicUsize::new(0)));
+            let mut manager = Manager::init(context.child("manager"), cfg).await.unwrap();
+            for section in 0..count {
+                manager.get_or_create(section).await.unwrap();
+            }
+            let handle = manager
+                .start_sync((0..count).collect::<Vec<_>>())
+                .await
+                .unwrap();
+
+            // Leave the first sync pending while completing the last one with an error.
+            pending
+                .lock()
+                .pop()
+                .unwrap()
+                .send(Err(RError::Closed))
+                .unwrap();
+            let result = commonware_macros::select! {
+                result = async {
+                    if clear {
+                        drop(handle);
+                        manager.clear().await
+                    } else {
+                        handle.await.map_err(Error::Runtime)
+                    }
+                } => Some(result),
+                _ = context.sleep(std::time::Duration::from_secs(1)) => None,
+            };
+            assert!(matches!(result, Some(Err(Error::Runtime(RError::Closed)))));
+            // A mutable storage error is fatal; do not reuse the manager.
+            drop(manager);
+        });
     }
 
     #[test]

--- a/storage/src/journal/segmented/manager.rs
+++ b/storage/src/journal/segmented/manager.rs
@@ -13,7 +13,8 @@ use commonware_runtime::{
     },
     telemetry::metrics::{Counter, Gauge, GaugeExt, MetricsExt as _},
 };
-use futures::{TryStreamExt as _, future::join_all, stream::FuturesUnordered};
+use commonware_utils::futures::try_join_all;
+use futures::future::join_all;
 use std::{
     collections::{BTreeMap, BTreeSet},
     future::Future,
@@ -209,12 +210,9 @@ impl<E: Storage + Metrics, F: BufferFactory<E::Blob>> Manager<E, F> {
     where
         F::Buffer: 'a,
     {
-        blobs
-            .into_iter()
-            .map(|blob| blob.wait_for_sync())
-            .collect::<FuturesUnordered<_>>()
-            .try_collect::<()>()
+        try_join_all(blobs.into_iter().map(|blob| blob.wait_for_sync()))
             .await
+            .map(|_| ())
             .map_err(Error::Runtime)
     }
 
@@ -296,14 +294,14 @@ impl<E: Storage + Metrics, F: BufferFactory<E::Blob>> Manager<E, F> {
         for &section in &sections {
             self.prune_guard(section)?;
         }
-        let futures: FuturesUnordered<_> = self
+        let futures: Vec<_> = self
             .blobs
             .iter_mut()
             .filter(|(section, _)| sections.contains(section))
             .map(|(_, blob)| blob.sync())
             .collect();
         let count = futures.len() as u64;
-        futures.try_collect::<()>().await.map_err(Error::Runtime)?;
+        try_join_all(futures).await.map_err(Error::Runtime)?;
         self.synced.inc_by(count);
         Ok(())
     }
@@ -338,22 +336,14 @@ impl<E: Storage + Metrics, F: BufferFactory<E::Blob>> Manager<E, F> {
         self.synced.inc_by(futures.len() as u64);
         let handles = join_all(futures).await;
         Ok(Handle::from_future(async move {
-            handles
-                .into_iter()
-                .collect::<FuturesUnordered<_>>()
-                .try_collect::<()>()
-                .await
+            try_join_all(handles).await.map(|_| ())
         }))
     }
 
     /// Sync all sections to storage.
     pub async fn sync_all(&mut self) -> Result<(), Error> {
         let count = self.blobs.len() as u64;
-        self.blobs
-            .values_mut()
-            .map(|b| b.sync())
-            .collect::<FuturesUnordered<_>>()
-            .try_collect::<()>()
+        try_join_all(self.blobs.values_mut().map(|b| b.sync()))
             .await
             .map_err(Error::Runtime)?;
         self.synced.inc_by(count);

--- a/storage/src/merkle/persisted/full.rs
+++ b/storage/src/merkle/persisted/full.rs
@@ -34,7 +34,6 @@ use commonware_cryptography::Digest;
 use commonware_parallel::Strategy;
 use commonware_runtime::{Handle, buffer::paged::CacheRef};
 use commonware_utils::{range::NonEmptyRange, sequence::prefixed_u64::U64};
-use futures::{TryStreamExt as _, stream::FuturesUnordered};
 use std::{
     collections::{BTreeMap, BTreeSet},
     num::{NonZeroU64, NonZeroUsize},
@@ -696,20 +695,10 @@ impl<F: Family, E: Context, D: Digest, S: Strategy> Merkle<F, E, D, S> {
         if !loc.is_valid() {
             return Err(Error::LocationOverflow(loc));
         }
-        // Avoid `try_join_all`: its ordered collector can hide errors behind pending reads.
-        // Track indices to preserve the family's pinned-node order without delaying errors.
-        let mut reads = F::nodes_to_pin(loc)
-            .enumerate()
-            .map(|(index, p)| async move {
-                let node = self.get_node(p).await?.ok_or(Error::ElementPruned(p))?;
-                Ok::<_, Error<F>>((index, node))
-            })
-            .collect::<FuturesUnordered<_>>();
-        let mut nodes: Vec<_> = (0..reads.len()).map(|_| None).collect();
-        while let Some((index, node)) = reads.try_next().await? {
-            nodes[index] = Some(node);
-        }
-        Ok(nodes.into_iter().map(Option::unwrap).collect())
+        let futs = F::nodes_to_pin(loc)
+            .map(|p| async move { self.get_node(p).await?.ok_or(Error::ElementPruned(p)) })
+            .collect::<Vec<_>>();
+        commonware_utils::futures::try_join_all(futs).await
     }
 
     /// Flush all nodes cached in the in-memory structure to the journal without forcing them to

--- a/storage/src/merkle/persisted/full.rs
+++ b/storage/src/merkle/persisted/full.rs
@@ -696,7 +696,8 @@ impl<F: Family, E: Context, D: Digest, S: Strategy> Merkle<F, E, D, S> {
         if !loc.is_valid() {
             return Err(Error::LocationOverflow(loc));
         }
-        // Observe errors in completion order while keeping the family's pinned-node order.
+        // Avoid `try_join_all`: its ordered collector can hide errors behind pending reads.
+        // Track indices to preserve the family's pinned-node order without delaying errors.
         let mut reads = F::nodes_to_pin(loc)
             .enumerate()
             .map(|(index, p)| async move {

--- a/storage/src/merkle/persisted/full.rs
+++ b/storage/src/merkle/persisted/full.rs
@@ -34,6 +34,7 @@ use commonware_cryptography::Digest;
 use commonware_parallel::Strategy;
 use commonware_runtime::{Handle, buffer::paged::CacheRef};
 use commonware_utils::{range::NonEmptyRange, sequence::prefixed_u64::U64};
+use futures::{TryStreamExt as _, stream::FuturesUnordered};
 use std::{
     collections::{BTreeMap, BTreeSet},
     num::{NonZeroU64, NonZeroUsize},
@@ -695,10 +696,19 @@ impl<F: Family, E: Context, D: Digest, S: Strategy> Merkle<F, E, D, S> {
         if !loc.is_valid() {
             return Err(Error::LocationOverflow(loc));
         }
-        let futs = F::nodes_to_pin(loc)
-            .map(|p| async move { self.get_node(p).await?.ok_or(Error::ElementPruned(p)) })
-            .collect::<Vec<_>>();
-        futures::future::try_join_all(futs).await
+        // Observe errors in completion order while keeping the family's pinned-node order.
+        let mut reads = F::nodes_to_pin(loc)
+            .enumerate()
+            .map(|(index, p)| async move {
+                let node = self.get_node(p).await?.ok_or(Error::ElementPruned(p))?;
+                Ok::<_, Error<F>>((index, node))
+            })
+            .collect::<FuturesUnordered<_>>();
+        let mut nodes: Vec<_> = (0..reads.len()).map(|_| None).collect();
+        while let Some((index, node)) = reads.try_next().await? {
+            nodes[index] = Some(node);
+        }
+        Ok(nodes.into_iter().map(Option::unwrap).collect())
     }
 
     /// Flush all nodes cached in the in-memory structure to the journal without forcing them to

--- a/storage/src/metadata/storage.rs
+++ b/storage/src/metadata/storage.rs
@@ -7,7 +7,7 @@ use commonware_runtime::{
     telemetry::metrics::{Counter, Gauge, GaugeExt, MetricsExt as _},
 };
 use commonware_utils::Span;
-use futures::{FutureExt as _, future::try_join_all};
+use futures::{FutureExt as _, TryStreamExt as _, stream::FuturesUnordered};
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use tracing::{debug, warn};
 
@@ -465,7 +465,10 @@ impl<E: Context, K: Span, V: Codec> Inner<E, K, V> {
                         WriteOptions::DONT_CACHE,
                     ),
                 ]);
-            try_join_all(writes).await?;
+            writes
+                .collect::<FuturesUnordered<_>>()
+                .try_collect::<()>()
+                .await?;
             let sync = if pipelined {
                 Some(target.blob.start_sync().await)
             } else {

--- a/storage/src/metadata/storage.rs
+++ b/storage/src/metadata/storage.rs
@@ -6,8 +6,8 @@ use commonware_runtime::{
     Blob, BufMut, Error as RError, Handle, IoBufMut, ReadOptions, WriteOptions,
     telemetry::metrics::{Counter, Gauge, GaugeExt, MetricsExt as _},
 };
-use commonware_utils::Span;
-use futures::{FutureExt as _, TryStreamExt as _, stream::FuturesUnordered};
+use commonware_utils::{Span, futures::try_join_all};
+use futures::FutureExt as _;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use tracing::{debug, warn};
 
@@ -465,10 +465,7 @@ impl<E: Context, K: Span, V: Codec> Inner<E, K, V> {
                         WriteOptions::DONT_CACHE,
                     ),
                 ]);
-            writes
-                .collect::<FuturesUnordered<_>>()
-                .try_collect::<()>()
-                .await?;
+            try_join_all(writes).await?;
             let sync = if pipelined {
                 Some(target.blob.start_sync().await)
             } else {

--- a/storage/src/ordinal/storage.rs
+++ b/storage/src/ordinal/storage.rs
@@ -9,7 +9,7 @@ use commonware_runtime::{
     telemetry::metrics::{Counter, MetricsExt as _},
 };
 use commonware_utils::bitmap::BitMap;
-use futures::future::try_join_all;
+use futures::{TryStreamExt as _, stream::FuturesUnordered};
 use std::{
     collections::{BTreeMap, BTreeSet, btree_map::Entry},
     marker::PhantomData,
@@ -427,13 +427,13 @@ impl<E: Context, V: CodecFixed<Cfg = ()>> Inner<E, V> {
             return Ok(());
         }
 
-        let futures: Vec<_> = self
+        let futures: FuturesUnordered<_> = self
             .blobs
             .iter_mut()
             .filter(|(section, _)| self.pending.contains(section))
             .map(|(_, blob)| blob.sync())
             .collect();
-        try_join_all(futures).await?;
+        futures.try_collect::<()>().await?;
 
         // Clear pending sections.
         self.pending.clear();

--- a/storage/src/ordinal/storage.rs
+++ b/storage/src/ordinal/storage.rs
@@ -8,8 +8,7 @@ use commonware_runtime::{
     buffer::{Read as ReadBuffer, Write},
     telemetry::metrics::{Counter, MetricsExt as _},
 };
-use commonware_utils::bitmap::BitMap;
-use futures::{TryStreamExt as _, stream::FuturesUnordered};
+use commonware_utils::{bitmap::BitMap, futures::try_join_all};
 use std::{
     collections::{BTreeMap, BTreeSet, btree_map::Entry},
     marker::PhantomData,
@@ -427,13 +426,13 @@ impl<E: Context, V: CodecFixed<Cfg = ()>> Inner<E, V> {
             return Ok(());
         }
 
-        let futures: FuturesUnordered<_> = self
+        let futures: Vec<_> = self
             .blobs
             .iter_mut()
             .filter(|(section, _)| self.pending.contains(section))
             .map(|(_, blob)| blob.sync())
             .collect();
-        futures.try_collect::<()>().await?;
+        try_join_all(futures).await?;
 
         // Clear pending sections.
         self.pending.clear();

--- a/storage/src/qmdb/any/ordered/concurrency_tests.rs
+++ b/storage/src/qmdb/any/ordered/concurrency_tests.rs
@@ -1,0 +1,310 @@
+use super::*;
+use crate::{
+    index::ordered::Index as OrderedIndex,
+    journal::{Error as JournalError, authenticated, contiguous::fixed::Journal},
+    merkle::{conformance::build_test_mem, mem::Mem},
+    mmr,
+    qmdb::{
+        any::BITMAP_CHUNK_BYTES,
+        current::proof::{RangeProof, RangeProofSpec},
+    },
+    translator::TwoCap,
+};
+use commonware_cryptography::{Sha256, sha256::Digest};
+use commonware_parallel::Sequential;
+use commonware_runtime::{Clock as _, ReadOptions, Runner as _, Supervisor as _, deterministic};
+use commonware_utils::{bitmap::Prunable, channel::oneshot, sync::Mutex};
+use futures::future::pending;
+use std::{
+    num::{NonZeroU64, NonZeroUsize},
+    ops::Range,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::Duration,
+};
+
+#[derive(Clone, Copy, Debug)]
+enum Mode {
+    Error,
+    Cancel,
+    Reorder,
+}
+
+#[derive(Default)]
+struct State {
+    release: Mutex<Option<oneshot::Receiver<()>>>,
+    releaser: Mutex<Option<oneshot::Sender<()>>>,
+    completed: Mutex<Vec<u64>>,
+    blocked_started: AtomicBool,
+    blocked_dropped: AtomicBool,
+    error_seen: AtomicBool,
+}
+
+struct PendingGuard(Arc<State>);
+
+impl Drop for PendingGuard {
+    fn drop(&mut self) {
+        self.0.blocked_dropped.store(true, Ordering::SeqCst);
+    }
+}
+
+struct Controlled<C> {
+    inner: C,
+    mode: Mode,
+    blocked: u64,
+    failed: u64,
+    state: Arc<State>,
+}
+
+impl<C: Contiguous> Contiguous for Controlled<C> {
+    type Item = C::Item;
+
+    fn bounds(&self) -> Range<u64> {
+        self.inner.bounds()
+    }
+
+    async fn read(&self, position: u64) -> Result<Self::Item, JournalError> {
+        if position == self.blocked {
+            let _guard = PendingGuard(self.state.clone());
+            self.state.blocked_started.store(true, Ordering::SeqCst);
+            if matches!(self.mode, Mode::Reorder) {
+                let release = self.state.release.lock().take().unwrap();
+                release.await.unwrap();
+            } else {
+                pending::<()>().await;
+            }
+        }
+        if position == self.failed && matches!(self.mode, Mode::Error) {
+            self.state.error_seen.store(true, Ordering::SeqCst);
+            return Err(JournalError::Runtime(commonware_runtime::Error::ReadFailed));
+        }
+        let item = self.inner.read(position).await?;
+        self.state.completed.lock().push(position);
+        if position == self.failed && matches!(self.mode, Mode::Reorder) {
+            self.state.releaser.lock().take().unwrap().send(()).unwrap();
+        }
+        Ok(item)
+    }
+
+    async fn read_many(&self, positions: &[u64]) -> Result<Vec<Self::Item>, JournalError> {
+        self.inner.read_many(positions).await
+    }
+
+    fn try_read_sync(&self, position: u64) -> Option<Self::Item> {
+        self.inner.try_read_sync(position)
+    }
+
+    fn try_read_many_sync(&self, positions: &[u64]) -> Vec<Option<Self::Item>> {
+        self.inner.try_read_many_sync(positions)
+    }
+
+    async fn replay(
+        &self,
+        start_pos: u64,
+        buffer: NonZeroUsize,
+        read_options: ReadOptions,
+    ) -> Result<impl Stream<Item = Result<(u64, Self::Item), JournalError>> + Send, JournalError>
+    {
+        self.inner.replay(start_pos, buffer, read_options).await
+    }
+}
+
+type ControlledDb = Db<
+    mmr::Family,
+    deterministic::Context,
+    Controlled<Journal<deterministic::Context, fixed::Operation<mmr::Family, Digest, Digest>>>,
+    OrderedIndex<TwoCap, Location<mmr::Family>>,
+    Sha256,
+    fixed::Update<Digest, Digest>,
+    BITMAP_CHUNK_BYTES,
+    Sequential,
+>;
+
+async fn make_db(
+    context: deterministic::Context,
+    count: usize,
+    mode: Mode,
+) -> (ControlledDb, Vec<Location<mmr::Family>>, Arc<State>) {
+    let db = fixed::test::create_test_db(context).await;
+    let keys: Vec<_> = (0..count)
+        .map(|i| {
+            let mut key = [0u8; 32];
+            key[31] = i as u8;
+            Digest::from(key)
+        })
+        .collect();
+    let mut batch = db.new_batch();
+    for key in &keys {
+        batch = batch.write(*key, Some(Sha256::fill(7)));
+    }
+    let batch = batch.merkleize(&db, None).await.unwrap();
+    let (db, _) = db.apply_batch(batch).await.unwrap();
+    let mut locs = Vec::new();
+    for key in &keys {
+        locs.push(db.get_with_loc(key).await.unwrap().unwrap().1);
+    }
+    locs.sort();
+
+    let (releaser, release) = oneshot::channel();
+    let state = Arc::new(State {
+        release: Mutex::new(Some(release)),
+        releaser: Mutex::new(Some(releaser)),
+        ..State::default()
+    });
+    let Db {
+        log,
+        root,
+        inactivity_floor_loc,
+        snapshot,
+        active_keys,
+        bitmap,
+        metrics,
+        _update,
+    } = db;
+    let authenticated::Journal {
+        merkle,
+        journal,
+        hasher,
+    } = log;
+    let log = authenticated::Journal {
+        merkle,
+        journal: Controlled {
+            inner: journal,
+            mode,
+            blocked: *locs[0],
+            failed: *locs[1],
+            state: state.clone(),
+        },
+        hasher,
+    };
+    (
+        Db {
+            log,
+            root,
+            inactivity_floor_loc,
+            snapshot,
+            active_keys,
+            bitmap,
+            metrics,
+            _update,
+        },
+        locs,
+        state,
+    )
+}
+
+/// Check error cleanup before dropping the completed outer future, and cancellation cleanup
+/// after dropping a still-pending one. Reordered reads must complete the second read first.
+fn check_completion<T>(
+    result: Option<Result<T, crate::qmdb::Error<mmr::Family>>>,
+    state: &State,
+    mode: Mode,
+    locs: &[Location<mmr::Family>],
+) -> Option<T> {
+    assert!(state.blocked_started.load(Ordering::SeqCst));
+    match mode {
+        Mode::Error => {
+            assert!(state.error_seen.load(Ordering::SeqCst));
+            assert!(
+                matches!(
+                    result,
+                    Some(Err(crate::qmdb::Error::Journal(JournalError::Runtime(
+                        commonware_runtime::Error::ReadFailed
+                    ))))
+                ),
+                "completed error hidden behind a pending read"
+            );
+            assert!(state.blocked_dropped.load(Ordering::SeqCst));
+            None
+        }
+        Mode::Cancel => {
+            assert!(result.is_none());
+            assert!(!state.blocked_dropped.load(Ordering::SeqCst));
+            None
+        }
+        Mode::Reorder => {
+            let completed = state.completed.lock();
+            let first = completed.iter().position(|loc| *loc == *locs[0]).unwrap();
+            let second = completed.iter().position(|loc| *loc == *locs[1]).unwrap();
+            assert!(second < first);
+            Some(result.expect("reads did not finish").expect("reads failed"))
+        }
+    }
+}
+
+#[rstest::rstest]
+#[case(30)]
+#[case(31)]
+#[case(64)]
+fn test_ordered_concurrent_reads(
+    #[case] count: usize,
+    #[values(Mode::Error, Mode::Cancel, Mode::Reorder)] mode: Mode,
+) {
+    deterministic::Runner::default().start(|context| async move {
+        let (db, locs, state) = make_db(context.child("db"), count, mode).await;
+        let mut read = Box::pin(db.fetch_all_updates(locs.iter()));
+        let result = commonware_macros::select! {
+            result = &mut read => Some(result),
+            _ = context.sleep(Duration::from_secs(1)) => None,
+        };
+        let updates = check_completion(result, &state, mode, &locs);
+        drop(read);
+        assert!(state.blocked_dropped.load(Ordering::SeqCst));
+        if let Some(updates) = updates {
+            let keys: Vec<_> = updates
+                .iter()
+                .map(|update| update.key.as_ref()[31])
+                .collect();
+            assert_eq!(keys, (0..count as u8).rev().collect::<Vec<_>>());
+        }
+    });
+}
+
+#[rstest::rstest]
+#[case(30)]
+#[case(31)]
+#[case(64)]
+fn test_range_concurrent_reads(
+    #[case] count: usize,
+    #[values(Mode::Error, Mode::Cancel, Mode::Reorder)] mode: Mode,
+) {
+    deterministic::Runner::default().start(|context| async move {
+        let (db, locs, state) = make_db(context.child("db"), count, mode).await;
+        const N: usize = 64;
+        let leaf_count = db.log.bounds().end;
+        let mut status = Prunable::<N>::new();
+        for _ in 0..leaf_count {
+            status.push(true);
+        }
+        let hasher = crate::qmdb::hasher::<Sha256>();
+        let ops = build_test_mem(&hasher, Mem::<mmr::Family, Digest>::new(), leaf_count);
+        let ops_root = ops.root(&hasher, 0).unwrap();
+        let mut read = Box::pin(RangeProof::new_with_ops::<Sha256, _, _, N>(
+            &status,
+            &ops,
+            &db.log,
+            RangeProofSpec {
+                start_loc: locs[0],
+                max_ops: NonZeroU64::new(count as u64).unwrap(),
+                inactivity_floor: Location::new(0),
+                ops_root,
+            },
+        ));
+        let result = commonware_macros::select! {
+            result = &mut read => Some(result),
+            _ = context.sleep(Duration::from_secs(1)) => None,
+        };
+        let result = check_completion(result, &state, mode, &locs);
+        drop(read);
+        assert!(state.blocked_dropped.load(Ordering::SeqCst));
+        if let Some((_, operations, _)) = result {
+            let mut expected = Vec::new();
+            for loc in *locs[0]..*locs[0] + count as u64 {
+                expected.push(db.log.journal.inner.read(loc).await.unwrap());
+            }
+            assert_eq!(operations, expected);
+        }
+    });
+}

--- a/storage/src/qmdb/any/ordered/mod.rs
+++ b/storage/src/qmdb/any/ordered/mod.rs
@@ -12,12 +12,15 @@ use commonware_codec::Codec;
 use commonware_cryptography::Hasher;
 use commonware_parallel::Strategy;
 use futures::{
-    future::try_join_all,
-    stream::{self, Stream},
+    TryStreamExt as _,
+    stream::{self, FuturesUnordered, Stream},
 };
 
 pub mod fixed;
 pub mod variable;
+
+#[cfg(test)]
+mod concurrency_tests;
 
 pub use crate::qmdb::any::operation::{Ordered as Operation, update::Ordered as Update};
 
@@ -197,7 +200,10 @@ where
         let futures = locs
             .into_iter()
             .map(|loc| Self::get_update_op(&self.log, *loc));
-        let mut updates = try_join_all(futures).await?;
+        let mut updates: Vec<_> = futures
+            .collect::<FuturesUnordered<_>>()
+            .try_collect()
+            .await?;
         updates.sort_by(|a, b| b.key.cmp(&a.key));
 
         Ok(updates)

--- a/storage/src/qmdb/any/ordered/mod.rs
+++ b/storage/src/qmdb/any/ordered/mod.rs
@@ -11,10 +11,8 @@ use crate::{
 use commonware_codec::Codec;
 use commonware_cryptography::Hasher;
 use commonware_parallel::Strategy;
-use futures::{
-    TryStreamExt as _,
-    stream::{self, FuturesUnordered, Stream},
-};
+use commonware_utils::futures::try_join_all;
+use futures::stream::{self, Stream};
 
 pub mod fixed;
 pub mod variable;
@@ -200,10 +198,7 @@ where
         let futures = locs
             .into_iter()
             .map(|loc| Self::get_update_op(&self.log, *loc));
-        let mut updates: Vec<_> = futures
-            .collect::<FuturesUnordered<_>>()
-            .try_collect()
-            .await?;
+        let mut updates = try_join_all(futures).await?;
         updates.sort_by(|a, b| b.key.cmp(&a.key));
 
         Ok(updates)

--- a/storage/src/qmdb/current/proof/mod.rs
+++ b/storage/src/qmdb/current/proof/mod.rs
@@ -47,7 +47,7 @@ use commonware_codec::{Buf, Codec, EncodeSize, Read, ReadExt as _, Write, varint
 use commonware_cryptography::{Digest, Hasher};
 use commonware_utils::bitmap::{Prunable as BitMap, Readable as BitmapReadable};
 use core::{num::NonZeroU64, ops::Range};
-use futures::future::try_join_all;
+use futures::{TryStreamExt as _, stream::FuturesUnordered};
 use tracing::debug;
 
 pub mod operation;
@@ -339,11 +339,16 @@ impl<F: Graftable, D: Digest> RangeProof<F, D> {
         )
         .await?;
 
-        // Collect the operations necessary to verify the proof.
+        // Observe errors in completion order while keeping operations in location order.
         let futures = (*request.start_loc..*end_loc)
-            .map(|i| log.read(i))
-            .collect::<Vec<_>>();
-        let ops = try_join_all(futures).await?;
+            .enumerate()
+            .map(|(index, loc)| async move { log.read(loc).await.map(|op| (index, op)) });
+        let mut reads = futures.collect::<FuturesUnordered<_>>();
+        let mut ops: Vec<_> = (0..reads.len()).map(|_| None).collect();
+        while let Some((index, op)) = reads.try_next().await? {
+            ops[index] = Some(op);
+        }
+        let ops = ops.into_iter().map(Option::unwrap).collect();
 
         // Gather the chunks necessary to verify the proof.
         let end = (*end_loc - 1) / chunk_bits; // chunk that contains the last bit

--- a/storage/src/qmdb/current/proof/mod.rs
+++ b/storage/src/qmdb/current/proof/mod.rs
@@ -45,9 +45,11 @@ use crate::{
 use bytes::BufMut;
 use commonware_codec::{Buf, Codec, EncodeSize, Read, ReadExt as _, Write, varint::UInt};
 use commonware_cryptography::{Digest, Hasher};
-use commonware_utils::bitmap::{Prunable as BitMap, Readable as BitmapReadable};
+use commonware_utils::{
+    bitmap::{Prunable as BitMap, Readable as BitmapReadable},
+    futures::try_join_all,
+};
 use core::{num::NonZeroU64, ops::Range};
-use futures::{TryStreamExt as _, stream::FuturesUnordered};
 use tracing::debug;
 
 pub mod operation;
@@ -339,17 +341,11 @@ impl<F: Graftable, D: Digest> RangeProof<F, D> {
         )
         .await?;
 
-        // Avoid `try_join_all`: its ordered collector can hide errors behind pending reads.
-        // Track indices to preserve location order without delaying error delivery.
+        // Collect the operations necessary to verify the proof.
         let futures = (*request.start_loc..*end_loc)
-            .enumerate()
-            .map(|(index, loc)| async move { log.read(loc).await.map(|op| (index, op)) });
-        let mut reads = futures.collect::<FuturesUnordered<_>>();
-        let mut ops: Vec<_> = (0..reads.len()).map(|_| None).collect();
-        while let Some((index, op)) = reads.try_next().await? {
-            ops[index] = Some(op);
-        }
-        let ops = ops.into_iter().map(Option::unwrap).collect();
+            .map(|i| log.read(i))
+            .collect::<Vec<_>>();
+        let ops = try_join_all(futures).await?;
 
         // Gather the chunks necessary to verify the proof.
         let end = (*end_loc - 1) / chunk_bits; // chunk that contains the last bit

--- a/storage/src/qmdb/current/proof/mod.rs
+++ b/storage/src/qmdb/current/proof/mod.rs
@@ -339,7 +339,8 @@ impl<F: Graftable, D: Digest> RangeProof<F, D> {
         )
         .await?;
 
-        // Observe errors in completion order while keeping operations in location order.
+        // Avoid `try_join_all`: its ordered collector can hide errors behind pending reads.
+        // Track indices to preserve location order without delaying error delivery.
         let futures = (*request.start_loc..*end_loc)
             .enumerate()
             .map(|(index, loc)| async move { log.read(loc).await.map(|op| (index, op)) });

--- a/utils/src/futures.rs
+++ b/utils/src/futures.rs
@@ -9,6 +9,9 @@ use futures::{
 use pin_project::pin_project;
 use std::{collections::BTreeMap, future::Future, pin::Pin, task::Poll};
 
+mod try_join_all;
+pub use try_join_all::try_join_all;
+
 /// A future type that can be used in [Pool].
 type PooledFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 

--- a/utils/src/futures/try_join_all.rs
+++ b/utils/src/futures/try_join_all.rs
@@ -1,0 +1,306 @@
+//! Concurrent collection with ordered results and prompt error propagation.
+
+use futures::{StreamExt as _, stream::FuturesUnordered};
+use std::future::Future;
+
+/// Runs futures concurrently, returning successful values in input order.
+///
+/// Consumes the iterator immediately and polls its futures when the returned future is polled.
+/// The first observed error is returned without waiting for earlier futures. Pending futures
+/// and collected successful values are dropped before returning the error.
+///
+/// Successful values are retained until the batch finishes. Futures must not depend on those
+/// values being released while the batch is pending.
+///
+/// # Cancellation
+///
+/// Dropping the returned future drops all remaining futures and collected values. Dropping a
+/// future that observes separately spawned work does not necessarily cancel that work.
+///
+/// # Examples
+///
+/// ```
+/// use commonware_utils::futures::try_join_all;
+/// use futures::{executor::block_on, future::ready};
+///
+/// let values = block_on(try_join_all([ready(Ok::<_, ()>(1)), ready(Ok(2))]));
+/// assert_eq!(values, Ok(vec![1, 2]));
+/// ```
+pub fn try_join_all<F, T, E>(
+    futures: impl IntoIterator<Item = F>,
+) -> impl Future<Output = Result<Vec<T>, E>>
+where
+    F: Future<Output = Result<T, E>>,
+{
+    // The upstream ordered collector delays errors behind earlier pending futures:
+    // https://github.com/rust-lang/futures-rs/issues/2866
+    let futures = futures
+        .into_iter()
+        .enumerate()
+        .map(|(index, future)| async move { future.await.map(|value| (index, value)) })
+        .collect::<FuturesUnordered<_>>();
+    async move {
+        let mut futures = futures;
+        let mut values: Vec<_> = (0..futures.len()).map(|_| None).collect();
+        while let Some(result) = futures.next().await {
+            let (index, value) = result?;
+            values[index] = Some(value);
+        }
+        Ok(values.into_iter().map(Option::unwrap).collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::channel::oneshot;
+    use futures::{
+        FutureExt as _,
+        future::{Either, ready},
+        task::{ArcWake, waker},
+    };
+    use pin_project::pin_project;
+    use std::{
+        pin::Pin,
+        rc::Rc,
+        sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        },
+        task::{Context, Poll},
+    };
+
+    #[derive(Debug)]
+    struct CountDrop(Arc<AtomicUsize>);
+
+    impl Drop for CountDrop {
+        fn drop(&mut self) {
+            self.0.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    #[pin_project]
+    struct Watch<F, D> {
+        #[pin]
+        future: F,
+        _on_drop: D,
+    }
+
+    impl<F: Future, D> Future for Watch<F, D> {
+        type Output = F::Output;
+
+        fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+            self.project().future.poll(cx)
+        }
+    }
+
+    struct WithHint<I> {
+        inner: I,
+        known: bool,
+    }
+
+    impl<I: Iterator> Iterator for WithHint<I> {
+        type Item = I::Item;
+
+        fn next(&mut self) -> Option<Self::Item> {
+            self.inner.next()
+        }
+
+        fn size_hint(&self) -> (usize, Option<usize>) {
+            if self.known {
+                self.inner.size_hint()
+            } else {
+                (0, None)
+            }
+        }
+    }
+
+    #[rstest::rstest]
+    #[case(0)]
+    #[case(1)]
+    #[case(30)]
+    #[case(31)]
+    #[case(64)]
+    fn preserves_order(#[case] count: usize) {
+        let (senders, futures): (Vec<_>, Vec<_>) = (0..count)
+            .map(|_| oneshot::channel::<Result<usize, ()>>())
+            .map(|(sender, receiver)| (sender, async move { receiver.await.unwrap() }))
+            .unzip();
+        let mut joined = Box::pin(try_join_all(futures));
+        for (index, sender) in senders.into_iter().enumerate().rev() {
+            assert!(joined.as_mut().now_or_never().is_none());
+            sender.send(Ok(index)).unwrap();
+        }
+        assert_eq!(
+            joined.as_mut().now_or_never(),
+            Some(Ok((0..count).collect()))
+        );
+    }
+
+    #[rstest::rstest]
+    #[case(2)]
+    #[case(30)]
+    #[case(31)]
+    #[case(64)]
+    fn later_error_drops_futures_and_values(
+        #[case] count: usize,
+        #[values(false, true)] known: bool,
+    ) {
+        let future_drops = Arc::new(AtomicUsize::new(0));
+        let value_drops = Arc::new(AtomicUsize::new(0));
+        let (pending_tx, pending_rx) = oneshot::channel();
+        let mut pending_rx = Some(pending_rx);
+        let futures = (0..count).map(|index| Watch {
+            future: if index == 0 {
+                let receiver = pending_rx.take().unwrap();
+                Either::Left(async move { receiver.await.unwrap() })
+            } else {
+                Either::Right(ready(if index == count - 1 {
+                    Err("failed")
+                } else {
+                    Ok(CountDrop(value_drops.clone()))
+                }))
+            },
+            _on_drop: CountDrop(future_drops.clone()),
+        });
+        let mut joined = Box::pin(try_join_all(WithHint {
+            inner: futures,
+            known,
+        }));
+        assert!(matches!(
+            joined.as_mut().now_or_never(),
+            Some(Err("failed"))
+        ));
+        assert_eq!(future_drops.load(Ordering::SeqCst), count);
+        assert_eq!(value_drops.load(Ordering::SeqCst), count - 2);
+        assert!(pending_tx.send(Err("cancelled")).is_err());
+        drop(joined);
+    }
+
+    #[rstest::rstest]
+    #[case(1)]
+    #[case(31)]
+    #[case(64)]
+    fn cancellation_drops_futures_and_values(
+        #[case] count: usize,
+        #[values(false, true)] poll: bool,
+    ) {
+        let future_drops = Arc::new(AtomicUsize::new(0));
+        let value_drops = Arc::new(AtomicUsize::new(0));
+        let (mut senders, futures): (Vec<_>, Vec<_>) = (0..count)
+            .map(|_| {
+                let (sender, receiver) = oneshot::channel::<Result<CountDrop, ()>>();
+                (
+                    sender,
+                    Watch {
+                        future: async move { receiver.await.unwrap() },
+                        _on_drop: CountDrop(future_drops.clone()),
+                    },
+                )
+            })
+            .unzip();
+        let mut joined = Box::pin(try_join_all(futures));
+        let completed = if poll { count / 2 } else { 0 };
+        for sender in senders.drain(..completed) {
+            sender.send(Ok(CountDrop(value_drops.clone()))).unwrap();
+        }
+        if poll {
+            assert!(joined.as_mut().now_or_never().is_none());
+            assert_eq!(future_drops.load(Ordering::SeqCst), completed);
+            assert_eq!(value_drops.load(Ordering::SeqCst), 0);
+        }
+        drop(joined);
+        assert_eq!(future_drops.load(Ordering::SeqCst), count);
+        assert_eq!(value_drops.load(Ordering::SeqCst), completed);
+        for sender in senders {
+            assert!(sender.send(Err(())).is_err());
+        }
+    }
+
+    struct ReleaseOnDrop(Option<oneshot::Sender<()>>);
+
+    impl Drop for ReleaseOnDrop {
+        fn drop(&mut self) {
+            if let Some(sender) = self.0.take() {
+                sender.send(()).unwrap();
+            }
+        }
+    }
+
+    #[rstest::rstest]
+    #[case(2)]
+    #[case(31)]
+    #[case(64)]
+    fn completed_future_drop_unblocks_another(#[case] count: usize) {
+        let (sender, receiver) = oneshot::channel();
+        let mut sender = Some(sender);
+        let mut receiver = Some(receiver);
+        let futures = (0..count).map(|index| Watch {
+            future: if index == 0 {
+                let receiver = receiver.take().unwrap();
+                Either::Left(async move {
+                    receiver.await.unwrap();
+                    Ok::<_, ()>(index)
+                })
+            } else {
+                Either::Right(ready(Ok(index)))
+            },
+            _on_drop: ReleaseOnDrop(if index == 1 { sender.take() } else { None }),
+        });
+        let mut joined = Box::pin(try_join_all(futures));
+        // The first pass may yield after the release wakes the earlier future.
+        let result = joined
+            .as_mut()
+            .now_or_never()
+            .or_else(|| joined.as_mut().now_or_never());
+        assert_eq!(result, Some(Ok((0..count).collect())));
+    }
+
+    struct WakeCount(AtomicUsize);
+
+    impl ArcWake for WakeCount {
+        fn wake_by_ref(arc_self: &Arc<Self>) {
+            arc_self.0.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    #[rstest::rstest]
+    #[case(2)]
+    #[case(31)]
+    #[case(64)]
+    fn later_error_wakes_caller(#[case] count: usize) {
+        let (mut senders, receivers): (Vec<_>, Vec<_>) = (0..count)
+            .map(|_| oneshot::channel::<Result<(), &str>>())
+            .unzip();
+        let mut joined = Box::pin(try_join_all(
+            receivers
+                .into_iter()
+                .map(|receiver| async move { receiver.await.unwrap() }),
+        ));
+        let wakes = Arc::new(WakeCount(AtomicUsize::new(0)));
+        let waker = waker(wakes.clone());
+        let mut cx = Context::from_waker(&waker);
+        assert!(joined.as_mut().poll(&mut cx).is_pending());
+        wakes.0.store(0, Ordering::SeqCst);
+        senders.pop().unwrap().send(Err("failed")).unwrap();
+        assert!(wakes.0.load(Ordering::SeqCst) > 0);
+        assert_eq!(joined.as_mut().poll(&mut cx), Poll::Ready(Err("failed")));
+    }
+
+    #[test]
+    fn consumes_non_send_iterator_before_returning_send_future() {
+        fn assert_send(_: &impl Send) {}
+        let offset = Rc::new(7);
+        let futures = (0..2).map(move |index| ready(Ok::<_, ()>(index + *offset)));
+        let joined = try_join_all(futures);
+        assert_send(&joined);
+        assert_eq!(joined.now_or_never(), Some(Ok(vec![7, 8])));
+    }
+
+    #[test]
+    fn supports_borrowed_non_send_values() {
+        let values = [Rc::new(1), Rc::new(2)];
+        let joined = try_join_all(values.iter().map(|value| ready(Ok::<_, ()>(value))));
+        assert_eq!(joined.now_or_never(), Some(Ok(values.iter().collect())));
+    }
+}

--- a/utils/src/futures/try_join_all.rs
+++ b/utils/src/futures/try_join_all.rs
@@ -1,7 +1,29 @@
 //! Concurrent collection with ordered results and prompt error propagation.
 
-use futures::{StreamExt as _, stream::FuturesUnordered};
+use futures::{StreamExt as _, future::Either, stream::FuturesUnordered};
 use std::future::Future;
+
+/// Preserves the selected size bound across upstream's repeated size-hint queries.
+struct Bounded<I> {
+    inner: I,
+    lower: usize,
+    upper: usize,
+}
+
+impl<I: Iterator> Iterator for Bounded<I> {
+    type Item = I::Item;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let next = self.inner.next();
+        self.lower = self.lower.saturating_sub(1);
+        self.upper = self.upper.saturating_sub(1);
+        next
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.lower, Some(self.upper))
+    }
+}
 
 /// Runs futures concurrently, returning successful values in input order.
 ///
@@ -32,14 +54,23 @@ pub fn try_join_all<F, T, E>(
 where
     F: Future<Output = Result<T, E>>,
 {
+    let futures = futures.into_iter();
+    let (lower, upper) = futures.size_hint();
+    // Upstream's small collector handles errors promptly without per-future allocations.
+    if let Some(upper) = upper.filter(|&upper| upper <= 30) {
+        return Either::Left(futures::future::try_join_all(Bounded {
+            inner: futures,
+            lower,
+            upper,
+        }));
+    }
     // The upstream ordered collector delays errors behind earlier pending futures:
     // https://github.com/rust-lang/futures-rs/issues/2866
     let futures = futures
-        .into_iter()
         .enumerate()
         .map(|(index, future)| async move { future.await.map(|value| (index, value)) })
         .collect::<FuturesUnordered<_>>();
-    async move {
+    Either::Right(async move {
         let mut futures = futures;
         let mut values: Vec<_> = (0..futures.len()).map(|_| None).collect();
         while let Some(result) = futures.next().await {
@@ -47,7 +78,7 @@ where
             values[index] = Some(value);
         }
         Ok(values.into_iter().map(Option::unwrap).collect())
-    }
+    })
 }
 
 #[cfg(test)]
@@ -61,6 +92,7 @@ mod tests {
     };
     use pin_project::pin_project;
     use std::{
+        cell::Cell,
         pin::Pin,
         rc::Rc,
         sync::{
@@ -96,7 +128,8 @@ mod tests {
 
     struct WithHint<I> {
         inner: I,
-        known: bool,
+        known: Cell<bool>,
+        forget: bool,
     }
 
     impl<I: Iterator> Iterator for WithHint<I> {
@@ -107,7 +140,11 @@ mod tests {
         }
 
         fn size_hint(&self) -> (usize, Option<usize>) {
-            if self.known {
+            let known = self.known.get();
+            if self.forget {
+                self.known.set(false);
+            }
+            if known {
                 self.inner.size_hint()
             } else {
                 (0, None)
@@ -165,7 +202,8 @@ mod tests {
         });
         let mut joined = Box::pin(try_join_all(WithHint {
             inner: futures,
-            known,
+            known: Cell::new(known),
+            forget: false,
         }));
         assert!(matches!(
             joined.as_mut().now_or_never(),
@@ -302,5 +340,19 @@ mod tests {
         let values = [Rc::new(1), Rc::new(2)];
         let joined = try_join_all(values.iter().map(|value| ready(Ok::<_, ()>(value))));
         assert_eq!(joined.now_or_never(), Some(Ok(values.iter().collect())));
+    }
+
+    #[test]
+    fn size_hint_can_change() {
+        let futures = [
+            Either::Left(futures::future::pending::<Result<(), &str>>()),
+            Either::Right(ready(Err("failed"))),
+        ];
+        let joined = try_join_all(WithHint {
+            inner: futures.into_iter(),
+            known: Cell::new(true),
+            forget: true,
+        });
+        assert_eq!(joined.now_or_never(), Some(Err("failed")));
     }
 }

--- a/utils/src/futures/try_join_all.rs
+++ b/utils/src/futures/try_join_all.rs
@@ -85,6 +85,7 @@ where
     let (lower, upper) = futures.size_hint();
     // Upstream's small collector handles errors promptly without per-future allocations.
     if let Some(upper) = upper.filter(|&upper| upper <= 30) {
+        #[allow(clippy::disallowed_methods)]
         return Either::Left(futures::future::try_join_all(Bounded {
             inner: futures,
             lower,

--- a/utils/src/futures/try_join_all.rs
+++ b/utils/src/futures/try_join_all.rs
@@ -1,7 +1,34 @@
 //! Concurrent collection with ordered results and prompt error propagation.
 
 use futures::{StreamExt as _, future::Either, stream::FuturesUnordered};
-use std::future::Future;
+use pin_project::pin_project;
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+/// Attaches an index without an async block's extra storage for the inner future.
+#[pin_project]
+struct Indexed<F> {
+    #[pin]
+    future: F,
+    index: usize,
+}
+
+impl<F, T, E> Future for Indexed<F>
+where
+    F: Future<Output = Result<T, E>>,
+{
+    type Output = Result<(usize, T), E>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+        this.future
+            .poll(cx)
+            .map(|result| result.map(|value| (*this.index, value)))
+    }
+}
 
 /// Preserves the selected size bound across upstream's repeated size-hint queries.
 struct Bounded<I> {
@@ -68,7 +95,7 @@ where
     // https://github.com/rust-lang/futures-rs/issues/2866
     let futures = futures
         .enumerate()
-        .map(|(index, future)| async move { future.await.map(|value| (index, value)) })
+        .map(|(index, future)| Indexed { index, future })
         .collect::<FuturesUnordered<_>>();
     Either::Right(async move {
         let mut futures = futures;
@@ -90,16 +117,13 @@ mod tests {
         future::{Either, ready},
         task::{ArcWake, waker},
     };
-    use pin_project::pin_project;
     use std::{
         cell::Cell,
-        pin::Pin,
         rc::Rc,
         sync::{
             Arc,
             atomic::{AtomicUsize, Ordering},
         },
-        task::{Context, Poll},
     };
 
     #[derive(Debug)]


### PR DESCRIPTION
`futures::future::try_join_all` can indefinitely delay reporting a later error behind an earlier pending future for large or unknown-size batches ([upstream bug #2866](https://github.com/rust-lang/futures-rs/issues/2866)).

Add a shared `commonware_utils::futures::try_join_all` and migrate every repository caller. It preserves result order and propagates errors promptly, using upstream's small collector for known bounds of at most 30 futures and `FuturesUnordered` otherwise.

Validation: affected-crate tests, including cancellation, dependent futures, ordering, and changing size hints; stability and WASM checks passed. Existing lint failures were reproduced on the base.

Benchmarks: no clear regressions across 16 journal cases in both orders; single-future helper overhead remains about 30 ns.
