### PR TITLE
[storage,runtime] Grow the log page cache after snapshot build

### DIFF
--- a/examples/reshare/src/types.rs
+++ b/examples/reshare/src/types.rs
@@ -486,6 +486,7 @@ pub fn db_config(prefix: &str, page_cache: CacheRef) -> FixedConfig<TwoCap, Sequ
         },
         translator: TwoCap,
         init_cache_size: Some(NZUsize!(1024)),
+        page_cache_size: None,
         init_buffer: NZUsize!(1 << 21),
         init_concurrency: (),
     }

--- a/glue/src/dkg/tests/reshare/harness.rs
+++ b/glue/src/dkg/tests/reshare/harness.rs
@@ -1026,6 +1026,7 @@ impl EngineDefinition for ReshareEngine {
             },
             translator: TwoCap,
             init_cache_size: Some(NZUsize!(1024)),
+            page_cache_size: None,
             init_buffer: NZUsize!(1 << 21),
             init_concurrency: (),
         };

--- a/glue/src/stateful/actor/processor/mod.rs
+++ b/glue/src/stateful/actor/processor/mod.rs
@@ -2292,6 +2292,7 @@ mod tests {
             },
             translator: TwoCap,
             init_cache_size: Some(NZUsize!(1024)),
+            page_cache_size: None,
             init_buffer: NZUsize!(1 << 21),
             init_concurrency: (),
         }

--- a/glue/src/stateful/db/any.rs
+++ b/glue/src/stateful/db/any.rs
@@ -831,6 +831,7 @@ mod tests {
             },
             translator: TwoCap,
             init_cache_size: Some(NZUsize!(1024)),
+            page_cache_size: None,
             init_buffer: NZUsize!(1 << 21),
             init_concurrency: (),
         }

--- a/glue/src/stateful/db/current.rs
+++ b/glue/src/stateful/db/current.rs
@@ -1274,6 +1274,7 @@ mod tests {
             grafted_metadata_partition: format!("stateful-current-grafted-{suffix}"),
             translator: TwoCap,
             init_cache_size: Some(NZUsize!(1024)),
+            page_cache_size: None,
             init_buffer: NZUsize!(1 << 21),
             init_concurrency: (),
         }
@@ -1306,6 +1307,7 @@ mod tests {
             grafted_metadata_partition: format!("stateful-current-grafted-{suffix}"),
             translator: TwoCap,
             init_cache_size: Some(NZUsize!(1024)),
+            page_cache_size: None,
             init_buffer: NZUsize!(1 << 21),
             init_concurrency: (),
         }

--- a/glue/src/stateful/db/mod.rs
+++ b/glue/src/stateful/db/mod.rs
@@ -2193,6 +2193,7 @@ mod tests {
                 journal_config: fixed_journal_config(context, suffix),
                 translator: TwoCap,
                 init_cache_size: Some(NZUsize!(1024)),
+                page_cache_size: None,
                 init_buffer: NZUsize!(1 << 21),
                 init_concurrency: (),
             }
@@ -2207,6 +2208,7 @@ mod tests {
                 journal_config: variable_journal_config(context, suffix, ((), ())),
                 translator: TwoCap,
                 init_cache_size: Some(NZUsize!(1024)),
+                page_cache_size: None,
                 init_buffer: NZUsize!(1 << 21),
                 init_concurrency: (),
             }
@@ -2222,6 +2224,7 @@ mod tests {
                 grafted_metadata_partition: format!("initial-target-{suffix}-grafted-metadata"),
                 translator: TwoCap,
                 init_cache_size: Some(NZUsize!(1024)),
+                page_cache_size: None,
                 init_buffer: NZUsize!(1 << 21),
                 init_concurrency: (),
             }
@@ -2237,6 +2240,7 @@ mod tests {
                 grafted_metadata_partition: format!("initial-target-{suffix}-grafted-metadata"),
                 translator: TwoCap,
                 init_cache_size: Some(NZUsize!(1024)),
+                page_cache_size: None,
                 init_buffer: NZUsize!(1 << 21),
                 init_concurrency: (),
             }

