### PR TITLE
[cryptography/ed25519] Pin ZIP215 small-order and non-canonical cases

### DIFF
--- a/cryptography/src/ed25519/core/mod.rs
+++ b/cryptography/src/ed25519/core/mod.rs
@@ -27,6 +27,8 @@ mod error;
 mod signature;
 mod signing_key;
 mod verification_key;
+#[cfg(test)]
+mod zip215;
 
 pub use error::Error;
 pub use signature::Signature;

--- a/cryptography/src/ed25519/core/zip215.rs
+++ b/cryptography/src/ed25519/core/zip215.rs
@@ -1,0 +1,149 @@
+//! ZIP215 conformance cases ported from `ed25519-zebra`'s `small_order` test suite.
+//!
+//! ZIP215 requires non-canonical point encodings to be accepted and the cofactored
+//! verification equation `[8][s]B = [8]R + [8][k]A` to be used, so every signature whose `R`
+//! and `A` are low-order points with `s = 0` verifies. These cases pin that behavior for both
+//! individual and batch verification.
+
+use super::{Signature, VerificationKey, batch};
+use commonware_parallel::Sequential;
+use commonware_utils::test_rng;
+use curve25519_dalek::{
+    constants::EIGHT_TORSION,
+    edwards::{CompressedEdwardsY, EdwardsPoint},
+    traits::IsIdentity,
+};
+
+const MSG: &[u8] = b"Zcash";
+
+/// The 19 field elements that also have a non-canonical 255-bit encoding `y + p`.
+fn non_canonical_field_encodings() -> Vec<[u8; 32]> {
+    let mut bytes = [0xff; 32];
+    bytes[31] = 0x7f;
+    (0..19u8)
+        .map(|i| {
+            bytes[0] = 237 + i;
+            bytes
+        })
+        .collect()
+}
+
+/// All 26 non-canonical point encodings. The first six are low order.
+///
+/// An encoding is non-canonical either because `x = 0` and the sign bit is set (`y = 1` or
+/// `y = -1`) or because `y` is encoded as `y + p`; twelve of the nineteen such field elements
+/// are `y` coordinates of curve points, and each of those decodes with either sign bit.
+fn non_canonical_point_encodings() -> Vec<[u8; 32]> {
+    let mut encodings = Vec::new();
+
+    // Canonical y with a non-canonical sign bit.
+    let mut y1 = [0u8; 32];
+    y1[0] = 1;
+    y1[31] = 128;
+    encodings.push(y1);
+    let mut ym1 = [0xff; 32];
+    ym1[0] = 236;
+    encodings.push(ym1);
+
+    // Non-canonical y with either sign bit, kept only when it decodes to a curve point.
+    for mut y in non_canonical_field_encodings() {
+        if CompressedEdwardsY(y).decompress().is_some() {
+            encodings.push(y);
+        }
+        y[31] |= 128;
+        if CompressedEdwardsY(y).decompress().is_some() {
+            encodings.push(y);
+        }
+    }
+
+    assert_eq!(encodings.len(), 26);
+    for encoding in &encodings {
+        let point = CompressedEdwardsY(*encoding).decompress().unwrap();
+        assert_ne!(point.compress().to_bytes(), *encoding);
+    }
+    encodings
+}
+
+/// Every encoding of a low-order point: the eight canonical torsion encodings plus the six
+/// low-order non-canonical encodings.
+fn low_order_encodings() -> Vec<[u8; 32]> {
+    let non_canonical = non_canonical_point_encodings();
+    let (low, high) = non_canonical.split_at(6);
+    for encoding in low {
+        let point = CompressedEdwardsY(*encoding).decompress().unwrap();
+        assert!(point.mul_by_cofactor().is_identity());
+    }
+    for encoding in high {
+        let point = CompressedEdwardsY(*encoding).decompress().unwrap();
+        assert!(!point.mul_by_cofactor().is_identity());
+    }
+    EIGHT_TORSION
+        .iter()
+        .map(|point| point.compress().to_bytes())
+        .chain(low.iter().copied())
+        .collect()
+}
+
+/// Builds the signature `(R, 0)` for the given `R` encoding.
+fn zero_s_signature(r: [u8; 32]) -> Signature {
+    let mut bytes = [0u8; 64];
+    bytes[..32].copy_from_slice(&r);
+    Signature::from(bytes)
+}
+
+fn verify_individually(vk: [u8; 32], sig: &Signature) -> bool {
+    VerificationKey::try_from(vk).is_ok_and(|vk| vk.verify(sig, MSG).is_ok())
+}
+
+fn verify_batched(vk: [u8; 32], sig: &Signature) -> bool {
+    VerificationKey::try_from(vk).is_ok_and(|vk| {
+        let mut verifier = batch::Verifier::new(1);
+        verifier.queue(vk, *sig, MSG);
+        verifier.verify(test_rng(), &Sequential).is_ok()
+    })
+}
+
+#[test]
+fn non_canonical_encodings_are_accepted() {
+    for encoding in non_canonical_point_encodings() {
+        assert!(VerificationKey::try_from(encoding).is_ok(), "{encoding:?}");
+    }
+}
+
+#[test]
+fn small_order_signatures_verify() {
+    let encodings = low_order_encodings();
+    assert_eq!(encodings.len(), 14);
+    for a in &encodings {
+        for r in &encodings {
+            let sig = zero_s_signature(*r);
+            assert!(verify_individually(*a, &sig), "A={a:?} R={r:?}");
+        }
+    }
+}
+
+#[test]
+fn small_order_signatures_reject_full_order_r() {
+    let identity = EIGHT_TORSION[0].compress().to_bytes();
+    let full_order = EdwardsPoint::mul_base(&curve25519_dalek::scalar::Scalar::ONE)
+        .compress()
+        .to_bytes();
+    let sig = zero_s_signature(full_order);
+    assert!(!verify_individually(identity, &sig));
+    assert!(!verify_batched(identity, &sig));
+}
+
+#[test]
+fn individual_matches_batch_verification() {
+    let encodings = low_order_encodings();
+    for a in &encodings {
+        for r in &encodings {
+            let sig = zero_s_signature(*r);
+            assert_eq!(
+                verify_individually(*a, &sig),
+                verify_batched(*a, &sig),
+                "A={a:?} R={r:?}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

`ed25519::core` documents that it follows ZIP215, and `verify` implements the cofactored equation with non-canonical encodings accepted, but the only vectors in tree are the RFC 8032 ones from `scheme.rs`. Upstream's `small_order` suite, which pins the ZIP215-specific behavior, was not carried over with the vendored code.

This PR ports those cases as `ed25519::core::zip215`:

- every non-canonical point encoding (the two `x = 0` sign-bit cases plus the `y + p` encodings that decode with either sign bit, 26 in total) is accepted as a verification key;
- for all 14 low-order `A` and `R` encodings (eight canonical torsion points plus the six low-order non-canonical encodings), the signature `(R, 0)` verifies, and a full-order `R` does not;
- individual and batch verification agree on all of those pairs.

The cases are derived from `curve25519_dalek::constants::EIGHT_TORSION` and the field-element taxonomy rather than hard-coded, so they stay valid if the backend changes (#4706). Replacing the cofactored check in `verify_prehashed` with the plain `R == R'` comparison fails `small_order_signatures_verify` and `individual_matches_batch_verification` while the existing 57 ed25519 tests stay green. I also checked the vendored core against `ed25519-consensus` and `ed25519-zebra` on 6160 structured cases (all low-order and non-canonical `A`/`R` pairs across several `s` values) and found no disagreement.

No production code is changed.
