### PR TITLE
[storage] Pool partitioned ordered index buffers in reclaimable slabs

### DIFF
--- a/storage/src/index/benches/scale.rs
+++ b/storage/src/index/benches/scale.rs
@@ -12,6 +12,10 @@
 //! (including CI's full-suite run) does nothing. Non-numeric args restrict which variants run by
 //! name, e.g. `-- 1000000000 partitioned_ordered_3` runs only the SoA index at 1B (the heavy flat
 //! baselines would need ~40+ GB at that size).
+//!
+//! For a smaller memory experiment with the same mean partition occupancy as 1B keys at P=3,
+//! use `-- 3906250 partitioned_ordered_2`. Run each variant in a fresh process under a memory
+//! profiler to include allocator fragmentation as well as live allocations.
 
 use commonware_runtime::{
     Metrics, Name, Supervisor,
@@ -140,6 +144,12 @@ fn main() {
             "partitioned_ordered_3",
             partitioned::ordered::Index::<_, _, 3>::new(DummyMetrics, Cap::<5>::new())
         );
+        if only.iter().any(|v| v == "partitioned_ordered_2") {
+            run!(
+                "partitioned_ordered_2",
+                partitioned::ordered::Index::<_, _, 2>::new(DummyMetrics, Cap::<5>::new())
+            );
+        }
         run!("unordered", unordered::Index::new(DummyMetrics, EightCap));
         run!(
             "partitioned_unordered_1",

--- a/storage/src/index/partitioned/ordered/array.rs
+++ b/storage/src/index/partitioned/ordered/array.rs
@@ -1,0 +1,483 @@
+//! Parallel key/value arrays sharing one slab slot, length, and capacity.
+//!
+//! Keys precede values, with padding only between the arrays. This avoids per-entry padding and
+//! two independently growing allocations per partition. Only the first `len` entries are live.
+
+use super::pool::{Allocation, Pool};
+use std::{
+    alloc::Layout,
+    marker::PhantomData,
+    num::NonZeroUsize,
+    ops::Range,
+    ptr::{self, NonNull},
+    slice,
+    sync::Arc,
+};
+
+/// A slab slot containing space for `cap` keys followed by `cap` values.
+struct Buffer<K, V> {
+    allocation: Option<Allocation>,
+    cap: usize,
+    marker: PhantomData<(K, V)>,
+}
+
+impl<K, V> Default for Buffer<K, V> {
+    fn default() -> Self {
+        Self {
+            allocation: None,
+            cap: 0,
+            marker: PhantomData,
+        }
+    }
+}
+
+impl<K, V> Buffer<K, V> {
+    /// Combined layout and the offset of the values. Layout checks all size arithmetic.
+    fn layout(cap: usize) -> (Layout, usize) {
+        Layout::array::<K>(cap)
+            .and_then(|keys| keys.extend(Layout::array::<V>(cap)?))
+            .expect("partition capacity overflow")
+    }
+
+    const fn keys(&self) -> *mut K {
+        match &self.allocation {
+            Some(allocation) => allocation.ptr.as_ptr().cast(),
+            None => NonNull::<K>::dangling().as_ptr(),
+        }
+    }
+
+    const fn values(&self) -> *mut V {
+        // Capacity was validated by layout() on growth. Wrapping arithmetic avoids repeating
+        // overflow checks on every lookup; these operations cannot wrap for a valid buffer.
+        let align = align_of::<V>();
+        let offset = self
+            .cap
+            .wrapping_mul(size_of::<K>())
+            .wrapping_add(align - 1)
+            & !(align - 1);
+        // SAFETY: The offset is within the allocation (or zero for an empty/ZST buffer),
+        // and the layout and dangling pointer both satisfy V's alignment.
+        unsafe {
+            match &self.allocation {
+                Some(allocation) => allocation.ptr.as_ptr().add(offset).cast(),
+                None => NonNull::<V>::dangling().as_ptr(),
+            }
+        }
+    }
+
+    /// Grow a full buffer, preserving all `cap` initialized entries in both arrays.
+    fn grow(&mut self, pool: &Arc<Pool>) {
+        let (old_layout, _) = Self::layout(self.cap);
+        let cap = if let Some(entry_size) = NonZeroUsize::new(size_of::<K>() + size_of::<V>()) {
+            // Use the capacity available in a power-of-two byte budget, including space that
+            // would otherwise be lost to allocator size-class rounding.
+            let bytes = old_layout
+                .size()
+                .checked_next_power_of_two()
+                .and_then(|bytes| bytes.checked_mul(2))
+                .expect("partition capacity overflow")
+                .max(64)
+                .max(Self::layout(1).0.size().next_power_of_two());
+            // bytes and each value's size are multiples of V's alignment, so inter-array padding
+            // still fits within the byte budget.
+            (bytes / entry_size).max(1)
+        } else {
+            self.cap
+                .checked_add(1)
+                .expect("partition capacity overflow")
+        };
+        let (layout, offset) = Self::layout(cap);
+        if layout.size() != 0 {
+            let pool = self.allocation.as_ref().map_or(pool, |a| &a.slab.pool);
+            let allocation = pool.allocate(layout);
+            // SAFETY: The new slot is disjoint from the old one, fits both arrays, and preserves
+            // their alignment. Transfer all initialized entries before releasing the old slot.
+            unsafe {
+                ptr::copy_nonoverlapping(self.keys(), allocation.ptr.as_ptr().cast(), self.cap);
+                ptr::copy_nonoverlapping(
+                    self.values(),
+                    allocation.ptr.as_ptr().add(offset).cast(),
+                    self.cap,
+                );
+            }
+            self.allocation = Some(allocation);
+        }
+        self.cap = cap;
+    }
+}
+
+// SAFETY: The slot is uniquely owned; moving it transfers ownership of its keys and values.
+unsafe impl<K: Send, V: Send> Send for Buffer<K, V> {}
+// SAFETY: Shared access only exposes shared references to initialized keys and values.
+unsafe impl<K: Sync, V: Sync> Sync for Buffer<K, V> {}
+
+// Moving the buffer does not move its heap-allocated entries.
+impl<K, V> Unpin for Buffer<K, V> {}
+
+/// Parallel arrays with a shared length. Keys are Copy; values may own resources.
+pub(super) struct Entries<K: Copy, V> {
+    buffer: Buffer<K, V>,
+    len: usize,
+}
+
+impl<K: Copy, V> Default for Entries<K, V> {
+    fn default() -> Self {
+        Self {
+            buffer: Buffer::default(),
+            len: 0,
+        }
+    }
+}
+
+impl<K: Copy, V> Entries<K, V> {
+    pub(super) const fn len(&self) -> usize {
+        self.len
+    }
+
+    pub(super) const fn keys(&self) -> &[K] {
+        // SAFETY: The first len keys are initialized, aligned, and borrowed from self.
+        unsafe { slice::from_raw_parts(self.buffer.keys(), self.len) }
+    }
+
+    pub(super) const fn values(&self) -> &[V] {
+        // SAFETY: The first len values are initialized, aligned, and borrowed from self.
+        unsafe { slice::from_raw_parts(self.buffer.values(), self.len) }
+    }
+
+    pub(super) const fn values_mut(&mut self) -> &mut [V] {
+        // SAFETY: The first len values are initialized and aligned; self is exclusively borrowed.
+        unsafe { slice::from_raw_parts_mut(self.buffer.values(), self.len) }
+    }
+
+    pub(super) fn insert(&mut self, idx: usize, key: K, value: V, pool: &Arc<Pool>) {
+        assert!(idx <= self.len, "partition insertion out of bounds");
+        if self.len == self.buffer.cap {
+            self.buffer.grow(pool);
+        }
+        // SAFETY: idx <= len < cap. Shift initialized entries within each array (possibly
+        // overlapping), then initialize the gap. No reference survives growth or the moves.
+        unsafe {
+            let keys = self.buffer.keys();
+            let values = self.buffer.values();
+            ptr::copy(keys.add(idx), keys.add(idx + 1), self.len - idx);
+            ptr::copy(values.add(idx), values.add(idx + 1), self.len - idx);
+            keys.add(idx).write(key);
+            values.add(idx).write(value);
+        }
+        self.len += 1;
+    }
+
+    pub(super) fn remove(&mut self, idx: usize) -> V {
+        assert!(idx < self.len, "partition removal out of bounds");
+        // SAFETY: idx is initialized. Transfer ownership of its value to the caller and shift
+        // the tail into the gap. The duplicate last entry is excluded by reducing len below.
+        let value = unsafe {
+            let keys = self.buffer.keys();
+            let values = self.buffer.values();
+            let value = values.add(idx).read();
+            ptr::copy(keys.add(idx + 1), keys.add(idx), self.len - idx - 1);
+            ptr::copy(values.add(idx + 1), values.add(idx), self.len - idx - 1);
+            value
+        };
+        self.len -= 1;
+        self.release_empty();
+        value
+    }
+
+    pub(super) fn remove_range(&mut self, range: Range<usize>) {
+        assert!(range.start <= range.end && range.end <= self.len);
+        let count = range.len();
+        if count == 0 {
+            return;
+        }
+        // Move removed values to the tail before dropping them, so even a panicking destructor
+        // leaves an initialized, aligned prefix of keys and values.
+        self.values_mut()[range.start..].rotate_left(count);
+        // SAFETY: The range was checked; the live key tail fits at range.start and may overlap.
+        unsafe {
+            let keys = self.buffer.keys();
+            ptr::copy(
+                keys.add(range.end),
+                keys.add(range.start),
+                self.len - range.end,
+            );
+        }
+        self.len -= count;
+        // SAFETY: The removed values now occupy the initialized tail, excluded from len so
+        // unwinding cannot drop them twice. Slice drop also drops remaining values on unwind.
+        unsafe {
+            ptr::drop_in_place(ptr::slice_from_raw_parts_mut(
+                self.buffer.values().add(self.len),
+                count,
+            ));
+        }
+        self.release_empty();
+    }
+
+    fn release_empty(&mut self) {
+        if self.len == 0 {
+            self.buffer = Buffer::default();
+        }
+    }
+
+    pub(super) fn into_vecs(mut self) -> (Vec<K>, Vec<V>) {
+        let keys = self.keys().to_vec();
+        let mut values = Vec::with_capacity(self.len);
+        // SAFETY: The destination has space for len values, the source is initialized, and the
+        // allocations do not overlap. Transfer ownership by setting the lengths after the copy.
+        unsafe {
+            ptr::copy_nonoverlapping(self.buffer.values(), values.as_mut_ptr(), self.len);
+            values.set_len(self.len);
+        }
+        self.len = 0;
+        (keys, values)
+    }
+}
+
+impl<K: Copy, V> Drop for Entries<K, V> {
+    fn drop(&mut self) {
+        // SAFETY: Exactly the first len values are live. Buffer's field destructor releases the
+        // slot afterwards, including when a value destructor panics. Keys are Copy.
+        unsafe {
+            ptr::drop_in_place(ptr::slice_from_raw_parts_mut(
+                self.buffer.values(),
+                self.len,
+            ))
+        };
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use commonware_utils::test_rng;
+    use rand::RngExt;
+    use std::{
+        cell::Cell,
+        marker::PhantomPinned,
+        panic::{AssertUnwindSafe, catch_unwind},
+        rc::Rc,
+        sync::atomic::{AtomicUsize, Ordering},
+    };
+
+    #[test]
+    fn test_auto_traits() {
+        fn check<T: Send + Sync + Unpin>() {}
+        check::<Entries<[u8; 5], PhantomPinned>>();
+        check::<super::super::Index<crate::translator::Cap<5>, PhantomPinned, 3>>();
+    }
+
+    #[test]
+    fn test_memory_budget_and_release() {
+        let mut entries = Entries::<[u8; 5], u64>::default();
+        assert_eq!(
+            Buffer::<[u8; 5], u64>::layout(entries.buffer.cap).0.size(),
+            0
+        );
+        for i in 0..256 {
+            entries.insert(i, [0; 5], i as u64, &Arc::default());
+            let bytes = Buffer::<[u8; 5], u64>::layout(entries.buffer.cap).0.size();
+            // Geometric growth, plus padding between the two arrays.
+            assert!(bytes <= entries.len().max(2) * 13 * 2 + 7);
+        }
+        entries.remove_range(0..256);
+        assert_eq!(entries.buffer.cap, 0);
+        entries.insert(0, [1; 5], 7, &Arc::default());
+        assert_eq!(entries.remove(0), 7);
+        assert_eq!(entries.buffer.cap, 0);
+    }
+
+    #[test]
+    fn test_operations_match_vecs() {
+        let mut rng = test_rng();
+        let mut entries = Entries::<[u8; 5], Box<u64>>::default();
+        let mut keys = Vec::new();
+        let mut values = Vec::new();
+        for _ in 0..1000 {
+            match rng.random_range(0..5) {
+                0..=1 => {
+                    let idx = rng.random_range(0..=keys.len());
+                    let key = rng.random();
+                    let value = rng.random();
+                    keys.insert(idx, key);
+                    values.insert(idx, Box::new(value));
+                    entries.insert(idx, key, Box::new(value), &Arc::default());
+                }
+                2 if !keys.is_empty() => {
+                    let idx = rng.random_range(0..keys.len());
+                    keys.remove(idx);
+                    assert_eq!(entries.remove(idx), values.remove(idx));
+                }
+                3 => {
+                    let start = rng.random_range(0..=keys.len());
+                    let end = rng.random_range(start..=keys.len());
+                    keys.drain(start..end);
+                    values.drain(start..end);
+                    entries.remove_range(start..end);
+                }
+                4 if !keys.is_empty() => {
+                    let idx = rng.random_range(0..keys.len());
+                    let value = rng.random();
+                    *values[idx] = value;
+                    *entries.values_mut()[idx] = value;
+                }
+                _ => {}
+            }
+            assert_eq!(entries.keys(), keys);
+            assert_eq!(entries.values(), values);
+        }
+        assert_eq!(entries.into_vecs(), (keys, values));
+    }
+
+    #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+    #[repr(align(64))]
+    struct Aligned(u64);
+
+    fn check_types<K: Copy + Eq + std::fmt::Debug, V: Clone + Eq + std::fmt::Debug>(
+        key: K,
+        value: V,
+    ) {
+        let mut entries = Entries::default();
+        assert!(entries.keys().is_empty());
+        assert!(entries.values().is_empty());
+        // Cross every growth boundary up to and beyond the production spill threshold. A cursor
+        // can keep adding collisions past that threshold before the index regains control.
+        for i in 0..600 {
+            entries.insert(i / 2, key, value.clone(), &Arc::default());
+            assert_eq!(entries.keys()[i / 2], key);
+            assert_eq!(entries.values()[i / 2], value);
+        }
+        assert_eq!(entries.keys(), vec![key; 600]);
+        assert_eq!(entries.values(), vec![value.clone(); 600]);
+        entries.remove_range(100..500);
+        assert_eq!(entries.remove(0), value);
+        let (keys, values) = entries.into_vecs();
+        assert_eq!(keys, vec![key; 199]);
+        assert_eq!(values, vec![value; 199]);
+    }
+
+    #[test]
+    fn test_alignment_and_zero_sized_types() {
+        check_types([1; 5], Aligned(2));
+        check_types(Aligned(3), [4u8; 5]);
+        check_types((), Aligned(5));
+        check_types(Aligned(6), ());
+        check_types((), ());
+    }
+
+    struct Tracked {
+        drops: Rc<Cell<usize>>,
+        panic: bool,
+    }
+
+    impl Drop for Tracked {
+        fn drop(&mut self) {
+            self.drops.set(self.drops.get() + 1);
+            assert!(!self.panic, "value drop panic");
+        }
+    }
+
+    #[test]
+    fn test_value_ownership() {
+        let drops = Rc::new(Cell::new(0));
+        let value = || Tracked {
+            drops: drops.clone(),
+            panic: false,
+        };
+        let mut entries = Entries::default();
+        for i in 0..100 {
+            entries.insert(i, i, value(), &Arc::default());
+        }
+        drop(entries.remove(10));
+        entries.remove_range(10..20);
+        entries.values_mut()[0] = value();
+        assert_eq!(drops.get(), 12);
+        let (_, values) = entries.into_vecs();
+        assert_eq!(drops.get(), 12);
+        drop(values);
+        assert_eq!(drops.get(), 101);
+    }
+
+    #[test]
+    fn test_panicking_destructor() {
+        for range in [0..4, 1..3] {
+            let drops = Rc::new(Cell::new(0));
+            let mut entries = Entries::default();
+            for i in 0..4 {
+                entries.insert(
+                    i,
+                    i,
+                    Tracked {
+                        drops: drops.clone(),
+                        panic: i == 1,
+                    },
+                    &Arc::default(),
+                );
+            }
+            assert!(
+                catch_unwind(AssertUnwindSafe(|| entries.remove_range(range.clone()))).is_err()
+            );
+            assert_eq!(drops.get(), range.len());
+            if range == (1..3) {
+                assert_eq!(entries.keys(), &[0, 3]);
+            } else {
+                assert_eq!(entries.len(), 0);
+            }
+            drop(entries);
+            assert_eq!(drops.get(), 4);
+        }
+        let drops = Rc::new(Cell::new(0));
+        let mut entries = Entries::default();
+        entries.insert(
+            0,
+            (),
+            Tracked {
+                drops: drops.clone(),
+                panic: true,
+            },
+            &Arc::default(),
+        );
+        assert!(catch_unwind(AssertUnwindSafe(|| drop(entries))).is_err());
+        assert_eq!(drops.get(), 1);
+    }
+
+    #[test]
+    fn test_zero_sized_destructors() {
+        static DROPS: AtomicUsize = AtomicUsize::new(0);
+        #[repr(align(64))]
+        struct ZeroSized;
+        impl Drop for ZeroSized {
+            fn drop(&mut self) {
+                DROPS.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+        let mut entries = Entries::default();
+        for i in 0..100 {
+            entries.insert(i, (), ZeroSized, &Arc::default());
+        }
+        drop(entries.remove(0));
+        entries.remove_range(10..20);
+        let (_, values) = entries.into_vecs();
+        drop(values);
+        assert_eq!(DROPS.load(Ordering::Relaxed), 100);
+    }
+
+    #[test]
+    fn test_capacity_overflow() {
+        assert!(catch_unwind(|| Buffer::<[u8; 5], u64>::layout(usize::MAX)).is_err());
+        assert!(catch_unwind(|| Buffer::<[u8; 5], u64>::layout(isize::MAX as usize / 8)).is_err());
+        let mut entries = Entries::<(), ()>::default();
+        entries.len = usize::MAX;
+        entries.buffer.cap = usize::MAX;
+        assert!(
+            catch_unwind(AssertUnwindSafe(|| entries.insert(
+                0,
+                (),
+                (),
+                &Arc::default()
+            )))
+            .is_err()
+        );
+        entries.len = 0;
+    }
+}

--- a/storage/src/index/partitioned/ordered/cursor.rs
+++ b/storage/src/index/partitioned/ordered/cursor.rs
@@ -7,12 +7,13 @@
 //! is written once here; [Backing] holds the only thing that differs: the positional store
 //! operations.
 
-use super::partition::Partition;
+use super::{partition::Partition, pool::Pool};
 use crate::index::Cursor as CursorTrait;
 use commonware_runtime::telemetry::metrics::{Counter, Gauge};
 use std::{
     collections::{BTreeMap, HashMap, btree_map, hash_map},
     ops::Range,
+    sync::Arc,
 };
 
 const MUST_CALL_NEXT: &str = "must call Cursor::next()";
@@ -39,6 +40,7 @@ enum Backing<'a, K: Ord + Copy, V> {
     /// run. `run.end` is adjusted by one on each insert/remove to stay aligned with the array.
     Soa {
         partition: &'a mut Partition<K, V>,
+        pool: &'a Arc<Pool>,
         key: K,
         run: Range<usize>,
     },
@@ -104,12 +106,13 @@ impl<K: Ord + Copy, V> Backing<'_, K, V> {
         match self {
             Self::Soa {
                 partition,
+                pool,
                 key,
                 run,
             } => {
                 #[allow(unstable_name_collisions)]
                 let created = run.is_empty(); // empty run => key absent => this creates it
-                partition.insert_at(run.start + off, *key, value);
+                partition.insert_at(run.start + off, *key, value, pool);
                 run.end += 1;
                 created
             }
@@ -183,6 +186,7 @@ impl<'a, K: Ord + Copy, V> Cursor<'a, K, V> {
     /// index range of `key`'s values within the partition.
     pub(super) const fn soa(
         partition: &'a mut Partition<K, V>,
+        pool: &'a Arc<Pool>,
         key: K,
         run: Range<usize>,
         keys: &'a Gauge,
@@ -192,6 +196,7 @@ impl<'a, K: Ord + Copy, V> Cursor<'a, K, V> {
         Self {
             backing: Backing::Soa {
                 partition,
+                pool,
                 key,
                 run,
             },

--- a/storage/src/index/partitioned/ordered/mod.rs
+++ b/storage/src/index/partitioned/ordered/mod.rs
@@ -7,6 +7,10 @@
 //! lookup/insert speed for memory density at scale; the unordered variant ([`super::unordered`])
 //! uses hash sub-indices instead and is faster when ordering is not required.
 //!
+//! Each partition's key/value arrays share one length, capacity, and slot in a slab.
+//! Buffers of the same capacity share slabs, which are released once all their buffers are freed.
+//! Buffers grow geometrically by byte size. Emptied partitions return their buffers to the pool.
+//!
 //! # Spilling over-full partitions
 //!
 //! Each sorted-array insert is an O(occupancy) memmove, so a partition that grows large makes
@@ -38,11 +42,13 @@
 //! The next index mutation of that partition spills it before access. `insert_and_retain` performs
 //! the check after releasing its internal cursor.
 
+mod array;
 mod cursor;
 mod partition;
+mod pool;
 
 pub use self::cursor::Cursor;
-use self::partition::Partition;
+use self::{partition::Partition, pool::Pool};
 #[commonware_macros::stability(ALPHA)]
 use crate::index::partitioned::{PartitionRange, Partitioned};
 use crate::{
@@ -59,6 +65,7 @@ use commonware_runtime::{
 use std::{
     collections::{BTreeMap, HashMap, btree_map, hash_map},
     ops::Bound,
+    sync::Arc,
 };
 
 /// Sorted-array length at which a partition converts to a `BTreeMap`, bounding the O(occupancy)
@@ -80,6 +87,9 @@ pub struct Index<T: Translator, V: Send + Sync, const P: usize> {
     /// local slot). Each stores its translated keys and values as sorted arrays (the inline
     /// representation), though an emptied partition may instead have spilled (see `spilled`).
     partitions: Box<[Partition<T::Key, V>]>,
+
+    /// Shared slabs for new partition buffers. Existing buffers retain their build worker's pool.
+    pool: Arc<Pool>,
 
     /// Partitions that have spilled out of their sorted arrays (reached `SPILL_THRESHOLD` entries),
     /// keyed by partition index; each maps translated keys to their value runs. Empty until a
@@ -119,6 +129,7 @@ impl<T: Translator, V: Send + Sync, const P: usize> Index<T, V, P> {
         Self {
             translator,
             partitions,
+            pool: Arc::default(),
             spilled: HashMap::new(),
             threshold: SPILL_THRESHOLD,
             keys: ctx.gauge("keys", "Number of translated keys in the index"),
@@ -253,6 +264,7 @@ impl<T: Translator, V: Send + Sync, const P: usize> Index<T, V, P> {
             }
             return Some(Cursor::soa(
                 &mut self.partitions[i],
+                &self.pool,
                 k,
                 run,
                 &self.keys,
@@ -296,6 +308,7 @@ impl<T: Translator, V: Send + Sync, const P: usize> Index<T, V, P> {
             if !run.is_empty() {
                 return Some(Cursor::soa(
                     &mut self.partitions[i],
+                    &self.pool,
                     k,
                     run,
                     &self.keys,
@@ -303,7 +316,7 @@ impl<T: Translator, V: Send + Sync, const P: usize> Index<T, V, P> {
                     &self.pruned,
                 ));
             }
-            self.partitions[i].insert_at(run.end, k, value);
+            self.partitions[i].insert_at(run.end, k, value, &self.pool);
             self.keys.inc();
             self.items.inc();
             self.maybe_spill(i);
@@ -330,7 +343,7 @@ impl<T: Translator, V: Send + Sync, const P: usize> Index<T, V, P> {
         }
 
         // Partition i is genuinely empty: start a fresh sorted array.
-        self.partitions[i].insert_at(0, k, value);
+        self.partitions[i].insert_at(0, k, value, &self.pool);
         self.keys.inc();
         self.items.inc();
         self.maybe_spill(i);
@@ -363,6 +376,7 @@ impl<T: Translator, V: Send + Sync + 'static, const P: usize> Partitioned for In
             index: Self {
                 translator: self.translator.clone(),
                 partitions,
+                pool: Arc::default(),
                 spilled: HashMap::new(),
                 threshold: self.threshold,
                 keys: self.keys.clone(),
@@ -508,7 +522,7 @@ impl<T: Translator, V: Send + Sync, const P: usize> Unordered for Index<T, V, P>
         if !self.partitions[i].is_empty() {
             let run = self.partitions[i].run_range(&k);
             let new_key = run.is_empty();
-            self.partitions[i].insert_at(run.end, k, value);
+            self.partitions[i].insert_at(run.end, k, value, &self.pool);
             self.items.inc();
             if new_key {
                 self.keys.inc();
@@ -533,7 +547,7 @@ impl<T: Translator, V: Send + Sync, const P: usize> Unordered for Index<T, V, P>
         }
 
         // Genuinely empty partition: start a fresh sorted array.
-        self.partitions[i].insert_at(0, k, value);
+        self.partitions[i].insert_at(0, k, value, &self.pool);
         self.items.inc();
         self.keys.inc();
         self.maybe_spill(i);

--- a/storage/src/index/partitioned/ordered/partition.rs
+++ b/storage/src/index/partitioned/ordered/partition.rs
@@ -1,29 +1,27 @@
 //! Storage for a single partition of a partitioned index.
 //!
 //! A partition holds the values for all translated keys that share a key prefix, stored as sorted
-//! struct-of-arrays: parallel `keys`/`vals` vectors ordered by translated key. Storing keys and
-//! values contiguously (rather than in a per-entry map node) is what makes the partitioned index
-//! memory-efficient at scale.
+//! struct-of-arrays: parallel key/value arrays ordered by translated key, sharing one slab slot.
+//! Storing keys and values contiguously (rather than in a per-entry map node) is what makes the
+//! partitioned index memory-efficient at scale.
 //!
 //! Multiple values for the same translated key (collisions, or repeated inserts) form a contiguous
 //! run of equal keys. Collisions are rare for well-distributed translated keys, so most runs have
 //! length one. The index's insertion path appends new values to the end of an existing run.
 
-use std::ops::Range;
+use super::{array::Entries, pool::Pool};
+use std::{ops::Range, sync::Arc};
 
 /// A single partition's values as sorted parallel arrays keyed by translated key.
-pub(super) struct Partition<K, V> {
-    /// Translated keys in ascending order. Equal keys are adjacent (a value run).
-    keys: Vec<K>,
-    /// Values, aligned with `keys`: `vals[i]` belongs to `keys[i]`.
-    vals: Vec<V>,
+pub(super) struct Partition<K: Copy, V> {
+    /// Keys in ascending order, aligned with their values. Equal keys form a value run.
+    entries: Entries<K, V>,
 }
 
-impl<K, V> Default for Partition<K, V> {
+impl<K: Copy, V> Default for Partition<K, V> {
     fn default() -> Self {
         Self {
-            keys: Vec::new(),
-            vals: Vec::new(),
+            entries: Entries::default(),
         }
     }
 }
@@ -31,19 +29,18 @@ impl<K, V> Default for Partition<K, V> {
 impl<K: Ord + Copy, V> Partition<K, V> {
     /// Whether the partition holds no entries.
     pub(super) const fn is_empty(&self) -> bool {
-        self.keys.is_empty()
+        self.entries.len() == 0
     }
 
     /// The number of stored entries (values, counting collisions).
     pub(super) const fn len(&self) -> usize {
-        self.keys.len()
+        self.entries.len()
     }
 
     /// Move every entry out of the partition, leaving it empty, returning one `(key, values)` pair
     /// per distinct key with its values in their current run order.
     pub(super) fn drain_runs(&mut self) -> Vec<(K, Vec<V>)> {
-        let keys = std::mem::take(&mut self.keys);
-        let vals = std::mem::take(&mut self.vals);
+        let (keys, vals) = std::mem::take(&mut self.entries).into_vecs();
         let mut vals = vals.into_iter();
         let mut runs = Vec::new();
         let mut i = 0;
@@ -62,15 +59,15 @@ impl<K: Ord + Copy, V> Partition<K, V> {
     /// Index of the first entry whose key is `>= key` (the start of `key`'s run, or its insertion
     /// point if absent).
     fn lower_bound(&self, key: &K) -> usize {
-        self.keys.partition_point(|k| k < key)
+        self.entries.keys().partition_point(|k| k < key)
     }
 
     /// The half-open `[idx, end)` index range of the run of entries equal to `keys[idx]`, given
     /// that `idx` is known to be the run's start (scans forward only).
     fn run_starting_at(&self, idx: usize) -> Range<usize> {
-        let key = self.keys[idx];
+        let key = self.entries.keys()[idx];
         let mut end = idx + 1;
-        while end < self.keys.len() && self.keys[end] == key {
+        while end < self.entries.len() && self.entries.keys()[end] == key {
             end += 1;
         }
         idx..end
@@ -79,9 +76,9 @@ impl<K: Ord + Copy, V> Partition<K, V> {
     /// The half-open `[start, idx + 1)` index range of the run of entries equal to `keys[idx]`,
     /// given that `idx` is known to be the run's end (scans backward only).
     fn run_ending_at(&self, idx: usize) -> Range<usize> {
-        let key = self.keys[idx];
+        let key = self.entries.keys()[idx];
         let mut start = idx;
-        while start > 0 && self.keys[start - 1] == key {
+        while start > 0 && self.entries.keys()[start - 1] == key {
             start -= 1;
         }
         start..idx + 1
@@ -91,11 +88,11 @@ impl<K: Ord + Copy, V> Partition<K, V> {
     /// key is absent).
     pub(super) fn run_range(&self, key: &K) -> Range<usize> {
         let start = self.lower_bound(key);
-        if self.keys.get(start) != Some(key) {
+        if self.entries.keys().get(start) != Some(key) {
             return start..start;
         }
         let mut end = start + 1;
-        while end < self.keys.len() && self.keys[end] == *key {
+        while end < self.entries.len() && self.entries.keys()[end] == *key {
             end += 1;
         }
         start..end
@@ -103,75 +100,72 @@ impl<K: Ord + Copy, V> Partition<K, V> {
 
     /// The values associated with `key` in their current run order (empty if absent).
     pub(super) fn values(&self, key: &K) -> &[V] {
-        &self.vals[self.run_range(key)]
+        &self.entries.values()[self.run_range(key)]
     }
 
     /// The value at array index `idx`.
-    pub(super) fn value_at(&self, idx: usize) -> &V {
-        &self.vals[idx]
+    pub(super) const fn value_at(&self, idx: usize) -> &V {
+        &self.entries.values()[idx]
     }
 
     /// Iterate every value held by the partition (in array order, all runs).
     #[commonware_macros::stability(ALPHA)]
     pub(super) fn values_iter(&self) -> std::slice::Iter<'_, V> {
-        self.vals.iter()
+        self.entries.values().iter()
     }
 
     /// Insert `(key, value)` at array index `idx`. The caller must pass an `idx` that keeps `keys`
     /// sorted (i.e. within or adjacent to `key`'s run).
-    pub(super) fn insert_at(&mut self, idx: usize, key: K, value: V) {
-        self.keys.insert(idx, key);
-        self.vals.insert(idx, value);
+    pub(super) fn insert_at(&mut self, idx: usize, key: K, value: V, pool: &Arc<Pool>) {
+        self.entries.insert(idx, key, value, pool);
     }
 
     /// Remove the entry at array index `idx`, returning its value.
     pub(super) fn remove(&mut self, idx: usize) -> V {
-        self.keys.remove(idx);
-        self.vals.remove(idx)
+        self.entries.remove(idx)
     }
 
     /// Remove every entry in the array range `range` (a whole key's run).
     pub(super) fn remove_run(&mut self, range: Range<usize>) {
-        self.keys.drain(range.clone());
-        self.vals.drain(range);
+        self.entries.remove_range(range);
     }
 
     /// Overwrite the value at array index `idx`.
     pub(super) fn set(&mut self, idx: usize, value: V) {
-        self.vals[idx] = value;
+        self.entries.values_mut()[idx] = value;
     }
 
     /// The values of the lexicographically smallest key in their current run order (None if the
     /// partition is empty).
     pub(super) fn first_values(&self) -> Option<&[V]> {
-        if self.keys.is_empty() {
+        if self.entries.len() == 0 {
             return None;
         }
-        Some(&self.vals[self.run_starting_at(0)])
+        Some(&self.entries.values()[self.run_starting_at(0)])
     }
 
     /// The values of the lexicographically largest key in their current run order (None if the
     /// partition is empty).
     pub(super) fn last_values(&self) -> Option<&[V]> {
-        let last = self.keys.len().checked_sub(1)?;
-        Some(&self.vals[self.run_ending_at(last)])
+        let last = self.entries.len().checked_sub(1)?;
+        Some(&self.entries.values()[self.run_ending_at(last)])
     }
 
     /// The values of the smallest key strictly greater than `key` in their current run order (None
     /// if no such key exists).
     pub(super) fn next_values_after(&self, key: &K) -> Option<&[V]> {
-        let idx = self.keys.partition_point(|k| *k <= *key);
-        if idx >= self.keys.len() {
+        let idx = self.entries.keys().partition_point(|k| *k <= *key);
+        if idx >= self.entries.len() {
             return None;
         }
-        Some(&self.vals[self.run_starting_at(idx)])
+        Some(&self.entries.values()[self.run_starting_at(idx)])
     }
 
     /// The values of the largest key strictly less than `key` in their current run order (None if
     /// no such key exists).
     pub(super) fn prev_values_before(&self, key: &K) -> Option<&[V]> {
         let prev = self.lower_bound(key).checked_sub(1)?;
-        Some(&self.vals[self.run_ending_at(prev)])
+        Some(&self.entries.values()[self.run_ending_at(prev)])
     }
 }
 
@@ -179,12 +173,18 @@ impl<K: Ord + Copy, V> Partition<K, V> {
 mod tests {
     use super::*;
 
+    #[test]
+    fn test_partition_header_size() {
+        // P=3 allocates 16.8M headers, including those for empty partitions.
+        assert!(size_of::<Partition<[u8; 5], u64>>() <= 4 * size_of::<usize>());
+    }
+
     /// Append `value` to `key`'s run, keeping the arrays sorted. The production hot path instead
     /// reuses the run it already computed (`insert_at(run.end, ..)`) to avoid a second lookup; this
     /// helper keeps the tests concise.
     fn insert<K: Ord + Copy, V>(p: &mut Partition<K, V>, key: K, value: V) {
         let end = p.run_range(&key).end;
-        p.insert_at(end, key, value);
+        p.insert_at(end, key, value, &Arc::default());
     }
 
     #[test]
@@ -205,8 +205,8 @@ mod tests {
         for (k, v) in [(30u16, 300u64), (10, 100), (20, 200)] {
             insert(&mut p, k, v);
         }
-        assert_eq!(p.keys, vec![10, 20, 30]);
-        assert_eq!(p.vals, vec![100, 200, 300]);
+        assert_eq!(p.entries.keys(), vec![10, 20, 30]);
+        assert_eq!(p.entries.values(), vec![100, 200, 300]);
         assert_eq!(p.first_values(), Some(&[100u64] as &[u64]));
         assert_eq!(p.last_values(), Some(&[300u64] as &[u64]));
         assert_eq!(p.values(&20), &[200]);
@@ -242,7 +242,7 @@ mod tests {
         assert_eq!(p.values(&10), &[1, 11, 111]);
         assert_eq!(p.values(&20), &[2]);
         // Keys remain sorted with the run adjacent.
-        assert_eq!(p.keys, vec![10, 10, 10, 20]);
+        assert_eq!(p.entries.keys(), vec![10, 10, 10, 20]);
         assert_eq!(p.run_range(&10), 0..3);
         assert_eq!(p.run_range(&20), 3..4);
     }
@@ -256,8 +256,8 @@ mod tests {
         // keys=[10,10,20] vals=[1,11,2]; remove the newer value of key 10 (index 1).
         let removed = p.remove(1);
         assert_eq!(removed, 11);
-        assert_eq!(p.keys, vec![10, 20]);
-        assert_eq!(p.vals, vec![1, 2]);
+        assert_eq!(p.entries.keys(), vec![10, 20]);
+        assert_eq!(p.entries.values(), vec![1, 2]);
         assert_eq!(p.values(&10), &[1]);
     }
 

--- a/storage/src/index/partitioned/ordered/pool.rs
+++ b/storage/src/index/partitioned/ordered/pool.rs
@@ -10,7 +10,7 @@ use std::{
 
 // Keep slabs small enough that a few surviving buffers do not pin large allocations after
 // most partitions have grown into the next size class.
-const SLAB_BYTES: usize = 4 * 1024;
+const SLAB_BYTES: usize = 2 * 1024;
 
 type Available = HashMap<(usize, usize), Vec<Weak<Slab>>>;
 
@@ -34,8 +34,10 @@ impl Pool {
                 continue;
             };
             let mut free = slab.free.lock();
-            let offset = free.pop().expect("available slab has a free slot");
-            if free.is_empty() {
+            assert_ne!(*free, 0, "available slab has a free slot");
+            let offset = free.trailing_zeros() as usize * slot.size();
+            *free &= *free - 1;
+            if *free == 0 {
                 slabs.pop();
             }
             drop(free);
@@ -44,7 +46,7 @@ impl Pool {
             return Allocation { ptr, slab };
         }
 
-        let count = (SLAB_BYTES / slot.size()).max(1);
+        let count = (SLAB_BYTES / slot.size()).clamp(1, u64::BITS as usize);
         let layout = Layout::from_size_align(slot.size() * count, slot.align()).unwrap();
         // SAFETY: layout is nonzero and valid.
         let raw = unsafe { alloc(layout) };
@@ -55,7 +57,8 @@ impl Pool {
             ptr,
             layout,
             slot,
-            free: Mutex::new((1..count).rev().map(|i| i * slot.size()).collect()),
+            // The low count bits describe slots; slot zero belongs to the returned allocation.
+            free: Mutex::new((u64::MAX >> (u64::BITS as usize - count)) & !1),
             pool: self.clone(),
         });
         if count > 1 {
@@ -70,7 +73,7 @@ pub(super) struct Slab {
     ptr: NonNull<u8>,
     layout: Layout,
     slot: Layout,
-    free: Mutex<Vec<usize>>,
+    free: Mutex<u64>,
     pub(super) pool: Arc<Pool>,
 }
 
@@ -103,8 +106,8 @@ impl Drop for Allocation {
         let offset = unsafe { self.ptr.as_ptr().offset_from(self.slab.ptr.as_ptr()) } as usize;
         let was_full = {
             let mut free = self.slab.free.lock();
-            let was_full = free.is_empty();
-            free.push(offset);
+            let was_full = *free == 0;
+            *free |= 1 << (offset / self.slab.slot.size());
             was_full
         };
         if was_full {
@@ -126,9 +129,41 @@ mod tests {
     use super::*;
 
     #[test]
+    fn test_slot_mask_boundaries() {
+        for (size, align, count) in [(1, 1, 64), (32, 8, 64), (56, 8, 36), (512, 8, 4)] {
+            let pool = Arc::new(Pool::default());
+            let layout = Layout::from_size_align(size, align).unwrap();
+            let allocations: Vec<_> = (0..count).map(|_| pool.allocate(layout)).collect();
+            let slab = allocations[0].slab.clone();
+            assert!(allocations.iter().all(|a| Arc::ptr_eq(&a.slab, &slab)));
+            for (i, allocation) in allocations.iter().enumerate() {
+                assert_eq!(
+                    allocation.ptr.as_ptr().addr(),
+                    slab.ptr.as_ptr().addr() + i * size
+                );
+            }
+            let extra = pool.allocate(layout);
+            assert!(!Arc::ptr_eq(&extra.slab, &slab));
+
+            // Return high slots first, exercising bit 63 before eventually making every bit free.
+            for allocation in allocations.into_iter().rev() {
+                let ptr = allocation.ptr;
+                drop(allocation);
+                let reused = pool.allocate(layout);
+                assert_eq!(reused.ptr, ptr);
+                drop(reused);
+            }
+            let weak = Arc::downgrade(&slab);
+            drop(slab);
+            assert!(weak.upgrade().is_none());
+            drop(extra);
+        }
+    }
+
+    #[test]
     fn test_reuse_and_release() {
         let pool = Arc::new(Pool::default());
-        let layout = Layout::from_size_align(1024, 8).unwrap();
+        let layout = Layout::from_size_align(SLAB_BYTES / 4, 8).unwrap();
         let mut allocations: Vec<_> = (0..4).map(|_| pool.allocate(layout)).collect();
         let slab = Arc::downgrade(&allocations[0].slab);
         assert!(

--- a/storage/src/index/partitioned/ordered/pool.rs
+++ b/storage/src/index/partitioned/ordered/pool.rs
@@ -1,0 +1,179 @@
+//! Size-segregated slabs for partition buffers. An empty slab is released immediately.
+
+use commonware_utils::sync::Mutex;
+use std::{
+    alloc::{Layout, alloc, dealloc, handle_alloc_error},
+    collections::HashMap,
+    ptr::NonNull,
+    sync::{Arc, Weak},
+};
+
+// Keep slabs small enough that a few surviving buffers do not pin large allocations after
+// most partitions have grown into the next size class.
+const SLAB_BYTES: usize = 4 * 1024;
+
+type Available = HashMap<(usize, usize), Vec<Weak<Slab>>>;
+
+/// Available slabs by slot size and alignment. Weak references let empty slabs be reclaimed.
+#[derive(Default)]
+pub(super) struct Pool {
+    available: Mutex<Available>,
+}
+
+impl Pool {
+    /// Allocate an exclusively owned slot with the requested nonzero layout.
+    pub(super) fn allocate(self: &Arc<Self>, layout: Layout) -> Allocation {
+        assert_ne!(layout.size(), 0);
+        let slot = layout.pad_to_align();
+        let key = (slot.size(), slot.align());
+        let mut available = self.available.lock();
+        let slabs = available.entry(key).or_default();
+        while let Some(weak) = slabs.last() {
+            let Some(slab) = weak.upgrade() else {
+                slabs.pop();
+                continue;
+            };
+            let mut free = slab.free.lock();
+            let offset = free.pop().expect("available slab has a free slot");
+            if free.is_empty() {
+                slabs.pop();
+            }
+            drop(free);
+            // SAFETY: offset is a free, aligned slot wholly within the slab allocation.
+            let ptr = unsafe { NonNull::new_unchecked(slab.ptr.as_ptr().add(offset)) };
+            return Allocation { ptr, slab };
+        }
+
+        let count = (SLAB_BYTES / slot.size()).max(1);
+        let layout = Layout::from_size_align(slot.size() * count, slot.align()).unwrap();
+        // SAFETY: layout is nonzero and valid.
+        let raw = unsafe { alloc(layout) };
+        let Some(ptr) = NonNull::new(raw) else {
+            handle_alloc_error(layout);
+        };
+        let slab = Arc::new(Slab {
+            ptr,
+            layout,
+            slot,
+            free: Mutex::new((1..count).rev().map(|i| i * slot.size()).collect()),
+            pool: self.clone(),
+        });
+        if count > 1 {
+            slabs.push(Arc::downgrade(&slab));
+        }
+        Allocation { ptr, slab }
+    }
+}
+
+/// Raw storage shared by disjoint slots. Each live slot keeps the slab and its pool alive.
+pub(super) struct Slab {
+    ptr: NonNull<u8>,
+    layout: Layout,
+    slot: Layout,
+    free: Mutex<Vec<usize>>,
+    pub(super) pool: Arc<Pool>,
+}
+
+impl Drop for Slab {
+    fn drop(&mut self) {
+        // SAFETY: Every live allocation holds a strong reference to the slab, so no slots remain
+        // in use. This is the layout with which ptr was allocated.
+        unsafe { dealloc(self.ptr.as_ptr(), self.layout) };
+    }
+}
+
+// SAFETY: Slot ownership is exclusive and free-slot bookkeeping is protected by a mutex.
+unsafe impl Send for Slab {}
+// SAFETY: Shared access never exposes the backing bytes; only disjoint owned slots expose them.
+unsafe impl Sync for Slab {}
+
+/// An owned, uninitialized slot. Its owner must drop any stored values before releasing it.
+pub(super) struct Allocation {
+    pub(super) ptr: NonNull<u8>,
+    pub(super) slab: Arc<Slab>,
+}
+
+impl Drop for Allocation {
+    fn drop(&mut self) {
+        // SAFETY: ptr addresses a slot within this slab's allocation.
+        let offset = unsafe { self.ptr.as_ptr().offset_from(self.slab.ptr.as_ptr()) } as usize;
+        let was_full = {
+            let mut free = self.slab.free.lock();
+            let was_full = free.is_empty();
+            free.push(offset);
+            was_full
+        };
+        if was_full {
+            // Release the slab lock before taking the pool lock: allocation takes them in the
+            // opposite order. Only the first return to a full slab queues it as available.
+            self.slab
+                .pool
+                .available
+                .lock()
+                .entry((self.slab.slot.size(), self.slab.slot.align()))
+                .or_default()
+                .push(Arc::downgrade(&self.slab));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_reuse_and_release() {
+        let pool = Arc::new(Pool::default());
+        let layout = Layout::from_size_align(1024, 8).unwrap();
+        let mut allocations: Vec<_> = (0..4).map(|_| pool.allocate(layout)).collect();
+        let slab = Arc::downgrade(&allocations[0].slab);
+        assert!(
+            allocations
+                .iter()
+                .all(|a| Arc::ptr_eq(&a.slab, &allocations[0].slab))
+        );
+        let ptr = allocations[0].ptr;
+        drop(allocations.remove(0));
+        let reused = pool.allocate(layout);
+        assert_eq!(reused.ptr, ptr);
+        drop(allocations);
+        assert!(slab.upgrade().is_some());
+        drop(reused);
+        assert!(slab.upgrade().is_none());
+        let allocation = pool.allocate(layout);
+        assert_eq!(allocation.ptr.as_ptr().align_offset(layout.align()), 0);
+    }
+
+    #[test]
+    fn test_pool_lives_with_allocations() {
+        let pool = Arc::new(Pool::default());
+        let weak = Arc::downgrade(&pool);
+        let allocation = pool.allocate(Layout::new::<u64>());
+        drop(pool);
+        assert!(weak.upgrade().is_some());
+        drop(allocation);
+        assert!(weak.upgrade().is_none());
+    }
+
+    #[test]
+    fn test_concurrent_allocation() {
+        let pool = Arc::new(Pool::default());
+        std::thread::scope(|scope| {
+            for _ in 0..4 {
+                let pool = &pool;
+                scope.spawn(move || {
+                    for i in 0..100 {
+                        let allocation = pool.allocate(Layout::new::<[u64; 128]>());
+                        // SAFETY: This slot has sufficient space and alignment and is exclusively
+                        // owned by this thread. Other threads must receive disjoint slots.
+                        unsafe {
+                            allocation.ptr.as_ptr().cast::<[u64; 128]>().write([i; 128]);
+                            std::thread::yield_now();
+                            assert_eq!(*allocation.ptr.as_ptr().cast::<[u64; 128]>(), [i; 128]);
+                        }
+                    }
+                });
+            }
+        });
+    }
+}

--- a/storage/src/index/partitioned/ordered/pool.rs
+++ b/storage/src/index/partitioned/ordered/pool.rs
@@ -95,6 +95,10 @@ pub(super) struct Allocation {
 
 impl Drop for Allocation {
     fn drop(&mut self) {
+        // A single-slot slab cannot be reused; dropping its Arc releases the slab directly.
+        if self.slab.layout.size() == self.slab.slot.size() {
+            return;
+        }
         // SAFETY: ptr addresses a slot within this slab's allocation.
         let offset = unsafe { self.ptr.as_ptr().offset_from(self.slab.ptr.as_ptr()) } as usize;
         let was_full = {
@@ -142,6 +146,24 @@ mod tests {
         assert!(slab.upgrade().is_none());
         let allocation = pool.allocate(layout);
         assert_eq!(allocation.ptr.as_ptr().align_offset(layout.align()), 0);
+    }
+
+    #[test]
+    fn test_dedicated_slabs_leave_no_available_entries() {
+        for size in [SLAB_BYTES / 2 + 8, SLAB_BYTES, SLAB_BYTES * 2] {
+            let pool = Arc::new(Pool::default());
+            let layout = Layout::from_size_align(size, 8).unwrap();
+            let allocations: Vec<_> = (0..64).map(|_| pool.allocate(layout)).collect();
+            let slab = Arc::downgrade(&allocations[0].slab);
+
+            // Release the whole batch without allocating again to sweep dead weak references.
+            drop(allocations);
+            assert!(slab.upgrade().is_none());
+            assert_eq!(
+                pool.available.lock().values().map(Vec::len).sum::<usize>(),
+                0
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
Store each partition's key and value arrays in one pooled buffer backed by reclaimable 2 KiB slabs. A bitmap tracks free slots, empty slabs release their storage, and shared length/capacity reduces partition headers from 48 to 32 bytes. Lookups do not acquire pool locks.

Compared with main (`ecb6895bd`) on macOS/arm64, using 3,906,250 keys, `P=2`, five-byte suffixes, and `u64` values. Results are medians of three fresh-process runs; this workload has the same mean partition occupancy as 1B keys at `P=3`.

| Metric | Main | This PR |
| --- | ---: | ---: |
| Peak RSS per key | 34.42 B | 21.92 B |
| Insert | 195 ns/op | 179 ns/op |
| Lookup | 80 ns/op | 81 ns/op |

Peak RSS decreases **36%**, with inserts 8% faster and lookup time roughly unchanged in this benchmark. Timings include key generation. Separately, the PR measured **20.25 GB peak RSS (20.25 B/key)** at 1B keys with `P=3`.

Validation: 3,094 storage tests, 13 Miri tests, and the WASM release build passed. Full `pre-pr` stopped at an existing Clippy lint in `utils/src/bitmap/mod.rs`.