--- a/glue/src/stateful/db/p2p/actor.rs
+++ b/glue/src/stateful/db/p2p/actor.rs
@@ -493,6 +493,7 @@ mod tests {
             },
             translator: TwoCap,
             init_cache_size: Some(NZUsize!(1024)),
+            page_cache_size: None,
             init_buffer: NZUsize!(1 << 21),
             init_concurrency: (),
         }

--- a/glue/src/stateful/tests/multi_db_app.rs
+++ b/glue/src/stateful/tests/multi_db_app.rs
@@ -106,6 +106,7 @@ pub(super) fn qmdb_config(
         },
         translator: TwoCap,
         init_cache_size: Some(NZUsize!(1024)),
+        page_cache_size: None,
         init_buffer: NZUsize!(1 << 21),
         init_concurrency: (),
     };

--- a/glue/src/stateful/tests/single_db_app.rs
+++ b/glue/src/stateful/tests/single_db_app.rs
@@ -88,6 +88,7 @@ pub(super) fn qmdb_config(prefix: &str, page_cache: CacheRef) -> FixedConfig<Two
         },
         translator: TwoCap,
         init_cache_size: Some(NZUsize!(1024)),
+        page_cache_size: None,
         init_buffer: NZUsize!(1 << 21),
         init_concurrency: (),
     }

--- a/runtime/src/utils/buffer/paged/cache.rs
+++ b/runtime/src/utils/buffer/paged/cache.rs
@@ -216,6 +216,22 @@ impl CacheRef {
         self.next_id.fetch_add(1, Ordering::Relaxed)
     }
 
+    /// Replace the backing cache with an empty one holding at most `capacity` pages, discarding all
+    /// currently cached pages. Blob ids assigned via [Self::next_id] stay valid, so previously cached
+    /// pages are simply re-fetched on their next access.
+    ///
+    /// Intended for a one-time capacity handoff at a quiescent point (for example, growing a small
+    /// init-time cache to the full runtime size once startup finishes). It takes the write lock and
+    /// must not run concurrently with reads or writes through this cache.
+    pub fn resize(&self, capacity: NonZeroUsize) {
+        *self.cache.write() = Cache::new(self.pool.clone(), self.page_size, capacity);
+    }
+
+    /// The maximum number of pages the backing cache currently holds.
+    pub fn capacity(&self) -> NonZeroUsize {
+        NonZeroUsize::new(self.cache.read().capacity()).expect("cache capacity is non-zero")
+    }
+
     /// Convert a logical offset into the number of the page it belongs to and the offset within
     /// that page.
     pub fn offset_to_page(&self, offset: u64) -> (u64, u64) {
@@ -486,6 +502,11 @@ impl Cache {
             pool,
             page_fetches: AHashMap::new(),
         }
+    }
+
+    /// The maximum number of pages this cache can hold.
+    fn capacity(&self) -> usize {
+        self.cache.capacity()
     }
 
     /// Convert a logical offset into the number of the page it belongs to and the offset within

--- a/storage/fuzz/fuzz_targets/qmdb_any_fixed_sync.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_any_fixed_sync.rs
@@ -114,6 +114,7 @@ fn test_config(test_name: &str, pooler: &impl BufferPooler) -> Config<TwoCap, Se
         },
         translator: TwoCap,
         init_cache_size: Some(NZUsize!(3)),
+        page_cache_size: None,
         init_buffer: NZUsize!(1 << 21),
         init_concurrency: (),
     }

--- a/storage/fuzz/fuzz_targets/qmdb_any_ordered_batch_root.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_any_ordered_batch_root.rs
@@ -125,6 +125,7 @@ fn test_config(name: &str, pooler: &impl BufferPooler) -> Config<OneCap, Sequent
         },
         translator: OneCap,
         init_cache_size: Some(NZUsize!(3)),
+        page_cache_size: None,
         init_buffer: NZUsize!(1 << 21),
         init_concurrency: (),
     }

--- a/storage/fuzz/fuzz_targets/qmdb_any_ordered_batching.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_any_ordered_batching.rs
@@ -111,6 +111,7 @@ fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
                 },
                 translator: EightCap,
                 init_cache_size: Some(NZUsize!(3)),
