### PR TITLE
[storage/qmdb] Remove redundant ancestor deletion filtering

### DIFF
--- a/storage/src/qmdb/any/batch.rs
+++ b/storage/src/qmdb/any/batch.rs
@@ -2290,11 +2290,11 @@ where
         //
         // Each diff is key-sorted, as are `updated`/`created`/`deleted`, so the handled check
         // advances three cursors in a sorted merge instead of three binary searches per key.
-        // Each diff records only its owning batch's changes, so active operations
-        // can be read directly from that batch's journal suffix.
-        // Existing-key updates preserve membership, so the classifier's successors suffice and
-        // no predecessor is rewritten. Its candidates passed the stale-ancestor guard, so the
-        // deleted-key filter below has nothing to remove either.
+        // Each diff records only its owning batch's changes, so active operations can be read
+        // directly from that batch's journal suffix.
+        //
+        // Existing-key updates preserve membership, so their resolved successors suffice and
+        // no predecessor is rewritten.
         let changes_membership = !created.is_empty() || !deleted.is_empty();
         let candidate_ancestors = if changes_membership {
             m.ancestors.as_slice()
@@ -2308,7 +2308,6 @@ where
             0
         };
         let mut seen: AHashSet<&K> = AHashSet::with_capacity(seen_cap);
-        let mut ancestor_deleted: Vec<&K> = Vec::new();
         for batch in candidate_ancestors.iter() {
             let (mut ui, mut ci, mut di) = (0, 0, 0);
             for (key, entry) in batch.diff.iter() {
@@ -2331,46 +2330,36 @@ where
                 {
                     continue;
                 }
-                match entry {
-                    DiffEntry::Active { loc, .. } => {
-                        let index = (**loc - *batch.bounds.base.size) as usize;
-                        let data = match &batch.journal_batch.items()[index] {
-                            Operation::Update(data) => data,
-                            _ => unreachable!("ancestor diff Active should reference Update op"),
-                        };
-                        next_candidates.push(data.key.clone());
-                        next_candidates.push(data.next_key.clone());
-                        prev_candidates
-                            .push((data.key.clone(), (Some(Cow::Borrowed(&data.value)), *loc)));
-                    }
-                    DiffEntry::Deleted { .. } => {
-                        ancestor_deleted.push(key);
-                    }
-                }
+                let DiffEntry::Active { loc, .. } = entry else {
+                    continue;
+                };
+                let index = (**loc - *batch.bounds.base.size) as usize;
+                let data = match &batch.journal_batch.items()[index] {
+                    Operation::Update(data) => data,
+                    _ => unreachable!("ancestor diff Active should reference Update op"),
+                };
+                next_candidates.push(data.key.clone());
+                next_candidates.push(data.next_key.clone());
+                prev_candidates.push((data.key.clone(), (Some(Cow::Borrowed(&data.value)), *loc)));
             }
         }
-        ancestor_deleted.sort();
 
-        // Sort + dedup candidate sets now so find_next_key/find_prev_key_mut can binary-search.
+        // Sort and deduplicate successor candidates for binary search.
         db.strategy().sort_by(&mut next_candidates, |a, b| a.cmp(b));
         next_candidates.dedup();
 
