### PR TITLE
[cryptography/reed_solomon] Run pinned roundtrips on every SIMD engine

### DIFF
--- a/cryptography/src/reed_solomon/engine.rs
+++ b/cryptography/src/reed_solomon/engine.rs
@@ -41,7 +41,7 @@
     deprecated,
     reason = "tracked by https://github.com/commonwarexyz/monorepo/issues/4414"
 )]
-mod cpu_features {
+pub(crate) mod cpu_features {
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     cpufeatures::new!(has_avx2, "avx2");
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
@@ -50,9 +50,9 @@ mod cpu_features {
     cpufeatures::new!(has_neon, "neon");
 
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    pub(super) use self::{has_avx2::get as avx2, has_ssse3::get as ssse3};
+    pub(crate) use self::{has_avx2::get as avx2, has_ssse3::get as ssse3};
     #[cfg(target_arch = "aarch64")]
-    pub(super) use has_neon::get as neon;
+    pub(crate) use has_neon::get as neon;
 }
 
 #[cfg(target_arch = "aarch64")]

--- a/cryptography/src/reed_solomon/test_util.rs
+++ b/cryptography/src/reed_solomon/test_util.rs
@@ -197,6 +197,32 @@ macro_rules! roundtrip_single {
             crate::reed_solomon::engine::NoSimd::new,
             &cfg,
         );
+
+        // Run every SIMD engine the host supports against the same pinned hashes.
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        {
+            if crate::reed_solomon::engine::cpu_features::avx2() {
+                crate::reed_solomon::test_util::roundtrip_single::<$Rate<_>, _>(
+                    crate::reed_solomon::engine::Avx2::new,
+                    &cfg,
+                );
+            }
+            if crate::reed_solomon::engine::cpu_features::ssse3() {
+                crate::reed_solomon::test_util::roundtrip_single::<$Rate<_>, _>(
+                    crate::reed_solomon::engine::Ssse3::new,
+                    &cfg,
+                );
+            }
+        }
+        #[cfg(target_arch = "aarch64")]
+        {
+            if crate::reed_solomon::engine::cpu_features::neon() {
+                crate::reed_solomon::test_util::roundtrip_single::<$Rate<_>, _>(
+                    crate::reed_solomon::engine::Neon::new,
+                    &cfg,
+                );
+            }
+        }
     };
 }
 
@@ -275,6 +301,91 @@ macro_rules! roundtrip_two_rounds {
                 $seed_b,
             ),
         );
+
+        // Run every SIMD engine the host supports against the same pinned hashes.
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+        {
+            use crate::reed_solomon::engine::{Avx2, Ssse3, cpu_features};
+            if cpu_features::avx2() {
+                roundtrip_two_rounds_inner!(
+                    $Rate,
+                    Avx2,
+                    $explicit_reset,
+                    (
+                        $original_count_a,
+                        $recovery_count_a,
+                        $shard_bytes_a,
+                        $recovery_hash_a,
+                        $decoder_original_a,
+                        $decoder_recovery_a,
+                        $seed_a,
+                    ),
+                    (
+                        $original_count_b,
+                        $recovery_count_b,
+                        $shard_bytes_b,
+                        $recovery_hash_b,
+                        $decoder_original_b,
+                        $decoder_recovery_b,
+                        $seed_b,
+                    ),
+                );
+            }
+            if cpu_features::ssse3() {
+                roundtrip_two_rounds_inner!(
+                    $Rate,
+                    Ssse3,
+                    $explicit_reset,
+                    (
+                        $original_count_a,
+                        $recovery_count_a,
+                        $shard_bytes_a,
+                        $recovery_hash_a,
+                        $decoder_original_a,
+                        $decoder_recovery_a,
+                        $seed_a,
+                    ),
+                    (
+                        $original_count_b,
+                        $recovery_count_b,
+                        $shard_bytes_b,
+                        $recovery_hash_b,
+                        $decoder_original_b,
+                        $decoder_recovery_b,
+                        $seed_b,
+                    ),
+                );
+            }
+        }
+        #[cfg(target_arch = "aarch64")]
+        {
+            use crate::reed_solomon::engine::{Neon, cpu_features};
+            if cpu_features::neon() {
+                roundtrip_two_rounds_inner!(
+                    $Rate,
+                    Neon,
+                    $explicit_reset,
+                    (
+                        $original_count_a,
+                        $recovery_count_a,
+                        $shard_bytes_a,
+                        $recovery_hash_a,
+                        $decoder_original_a,
+                        $decoder_recovery_a,
+                        $seed_a,
+                    ),
+                    (
+                        $original_count_b,
+                        $recovery_count_b,
+                        $shard_bytes_b,
+                        $recovery_hash_b,
+                        $decoder_original_b,
+                        $decoder_recovery_b,
+                        $seed_b,
+                    ),
+                );
+            }
+        }
     };
 }
 


### PR DESCRIPTION
## Summary

The vendored Reed-Solomon engines are only tested through `DefaultEngine`, which picks one engine per host. `test_util::roundtrip_single!` and `roundtrip_two_rounds!` run every pinned-hash roundtrip against `Naive` and `NoSimd` only, and the upstream `tests/integration_test.rs` that compared each SIMD engine to `NoSimd` was not carried over in #4092. On the AVX2 CI runners that leaves `Ssse3` unexecuted entirely: Codecov reports `engine/engine_ssse3.rs` at 0% on `main`, while `engine_avx2.rs` is covered only incidentally.

This PR runs each SIMD engine the host supports (`Avx2` and `Ssse3` on x86, `Neon` on aarch64) through the same pinned recovery hashes and decoder selections as the scalar engines, gated on the existing `cpu_features` checks so unsupported hosts skip them. `cpu_features` becomes `pub(crate)` for that.

Verified by mutation: making `Ssse3::mul` a no-op for non-zero `log_m` fails 19 of the 92 `reed_solomon` tests with this change on an x86_64 build (run under Rosetta, which exposes SSSE3 but not AVX2), versus 4 on `main` where only the `DefaultEngine`-backed tests notice. On an AVX2 host `main` catches none. The same mutation on `Neon::mul` fails the aarch64 run.

No production code is changed.