+                page_cache_size: None,
                 init_buffer: NZUsize!(1 << 21),
                 init_concurrency: (),
             };

--- a/storage/fuzz/fuzz_targets/qmdb_any_ordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_any_ordered_operations.rs
@@ -138,6 +138,7 @@ fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
                 },
                 translator: EightCap,
                 init_cache_size: Some(NZUsize!(3)),
+                page_cache_size: None,
                 init_buffer: NZUsize!(1 << 21),
                 init_concurrency: (),
             };

--- a/storage/fuzz/fuzz_targets/qmdb_any_unordered_batch_root.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_any_unordered_batch_root.rs
@@ -120,6 +120,7 @@ fn test_config(name: &str, pooler: &impl BufferPooler) -> Config<OneCap, Sequent
         },
         translator: OneCap,
         init_cache_size: Some(NZUsize!(3)),
+        page_cache_size: None,
         init_buffer: NZUsize!(1 << 21),
         init_concurrency: (),
     }

--- a/storage/fuzz/fuzz_targets/qmdb_any_unordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_any_unordered_operations.rs
@@ -113,6 +113,7 @@ fn fuzz_family<F: MerkleFamily>(data: &FuzzInput, suffix: &str) {
                 },
                 translator: EightCap,
                 init_cache_size: Some(NZUsize!(3)),
+                page_cache_size: None,
                 init_buffer: NZUsize!(1 << 21),
                 init_concurrency: (),
             };

--- a/storage/fuzz/fuzz_targets/qmdb_any_variable_sync.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_any_variable_sync.rs
@@ -162,6 +162,7 @@ fn test_config(
         },
         translator: TwoCap,
         init_cache_size: Some(NZUsize!(3)),
+        page_cache_size: None,
         init_buffer: NZUsize!(1 << 21),
         init_concurrency: (),
     }

--- a/storage/fuzz/fuzz_targets/qmdb_current_mmb_prune_grow.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_current_mmb_prune_grow.rs
@@ -167,6 +167,7 @@ fn test_config(name: &str, page_cache: CacheRef) -> Config<TwoCap, Sequential> {
         grafted_metadata_partition: format!("fuzz-current-mmb-pruning-{name}-grafted-metadata"),
         translator: TwoCap,
         init_cache_size: Some(NZUsize!(3)),
+        page_cache_size: None,
         init_buffer: NZUsize!(1 << 21),
         init_concurrency: (),
     }

--- a/storage/fuzz/fuzz_targets/qmdb_current_ordered_batch_root.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_current_ordered_batch_root.rs
@@ -125,6 +125,7 @@ fn test_config(name: &str, pooler: &impl BufferPooler) -> Config<OneCap, Sequent
         grafted_metadata_partition: format!("{name}-grafted"),
         translator: OneCap,
         init_cache_size: Some(NZUsize!(3)),
+        page_cache_size: None,
         init_buffer: NZUsize!(1 << 21),
         init_concurrency: (),
     }

--- a/storage/fuzz/fuzz_targets/qmdb_current_ordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_current_ordered_operations.rs
@@ -162,6 +162,7 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
             grafted_metadata_partition: format!("fuzz-current-ord-{suffix}-grafted-merkle-metadata"),
             translator: TwoCap,
             init_cache_size: Some(NZUsize!(3)),
+            page_cache_size: None,
             init_buffer: NZUsize!(1 << 21),
             init_concurrency: (),
         };

--- a/storage/fuzz/fuzz_targets/qmdb_current_recovery.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_current_recovery.rs
@@ -136,6 +136,7 @@ fn make_config(
         grafted_metadata_partition: format!("crash-grafted-merkle-metadata-{suffix}"),
         translator: TwoCap,
         init_cache_size: Some(NZUsize!(3)),
+        page_cache_size: None,
         init_buffer: NZUsize!(1 << 21),
         init_concurrency: (),
     }

--- a/storage/fuzz/fuzz_targets/qmdb_current_unordered_batch_root.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_current_unordered_batch_root.rs
@@ -121,6 +121,7 @@ fn test_config(name: &str, pooler: &impl BufferPooler) -> Config<OneCap, Sequent
         grafted_metadata_partition: format!("{name}-grafted"),
         translator: OneCap,
         init_cache_size: Some(NZUsize!(3)),