-        // Remove all known-deleted keys from possible_* sets. The prev_translated_key lookup
-        // already did this for this batch's deletes, but the ancestor diff incorporation may
-        // have re-added them via next_key references. Also remove parent-deleted keys that the
-        // base DB lookup may have added.
-        let is_deleted = |k: &K| -> bool {
-            deleted.binary_search_by(|(dk, _)| dk.cmp(k)).is_ok()
-                || ancestor_deleted.binary_search(&k).is_ok()
-        };
-        next_candidates.retain(|k| !is_deleted(k));
-
-        // `prev_candidates` is consulted only by the predecessor rewrites below. Duplicates can
-        // occur when the same key is pushed from multiple sources (main scan, prev_results,
-        // ancestor walk). Later pushes carry the freshest state (ancestor walk runs last), so
-        // dedup keeps the LAST push per key. `dedup_by` retains the first of each consecutive
-        // run; swap so the retained slot holds the later push.
+        // Only membership changes require filtering deleted successors and preparing
+        // predecessor candidates for rewrites.
         if changes_membership {
+            // Resolved operations can still reference keys deleted by this batch.
+            let is_deleted = |k: &K| deleted.binary_search_by(|(dk, _)| dk.cmp(k)).is_ok();
+            next_candidates.retain(|k| !is_deleted(k));
+
+            // `prev_candidates` is consulted only by the predecessor rewrites below. Duplicates
+            // can occur when the same key is pushed from multiple sources (main scan,
+            // prev_results, ancestor walk). Later pushes carry the freshest state (ancestor
+            // walk runs last), so dedup keeps the LAST push per key. `dedup_by` retains the
+            // first of each consecutive run; swap so the retained slot holds the later push.
             prev_candidates.sort_by(|a, b| a.0.cmp(&b.0));
             prev_candidates.dedup_by(|a, b| {
                 if a.0 == b.0 {
@@ -5697,9 +5686,8 @@ mod tests {
                 .await
                 .unwrap();
 
-            // Child: overwrite only existing keys. Two resolve from the parent journal while
-            // their bucket scan reads the deleted key's stale committed op, one is the
-            // parent-created key, and one is untouched by the parent.
+            // Child: overwrite only existing keys. Its bucket scan encounters the deleted
+            // key's stale committed op alongside keys created or rewritten by the parent.
             let pending_child = parent
                 .new_batch::<Sha256>()
                 .write(colliding_digest(0, 0), Some(v(5)))


### PR DESCRIPTION
Stacks on #4726.

Remove the redundant ancestor-deleted-key collection and filtering from ordered neighbor discovery. Stale-location guards and closest-first tombstone shadowing already admit only live parent operations, whose successors reflect earlier membership changes. Keep filtering keys deleted by the child, and use the existing membership gate to skip that filtering when it is an identity operation. The stable predecessor deduplication and value ownership rules stay intact.

Constantinople benchmark, Apple M5 Pro (64 GiB), Rust 1.98.1: 1,000,000 keys; 32,768 read/update slots per batch; one read chunk; eight strategy threads; 512 MiB configured page cache. Each case has six serial process runs per variant in balanced order, with 25 iterations per run and the first five excluded uniformly. Times below are medians of the six process medians, in milliseconds.

| Ordered fixed MMB database | Pending ancestors | Main | #4726 | This PR |
|---|---:|---:|---:|---:|
| Any | 0 | 8.79 | 8.12 | 8.20 |
| Any | 4 | 41.91 | 18.63 | 18.54 |
| Current | 0 | 10.60 | 11.23 | 10.17 |
| Current | 4 | 47.56 | 22.55 | 22.59 |

The main baseline is `ae2cf22f4e4a1302ae596fedaef8ae7b6538e5cd`; #4726 is `8807bee1e73c2846d0cdd5ce2912e6e9907b4312`. Both PR variants were combined with the same main snapshot and built at the same source path with identical compiler/profile settings; both the storage library and benchmark rebuilt for each variant. The final edits after measurement affect comments only.

At depth four, this PR's median paired latency reduction versus main is 54.84% for Any and 52.15% for Current, computed from same-round process medians. All six rounds favor the modified code over main. This cleanup's incremental difference against #4726 changes sign in every case; no consistent gain or regression is established. Depth-zero comparisons are also less stable. Observed system load varied, and these runs do not resolve small effects.

Incremental changes against #4726 are below. Positive percentages mean lower latency; negative percentages mean higher latency. Each percentage is computed within a round as `100 * (#4726 - this PR) / #4726`, then summarized across the six rounds. These paired percentages are separate from the aggregate latency medians above.

| Ordered fixed MMB database | Pending ancestors | Median latency reduction vs #4726 | Observed per-round range |
|---|---:|---:|---:|
| Any | 0 | -2.13% | -6.85% to +7.89% |
| Any | 4 | +0.65% | -13.01% to +9.79% |
| Current | 0 | +3.24% | -4.22% to +11.27% |
| Current | 4 | -0.46% | -6.80% to +11.48% |

Every range includes both improvement and regression. These ranges describe observed variation, not confidence intervals; the measurements do not establish a consistent incremental speedup.

All 1,800 root outputs matched the corresponding main sequence, including warmup iterations. This is a warm, speculative existing-key workload: timing covers staged load/expand and merkleization/root access, while ancestor construction and apply/commit/sync are excluded.

Reproduce each variant/case with the saved `constantinople` executable using `<binary> <any|current>::ordered::fixed::mmb <0|4> 25 1000000 32768 1 32768 8 131072`; build with `cargo bench -p commonware-storage --bench constantinople --locked --no-run`.

LOC versus #4726, counting added/deleted diff lines including comments and blanks: production +28/-39; tests/test infrastructure +2/-3 (test changes are comment-only); total +30/-42, net -12.
