### PR TITLE
[runtime] simplify io_uring ownership and retirement

### DIFF
--- a/runtime/src/iouring/driver.rs
+++ b/runtime/src/iouring/driver.rs
@@ -136,15 +136,27 @@ impl Driver {
         })
     }
 
-    /// Accept an owned request into the FIFO without staging kernel work.
+    /// Accept an owned request without staging kernel work.
     ///
-    /// Deadline validation happens during service after the wheel has advanced.
-    pub fn admit(&mut self, request: Request, observer: Observer) -> WaiterId {
-        let timed = request.deadline().is_some();
+    /// Cached time can reject expired requests immediately. Service validates
+    /// remaining deadlines after the wheel has advanced.
+    pub fn admit(
+        &mut self,
+        request: Request,
+        observer: Observer,
+        now: Instant,
+        deferred: &mut Deferred,
+    ) -> WaiterId {
+        let deadline = request.deadline();
 
         // Transfer ownership once. Both queues below carry only this identity.
         let id = self.state.waiters.insert(request, observer);
-        if timed {
+        if let Some(deadline) = deadline {
+            if deadline <= now {
+                self.state.complete(id, Err(Error::Timeout), deferred);
+                return id;
+            }
+
             // A task poll may have taken long enough to leave the wheel behind.
             // Service refreshes it before assigning this deadline a tick.
             self.state.pending_deadlines.push_back(id);
@@ -721,9 +733,12 @@ pub mod tests {
         /// Queue an ordinary request whose result `collect` will consume automatically.
         fn admit(&mut self, request: Request, tag: u64) -> WaiterId {
             let waker = TaskWaker::from(Arc::new(Notify));
-            let id = self
-                .driver
-                .admit(request, Observer::Ordinary(Some(waker.clone())));
+            let id = self.driver.admit(
+                request,
+                Observer::Ordinary(Some(waker.clone())),
+                self.start,
+                &mut self.deferred,
+            );
             self.tracked.push((id, tag, waker));
             id
         }
@@ -906,11 +921,14 @@ pub mod tests {
         // Keep completed results in their slots while the sole operation slot
         // stays occupied. Their queue IDs must still count as stale.
         let mut results = Vec::new();
+        let deadline = harness.start + Duration::from_nanos(1);
         for _ in 0..65 {
             let (socket, _peer) = UnixStream::pair().unwrap();
             results.push(harness.driver.admit(
-                recv(socket, 1, Some(harness.start)),
+                recv(socket, 1, Some(deadline)),
                 Observer::Ordinary(None),
+                harness.start,
+                &mut harness.deferred,
             ));
         }
         harness.service();
@@ -925,8 +943,10 @@ pub mod tests {
         // even though its generation still matches a retained result.
         let (socket, _peer) = UnixStream::pair().unwrap();
         results.push(harness.driver.admit(
-            recv(socket, 1, Some(harness.start)),
+            recv(socket, 1, Some(deadline)),
             Observer::Ordinary(None),
+            harness.start,
+            &mut harness.deferred,
         ));
         harness.service();
 
@@ -1126,9 +1146,12 @@ pub mod tests {
         first_peer.write_all(b"a").unwrap();
 
         // Omit the observer waker so the harness leaves this result in Waiters.
-        let first = harness
-            .driver
-            .admit(recv(first, 1, None), Observer::Ordinary(None));
+        let first = harness.driver.admit(
+            recv(first, 1, None),
+            Observer::Ordinary(None),
+            harness.start,
+            &mut harness.deferred,
+        );
 
         let (second, mut second_peer) = UnixStream::pair().unwrap();
         second_peer.write_all(b"b").unwrap();
@@ -1154,10 +1177,11 @@ pub mod tests {
     fn test_expired_registration_never_stages() {
         let mut harness = Harness::new(1);
         let (left, _right) = UnixStream::pair().unwrap();
-        harness.admit(recv(left, 8, Some(harness.start)), 0);
+        let deadline = harness.start + Duration::from_nanos(1);
+        harness.admit(recv(left, 8, Some(deadline)), 0);
 
         // A deadline equal to this turn's time has already expired.
-        harness.service_at(harness.start, true);
+        harness.service_at(deadline, true);
 
         assert!(matches!(
             harness.completed[0].output,
@@ -1999,6 +2023,8 @@ pub mod tests {
         harness.driver.admit(
             Request::Sync(SyncRequest { file: held }),
             Observer::DetachedSync(sender),
+            harness.start,
+            &mut harness.deferred,
         );
 
         // Retained completion receivers do not participate in drain progress.

--- a/runtime/src/iouring/driver.rs
+++ b/runtime/src/iouring/driver.rs
@@ -29,9 +29,9 @@
 //! Queued requests expire even while all operation slots are occupied.
 //!
 //! The ring uses SINGLE_ISSUER and DEFER_TASKRUN, requiring Linux 6.1 or newer.
-//! Pending operation and cancellation SQEs need a GETEVENTS enter even when tasks
-//! keep the worker busy. An idle turn may defer that enter to [`Driver::park`].
-//! The mailbox wake poll alone requires no syscall on a busy turn.
+//! Unfinished requests need a GETEVENTS enter even when tasks keep the worker
+//! busy. An idle turn may defer that enter to [`Driver::park`]. Control SQEs carry
+//! no request resources and may remain until later I/O service or ring teardown.
 //!
 //! Parking installs the wake poll if needed, then arms the mailbox waker and
 //! rechecks publication before blocking. A wake CQE without MORE requires rearm
@@ -41,8 +41,8 @@
 //!
 //! All callbacks and resource destruction go through [`Deferred`], outside the
 //! worker borrow. Closure detaches ordinary observers and cancels eligible
-//! requests. The worker continues servicing until all requests and cancellation
-//! CQEs retire, keeping the driver in place throughout the drain.
+//! requests. The worker continues servicing until all requests retire, keeping
+//! the driver in place throughout the drain.
 
 use super::{
     request::Request,
@@ -71,14 +71,6 @@ use tracing::warn;
 /// Like the wake token, this uses the slot index reserved by [`Waiters::insert`].
 const CANCEL_USER_DATA: UserData = u32::MAX as UserData;
 
-/// Wake notification and kernel-service status from one driver turn.
-pub struct ServiceOutcome {
-    /// Whether a wake CQE requested an inbox check.
-    pub woke: bool,
-    /// Whether pending kernel work received no GETEVENTS service point this turn.
-    pub kernel_deferred: bool,
-}
-
 /// Ring and request state accessed exclusively by the owning worker.
 pub struct Driver {
     /// Declared first so ring destruction precedes descriptor and buffer release.
@@ -105,10 +97,6 @@ struct State {
     waker: Waker,
     /// Whether the multishot wake poll needs to be installed again.
     wake_rearm_needed: bool,
-    /// Cancellation SQEs staged but not yet acknowledged by their own CQEs.
-    outstanding_cancels: usize,
-    /// Whether a transient submit left work requiring another service enter.
-    submit_retry: bool,
 }
 
 impl Driver {
@@ -144,8 +132,6 @@ impl Driver {
                 timeout_wheel: TimeoutWheel::new(max_timeout, cfg.timeout_wheel_tick, now),
                 waker,
                 wake_rearm_needed: true,
-                outstanding_cancels: 0,
-                submit_retry: false,
             },
         })
     }
@@ -174,14 +160,9 @@ impl Driver {
         self.state.waiters.len()
     }
 
-    /// Whether all logical requests and cancellation acknowledgements retired.
+    /// Whether all logical requests retired, excluding retained completed outputs.
     pub const fn is_empty(&self) -> bool {
-        self.state.waiters.is_empty() && self.state.outstanding_cancels == 0
-    }
-
-    /// Whether kernel work needs a GETEVENTS service opportunity.
-    pub const fn needs_kernel_service(&self) -> bool {
-        !self.is_empty() || self.state.submit_retry
+        self.state.waiters.is_empty()
     }
 
     /// Whether actionable staging or deadline registration must run before parking.
@@ -190,7 +171,6 @@ impl Driver {
             && self.state.waiters.in_flight() < self.state.in_flight_limit)
             || !self.state.pending_deadlines.is_empty()
             || !self.state.pending_cancels.is_empty()
-            || self.state.submit_retry
     }
 
     /// Earliest active deadline registered on the operation wheel.
@@ -215,11 +195,6 @@ impl Driver {
         }
     }
 
-    /// Reject an expired registration before its first SQE.
-    pub fn expire(&mut self, id: WaiterId, deferred: &mut Deferred) {
-        self.state.cancel(id, deferred);
-    }
-
     /// Clear ordinary observation before draining retained writes and syncs.
     pub fn close(&mut self, deferred: &mut Deferred) {
         for id in self.state.waiters.close(deferred) {
@@ -229,7 +204,7 @@ impl Driver {
 
     /// Process completions, deadlines, and queued submissions without callbacks.
     ///
-    /// Reports wake CQEs and whether kernel service was deferred. The
+    /// Returns whether this turn deferred GETEVENTS for unfinished requests. The
     /// `defer_kernel_service` argument permits the following idle ring wait to
     /// supply GETEVENTS. It is ignored when callbacks or unfinished staging
     /// already require another busy turn.
@@ -238,10 +213,10 @@ impl Driver {
         now: Instant,
         defer_kernel_service: bool,
         deferred: &mut Deferred,
-    ) -> io::Result<ServiceOutcome> {
+    ) -> io::Result<bool> {
         // Finish posted work before expiring requests, then register deadlines
         // against the refreshed wheel so an idle interval cannot shorten them.
-        let mut woke = self.state.reap(&mut self.ring, deferred);
+        self.state.reap(&mut self.ring, deferred);
         self.state.advance_timeouts(now, deferred);
         self.state.register_deadlines(now, deferred);
         self.state.compact_ready_queue();
@@ -253,32 +228,27 @@ impl Driver {
                 // A transient enter may leave the SQ full. Preserve queued
                 // identities and give the kernel a completion-service point
                 // before another staging attempt.
-                self.state.submit_retry = true;
                 break;
             }
         }
 
         // Busy turns must run deferred kernel work. An idle turn can leave this
         // enter to park, unless callbacks or more submissions need attention.
-        let service_kernel = self.needs_kernel_service()
+        let service_kernel = !self.is_empty()
             && (!defer_kernel_service || !deferred.is_empty() || self.has_pending_submissions());
 
         if service_kernel {
             Self::submit_and_wait(&mut self.ring, 1, Some(Duration::ZERO))?;
-            self.state.submit_retry = !self.ring.submission().is_empty();
         }
 
         // New CQEs can complete requests or terminate the multishot wake poll.
         // Park rechecks rearm before its next blocking enter.
-        woke |= self.state.reap(&mut self.ring, deferred);
+        self.state.reap(&mut self.ring, deferred);
 
         #[cfg(test)]
         tests::after_service(&self.ring, deferred)?;
 
-        Ok(ServiceOutcome {
-            woke,
-            kernel_deferred: !service_kernel && self.needs_kernel_service(),
-        })
+        Ok(!service_kernel && !self.is_empty())
     }
 
     /// Wait for ring activity or the deadline while retaining worker ownership.
@@ -298,7 +268,6 @@ impl Driver {
             if !self.state.waker.reinstall(&mut self.ring.submission()) {
                 Self::submit_and_wait(&mut self.ring, 0, None)?;
                 if !self.state.waker.reinstall(&mut self.ring.submission()) {
-                    self.state.submit_retry = true;
                     return Ok(false);
                 }
             }
@@ -313,7 +282,6 @@ impl Driver {
         }
         let timeout = deadline.map(|deadline| deadline.saturating_duration_since(Instant::now()));
         Self::submit_and_wait(&mut self.ring, 1, timeout)?;
-        self.state.submit_retry = !self.ring.submission().is_empty();
         Ok(true)
     }
 
@@ -395,12 +363,8 @@ impl State {
         let Some(expired) = self.timeout_wheel.advance(now) else {
             return;
         };
-        for entry in expired {
-            // A stale wheel entry must match both the waiter generation and
-            // its scheduled tick before changing deadline state.
-            if self.waiters.target_tick(entry.waiter_id) == Some(entry.target_tick) {
-                self.cancel(entry.waiter_id, deferred);
-            }
+        for id in expired {
+            self.cancel(id, deferred);
         }
     }
 
@@ -511,7 +475,6 @@ impl State {
                     .push(&cancel)
                     .expect("checked cancellation SQ capacity");
             }
-            self.outstanding_cancels += 1;
         }
 
         !self.pending_cancels.is_empty()
@@ -542,27 +505,22 @@ impl State {
     }
 
     /// Reap every posted CQE without invoking observer callbacks.
-    fn reap(&mut self, ring: &mut IoUring, deferred: &mut Deferred) -> bool {
-        let mut woke = false;
-
+    fn reap(&mut self, ring: &mut IoUring, deferred: &mut Deferred) {
         // Dropping this CQ view returns the consumed slots to the kernel.
         // Observer callbacks remain deferred until the worker borrow ends.
         for cqe in ring.completion() {
-            // Keep processing the batch after a wake has requested an inbox check.
-            woke |= self.handle_cqe(cqe.user_data(), cqe.result(), cqe.flags(), deferred);
+            self.handle_cqe(cqe.user_data(), cqe.result(), cqe.flags(), deferred);
         }
-
-        woke
     }
 
-    /// Apply a CQE, returning whether the worker should recheck its mailbox.
+    /// Apply a CQE without invoking observer callbacks.
     fn handle_cqe(
         &mut self,
         user_data: UserData,
         result: i32,
         flags: u32,
         deferred: &mut Deferred,
-    ) -> bool {
+    ) {
         // The reserved mailbox token is outside the waiter's ID space.
         if user_data == WAKE_USER_DATA {
             assert!(
@@ -577,8 +535,10 @@ impl State {
                 // the next blocking wait, even if this was service's final reap.
                 self.wake_rearm_needed = true;
             }
-            return true;
+            return;
         }
+
+        // Only the target operation's CQE can retire its resource owners.
         if user_data == CANCEL_USER_DATA {
             if result == 0 {
                 // Cancellation successful.
@@ -593,14 +553,7 @@ impl State {
                 warn!(result, "unexpected async cancel CQE result");
             }
 
-            // The target's slot may already hold another request. Only the global
-            // count changes, so shutdown still waits for every acknowledgement.
-            self.outstanding_cancels = self
-                .outstanding_cancels
-                .checked_sub(1)
-                .expect("untracked cancellation CQE");
-
-            return false;
+            return;
         }
 
         // Waiters releases an operation's in-flight count before returning its outcome.
@@ -609,7 +562,6 @@ impl State {
             CompletionOutcome::Requeue(id) => self.ready_queue.push_back(id),
             CompletionOutcome::Complete(id, result) => self.complete(id, result, deferred),
         }
-        false
     }
 }
 
@@ -851,16 +803,32 @@ pub mod tests {
             self.collect();
         }
 
-        /// Service at a chosen time, collect results, and report mailbox wake CQEs.
-        fn service_at(&mut self, now: Instant, defer: bool) -> bool {
-            let outcome = self.driver.service(now, defer, &mut self.deferred).unwrap();
+        /// Service at a chosen time and collect results.
+        fn service_at(&mut self, now: Instant, defer: bool) {
+            self.driver.service(now, defer, &mut self.deferred).unwrap();
             self.collect();
-            outcome.woke
         }
 
         /// Service using wall-clock time and run deferred kernel work immediately.
-        fn service(&mut self) -> bool {
-            self.service_at(Instant::now(), false)
+        fn service(&mut self) {
+            self.service_at(Instant::now(), false);
+        }
+
+        /// Require a real wake CQE before any further submission can mask its absence.
+        fn reap_wake(&mut self) {
+            let cqe = self
+                .driver
+                .ring
+                .completion()
+                .next()
+                .expect("missing wake CQE");
+            assert_eq!(cqe.user_data(), WAKE_USER_DATA);
+            self.driver.state.handle_cqe(
+                cqe.user_data(),
+                cqe.result(),
+                cqe.flags(),
+                &mut self.deferred,
+            );
         }
 
         /// Drive until `count` results have been collected, failing if progress stalls.
@@ -873,7 +841,7 @@ pub mod tests {
             }
         }
 
-        /// Close ordinary observation and wait for request and cancellation retirement.
+        /// Close ordinary observation and wait for request retirement.
         fn drain(&mut self) {
             self.driver.close(&mut self.deferred);
             self.collect();
@@ -970,7 +938,6 @@ pub mod tests {
         harness.service();
 
         assert!(harness.driver.is_empty());
-        assert!(!harness.driver.needs_kernel_service());
         assert!(!harness.driver.has_pending_submissions());
 
         // Neither compaction nor skipped staging may consume the results.
@@ -1150,7 +1117,6 @@ pub mod tests {
         harness.drain();
 
         assert_eq!(harness.driver.state.waiters.in_flight(), 0);
-        assert_eq!(harness.driver.state.outstanding_cancels, 0);
     }
 
     #[test]
@@ -1389,15 +1355,11 @@ pub mod tests {
 
         // Acknowledgements cannot release the operation's kernel resources.
         for result in [0, -libc::EALREADY, -libc::ENOENT, -libc::EPERM] {
-            harness.driver.state.outstanding_cancels += 1;
-            assert!(!harness.driver.state.handle_cqe(
-                CANCEL_USER_DATA,
-                result,
-                0,
-                &mut harness.deferred
-            ));
+            harness
+                .driver
+                .state
+                .handle_cqe(CANCEL_USER_DATA, result, 0, &mut harness.deferred);
 
-            assert_eq!(harness.driver.state.outstanding_cancels, 0);
             assert_eq!(harness.driver.state.waiters.in_flight(), 1);
             assert!(harness.driver.state.waiters.is_pending(id));
         }
@@ -1418,15 +1380,11 @@ pub mod tests {
             .complete(id, result, &mut harness.deferred);
 
         for result in [0, -libc::ENOENT] {
-            harness.driver.state.outstanding_cancels += 1;
-            assert!(!harness.driver.state.handle_cqe(
-                CANCEL_USER_DATA,
-                result,
-                0,
-                &mut harness.deferred
-            ));
+            harness
+                .driver
+                .state
+                .handle_cqe(CANCEL_USER_DATA, result, 0, &mut harness.deferred);
 
-            assert_eq!(harness.driver.state.outstanding_cancels, 0);
             assert_eq!(harness.driver.state.waiters.in_flight(), 0);
         }
 
@@ -1445,7 +1403,6 @@ pub mod tests {
         }
 
         let mut harness = Harness::new(1);
-        harness.driver.state.outstanding_cancels = 1;
 
         // EINVAL rejects the cancellation SQE itself, regardless of slot reuse.
         assert!(
@@ -1459,88 +1416,104 @@ pub mod tests {
             }))
             .is_err()
         );
-        assert_eq!(harness.driver.state.outstanding_cancels, 1);
-
-        harness
-            .driver
-            .state
-            .handle_cqe(CANCEL_USER_DATA, 0, 0, &mut harness.deferred);
-        assert_eq!(harness.driver.state.outstanding_cancels, 0);
-
-        // An acknowledgement without a staged cancellation is an accounting error.
-        assert!(
-            catch_unwind(AssertUnwindSafe(|| {
-                harness
-                    .driver
-                    .state
-                    .handle_cqe(CANCEL_USER_DATA, 0, 0, &mut harness.deferred);
-            }))
-            .is_err()
-        );
-        assert_eq!(harness.driver.state.outstanding_cancels, 0);
     }
 
     #[test]
-    fn test_drain_waits_for_cancel_cqe_after_request_finishes() {
-        for reuse in [false, true] {
-            let mut harness = Harness::new(1);
-            let (left, _right) = UnixStream::pair().unwrap();
-            let id = harness.stage(recv(left, 8, None), Some(1), 0);
+    fn test_request_retirement_releases_hold_before_cancel_acknowledgement() {
+        for consume_cancel in [false, true] {
+            for reuse in [false, true] {
+                let mut harness = Harness::new(1);
+                let directory = std::env::temp_dir().join(format!(
+                    "commonware_driver_retirement_{}_{}_{}",
+                    std::process::id(),
+                    consume_cancel,
+                    reuse,
+                ));
+                let hold = Hold::acquire(&directory).unwrap();
+                let path = directory.join("read");
+                fs::write(&path, b"hello").unwrap();
+                let file = OpenOptions::new().read(true).open(path).unwrap();
+                let probe = OpenOptions::new()
+                    .read(true)
+                    .write(true)
+                    .open(directory.join(".hold"))
+                    .unwrap();
+                let id = harness.admit(
+                    Request::ReadAt(ReadAtRequest {
+                        file: Held::new(file, hold),
+                        offset: 0,
+                        read: 0,
+                        buf: IoBufMut::zeroed(5),
+                        cache: Cache::Enabled,
+                    }),
+                    0,
+                );
 
-            // Submit only the cancellation to the real kernel. Simulate the
-            // operation CQE so logical retirement is guaranteed to happen first.
-            harness.driver.state.advance_timeouts(
-                harness.start + Duration::from_millis(5),
-                &mut harness.deferred,
-            );
-            assert!(
-                !harness
+                // Complete the real read in the kernel, retaining its CQE and
+                // userspace owner while a later cancellation enters the SQ.
+                assert!(
+                    !harness
+                        .driver
+                        .state
+                        .stage_ready_requests(&mut harness.driver.ring.submission())
+                );
+                harness.driver.ring.submit_and_wait(1).unwrap();
+                assert!(matches!(
+                    probe.try_lock(),
+                    Err(fs::TryLockError::WouldBlock)
+                ));
+                harness.driver.orphan(id, &mut harness.deferred);
+                assert!(
+                    !harness
+                        .driver
+                        .state
+                        .stage_cancellations(&mut harness.driver.ring.submission())
+                );
+                assert_eq!(harness.driver.ring.submission().len(), 1);
+
+                // Only processing the target CQE permits resource retirement.
+                // The deferred owner still protects the directory until disposal.
+                harness
                     .driver
                     .state
-                    .stage_cancellations(&mut harness.driver.ring.submission())
-            );
-            assert_eq!(harness.driver.state.outstanding_cancels, 1);
+                    .reap(&mut harness.driver.ring, &mut harness.deferred);
+                assert!(matches!(
+                    probe.try_lock(),
+                    Err(fs::TryLockError::WouldBlock)
+                ));
+                harness.collect();
+                let RequestOutput::ReadAt(Ok(buf)) = &harness.completed[0].output else {
+                    panic!("real read did not complete successfully");
+                };
+                assert_eq!(buf.as_ref(), b"hello");
+                probe.try_lock().unwrap();
+                probe.unlock().unwrap();
 
-            harness.simulated_completion(id, 4);
-
-            assert!(matches!(
-                harness.completed[0].output,
-                RequestOutput::Recv(Err((_, Error::Timeout)))
-            ));
-
-            // The kernel will acknowledge the staged cancel after logical
-            // retirement. Drain must wait for that CQE despite the empty slab.
-            assert_eq!(harness.driver.len(), 0);
-            assert!(!harness.driver.is_empty());
-            assert!(harness.driver.next_deadline().is_none());
-
-            if reuse {
-                let (left, _right) = UnixStream::pair().unwrap();
-                let current = harness.stage(recv(left, 1, None), None, 1);
-                assert_eq!(current.0.index, id.0.index);
-                assert_ne!(current, id);
-
-                // Deliver the real cancellation CQE while the reused slot holds
-                // another operation. Its target identity must not affect lookup.
-                let limit = Instant::now() + Duration::from_secs(10);
-                while harness.driver.state.outstanding_cancels != 0 {
-                    assert!(
-                        Instant::now() < limit,
-                        "cancellation acknowledgement stalled"
-                    );
-                    harness.service();
-                    thread::yield_now();
+                if consume_cancel {
+                    // Leave the real cancellation acknowledgement unobserved.
+                    harness.driver.ring.submit_and_wait(1).unwrap();
+                    assert!(harness.driver.ring.submission().is_empty());
+                    assert!(!harness.driver.ring.completion().is_empty());
+                } else {
+                    assert_eq!(harness.driver.ring.submission().len(), 1);
                 }
 
-                assert!(harness.driver.state.waiters.is_in_flight(current));
-                assert_eq!(harness.driver.state.waiters.in_flight(), 1);
-                assert_eq!(harness.completed.len(), 1);
-                harness.simulated_completion(current, 1);
+                if reuse {
+                    let (left, mut right) = UnixStream::pair().unwrap();
+                    right.write_all(b"x").unwrap();
+                    let next = harness.admit(recv(left, 1, None), 1);
+                    assert_eq!(next.0.index, id.0.index);
+                    assert_ne!(next, id);
+                    harness.until(2);
+                    assert_eq!(received(&harness.completed[1]), b"x");
+                }
+
+                harness.drain();
+                drop(harness);
+                probe.try_lock().unwrap();
+                drop(probe);
+                fs::remove_dir_all(directory).unwrap();
             }
-
-            harness.drain();
-
-            assert_eq!(harness.driver.state.outstanding_cancels, 0);
         }
     }
 
@@ -1615,9 +1588,8 @@ pub mod tests {
                     Request::ReadAt(ReadAtRequest {
                         file: held.clone(),
                         offset: 0,
-                        len: 5,
                         read: 0,
-                        buf: IoBufMut::with_capacity(5),
+                        buf: IoBufMut::zeroed(5),
                         cache: Cache::Enabled,
                     }),
                     None,
@@ -1653,30 +1625,103 @@ pub mod tests {
 
     #[test]
     fn test_orphan_in_flight_cancels_once_and_releases_deadline() {
+        for expire_bucket in [false, true] {
+            let mut harness = Harness::new(1);
+            let deadline = harness.start + Duration::from_secs(10);
+            let (left, _right) = UnixStream::pair().unwrap();
+            let id = harness.admit(recv(left, 8, Some(deadline)), 0);
+            let (survivor, _survivor_peer) = UnixStream::pair().unwrap();
+            if expire_bucket {
+                harness.admit(recv(survivor, 1, Some(deadline)), 1);
+            }
+            harness.service();
+
+            assert!(harness.driver.state.waiters.is_in_flight(id));
+
+            // Repeated observer drops must not queue another cancel or remove the
+            // same deadline from the wheel twice.
+            harness.orphan(id);
+            harness.orphan(id);
+
+            if expire_bucket {
+                // A live sibling forces the orphan's stale wheel record through
+                // expiry before its cancellation or operation CQE arrives.
+                harness
+                    .driver
+                    .state
+                    .advance_timeouts(deadline, &mut harness.deferred);
+                assert!(harness.driver.state.waiters.is_in_flight(id));
+            }
+            assert_eq!(harness.driver.state.pending_cancels.len(), 1);
+            assert!(harness.driver.next_deadline().is_none());
+
+            harness.collect();
+            harness.drain();
+
+            assert_eq!(harness.completed.len(), 1 + usize::from(expire_bucket));
+            assert_eq!(
+                harness
+                    .completed
+                    .iter()
+                    .filter(|completed| matches!(completed.observer, TestObserver::Orphaned))
+                    .count(),
+                1
+            );
+            if expire_bucket {
+                let survivor = harness
+                    .completed
+                    .iter()
+                    .find(|completed| matches!(completed.observer, TestObserver::Ordinary(1)))
+                    .unwrap();
+                assert!(matches!(
+                    survivor.output,
+                    RequestOutput::Recv(Err((_, Error::Timeout)))
+                ));
+            }
+        }
+    }
+
+    #[test]
+    fn test_expiring_bucket_preserves_unconsumed_success() {
         let mut harness = Harness::new(1);
-        let (left, _right) = UnixStream::pair().unwrap();
-        let id = harness.admit(
-            recv(left, 8, Some(harness.start + Duration::from_secs(10))),
-            0,
-        );
-        harness.service();
+        let deadline = harness.start + Duration::from_secs(30);
+        let (socket, mut peer) = UnixStream::pair().unwrap();
+        peer.write_all(b"x").unwrap();
+        let completed = harness.admit(recv(socket, 1, Some(deadline)), 0);
+        let (survivor, _peer) = UnixStream::pair().unwrap();
+        harness.admit(recv(survivor, 1, Some(deadline)), 1);
 
-        assert!(harness.driver.state.waiters.is_in_flight(id));
-
-        // Repeated observer drops must not queue another cancel or remove the
-        // same deadline from the wheel twice.
-        harness.orphan(id);
-        harness.orphan(id);
-
-        assert_eq!(harness.driver.state.pending_cancels.len(), 1);
+        // Retain the first result while another request keeps its bucket live.
+        let limit = Instant::now() + Duration::from_secs(10);
+        while harness.driver.state.waiters.is_pending(completed) {
+            assert!(Instant::now() < limit, "receive stalled");
+            harness
+                .driver
+                .service(Instant::now(), false, &mut harness.deferred)
+                .unwrap();
+            thread::yield_now();
+        }
+        harness
+            .driver
+            .state
+            .advance_timeouts(deadline, &mut harness.deferred);
         assert!(harness.driver.next_deadline().is_none());
 
-        harness.drain();
-
-        assert_eq!(harness.completed.len(), 1);
+        harness.collect();
         assert!(matches!(
             harness.completed[0].observer,
-            TestObserver::Orphaned
+            TestObserver::Ordinary(0)
+        ));
+        assert_eq!(received(&harness.completed[0]), b"x");
+        harness.drain();
+        assert_eq!(harness.completed.len(), 2);
+        assert!(matches!(
+            harness.completed[1].observer,
+            TestObserver::Ordinary(1)
+        ));
+        assert!(matches!(
+            harness.completed[1].output,
+            RequestOutput::Recv(Err((_, Error::Timeout)))
         ));
     }
 
@@ -1719,7 +1764,7 @@ pub mod tests {
         harness.service_at(harness.start, true);
 
         assert!(harness.completed.is_empty());
-        assert!(harness.driver.needs_kernel_service());
+        assert!(!harness.driver.is_empty());
 
         // No further admission is needed to drive the deferred task work.
         harness.until(1);
@@ -1736,7 +1781,7 @@ pub mod tests {
         // Staging the mailbox poll must not make a CPU-only turn enter the kernel.
         harness.service();
 
-        assert!(!harness.driver.needs_kernel_service());
+        assert!(harness.driver.is_empty());
         assert!(!harness.driver.has_pending_submissions());
         assert_eq!(harness.driver.ring.submission().len(), 1);
 
@@ -1753,9 +1798,11 @@ pub mod tests {
 
         // Publication prevents parking, so the deferred GETEVENTS enter must
         // still happen through service before the next busy turn.
-        harness.driver.state.waker.wake();
+        if harness.driver.state.waker.publish() {
+            harness.driver.state.waker.wake();
+        }
         assert!(!harness.driver.park(0, None).unwrap());
-        assert!(harness.driver.needs_kernel_service());
+        assert!(!harness.driver.is_empty());
         harness.until(1);
 
         harness.drain();
@@ -1783,8 +1830,7 @@ pub mod tests {
         assert!(harness.driver.state.waker.pending(0));
 
         // A published sequence alone does not prove eventfd reached the ring.
-        // Service must observe the wake CQE produced during the wait.
-        assert!(harness.service());
+        harness.reap_wake();
 
         harness.drain();
     }
@@ -1811,10 +1857,10 @@ pub mod tests {
             let _fault = stalled.then(|| inject(&harness.driver, Fault::StallFlush));
             if stalled {
                 // An unchanged SQ cannot accept the wake poll. Park must return
-                // to service with both rearm and submission retry still pending.
+                // to service with the request and rearm still pending.
                 assert!(!harness.driver.park(0, Some(Instant::now())).unwrap());
                 assert!(harness.driver.state.wake_rearm_needed);
-                assert!(harness.driver.has_pending_submissions());
+                assert!(!harness.driver.is_empty());
                 assert!(harness.driver.ring.submission().is_full());
                 harness.service();
 
@@ -1839,12 +1885,7 @@ pub mod tests {
 
             // Reap directly so service cannot hide a missing poll by installing
             // one after park returns. The receive must still be in flight.
-            assert!(
-                harness
-                    .driver
-                    .state
-                    .reap(&mut harness.driver.ring, &mut harness.deferred)
-            );
+            harness.reap_wake();
             assert!(harness.driver.state.waiters.is_in_flight(id));
 
             // Rearming must preserve the receive that occupied the SQ.
@@ -1946,7 +1987,6 @@ pub mod tests {
             Request::WriteAt(WriteAtRequest {
                 file: held.clone(),
                 offset: 0,
-                written: 0,
                 write: bufs.into(),
                 state: WriteAtState::WritingBeforeSync,
                 cache: Cache::Enabled,

--- a/runtime/src/iouring/mailbox.rs
+++ b/runtime/src/iouring/mailbox.rs
@@ -118,7 +118,7 @@ impl Mailbox {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::iouring::{task::Task, waker::tests::eventfd_count};
+    use crate::iouring::waker::tests::eventfd_count;
     use std::{
         future::pending,
         sync::{
@@ -154,7 +154,7 @@ mod tests {
             mailbox: Arc::downgrade(mailbox),
             dropped: dropped.clone(),
         };
-        let task = Task::boxed(async move {
+        let task = Box::pin(async move {
             let _guard = guard;
             pending::<()>().await;
         });
@@ -172,10 +172,10 @@ mod tests {
 
         // Multiple messages share one publication and retain their send order.
         assert!(mailbox.send(Message::Wake(Target::Root)).is_ok());
-        assert!(mailbox.send(Message::Spawn(Task::boxed(pending()))).is_ok());
+        assert!(mailbox.send(Message::Spawn(Box::pin(pending()))).is_ok());
         assert!(mailbox.waker.pending(0));
-        assert!(!mailbox.waker.pending(1));
         assert!(mailbox.take(&mut scratch));
+        assert!(!mailbox.waker.pending(1));
         assert!(matches!(
             scratch.as_slice(),
             [Message::Wake(Target::Root), Message::Spawn(_)]
@@ -184,10 +184,10 @@ mod tests {
         // A new batch remains pending while the worker drains its scratch.
         assert!(mailbox.send(Message::Wake(Target::Root)).is_ok());
         assert!(mailbox.waker.pending(1));
-        assert!(!mailbox.waker.pending(2));
 
         scratch.clear();
         assert!(mailbox.take(&mut scratch));
+        assert!(!mailbox.waker.pending(2));
         assert!(matches!(scratch.as_slice(), [Message::Wake(Target::Root)]));
 
         scratch.clear();

--- a/runtime/src/iouring/operation.rs
+++ b/runtime/src/iouring/operation.rs
@@ -338,7 +338,7 @@ pub mod tests {
         }))
     }
 
-    /// Service the worker until every request and cancellation CQE retires.
+    /// Service the worker until every logical request retires.
     async fn drained() {
         let deadline = Instant::now() + Duration::from_secs(10);
         while !Local::current()

--- a/runtime/src/iouring/operation.rs
+++ b/runtime/src/iouring/operation.rs
@@ -65,23 +65,15 @@ impl Operation {
             };
         }
 
-        let expired = request
-            .deadline()
-            .is_some_and(|deadline| deadline <= local.now);
         let mailbox = Arc::downgrade(&local.mailbox);
-        let Local {
-            driver, deferred, ..
-        } = &mut *local;
-        let driver = driver.as_mut().unwrap();
 
         // The driver takes ownership even when the SQ is full. Polling installs
         // a waker only while the request is still pending.
-        let waiter_id = driver.admit(request, Observer::Ordinary(None));
-
-        if expired {
-            // Immediate timeouts use the same result path as CQE completions.
-            driver.expire(waiter_id, deferred);
-        }
+        let waiter_id = local
+            .driver
+            .as_mut()
+            .unwrap()
+            .admit(request, Observer::Ordinary(None));
 
         Self {
             state: State::Waiting { mailbox, waiter_id },
@@ -124,50 +116,41 @@ impl Future for Operation {
             }
         };
 
-        let mut cloned_waker = None;
-        loop {
-            let mut local = owner.borrow_mut();
-            if local.closing {
-                // A waker clone may have closed the worker. Defer its destruction
-                // before release borrows the worker again.
-                local.deferred.drops.extend(cloned_waker);
-                drop(local);
-                this.release();
-                return Poll::Ready(Err(Error::Closed));
-            }
-
-            let Local {
-                driver, deferred, ..
-            } = &mut *local;
-            let driver = driver.as_mut().unwrap();
-
-            // Inspect before cloning: ready results and matching wakers require
-            // no callback.
-            match driver.observe(waiter_id, cx.waker()) {
-                Observation::Ready(output) => {
-                    this.state = State::Done;
-
-                    // Completion may have raced the clone, leaving it unused.
-                    deferred.drops.extend(cloned_waker);
-                    return Poll::Ready(Ok(output));
-                }
-                Observation::Pending => {
-                    deferred.drops.extend(cloned_waker);
-                    return Poll::Pending;
-                }
-                Observation::Refresh => {
-                    if let Some(waker) = cloned_waker.take() {
-                        deferred.drops.extend(driver.set_waker(waiter_id, waker));
-                        return Poll::Pending;
-                    }
-                }
-            }
-
-            // A clone can reenter and finish this request, or panic. Keep its
-            // identity intact and inspect the slot again after the callback.
+        let mut local = owner.borrow_mut();
+        if local.closing {
             drop(local);
-            cloned_waker = Some(cx.waker().clone());
+            this.release();
+            return Poll::Ready(Err(Error::Closed));
         }
+
+        // Inspect before cloning: ready results and matching wakers require
+        // no callback.
+        match local
+            .driver
+            .as_mut()
+            .unwrap()
+            .observe(waiter_id, cx.waker())
+        {
+            Observation::Ready(output) => {
+                this.state = State::Done;
+                return Poll::Ready(Ok(output));
+            }
+            Observation::Pending => return Poll::Pending,
+            Observation::Refresh => {}
+        }
+
+        // Worker service cannot run during this poll. Clone outside its borrow,
+        // retaining the cancellation identity if the callback panics.
+        drop(local);
+        let waker = cx.waker().clone();
+        let mut local = owner.borrow_mut();
+        let Local {
+            driver, deferred, ..
+        } = &mut *local;
+        deferred
+            .drops
+            .extend(driver.as_mut().unwrap().set_waker(waiter_id, waker));
+        Poll::Pending
     }
 }
 
@@ -216,6 +199,7 @@ pub mod tests {
     };
     use futures::{FutureExt as _, future::pending, poll};
     use std::{
+        io::Write as _,
         os::{fd::OwnedFd, unix::net::UnixStream},
         panic::{AssertUnwindSafe, catch_unwind},
         pin::pin,
@@ -346,7 +330,7 @@ pub mod tests {
     fn recv(fd: Arc<OwnedFd>, deadline: Option<Instant>) -> Operation {
         Operation::register(Request::Recv(RecvRequest {
             fd,
-            buf: IoBufMut::with_capacity(1),
+            buf: IoBufMut::from([0]),
             offset: 0,
             len: 1,
             exact: true,
@@ -396,103 +380,103 @@ pub mod tests {
     }
 
     #[test]
-    fn test_worker_closure_rejects_registration_and_polling() {
-        for during_clone in [false, true] {
-            let callbacks = Arc::new(Reentrant {
-                on_clone: Some(|| Local::current().unwrap().borrow_mut().closing = true),
-                ..Default::default()
-            });
+    fn test_expired_registration_does_not_consume_ready_data() {
+        runner().start(|_| async {
+            let (fd, mut peer) = socket();
+            peer.write_all(b"x").unwrap();
+            let output = recv(fd.clone(), Some(Instant::now())).await.unwrap();
+            assert!(matches!(
+                output,
+                RequestOutput::Recv(Err((_, Error::Timeout)))
+            ));
 
-            runner().start(|context| async move {
-                let (blob, _) = context.open("observer_closed", b"file").await.unwrap();
-                let (fd, _peer) = socket();
-                let mut operation = recv(fd.clone(), None);
-                let waker = callbacks.waker();
-                let mut cx = Context::from_waker(&waker);
-
-                // Closure can precede polling or happen while a waker clone
-                // temporarily releases the worker borrow.
-                if !during_clone {
-                    Local::current().unwrap().borrow_mut().closing = true;
-                }
-                assert!(matches!(
-                    operation.poll_unpin(&mut cx),
-                    Poll::Ready(Err(Error::Closed))
-                ));
-                assert_eq!(
-                    callbacks.clones.load(Ordering::Relaxed),
-                    usize::from(during_clone)
-                );
-
-                // New ordinary and detached requests must also reject closure.
-                let mut rejected = recv(fd, None);
-                assert!(matches!(
-                    rejected.poll_unpin(&mut cx),
-                    Poll::Ready(Err(Error::Closed))
-                ));
-                let handle = blob.start_sync().await;
-                assert!(matches!(handle.await, Err(Error::Closed)));
-                assert!(
-                    Local::current()
-                        .unwrap()
-                        .borrow()
-                        .driver
-                        .as_ref()
-                        .unwrap()
-                        .is_empty()
-                );
-            });
-        }
+            let RequestOutput::Recv(Ok((buffer, len))) = recv(fd, None).await.unwrap() else {
+                panic!("expired receive consumed ready data");
+            };
+            assert_eq!(len, 1);
+            assert_eq!(buffer.as_ref(), b"x");
+        });
     }
 
     #[test]
-    fn test_observer_clone_reentry_rechecks_expired_registrations() {
-        for sleep_first in [false, true] {
+    fn test_worker_closure_rejects_registration_and_polling() {
+        let callbacks = Arc::new(Reentrant::default());
+        runner().start(|context| async move {
+            let (blob, _) = context.open("observer_closed", b"file").await.unwrap();
+            let (fd, _peer) = socket();
+            let mut operation = recv(fd.clone(), None);
+            let waker = callbacks.waker();
+            let mut cx = Context::from_waker(&waker);
+
+            Local::current().unwrap().borrow_mut().closing = true;
+            assert!(matches!(
+                operation.poll_unpin(&mut cx),
+                Poll::Ready(Err(Error::Closed))
+            ));
+            assert_eq!(callbacks.clones.load(Ordering::Relaxed), 0);
+
+            // New ordinary and detached requests must also reject closure.
+            let mut rejected = recv(fd, None);
+            assert!(matches!(
+                rejected.poll_unpin(&mut cx),
+                Poll::Ready(Err(Error::Closed))
+            ));
+            let handle = blob.start_sync().await;
+            assert!(matches!(handle.await, Err(Error::Closed)));
+            assert!(
+                Local::current()
+                    .unwrap()
+                    .borrow()
+                    .driver
+                    .as_ref()
+                    .unwrap()
+                    .is_empty()
+            );
+        });
+    }
+
+    #[test]
+    fn test_observer_clone_can_register_and_cancel_other_work() {
+        for in_flight in [false, true] {
             let callbacks = Arc::new(Reentrant {
                 on_clone: Some(|| {
-                    let owner = Local::current().unwrap();
-                    let mut local = owner.borrow_mut();
-                    local.now += Duration::from_secs(120);
-                    let Local {
-                        driver,
-                        deferred,
-                        now,
-                        timers,
-                        ..
-                    } = &mut *local;
-                    driver
-                        .as_mut()
-                        .unwrap()
-                        .service(*now, false, deferred)
-                        .unwrap();
-                    timers.expire(*now, &mut deferred.wakes);
+                    let mut sleep = Sleep::new(Duration::from_secs(60));
+                    let (fd, _peer) = socket();
+                    let mut operation = recv(fd, None);
+                    let mut cx = Context::from_waker(Waker::noop());
+                    assert!(sleep.poll_unpin(&mut cx).is_pending());
+                    assert!(operation.poll_unpin(&mut cx).is_pending());
+                    drop(operation);
+                    drop(sleep);
                 }),
                 ..Default::default()
             });
 
             runner().start(|_| async {
-                let (fd, _peer) = socket();
-                let mut blocker = recv(fd.clone(), None);
-                assert!(poll!(&mut blocker).is_pending());
-                let mut queued = recv(fd, Some(Instant::now() + Duration::from_secs(60)));
+                let (fd, mut peer) = socket();
+                let mut operation = recv(fd, Some(Instant::now() + Duration::from_secs(60)));
                 let mut sleep = Sleep::new(Duration::from_secs(60));
-                assert!(poll!(&mut queued).is_pending());
+                assert!(poll!(&mut operation).is_pending());
                 assert!(poll!(&mut sleep).is_pending());
+                if in_flight {
+                    reschedule().await;
+                }
 
-                // The first future triggers expiry while cloning its waker.
-                // It must recheck before installation, and the other future
-                // must observe its ready result without cloning at all.
+                // Each replacement may register and cancel other identities.
+                // The current registrations still need their own completion.
                 let waker = callbacks.waker();
                 let mut cx = Context::from_waker(&waker);
-                if sleep_first {
-                    assert!(sleep.poll_unpin(&mut cx).is_ready());
-                }
-                assert!(matches!(
-                    queued.poll_unpin(&mut cx),
-                    Poll::Ready(Ok(RequestOutput::Recv(Err((_, Error::Timeout)))))
-                ));
-                assert!(sleep.poll_unpin(&mut cx).is_ready());
-                assert_eq!(callbacks.clones.load(Ordering::Relaxed), 1);
+                assert!(operation.poll_unpin(&mut cx).is_pending());
+                assert!(sleep.poll_unpin(&mut cx).is_pending());
+                assert_eq!(callbacks.clones.load(Ordering::Relaxed), 2);
+
+                drop(sleep);
+                peer.write_all(b"x").unwrap();
+                let RequestOutput::Recv(Ok((buffer, len))) = operation.await.unwrap() else {
+                    panic!("receive failed after observer replacement");
+                };
+                assert_eq!(len, 1);
+                assert_eq!(buffer.as_ref(), b"x");
             });
         }
     }

--- a/runtime/src/iouring/operation.rs
+++ b/runtime/src/iouring/operation.rs
@@ -69,11 +69,17 @@ impl Operation {
 
         // The driver takes ownership even when the SQ is full. Polling installs
         // a waker only while the request is still pending.
-        let waiter_id = local
-            .driver
-            .as_mut()
-            .unwrap()
-            .admit(request, Observer::Ordinary(None));
+        let Local {
+            driver,
+            deferred,
+            now,
+            ..
+        } = &mut *local;
+        let waiter_id =
+            driver
+                .as_mut()
+                .unwrap()
+                .admit(request, Observer::Ordinary(None), *now, deferred);
 
         Self {
             state: State::Waiting { mailbox, waiter_id },
@@ -176,11 +182,18 @@ pub fn start_sync(request: SyncRequest) -> oneshot::Receiver<Result<(), Error>> 
     } else {
         // Registration needs no task waker. The worker publishes to this
         // channel when the sync finishes.
-        local
-            .driver
-            .as_mut()
-            .unwrap()
-            .admit(Request::Sync(request), Observer::DetachedSync(sender));
+        let Local {
+            driver,
+            deferred,
+            now,
+            ..
+        } = &mut *local;
+        driver.as_mut().unwrap().admit(
+            Request::Sync(request),
+            Observer::DetachedSync(sender),
+            *now,
+            deferred,
+        );
     }
     receiver
 }
@@ -381,16 +394,36 @@ pub mod tests {
 
     #[test]
     fn test_expired_registration_does_not_consume_ready_data() {
-        runner().start(|_| async {
+        let callbacks = Arc::new(Reentrant::default());
+        runner().start(|context| async move {
+            let deadline = Instant::now();
+            context.sleep(Duration::from_millis(1)).await;
+            assert!(Local::current().unwrap().borrow().now >= deadline);
+
             let (fd, mut peer) = socket();
             peer.write_all(b"x").unwrap();
-            let output = recv(fd.clone(), Some(Instant::now())).await.unwrap();
+            let mut operation = recv(fd.clone(), Some(deadline));
+            let waker = callbacks.waker();
             assert!(matches!(
-                output,
-                RequestOutput::Recv(Err((_, Error::Timeout)))
+                operation.poll_unpin(&mut Context::from_waker(&waker)),
+                Poll::Ready(Ok(RequestOutput::Recv(Err((_, Error::Timeout)))))
             ));
+            assert_eq!(callbacks.clones.load(Ordering::Relaxed), 0);
+            assert!(
+                Local::current()
+                    .unwrap()
+                    .borrow()
+                    .driver
+                    .as_ref()
+                    .unwrap()
+                    .is_empty()
+            );
 
-            let RequestOutput::Recv(Ok((buffer, len))) = recv(fd, None).await.unwrap() else {
+            let RequestOutput::Recv(Ok((buffer, len))) =
+                recv(fd, Some(Instant::now() + Duration::from_secs(1)))
+                    .await
+                    .unwrap()
+            else {
                 panic!("expired receive consumed ready data");
             };
             assert_eq!(len, 1);

--- a/runtime/src/iouring/request.rs
+++ b/runtime/src/iouring/request.rs
@@ -534,11 +534,9 @@ pub struct ReadAtRequest {
     pub file: Arc<Held>,
     /// Starting file offset for the logical read.
     pub offset: u64,
-    /// Total number of bytes requested.
-    pub len: usize,
     /// Bytes already read into `buf`.
     pub read: usize,
-    /// Destination buffer owned by the request.
+    /// Fixed-length destination buffer owned by the request.
     pub buf: IoBufMut,
     /// Page-cache policy for this request.
     pub cache: Cache,
@@ -548,13 +546,15 @@ impl ReadAtRequest {
     /// Build the next positioned read SQE for the unread suffix of the target.
     fn build_sqe(&mut self) -> SqueueEntry {
         let fd = Fd(self.file.as_raw_fd());
+        let len = self.buf.len();
         assert!(
-            self.read <= self.len && self.len <= self.buf.capacity(),
-            "read_at invariant violated: need read <= len <= capacity"
+            self.read <= len,
+            "read_at progress exceeds destination length"
         );
-        // SAFETY: buf is an IoBufMut with stable memory. read <= len <= capacity.
+
+        // SAFETY: buf owns stable memory with read <= buf.len() <= capacity.
         let ptr = unsafe { self.buf.as_mut_ptr().add(self.read) };
-        let remaining = self.len - self.read;
+        let remaining = len - self.read;
         let offset = self.offset + self.read as u64;
         let rw_flags = self.cache.rw_flag();
         opcode::Read::new(fd, ptr, scalar_len(remaining))
@@ -572,13 +572,13 @@ impl ReadAtRequest {
             CqeResult::Cancelled | CqeResult::Error(_) => Some(Err(Error::ReadFailed)),
             CqeResult::Zero => Some(Err(Error::BlobInsufficientLength)),
             CqeResult::Positive(n) => {
-                let remaining = self.len - self.read;
+                let remaining = self.buf.len() - self.read;
                 assert!(
                     n <= remaining,
                     "read CQE exceeds requested length: n={n} remaining={remaining}"
                 );
                 self.read += n;
-                if self.read >= self.len {
+                if self.read >= self.buf.len() {
                     Some(Ok(()))
                 } else {
                     None
@@ -669,10 +669,8 @@ fn on_sync_cqe(state: WaiterState, result: i32) -> Option<Result<(), Error>> {
 pub struct WriteAtRequest {
     /// File used by the current write SQE.
     pub file: Arc<Held>,
-    /// Starting file offset for the logical write.
+    /// File offset for the next write SQE.
     pub offset: u64,
-    /// Bytes already written successfully.
-    pub written: usize,
     /// Write cursor and buffers that still need to be written.
     pub write: WriteBuffers,
     /// Current write and durability phase.
@@ -699,14 +697,13 @@ impl WriteAtRequest {
         }
 
         let fd = Fd(self.file.as_raw_fd());
-        let file_offset = self.offset + self.written as u64;
         let rw_flags = self.rw_flags();
         match &mut self.write {
             WriteBuffers::Single { buf, offset } => {
                 let bytes = &buf.as_ref()[*offset..];
                 let ptr = bytes.as_ptr();
                 opcode::Write::new(fd, ptr, scalar_len(bytes.len()))
-                    .offset(file_offset)
+                    .offset(self.offset)
                     .rw_flags(rw_flags)
                     .build()
             }
@@ -720,7 +717,7 @@ impl WriteAtRequest {
                 let iovecs_len = fill_iovecs(bufs, *chunk, *offset, iovecs);
 
                 opcode::Writev::new(fd, iovecs.as_ptr(), iovecs_len)
-                    .offset(file_offset)
+                    .offset(self.offset)
                     .rw_flags(rw_flags)
                     .build()
             }
@@ -741,8 +738,8 @@ impl WriteAtRequest {
                 Some(Err(Error::WriteFailed))
             }
             CqeResult::Positive(n) => {
-                self.written += n;
                 self.write.advance(n);
+                self.offset += n as u64;
                 if self.write.is_complete() {
                     if self.state == WriteAtState::WritingBeforeSync {
                         // All batches must finish before the trailing sync starts.
@@ -823,8 +820,6 @@ impl ConnectRequest {
 pub struct PollRequest {
     /// Descriptor retained until readiness completes or cancellation retires.
     pub fd: Arc<TcpListener>,
-    /// Native poll flags identifying the readiness event of interest.
-    pub flags: u32,
     /// Absolute deadline for this readiness observation.
     pub deadline: Option<Instant>,
 }
@@ -832,7 +827,7 @@ pub struct PollRequest {
 impl PollRequest {
     /// Build one readiness SQE, leaving multishot mode disabled.
     fn build_sqe(&self) -> SqueueEntry {
-        opcode::PollAdd::new(Fd(self.fd.as_raw_fd()), self.flags).build()
+        opcode::PollAdd::new(Fd(self.fd.as_raw_fd()), libc::POLLIN as u32).build()
     }
 
     /// Treat readiness as a hint, allowing the caller to retry the actual syscall.
@@ -912,9 +907,8 @@ mod tests {
         ReadAtRequest {
             file: make_file_fd(),
             offset: 0,
-            len: 5,
             read: 0,
-            buf: IoBufMut::with_capacity(5),
+            buf: IoBufMut::zeroed(5),
             cache,
         }
     }
@@ -924,7 +918,6 @@ mod tests {
         WriteAtRequest {
             file: make_file_fd(),
             offset: 0,
-            written: 0,
             write: IoBufs::from(IoBuf::from(b"hello")).into(),
             state: WriteAtState::Writing,
             cache,
@@ -944,7 +937,6 @@ mod tests {
     fn make_poll_request() -> PollRequest {
         PollRequest {
             fd: Arc::new(TcpListener::bind("127.0.0.1:0").unwrap()),
-            flags: libc::POLLIN as u32,
             deadline: None,
         }
     }
@@ -1263,12 +1255,11 @@ mod tests {
             recv.offset = progress;
             recv.len = len;
             assert!(catch_unwind(AssertUnwindSafe(|| recv.build_sqe())).is_err());
-
-            let mut read = make_read_request(Cache::Enabled);
-            read.read = progress;
-            read.len = len;
-            assert!(catch_unwind(AssertUnwindSafe(|| read.build_sqe())).is_err());
         }
+
+        let mut read = make_read_request(Cache::Enabled);
+        read.read = 6;
+        assert!(catch_unwind(AssertUnwindSafe(|| read.build_sqe())).is_err());
     }
 
     #[test]
@@ -1497,8 +1488,7 @@ mod tests {
             let trailing_sync = state == WriteAtState::WritingBeforeSync;
             let mut write = WriteAtRequest {
                 file: make_file_fd(),
-                offset: 0,
-                written: 0,
+                offset: 17,
                 write: IoBufs::from(buf.clone()).into(),
                 state,
                 cache: Cache::Enabled,
@@ -1513,7 +1503,7 @@ mod tests {
             assert_eq!(write.write.remaining_len(), 2);
             assert_eq!(write.build_sqe().get_opcode(), opcode::Write::CODE as u32);
             let mut result = write.on_cqe(ACTIVE, 2);
-            assert_eq!(write.written, len);
+            assert_eq!(write.offset, 17 + len as u64);
             assert!(write.write.is_complete());
 
             if trailing_sync {
@@ -1577,7 +1567,6 @@ mod tests {
         let mut request = WriteAtRequest {
             file: make_file_fd(),
             offset: 0,
-            written: 0,
             write: IoBufs::from(IoBuf::from(b"hello")).into(),
             state: WriteAtState::WritingSync,
             cache: Cache::Disabled(dont_cache_supported.clone()),

--- a/runtime/src/iouring/runtime.rs
+++ b/runtime/src/iouring/runtime.rs
@@ -103,12 +103,12 @@
 //! destruction on one-off threads can follow registration release.
 
 use super::{
-    driver::{Driver, ServiceOutcome},
+    driver::Driver,
     mailbox::{Mailbox, Message},
     request::{RequestOutput, RetiredResources},
     sleep::{Sleep, TimerId, Timers},
     spinner::{Config as SpinnerConfig, Spinner},
-    task::{BoxedTask, Running, Target, Task, TaskWaker, Tasks},
+    task::{BoxedTask, Running, Target, TaskWaker, Tasks},
     timeout::TimeoutWheel,
     waiter::WaiterId,
     waker::SUBMISSION_SEQ_MASK,
@@ -743,7 +743,7 @@ impl crate::Spawner for Context {
             parent.register(aborter);
         }
 
-        let task = Task::boxed(future);
+        let task: BoxedTask = Box::pin(future);
         let result = if let Some(active) = active {
             shared.launch(task, active);
             Ok(())
@@ -1477,8 +1477,9 @@ impl Worker {
             drop(waker);
         }
 
-        // Escaped handles can outlive task disposal. Detach their ordinary I/O
-        // observers and clear sleep registrations before draining retained work.
+        // Close every ordinary observer and timer before running callbacks.
+        // Admission is closed, so subsequent handle drops find no registration
+        // to detach. Only driver service can produce further deferred work.
         {
             let mut local = self.local.borrow_mut();
             let Local {
@@ -1494,7 +1495,7 @@ impl Worker {
         self.callbacks();
 
         // Retained writes and syncs still need to finish. Cancelled operations
-        // and their cancellation acknowledgements must also retire before exit.
+        // retain their resources until their own completion arrives.
         loop {
             // A retained write may still be queued without an SQE in flight.
             // Service must stage that work before we consider waiting for a CQE.
@@ -1503,14 +1504,6 @@ impl Worker {
 
             let mut local = self.local.borrow_mut();
 
-            // Callbacks can enqueue another batch. Keep TLS installed until
-            // all deferred work and kernel completions have been handled.
-            if !local.deferred.is_empty() {
-                continue;
-            }
-
-            // An operation can finish before its cancellation acknowledgement.
-            // The driver's empty check includes both kinds of outstanding work.
             if local.driver.as_ref().unwrap().is_empty() {
                 break;
             }
@@ -1550,11 +1543,10 @@ impl Worker {
     }
 
     /// Apply a bounded batch of messages, taking another mailbox batch when needed.
-    /// `woke` records a wake CQE. The publication sequence also detects messages
-    /// received while the worker was busy and had no kernel wait armed.
-    fn messages(&mut self, mailbox: &Arc<Mailbox>, woke: bool) {
+    /// The publication sequence records accepted work independently of signaling.
+    fn messages(&mut self, mailbox: &Arc<Mailbox>) {
         if self.inbox.is_empty()
-            && (woke || mailbox.waker.pending(self.processed_seq))
+            && mailbox.waker.pending(self.processed_seq)
             && mailbox.take(&mut self.inbox)
         {
             // Count transfer once, not each message application. Reversing
@@ -1569,9 +1561,10 @@ impl Worker {
             };
             match message {
                 Message::Spawn(task) => {
-                    if let Err(task) = Tasks::register(&Arc::downgrade(mailbox), task) {
-                        Panics::contain(|| drop(task));
-                    }
+                    self.local
+                        .borrow_mut()
+                        .tasks
+                        .insert(task, Arc::downgrade(mailbox));
                 }
                 Message::Wake(target) => {
                     let mut local = self.local.borrow_mut();
@@ -1587,8 +1580,8 @@ impl Worker {
     }
 
     /// Service the ring and timers using one time sample, collecting callbacks.
-    /// Reports wake CQEs and whether kernel service was deferred to an idle wait.
-    fn service(&mut self, defer_kernel_service: bool) -> ServiceOutcome {
+    /// Returns whether kernel service was deferred to an idle wait.
+    fn service(&mut self, defer_kernel_service: bool) -> bool {
         let mut local = self.local.borrow_mut();
         local.now = Instant::now();
         let Local {
@@ -1689,11 +1682,11 @@ impl Worker {
             let defer = !self.local.borrow().is_ready()
                 && self.inbox.is_empty()
                 && !mailbox.waker.pending(self.processed_seq);
-            let service = self.service(defer);
+            let kernel_deferred = self.service(defer);
 
             // Apply foreign messages and completion callbacks before considering
             // a wait. Any tasks they make ready will be polled on the next turn.
-            self.messages(&mailbox, service.woke);
+            self.messages(&mailbox);
             self.callbacks();
             if self.panics.first.is_some() {
                 return None;
@@ -1705,7 +1698,7 @@ impl Worker {
                 let mut local = self.local.borrow_mut();
                 (
                     local.is_ready(),
-                    local.driver.as_ref().unwrap().needs_kernel_service(),
+                    !local.driver.as_ref().unwrap().is_empty(),
                     local.driver.as_ref().unwrap().has_pending_submissions(),
                     local.next_deadline(),
                 )
@@ -1718,7 +1711,7 @@ impl Worker {
                 || !self.inbox.is_empty()
                 || mailbox.waker.pending(self.processed_seq)
             {
-                if (service.kernel_deferred && needs_kernel) || (defer && pending_submissions) {
+                if (kernel_deferred && needs_kernel) || (defer && pending_submissions) {
                     // An idle turn must stage work introduced by its callbacks.
                     // A wake alone needs catch-up only if GETEVENTS was deferred.
                     self.service(false);
@@ -1731,7 +1724,7 @@ impl Worker {
             // at this actual idle boundary after any elapsed callback time.
             let now = Instant::now();
             if deadline.is_some_and(|deadline| deadline <= now) {
-                if service.kernel_deferred && needs_kernel {
+                if kernel_deferred && needs_kernel {
                     self.service(false);
                     self.callbacks();
                 }
@@ -1741,8 +1734,8 @@ impl Worker {
             #[cfg(test)]
             tests::before_park();
 
-            // Outstanding operations and cancellations need the ring wait to run
-            // deferred kernel work. A futex wake alone cannot advance their I/O.
+            // Unfinished requests need the ring wait to run deferred kernel work.
+            // A futex wake alone cannot advance their I/O.
             if needs_kernel {
                 let result = self
                     .local
@@ -1929,7 +1922,7 @@ impl crate::Runner for Runner {
                     execution: Execution::default(),
                 })
             },
-            Some(Task::boxed(process.collect(Sleep::new))),
+            Some(Box::pin(process.collect(Sleep::new))),
             Some(tasks),
         )
         .and_then(|(mut worker, output)| {

--- a/runtime/src/iouring/runtime.rs
+++ b/runtime/src/iouring/runtime.rs
@@ -108,7 +108,7 @@ use super::{
     request::{RequestOutput, RetiredResources},
     sleep::{Sleep, TimerId, Timers},
     spinner::{Config as SpinnerConfig, Spinner},
-    task::{BoxedTask, Running, Target, TaskWaker, Tasks},
+    task::{BoxedTask, Running, Target, Task, TaskWaker, Tasks},
     timeout::TimeoutWheel,
     waiter::WaiterId,
     waker::SUBMISSION_SEQ_MASK,
@@ -743,7 +743,7 @@ impl crate::Spawner for Context {
             parent.register(aborter);
         }
 
-        let task: BoxedTask = Box::pin(future);
+        let task = Task::boxed(future);
         let result = if let Some(active) = active {
             shared.launch(task, active);
             Ok(())
@@ -1922,7 +1922,7 @@ impl crate::Runner for Runner {
                     execution: Execution::default(),
                 })
             },
-            Some(Box::pin(process.collect(Sleep::new))),
+            Some(Task::boxed(process.collect(Sleep::new))),
             Some(tasks),
         )
         .and_then(|(mut worker, output)| {

--- a/runtime/src/iouring/sleep.rs
+++ b/runtime/src/iouring/sleep.rs
@@ -15,6 +15,7 @@ use super::{
     mailbox::{Mailbox, Message},
     runtime::Local,
     slab::{Id, Slab},
+    timeout::TimeoutWheel,
 };
 use std::{
     cmp::Reverse,
@@ -54,10 +55,7 @@ pub struct Sleep {
 }
 
 impl Sleep {
-    /// Fallback duration when the requested deadline exceeds `Instant`'s range.
-    const OVERFLOW_TIMEOUT: Duration = Duration::from_secs(30 * 365 * 24 * 60 * 60);
-
-    /// Establish a relative deadline, using a far-future fallback on overflow.
+    /// Establish a relative deadline, clamping the duration to [`TimeoutWheel::MAX_TIMEOUT`].
     ///
     /// Zero sleeps take the ready path without reading a clock or accessing TLS.
     pub fn new(duration: Duration) -> Self {
@@ -65,10 +63,9 @@ impl Sleep {
             return Self { state: State::Done };
         }
 
-        let now = Instant::now();
-        let deadline = now
-            .checked_add(duration)
-            .unwrap_or_else(|| now + Self::OVERFLOW_TIMEOUT);
+        let deadline = Instant::now()
+            .checked_add(duration.min(TimeoutWheel::MAX_TIMEOUT))
+            .expect("sleep deadline clamped to TimeoutWheel::MAX_TIMEOUT is not representable");
 
         Self {
             state: State::Unregistered { deadline },
@@ -333,21 +330,7 @@ mod tests {
     }
 
     #[test]
-    fn test_representable_sleep_preserves_requested_duration() {
-        let duration = Duration::from_secs(31 * 365 * 24 * 60 * 60);
-        let before = Instant::now();
-        let sleep = Sleep::new(duration);
-        let after = Instant::now();
-        let State::Unregistered { deadline } = sleep.state else {
-            panic!("positive sleep must retain a deadline");
-        };
-
-        assert!(deadline >= before + duration);
-        assert!(deadline <= after + duration);
-    }
-
-    #[test]
-    fn test_overflowing_sleep_uses_far_future_deadline() {
+    fn test_far_future_sleep_clamps_the_deadline() {
         let before = Instant::now();
         let sleep = Sleep::new(Duration::MAX);
         let after = Instant::now();
@@ -355,8 +338,8 @@ mod tests {
             panic!("positive sleep must retain a deadline");
         };
 
-        assert!(deadline >= before + Sleep::OVERFLOW_TIMEOUT);
-        assert!(deadline <= after + Sleep::OVERFLOW_TIMEOUT);
+        assert!(deadline >= before + TimeoutWheel::MAX_TIMEOUT);
+        assert!(deadline <= after + TimeoutWheel::MAX_TIMEOUT);
     }
 
     #[test]

--- a/runtime/src/iouring/sleep.rs
+++ b/runtime/src/iouring/sleep.rs
@@ -15,7 +15,6 @@ use super::{
     mailbox::{Mailbox, Message},
     runtime::Local,
     slab::{Id, Slab},
-    timeout::TimeoutWheel,
 };
 use std::{
     cmp::Reverse,
@@ -55,7 +54,10 @@ pub struct Sleep {
 }
 
 impl Sleep {
-    /// Establish a relative deadline, clamping the duration to [`TimeoutWheel::MAX_TIMEOUT`].
+    /// Fallback duration when the requested deadline exceeds `Instant`'s range.
+    const OVERFLOW_TIMEOUT: Duration = Duration::from_secs(30 * 365 * 24 * 60 * 60);
+
+    /// Establish a relative deadline, using a far-future fallback on overflow.
     ///
     /// Zero sleeps take the ready path without reading a clock or accessing TLS.
     pub fn new(duration: Duration) -> Self {
@@ -63,9 +65,10 @@ impl Sleep {
             return Self { state: State::Done };
         }
 
-        let deadline = Instant::now()
-            .checked_add(duration.min(TimeoutWheel::MAX_TIMEOUT))
-            .expect("sleep deadline clamped to TimeoutWheel::MAX_TIMEOUT is not representable");
+        let now = Instant::now();
+        let deadline = now
+            .checked_add(duration)
+            .unwrap_or_else(|| now + Self::OVERFLOW_TIMEOUT);
 
         Self {
             state: State::Unregistered { deadline },
@@ -118,69 +121,53 @@ impl Future for Sleep {
             ),
         };
 
-        let mut cloned_waker = None;
-        loop {
-            let mut local = owner.borrow_mut();
+        let mut local = owner.borrow_mut();
+        assert!(
+            !local.closing,
+            "io_uring sleep polled after its worker closed"
+        );
 
-            // A waker clone can reenter and close the worker between passes.
-            assert!(
-                !local.closing,
-                "io_uring sleep polled after its worker closed"
-            );
-
-            // Expiry removes the registration before waking the task. Use the
-            // retained deadline to recognize completion even if the slot is gone.
-            if deadline <= local.now {
-                this.state = State::Done;
-
-                // If expiry has not removed the registration, detach its waker
-                // here. A clone that raced expiry also needs deferred destruction.
-                if let Some(timer_id) = registered
-                    && let Some(waker) = local.timers.cancel(timer_id)
-                {
-                    local.deferred.drops.push(waker);
-                }
-                local.deferred.drops.extend(cloned_waker);
-
-                return Poll::Ready(());
-            }
-
-            // An equivalent waker needs no clone or replacement.
-            if cloned_waker.is_none()
-                && registered.is_some_and(|id| local.timers.will_wake(id, cx.waker()))
+        // Expiry removes the registration before waking the task. Use the
+        // retained deadline to recognize completion even if the slot is gone.
+        if deadline <= local.now {
+            this.state = State::Done;
+            if let Some(timer_id) = registered
+                && let Some(waker) = local.timers.cancel(timer_id)
             {
-                return Poll::Pending;
+                local.deferred.drops.push(waker);
             }
+            return Poll::Ready(());
+        }
 
-            let Some(waker) = cloned_waker.take() else {
-                // Cloning can reenter deadline service or panic. Retain the
-                // registration identity and recheck expiry before refreshing.
-                drop(local);
-                cloned_waker = Some(cx.waker().clone());
-                continue;
-            };
-
-            if let Some(timer_id) = registered {
-                // Refresh only the observer, leaving the deadline and heap record
-                // in place. The displaced waker is dropped after this borrow.
-                let old = local
-                    .timers
-                    .refresh(timer_id, waker)
-                    .expect("live io_uring sleeper registration missing");
-                local.deferred.drops.push(old);
-            } else {
-                // Register after cloning succeeds, so a clone panic cannot leave
-                // a timer behind without a cancellation identity in this future.
-                let timer_id = local.timers.insert(deadline, waker);
-                this.state = State::Registered {
-                    mailbox: Arc::downgrade(&local.mailbox),
-                    timer_id,
-                    deadline,
-                };
-            }
-
+        if registered.is_some_and(|id| local.timers.will_wake(id, cx.waker())) {
             return Poll::Pending;
         }
+
+        // Worker service cannot run during this poll. Clone outside its borrow,
+        // retaining the cancellation identity if the callback panics.
+        drop(local);
+        let waker = cx.waker().clone();
+        let mut local = owner.borrow_mut();
+        if let Some(timer_id) = registered {
+            // Refresh only the observer, leaving the deadline and heap record
+            // in place. The displaced waker is dropped after this borrow.
+            let old = local
+                .timers
+                .refresh(timer_id, waker)
+                .expect("live io_uring sleeper registration missing");
+            local.deferred.drops.push(old);
+        } else {
+            // Register after cloning succeeds, so a clone panic cannot leave
+            // a timer behind without a cancellation identity in this future.
+            let timer_id = local.timers.insert(deadline, waker);
+            this.state = State::Registered {
+                mailbox: Arc::downgrade(&local.mailbox),
+                timer_id,
+                deadline,
+            };
+        }
+
+        Poll::Pending
     }
 }
 
@@ -346,7 +333,21 @@ mod tests {
     }
 
     #[test]
-    fn test_far_future_sleep_clamps_the_deadline() {
+    fn test_representable_sleep_preserves_requested_duration() {
+        let duration = Duration::from_secs(31 * 365 * 24 * 60 * 60);
+        let before = Instant::now();
+        let sleep = Sleep::new(duration);
+        let after = Instant::now();
+        let State::Unregistered { deadline } = sleep.state else {
+            panic!("positive sleep must retain a deadline");
+        };
+
+        assert!(deadline >= before + duration);
+        assert!(deadline <= after + duration);
+    }
+
+    #[test]
+    fn test_overflowing_sleep_uses_far_future_deadline() {
         let before = Instant::now();
         let sleep = Sleep::new(Duration::MAX);
         let after = Instant::now();
@@ -354,8 +355,8 @@ mod tests {
             panic!("positive sleep must retain a deadline");
         };
 
-        assert!(deadline >= before + TimeoutWheel::MAX_TIMEOUT);
-        assert!(deadline <= after + TimeoutWheel::MAX_TIMEOUT);
+        assert!(deadline >= before + Sleep::OVERFLOW_TIMEOUT);
+        assert!(deadline <= after + Sleep::OVERFLOW_TIMEOUT);
     }
 
     #[test]

--- a/runtime/src/iouring/task.rs
+++ b/runtime/src/iouring/task.rs
@@ -21,7 +21,7 @@ use std::{
     future::Future,
     pin::Pin,
     sync::{Arc, Weak},
-    task::{Context, Poll, Wake, Waker},
+    task::{Wake, Waker},
 };
 
 /// Root or spawned task selected by a routing waker.
@@ -81,30 +81,6 @@ pub struct TaskId(Id);
 
 /// Pinned future owned by the scheduler until completion or cancellation.
 pub type BoxedTask = Pin<Box<dyn Future<Output = ()> + Send>>;
-
-/// Pinned task with a separate poll entry point for its execution wrapper.
-pub struct Task<F> {
-    /// Future pinned in place with the enclosing task until destruction.
-    future: F,
-}
-
-impl<F: Future<Output = ()> + Send + 'static> Task<F> {
-    /// Allocate the task and erase its concrete type for scheduling.
-    pub fn boxed(future: F) -> BoxedTask {
-        Box::pin(Self { future })
-    }
-}
-
-impl<F: Future<Output = ()> + Send + 'static> Future for Task<F> {
-    type Output = ();
-
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
-        // SAFETY: The pinned Task allocation owns `future`. Neither this type
-        // nor its scheduler moves the field after pinning, and destruction runs
-        // in place. This projection grants exclusive access only for this poll.
-        unsafe { self.map_unchecked_mut(|task| &mut task.future) }.poll(cx)
-    }
-}
 
 /// Scheduling state changed exclusively by the owning worker.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -340,7 +316,7 @@ mod tests {
 
     /// Insert a pending task without a live worker or mailbox.
     fn insert(tasks: &mut Tasks) -> TaskId {
-        tasks.insert(Task::boxed(pending()), Weak::new())
+        tasks.insert(Box::pin(pending()), Weak::new())
     }
 
     #[test]
@@ -500,7 +476,7 @@ mod tests {
         let ids = [(); 4].map(|_| {
             let guard = DropCount(drops.clone());
             tasks.insert(
-                Task::boxed(async move {
+                Box::pin(async move {
                     let _guard = guard;
                     pending::<()>().await;
                 }),

--- a/runtime/src/iouring/task.rs
+++ b/runtime/src/iouring/task.rs
@@ -21,7 +21,7 @@ use std::{
     future::Future,
     pin::Pin,
     sync::{Arc, Weak},
-    task::{Wake, Waker},
+    task::{Context, Poll, Wake, Waker},
 };
 
 /// Root or spawned task selected by a routing waker.
@@ -81,6 +81,30 @@ pub struct TaskId(Id);
 
 /// Pinned future owned by the scheduler until completion or cancellation.
 pub type BoxedTask = Pin<Box<dyn Future<Output = ()> + Send>>;
+
+/// Pinned task with a separate poll entry point for its execution wrapper.
+pub struct Task<F> {
+    /// Future pinned in place with the enclosing task until destruction.
+    future: F,
+}
+
+impl<F: Future<Output = ()> + Send + 'static> Task<F> {
+    /// Allocate the task and erase its concrete type for scheduling.
+    pub fn boxed(future: F) -> BoxedTask {
+        Box::pin(Self { future })
+    }
+}
+
+impl<F: Future<Output = ()> + Send + 'static> Future for Task<F> {
+    type Output = ();
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+        // SAFETY: The pinned Task allocation owns `future`. Neither this type
+        // nor its scheduler moves the field after pinning, and destruction runs
+        // in place. This projection grants exclusive access only for this poll.
+        unsafe { self.map_unchecked_mut(|task| &mut task.future) }.poll(cx)
+    }
+}
 
 /// Scheduling state changed exclusively by the owning worker.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -316,7 +340,7 @@ mod tests {
 
     /// Insert a pending task without a live worker or mailbox.
     fn insert(tasks: &mut Tasks) -> TaskId {
-        tasks.insert(Box::pin(pending()), Weak::new())
+        tasks.insert(Task::boxed(pending()), Weak::new())
     }
 
     #[test]
@@ -476,7 +500,7 @@ mod tests {
         let ids = [(); 4].map(|_| {
             let guard = DropCount(drops.clone());
             tasks.insert(
-                Box::pin(async move {
+                Task::boxed(async move {
                     let _guard = guard;
                     pending::<()>().await;
                 }),

--- a/runtime/src/iouring/tests.rs
+++ b/runtime/src/iouring/tests.rs
@@ -1505,7 +1505,7 @@ fn test_shutdown_cancels_tasks_before_destruction() {
                         tree.clone(),
                     );
                     tree.register(handle.aborter().unwrap());
-                    let task = Task::boxed(future);
+                    let task: BoxedTask = Box::pin(future);
                     if matches!(placement, Placement::Foreign) {
                         let origin = context.origin.clone();
                         thread::spawn(move || assert!(Tasks::register(&origin, task).is_ok()))
@@ -2025,55 +2025,52 @@ fn test_callback_generated_work_prevents_parking() {
 
 #[test]
 fn test_final_callbacks_finish_before_tls_removal() {
-    /// Extend shutdown cleanup from each destructor, then panic at the chain's end.
-    struct Chain {
-        /// Number of additional callbacks to leave in the next deferred batch.
-        remaining: usize,
-        /// Count every callback, including the final one that panics.
-        drops: Arc<AtomicUsize>,
-    }
+    /// Observe final timer disposal through the registered waker's destructor.
+    struct Callback(Arc<AtomicUsize>);
 
     // This waker owns a reentrant destructor, which Waker::noop cannot model.
     #[allow(clippy::manual_noop_waker)]
-    impl Wake for Chain {
+    impl Wake for Callback {
         fn wake(self: Arc<Self>) {}
     }
 
-    impl Drop for Chain {
+    impl Drop for Callback {
         fn drop(&mut self) {
-            self.drops.fetch_add(1, Ordering::SeqCst);
             let local = Local::current().expect("callback ran after TLS removal");
-            if self.remaining == 0 {
-                panic!("terminal callback panic");
-            }
+            assert!(local.try_borrow_mut().unwrap().closing);
 
-            // Each destructor generates another ownership batch. No Local
-            // reference escapes shutdown or postpones its final destruction.
-            local
-                .borrow_mut()
-                .deferred
-                .drops
-                .push(Waker::from(Arc::new(Self {
-                    remaining: self.remaining - 1,
-                    drops: self.drops.clone(),
-                })));
+            // Public callbacks cannot register another timer on a closed worker.
+            let mut sleep = Sleep::new(Duration::from_secs(60));
+            let panic = catch_unwind(AssertUnwindSafe(|| {
+                Pin::new(&mut sleep).poll(&mut TaskContext::from_waker(Waker::noop()))
+            }))
+            .expect_err("sleep must reject polling after worker closure");
+            assert_eq!(
+                extract_panic_message(&*panic),
+                "io_uring sleep polled after its worker closed"
+            );
+
+            // The outer assertion must observe successful validation even when
+            // the runtime contains this callback's deliberate secondary panic.
+            self.0.fetch_add(1, Ordering::SeqCst);
+            panic!("terminal callback panic");
         }
     }
 
     let drops = Arc::new(AtomicUsize::new(0));
     let observed = drops.clone();
-
+    let mut escaped = None;
     let result = catch_unwind(AssertUnwindSafe(|| {
-        Runner::new(config()).start(|_| async move {
-            Local::current()
-                .unwrap()
-                .borrow_mut()
-                .deferred
-                .drops
-                .push(Waker::from(Arc::new(Chain {
-                    remaining: 8,
-                    drops,
-                })));
+        Runner::new(config()).start(|_| async {
+            let mut sleep = Sleep::new(Duration::from_secs(60));
+            let waker = Waker::from(Arc::new(Callback(drops)));
+            assert!(
+                Pin::new(&mut sleep)
+                    .poll(&mut TaskContext::from_waker(&waker))
+                    .is_pending()
+            );
+            drop(waker);
+            escaped = Some(sleep);
             panic!("primary root panic");
         });
     }));
@@ -2082,7 +2079,8 @@ fn test_final_callbacks_finish_before_tls_removal() {
         extract_panic_message(&*result.unwrap_err()),
         "primary root panic"
     );
-    assert_eq!(observed.load(Ordering::SeqCst), 9);
+    assert_eq!(observed.load(Ordering::SeqCst), 1);
+    drop(escaped);
 }
 
 #[test]

--- a/runtime/src/iouring/tests.rs
+++ b/runtime/src/iouring/tests.rs
@@ -2025,6 +2025,17 @@ fn test_callback_generated_work_prevents_parking() {
 
 #[test]
 fn test_final_callbacks_finish_before_tls_removal() {
+    /// Observe disposal of a successful root result when shutdown fails.
+    #[derive(Debug)]
+    struct Output(Arc<AtomicUsize>);
+
+    impl Drop for Output {
+        fn drop(&mut self) {
+            self.0.fetch_add(1, Ordering::SeqCst);
+            panic!("root output drop panic");
+        }
+    }
+
     /// Observe final timer disposal through the registered waker's destructor.
     struct Callback(Arc<AtomicUsize>);
 
@@ -2057,30 +2068,45 @@ fn test_final_callbacks_finish_before_tls_removal() {
         }
     }
 
-    let drops = Arc::new(AtomicUsize::new(0));
-    let observed = drops.clone();
-    let mut escaped = None;
-    let result = catch_unwind(AssertUnwindSafe(|| {
-        Runner::new(config()).start(|_| async {
-            let mut sleep = Sleep::new(Duration::from_secs(60));
-            let waker = Waker::from(Arc::new(Callback(drops)));
-            assert!(
-                Pin::new(&mut sleep)
-                    .poll(&mut TaskContext::from_waker(&waker))
-                    .is_pending()
-            );
-            drop(waker);
-            escaped = Some(sleep);
-            panic!("primary root panic");
-        });
-    }));
+    for root_panics in [true, false] {
+        let drops = Arc::new(AtomicUsize::new(0));
+        let observed = drops.clone();
+        let output_drops = Arc::new(AtomicUsize::new(0));
+        let observed_output = output_drops.clone();
+        let mut escaped = None;
+        let result = catch_unwind(AssertUnwindSafe(|| {
+            Runner::new(config()).start(|_| async {
+                let mut sleep = Sleep::new(Duration::from_secs(60));
+                let waker = Waker::from(Arc::new(Callback(drops)));
+                assert!(
+                    Pin::new(&mut sleep)
+                        .poll(&mut TaskContext::from_waker(&waker))
+                        .is_pending()
+                );
+                drop(waker);
+                escaped = Some(sleep);
+                if root_panics {
+                    panic!("primary root panic");
+                }
+                Output(output_drops)
+            })
+        }));
 
-    assert_eq!(
-        extract_panic_message(&*result.unwrap_err()),
-        "primary root panic"
-    );
-    assert_eq!(observed.load(Ordering::SeqCst), 1);
-    drop(escaped);
+        assert_eq!(
+            extract_panic_message(&*result.unwrap_err()),
+            if root_panics {
+                "primary root panic"
+            } else {
+                "terminal callback panic"
+            }
+        );
+        assert_eq!(observed.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            observed_output.load(Ordering::SeqCst),
+            usize::from(!root_panics)
+        );
+        drop(escaped);
+    }
 }
 
 #[test]

--- a/runtime/src/iouring/timeout.rs
+++ b/runtime/src/iouring/timeout.rs
@@ -13,8 +13,8 @@
 //!   whether an entry is still active or stale.
 //! - Stale entries are expected and cheap to skip, which keeps bookkeeping overhead low
 //!   when timeout expirations are rare.
-//! - Expiry entries carry waiter slot plus scheduled tick identity so callers can safely
-//!   ignore stale entries after slot reuse.
+//! - Expiry entries carry full waiter generations so callers can safely ignore stale
+//!   entries after slot reuse. Each registration has at most one deadline.
 //! - Buckets are drained in place, so inner `Vec` capacity is retained and reused across
 //!   cycles to reduce allocations.
 //! - Reusing an inactive bucket clears its stale entries without releasing capacity.
@@ -37,27 +37,6 @@ use std::{
 /// treated as an opaque counter.
 pub type Tick = u64;
 
-/// Entry yielded when a wheel bucket expires.
-///
-/// Includes waiter identity and target tick.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct TimeoutEntry {
-    /// Stable waiter identity to inspect.
-    pub waiter_id: WaiterId,
-    /// Tick the waiter was originally scheduled for.
-    pub target_tick: Tick,
-}
-
-impl TimeoutEntry {
-    /// Pair a registration's identity with its scheduled tick.
-    const fn new(waiter_id: WaiterId, target_tick: Tick) -> Self {
-        Self {
-            waiter_id,
-            target_tick,
-        }
-    }
-}
-
 /// Single-level (non-hierarchical) hashed timing wheel used for deadline tracking.
 pub struct TimeoutWheel {
     /// Bitmask used to map ticks to slot indices.
@@ -66,7 +45,7 @@ pub struct TimeoutWheel {
     ///
     /// A slot is chosen by `tick & slot_mask`. Multiple target ticks can map to
     /// the same slot over time, and each slot bucket may contain multiple entries.
-    buckets: Vec<Vec<TimeoutEntry>>,
+    buckets: Vec<Vec<WaiterId>>,
     /// Occupancy bitset for buckets that contain any entries (active or stale).
     occupied: Vec<u64>,
     /// Number of occupied bucket slots currently represented in `occupied`.
@@ -242,7 +221,7 @@ impl TimeoutWheel {
         }
 
         // Append timeout candidate, stale entries are filtered by caller on drain.
-        self.buckets[slot].push(TimeoutEntry::new(id, target_tick));
+        self.buckets[slot].push(id);
         self.active_deadlines += 1;
 
         // Track active deadlines per slot to support fast min recomputation.
@@ -320,7 +299,7 @@ impl TimeoutWheel {
     ///
     /// When no active deadlines exist, this still advances `current_tick` and may
     /// purge stale occupied buckets.
-    pub fn advance(&mut self, now: Instant) -> Option<Vec<TimeoutEntry>> {
+    pub fn advance(&mut self, now: Instant) -> Option<Vec<WaiterId>> {
         let elapsed = now.saturating_duration_since(self.start);
         let now_tick = Self::duration_to_nanos_saturating(elapsed) / self.tick_nanos;
 
@@ -408,7 +387,7 @@ impl TimeoutWheel {
     ///
     /// For each set slot in the occupied bitset, invokes `drain` with that slot's
     /// bucket and clears occupancy metadata.
-    fn drain_occupied_buckets(&mut self, mut drain: impl FnMut(&mut Vec<TimeoutEntry>)) {
+    fn drain_occupied_buckets(&mut self, mut drain: impl FnMut(&mut Vec<WaiterId>)) {
         for word_index in 0..self.occupied.len() {
             let mut word = self.occupied[word_index];
             if word == 0 {
@@ -440,7 +419,7 @@ impl TimeoutWheel {
     ///
     /// This reads occupancy at word granularity, clears occupied bits for the
     /// drained range, and appends drained buckets into `expired`.
-    fn drain_occupied_range(&mut self, start: usize, end: usize, expired: &mut Vec<TimeoutEntry>) {
+    fn drain_occupied_range(&mut self, start: usize, end: usize, expired: &mut Vec<WaiterId>) {
         if start >= end {
             return;
         }
@@ -570,7 +549,7 @@ mod tests {
     }
 
     /// Advance to a fixture tick, returning any drained candidates.
-    fn advance(wheel: &mut TimeoutWheel, tick: Tick) -> Vec<TimeoutEntry> {
+    fn advance(wheel: &mut TimeoutWheel, tick: Tick) -> Vec<WaiterId> {
         wheel.advance(now_for_tick(wheel, tick)).unwrap_or_default()
     }
 
@@ -651,10 +630,7 @@ mod tests {
         wheel.schedule(waiter_id(0, 0), 4);
         assert_eq!(wheel.next_deadline(), Some(now_for_tick(&wheel, 4)));
         assert!(advance(&mut wheel, 3).is_empty());
-        assert_eq!(
-            advance(&mut wheel, 4),
-            vec![TimeoutEntry::new(waiter_id(0, 0), 4)]
-        );
+        assert_eq!(advance(&mut wheel, 4), vec![waiter_id(0, 0)]);
         wheel.remove(4);
         assert_eq!(wheel.next_deadline(), None);
     }
@@ -680,10 +656,7 @@ mod tests {
         assert_eq!(wheel.next_deadline(), Some(deadline));
         assert!(wheel.advance(now + Duration::from_millis(6)).is_none());
         assert_eq!(wheel.next_deadline(), Some(deadline));
-        assert_eq!(
-            advance(&mut wheel, target),
-            vec![TimeoutEntry::new(waiter_id(0, 0), target)]
-        );
+        assert_eq!(advance(&mut wheel, target), vec![waiter_id(0, 0)]);
         wheel.remove(target);
     }
 
@@ -705,10 +678,7 @@ mod tests {
         wheel.schedule(waiter_id(0, 0), 5);
         assert!(advance(&mut wheel, 4).is_empty());
         assert_eq!(wheel.next_deadline(), Some(now_for_tick(&wheel, 5)));
-        assert_eq!(
-            advance(&mut wheel, 5),
-            vec![TimeoutEntry::new(waiter_id(0, 0), 5)]
-        );
+        assert_eq!(advance(&mut wheel, 5), vec![waiter_id(0, 0)]);
         wheel.remove(5);
     }
 
@@ -722,19 +692,13 @@ mod tests {
         // New registrations can join a later bucket between service turns.
         assert!(advance(&mut wheel, 1).is_empty());
         wheel.schedule(waiter_id(3, 0), 5);
-        assert_eq!(
-            advance(&mut wheel, 2),
-            vec![TimeoutEntry::new(waiter_id(1, 0), 2)]
-        );
+        assert_eq!(advance(&mut wheel, 2), vec![waiter_id(1, 0)]);
         wheel.remove(2);
         assert_eq!(wheel.next_deadline(), Some(now_for_tick(&wheel, 5)));
 
         assert_eq!(
             advance(&mut wheel, 5),
-            vec![
-                TimeoutEntry::new(waiter_id(2, 0), 5),
-                TimeoutEntry::new(waiter_id(3, 0), 5)
-            ]
+            vec![waiter_id(2, 0), waiter_id(3, 0)]
         );
 
         // Draining returns candidates. Each active registration still needs removal.
@@ -775,11 +739,7 @@ mod tests {
         // One advance crosses slot zero and drains both the tail and head ranges.
         assert_eq!(
             advance(&mut wheel, 33),
-            vec![
-                TimeoutEntry::new(waiter_id(1, 0), 31),
-                TimeoutEntry::new(waiter_id(3, 0), 33),
-                TimeoutEntry::new(waiter_id(2, 0), 33),
-            ]
+            vec![waiter_id(1, 0), waiter_id(3, 0), waiter_id(2, 0),]
         );
         wheel.remove(31);
         wheel.remove(33);
@@ -797,20 +757,13 @@ mod tests {
         // Cross a bitset word boundary, leaving a later bit in that word untouched.
         assert_eq!(
             advance(&mut wheel, 65),
-            vec![
-                TimeoutEntry::new(waiter_id(63, 0), 63),
-                TimeoutEntry::new(waiter_id(64, 0), 64),
-                TimeoutEntry::new(waiter_id(65, 0), 65),
-            ]
+            vec![waiter_id(63, 0), waiter_id(64, 0), waiter_id(65, 0),]
         );
         for tick in [63, 64, 65] {
             wheel.remove(tick);
         }
         assert_eq!(wheel.next_deadline(), Some(now_for_tick(&wheel, 100)));
-        assert_eq!(
-            advance(&mut wheel, 100),
-            vec![TimeoutEntry::new(waiter_id(100, 0), 100)]
-        );
+        assert_eq!(advance(&mut wheel, 100), vec![waiter_id(100, 0)]);
         wheel.remove(100);
     }
 
@@ -823,14 +776,8 @@ mod tests {
 
             // Advancing by a full revolution or more drains every occupied bucket.
             let mut expired = advance(&mut wheel, tick);
-            expired.sort_unstable_by_key(|entry| entry.target_tick);
-            assert_eq!(
-                expired,
-                vec![
-                    TimeoutEntry::new(waiter_id(2, 0), 5),
-                    TimeoutEntry::new(waiter_id(1, 0), 20)
-                ]
-            );
+            expired.sort_unstable_by_key(|id| id.0.index);
+            assert_eq!(expired, vec![waiter_id(1, 0), waiter_id(2, 0)]);
             wheel.remove(5);
             wheel.remove(20);
             assert_eq!(wheel.occupied_slots, 0);
@@ -838,10 +785,7 @@ mod tests {
 
             // Reuse the wheel immediately after draining it.
             wheel.schedule(waiter_id(2, 1), tick + 1);
-            assert_eq!(
-                advance(&mut wheel, tick + 1),
-                vec![TimeoutEntry::new(waiter_id(2, 1), tick + 1)]
-            );
+            assert_eq!(advance(&mut wheel, tick + 1), vec![waiter_id(2, 1)]);
             wheel.remove(tick + 1);
         }
     }
@@ -869,7 +813,7 @@ mod tests {
     }
 
     #[test]
-    fn test_reused_slot_preserves_registration_and_tick() {
+    fn test_reused_slot_preserves_registration_identity() {
         let mut wheel = wheel(Duration::from_millis(100));
         let old = waiter_id(7, 0);
         let current = waiter_id(7, 1);
@@ -877,11 +821,8 @@ mod tests {
         wheel.remove(5);
         wheel.schedule(current, 10);
 
-        // Lazy removal preserves the old identity and tick beside the replacement.
-        assert_eq!(
-            advance(&mut wheel, 10),
-            vec![TimeoutEntry::new(old, 5), TimeoutEntry::new(current, 10)]
-        );
+        // Lazy removal preserves the old identity beside the replacement.
+        assert_eq!(advance(&mut wheel, 10), vec![old, current]);
 
         // The caller rejects the old candidate and removes only the live expiry.
         wheel.remove(10);
@@ -910,7 +851,7 @@ mod tests {
         );
 
         let expired = advance(&mut wheel, 1034);
-        assert!(expired.contains(&TimeoutEntry::new(waiter_id(1024, 0), 1034)));
+        assert!(expired.contains(&waiter_id(1024, 0)));
         wheel.remove(1034);
         assert!(advance(&mut wheel, 1035).is_empty());
         assert_eq!(wheel.occupied_slots, 0);
@@ -935,15 +876,12 @@ mod tests {
         // Once the bucket is inactive, reuse discards stale records but keeps its storage.
         let current = waiter_id(0, 1);
         wheel.schedule(current, 10);
-        assert_eq!(wheel.buckets[slot], vec![TimeoutEntry::new(current, 10)]);
+        assert_eq!(wheel.buckets[slot], vec![current]);
         assert_eq!(wheel.buckets[slot].capacity(), capacity);
         assert_eq!(wheel.occupied_slots, 1);
         assert_eq!(wheel.active_deadlines, 1);
 
-        assert_eq!(
-            advance(&mut wheel, 10),
-            vec![TimeoutEntry::new(current, 10)]
-        );
+        assert_eq!(advance(&mut wheel, 10), vec![current]);
         wheel.remove(10);
         assert_eq!(wheel.occupied_slots, 0);
         assert_eq!(wheel.active_deadlines, 0);

--- a/runtime/src/iouring/waiter.rs
+++ b/runtime/src/iouring/waiter.rs
@@ -124,7 +124,7 @@ pub enum Observation {
     Ready(RequestOutput),
     /// Request is unfinished and its installed waker already matches the caller.
     Pending,
-    /// The caller must clone its waker outside the worker borrow, then recheck.
+    /// The caller must clone its waker outside the worker borrow before installing it.
     Refresh,
 }
 
@@ -268,9 +268,8 @@ impl Waiters {
 
     /// Install a waker already cloned outside the worker borrow.
     ///
-    /// Returns the previous waker for deferred destruction. The caller must
-    /// recheck [`Self::observe`] after cloning, since cloning can reenter and
-    /// finish the request. Panics unless a pending ordinary observer remains.
+    /// Returns the previous waker for deferred destruction. Panics unless the
+    /// request has a pending ordinary observer.
     pub fn set_waker(&mut self, id: WaiterId, waker: Waker) -> Option<Waker> {
         let waiter = self.get_mut(id).expect("observer waiter missing");
         let Observer::Ordinary(current) = &mut waiter.observer else {
@@ -588,9 +587,8 @@ pub mod tests {
         Request::ReadAt(ReadAtRequest {
             file: held(File::from(make_socket_fd())),
             offset: 0,
-            len: 5,
             read: 0,
-            buf: IoBufMut::with_capacity(5),
+            buf: IoBufMut::zeroed(5),
             cache: Cache::Enabled,
         })
     }
@@ -608,7 +606,6 @@ pub mod tests {
     fn make_poll_request() -> Request {
         Request::Poll(PollRequest {
             fd: Arc::new(TcpListener::bind("127.0.0.1:0").unwrap()),
-            flags: libc::POLLIN as u32,
             deadline: None,
         })
     }

--- a/runtime/src/iouring/waker.rs
+++ b/runtime/src/iouring/waker.rs
@@ -7,7 +7,7 @@
 //!   blocking in `submit_and_wait`.
 //! - Producers wake only the currently armed wait target.
 //! - A dedicated "wake signalled" bit coalesces repeated wake attempts.
-//! - Out-of-band wake requests use [`Waker::wake`].
+//! - Producers complete requested signaling with [`Waker::wake`] after unlocking.
 //! - Wake CQEs are acknowledged with [`Waker::acknowledge`].
 //!
 //! The packed atomic state combines:
@@ -63,13 +63,11 @@ const WAITING_MASK: u32 = WAITING_ON_FUTEX_BIT | WAITING_ON_EVENTFD_BIT;
 const SUBMISSION_INCREMENT: u32 = 1 << STATE_BITS;
 /// Full sequence domain used by the packed submission counter (state >> 3).
 pub const SUBMISSION_SEQ_MASK: u32 = u32::MAX >> STATE_BITS;
-/// Maximum live published-minus-processed gap that keeps modular order directional.
-const HALF_SUBMISSION_SEQUENCE_DOMAIN: u32 = SUBMISSION_SEQ_MASK.div_ceil(2);
 
 /// RAII guard returned by [`Waker::arm`] for a `submit_and_wait` blocking section.
 ///
 /// While this guard is live, the loop is armed to receive an eventfd-based
-/// wake if producers publish new work or request an out-of-band notification.
+/// wake from a producer completing its publication signal.
 pub struct ArmGuard<'a> {
     /// Wake source to disarm when the guard is dropped.
     waker: &'a Waker,
@@ -105,20 +103,19 @@ impl Drop for ArmGuard<'_> {
 /// the loop blocks only if the same snapshot still shows no latched wake and carries
 /// the exact `submitted_seq == processed_seq` snapshot the loop armed against.
 ///
-/// The live published-minus-processed gap must remain below half the sequence
-/// domain. A mailbox has at most one published batch in its shared inbox and one
-/// transferred batch awaiting its processed increment, independently of message
-/// count. This makes the modular delta `submitted_seq - processed_seq`
-/// directional: a nonzero delta smaller than half the domain means publication
-/// is ahead. No bound on the number of messages in a batch is needed.
+/// Transferring a batch acquires the inbox mutex before acknowledging its
+/// publication. The owner's subsequent sequence reads cannot precede that
+/// publication. At each pending check, only the shared inbox can hold an
+/// unacknowledged batch, so unequal sequences mean work remains pending even
+/// across counter wrap. No bound on the number of messages in a batch is needed.
 ///
 /// Blocking follows an arm-and-recheck protocol:
-/// - The loop first checks for a published-ahead delta, then arms a wait target.
+/// - The loop first checks for pending publication, then arms a wait target.
 /// - The loop blocks only if the post-arm snapshot still looks idle after that
 ///   same atomic state transition.
 /// - Submitters signal the currently armed wait target exactly once.
-/// - Out-of-band notifications latch one wake even while unarmed, so the next
-///   arm-and-recheck cycle skips blocking once.
+/// - A delayed signal may latch a wake while unarmed, causing the next
+///   arm-and-recheck cycle to skip blocking once.
 ///
 /// This makes submissions racing with the sleep transition observable either by
 /// sequence mismatch in the loop or by a futex/eventfd wakeup.
@@ -157,7 +154,7 @@ struct WakerInner {
 /// Internal hybrid futex/eventfd wake source for the io_uring loop.
 ///
 /// - Publish submissions from producers via [`Waker::publish`]
-/// - Wake without publishing via [`Waker::wake`]
+/// - Complete publication signaling after unlocking via [`Waker::wake`]
 /// - Test whether published work is still pending via [`Waker::pending`]
 /// - Park in the fully-idle path via [`Waker::park_idle`]
 /// - Arm a `submit_and_wait` blocking section via [`Waker::arm`]
@@ -217,19 +214,14 @@ impl Waker {
         })
     }
 
-    /// Latch one pending wake and, if a target is currently armed, wake it.
+    /// Complete signaling requested by [`Self::publish`] after releasing the inbox.
     ///
-    /// The first caller to set `WAKE_SIGNALLED_BIT` in an epoch performs the
-    /// wake. Subsequent callers do nothing until the loop disarms and clears
-    /// the bit.
-    ///
-    /// All claimed wakes flow through this path, whether they come from
-    /// producers signaling after publication or from an out-of-band caller
-    /// such as a runtime stop notification.
+    /// The batch may already be consumed and the wait target may have changed.
+    /// The first caller to set `WAKE_SIGNALLED_BIT` in the current epoch performs
+    /// the wake. Later callers do nothing until the loop disarms and clears it.
+    /// This coalesces delayed signals from previously consumed batches.
     pub fn wake(&self) {
-        // Publish the notification before signaling. The owner's disarm
-        // acquire then observes the state that caused an out-of-band wake,
-        // even when no mailbox batch advanced the sequence.
+        // Claim one signal for the target observed by this atomic transition.
         let prev = self
             .inner
             .state
@@ -284,15 +276,11 @@ impl Waker {
     /// of that drained sequence.
     #[inline]
     pub fn pending(&self, processed_seq: u32) -> bool {
-        // Pair this `Acquire` with publication's `Release`. The outstanding
-        // batch count stays below half the packed sequence domain, so a
-        // non-zero modular delta smaller than that half-range unambiguously
-        // means `published_seq` is ahead of `processed_seq`.
+        // Pair this `Acquire` with publication's `Release` before inbox transfer.
         let published_seq =
             (self.inner.state.load(Ordering::Acquire) >> STATE_BITS) & SUBMISSION_SEQ_MASK;
 
-        let delta = published_seq.wrapping_sub(processed_seq) & SUBMISSION_SEQ_MASK;
-        delta != 0 && delta < HALF_SUBMISSION_SEQUENCE_DOMAIN
+        published_seq != (processed_seq & SUBMISSION_SEQ_MASK)
     }
 
     /// Park while idle until notification or the optional absolute deadline.
@@ -302,9 +290,8 @@ impl Waker {
     /// not count as a quick notification wake for adaptive spinning. Every
     /// return clears the armed wait state, including skipped sleeps.
     pub fn park_idle(&self, processed_seq: u32, deadline: Option<Instant>) -> Option<Duration> {
-        // Arming only updates the packed wake state machine. It does not
-        // publish queue memory or consume any out-of-band wake publication, so
-        // `Relaxed` is sufficient on this RMW.
+        // Arming changes only wait state; the inbox mutex owns message
+        // visibility. The atomic snapshot alone decides whether to block.
         let prev = self
             .inner
             .state
@@ -340,9 +327,8 @@ impl Waker {
     /// normal idle path. A latched wake or sequence mismatch rejects sleeping
     /// and requires the owner to recheck its work.
     pub fn arm(&self, processed_seq: u32) -> ArmGuard<'_> {
-        // Arming only updates the packed wake state machine. It does not
-        // publish queue memory or consume any out-of-band wake publication, so
-        // `Relaxed` is sufficient on this RMW.
+        // Arming changes only wait state; the inbox mutex owns message
+        // visibility. The atomic snapshot alone decides whether to block.
         let prev = self
             .inner
             .state
@@ -580,7 +566,7 @@ impl Waker {
     /// The caller must pass the exact post-arm snapshot from the same atomic
     /// transition that set `WAITING_ON_FUTEX_BIT`. `FUTEX_WAIT` only blocks
     /// while the word still equals that value, which closes the race between
-    /// arming idle sleep and a concurrent publish or out-of-band wake.
+    /// arming idle sleep and a concurrent publication or delayed signal.
     ///
     /// Returns to the loop on `EINTR`, preserving the absolute deadline for the
     /// next parking attempt. Treats `EAGAIN` as "state already changed before
@@ -929,32 +915,22 @@ pub mod tests {
     }
 
     #[test]
-    fn test_pending_uses_directional_half_range_compare() {
-        // Verify `pending()` only reports work when the published sequence is
-        // directionally ahead within the half-range window.
-        let waker = Waker::new().expect("eventfd creation should succeed");
+    fn test_pending_tracks_publication_across_wrap() {
+        for start in [0, SUBMISSION_SEQ_MASK] {
+            let waker = Waker::new().expect("eventfd creation should succeed");
+            waker
+                .inner
+                .state
+                .store(start << STATE_BITS, Ordering::Relaxed);
+            let mut processed = start;
+            assert!(!waker.pending(processed));
 
-        // A one-step published-ahead delta is pending for `processed_seq = 0`,
-        // but not once the loop has caught up.
-        waker.inner.state.store(1 << STATE_BITS, Ordering::Relaxed);
-        assert!(waker.pending(0));
-        assert!(!waker.pending(1));
-
-        // A visible published sequence that lags behind `processed_seq` must
-        // not be treated as pending work.
-        waker.inner.state.store(0, Ordering::Relaxed);
-        assert!(!waker.pending(1));
-
-        // Exactly half the domain is ambiguous and therefore not directional.
-        waker.inner.state.store(
-            HALF_SUBMISSION_SEQUENCE_DOMAIN << STATE_BITS,
-            Ordering::Relaxed,
-        );
-        assert!(!waker.pending(0));
-
-        // Wrapping by one still counts as a published-ahead delta.
-        waker.inner.state.store(0, Ordering::Relaxed);
-        assert!(waker.pending(SUBMISSION_SEQ_MASK));
+            assert!(!waker.publish());
+            assert!(waker.pending(processed));
+            processed = processed.wrapping_add(1);
+            assert!(!waker.pending(processed));
+            assert!(!waker.pending(processed & SUBMISSION_SEQ_MASK));
+        }
     }
 
     #[test]
@@ -1555,9 +1531,13 @@ mod loom_tests {
             let mut received = Vec::new();
             let mut scratch = Vec::new();
             while received.len() < 2 {
+                let published = submitted_seq(&waker);
+                assert!((published.wrapping_sub(processed) & SUBMISSION_SEQ_MASK) <= 1);
                 if scratch.is_empty() && waker.pending(processed) {
-                    let mut inbox = inbox.lock().unwrap();
-                    std::mem::swap(&mut *inbox, &mut scratch);
+                    {
+                        let mut inbox = inbox.lock().unwrap();
+                        std::mem::swap(&mut *inbox, &mut scratch);
+                    }
                     if !scratch.is_empty() {
                         processed = processed.wrapping_add(1) & SUBMISSION_SEQ_MASK;
                     }
@@ -1611,7 +1591,7 @@ mod loom_tests {
                 let mut inbox = inbox.lock().unwrap();
                 std::mem::swap(&mut inbox.1, &mut scratch);
             }
-            let processed = 1;
+            let mut processed = 1;
             assert!(!waker.pending(processed));
             let first = scratch.remove(0);
             let arm = waker.arm(processed);
@@ -1642,10 +1622,20 @@ mod loom_tests {
                 inbox.0 = false;
                 std::mem::take(&mut inbox.1)
             };
+            if !detached.is_empty() {
+                processed += 1;
+            }
+            assert!(!waker.pending(processed));
+            {
+                let mut inbox = inbox.lock().unwrap();
+                inbox.0 = false;
+                assert!(std::mem::take(&mut inbox.1).is_empty());
+            }
+            assert!(!waker.pending(processed));
             drop(arm);
             let rejected = producer.join().unwrap();
-            let accepted = usize::from(rejected.is_none());
-            assert_eq!(submitted_seq(&waker), processed + accepted as u32);
+            assert_eq!(processed, 1 + u32::from(rejected.is_none()));
+            assert_eq!(submitted_seq(&waker), processed);
             detached.push(first);
             detached.append(&mut scratch);
             detached.extend(rejected);
@@ -1716,7 +1706,7 @@ mod loom_tests {
 
     #[test]
     fn test_wake_clear_wait_pairing() {
-        // `wake` is used by out-of-band callers such as runtime shutdown. It
+        // Exercise wake/clear ordering directly, without a mailbox prefix. It
         // must publish the caller's earlier state change to the loop even though
         // it does not advance the submitted sequence.
         //
@@ -1846,8 +1836,7 @@ mod loom_tests {
     fn test_wake_clear_wait_pairing_when_armed() {
         // When an out-of-band wake lands in an armed eventfd epoch, the loop
         // resumes without any sequence progress. `clear_wait()` must still
-        // acquire the notifier's earlier state change before the loop checks for
-        // disconnect or shutdown state after waking.
+        // acquire the notifier's earlier state change before reading its payload.
         loom::model(|| {
             let waker = Waker::new().unwrap();
             let queued = Arc::new(QueuedRequest::empty());
@@ -2033,9 +2022,8 @@ mod loom_tests {
     #[test]
     fn test_sequence_wraparound() {
         // Preload the sequence to the last representable value, then publish
-        // twice so the visible sequence wraps through zero to one. The
-        // half-range modular `pending()` check must remain directional across
-        // that boundary.
+        // twice so the visible sequence wraps through zero to one. Pending
+        // publication must remain observable across that boundary.
         loom::model(|| {
             let waker = Waker::new().unwrap();
             waker

--- a/runtime/src/network/iouring.rs
+++ b/runtime/src/network/iouring.rs
@@ -571,16 +571,31 @@ mod tests {
         telemetry::metrics::{Register, Registry},
     };
     use commonware_macros::{select, test_group};
+    use futures::FutureExt as _;
     use std::{
-        io::Write,
+        io::{Read, Write},
         net::TcpStream,
         os::{
             fd::{AsRawFd, OwnedFd},
             unix::net::UnixStream,
         },
-        sync::Arc,
+        pin::pin,
+        sync::{
+            Arc,
+            atomic::{AtomicBool, Ordering},
+        },
+        task::{Context, Poll, Wake, Waker},
         time::{Duration, Instant},
     };
+
+    #[derive(Default)]
+    struct Notify(AtomicBool);
+
+    impl Wake for Notify {
+        fn wake(self: Arc<Self>) {
+            self.0.store(true, Ordering::Relaxed);
+        }
+    }
 
     /// Allocate receive buffers with the network pool configuration.
     fn test_pool(scope: &mut impl Register) -> BufferPool {
@@ -777,6 +792,58 @@ mod tests {
 
             // Allow some margin for scheduling and timer precision.
             assert!(elapsed < op_timeout * 3);
+        });
+    }
+
+    #[test]
+    fn test_carried_receive_deadline_completes_without_rescheduling() {
+        iouring::Runner::default().start(|context| async move {
+            let timeout = Duration::from_secs(1);
+            let (socket, mut peer) = UnixStream::pair().unwrap();
+            socket.set_nonblocking(true).unwrap();
+            let mut observer = socket.try_clone().unwrap();
+            let mut registry = Registry::default();
+            let mut stream = Stream::new(
+                Arc::new(socket.into()),
+                timeout,
+                8,
+                test_pool(&mut registry),
+            );
+            let notified = Arc::new(Notify::default());
+            let waker = Waker::from(notified.clone());
+            let mut cx = Context::from_waker(&waker);
+
+            peer.write_all(b"x").unwrap();
+            {
+                let deadline = Instant::now() + timeout;
+                let mut receive = pin!(stream.recv(2));
+                assert!(receive.poll_unpin(&mut cx).is_pending());
+
+                // Let the first refill complete without observing its result.
+                while !notified.0.load(Ordering::Relaxed) {
+                    assert!(Instant::now() < deadline, "first refill did not complete");
+                    context.sleep(Duration::from_millis(1)).await;
+                }
+                assert!(Instant::now() < deadline);
+                assert_eq!(
+                    observer.read(&mut [0]).unwrap_err().kind(),
+                    std::io::ErrorKind::WouldBlock
+                );
+
+                // The next refill carries the first call's deadline. A timer
+                // wake proves the worker's cached time has passed that deadline.
+                context.sleep(timeout).await;
+                peer.write_all(b"y").unwrap();
+                assert!(matches!(
+                    receive.poll_unpin(&mut cx),
+                    Poll::Ready(Err(Error::Timeout))
+                ));
+            }
+
+            context.sleep(Duration::from_millis(1)).await;
+            let mut remaining = [0];
+            assert_eq!(observer.read(&mut remaining).unwrap(), 1);
+            assert_eq!(&remaining, b"y");
         });
     }
 

--- a/runtime/src/network/iouring.rs
+++ b/runtime/src/network/iouring.rs
@@ -877,12 +877,29 @@ mod tests {
             assert_eq!(stream.peek(100), b" world");
             assert_eq!(stream.peek(3), b" wo");
             assert!(stream.peek(0).is_empty());
+
+            // A shorter refill must replace the previous readable extent.
+            peer.write_all(b"xy").unwrap();
+            assert_eq!(stream.recv(7).await.unwrap().coalesce(), b" worldx");
+            assert_eq!(stream.peek(100), b"y");
+
+            // Buffered prefixes and later refills must survive the direct path.
+            let direct = [b'z'; 64];
+            peer.write_all(&direct).unwrap();
+            let received = stream.recv(65).await.unwrap().coalesce();
+            assert_eq!(&received.as_ref()[..1], b"y");
+            assert_eq!(&received.as_ref()[1..], &direct);
+            assert!(stream.peek(100).is_empty());
+
+            peer.write_all(b"next").unwrap();
+            assert_eq!(stream.recv(2).await.unwrap().coalesce(), b"ne");
+            assert_eq!(stream.peek(100), b"xt");
             stream
         });
 
         // Buffered bytes remain readable after the worker has shut down.
-        let rest = futures::executor::block_on(stream.recv(6)).unwrap();
-        assert_eq!(rest.coalesce(), b" world");
+        let rest = futures::executor::block_on(stream.recv(2)).unwrap();
+        assert_eq!(rest.coalesce(), b"xt");
         assert!(stream.peek(100).is_empty());
     }
 

--- a/runtime/src/network/iouring.rs
+++ b/runtime/src/network/iouring.rs
@@ -271,7 +271,6 @@ impl crate::Listener for Listener {
 
             let output = Operation::register(Request::Poll(PollRequest {
                 fd: self.inner.clone(),
-                flags: libc::POLLIN as u32,
                 deadline: Some(Instant::now() + self.read_write_timeout),
             }))
             .await
@@ -427,8 +426,6 @@ pub struct Stream {
     buffer: IoBufMut,
     /// Current read position in the buffer.
     buffer_pos: usize,
-    /// Number of valid bytes in the buffer.
-    buffer_len: usize,
     /// Buffer pool for recv allocations.
     pool: BufferPool,
 }
@@ -442,7 +439,6 @@ impl Stream {
             poisoned: false,
             buffer: IoBufMut::with_capacity(buffer_capacity),
             buffer_pos: 0,
-            buffer_len: 0,
             pool,
         }
     }
@@ -484,21 +480,19 @@ impl Stream {
     }
 
     /// Fills the internal buffer by reading from the socket via io_uring.
-    async fn fill_buffer(&mut self, deadline: Instant) -> Result<usize, Error> {
+    async fn fill_buffer(&mut self, deadline: Instant) -> Result<(), Error> {
         self.buffer_pos = 0;
-        self.buffer_len = 0;
 
         let buffer = std::mem::take(&mut self.buffer);
         let len = buffer.capacity();
 
         let (buffer, read) = self.submit_recv(buffer, 0, len, false, deadline).await?;
         self.buffer = buffer;
-        self.buffer_len = read;
 
-        // SAFETY: The kernel has written exactly `buffer_len` bytes into the buffer.
-        unsafe { self.buffer.set_len(self.buffer_len) };
+        // SAFETY: The successful receive initialized the first `read` bytes.
+        unsafe { self.buffer.set_len(read) };
 
-        Ok(self.buffer_len)
+        Ok(())
     }
 }
 
@@ -520,7 +514,7 @@ impl crate::Stream for Stream {
 
             while bytes_received < len {
                 // First drain any buffered data
-                let buffered = self.buffer_len - self.buffer_pos;
+                let buffered = self.buffer.len() - self.buffer_pos;
                 if buffered > 0 {
                     let to_copy = std::cmp::min(buffered, len - bytes_received);
                     owned_buf.as_mut()[bytes_received..bytes_received + to_copy].copy_from_slice(
@@ -561,7 +555,7 @@ impl crate::Stream for Stream {
     }
 
     fn peek(&self, max_len: usize) -> &[u8] {
-        let buffered = self.buffer_len - self.buffer_pos;
+        let buffered = self.buffer.len() - self.buffer_pos;
         let len = std::cmp::min(buffered, max_len);
         &self.buffer.as_ref()[self.buffer_pos..self.buffer_pos + len]
     }

--- a/runtime/src/storage/iouring.rs
+++ b/runtime/src/storage/iouring.rs
@@ -342,7 +342,6 @@ impl crate::Blob for Blob {
         let output = Operation::register(Request::ReadAt(ReadAtRequest {
             file: self.file.clone(),
             offset,
-            len,
             read: 0,
             buf: io_buf,
             cache,
@@ -402,7 +401,6 @@ impl crate::Blob for Blob {
         let output = Operation::register(Request::WriteAt(WriteAtRequest {
             file: self.file.clone(),
             offset,
-            written: 0,
             write: bufs.into(),
             state,
             cache,


### PR DESCRIPTION
This follow-up to #4674 simplifies request completion, wake delivery, deadlines, and buffer handling.

| Decision | Why we kept it |
| --- | --- |
| Use unfinished requests to drive service and shutdown | Requests own resources until their I/O completes and keep the worker servicing pending work. Separate cancellation ACK tracking adds final diagnostics, which may now be missed. |
| Reject known-expired requests at admission | Cached time lets the driver complete them immediately through its existing result path, avoiding a worker turn and waker clone. Service still checks fresh time before submitting other requests. |
| Keep the 30-year sleep cap | The existing limit keeps deadline construction bounded and reuses the shared timeout constant. |
| Use mailbox publication to detect work | Publication precedes transfer under the mailbox lock. The old channel could expose work before publication, which required the more complex sequence comparison. |
| Use full waiter identities for timeout entries | Each registration has one fixed deadline. Generations reject stale entries after slot reuse, so the wheel need not duplicate the deadline. |
| Derive lengths and progress from buffers and file offsets | Read lengths are established before admission, failed receive buffers are discarded, and writes advance on successful completion. Original write buffers remain owned until retirement. |
| Rely on worker boundaries for callback handling | Callbacks cannot service the worker during a poll. Closing observers and timers before final callbacks prevents them from refilling deferred cleanup. |
| Keep the task wrapper | Its separate poll entry produced smaller outer poll bodies without adding scheduled polls. Timings gave no clear reason to remove it. |
| Admit accepted tasks directly | Once the worker accepts a supervised task, repeating admission adds no protection. Supervision and panic handling stay in place. |
| Fix listener polling to read readiness | Accept is the only caller and always requests read readiness. Polling still cannot consume a connection when an accept future is dropped. |