+        page_cache_size: None,
         init_buffer: NZUsize!(1 << 21),
         init_concurrency: (),
     }

--- a/storage/fuzz/fuzz_targets/qmdb_current_unordered_operations.rs
+++ b/storage/fuzz/fuzz_targets/qmdb_current_unordered_operations.rs
@@ -149,6 +149,7 @@ fn fuzz_family<F: Graftable>(data: &FuzzInput, suffix: &str) {
             grafted_metadata_partition: format!("fuzz-current-{suffix}-grafted-merkle-metadata"),
             translator: TwoCap,
             init_cache_size: Some(NZUsize!(3)),
+            page_cache_size: None,
             init_buffer: NZUsize!(1 << 21),
             init_concurrency: (),
         };

--- a/storage/src/qmdb/any/mod.rs
+++ b/storage/src/qmdb/any/mod.rs
@@ -133,6 +133,17 @@ pub struct Config<T: Translator, J, S: Strategy, B = ()> {
     /// collisions without re-reading the log; `None` disables it.
     pub init_cache_size: Option<NonZeroUsize>,
 
+    /// Steady-state page-cache capacity (in pages) to grow the log's page cache to after the
+    /// snapshot build. Create the log's page cache (in the merkle and journal configs) at the
+    /// smaller size wanted during init, and set this to the larger size wanted for serving: the
+    /// snapshot build reads the log once (streamed replay plus scattered collision probes) and gets
+    /// no reuse from a large data cache, so a small cache during init frees memory for the snapshot
+    /// index. After the build the cache is grown to this size, discarding the pages cached during
+    /// init (re-fetched on demand). `None` leaves the cache at its configured size. Only grows (a
+    /// value not larger than the configured size is ignored). Assumes the merkle and log journals
+    /// share one page cache, as in the standard configuration.
+    pub page_cache_size: Option<NonZeroUsize>,
+
     /// Size (in bytes) of the read buffer used to replay the log during init.
     pub init_buffer: NonZeroUsize,
 
@@ -186,6 +197,15 @@ where
     S: Strategy,
     Operation<F, U>: Codec,
 {
+    // The snapshot build below runs with the caller-configured page cache. For a memory-constrained
+    // init the caller sizes that cache small: the build streams the log once and probes scattered
+    // collisions, gaining no reuse from a large data cache, so a small cache leaves room for the
+    // snapshot index. After the build the cache is grown to its steady-state size (see
+    // `page_cache_size`). Assumes the merkle and log journals share one page cache (the standard
+    // configuration).
+    let page_cache = cfg.merkle_config.page_cache.clone();
+    let serving_page_cache_size = cfg.page_cache_size;
+
     let mut log = authenticated::Journal::<F, E, J, H, S>::new(
         context.child("log"),
         cfg.merkle_config,
@@ -205,7 +225,7 @@ where
     let index = I::new(context.child("index"), cfg.translator);
     let snapshot_context = context.child("snapshot");
     let metrics = Metrics::new(context);
-    db::Db::init_from_log(
+    let db = db::Db::init_from_log(
         snapshot_context,
         index,
         log,
@@ -215,7 +235,17 @@ where
         cfg.init_cache_size,
         metrics,
     )
-    .await
+    .await?;
+
+    // Grow the log's page cache to its steady-state size for the grafted-tree rebuild and serving.
+    // Pages cached during the build are discarded; they are re-fetched on demand. Only grows, so a
+    // value not larger than the caller's cache is a no-op.
+    if let Some(size) = serving_page_cache_size {
+        if size > page_cache.capacity() {
+            page_cache.resize(size);
+        }
+    }
+    Ok(db)
 }
 
 #[cfg(test)]
@@ -300,6 +330,7 @@ pub(crate) mod test {
             },
             translator: T::default(),
             init_cache_size: Some(NZUsize!(1024)),
+            page_cache_size: None,
             init_buffer: NZUsize!(1 << 21),
             init_concurrency,
         }
@@ -357,6 +388,7 @@ pub(crate) mod test {
             },
             translator: T::default(),
             init_cache_size: Some(NZUsize!(1024)),
+            page_cache_size: None,
             init_buffer: NZUsize!(1 << 21),
             init_concurrency,
         }

--- a/storage/src/qmdb/any/ordered/variable.rs
+++ b/storage/src/qmdb/any/ordered/variable.rs
@@ -208,6 +208,7 @@ pub(crate) mod test {
             },
             translator: TwoCap,
             init_cache_size: Some(NZUsize!(1024)),
+            page_cache_size: None,
             init_buffer: NZUsize!(1 << 21),
             init_concurrency,
         }

--- a/storage/src/qmdb/any/unordered/variable.rs
+++ b/storage/src/qmdb/any/unordered/variable.rs
@@ -185,6 +185,7 @@ pub(crate) mod test {
             },
             translator: TwoCap,
             init_cache_size: Some(NZUsize!(1024)),
+            page_cache_size: None,
             init_buffer: NZUsize!(1 << 21),
             init_concurrency: (),
         }

--- a/storage/src/qmdb/benches/chained_growth.rs
+++ b/storage/src/qmdb/benches/chained_growth.rs
@@ -88,6 +88,7 @@ fn cur_fix_cfg(
         grafted_metadata_partition: format!("grafted-metadata-{PARTITION}"),
         translator: EightCap,
         init_cache_size: crate::common::INIT_CACHE_SIZE,
+        page_cache_size: None,
         init_buffer: NZUsize!(1 << 21),
         init_concurrency: (),
     }

--- a/storage/src/qmdb/benches/common.rs
+++ b/storage/src/qmdb/benches/common.rs
@@ -181,6 +181,7 @@ pub fn any_fix_cfg_full<B>(
         journal_config: fix_log_cfg(PARTITION_FIX, page_cache, items_per_blob),
         translator: EightCap,
         init_cache_size: INIT_CACHE_SIZE,
+        page_cache_size: None,
         init_buffer: NZUsize!(1 << 21),
         init_concurrency,
     }
@@ -214,6 +215,7 @@ pub fn cur_fix_cfg_with(
         grafted_metadata_partition: format!("grafted-metadata-{PARTITION_FIX}"),
         translator: EightCap,
         init_cache_size: INIT_CACHE_SIZE,
+        page_cache_size: None,
         init_buffer: NZUsize!(1 << 21),
         init_concurrency: (),
     }
@@ -235,6 +237,7 @@ pub fn any_var_digest_cfg_with(
         journal_config: var_log_cfg(PARTITION_VAR, page_cache, ((), ()), items_per_blob),
         translator: EightCap,
         init_cache_size: INIT_CACHE_SIZE,
+        page_cache_size: None,
         init_buffer: NZUsize!(1 << 21),
         init_concurrency: (),
     }
@@ -257,6 +260,7 @@ pub fn cur_var_digest_cfg_with(
         grafted_metadata_partition: format!("grafted-metadata-{PARTITION_VAR}"),
         translator: EightCap,
         init_cache_size: INIT_CACHE_SIZE,
+        page_cache_size: None,
         init_buffer: NZUsize!(1 << 21),
         init_concurrency: (),
     }
@@ -286,6 +290,7 @@ pub fn any_var_vec_cfg_with(
         ),
         translator: EightCap,
         init_cache_size: INIT_CACHE_SIZE,
+        page_cache_size: None,
         init_buffer: NZUsize!(1 << 21),
         init_concurrency: (),
     }
@@ -313,6 +318,7 @@ pub fn cur_var_vec_cfg_with(
         grafted_metadata_partition: format!("grafted-metadata-{PARTITION_VAR}"),
         translator: EightCap,
         init_cache_size: INIT_CACHE_SIZE,
+        page_cache_size: None,
         init_buffer: NZUsize!(1 << 21),
         init_concurrency: (),
     }

--- a/storage/src/qmdb/benches/constantinople.rs
+++ b/storage/src/qmdb/benches/constantinople.rs
@@ -366,6 +366,7 @@ fn main() {
                     grafted_metadata_partition: "constantinople-grafted-metadata".into(),
                     translator: EightCap,
                     init_cache_size: Some(NZUsize!(1 << 18)),
+                    page_cache_size: None,
                     init_buffer: NZUsize!(1 << 21),
                     init_concurrency: (),
                 };
@@ -384,6 +385,7 @@ fn main() {
                     grafted_metadata_partition: "constantinople-grafted-metadata".into(),
                     translator: EightCap,
                     init_cache_size: Some(NZUsize!(1 << 18)),
+                    page_cache_size: None,
                     init_buffer: NZUsize!(1 << 21),
                     init_concurrency: (),
                 };
@@ -401,6 +403,7 @@ fn main() {
                     journal_config,
                     translator: EightCap,
                     init_cache_size: Some(NZUsize!(1 << 18)),
+                    page_cache_size: None,
                     init_buffer: NZUsize!(1 << 21),
                     init_concurrency: (),
                 };
@@ -421,6 +424,7 @@ fn main() {
                     },
                     translator: EightCap,
                     init_cache_size: Some(NZUsize!(1 << 18)),
+                    page_cache_size: None,
                     init_buffer: NZUsize!(1 << 21),
                     init_concurrency: (),
                 };
@@ -433,6 +437,7 @@ fn main() {
                     journal_config,
                     translator: EightCap,
                     init_cache_size: Some(NZUsize!(1 << 18)),
+                    page_cache_size: None,
                     init_buffer: NZUsize!(1 << 21),
                     init_concurrency: (),
                 };

--- a/storage/src/qmdb/benches/merkleize.rs
+++ b/storage/src/qmdb/benches/merkleize.rs
@@ -334,6 +334,7 @@ pub(crate) fn any_fix_cfg_with_cache(
         journal_config: fix_log_cfg(pc),
         translator: EightCap,
         init_cache_size: crate::common::INIT_CACHE_SIZE,
+        page_cache_size: None,
         init_buffer: NZUsize!(1 << 21),
         init_concurrency: (),
     }
@@ -348,6 +349,7 @@ fn any_var_cfg_with_cache(
         journal_config: var_log_cfg(pc),
         translator: EightCap,
         init_cache_size: crate::common::INIT_CACHE_SIZE,
+        page_cache_size: None,
         init_buffer: NZUsize!(1 << 21),
         init_concurrency: (),
     }
@@ -363,6 +365,7 @@ pub(crate) fn cur_fix_cfg_with_cache(
         grafted_metadata_partition: format!("grafted-metadata-{PARTITION}"),
         translator: EightCap,
         init_cache_size: crate::common::INIT_CACHE_SIZE,
+        page_cache_size: None,
         init_buffer: NZUsize!(1 << 21),
         init_concurrency: (),
     }
@@ -378,6 +381,7 @@ fn cur_var_cfg_with_cache(
         grafted_metadata_partition: format!("grafted-metadata-{PARTITION}"),
         translator: EightCap,
         init_cache_size: crate::common::INIT_CACHE_SIZE,
+        page_cache_size: None,
         init_buffer: NZUsize!(1 << 21),
         init_concurrency: (),
     }

--- a/storage/src/qmdb/conformance.rs
+++ b/storage/src/qmdb/conformance.rs
@@ -167,6 +167,7 @@ fn any_fixed_config(
         journal_config: fixed_log_config(suffix, pc),
         translator: OneCap,
         init_cache_size: Some(NZUsize!(1024)),
+        page_cache_size: None,
         init_buffer: NZUsize!(1 << 21),
         init_concurrency: (),
     }
@@ -182,6 +183,7 @@ fn any_variable_config(
         journal_config: variable_log_config(suffix, pc, ((), ())),
         translator: OneCap,
         init_cache_size: Some(NZUsize!(1024)),
+        page_cache_size: None,
         init_buffer: NZUsize!(1 << 21),
         init_concurrency: (),
     }
@@ -198,6 +200,7 @@ fn current_fixed_config(
         grafted_metadata_partition: format!("{suffix}-graft"),
         translator: OneCap,
         init_cache_size: Some(NZUsize!(1024)),
+        page_cache_size: None,
         init_buffer: NZUsize!(1 << 21),
         init_concurrency: (),
     }
@@ -214,6 +217,7 @@ fn current_variable_config(
         grafted_metadata_partition: format!("{suffix}-graft"),
         translator: OneCap,
         init_cache_size: Some(NZUsize!(1024)),
+        page_cache_size: None,
         init_buffer: NZUsize!(1 << 21),
         init_concurrency: (),
     }

--- a/storage/src/qmdb/current/mod.rs
+++ b/storage/src/qmdb/current/mod.rs
@@ -380,6 +380,13 @@ pub struct Config<T: Translator, J, S: Strategy, B = ()> {
     /// collisions without re-reading the log; `None` disables it.
     pub init_cache_size: Option<NonZeroUsize>,
 
+    /// Page-cache capacity (in pages) to shrink the log's page cache to for the duration of the
+    /// snapshot build, restored to its original size before serving. Lets init run with a small
+    /// page cache (the build gets no reuse from a large data cache) while the full cache is reserved
+    /// for steady-state operation. `None` leaves it at its configured size. See
+    /// [`crate::qmdb::any::Config::page_cache_size`].
+    pub page_cache_size: Option<NonZeroUsize>,
+
     /// Size (in bytes) of the read buffer used to replay the log during init.
     pub init_buffer: NonZeroUsize,
 
@@ -398,6 +405,7 @@ impl<T: Translator, J, S: Strategy, B> From<Config<T, J, S, B>> for AnyConfig<T,
             journal_config: cfg.journal_config,
             translator: cfg.translator,
             init_cache_size: cfg.init_cache_size,
+            page_cache_size: cfg.page_cache_size,
             init_buffer: cfg.init_buffer,
             init_concurrency: cfg.init_concurrency,
         }
@@ -776,6 +784,7 @@ pub mod tests {
             grafted_metadata_partition: format!("{partition_prefix}-grafted-metadata-partition"),
             translator: T::default(),
             init_cache_size: Some(NZUsize!(1024)),
+            page_cache_size: None,
             init_buffer: NZUsize!(1 << 21),
             init_concurrency,
         }
@@ -819,6 +828,7 @@ pub mod tests {
             grafted_metadata_partition: format!("{partition_prefix}-grafted-metadata-partition"),
             translator: T::default(),
             init_cache_size: Some(NZUsize!(1024)),
+            page_cache_size: None,
             init_buffer: NZUsize!(1 << 21),
             init_concurrency,
         }
@@ -1740,6 +1750,7 @@ pub mod tests {
                 grafted_metadata_partition: "forged-exclusion-grafted".to_string(),
                 translator: OneCap,
                 init_cache_size: Some(NZUsize!(1024)),
+                page_cache_size: None,
                 init_buffer: NZUsize!(1 << 21),
                 init_concurrency: NZUsize!(1),
             };

--- a/storage/src/qmdb/current/unordered/variable.rs
+++ b/storage/src/qmdb/current/unordered/variable.rs
@@ -191,6 +191,7 @@ mod test {
                 grafted_metadata_partition: base.grafted_metadata_partition.clone(),
                 translator: TwoCap,
                 init_cache_size: base.init_cache_size,
+                page_cache_size: base.page_cache_size,
                 init_buffer: base.init_buffer,
                 init_concurrency: (),
             };


### PR DESCRIPTION
Adds a `page_cache_size` field to the `any` and `current` database configs so the log's page cache can be small during the snapshot build and grown to its steady-state size afterward.

The snapshot rebuild streams the log once and probes scattered collisions, gaining no reuse from a large data page cache. Sizing the cache small for init and growing it after the build frees memory for the snapshot index during the memory-heavy phase, then restores full caching for serving. Callers create the page cache at the init size and set `page_cache_size` to the serving size; `None` leaves it unchanged, so existing callers are unaffected.

Runtime support: `CacheRef::resize` replaces the backing page cache and `CacheRef::capacity` reports its current capacity.

Motivation: on large QMDB seeds the snapshot index dominates init memory while a full-size page cache sits idle during the build; this lets init run with a small cache without giving up steady-state caching.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q4BFdANo2LhVEr2ko3FK9n
